### PR TITLE
feat: Add module integration test step to CI pipeline

### DIFF
--- a/.github/workflows/dart-tests.yaml
+++ b/.github/workflows/dart-tests.yaml
@@ -240,6 +240,34 @@ jobs:
         run: dart test test_integration
         working-directory: ${{ matrix.path }}
 
+  module_integration_tests:
+    name: Module integration tests in ${{ matrix.module }} with Flutter ${{ matrix.flutter-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        flutter-version: ['3.19.0', '3.29.0']
+        module: ['tests/serverpod_test_module/serverpod_test_module_server']
+    steps:
+      - uses: actions/checkout@v3
+      - uses: subosito/flutter-action@v2
+        with:
+          flutter-version: ${{ matrix.flutter-version }}
+      - name: Start containers
+        run: docker compose up --build -V -d
+        working-directory: ${{ matrix.module }}
+      - name: Wait for services to be ready
+        run: |
+          ./wait-for-it.sh localhost:9090 -t 60 -- echo "### Postgres is UP at :9090"
+          ./wait-for-it.sh localhost:9091 -t 60 -- echo "### Redis is UP at :9091"
+        working-directory: tests/docker/tests_integration
+      - name: Run integration tests
+        run: dart test -t integration
+        working-directory: ${{ matrix.module }}
+      - name: Stop containers
+        if: always()
+        run: docker compose down
+        working-directory: ${{ matrix.module }}
+
   integration_test_server:
     name: Serverpod integration tests (server)
     runs-on: ubuntu-latest

--- a/tests/docker/tests_integration/run_tests.sh
+++ b/tests/docker/tests_integration/run_tests.sh
@@ -29,7 +29,3 @@ dart bin/main.dart -m production -r maintenance --apply-migrations
 echo "### Running tests"
 dart test test_integration -x integration --concurrency=1
 checkLastExitCode
-
-cd ../serverpod_test_module/serverpod_test_module_server/
-echo $(pwd)
-dart test ./test/integration

--- a/tests/serverpod_test_module/serverpod_test_module_server/config/passwords.yaml
+++ b/tests/serverpod_test_module/serverpod_test_module_server/config/passwords.yaml
@@ -1,4 +1,4 @@
 test:
-  database: 'password'
-  redis: 'password'
+  database: 'DB_TEST_PASSWORD'
+  redis: 'REDIS_TEST_PASSWORD'
   serviceSecret: 'super_SECRET_password'

--- a/tests/serverpod_test_module/serverpod_test_module_server/config/test.yaml
+++ b/tests/serverpod_test_module/serverpod_test_module_server/config/test.yaml
@@ -17,12 +17,12 @@ webServer:
   publicScheme: http
 
 database:
-  host: postgres
-  port: 5432
-  name: serverpod_test
+  host: localhost
+  port: 9090
+  name: projectname_test
   user: postgres
 
 redis:
-  enabled: true
-  host: redis
-  port: 6379
+  enabled: false
+  host: localhost
+  port: 9091

--- a/tests/serverpod_test_module/serverpod_test_module_server/docker-compose.yaml
+++ b/tests/serverpod_test_module/serverpod_test_module_server/docker-compose.yaml
@@ -1,0 +1,22 @@
+services:
+  # Test services
+  postgres_test:
+    image: postgres:16.3
+    ports:
+      - '9090:5432'
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_DB: projectname_test
+      POSTGRES_PASSWORD: "DB_TEST_PASSWORD"
+    volumes:
+      - projectname_test_data:/var/lib/postgresql/data
+  redis_test:
+    image: redis:6.2.6
+    ports:
+      - '9091:6379'
+    command: redis-server --requirepass "REDIS_TEST_PASSWORD"
+    environment:
+      - REDIS_REPLICATION_MODE=master
+
+volumes:
+  projectname_test_data:


### PR DESCRIPTION
To run each module's `withServerpod` integration tests.

Adds the (now default) `docker-compose.yaml` file to `serverpod_test_module_server` to showcase the new behavior.