### PR TITLE
refactor(serverpod_flutter): Avoid using conditional import for localhost

### DIFF
--- a/.github/workflows/dart-tests.yaml
+++ b/.github/workflows/dart-tests.yaml
@@ -163,6 +163,26 @@ jobs:
         run: dart test -p chrome
         working-directory: ${{ matrix.path }}
 
+  flutter_unit_tests:
+    name: Flutter unit tests
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        flutter-version: ['3.19.0', '3.29.0']
+        os: [windows-latest, ubuntu-latest]
+        path:
+          [
+            'packages/serverpod_flutter',
+          ]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: subosito/flutter-action@v2
+        with:
+          flutter-version: ${{ matrix.flutter-version }}
+      - name: Run unit tests
+        run: flutter test
+        working-directory: ${{ matrix.path }}
+
   e2e_io_tests:
     name: Serverpod E2E IO tests
     runs-on: ubuntu-latest

--- a/packages/serverpod_flutter/lib/serverpod_flutter.dart
+++ b/packages/serverpod_flutter/lib/serverpod_flutter.dart
@@ -1,2 +1,2 @@
 export 'src/flutter_connectivity_monitor.dart';
-export 'src/localhost_web.dart' if (dart.library.io) 'src/localhost_io.dart';
+export 'src/localhost.dart';

--- a/packages/serverpod_flutter/lib/src/localhost.dart
+++ b/packages/serverpod_flutter/lib/src/localhost.dart
@@ -1,0 +1,7 @@
+import 'package:flutter/foundation.dart';
+
+/// Returns the localhost address for the current platform.
+String get localhost =>
+    defaultTargetPlatform == TargetPlatform.android && !kIsWeb
+        ? '10.0.2.2'
+        : 'localhost';

--- a/packages/serverpod_flutter/lib/src/localhost_io.dart
+++ b/packages/serverpod_flutter/lib/src/localhost_io.dart
@@ -1,4 +1,0 @@
-import 'dart:io';
-
-/// Returns the localhost address for the current platform.
-String get localhost => Platform.isAndroid ? '10.0.2.2' : 'localhost';

--- a/packages/serverpod_flutter/lib/src/localhost_web.dart
+++ b/packages/serverpod_flutter/lib/src/localhost_web.dart
@@ -1,2 +1,0 @@
-/// Returns the localhost address for the current platform.
-String get localhost => 'localhost';

--- a/packages/serverpod_flutter/test/localhost_test.dart
+++ b/packages/serverpod_flutter/test/localhost_test.dart
@@ -3,28 +3,26 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:serverpod_flutter/src/localhost.dart';
 
 void main() {
-  group('localhost', () {
-    tearDown(() => debugDefaultTargetPlatformOverride = null);
+  tearDown(() => debugDefaultTargetPlatformOverride = null);
 
-    test(
-        'Given target platform is android when reading localhost then 10.0.2.2 is returned',
-        () {
-      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+  test(
+      'Given target platform is android when reading localhost then 10.0.2.2 is returned',
+      () {
+    debugDefaultTargetPlatformOverride = TargetPlatform.android;
 
-      expect(localhost, '10.0.2.2');
-    });
-
-    final nonAndroidPlatforms = TargetPlatform.values.toList()
-      ..removeWhere((platform) => platform == TargetPlatform.android);
-
-    for (final testPlatform in nonAndroidPlatforms) {
-      test(
-          'Given target platform is ${testPlatform.name} when reading localhost then localhost is returned',
-          () {
-        debugDefaultTargetPlatformOverride = testPlatform;
-
-        expect(localhost, 'localhost');
-      });
-    }
+    expect(localhost, '10.0.2.2');
   });
+
+  final nonAndroidPlatforms = TargetPlatform.values.toList()
+    ..removeWhere((platform) => platform == TargetPlatform.android);
+
+  for (final testPlatform in nonAndroidPlatforms) {
+    test(
+        'Given non-android target platform "${testPlatform.name}" when reading localhost then localhost is returned',
+        () {
+      debugDefaultTargetPlatformOverride = testPlatform;
+
+      expect(localhost, 'localhost');
+    });
+  }
 }

--- a/packages/serverpod_flutter/test/localhost_test.dart
+++ b/packages/serverpod_flutter/test/localhost_test.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:serverpod_flutter/src/localhost.dart';
+
+void main() {
+  group('localhost', () {
+    tearDown(() => debugDefaultTargetPlatformOverride = null);
+
+    test(
+        'Given target platform is android when reading localhost then 10.0.2.2 is returned',
+        () {
+      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+
+      expect(localhost, '10.0.2.2');
+    });
+
+    final nonAndroidPlatforms = TargetPlatform.values.toList()
+      ..removeWhere((platform) => platform == TargetPlatform.android);
+
+    for (final testPlatform in nonAndroidPlatforms) {
+      test(
+          'Given target platform is ${testPlatform.name} when reading localhost then localhost is returned',
+          () {
+        debugDefaultTargetPlatformOverride = testPlatform;
+
+        expect(localhost, 'localhost');
+      });
+    }
+  });
+}


### PR DESCRIPTION
_Avoid using conditional import in the `serverpod_flutter` package and adding simple unit tests to cover `localhost` getter_

- *Fix #3438*

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.
