### PR TITLE
feat: Support configuring database search path.

### DIFF
--- a/packages/serverpod/lib/src/database/database_pool_manager.dart
+++ b/packages/serverpod/lib/src/database/database_pool_manager.dart
@@ -45,13 +45,13 @@ class DatabasePoolManager {
           maxConnectionCount: 10,
           queryTimeout: const Duration(minutes: 1),
           sslMode: config.requireSsl ? pg.SslMode.require : pg.SslMode.disable,
-          onOpen: config.defaultSchema != null
+          onOpen: config.searchPaths != null
               ? (connection) async {
                   await connection.execute(
                       //TODO(SandPod): I included your code just here...
                       // This should be created by the migrations system, right?
                       // 'CREATE SCHEMA IF NOT EXISTS ${config.defaultSchema};'
-                      'SET search_path TO ${config.defaultSchema};');
+                      'SET search_path TO ${config.searchPaths};');
                 }
               : null,
         ) {

--- a/packages/serverpod/lib/src/database/database_pool_manager.dart
+++ b/packages/serverpod/lib/src/database/database_pool_manager.dart
@@ -45,6 +45,15 @@ class DatabasePoolManager {
           maxConnectionCount: 10,
           queryTimeout: const Duration(minutes: 1),
           sslMode: config.requireSsl ? pg.SslMode.require : pg.SslMode.disable,
+          onOpen: config.defaultSchema != null
+              ? (connection) async {
+                  await connection.execute(
+                      //TODO(SandPod): I included your code just here...
+                      // This should be created by the migrations system, right?
+                      // 'CREATE SCHEMA IF NOT EXISTS ${config.defaultSchema};'
+                      'SET search_path TO ${config.defaultSchema};');
+                }
+              : null,
         ) {
     _serializationManager = serializationManager;
   }

--- a/packages/serverpod/lib/src/database/database_pool_manager.dart
+++ b/packages/serverpod/lib/src/database/database_pool_manager.dart
@@ -47,11 +47,12 @@ class DatabasePoolManager {
           sslMode: config.requireSsl ? pg.SslMode.require : pg.SslMode.disable,
           onOpen: config.searchPaths != null
               ? (connection) async {
+                  var encodedSearchPaths = config.searchPaths
+                      ?.map((s) => encoder.convert(s))
+                      .join(',');
                   await connection.execute(
-                      //TODO(SandPod): I included your code just here...
-                      // This should be created by the migrations system, right?
-                      // 'CREATE SCHEMA IF NOT EXISTS ${config.defaultSchema};'
-                      'SET search_path TO ${config.searchPaths};');
+                    'SET search_path TO $encodedSearchPaths;',
+                  );
                 }
               : null,
         ) {

--- a/packages/serverpod/lib/src/database/extensions.dart
+++ b/packages/serverpod/lib/src/database/extensions.dart
@@ -79,16 +79,6 @@ extension TableComparisons on TableDefinition {
       );
     }
 
-    if (other.schema != schema) {
-      mismatches.add(
-        TableComparisonWarning(
-          name: 'schema',
-          expected: schema,
-          found: other.schema,
-        ),
-      );
-    }
-
     if (managed != null && other.managed != null && managed != other.managed) {
       mismatches.add(
         TableComparisonWarning(
@@ -379,16 +369,6 @@ extension ForeignKeyComparisons on ForeignKeyDefinition {
           name: 'reference table',
           expected: referenceTable,
           found: other.referenceTable,
-        ),
-      );
-    }
-
-    if (referenceTableSchema != other.referenceTableSchema) {
-      mismatches.add(
-        ForeignKeyComparisonWarning(
-          name: 'reference schema',
-          expected: referenceTableSchema,
-          found: other.referenceTableSchema,
         ),
       );
     }

--- a/packages/serverpod/lib/src/server/command_line_args.dart
+++ b/packages/serverpod/lib/src/server/command_line_args.dart
@@ -59,6 +59,9 @@ class CommandLineArgs {
   /// If true, the server will apply database repair migration on startup.
   late final bool applyRepairMigration;
 
+  /// The default database schema.
+  late final String? databaseDefaultSchema;
+
   /// Parses the command line arguments passed to Serverpod and creates a
   /// [CommandLineArgs] object.
   CommandLineArgs(List<String> args) {
@@ -101,6 +104,12 @@ class CommandLineArgs {
           'apply-repair-migration',
           abbr: 'A',
           defaultsTo: false,
+        )
+        ..addOption(
+          'database-default-schema',
+          abbr: 's',
+          help: 'Specifies the default database schema.',
+          defaultsTo: 'public',
         );
       var results = argParser.parse(args);
 
@@ -130,6 +139,7 @@ class CommandLineArgs {
 
       applyMigrations = results['apply-migrations'] ?? false;
       applyRepairMigration = results['apply-repair-migration'] ?? false;
+      databaseDefaultSchema = results['database-default-schema'] ?? 'public';
     } catch (e) {
       stdout.writeln(
         'Failed to parse command line arguments. Using default values. $e',
@@ -140,6 +150,7 @@ class CommandLineArgs {
       role = ServerpodRole.monolith;
       applyMigrations = false;
       applyRepairMigration = false;
+      databaseDefaultSchema = 'public';
     }
   }
 
@@ -168,6 +179,8 @@ class CommandLineArgs {
         break;
     }
 
-    return 'mode: $runMode, role: $formattedRole, logging: $formattedLoggingMode, serverId: $serverId';
+    return 'mode: $runMode, role: $formattedRole, logging: $formattedLoggingMode, '
+        'serverId: $serverId, databaseDefaultSchema: $databaseDefaultSchema, '
+        'applyMigrations: $applyMigrations, applyRepairMigration: $applyRepairMigration';
   }
 }

--- a/packages/serverpod/lib/src/server/command_line_args.dart
+++ b/packages/serverpod/lib/src/server/command_line_args.dart
@@ -59,9 +59,6 @@ class CommandLineArgs {
   /// If true, the server will apply database repair migration on startup.
   late final bool applyRepairMigration;
 
-  /// The default database schema.
-  late final String? databaseDefaultSchema;
-
   /// Parses the command line arguments passed to Serverpod and creates a
   /// [CommandLineArgs] object.
   CommandLineArgs(List<String> args) {
@@ -104,12 +101,6 @@ class CommandLineArgs {
           'apply-repair-migration',
           abbr: 'A',
           defaultsTo: false,
-        )
-        ..addOption(
-          'database-default-schema',
-          abbr: 's',
-          help: 'Specifies the default database schema.',
-          defaultsTo: 'public',
         );
       var results = argParser.parse(args);
 
@@ -139,7 +130,6 @@ class CommandLineArgs {
 
       applyMigrations = results['apply-migrations'] ?? false;
       applyRepairMigration = results['apply-repair-migration'] ?? false;
-      databaseDefaultSchema = results['database-default-schema'] ?? 'public';
     } catch (e) {
       stdout.writeln(
         'Failed to parse command line arguments. Using default values. $e',
@@ -150,7 +140,6 @@ class CommandLineArgs {
       role = ServerpodRole.monolith;
       applyMigrations = false;
       applyRepairMigration = false;
-      databaseDefaultSchema = 'public';
     }
   }
 
@@ -179,8 +168,6 @@ class CommandLineArgs {
         break;
     }
 
-    return 'mode: $runMode, role: $formattedRole, logging: $formattedLoggingMode, '
-        'serverId: $serverId, databaseDefaultSchema: $databaseDefaultSchema, '
-        'applyMigrations: $applyMigrations, applyRepairMigration: $applyRepairMigration';
+    return 'mode: $runMode, role: $formattedRole, logging: $formattedLoggingMode, serverId: $serverId';
   }
 }

--- a/packages/serverpod/pubspec.yaml
+++ b/packages/serverpod/pubspec.yaml
@@ -27,7 +27,7 @@ dependencies:
   meta: ^1.8.0
   mustache_template: ^2.0.0
   path: ^1.8.2
-  postgres: ^3.0.1
+  postgres: ^3.1.2
   redis: ^4.0.0
   retry: ^3.1.1
   synchronized: ^3.1.0

--- a/packages/serverpod/test/database/extensions/table_comparison_test.dart
+++ b/packages/serverpod/test/database/extensions/table_comparison_test.dart
@@ -71,40 +71,6 @@ void main() {
     );
 
     test(
-      'when tables have different schemas then mismatches include schema mismatch',
-      () {
-        var tableA = TableDefinition(
-          name: 'test_table',
-          schema: 'schema_a',
-          columns: [],
-          foreignKeys: [],
-          indexes: [],
-          managed: true,
-        );
-
-        var tableB = TableDefinition(
-          name: 'test_table',
-          schema: 'schema_b',
-          columns: [],
-          foreignKeys: [],
-          indexes: [],
-          managed: true,
-        );
-
-        var mismatches = tableA.like(tableB);
-
-        expect(mismatches.length, 1);
-        expect(mismatches.first.subs, isEmpty);
-        expect(mismatches.first, isA<TableComparisonWarning>());
-        expect(mismatches.first.expected, equals('schema_a'));
-        expect(mismatches.first.found, equals('schema_b'));
-        expect(mismatches.first.isMismatch, isTrue);
-        expect(mismatches.first.isMissing, isFalse);
-        expect(mismatches.first.isAdded, isFalse);
-      },
-    );
-
-    test(
       'when tables have different tablespaces then mismatches include tablespace mismatch',
       () {
         var tableA = TableDefinition(

--- a/packages/serverpod_shared/lib/src/config.dart
+++ b/packages/serverpod_shared/lib/src/config.dart
@@ -303,7 +303,7 @@ class DatabaseConfig {
   final bool isUnixSocket;
 
   /// Override the search path all connections to the database.
-  final String? searchPaths;
+  final List<String>? searchPaths;
 
   /// Creates a new [DatabaseConfig].
   DatabaseConfig({
@@ -343,7 +343,8 @@ class DatabaseConfig {
       isUnixSocket:
           dbSetup[ServerpodEnv.databaseIsUnixSocket.configKey] ?? false,
       password: password,
-      searchPaths: dbSetup[ServerpodEnv.databaseSearchPaths.configKey],
+      searchPaths:
+          _parseList(dbSetup[ServerpodEnv.databaseSearchPaths.configKey]),
     );
   }
 
@@ -640,6 +641,12 @@ void _validateJsonConfig(
       );
     }
   }
+}
+
+/// Parses a comma-separated string into a list of strings.
+List<String>? _parseList(String? value) {
+  if (value == null) return null;
+  return value.split(',').map((e) => e.trim()).toList();
 }
 
 /// The configuration keys for the serverpod configuration file.

--- a/packages/serverpod_shared/lib/src/config.dart
+++ b/packages/serverpod_shared/lib/src/config.dart
@@ -302,6 +302,9 @@ class DatabaseConfig {
   /// True if the database is running on a unix socket.
   final bool isUnixSocket;
 
+  /// Default schema for the database.
+  final String? defaultSchema;
+
   /// Creates a new [DatabaseConfig].
   DatabaseConfig({
     required this.host,
@@ -311,6 +314,7 @@ class DatabaseConfig {
     required this.name,
     this.requireSsl = false,
     this.isUnixSocket = false,
+    this.defaultSchema,
   });
 
   factory DatabaseConfig._fromJson(Map dbSetup, Map passwords, String name) {
@@ -320,6 +324,7 @@ class DatabaseConfig {
         ServerpodEnv.databasePort.configKey: int,
         ServerpodEnv.databaseName.configKey: String,
         ServerpodEnv.databaseUser.configKey: String,
+        ServerpodEnv.databaseDefaultSchema.configKey: String,
       },
       dbSetup,
       name,
@@ -339,6 +344,7 @@ class DatabaseConfig {
       isUnixSocket:
           dbSetup[ServerpodEnv.databaseIsUnixSocket.configKey] ?? false,
       password: password,
+      defaultSchema: dbSetup[ServerpodEnv.databaseDefaultSchema.configKey],
     );
   }
 
@@ -352,6 +358,9 @@ class DatabaseConfig {
     str += 'database require SSL: $requireSsl\n';
     str += 'database unix socket: $isUnixSocket\n';
     str += 'database pass: ********\n';
+    if (defaultSchema != null) {
+      str += 'database default schema: $defaultSchema\n';
+    }
     return str;
   }
 }
@@ -521,6 +530,7 @@ Map? _databaseConfigMap(Map configMap, Map<String, String> environment) {
     (ServerpodEnv.databaseUser, null),
     (ServerpodEnv.databaseRequireSsl, bool.parse),
     (ServerpodEnv.databaseIsUnixSocket, bool.parse),
+    (ServerpodEnv.databaseDefaultSchema, null),
   ]);
 }
 

--- a/packages/serverpod_shared/lib/src/config.dart
+++ b/packages/serverpod_shared/lib/src/config.dart
@@ -302,8 +302,8 @@ class DatabaseConfig {
   /// True if the database is running on a unix socket.
   final bool isUnixSocket;
 
-  /// Default schema for the database.
-  final String? defaultSchema;
+  /// Override the search path all connections to the database.
+  final String? searchPaths;
 
   /// Creates a new [DatabaseConfig].
   DatabaseConfig({
@@ -314,7 +314,7 @@ class DatabaseConfig {
     required this.name,
     this.requireSsl = false,
     this.isUnixSocket = false,
-    this.defaultSchema,
+    this.searchPaths,
   });
 
   factory DatabaseConfig._fromJson(Map dbSetup, Map passwords, String name) {
@@ -324,7 +324,7 @@ class DatabaseConfig {
         ServerpodEnv.databasePort.configKey: int,
         ServerpodEnv.databaseName.configKey: String,
         ServerpodEnv.databaseUser.configKey: String,
-        ServerpodEnv.databaseDefaultSchema.configKey: String,
+        ServerpodEnv.databaseSearchPaths.configKey: String,
       },
       dbSetup,
       name,
@@ -344,7 +344,7 @@ class DatabaseConfig {
       isUnixSocket:
           dbSetup[ServerpodEnv.databaseIsUnixSocket.configKey] ?? false,
       password: password,
-      defaultSchema: dbSetup[ServerpodEnv.databaseDefaultSchema.configKey],
+      searchPaths: dbSetup[ServerpodEnv.databaseSearchPaths.configKey],
     );
   }
 
@@ -358,8 +358,8 @@ class DatabaseConfig {
     str += 'database require SSL: $requireSsl\n';
     str += 'database unix socket: $isUnixSocket\n';
     str += 'database pass: ********\n';
-    if (defaultSchema != null) {
-      str += 'database default schema: $defaultSchema\n';
+    if (searchPaths != null) {
+      str += 'database search path overrides: $searchPaths\n';
     }
     return str;
   }
@@ -530,7 +530,7 @@ Map? _databaseConfigMap(Map configMap, Map<String, String> environment) {
     (ServerpodEnv.databaseUser, null),
     (ServerpodEnv.databaseRequireSsl, bool.parse),
     (ServerpodEnv.databaseIsUnixSocket, bool.parse),
-    (ServerpodEnv.databaseDefaultSchema, null),
+    (ServerpodEnv.databaseSearchPaths, null),
   ]);
 }
 

--- a/packages/serverpod_shared/lib/src/config.dart
+++ b/packages/serverpod_shared/lib/src/config.dart
@@ -324,7 +324,6 @@ class DatabaseConfig {
         ServerpodEnv.databasePort.configKey: int,
         ServerpodEnv.databaseName.configKey: String,
         ServerpodEnv.databaseUser.configKey: String,
-        ServerpodEnv.databaseSearchPaths.configKey: String,
       },
       dbSetup,
       name,

--- a/packages/serverpod_shared/lib/src/environment_variables.dart
+++ b/packages/serverpod_shared/lib/src/environment_variables.dart
@@ -49,7 +49,7 @@ enum ServerpodEnv {
   databaseUser,
 
   /// The default schema for the database.
-  databaseDefaultSchema,
+  databaseSearchPaths,
 
   /// Toggle to require SSL for the database.
   databaseRequireSsl,
@@ -124,7 +124,7 @@ enum ServerpodEnv {
       (ServerpodEnv.databasePort) => 'port',
       (ServerpodEnv.databaseName) => 'name',
       (ServerpodEnv.databaseUser) => 'user',
-      (ServerpodEnv.databaseDefaultSchema) => 'defaultSchema',
+      (ServerpodEnv.databaseSearchPaths) => 'searchPaths',
       (ServerpodEnv.databaseRequireSsl) => 'requireSsl',
       (ServerpodEnv.databaseIsUnixSocket) => 'isUnixSocket',
       (ServerpodEnv.redisHost) => 'host',
@@ -158,8 +158,7 @@ enum ServerpodEnv {
       (ServerpodEnv.databasePort) => 'SERVERPOD_DATABASE_PORT',
       (ServerpodEnv.databaseName) => 'SERVERPOD_DATABASE_NAME',
       (ServerpodEnv.databaseUser) => 'SERVERPOD_DATABASE_USER',
-      (ServerpodEnv.databaseDefaultSchema) =>
-        'SERVERPOD_DATABASE_DEFAULT_SCHEMA',
+      (ServerpodEnv.databaseSearchPaths) => 'SERVERPOD_DATABASE_SEARCH_PATHS',
       (ServerpodEnv.databaseRequireSsl) => 'SERVERPOD_DATABASE_REQUIRE_SSL',
       (ServerpodEnv.databaseIsUnixSocket) =>
         'SERVERPOD_DATABASE_IS_UNIX_SOCKET',

--- a/packages/serverpod_shared/lib/src/environment_variables.dart
+++ b/packages/serverpod_shared/lib/src/environment_variables.dart
@@ -48,6 +48,9 @@ enum ServerpodEnv {
   /// The user for the database.
   databaseUser,
 
+  /// The default schema for the database.
+  databaseDefaultSchema,
+
   /// Toggle to require SSL for the database.
   databaseRequireSsl,
 
@@ -121,6 +124,7 @@ enum ServerpodEnv {
       (ServerpodEnv.databasePort) => 'port',
       (ServerpodEnv.databaseName) => 'name',
       (ServerpodEnv.databaseUser) => 'user',
+      (ServerpodEnv.databaseDefaultSchema) => 'defaultSchema',
       (ServerpodEnv.databaseRequireSsl) => 'requireSsl',
       (ServerpodEnv.databaseIsUnixSocket) => 'isUnixSocket',
       (ServerpodEnv.redisHost) => 'host',
@@ -154,6 +158,8 @@ enum ServerpodEnv {
       (ServerpodEnv.databasePort) => 'SERVERPOD_DATABASE_PORT',
       (ServerpodEnv.databaseName) => 'SERVERPOD_DATABASE_NAME',
       (ServerpodEnv.databaseUser) => 'SERVERPOD_DATABASE_USER',
+      (ServerpodEnv.databaseDefaultSchema) =>
+        'SERVERPOD_DATABASE_DEFAULT_SCHEMA',
       (ServerpodEnv.databaseRequireSsl) => 'SERVERPOD_DATABASE_REQUIRE_SSL',
       (ServerpodEnv.databaseIsUnixSocket) =>
         'SERVERPOD_DATABASE_IS_UNIX_SOCKET',

--- a/packages/serverpod_shared/test/database_config_test.dart
+++ b/packages/serverpod_shared/test/database_config_test.dart
@@ -1,0 +1,277 @@
+import 'package:serverpod_shared/serverpod_shared.dart';
+import 'package:test/test.dart';
+import 'package:yaml/yaml.dart';
+
+void main() {
+  var runMode = 'development';
+  var serverId = 'default';
+  var passwords = {'serviceSecret': 'longpasswordthatisrequired'};
+
+  test(
+      'Given a Serverpod config with api server configuration when loading from Map then database configuration is null.',
+      () {
+    var serverpodConfig = '''
+apiServer:
+  port: 8080
+  publicHost: localhost
+  publicPort: 8080
+  publicScheme: http
+''';
+
+    const runMode = 'myRunMode';
+    const serverId = 'myServerId';
+    const passwords = {'serviceSecret': 'LONG_PASSWORD_THAT_IS_REQUIRED'};
+
+    var config = ServerpodConfig.loadFromMap(
+      runMode,
+      serverId,
+      passwords,
+      loadYaml(serverpodConfig),
+    );
+
+    expect(config.database, isNull);
+  });
+
+  test(
+      'Given a Serverpod config with database configuration without password when loading from Map then exception is thrown.',
+      () {
+    var serverpodConfig = '''
+apiServer:
+  port: 8080
+  publicHost: localhost
+  publicPort: 8080
+  publicScheme: http
+database:
+  host: localhost
+  port: 5432
+  name: testDb
+  user: test
+''';
+
+    expect(
+      () => ServerpodConfig.loadFromMap(
+        runMode,
+        serverId,
+        passwords,
+        loadYaml(serverpodConfig),
+      ),
+      throwsA(isA<Exception>().having(
+        (e) => e.toString(),
+        'message',
+        equals('Exception: Missing database password.'),
+      )),
+    );
+  });
+
+  test(
+      'Given a Serverpod config with database configuration missing required field when loading from Map then exception is thrown.',
+      () {
+    var serverpodConfig = '''
+apiServer:
+  port: 8080
+  publicHost: localhost
+  publicPort: 8080
+  publicScheme: http
+database:
+  host: localhost
+  name: testDb
+  user: test
+''';
+
+    expect(
+      () => ServerpodConfig.loadFromMap(
+        runMode,
+        serverId,
+        {...passwords, 'database': 'password'},
+        loadYaml(serverpodConfig),
+      ),
+      throwsA(isA<Exception>().having(
+        (e) => e.toString(),
+        'message',
+        equals(
+            'Exception: database is missing required configuration for port.'),
+      )),
+    );
+  });
+
+  test(
+      'Given a Serverpod config with database configuration when loading from Map then database configuration is set.',
+      () {
+    var serverpodConfig = '''
+apiServer:
+  port: 8080
+  publicHost: localhost
+  publicPort: 8080
+  publicScheme: http
+database:
+  host: localhost
+  port: 5432
+  name: testDb
+  user: test
+''';
+
+    var config = ServerpodConfig.loadFromMap(
+      runMode,
+      serverId,
+      {...passwords, 'database': 'password'},
+      loadYaml(serverpodConfig),
+    );
+
+    expect(config.database?.host, 'localhost');
+    expect(config.database?.port, 5432);
+    expect(config.database?.name, 'testDb');
+    expect(config.database?.user, 'test');
+    expect(config.database?.password, 'password');
+    expect(config.database?.requireSsl, isFalse);
+    expect(config.database?.isUnixSocket, isFalse);
+  });
+
+  test(
+      'Given a Serverpod config with only the api server configuration but the environment variables containing the config for the database when loading from Map then the database config is created.',
+      () {
+    var config = ServerpodConfig.loadFromMap(
+      runMode,
+      serverId,
+      {...passwords, 'database': 'password'},
+      {
+        'apiServer': {
+          'port': 8080,
+          'publicHost': 'localhost',
+          'publicPort': 8080,
+          'publicScheme': 'http',
+        },
+      },
+      environment: {
+        'SERVERPOD_DATABASE_HOST': 'localhost',
+        'SERVERPOD_DATABASE_PORT': '5432',
+        'SERVERPOD_DATABASE_NAME': 'serverpod',
+        'SERVERPOD_DATABASE_USER': 'admin',
+      },
+    );
+
+    expect(config.database?.host, 'localhost');
+    expect(config.database?.port, 5432);
+    expect(config.database?.name, 'serverpod');
+    expect(config.database?.user, 'admin');
+  });
+
+  test(
+      'Given a Serverpod config map with half the values and the environment variables the other half for the database when loading from Map then configuration then the database config is created',
+      () {
+    var config = ServerpodConfig.loadFromMap(
+      runMode,
+      serverId,
+      {...passwords, 'database': 'password'},
+      {
+        'apiServer': {
+          'port': 8080,
+          'publicHost': 'localhost',
+          'publicPort': 8080,
+          'publicScheme': 'http',
+        },
+        'database': {
+          'port': 5432,
+          'name': 'serverpod',
+        },
+      },
+      environment: {
+        'SERVERPOD_DATABASE_HOST': 'localhost',
+        'SERVERPOD_DATABASE_USER': 'admin',
+      },
+    );
+
+    expect(config.database?.host, 'localhost');
+    expect(config.database?.port, 5432);
+    expect(config.database?.name, 'serverpod');
+    expect(config.database?.user, 'admin');
+  });
+
+  test(
+      'Given a Serverpod config map with all the values and the environment variables for the database when loading from Map then the config is overridden by the environment variables.',
+      () {
+    var config = ServerpodConfig.loadFromMap(
+      runMode,
+      serverId,
+      {...passwords, 'database': 'password'},
+      {
+        'apiServer': {
+          'port': 8080,
+          'publicHost': 'localhost',
+          'publicPort': 8080,
+          'publicScheme': 'http',
+        },
+        'database': {
+          'host': 'localhost',
+          'port': 5432,
+          'name': 'serverpod',
+          'user': 'admin',
+        },
+      },
+      environment: {
+        'SERVERPOD_DATABASE_HOST': 'remotehost',
+        'SERVERPOD_DATABASE_PORT': '5433',
+        'SERVERPOD_DATABASE_NAME': 'remote_serverpod',
+        'SERVERPOD_DATABASE_USER': 'remote_admin',
+      },
+    );
+
+    expect(config.database?.host, 'remotehost');
+    expect(config.database?.port, 5433);
+    expect(config.database?.name, 'remote_serverpod');
+    expect(config.database?.user, 'remote_admin');
+  });
+
+  test(
+      'Given a Serverpod config with only the api server configuration but the environment variables containing the optional database variable require ssl then the database config takes the value from the env.',
+      () {
+    var config = ServerpodConfig.loadFromMap(
+      runMode,
+      serverId,
+      {...passwords, 'database': 'password'},
+      {
+        'apiServer': {
+          'port': 8080,
+          'publicHost': 'localhost',
+          'publicPort': 8080,
+          'publicScheme': 'http',
+        },
+      },
+      environment: {
+        'SERVERPOD_DATABASE_HOST': 'localhost',
+        'SERVERPOD_DATABASE_PORT': '5432',
+        'SERVERPOD_DATABASE_NAME': 'serverpod',
+        'SERVERPOD_DATABASE_USER': 'admin',
+        'SERVERPOD_DATABASE_REQUIRE_SSL': 'true',
+      },
+    );
+
+    expect(config.database?.requireSsl, true);
+  });
+
+  test(
+      'Given a Serverpod config with only the api server configuration but the environment variables containing the optional database variable isUnixSocket then the database config takes the value from the env.',
+      () {
+    var config = ServerpodConfig.loadFromMap(
+      runMode,
+      serverId,
+      {...passwords, 'database': 'password'},
+      {
+        'apiServer': {
+          'port': 8080,
+          'publicHost': 'localhost',
+          'publicPort': 8080,
+          'publicScheme': 'http',
+        },
+      },
+      environment: {
+        'SERVERPOD_DATABASE_HOST': 'localhost',
+        'SERVERPOD_DATABASE_PORT': '5432',
+        'SERVERPOD_DATABASE_NAME': 'serverpod',
+        'SERVERPOD_DATABASE_USER': 'admin',
+        'SERVERPOD_DATABASE_IS_UNIX_SOCKET': 'true',
+      },
+    );
+
+    expect(config.database?.isUnixSocket, true);
+  });
+}

--- a/packages/serverpod_shared/test/database_config_test.dart
+++ b/packages/serverpod_shared/test/database_config_test.dart
@@ -360,4 +360,67 @@ database:
 
     expect(config.database?.searchPaths, equals(['env_path']));
   });
+
+  test(
+      'Given a Serverpod config with a list of searchPaths when loading from Map then all search paths are parsed.',
+      () {
+    var serverpodConfig = '''
+apiServer:
+  port: 8080
+  publicHost: localhost
+  publicPort: 8080
+  publicScheme: http
+database:
+  host: localhost
+  port: 5432
+  name: testDb
+  user: test
+  searchPaths: first_search_path, second_search_path, third_search_path
+''';
+
+    var config = ServerpodConfig.loadFromMap(
+      runMode,
+      serverId,
+      {...passwords, 'database': 'password'},
+      loadYaml(serverpodConfig),
+    );
+
+    expect(
+      config.database?.searchPaths,
+      equals(['first_search_path', 'second_search_path', 'third_search_path']),
+    );
+  });
+
+  test(
+      'Given a SERVERPOD_DATABASE_SEARCH_PATHS with a list of searchPaths when loading from Map then all search paths are parsed.',
+      () {
+    var serverpodConfig = '''
+apiServer:
+  port: 8080
+  publicHost: localhost
+  publicPort: 8080
+  publicScheme: http
+database:
+  host: localhost
+  port: 5432
+  name: testDb
+  user: test
+''';
+
+    var config = ServerpodConfig.loadFromMap(
+      runMode,
+      serverId,
+      {...passwords, 'database': 'password'},
+      loadYaml(serverpodConfig),
+      environment: {
+        'SERVERPOD_DATABASE_SEARCH_PATHS':
+            'first_search_path, second_search_path, third_search_path',
+      },
+    );
+
+    expect(
+      config.database?.searchPaths,
+      equals(['first_search_path', 'second_search_path', 'third_search_path']),
+    );
+  });
 }

--- a/packages/serverpod_shared/test/database_config_test.dart
+++ b/packages/serverpod_shared/test/database_config_test.dart
@@ -300,7 +300,8 @@ database:
       },
     );
 
-    expect(config.database?.searchPaths, 'custom_path');
+    expect(config.database?.searchPaths, isA<List<String>?>());
+    expect(config.database?.searchPaths, equals(['custom_path']));
   });
 
   test(
@@ -327,7 +328,7 @@ database:
       loadYaml(serverpodConfig),
     );
 
-    expect(config.database?.searchPaths, 'custom_path');
+    expect(config.database?.searchPaths, equals(['custom_path']));
   });
 
   test(
@@ -357,6 +358,6 @@ database:
       },
     );
 
-    expect(config.database?.searchPaths, 'env_path');
+    expect(config.database?.searchPaths, equals(['env_path']));
   });
 }

--- a/templates/pubspecs/packages/serverpod/pubspec.yaml
+++ b/templates/pubspecs/packages/serverpod/pubspec.yaml
@@ -26,7 +26,7 @@ dependencies:
   meta: ^1.8.0
   mustache_template: ^2.0.0
   path: ^1.8.2
-  postgres: ^3.0.1
+  postgres: ^3.1.2
   redis: ^4.0.0
   retry: ^3.1.1
   synchronized: ^3.1.0

--- a/tools/serverpod_cli/lib/src/database/extensions.dart
+++ b/tools/serverpod_cli/lib/src/database/extensions.dart
@@ -70,10 +70,7 @@ extension TableComparisons on TableDefinition {
 
   bool like(TableDefinition other) {
     var diff = generateTableMigration(this, other, []);
-    return diff != null &&
-        diff.isEmpty &&
-        other.name == name &&
-        other.schema == schema;
+    return diff != null && diff.isEmpty && other.name == name;
   }
 }
 
@@ -163,14 +160,8 @@ extension ForeignKeyComparisons on ForeignKeyDefinition {
     var cOnDelete = other.onDelete == onDelete;
     var cOnUpdate = (other.onUpdate ?? dKA) == (onUpdate ?? dKA);
     var cReferenceTable = other.referenceTable == referenceTable;
-    var cReferenceSchema = other.referenceTableSchema == referenceTableSchema;
 
-    return cName &&
-        cMatchType &&
-        cOnDelete &&
-        cOnUpdate &&
-        cReferenceTable &&
-        cReferenceSchema;
+    return cName && cMatchType && cOnDelete && cOnUpdate && cReferenceTable;
   }
 }
 


### PR DESCRIPTION
This PR introduces the possibility of configuring the database search path as a configurable parameter for all database pool connections.

This enables the possibility to define a different schema to use when applying migrations and running queries towards the database.

In order to support this feature, validation on the schema name has been removed. Since we don't provide any migration step it doesn't really make sense to validate the schema anyway.

Implementing support for full schema configuration will be part of this issue: https://github.com/serverpod/serverpod/issues/3385

This can be configured either through the config file like so:

```yaml
database:
  host: localhost
  port: 5432
  name: testDb
  user: test
  searchPaths: config_file_path
```

OR through the environment variable: `SERVERPOD_DATABASE_SEARCH_PATHS=config_file_path`

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

_If you have done any breaking changes, make sure to outline them here, so that they can be included in the notes for the next release._