### PR TITLE
fix: Allow only `defaultPersist` and `defaultModel` keys on `id` field

### DIFF
--- a/tests/serverpod_test_client/lib/src/protocol/changed_id_type/many_to_many/student.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/changed_id_type/many_to_many/student.dart
@@ -10,20 +10,19 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
-import 'package:uuid/uuid.dart' as _i2;
-import '../../changed_id_type/many_to_many/enrollment.dart' as _i3;
+import '../../changed_id_type/many_to_many/enrollment.dart' as _i2;
 
 abstract class StudentUuid implements _i1.SerializableModel {
   StudentUuid._({
-    _i1.UuidValue? id,
+    this.id,
     required this.name,
     this.enrollments,
-  }) : id = id ?? _i2.Uuid().v4obj();
+  });
 
   factory StudentUuid({
     _i1.UuidValue? id,
     required String name,
-    List<_i3.EnrollmentInt>? enrollments,
+    List<_i2.EnrollmentInt>? enrollments,
   }) = _StudentUuidImpl;
 
   factory StudentUuid.fromJson(Map<String, dynamic> jsonSerialization) {
@@ -33,7 +32,7 @@ abstract class StudentUuid implements _i1.SerializableModel {
           : _i1.UuidValueJsonExtension.fromJson(jsonSerialization['id']),
       name: jsonSerialization['name'] as String,
       enrollments: (jsonSerialization['enrollments'] as List?)
-          ?.map((e) => _i3.EnrollmentInt.fromJson((e as Map<String, dynamic>)))
+          ?.map((e) => _i2.EnrollmentInt.fromJson((e as Map<String, dynamic>)))
           .toList(),
     );
   }
@@ -45,7 +44,7 @@ abstract class StudentUuid implements _i1.SerializableModel {
 
   String name;
 
-  List<_i3.EnrollmentInt>? enrollments;
+  List<_i2.EnrollmentInt>? enrollments;
 
   /// Returns a shallow copy of this [StudentUuid]
   /// with some or all fields replaced by the given arguments.
@@ -53,7 +52,7 @@ abstract class StudentUuid implements _i1.SerializableModel {
   StudentUuid copyWith({
     _i1.UuidValue? id,
     String? name,
-    List<_i3.EnrollmentInt>? enrollments,
+    List<_i2.EnrollmentInt>? enrollments,
   });
   @override
   Map<String, dynamic> toJson() {
@@ -77,7 +76,7 @@ class _StudentUuidImpl extends StudentUuid {
   _StudentUuidImpl({
     _i1.UuidValue? id,
     required String name,
-    List<_i3.EnrollmentInt>? enrollments,
+    List<_i2.EnrollmentInt>? enrollments,
   }) : super._(
           id: id,
           name: name,
@@ -96,7 +95,7 @@ class _StudentUuidImpl extends StudentUuid {
     return StudentUuid(
       id: id is _i1.UuidValue? ? id : this.id,
       name: name ?? this.name,
-      enrollments: enrollments is List<_i3.EnrollmentInt>?
+      enrollments: enrollments is List<_i2.EnrollmentInt>?
           ? enrollments
           : this.enrollments?.map((e0) => e0.copyWith()).toList(),
     );

--- a/tests/serverpod_test_client/lib/src/protocol/changed_id_type/nested_one_to_many/player.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/changed_id_type/nested_one_to_many/player.dart
@@ -10,22 +10,21 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
-import 'package:uuid/uuid.dart' as _i2;
-import '../../changed_id_type/nested_one_to_many/team.dart' as _i3;
+import '../../changed_id_type/nested_one_to_many/team.dart' as _i2;
 
 abstract class PlayerUuid implements _i1.SerializableModel {
   PlayerUuid._({
-    _i1.UuidValue? id,
+    this.id,
     required this.name,
     this.teamId,
     this.team,
-  }) : id = id ?? _i2.Uuid().v4obj();
+  });
 
   factory PlayerUuid({
     _i1.UuidValue? id,
     required String name,
     int? teamId,
-    _i3.TeamInt? team,
+    _i2.TeamInt? team,
   }) = _PlayerUuidImpl;
 
   factory PlayerUuid.fromJson(Map<String, dynamic> jsonSerialization) {
@@ -37,7 +36,7 @@ abstract class PlayerUuid implements _i1.SerializableModel {
       teamId: jsonSerialization['teamId'] as int?,
       team: jsonSerialization['team'] == null
           ? null
-          : _i3.TeamInt.fromJson(
+          : _i2.TeamInt.fromJson(
               (jsonSerialization['team'] as Map<String, dynamic>)),
     );
   }
@@ -51,7 +50,7 @@ abstract class PlayerUuid implements _i1.SerializableModel {
 
   int? teamId;
 
-  _i3.TeamInt? team;
+  _i2.TeamInt? team;
 
   /// Returns a shallow copy of this [PlayerUuid]
   /// with some or all fields replaced by the given arguments.
@@ -60,7 +59,7 @@ abstract class PlayerUuid implements _i1.SerializableModel {
     _i1.UuidValue? id,
     String? name,
     int? teamId,
-    _i3.TeamInt? team,
+    _i2.TeamInt? team,
   });
   @override
   Map<String, dynamic> toJson() {
@@ -85,7 +84,7 @@ class _PlayerUuidImpl extends PlayerUuid {
     _i1.UuidValue? id,
     required String name,
     int? teamId,
-    _i3.TeamInt? team,
+    _i2.TeamInt? team,
   }) : super._(
           id: id,
           name: name,
@@ -107,7 +106,7 @@ class _PlayerUuidImpl extends PlayerUuid {
       id: id is _i1.UuidValue? ? id : this.id,
       name: name ?? this.name,
       teamId: teamId is int? ? teamId : this.teamId,
-      team: team is _i3.TeamInt? ? team : this.team?.copyWith(),
+      team: team is _i2.TeamInt? ? team : this.team?.copyWith(),
     );
   }
 }

--- a/tests/serverpod_test_client/lib/src/protocol/changed_id_type/one_to_one/company.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/changed_id_type/one_to_one/company.dart
@@ -10,22 +10,21 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
-import 'package:uuid/uuid.dart' as _i2;
-import '../../changed_id_type/one_to_one/town.dart' as _i3;
+import '../../changed_id_type/one_to_one/town.dart' as _i2;
 
 abstract class CompanyUuid implements _i1.SerializableModel {
   CompanyUuid._({
-    _i1.UuidValue? id,
+    this.id,
     required this.name,
     required this.townId,
     this.town,
-  }) : id = id ?? _i2.Uuid().v4obj();
+  });
 
   factory CompanyUuid({
     _i1.UuidValue? id,
     required String name,
     required int townId,
-    _i3.TownInt? town,
+    _i2.TownInt? town,
   }) = _CompanyUuidImpl;
 
   factory CompanyUuid.fromJson(Map<String, dynamic> jsonSerialization) {
@@ -37,7 +36,7 @@ abstract class CompanyUuid implements _i1.SerializableModel {
       townId: jsonSerialization['townId'] as int,
       town: jsonSerialization['town'] == null
           ? null
-          : _i3.TownInt.fromJson(
+          : _i2.TownInt.fromJson(
               (jsonSerialization['town'] as Map<String, dynamic>)),
     );
   }
@@ -51,7 +50,7 @@ abstract class CompanyUuid implements _i1.SerializableModel {
 
   int townId;
 
-  _i3.TownInt? town;
+  _i2.TownInt? town;
 
   /// Returns a shallow copy of this [CompanyUuid]
   /// with some or all fields replaced by the given arguments.
@@ -60,7 +59,7 @@ abstract class CompanyUuid implements _i1.SerializableModel {
     _i1.UuidValue? id,
     String? name,
     int? townId,
-    _i3.TownInt? town,
+    _i2.TownInt? town,
   });
   @override
   Map<String, dynamic> toJson() {
@@ -85,7 +84,7 @@ class _CompanyUuidImpl extends CompanyUuid {
     _i1.UuidValue? id,
     required String name,
     required int townId,
-    _i3.TownInt? town,
+    _i2.TownInt? town,
   }) : super._(
           id: id,
           name: name,
@@ -107,7 +106,7 @@ class _CompanyUuidImpl extends CompanyUuid {
       id: id is _i1.UuidValue? ? id : this.id,
       name: name ?? this.name,
       townId: townId ?? this.townId,
-      town: town is _i3.TownInt? ? town : this.town?.copyWith(),
+      town: town is _i2.TownInt? ? town : this.town?.copyWith(),
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/changed_id_type/many_to_many/student.dart
+++ b/tests/serverpod_test_server/lib/src/generated/changed_id_type/many_to_many/student.dart
@@ -10,21 +10,20 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
-import 'package:uuid/uuid.dart' as _i2;
-import '../../changed_id_type/many_to_many/enrollment.dart' as _i3;
+import '../../changed_id_type/many_to_many/enrollment.dart' as _i2;
 
 abstract class StudentUuid
     implements _i1.TableRow<_i1.UuidValue>, _i1.ProtocolSerialization {
   StudentUuid._({
-    _i1.UuidValue? id,
+    this.id,
     required this.name,
     this.enrollments,
-  }) : id = id ?? _i2.Uuid().v4obj();
+  });
 
   factory StudentUuid({
     _i1.UuidValue? id,
     required String name,
-    List<_i3.EnrollmentInt>? enrollments,
+    List<_i2.EnrollmentInt>? enrollments,
   }) = _StudentUuidImpl;
 
   factory StudentUuid.fromJson(Map<String, dynamic> jsonSerialization) {
@@ -34,7 +33,7 @@ abstract class StudentUuid
           : _i1.UuidValueJsonExtension.fromJson(jsonSerialization['id']),
       name: jsonSerialization['name'] as String,
       enrollments: (jsonSerialization['enrollments'] as List?)
-          ?.map((e) => _i3.EnrollmentInt.fromJson((e as Map<String, dynamic>)))
+          ?.map((e) => _i2.EnrollmentInt.fromJson((e as Map<String, dynamic>)))
           .toList(),
     );
   }
@@ -48,7 +47,7 @@ abstract class StudentUuid
 
   String name;
 
-  List<_i3.EnrollmentInt>? enrollments;
+  List<_i2.EnrollmentInt>? enrollments;
 
   @override
   _i1.Table<_i1.UuidValue> get table => t;
@@ -59,7 +58,7 @@ abstract class StudentUuid
   StudentUuid copyWith({
     _i1.UuidValue? id,
     String? name,
-    List<_i3.EnrollmentInt>? enrollments,
+    List<_i2.EnrollmentInt>? enrollments,
   });
   @override
   Map<String, dynamic> toJson() {
@@ -83,7 +82,7 @@ abstract class StudentUuid
   }
 
   static StudentUuidInclude include(
-      {_i3.EnrollmentIntIncludeList? enrollments}) {
+      {_i2.EnrollmentIntIncludeList? enrollments}) {
     return StudentUuidInclude._(enrollments: enrollments);
   }
 
@@ -119,7 +118,7 @@ class _StudentUuidImpl extends StudentUuid {
   _StudentUuidImpl({
     _i1.UuidValue? id,
     required String name,
-    List<_i3.EnrollmentInt>? enrollments,
+    List<_i2.EnrollmentInt>? enrollments,
   }) : super._(
           id: id,
           name: name,
@@ -138,7 +137,7 @@ class _StudentUuidImpl extends StudentUuid {
     return StudentUuid(
       id: id is _i1.UuidValue? ? id : this.id,
       name: name ?? this.name,
-      enrollments: enrollments is List<_i3.EnrollmentInt>?
+      enrollments: enrollments is List<_i2.EnrollmentInt>?
           ? enrollments
           : this.enrollments?.map((e0) => e0.copyWith()).toList(),
     );
@@ -155,36 +154,36 @@ class StudentUuidTable extends _i1.Table<_i1.UuidValue> {
 
   late final _i1.ColumnString name;
 
-  _i3.EnrollmentIntTable? ___enrollments;
+  _i2.EnrollmentIntTable? ___enrollments;
 
-  _i1.ManyRelation<_i3.EnrollmentIntTable>? _enrollments;
+  _i1.ManyRelation<_i2.EnrollmentIntTable>? _enrollments;
 
-  _i3.EnrollmentIntTable get __enrollments {
+  _i2.EnrollmentIntTable get __enrollments {
     if (___enrollments != null) return ___enrollments!;
     ___enrollments = _i1.createRelationTable(
       relationFieldName: '__enrollments',
       field: StudentUuid.t.id,
-      foreignField: _i3.EnrollmentInt.t.studentId,
+      foreignField: _i2.EnrollmentInt.t.studentId,
       tableRelation: tableRelation,
       createTable: (foreignTableRelation) =>
-          _i3.EnrollmentIntTable(tableRelation: foreignTableRelation),
+          _i2.EnrollmentIntTable(tableRelation: foreignTableRelation),
     );
     return ___enrollments!;
   }
 
-  _i1.ManyRelation<_i3.EnrollmentIntTable> get enrollments {
+  _i1.ManyRelation<_i2.EnrollmentIntTable> get enrollments {
     if (_enrollments != null) return _enrollments!;
     var relationTable = _i1.createRelationTable(
       relationFieldName: 'enrollments',
       field: StudentUuid.t.id,
-      foreignField: _i3.EnrollmentInt.t.studentId,
+      foreignField: _i2.EnrollmentInt.t.studentId,
       tableRelation: tableRelation,
       createTable: (foreignTableRelation) =>
-          _i3.EnrollmentIntTable(tableRelation: foreignTableRelation),
+          _i2.EnrollmentIntTable(tableRelation: foreignTableRelation),
     );
-    _enrollments = _i1.ManyRelation<_i3.EnrollmentIntTable>(
+    _enrollments = _i1.ManyRelation<_i2.EnrollmentIntTable>(
       tableWithRelations: relationTable,
-      table: _i3.EnrollmentIntTable(
+      table: _i2.EnrollmentIntTable(
           tableRelation: relationTable.tableRelation!.lastRelation),
     );
     return _enrollments!;
@@ -206,11 +205,11 @@ class StudentUuidTable extends _i1.Table<_i1.UuidValue> {
 }
 
 class StudentUuidInclude extends _i1.IncludeObject {
-  StudentUuidInclude._({_i3.EnrollmentIntIncludeList? enrollments}) {
+  StudentUuidInclude._({_i2.EnrollmentIntIncludeList? enrollments}) {
     _enrollments = enrollments;
   }
 
-  _i3.EnrollmentIntIncludeList? _enrollments;
+  _i2.EnrollmentIntIncludeList? _enrollments;
 
   @override
   Map<String, _i1.Include?> get includes => {'enrollments': _enrollments};
@@ -470,7 +469,7 @@ class StudentUuidAttachRepository {
   Future<void> enrollments(
     _i1.Session session,
     StudentUuid studentUuid,
-    List<_i3.EnrollmentInt> enrollmentInt, {
+    List<_i2.EnrollmentInt> enrollmentInt, {
     _i1.Transaction? transaction,
   }) async {
     if (enrollmentInt.any((e) => e.id == null)) {
@@ -483,9 +482,9 @@ class StudentUuidAttachRepository {
     var $enrollmentInt = enrollmentInt
         .map((e) => e.copyWith(studentId: studentUuid.id))
         .toList();
-    await session.db.update<_i3.EnrollmentInt>(
+    await session.db.update<_i2.EnrollmentInt>(
       $enrollmentInt,
-      columns: [_i3.EnrollmentInt.t.studentId],
+      columns: [_i2.EnrollmentInt.t.studentId],
       transaction: transaction,
     );
   }
@@ -499,7 +498,7 @@ class StudentUuidAttachRowRepository {
   Future<void> enrollments(
     _i1.Session session,
     StudentUuid studentUuid,
-    _i3.EnrollmentInt enrollmentInt, {
+    _i2.EnrollmentInt enrollmentInt, {
     _i1.Transaction? transaction,
   }) async {
     if (enrollmentInt.id == null) {
@@ -510,9 +509,9 @@ class StudentUuidAttachRowRepository {
     }
 
     var $enrollmentInt = enrollmentInt.copyWith(studentId: studentUuid.id);
-    await session.db.updateRow<_i3.EnrollmentInt>(
+    await session.db.updateRow<_i2.EnrollmentInt>(
       $enrollmentInt,
-      columns: [_i3.EnrollmentInt.t.studentId],
+      columns: [_i2.EnrollmentInt.t.studentId],
       transaction: transaction,
     );
   }

--- a/tests/serverpod_test_server/lib/src/generated/changed_id_type/nested_one_to_many/player.dart
+++ b/tests/serverpod_test_server/lib/src/generated/changed_id_type/nested_one_to_many/player.dart
@@ -10,23 +10,22 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
-import 'package:uuid/uuid.dart' as _i2;
-import '../../changed_id_type/nested_one_to_many/team.dart' as _i3;
+import '../../changed_id_type/nested_one_to_many/team.dart' as _i2;
 
 abstract class PlayerUuid
     implements _i1.TableRow<_i1.UuidValue>, _i1.ProtocolSerialization {
   PlayerUuid._({
-    _i1.UuidValue? id,
+    this.id,
     required this.name,
     this.teamId,
     this.team,
-  }) : id = id ?? _i2.Uuid().v4obj();
+  });
 
   factory PlayerUuid({
     _i1.UuidValue? id,
     required String name,
     int? teamId,
-    _i3.TeamInt? team,
+    _i2.TeamInt? team,
   }) = _PlayerUuidImpl;
 
   factory PlayerUuid.fromJson(Map<String, dynamic> jsonSerialization) {
@@ -38,7 +37,7 @@ abstract class PlayerUuid
       teamId: jsonSerialization['teamId'] as int?,
       team: jsonSerialization['team'] == null
           ? null
-          : _i3.TeamInt.fromJson(
+          : _i2.TeamInt.fromJson(
               (jsonSerialization['team'] as Map<String, dynamic>)),
     );
   }
@@ -54,7 +53,7 @@ abstract class PlayerUuid
 
   int? teamId;
 
-  _i3.TeamInt? team;
+  _i2.TeamInt? team;
 
   @override
   _i1.Table<_i1.UuidValue> get table => t;
@@ -66,7 +65,7 @@ abstract class PlayerUuid
     _i1.UuidValue? id,
     String? name,
     int? teamId,
-    _i3.TeamInt? team,
+    _i2.TeamInt? team,
   });
   @override
   Map<String, dynamic> toJson() {
@@ -88,7 +87,7 @@ abstract class PlayerUuid
     };
   }
 
-  static PlayerUuidInclude include({_i3.TeamIntInclude? team}) {
+  static PlayerUuidInclude include({_i2.TeamIntInclude? team}) {
     return PlayerUuidInclude._(team: team);
   }
 
@@ -125,7 +124,7 @@ class _PlayerUuidImpl extends PlayerUuid {
     _i1.UuidValue? id,
     required String name,
     int? teamId,
-    _i3.TeamInt? team,
+    _i2.TeamInt? team,
   }) : super._(
           id: id,
           name: name,
@@ -147,7 +146,7 @@ class _PlayerUuidImpl extends PlayerUuid {
       id: id is _i1.UuidValue? ? id : this.id,
       name: name ?? this.name,
       teamId: teamId is int? ? teamId : this.teamId,
-      team: team is _i3.TeamInt? ? team : this.team?.copyWith(),
+      team: team is _i2.TeamInt? ? team : this.team?.copyWith(),
     );
   }
 }
@@ -168,17 +167,17 @@ class PlayerUuidTable extends _i1.Table<_i1.UuidValue> {
 
   late final _i1.ColumnInt teamId;
 
-  _i3.TeamIntTable? _team;
+  _i2.TeamIntTable? _team;
 
-  _i3.TeamIntTable get team {
+  _i2.TeamIntTable get team {
     if (_team != null) return _team!;
     _team = _i1.createRelationTable(
       relationFieldName: 'team',
       field: PlayerUuid.t.teamId,
-      foreignField: _i3.TeamInt.t.id,
+      foreignField: _i2.TeamInt.t.id,
       tableRelation: tableRelation,
       createTable: (foreignTableRelation) =>
-          _i3.TeamIntTable(tableRelation: foreignTableRelation),
+          _i2.TeamIntTable(tableRelation: foreignTableRelation),
     );
     return _team!;
   }
@@ -200,11 +199,11 @@ class PlayerUuidTable extends _i1.Table<_i1.UuidValue> {
 }
 
 class PlayerUuidInclude extends _i1.IncludeObject {
-  PlayerUuidInclude._({_i3.TeamIntInclude? team}) {
+  PlayerUuidInclude._({_i2.TeamIntInclude? team}) {
     _team = team;
   }
 
-  _i3.TeamIntInclude? _team;
+  _i2.TeamIntInclude? _team;
 
   @override
   Map<String, _i1.Include?> get includes => {'team': _team};
@@ -464,7 +463,7 @@ class PlayerUuidAttachRowRepository {
   Future<void> team(
     _i1.Session session,
     PlayerUuid playerUuid,
-    _i3.TeamInt team, {
+    _i2.TeamInt team, {
     _i1.Transaction? transaction,
   }) async {
     if (playerUuid.id == null) {

--- a/tests/serverpod_test_server/lib/src/generated/changed_id_type/one_to_one/company.dart
+++ b/tests/serverpod_test_server/lib/src/generated/changed_id_type/one_to_one/company.dart
@@ -10,23 +10,22 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
-import 'package:uuid/uuid.dart' as _i2;
-import '../../changed_id_type/one_to_one/town.dart' as _i3;
+import '../../changed_id_type/one_to_one/town.dart' as _i2;
 
 abstract class CompanyUuid
     implements _i1.TableRow<_i1.UuidValue>, _i1.ProtocolSerialization {
   CompanyUuid._({
-    _i1.UuidValue? id,
+    this.id,
     required this.name,
     required this.townId,
     this.town,
-  }) : id = id ?? _i2.Uuid().v4obj();
+  });
 
   factory CompanyUuid({
     _i1.UuidValue? id,
     required String name,
     required int townId,
-    _i3.TownInt? town,
+    _i2.TownInt? town,
   }) = _CompanyUuidImpl;
 
   factory CompanyUuid.fromJson(Map<String, dynamic> jsonSerialization) {
@@ -38,7 +37,7 @@ abstract class CompanyUuid
       townId: jsonSerialization['townId'] as int,
       town: jsonSerialization['town'] == null
           ? null
-          : _i3.TownInt.fromJson(
+          : _i2.TownInt.fromJson(
               (jsonSerialization['town'] as Map<String, dynamic>)),
     );
   }
@@ -54,7 +53,7 @@ abstract class CompanyUuid
 
   int townId;
 
-  _i3.TownInt? town;
+  _i2.TownInt? town;
 
   @override
   _i1.Table<_i1.UuidValue> get table => t;
@@ -66,7 +65,7 @@ abstract class CompanyUuid
     _i1.UuidValue? id,
     String? name,
     int? townId,
-    _i3.TownInt? town,
+    _i2.TownInt? town,
   });
   @override
   Map<String, dynamic> toJson() {
@@ -88,7 +87,7 @@ abstract class CompanyUuid
     };
   }
 
-  static CompanyUuidInclude include({_i3.TownIntInclude? town}) {
+  static CompanyUuidInclude include({_i2.TownIntInclude? town}) {
     return CompanyUuidInclude._(town: town);
   }
 
@@ -125,7 +124,7 @@ class _CompanyUuidImpl extends CompanyUuid {
     _i1.UuidValue? id,
     required String name,
     required int townId,
-    _i3.TownInt? town,
+    _i2.TownInt? town,
   }) : super._(
           id: id,
           name: name,
@@ -147,7 +146,7 @@ class _CompanyUuidImpl extends CompanyUuid {
       id: id is _i1.UuidValue? ? id : this.id,
       name: name ?? this.name,
       townId: townId ?? this.townId,
-      town: town is _i3.TownInt? ? town : this.town?.copyWith(),
+      town: town is _i2.TownInt? ? town : this.town?.copyWith(),
     );
   }
 }
@@ -168,17 +167,17 @@ class CompanyUuidTable extends _i1.Table<_i1.UuidValue> {
 
   late final _i1.ColumnInt townId;
 
-  _i3.TownIntTable? _town;
+  _i2.TownIntTable? _town;
 
-  _i3.TownIntTable get town {
+  _i2.TownIntTable get town {
     if (_town != null) return _town!;
     _town = _i1.createRelationTable(
       relationFieldName: 'town',
       field: CompanyUuid.t.townId,
-      foreignField: _i3.TownInt.t.id,
+      foreignField: _i2.TownInt.t.id,
       tableRelation: tableRelation,
       createTable: (foreignTableRelation) =>
-          _i3.TownIntTable(tableRelation: foreignTableRelation),
+          _i2.TownIntTable(tableRelation: foreignTableRelation),
     );
     return _town!;
   }
@@ -200,11 +199,11 @@ class CompanyUuidTable extends _i1.Table<_i1.UuidValue> {
 }
 
 class CompanyUuidInclude extends _i1.IncludeObject {
-  CompanyUuidInclude._({_i3.TownIntInclude? town}) {
+  CompanyUuidInclude._({_i2.TownIntInclude? town}) {
     _town = town;
   }
 
-  _i3.TownIntInclude? _town;
+  _i2.TownIntInclude? _town;
 
   @override
   Map<String, _i1.Include?> get includes => {'town': _town};
@@ -462,7 +461,7 @@ class CompanyUuidAttachRowRepository {
   Future<void> town(
     _i1.Session session,
     CompanyUuid companyUuid,
-    _i3.TownInt town, {
+    _i2.TownInt town, {
     _i1.Transaction? transaction,
   }) async {
     if (companyUuid.id == null) {

--- a/tests/serverpod_test_server/lib/src/models/changed_id_type/many_to_many/course.spy.yaml
+++ b/tests/serverpod_test_server/lib/src/models/changed_id_type/many_to_many/course.spy.yaml
@@ -1,6 +1,6 @@
 class: CourseUuid
 table: course_uuid
 fields:
-  id: UuidValue, default=random
+  id: UuidValue?, defaultModel=random
   name: String
   enrollments: List<EnrollmentInt>?, relation(name=course_enrollments)

--- a/tests/serverpod_test_server/lib/src/models/changed_id_type/many_to_many/enrollment.spy.yaml
+++ b/tests/serverpod_test_server/lib/src/models/changed_id_type/many_to_many/enrollment.spy.yaml
@@ -1,7 +1,7 @@
 class: EnrollmentInt
 table: enrollment_int
 fields:
-  id: int
+  id: int?
   student: StudentUuid?, relation(name=student_enrollments, onDelete=Cascade)
   course: CourseUuid?, relation(name=course_enrollments, onDelete=Cascade)
 

--- a/tests/serverpod_test_server/lib/src/models/changed_id_type/many_to_many/student.spy.yaml
+++ b/tests/serverpod_test_server/lib/src/models/changed_id_type/many_to_many/student.spy.yaml
@@ -1,6 +1,6 @@
 class: StudentUuid
 table: student_uuid
 fields:
-  id: UuidValue, default=random
+  id: UuidValue?, defaultPersist=random
   name: String
   enrollments: List<EnrollmentInt>?, relation(name=student_enrollments)

--- a/tests/serverpod_test_server/lib/src/models/changed_id_type/nested_one_to_many/arena.spy.yaml
+++ b/tests/serverpod_test_server/lib/src/models/changed_id_type/nested_one_to_many/arena.spy.yaml
@@ -1,6 +1,6 @@
 class: ArenaUuid
 table: arena_uuid
 fields:
-  id: UuidValue, default=random
+  id: UuidValue?, defaultModel=random
   name: String
   team: TeamInt?, relation(name=arena_team)

--- a/tests/serverpod_test_server/lib/src/models/changed_id_type/nested_one_to_many/player.spy.yaml
+++ b/tests/serverpod_test_server/lib/src/models/changed_id_type/nested_one_to_many/player.spy.yaml
@@ -1,6 +1,6 @@
 class: PlayerUuid
 table: player_uuid
 fields:
-  id: UuidValue, default=random
+  id: UuidValue?, defaultPersist=random
   name: String
   team: TeamInt?, relation(name=team_player, optional, onDelete=SetNull)

--- a/tests/serverpod_test_server/lib/src/models/changed_id_type/nested_one_to_many/team.spy.yaml
+++ b/tests/serverpod_test_server/lib/src/models/changed_id_type/nested_one_to_many/team.spy.yaml
@@ -1,7 +1,7 @@
 class: TeamInt
 table: team_int
 fields:
-  id: int, default=serial
+  id: int?, defaultPersist=serial
   name: String
   arenaId: UuidValue?
   arena: ArenaUuid?, relation(name=arena_team, field=arenaId, onDelete=SetNull)

--- a/tests/serverpod_test_server/lib/src/models/changed_id_type/one_to_many/comment.spy.yaml
+++ b/tests/serverpod_test_server/lib/src/models/changed_id_type/one_to_many/comment.spy.yaml
@@ -1,6 +1,6 @@
 class: CommentInt
 table: comment_int
 fields:
-  id: int
+  id: int?
   description: String
   order: OrderUuid?, relation(name=order_comments, onDelete=Cascade)

--- a/tests/serverpod_test_server/lib/src/models/changed_id_type/one_to_many/customer.spy.yaml
+++ b/tests/serverpod_test_server/lib/src/models/changed_id_type/one_to_many/customer.spy.yaml
@@ -1,6 +1,6 @@
 class: CustomerInt
 table: customer_int
 fields:
-  id: int, default=serial
+  id: int?, defaultPersist=serial
   name: String
   orders: List<OrderUuid>?, relation(name=customer_orders)

--- a/tests/serverpod_test_server/lib/src/models/changed_id_type/one_to_many/order.spy.yaml
+++ b/tests/serverpod_test_server/lib/src/models/changed_id_type/one_to_many/order.spy.yaml
@@ -1,7 +1,7 @@
 class: OrderUuid
 table: order_uuid
 fields:
-  id: UuidValue, default=random
+  id: UuidValue?, defaultModel=random
   description: String
   customer: CustomerInt?, relation(name=customer_orders, onDelete=Cascade)
   comments: List<CommentInt>?, relation(name=order_comments)

--- a/tests/serverpod_test_server/lib/src/models/changed_id_type/one_to_one/address.spy.yaml
+++ b/tests/serverpod_test_server/lib/src/models/changed_id_type/one_to_one/address.spy.yaml
@@ -1,7 +1,7 @@
 class: AddressUuid
 table: address_uuid
 fields:
-  id: UuidValue, default=random
+  id: UuidValue?, defaultModel=random
   street: String
   inhabitantId: int?
   inhabitant: CitizenInt?, relation(name=citizen_address, field=inhabitantId, onDelete=Cascade)

--- a/tests/serverpod_test_server/lib/src/models/changed_id_type/one_to_one/citizen.spy.yaml
+++ b/tests/serverpod_test_server/lib/src/models/changed_id_type/one_to_one/citizen.spy.yaml
@@ -1,7 +1,7 @@
 class: CitizenInt
 table: citizen_int
 fields:
-  id: int, default=serial
+  id: int?, defaultPersist=serial
   name: String
   address: AddressUuid?, relation(name=citizen_address)
   company: CompanyUuid?, relation

--- a/tests/serverpod_test_server/lib/src/models/changed_id_type/one_to_one/company.spy.yaml
+++ b/tests/serverpod_test_server/lib/src/models/changed_id_type/one_to_one/company.spy.yaml
@@ -1,6 +1,6 @@
 class: CompanyUuid
 table: company_uuid
 fields:
-  id: UuidValue, default=random
+  id: UuidValue?, defaultPersist=random
   name: String
   town: TownInt?, relation

--- a/tests/serverpod_test_server/lib/src/models/changed_id_type/one_to_one/town.spy.yaml
+++ b/tests/serverpod_test_server/lib/src/models/changed_id_type/one_to_one/town.spy.yaml
@@ -1,6 +1,6 @@
 class: TownInt
 table: town_int
 fields:
-  id: int, default=serial
+  id: int?, defaultPersist=serial
   name: String
   mayor: CitizenInt?, relation(optional)

--- a/tests/serverpod_test_server/lib/src/models/changed_id_type/self.spy.yaml
+++ b/tests/serverpod_test_server/lib/src/models/changed_id_type/self.spy.yaml
@@ -1,7 +1,7 @@
 class: ChangedIdTypeSelf
 table: changed_id_type_self
 fields:
-  id: UuidValue, default=random
+  id: UuidValue?, defaultModel=random
   name: String
   previous: ChangedIdTypeSelf?, relation(name=changed_id_next_previous)
   nextId: UuidValue?

--- a/tests/serverpod_test_server/test_integration/database_operations/crud/create_test.dart
+++ b/tests/serverpod_test_server/test_integration/database_operations/crud/create_test.dart
@@ -56,17 +56,36 @@ void main() async {
       expect(second, isNull);
     });
 
-    test('when batch inserting with an id defined then the id is ignored.',
+    test('when batch inserting with an id defined then the id is not ignored.',
         () async {
-      const int max = 1 >>> 1;
+      const int id = 999;
 
       var data = <UniqueData>[
-        UniqueData(id: max, number: 1, email: 'info@serverpod.dev'),
+        UniqueData(id: id, number: 1, email: 'info@serverpod.dev'),
       ];
 
       var inserted = await UniqueData.db.insert(session, data);
 
-      expect(inserted.first.id, isNot(max));
+      expect(inserted.first.id, id);
+    });
+
+    test(
+        'when batch inserting with an id defined and other undefined then both are created in the database.',
+        () async {
+      const int id = 1999;
+
+      var data = <UniqueData>[
+        UniqueData(id: id, number: 10, email: 'info@serverpod.dev'),
+        UniqueData(number: 20, email: 'dev@serverpod.dev'),
+      ];
+
+      var inserted = await UniqueData.db.insert(session, data);
+
+      expect(inserted, hasLength(2));
+      expect(inserted.first.id, isNot(id));
+      expect(inserted.last.id, id);
+      expect(inserted.first.number, 20);
+      expect(inserted.last.number, 10);
     });
   });
 

--- a/tools/serverpod_cli/lib/src/analyzer/models/model_parser/model_parser.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/model_parser/model_parser.dart
@@ -296,7 +296,7 @@ class ModelParser {
           type: (maybeIdField?.type ?? defaultIdType.type).asNullable,
           scope: ModelFieldScopeDefinition.all,
           defaultModelValue: defaultModelValue,
-          defaultPersistValue: defaultPersistValue,
+          defaultPersistValue: defaultPersistValue ?? defaultModelValue,
           shouldPersist: true,
           documentation: maybeIdField?.documentation ?? defaultIdFieldDoc,
         ),

--- a/tools/serverpod_cli/lib/src/analyzer/models/model_parser/model_parser.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/model_parser/model_parser.dart
@@ -267,19 +267,21 @@ class ModelParser {
 
       var maybeIdField =
           fields.where((f) => f.name == defaultPrimaryKeyName).firstOrNull;
+
+      var idFieldType = maybeIdField?.type ?? defaultIdType.type.asNullable;
+
       var defaultPersistValue = (maybeIdField != null)
           ? maybeIdField.defaultPersistValue
-          : defaultIdType.defaultValue;
-      var defaultModelValue = (maybeIdField != null)
-          ? maybeIdField.defaultModelValue
           : defaultIdType.defaultValue;
 
       // The 'int' id type can be specified without a default value.
       if (maybeIdField?.type.className == 'int') {
         defaultPersistValue ??= SupportedIdType.int.defaultValue;
       }
-      if (defaultModelValue == defaultIntSerial) {
-        defaultModelValue = null;
+
+      var defaultModelValue = maybeIdField?.defaultModelValue;
+      if (maybeIdField == null && defaultIdType.type.className != 'int') {
+        defaultModelValue ??= defaultIdType.defaultValue;
       }
 
       var defaultIdFieldDoc = [
@@ -293,7 +295,7 @@ class ModelParser {
         0,
         SerializableModelFieldDefinition(
           name: defaultPrimaryKeyName,
-          type: (maybeIdField?.type ?? defaultIdType.type).asNullable,
+          type: idFieldType,
           scope: ModelFieldScopeDefinition.all,
           defaultModelValue: defaultModelValue,
           defaultPersistValue: defaultPersistValue ?? defaultModelValue,

--- a/tools/serverpod_cli/lib/src/analyzer/models/validation/restrictions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/validation/restrictions.dart
@@ -865,7 +865,9 @@ class Restrictions {
       } else if (!field.hasDefaults) {
         errors.add(
           SourceSpanSeverityException(
-            'The type "$typeClassName" must have a default value.',
+            'The type "$typeClassName" must have a default value. Use '
+            'either the "${Keyword.defaultModelKey}" key or the '
+            '"${Keyword.defaultPersistKey}" key to set it.',
             span,
           ),
         );
@@ -1386,6 +1388,19 @@ class Restrictions {
       );
     }
 
+    if ((definition is ModelClassDefinition) &&
+        (definition.tableName != null) &&
+        (parentNodeName == defaultPrimaryKeyName)) {
+      errors.add(
+        SourceSpanSeverityException(
+          'The "${Keyword.defaultKey}" key is not allowed on the "id" field. '
+          'Use either the "${Keyword.defaultModelKey}" key or the '
+          '"${Keyword.defaultPersistKey}" key instead.',
+          span,
+        ),
+      );
+    }
+
     return errors;
   }
 
@@ -1411,18 +1426,6 @@ class Restrictions {
       );
     }
 
-    if ((definition is ModelClassDefinition) &&
-        (definition.tableName != null) &&
-        (parentNodeName == defaultPrimaryKeyName)) {
-      errors.add(
-        SourceSpanSeverityException(
-          'The "${Keyword.defaultModelKey}" key is not allowed on the "id" '
-          'field. Use the "${Keyword.defaultKey}" key instead.',
-          span,
-        ),
-      );
-    }
-
     return errors;
   }
 
@@ -1436,18 +1439,6 @@ class Restrictions {
 
     var field = definition.findField(parentNodeName);
     if (field == null) return [];
-
-    if ((definition is ModelClassDefinition) &&
-        (definition.tableName != null) &&
-        (parentNodeName == defaultPrimaryKeyName)) {
-      return [
-        SourceSpanSeverityException(
-          'The "${Keyword.defaultPersistKey}" key is not allowed on the "id" '
-          'field. Use the "${Keyword.defaultKey}" key instead.',
-          span,
-        ),
-      ];
-    }
 
     var errors = <SourceSpanSeverityException>[];
 

--- a/tools/serverpod_cli/lib/src/analyzer/models/validation/restrictions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/validation/restrictions.dart
@@ -871,6 +871,17 @@ class Restrictions {
             span,
           ),
         );
+      } else if (typeClassName == 'int' &&
+          field.defaultModelValue == null &&
+          !field.type.nullable) {
+        errors.add(
+          SourceSpanSeverityException(
+            'The type "$typeClassName" must be nullable for the field '
+            '"$parentNodeName". Use the "?" operator to make it nullable '
+            '(e.g. $parentNodeName: int?).',
+            span,
+          ),
+        );
       }
     }
 

--- a/tools/serverpod_cli/lib/src/analyzer/models/validation/restrictions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/validation/restrictions.dart
@@ -871,14 +871,12 @@ class Restrictions {
             span,
           ),
         );
-      } else if (typeClassName == 'int' &&
-          field.defaultModelValue == null &&
-          !field.type.nullable) {
+      } else if (!field.type.nullable) {
         errors.add(
           SourceSpanSeverityException(
             'The type "$typeClassName" must be nullable for the field '
             '"$parentNodeName". Use the "?" operator to make it nullable '
-            '(e.g. $parentNodeName: int?).',
+            '(e.g. $parentNodeName: $typeClassName?).',
             span,
           ),
         );

--- a/tools/serverpod_cli/lib/src/analyzer/models/validation/restrictions/default.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/validation/restrictions/default.dart
@@ -3,6 +3,7 @@ import 'package:serverpod_cli/src/analyzer/code_analysis_collector.dart';
 import 'package:serverpod_cli/src/analyzer/models/definitions.dart';
 import 'package:serverpod_cli/src/analyzer/models/utils/duration_utils.dart';
 import 'package:serverpod_cli/src/analyzer/models/utils/quote_utils.dart';
+import 'package:serverpod_cli/src/analyzer/models/validation/keywords.dart';
 import 'package:serverpod_cli/src/analyzer/models/validation/restrictions/base.dart';
 import 'package:serverpod_cli/src/generator/types.dart';
 import 'package:serverpod_serialization/serverpod_serialization.dart';
@@ -35,6 +36,17 @@ class DefaultValueRestriction extends ValueRestriction {
     if ((definition is ModelClassDefinition) &&
         (definition.tableName != null) &&
         (parentNodeName == defaultPrimaryKeyName)) {
+      if ((value == defaultIntSerial) && (key == Keyword.defaultModelKey)) {
+        return [
+          SourceSpanSeverityException(
+            'The default value "$defaultIntSerial" can not be set for the '
+            '"int" $defaultPrimaryKeyName field using the "$key" keyword. '
+            'Use the "${Keyword.defaultPersistKey}" keyword instead.',
+            span,
+          ),
+        ];
+      }
+
       return _idTypeDefaultValidation(
         definition.tableName!,
         field.type,

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/field/default/integer/field_int_default_model_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/field/default/integer/field_int_default_model_test.dart
@@ -202,8 +202,8 @@ void main() {
 
       expect(
         collector.errors.first.message,
-        'The "defaultModel" key is not allowed on the "id" field. '
-        'Use the "default" key instead.',
+        'The default value "serial" can not be set for the "int" id field using '
+        'the "defaultModel" keyword. Use the "defaultPersist" keyword instead.',
       );
     },
   );

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/field/default/integer/field_int_default_model_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/field/default/integer/field_int_default_model_test.dart
@@ -187,7 +187,7 @@ void main() {
           class: Example
           table: example
           fields:
-            id: int, defaultModel=serial
+            id: int?, defaultModel=serial
           ''',
         ).build()
       ];

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/field/default/integer/field_int_default_persist_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/field/default/integer/field_int_default_persist_test.dart
@@ -253,7 +253,7 @@ void main() {
             class: Example
             table: example
             fields:
-              id: int, defaultPersist=serial
+              id: int?, defaultPersist=serial
             ''',
           ).build()
         ];
@@ -280,7 +280,7 @@ void main() {
             class: Example
             table: example
             fields:
-              id: int, defaultPersist=
+              id: int?, defaultPersist=
             ''',
           ).build()
         ];
@@ -309,7 +309,7 @@ void main() {
             class: Example
             table: example
             fields:
-              id: int, defaultPersist=10
+              id: int?, defaultPersist=10
             ''',
           ).build()
         ];
@@ -338,7 +338,7 @@ void main() {
             class: Example
             table: example
             fields:
-              id: int, defaultPersist=test
+              id: int?, defaultPersist=test
             ''',
           ).build()
         ];
@@ -354,6 +354,35 @@ void main() {
           firstError.message,
           'The default value "test" is not supported for the id type "int". '
           'Valid options are: "serial".',
+        );
+      },
+    );
+
+    test(
+      'when the field is of type int non-nullable type, then an error is generated',
+      () {
+        var models = [
+          ModelSourceBuilder().withYaml(
+            '''
+          class: Example
+          table: example
+          fields:
+            id: int, defaultPersist=serial
+          ''',
+          ).build()
+        ];
+
+        var collector = CodeGenerationCollector();
+        StatefulAnalyzer(config, models, onErrorsCollector(collector))
+            .validateAll();
+
+        expect(collector.errors, isNotEmpty);
+
+        var error = collector.errors.first as SourceSpanSeverityException;
+        expect(
+          error.message,
+          'The type "int" must be nullable for the field "id". Use the "?" '
+          'operator to make it nullable (e.g. id: int?).',
         );
       },
     );

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/field/default/integer/field_int_default_persist_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/field/default/integer/field_int_default_persist_test.dart
@@ -237,33 +237,125 @@ void main() {
     );
   });
 
-  test(
-    'Given a class with a declared id field of type int with a "defaultPersist" keyword, then an error is collected',
-    () {
-      var models = [
-        ModelSourceBuilder().withYaml(
-          '''
-          class: Example
-          table: example
-          fields:
-            id: int, defaultPersist=serial
-          ''',
-        ).build()
-      ];
+  group(
+      'Given a class with a declared id field with a "defaultPersist" keyword',
+      () {
+    var config = GeneratorConfigBuilder().withEnabledExperimentalFeatures(
+      [ExperimentalFeature.changeIdType],
+    ).build();
 
-      var config = GeneratorConfigBuilder().withEnabledExperimentalFeatures(
-        [ExperimentalFeature.changeIdType],
-      ).build();
+    test(
+      'when the field is of type int and the default is set to "serial", then the field should have a "default persist" value and not have a "default model" value',
+      () {
+        var models = [
+          ModelSourceBuilder().withYaml(
+            '''
+            class: Example
+            table: example
+            fields:
+              id: int, defaultPersist=serial
+            ''',
+          ).build()
+        ];
 
-      var collector = CodeGenerationCollector();
-      StatefulAnalyzer(config, models, onErrorsCollector(collector))
-          .validateAll();
+        var collector = CodeGenerationCollector();
+        var definitions =
+            StatefulAnalyzer(config, models, onErrorsCollector(collector))
+                .validateAll();
 
-      expect(
-        collector.errors.first.message,
-        'The "defaultPersist" key is not allowed on the "id" field. '
-        'Use the "default" key instead.',
-      );
-    },
-  );
+        expect(collector.errors, isEmpty);
+
+        var definition = definitions.first as ClassDefinition;
+        expect(definition.fields.last.defaultModelValue, isNull);
+        expect(definition.fields.last.defaultPersistValue, 'serial');
+      },
+    );
+
+    test(
+      'when the field is of type int and the defaultPersist is empty, then an error is generated',
+      () {
+        var models = [
+          ModelSourceBuilder().withYaml(
+            '''
+            class: Example
+            table: example
+            fields:
+              id: int, defaultPersist=
+            ''',
+          ).build()
+        ];
+
+        var collector = CodeGenerationCollector();
+        StatefulAnalyzer(config, models, onErrorsCollector(collector))
+            .validateAll();
+
+        expect(collector.errors, isNotEmpty);
+
+        var firstError = collector.errors.first as SourceSpanSeverityException;
+        expect(
+          firstError.message,
+          'The default value "" is not supported for the id type "int". '
+          'Valid options are: "serial".',
+        );
+      },
+    );
+
+    test(
+      'when the field is of type int and the defaultPersist is set to a constant value, then an error is generated',
+      () {
+        var models = [
+          ModelSourceBuilder().withYaml(
+            '''
+            class: Example
+            table: example
+            fields:
+              id: int, defaultPersist=10
+            ''',
+          ).build()
+        ];
+
+        var collector = CodeGenerationCollector();
+        StatefulAnalyzer(config, models, onErrorsCollector(collector))
+            .validateAll();
+
+        expect(collector.errors, isNotEmpty);
+
+        var firstError = collector.errors.first as SourceSpanSeverityException;
+        expect(
+          firstError.message,
+          'The default value "10" is not supported for the id type "int". '
+          'Valid options are: "serial".',
+        );
+      },
+    );
+
+    test(
+      'when the field is of type int and the defaultPersist is set to an invalid value, then an error is generated',
+      () {
+        var models = [
+          ModelSourceBuilder().withYaml(
+            '''
+            class: Example
+            table: example
+            fields:
+              id: int, defaultPersist=test
+            ''',
+          ).build()
+        ];
+
+        var collector = CodeGenerationCollector();
+        StatefulAnalyzer(config, models, onErrorsCollector(collector))
+            .validateAll();
+
+        expect(collector.errors, isNotEmpty);
+
+        var firstError = collector.errors.first as SourceSpanSeverityException;
+        expect(
+          firstError.message,
+          'The default value "test" is not supported for the id type "int". '
+          'Valid options are: "serial".',
+        );
+      },
+    );
+  });
 }

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/field/default/integer/field_int_default_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/field/default/integer/field_int_default_test.dart
@@ -180,123 +180,33 @@ void main() {
     );
   });
 
-  group('Given a class with a declared id field with a "default" keyword', () {
-    var config = GeneratorConfigBuilder().withEnabledExperimentalFeatures(
-      [ExperimentalFeature.changeIdType],
-    ).build();
+  test(
+    'Given a class with a declared id field of type int with a "default" keyword, then an error is collected.',
+    () {
+      var models = [
+        ModelSourceBuilder().withYaml(
+          '''
+          class: Example
+          table: example
+          fields:
+            id: int, default=serial
+          ''',
+        ).build()
+      ];
 
-    test(
-      'when the field is of type int and the default is set to "serial", then the field should have a "default persist" value and not have a "default model" value',
-      () {
-        var models = [
-          ModelSourceBuilder().withYaml(
-            '''
-            class: Example
-            table: example
-            fields:
-              id: int, default=serial
-            ''',
-          ).build()
-        ];
+      var config = GeneratorConfigBuilder().withEnabledExperimentalFeatures(
+        [ExperimentalFeature.changeIdType],
+      ).build();
 
-        var collector = CodeGenerationCollector();
-        var definitions =
-            StatefulAnalyzer(config, models, onErrorsCollector(collector))
-                .validateAll();
+      var collector = CodeGenerationCollector();
+      StatefulAnalyzer(config, models, onErrorsCollector(collector))
+          .validateAll();
 
-        expect(collector.errors, isEmpty);
-
-        var definition = definitions.first as ClassDefinition;
-        expect(definition.fields.last.defaultModelValue, isNull);
-        expect(definition.fields.last.defaultPersistValue, 'serial');
-      },
-    );
-
-    test(
-      'when the field is of type int and the default is empty, then an error is generated',
-      () {
-        var models = [
-          ModelSourceBuilder().withYaml(
-            '''
-            class: Example
-            table: example
-            fields:
-              id: int, default=
-            ''',
-          ).build()
-        ];
-
-        var collector = CodeGenerationCollector();
-        StatefulAnalyzer(config, models, onErrorsCollector(collector))
-            .validateAll();
-
-        expect(collector.errors, isNotEmpty);
-
-        var firstError = collector.errors.first as SourceSpanSeverityException;
-        expect(
-          firstError.message,
-          'The default value "" is not supported for the id type "int". '
-          'Valid options are: "serial".',
-        );
-      },
-    );
-
-    test(
-      'when the field is of type int and the default is set to a constant value, then an error is generated',
-      () {
-        var models = [
-          ModelSourceBuilder().withYaml(
-            '''
-            class: Example
-            table: example
-            fields:
-              id: int, default=10
-            ''',
-          ).build()
-        ];
-
-        var collector = CodeGenerationCollector();
-        StatefulAnalyzer(config, models, onErrorsCollector(collector))
-            .validateAll();
-
-        expect(collector.errors, isNotEmpty);
-
-        var firstError = collector.errors.first as SourceSpanSeverityException;
-        expect(
-          firstError.message,
-          'The default value "10" is not supported for the id type "int". '
-          'Valid options are: "serial".',
-        );
-      },
-    );
-
-    test(
-      'when the field is of type int and the default is set to an invalid value, then an error is generated',
-      () {
-        var models = [
-          ModelSourceBuilder().withYaml(
-            '''
-            class: Example
-            table: example
-            fields:
-              id: int, default=test
-            ''',
-          ).build()
-        ];
-
-        var collector = CodeGenerationCollector();
-        StatefulAnalyzer(config, models, onErrorsCollector(collector))
-            .validateAll();
-
-        expect(collector.errors, isNotEmpty);
-
-        var firstError = collector.errors.first as SourceSpanSeverityException;
-        expect(
-          firstError.message,
-          'The default value "test" is not supported for the id type "int". '
-          'Valid options are: "serial".',
-        );
-      },
-    );
-  });
+      expect(
+        collector.errors.first.message,
+        'The "default" key is not allowed on the "id" field. Use either '
+        'the "defaultModel" key or the "defaultPersist" key instead.',
+      );
+    },
+  );
 }

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/field/default/integer/field_int_default_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/field/default/integer/field_int_default_test.dart
@@ -189,7 +189,7 @@ void main() {
           class: Example
           table: example
           fields:
-            id: int, default=serial
+            id: int?, default=serial
           ''',
         ).build()
       ];

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/field/default/uuid/field_uuid_default_model_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/field/default/uuid/field_uuid_default_model_test.dart
@@ -245,8 +245,8 @@ void main() {
       [ExperimentalFeature.changeIdType],
     ).build();
 
-    test(
-      'when the field is of type UUID and the defaultModel is set to "random", then the field\'s default persist value is "random".',
+    group(
+      'when the field is of type UUID and the defaultModel is set to "random"',
       () {
         var models = [
           ModelSourceBuilder().withYaml(
@@ -260,14 +260,22 @@ void main() {
         ];
 
         var collector = CodeGenerationCollector();
-        var definitions =
+        late final definitions =
             StatefulAnalyzer(config, models, onErrorsCollector(collector))
                 .validateAll();
 
-        expect(collector.errors, isEmpty);
+        test('then no errors are collected.', () {
+          expect(collector.errors, isEmpty);
+        });
 
-        var definition = definitions.first as ClassDefinition;
-        expect(definition.fields.last.defaultModelValue, 'random');
+        late final definition = definitions.first as ClassDefinition;
+        test('then the field\'s default model value is "random".', () {
+          expect(definition.fields.last.defaultModelValue, 'random');
+        });
+
+        test('then the field\'s default persist value is also "random".', () {
+          expect(definition.fields.last.defaultPersistValue, 'random');
+        });
       },
     );
 

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/field/default/uuid/field_uuid_default_model_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/field/default/uuid/field_uuid_default_model_test.dart
@@ -254,7 +254,7 @@ void main() {
             class: Example
             table: example
             fields:
-              id: UuidValue, defaultModel=random
+              id: UuidValue?, defaultModel=random
             ''',
           ).build()
         ];
@@ -288,7 +288,7 @@ void main() {
             class: Example
             table: example
             fields:
-              id: UuidValue, defaultModel=
+              id: UuidValue?, defaultModel=
             ''',
           ).build()
         ];
@@ -317,7 +317,7 @@ void main() {
             class: Example
             table: example
             fields:
-              id: UuidValue, defaultModel='550e8400-e29b-41d4-a716-446655440000'
+              id: UuidValue?, defaultModel='550e8400-e29b-41d4-a716-446655440000'
             ''',
           ).build()
         ];
@@ -346,7 +346,7 @@ void main() {
             class: Example
             table: example
             fields:
-              id: UuidValue, defaultModel=test
+              id: UuidValue?, defaultModel=test
             ''',
           ).build()
         ];
@@ -362,6 +362,35 @@ void main() {
           firstError.message,
           'The default value "test" is not supported for the id type '
           '"UuidValue". Valid options are: "random".',
+        );
+      },
+    );
+
+    test(
+      'when the field is of type UUID and the type is not-nullable',
+      () {
+        var models = [
+          ModelSourceBuilder().withYaml(
+            '''
+            class: Example
+            table: example
+            fields:
+              id: UuidValue, defaultModel=
+            ''',
+          ).build()
+        ];
+
+        var collector = CodeGenerationCollector();
+        StatefulAnalyzer(config, models, onErrorsCollector(collector))
+            .validateAll();
+
+        expect(collector.errors, isNotEmpty);
+
+        var firstError = collector.errors.first as SourceSpanSeverityException;
+        expect(
+          firstError.message,
+          'The type "UuidValue" must be nullable for the field "id". Use the '
+          '"?" operator to make it nullable (e.g. id: UuidValue?).',
         );
       },
     );

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/field/default/uuid/field_uuid_default_persist_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/field/default/uuid/field_uuid_default_persist_test.dart
@@ -283,7 +283,7 @@ void main() {
             class: Example
             table: example
             fields:
-              id: UuidValue, defaultPersist=random
+              id: UuidValue?, defaultPersist=random
             ''',
           ).build()
         ];
@@ -317,7 +317,7 @@ void main() {
             class: Example
             table: example
             fields:
-              id: UuidValue, defaultPersist=
+              id: UuidValue?, defaultPersist=
             ''',
           ).build()
         ];
@@ -346,7 +346,7 @@ void main() {
             class: Example
             table: example
             fields:
-              id: UuidValue, defaultPersist='550e8400-e29b-41d4-a716-446655440000'
+              id: UuidValue?, defaultPersist='550e8400-e29b-41d4-a716-446655440000'
             ''',
           ).build()
         ];
@@ -375,7 +375,7 @@ void main() {
             class: Example
             table: example
             fields:
-              id: UuidValue, defaultPersist=test
+              id: UuidValue?, defaultPersist=test
             ''',
           ).build()
         ];
@@ -391,6 +391,34 @@ void main() {
           firstError.message,
           'The default value "test" is not supported for the id type '
           '"UuidValue". Valid options are: "random".',
+        );
+      },
+    );
+
+    test(
+      'when the field is of type UUID with a non-nullable type, then an error is generated.',
+      () {
+        var models = [
+          ModelSourceBuilder().withYaml(
+            '''
+          class: Example
+          table: example
+          fields:
+            uuidType: UuidValue, defaultPersist=random
+          ''',
+          ).build()
+        ];
+
+        var collector = CodeGenerationCollector();
+        StatefulAnalyzer(config, models, onErrorsCollector(collector))
+            .validateAll();
+
+        expect(collector.errors, isNotEmpty);
+
+        var error = collector.errors.first as SourceSpanSeverityException;
+        expect(
+          error.message,
+          'When setting only the "defaultPersist" key, its type should be nullable',
         );
       },
     );

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/field/default/uuid/field_uuid_default_persist_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/field/default/uuid/field_uuid_default_persist_test.dart
@@ -274,8 +274,8 @@ void main() {
       [ExperimentalFeature.changeIdType],
     ).build();
 
-    test(
-      'when the field is of type UUID and the defaultPersist is set to "random", then the field\'s default persist value is "random".',
+    group(
+      'when the field is of type UUID and the defaultPersist is set to "random"',
       () {
         var models = [
           ModelSourceBuilder().withYaml(
@@ -289,14 +289,22 @@ void main() {
         ];
 
         var collector = CodeGenerationCollector();
-        var definitions =
+        late final definitions =
             StatefulAnalyzer(config, models, onErrorsCollector(collector))
                 .validateAll();
 
-        expect(collector.errors, isEmpty);
+        test('then no errors are collected.', () {
+          expect(collector.errors, isEmpty);
+        });
 
-        var definition = definitions.first as ClassDefinition;
-        expect(definition.fields.last.defaultPersistValue, 'random');
+        late final definition = definitions.first as ClassDefinition;
+        test('then the field\'s default persist value is "random".', () {
+          expect(definition.fields.last.defaultPersistValue, 'random');
+        });
+
+        test('then the field\'s default model value is null.', () {
+          expect(definition.fields.last.defaultModelValue, isNull);
+        });
       },
     );
 

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/field/default/uuid/field_uuid_default_persist_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/field/default/uuid/field_uuid_default_persist_test.dart
@@ -267,33 +267,124 @@ void main() {
     );
   });
 
-  test(
-    'Given a class with a declared id field of type UUID with a "defaultPersist" keyword, then an error is collected',
-    () {
-      var models = [
-        ModelSourceBuilder().withYaml(
-          '''
-          class: Example
-          table: example
-          fields:
-            id: UuidValue, defaultPersist=random
-          ''',
-        ).build()
-      ];
+  group(
+      'Given a class with a declared id field with a "defaultPersist" keyword',
+      () {
+    var config = GeneratorConfigBuilder().withEnabledExperimentalFeatures(
+      [ExperimentalFeature.changeIdType],
+    ).build();
 
-      var config = GeneratorConfigBuilder().withEnabledExperimentalFeatures(
-        [ExperimentalFeature.changeIdType],
-      ).build();
+    test(
+      'when the field is of type UUID and the defaultPersist is set to "random", then the field\'s default persist value is "random".',
+      () {
+        var models = [
+          ModelSourceBuilder().withYaml(
+            '''
+            class: Example
+            table: example
+            fields:
+              id: UuidValue, defaultPersist=random
+            ''',
+          ).build()
+        ];
 
-      var collector = CodeGenerationCollector();
-      StatefulAnalyzer(config, models, onErrorsCollector(collector))
-          .validateAll();
+        var collector = CodeGenerationCollector();
+        var definitions =
+            StatefulAnalyzer(config, models, onErrorsCollector(collector))
+                .validateAll();
 
-      expect(
-        collector.errors.first.message,
-        'The "defaultPersist" key is not allowed on the "id" field. '
-        'Use the "default" key instead.',
-      );
-    },
-  );
+        expect(collector.errors, isEmpty);
+
+        var definition = definitions.first as ClassDefinition;
+        expect(definition.fields.last.defaultPersistValue, 'random');
+      },
+    );
+
+    test(
+      'when the field is of type UUID and the defaultPersist is empty, then an error is generated',
+      () {
+        var models = [
+          ModelSourceBuilder().withYaml(
+            '''
+            class: Example
+            table: example
+            fields:
+              id: UuidValue, defaultPersist=
+            ''',
+          ).build()
+        ];
+
+        var collector = CodeGenerationCollector();
+        StatefulAnalyzer(config, models, onErrorsCollector(collector))
+            .validateAll();
+
+        expect(collector.errors, isNotEmpty);
+
+        var firstError = collector.errors.first as SourceSpanSeverityException;
+        expect(
+          firstError.message,
+          'The default value "" is not supported for the id type "UuidValue". '
+          'Valid options are: "random".',
+        );
+      },
+    );
+
+    test(
+      'when the field is of type UUID and the defaultPersist is set to a constant value, then an error is generated',
+      () {
+        var models = [
+          ModelSourceBuilder().withYaml(
+            '''
+            class: Example
+            table: example
+            fields:
+              id: UuidValue, defaultPersist='550e8400-e29b-41d4-a716-446655440000'
+            ''',
+          ).build()
+        ];
+
+        var collector = CodeGenerationCollector();
+        StatefulAnalyzer(config, models, onErrorsCollector(collector))
+            .validateAll();
+
+        expect(collector.errors, isNotEmpty);
+
+        var firstError = collector.errors.first as SourceSpanSeverityException;
+        expect(
+          firstError.message,
+          'The default value "\'550e8400-e29b-41d4-a716-446655440000\'" is not '
+          'supported for the id type "UuidValue". Valid options are: "random".',
+        );
+      },
+    );
+
+    test(
+      'when the field is of type UUID and the defaultPersist is set to an invalid value, then an error is generated',
+      () {
+        var models = [
+          ModelSourceBuilder().withYaml(
+            '''
+            class: Example
+            table: example
+            fields:
+              id: UuidValue, defaultPersist=test
+            ''',
+          ).build()
+        ];
+
+        var collector = CodeGenerationCollector();
+        StatefulAnalyzer(config, models, onErrorsCollector(collector))
+            .validateAll();
+
+        expect(collector.errors, isNotEmpty);
+
+        var firstError = collector.errors.first as SourceSpanSeverityException;
+        expect(
+          firstError.message,
+          'The default value "test" is not supported for the id type '
+          '"UuidValue". Valid options are: "random".',
+        );
+      },
+    );
+  });
 }

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/field/default/uuid/field_uuid_default_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/field/default/uuid/field_uuid_default_test.dart
@@ -230,7 +230,7 @@ void main() {
           class: Example
           table: example
           fields:
-            id: UuidValue, default=random
+            id: UuidValue?, default=random
           ''',
         ).build()
       ];

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/field/default/uuid/field_uuid_default_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/field/default/uuid/field_uuid_default_test.dart
@@ -220,123 +220,34 @@ void main() {
     );
   });
 
-  group('Given a class with a declared id field with a "default" keyword', () {
-    var config = GeneratorConfigBuilder().withEnabledExperimentalFeatures(
-      [ExperimentalFeature.changeIdType],
-    ).build();
 
-    test(
-      'when the field is of type UUID and the default is set to "random", then the field\'s default model and persist values are "random".',
-      () {
-        var models = [
-          ModelSourceBuilder().withYaml(
-            '''
-            class: Example
-            table: example
-            fields:
-              id: UuidValue, default=random
-            ''',
-          ).build()
-        ];
+  test(
+    'Given a class with a declared id field of type UUID with a "default" keyword, then an error is collected.',
+    () {
+      var models = [
+        ModelSourceBuilder().withYaml(
+          '''
+          class: Example
+          table: example
+          fields:
+            id: UuidValue, default=random
+          ''',
+        ).build()
+      ];
 
-        var collector = CodeGenerationCollector();
-        var definitions =
-            StatefulAnalyzer(config, models, onErrorsCollector(collector))
-                .validateAll();
+      var config = GeneratorConfigBuilder().withEnabledExperimentalFeatures(
+        [ExperimentalFeature.changeIdType],
+      ).build();
 
-        expect(collector.errors, isEmpty);
+      var collector = CodeGenerationCollector();
+      StatefulAnalyzer(config, models, onErrorsCollector(collector))
+          .validateAll();
 
-        var definition = definitions.first as ClassDefinition;
-        expect(definition.fields.last.defaultModelValue, 'random');
-        expect(definition.fields.last.defaultPersistValue, 'random');
-      },
-    );
-
-    test(
-      'when the field is of type UUID and the default is empty, then an error is generated',
-      () {
-        var models = [
-          ModelSourceBuilder().withYaml(
-            '''
-            class: Example
-            table: example
-            fields:
-              id: UuidValue, default=
-            ''',
-          ).build()
-        ];
-
-        var collector = CodeGenerationCollector();
-        StatefulAnalyzer(config, models, onErrorsCollector(collector))
-            .validateAll();
-
-        expect(collector.errors, isNotEmpty);
-
-        var firstError = collector.errors.first as SourceSpanSeverityException;
-        expect(
-          firstError.message,
-          'The default value "" is not supported for the id type "UuidValue". '
-          'Valid options are: "random".',
-        );
-      },
-    );
-
-    test(
-      'when the field is of type UUID and the default is set to a constant value, then an error is generated',
-      () {
-        var models = [
-          ModelSourceBuilder().withYaml(
-            '''
-            class: Example
-            table: example
-            fields:
-              id: UuidValue, default='550e8400-e29b-41d4-a716-446655440000'
-            ''',
-          ).build()
-        ];
-
-        var collector = CodeGenerationCollector();
-        StatefulAnalyzer(config, models, onErrorsCollector(collector))
-            .validateAll();
-
-        expect(collector.errors, isNotEmpty);
-
-        var firstError = collector.errors.first as SourceSpanSeverityException;
-        expect(
-          firstError.message,
-          'The default value "\'550e8400-e29b-41d4-a716-446655440000\'" is not '
-          'supported for the id type "UuidValue". Valid options are: "random".',
-        );
-      },
-    );
-
-    test(
-      'when the field is of type UUID and the default is set to an invalid value, then an error is generated',
-      () {
-        var models = [
-          ModelSourceBuilder().withYaml(
-            '''
-            class: Example
-            table: example
-            fields:
-              id: UuidValue, default=test
-            ''',
-          ).build()
-        ];
-
-        var collector = CodeGenerationCollector();
-        StatefulAnalyzer(config, models, onErrorsCollector(collector))
-            .validateAll();
-
-        expect(collector.errors, isNotEmpty);
-
-        var firstError = collector.errors.first as SourceSpanSeverityException;
-        expect(
-          firstError.message,
-          'The default value "test" is not supported for the id type '
-          '"UuidValue". Valid options are: "random".',
-        );
-      },
-    );
-  });
+      expect(
+        collector.errors.first.message,
+        'The "default" key is not allowed on the "id" field. Use either '
+        'the "defaultModel" key or the "defaultPersist" key instead.',
+      );
+    },
+  );
 }

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/field/field_id_type_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/field/field_id_type_test.dart
@@ -81,7 +81,7 @@ void main() {
   });
 
   test(
-      'Given a class with the int id type and no default value, then no error is collected.',
+      'Given a class with the int id type set as non-nullable then an error is collected',
       () {
     var models = [
       ModelSourceBuilder().withYaml(
@@ -98,17 +98,23 @@ void main() {
     StatefulAnalyzer(config, models, onErrorsCollector(collector))
         .validateAll();
 
-    expect(collector.errors, isEmpty);
+    expect(
+      collector.errors.first.message,
+      'The type "int" must be nullable for the field "id". Use the "?" '
+      'operator to make it nullable (e.g. id: int?).',
+    );
   });
 
-  group('Given a class with the int id type correctly set', () {
+  group(
+      'Given a class with the int id type set as nullable with no default value',
+      () {
     var models = [
       ModelSourceBuilder().withYaml(
         '''
         class: Example
         table: example
         fields:
-          id: int
+          id: int?
         ''',
       ).build()
     ];
@@ -160,7 +166,7 @@ void main() {
         class: Example
         table: example
         fields:
-          id: UuidValue, defaultModel=random
+          id: UuidValue?, defaultModel=random
         ''',
       ).build()
     ];

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/field/field_id_type_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/field/field_id_type_test.dart
@@ -148,7 +148,8 @@ void main() {
 
     expect(
       collector.errors.first.message,
-      'The type "UuidValue" must have a default value.',
+      'The type "UuidValue" must have a default value. Use either the '
+      '"defaultModel" key or the "defaultPersist" key to set it.',
     );
   });
 
@@ -159,7 +160,7 @@ void main() {
         class: Example
         table: example
         fields:
-          id: UuidValue, default=random
+          id: UuidValue, defaultModel=random
         ''',
       ).build()
     ];

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/field/field_persist_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/field/field_persist_test.dart
@@ -354,7 +354,7 @@ void main() {
           class: Example
           table: example
           fields:
-            id: int, !persist
+            id: int?, !persist
           ''',
         ).build()
       ];

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/field/field_scope_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/field/field_scope_test.dart
@@ -626,7 +626,7 @@ void main() {
           class: Example
           table: example
           fields:
-            id: int, scope=none
+            id: int?, scope=none
           ''',
         ).build()
       ];

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/relation/relation_changed_field_id_type_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/relation/relation_changed_field_id_type_test.dart
@@ -35,7 +35,7 @@ void main() {
         class: ExampleParent
         table: example_parent
         fields:
-          id: UuidValue, defaultModel=random
+          id: UuidValue?, defaultModel=random
           name: String
         ''',
       ).build()
@@ -89,7 +89,7 @@ void main() {
         class: ExampleParent
         table: example_parent
         fields:
-          id: UuidValue, defaultModel=random
+          id: UuidValue?, defaultModel=random
           name: String
           example: Example?, relation(name=example_parent)
         ''',
@@ -148,7 +148,7 @@ void main() {
         class: Company
         table: company
         fields:
-          id: UuidValue, defaultModel=random
+          id: UuidValue?, defaultModel=random
           employees: List<Employee>?, relation(name=company_employees)
         ''',
       ).build()
@@ -210,7 +210,7 @@ void main() {
         class: Company
         table: company
         fields:
-          id: UuidValue, defaultModel=random
+          id: UuidValue?, defaultModel=random
           employees: List<Employee>?, relation
         ''',
       ).build(),
@@ -279,7 +279,7 @@ void main() {
         class: Company
         table: company
         fields:
-          id: UuidValue, defaultModel=random
+          id: UuidValue?, defaultModel=random
           employees: List<Employee>?, relation
         ''',
       ).build(),
@@ -332,7 +332,7 @@ void main() {
         class: Company
         table: company
         fields:
-          id: UuidValue, defaultModel=random
+          id: UuidValue?, defaultModel=random
           employees: List<Employee>?, relation(name=company_employees)
         ''',
       ).build()

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/relation/relation_changed_field_id_type_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/relation/relation_changed_field_id_type_test.dart
@@ -21,7 +21,7 @@ void main() {
         class: Example
         table: example
         fields:
-          id: int, defaultPersist=serial
+          id: int?, defaultPersist=serial
           myParentId: UuidValue
           parent: ExampleParent?, relation(field=myParentId)
         indexes:
@@ -75,7 +75,7 @@ void main() {
         class: Example
         table: example
         fields:
-          id: int, defaultPersist=serial
+          id: int?, defaultPersist=serial
           parentId: UuidValue?
           parent: ExampleParent?, relation(name=example_parent, field=parentId)
         indexes:
@@ -139,7 +139,7 @@ void main() {
         class: Employee
         table: employee
         fields:
-          id: int, defaultPersist=serial
+          id: int?, defaultPersist=serial
           company: Company?, relation(name=company_employees)
         ''',
       ).build(),
@@ -201,7 +201,7 @@ void main() {
         class: Employee
         table: employee
         fields:
-          id: int, defaultPersist=serial
+          id: int?, defaultPersist=serial
           company: Company?, relation
         ''',
       ).build(),
@@ -270,7 +270,7 @@ void main() {
         class: Employee
         table: employee
         fields:
-          id: int, defaultPersist=serial
+          id: int?, defaultPersist=serial
           name: String
         ''',
       ).build(),
@@ -323,7 +323,7 @@ void main() {
         class: Employee
         table: employee
         fields:
-          id: int, defaultPersist=serial
+          id: int?, defaultPersist=serial
           companyId: UuidValue, relation(name=company_employees, parent=company)
         ''',
       ).build(),

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/relation/relation_changed_field_id_type_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/relation/relation_changed_field_id_type_test.dart
@@ -21,7 +21,7 @@ void main() {
         class: Example
         table: example
         fields:
-          id: int, default=serial
+          id: int, defaultPersist=serial
           myParentId: UuidValue
           parent: ExampleParent?, relation(field=myParentId)
         indexes:
@@ -35,7 +35,7 @@ void main() {
         class: ExampleParent
         table: example_parent
         fields:
-          id: UuidValue, default=random
+          id: UuidValue, defaultModel=random
           name: String
         ''',
       ).build()
@@ -75,7 +75,7 @@ void main() {
         class: Example
         table: example
         fields:
-          id: int, default=serial
+          id: int, defaultPersist=serial
           parentId: UuidValue?
           parent: ExampleParent?, relation(name=example_parent, field=parentId)
         indexes:
@@ -89,7 +89,7 @@ void main() {
         class: ExampleParent
         table: example_parent
         fields:
-          id: UuidValue, default=random
+          id: UuidValue, defaultModel=random
           name: String
           example: Example?, relation(name=example_parent)
         ''',
@@ -139,7 +139,7 @@ void main() {
         class: Employee
         table: employee
         fields:
-          id: int, default=serial
+          id: int, defaultPersist=serial
           company: Company?, relation(name=company_employees)
         ''',
       ).build(),
@@ -148,7 +148,7 @@ void main() {
         class: Company
         table: company
         fields:
-          id: UuidValue, default=random
+          id: UuidValue, defaultModel=random
           employees: List<Employee>?, relation(name=company_employees)
         ''',
       ).build()
@@ -201,7 +201,7 @@ void main() {
         class: Employee
         table: employee
         fields:
-          id: int, default=serial
+          id: int, defaultPersist=serial
           company: Company?, relation
         ''',
       ).build(),
@@ -210,7 +210,7 @@ void main() {
         class: Company
         table: company
         fields:
-          id: UuidValue, default=random
+          id: UuidValue, defaultModel=random
           employees: List<Employee>?, relation
         ''',
       ).build(),
@@ -270,7 +270,7 @@ void main() {
         class: Employee
         table: employee
         fields:
-          id: int, default=serial
+          id: int, defaultPersist=serial
           name: String
         ''',
       ).build(),
@@ -279,7 +279,7 @@ void main() {
         class: Company
         table: company
         fields:
-          id: UuidValue, default=random
+          id: UuidValue, defaultModel=random
           employees: List<Employee>?, relation
         ''',
       ).build(),
@@ -323,7 +323,7 @@ void main() {
         class: Employee
         table: employee
         fields:
-          id: int, default=serial
+          id: int, defaultPersist=serial
           companyId: UuidValue, relation(name=company_employees, parent=company)
         ''',
       ).build(),
@@ -332,7 +332,7 @@ void main() {
         class: Company
         table: company
         fields:
-          id: UuidValue, default=random
+          id: UuidValue, defaultModel=random
           employees: List<Employee>?, relation(name=company_employees)
         ''',
       ).build()


### PR DESCRIPTION
As discussed on #3396, this PR removes the possibility of the user to declare an `id` field using the `default` keyword. This forces the user to decide whether to have UUID values being defined on the model (using the `defaultModel` keyword) or only on the database (using the `defaultPersist` keyword).

While making such change, it became clear that we were allowing the user to declare the type as non-nullable, but the resulting type was always set as nullable (as required by the `TableRow.id` model). This is now fixed, with the user being required to declare the `id` type as nullable (such as already happens when declaring foreign key fields).

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

No breaking changes.