### PR TITLE
chore: Add serverpod auth user client to pub_get_all script.

### DIFF
--- a/util/pub_get_all
+++ b/util/pub_get_all
@@ -49,6 +49,7 @@ declare -a dart_paths=(
   "templates/serverpod_templates/modulename_client"
   "modules/serverpod_auth/serverpod_auth_server"
   "modules/serverpod_auth/serverpod_auth_client"
+  "modules/new_serverpod_auth/serverpod_auth_user/serverpod_auth_user_client"
   "modules/new_serverpod_auth/serverpod_auth_user/serverpod_auth_user_server"
   "modules/serverpod_chat/serverpod_chat_server"
   "modules/serverpod_chat/serverpod_chat_client"


### PR DESCRIPTION
Noticed that serverpod auth user client was red after running the pub_get_all script.

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

_If you have done any breaking changes, make sure to outline them here, so that they can be included in the notes for the next release._