### PR TITLE
fix: Support record parameters named something other than "record"

### DIFF
--- a/tests/serverpod_test_client/lib/src/protocol/client.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/client.dart
@@ -2537,8 +2537,8 @@ class EndpointRecordParameters extends _i1.EndpointRef {
         'recordParameters',
         'recordParametersWithCustomNames',
         {
-          'positionalRecord': _i19.mapRecordToJson(record),
-          'namedRecord': _i19.mapRecordToJson(record),
+          'positionalRecord': _i19.mapRecordToJson(positionalRecord),
+          'namedRecord': _i19.mapRecordToJson(namedRecord),
         },
       );
 }

--- a/tests/serverpod_test_client/lib/src/protocol/client.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/client.dart
@@ -2529,11 +2529,11 @@ class EndpointRecordParameters extends _i1.EndpointRef {
             {'values': values},
           );
 
-  _i2.Future<void> recordParametersWithCustomNames(
+  _i2.Future<int> recordParametersWithCustomNames(
     (int,) positionalRecord, {
     required (int,) namedRecord,
   }) =>
-      caller.callServerEndpoint<void>(
+      caller.callServerEndpoint<int>(
         'recordParameters',
         'recordParametersWithCustomNames',
         {

--- a/tests/serverpod_test_client/lib/src/protocol/client.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/client.dart
@@ -2528,6 +2528,19 @@ class EndpointRecordParameters extends _i1.EndpointRef {
             {'initialValue': initialValue},
             {'values': values},
           );
+
+  _i2.Future<void> recordParametersWithCustomNames(
+    (int,) positionalRecord, {
+    required (int,) namedRecord,
+  }) =>
+      caller.callServerEndpoint<void>(
+        'recordParameters',
+        'recordParametersWithCustomNames',
+        {
+          'positionalRecord': _i19.mapRecordToJson(record),
+          'namedRecord': _i19.mapRecordToJson(record),
+        },
+      );
 }
 
 /// {@category Endpoint}

--- a/tests/serverpod_test_server/lib/src/endpoints/record_parameters.dart
+++ b/tests/serverpod_test_server/lib/src/endpoints/record_parameters.dart
@@ -316,4 +316,14 @@ class RecordParametersEndpoint extends Endpoint {
     }
   }
 // #endregion
+
+// #region Record parameter with custom name
+  Future<void> recordParametersWithCustomNames(
+    Session session,
+    (int,) positionalRecord, {
+    required (int,) namedRecord,
+  }) async {
+    return;
+  }
+// #endregion
 }

--- a/tests/serverpod_test_server/lib/src/endpoints/record_parameters.dart
+++ b/tests/serverpod_test_server/lib/src/endpoints/record_parameters.dart
@@ -318,12 +318,12 @@ class RecordParametersEndpoint extends Endpoint {
 // #endregion
 
 // #region Record parameter with custom name
-  Future<void> recordParametersWithCustomNames(
+  Future<int> recordParametersWithCustomNames(
     Session session,
     (int,) positionalRecord, {
     required (int,) namedRecord,
   }) async {
-    return;
+    return positionalRecord.$1 + namedRecord.$1;
   }
 // #endregion
 }

--- a/tests/serverpod_test_server/lib/src/generated/endpoints.dart
+++ b/tests/serverpod_test_server/lib/src/generated/endpoints.dart
@@ -5546,6 +5546,31 @@ class Endpoints extends _i1.EndpointDispatch {
             params['value'],
           ),
         ),
+        'recordParametersWithCustomNames': _i1.MethodConnector(
+          name: 'recordParametersWithCustomNames',
+          params: {
+            'positionalRecord': _i1.ParameterDescription(
+              name: 'positionalRecord',
+              type: _i1.getType<(int,)>(),
+              nullable: false,
+            ),
+            'namedRecord': _i1.ParameterDescription(
+              name: 'namedRecord',
+              type: _i1.getType<(int,)>(),
+              nullable: false,
+            ),
+          },
+          call: (
+            _i1.Session session,
+            Map<String, dynamic> params,
+          ) async =>
+              (endpoints['recordParameters'] as _i29.RecordParametersEndpoint)
+                  .recordParametersWithCustomNames(
+            session,
+            params['positionalRecord'],
+            namedRecord: params['namedRecord'],
+          ),
+        ),
         'streamNullableRecordOfNullableInt': _i1.MethodStreamConnector(
           name: 'streamNullableRecordOfNullableInt',
           params: {},

--- a/tests/serverpod_test_server/lib/src/generated/protocol.yaml
+++ b/tests/serverpod_test_server/lib/src/generated/protocol.yaml
@@ -299,6 +299,7 @@ recordParameters:
   - streamOfModelClassWithRecordField:
   - streamOfNullableModelClassWithRecordField:
   - streamOfNullableModelClassWithRecordFieldFromExternalModule:
+  - recordParametersWithCustomNames:
 redis:
   - setSimpleData:
   - setSimpleDataWithLifetime:

--- a/tests/serverpod_test_server/test_e2e/record_types_test.dart
+++ b/tests/serverpod_test_server/test_e2e/record_types_test.dart
@@ -807,4 +807,15 @@ void main() {
       ),
     );
   });
+
+  test(
+      'Given the test server, when calling the `recordParametersWithCustomNames`, then the sum of both input values is returned',
+      () async {
+    var result = await client.recordParameters.recordParametersWithCustomNames(
+      (1,),
+      namedRecord: (2,),
+    );
+
+    expect(result, 3);
+  });
 }

--- a/tests/serverpod_test_server/test_integration/test_tools/serverpod_test_tools.dart
+++ b/tests/serverpod_test_server/test_integration/test_tools/serverpod_test_tools.dart
@@ -8905,7 +8905,7 @@ class _RecordParametersEndpoint {
     return _localTestStreamManager.outputStreamController.stream;
   }
 
-  _i3.Future<void> recordParametersWithCustomNames(
+  _i3.Future<int> recordParametersWithCustomNames(
     _i1.TestSessionBuilder sessionBuilder,
     (int,) positionalRecord, {
     required (int,) namedRecord,
@@ -8930,7 +8930,7 @@ class _RecordParametersEndpoint {
         var _localReturnValue = await (_localCallContext.method.call(
           _localUniqueSession,
           _localCallContext.arguments,
-        ) as _i3.Future<void>);
+        ) as _i3.Future<int>);
         return _localReturnValue;
       } finally {
         await _localUniqueSession.close();

--- a/tests/serverpod_test_server/test_integration/test_tools/serverpod_test_tools.dart
+++ b/tests/serverpod_test_server/test_integration/test_tools/serverpod_test_tools.dart
@@ -8904,6 +8904,39 @@ class _RecordParametersEndpoint {
     );
     return _localTestStreamManager.outputStreamController.stream;
   }
+
+  _i3.Future<void> recordParametersWithCustomNames(
+    _i1.TestSessionBuilder sessionBuilder,
+    (int,) positionalRecord, {
+    required (int,) namedRecord,
+  }) async {
+    return _i1.callAwaitableFunctionAndHandleExceptions(() async {
+      var _localUniqueSession =
+          (sessionBuilder as _i1.InternalTestSessionBuilder).internalBuild(
+        endpoint: 'recordParameters',
+        method: 'recordParametersWithCustomNames',
+      );
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'recordParameters',
+          methodName: 'recordParametersWithCustomNames',
+          parameters: _i1.testObjectToJson({
+            'positionalRecord': _i20.mapRecordToJson(positionalRecord),
+            'namedRecord': _i20.mapRecordToJson(namedRecord),
+          }),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<void>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
+    });
+  }
 }
 
 class _RedisEndpoint {

--- a/tools/serverpod_cli/lib/src/generator/dart/library_generators/library_generator.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart/library_generators/library_generator.dart
@@ -790,7 +790,7 @@ class LibraryGenerator {
           // The generated classes implement `ProtocolSerialization` and get handle by `serverpod_serialization` later
           // For the records we need to transform them into a map that can be handled by the shared (non-project specific) serialization code
           literalString(parameterDef.name): parameterDef.type.isRecordType
-              ? mapRecordToJsonRef.call([refer('record')]).code
+              ? mapRecordToJsonRef.call([refer(parameterDef.name)]).code
               : (parameterDef.type.returnsRecordInContainer
                   ? Block.of([
                       if (parameterDef.type.nullable)


### PR DESCRIPTION
So we support all names and not just literally "record".