### PR TITLE
fix: Fix changing the id type of a table only dropping/creating the column

### DIFF
--- a/tools/serverpod_cli/lib/src/database/extensions.dart
+++ b/tools/serverpod_cli/lib/src/database/extensions.dart
@@ -100,7 +100,8 @@ extension ColumnComparisons on ColumnDefinition {
   }
 
   bool get canBeCreatedInTableMigration {
-    return isNullable || columnDefault != null;
+    return (isNullable || columnDefault != null) &&
+        name != defaultPrimaryKeyName;
   }
 }
 


### PR DESCRIPTION
After #3437 merge, one question remained to be solved: what happens when changing the type of an id in a migration? The answer is that the migration was allowing to only drop/create the column instead of the whole table. This PR fixes it by forcing to drop/create the table instead.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

N/A.