### PR TITLE
fix: Prevent reporting auth rejections as an exception for streaming endpoints.

### DIFF
--- a/packages/serverpod/lib/src/server/websocket_request_handlers/endpoint_websocket_request_handler.dart
+++ b/packages/serverpod/lib/src/server/websocket_request_handlers/endpoint_websocket_request_handler.dart
@@ -74,8 +74,8 @@ abstract class EndpointWebsocketRequestHandler {
           try {
             endpointConnector = await server.endpoints.getEndpointConnector(
                 session: session, endpointPath: endpointName);
-          } on NotAuthorizedException catch (e, s) {
-            _reportException(server, e, s, session: session);
+          } on NotAuthorizedException catch (_) {
+            // User is not authorized to communicate with this endpoint.
             continue;
           } on EndpointNotFoundException {
             throw Exception('Endpoint not found: $endpointName');

--- a/packages/serverpod/lib/src/server/websocket_request_handlers/endpoint_websocket_request_handler.dart
+++ b/packages/serverpod/lib/src/server/websocket_request_handlers/endpoint_websocket_request_handler.dart
@@ -156,8 +156,8 @@ abstract class EndpointWebsocketRequestHandler {
         endpointPath: endpointName,
       );
       await connector.endpoint.streamOpened(session);
-    } on NotAuthorizedException catch (e, s) {
-      _reportException(session.server, e, s, session: session);
+    } on NotAuthorizedException catch (_) {
+      // User is not authorized to communicate with this endpoint.
       return;
     } catch (e, s) {
       _reportException(session.server, e, s, session: session);
@@ -177,8 +177,8 @@ abstract class EndpointWebsocketRequestHandler {
         endpointPath: endpointName,
       );
       await connector.endpoint.streamClosed(session);
-    } on NotAuthorizedException catch (e, s) {
-      _reportException(session.server, e, s, session: session);
+    } on NotAuthorizedException catch (_) {
+      // User is not authorized to communicate with this endpoint.
       return;
     } catch (e, s) {
       _reportException(session.server, e, s, session: session);


### PR DESCRIPTION
When implementing Exception events hooks in this [PR](https://github.com/serverpod/serverpod/pull/3187), we accidentally started reporting authorization rejections as server exceptions for streaming endpoints.

This PR reverts that change.

Closes #3414 

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None - simply silences invalid exception reporting.