### PR TITLE
fix: Ensure foreign key relations are always defined after table creation.

### DIFF
--- a/tools/serverpod_cli/lib/src/database/extensions.dart
+++ b/tools/serverpod_cli/lib/src/database/extensions.dart
@@ -522,14 +522,17 @@ extension MigrationActionPgSqlGeneration on DatabaseMigrationAction {
   String foreignRelationToSql() {
     var out = '';
 
-    if (createTable == null) return out;
+    var noForeignKeys = (createTable?.foreignKeys.isEmpty ?? true) &&
+        (alterTable?.addForeignKeys.isEmpty ?? true);
 
-    if (createTable!.foreignKeys.isEmpty) return out;
+    if (noForeignKeys) return out;
 
     out += '--\n';
     out += '-- ACTION CREATE FOREIGN KEY\n';
     out += '--\n';
-    out += createTable!.foreignRelationToPgsql();
+
+    out += createTable?.foreignRelationToPgsql() ?? '';
+    out += alterTable?.foreignRelationToSql() ?? '';
 
     return out;
   }
@@ -569,10 +572,18 @@ extension TableMigrationPgSqlGenerator on TableMigration {
       out += addIndex.toPgSql(tableName: name);
     }
 
-    // Add foreign keys
+    return out;
+  }
+
+  String foreignRelationToSql() {
+    var out = '';
+
+    if (addForeignKeys.isEmpty) return out;
+
     for (var addKey in addForeignKeys) {
       out += addKey.toPgSql(tableName: name);
     }
+
     return out;
   }
 }

--- a/tools/serverpod_cli/test/database/extentions/migration_pgsql_code_generation_test.dart
+++ b/tools/serverpod_cli/test/database/extentions/migration_pgsql_code_generation_test.dart
@@ -1,9 +1,15 @@
-import 'package:serverpod_cli/src/database/extensions.dart';
-import 'package:serverpod_cli/src/database/migration.dart';
+import 'package:serverpod_cli/analyzer.dart';
+import 'package:serverpod_cli/src/analyzer/models/stateful_analyzer.dart';
+import 'package:serverpod_cli/src/database/create_definition.dart';
+import 'package:serverpod_cli/src/generator/code_generation_collector.dart';
+import 'package:serverpod_cli/src/util/model_helper.dart';
+import 'package:serverpod_service_client/serverpod_service_client.dart';
 import 'package:test/test.dart';
 
+import '../../generator/dart/client_code_generator/class_constructors_test.dart';
 import '../../test_util/builders/database/database_definition_builder.dart';
 import '../../test_util/builders/database/table_definition_builder.dart';
+import '../../test_util/builders/model_source_builder.dart';
 
 void main() {
   group(
@@ -40,4 +46,87 @@ void main() {
       expect(psql, contains('CREATE TABLE IF NOT EXISTS "example_table"'));
     });
   });
+
+  /// Issue: https://github.com/serverpod/serverpod/issues/3503
+  test(
+      'Given an existing table that that references a new table with a name lexically sorted before the existing one, when creating migraion sql then the migration code should create the table before defining the foreign key',
+      () {
+    var sourceModels = [
+      ModelSourceBuilder().withFileName('existing_table').withYaml(
+        '''
+class: ExistingModel
+table: a_existing_table
+fields:
+  name: String
+          ''',
+      ).build(),
+    ];
+
+    var targetModels = [
+      ModelSourceBuilder().withFileName('new_model').withYaml(
+        '''
+class: NewModel
+table: z_new_model
+fields:
+  name: String
+          ''',
+      ).build(),
+      ModelSourceBuilder().withFileName('existing_table').withYaml(
+        '''
+class: ExistingModel
+table: a_existing_table
+fields:
+  name: String
+  newModel: NewModel?, relation(optional)
+          ''',
+      ).build(),
+    ];
+
+    var (:sourceDefinition, :targetDefinition) =
+        _createDatabaseDefinitionFromModels(
+      sourceModels,
+      targetModels,
+    );
+
+    var migration = generateDatabaseMigration(
+      databaseSource: sourceDefinition,
+      databaseTarget: targetDefinition,
+    );
+
+    var psql = migration.toPgSql(installedModules: [], removedModules: []);
+
+    var createNewModelTable = psql.indexOf('CREATE TABLE "z_new_model"');
+    var addForeignKeyToExistingTable =
+        psql.indexOf('ADD CONSTRAINT "a_existing_table_fk_0"');
+
+    expect(createNewModelTable, greaterThanOrEqualTo(0));
+    expect(addForeignKeyToExistingTable, greaterThanOrEqualTo(0));
+
+    expect(createNewModelTable, lessThan(addForeignKeyToExistingTable));
+  });
+}
+
+({DatabaseDefinition sourceDefinition, DatabaseDefinition targetDefinition})
+    _createDatabaseDefinitionFromModels(
+  List<ModelSource> sourceModels,
+  List<ModelSource> targetModels,
+) {
+  DatabaseDefinition createDefinition(models) {
+    var collector = CodeGenerationCollector();
+    var analyzer =
+        StatefulAnalyzer(config, models, onErrorsCollector(collector));
+    var definitions = analyzer.validateAll();
+    expect(collector.errors, isEmpty);
+
+    return createDatabaseDefinitionFromModels(
+      definitions,
+      'example',
+      [],
+    );
+  }
+
+  return (
+    sourceDefinition: createDefinition(sourceModels),
+    targetDefinition: createDefinition(targetModels)
+  );
 }

--- a/tools/serverpod_cli/test/database/extentions/migration_pgsql_code_generation_test.dart
+++ b/tools/serverpod_cli/test/database/extentions/migration_pgsql_code_generation_test.dart
@@ -1,15 +1,10 @@
 import 'package:serverpod_cli/analyzer.dart';
-import 'package:serverpod_cli/src/analyzer/models/stateful_analyzer.dart';
-import 'package:serverpod_cli/src/database/create_definition.dart';
-import 'package:serverpod_cli/src/generator/code_generation_collector.dart';
-import 'package:serverpod_cli/src/util/model_helper.dart';
-import 'package:serverpod_service_client/serverpod_service_client.dart';
 import 'package:test/test.dart';
 
-import '../../generator/dart/client_code_generator/class_constructors_test.dart';
 import '../../test_util/builders/database/database_definition_builder.dart';
 import '../../test_util/builders/database/table_definition_builder.dart';
 import '../../test_util/builders/model_source_builder.dart';
+import '../../test_util/database_definition_helpers.dart';
 
 void main() {
   group(
@@ -82,8 +77,7 @@ fields:
       ).build(),
     ];
 
-    var (:sourceDefinition, :targetDefinition) =
-        _createDatabaseDefinitionFromModels(
+    var (:sourceDefinition, :targetDefinition) = databaseDefinitionsFromModels(
       sourceModels,
       targetModels,
     );
@@ -104,29 +98,4 @@ fields:
 
     expect(createNewModelTable, lessThan(addForeignKeyToExistingTable));
   });
-}
-
-({DatabaseDefinition sourceDefinition, DatabaseDefinition targetDefinition})
-    _createDatabaseDefinitionFromModels(
-  List<ModelSource> sourceModels,
-  List<ModelSource> targetModels,
-) {
-  DatabaseDefinition createDefinition(models) {
-    var collector = CodeGenerationCollector();
-    var analyzer =
-        StatefulAnalyzer(config, models, onErrorsCollector(collector));
-    var definitions = analyzer.validateAll();
-    expect(collector.errors, isEmpty);
-
-    return createDatabaseDefinitionFromModels(
-      definitions,
-      'example',
-      [],
-    );
-  }
-
-  return (
-    sourceDefinition: createDefinition(sourceModels),
-    targetDefinition: createDefinition(targetModels)
-  );
 }

--- a/tools/serverpod_cli/test/database/extentions/migration_with_many_to_many_relation_pgsql_code_generation_test.dart
+++ b/tools/serverpod_cli/test/database/extentions/migration_with_many_to_many_relation_pgsql_code_generation_test.dart
@@ -1,85 +1,56 @@
 import 'package:serverpod_cli/analyzer.dart';
-import 'package:serverpod_cli/src/analyzer/models/stateful_analyzer.dart';
-import 'package:serverpod_cli/src/database/create_definition.dart';
-import 'package:serverpod_cli/src/generator/code_generation_collector.dart';
-import 'package:serverpod_service_client/serverpod_service_client.dart';
 import 'package:test/test.dart';
 
-import '../../generator/dart/client_code_generator/class_constructors_test.dart';
 import '../../test_util/builders/model_source_builder.dart';
+import '../../test_util/database_definition_helpers.dart';
 
 void main() {
   test(
       'Given a table that is referenced by another one, when it is renamed, then the migration code should drop both tables and recreate them in a working order',
       () {
-    DatabaseDefinition sourceDefinition;
-    {
-      var models = [
-        ModelSourceBuilder().withFileName('target').withYaml(
-          '''
+    var sourceModels = [
+      ModelSourceBuilder().withFileName('target').withYaml(
+        '''
 class: Target
 table: target
 fields:
   name: String
           ''',
-        ).build(),
-        ModelSourceBuilder().withFileName('source').withYaml(
-          '''
+      ).build(),
+      ModelSourceBuilder().withFileName('source').withYaml(
+        '''
 class: Source
 table: source
 fields:
   target: Target?, relation
           ''',
-        ).build(),
-      ];
+      ).build(),
+    ];
 
-      var collector = CodeGenerationCollector();
-      var analyzer =
-          StatefulAnalyzer(config, models, onErrorsCollector(collector));
-      var definitions = analyzer.validateAll();
-      expect(collector.errors, isEmpty);
-
-      sourceDefinition = createDatabaseDefinitionFromModels(
-        definitions,
-        'example',
-        [],
-      );
-    }
-
-    DatabaseDefinition
-        targetDefinition; // renames table `target` to `target_new`
-    {
-      var models = [
-        ModelSourceBuilder().withFileName('target').withYaml(
-          '''
+    var targetModels = [
+      // renames table `target` to `target_new`
+      ModelSourceBuilder().withFileName('target').withYaml(
+        '''
 class: Target
 table: target_new
 fields:
   name: String
           ''',
-        ).build(),
-        ModelSourceBuilder().withFileName('source').withYaml(
-          '''
+      ).build(),
+      ModelSourceBuilder().withFileName('source').withYaml(
+        '''
 class: Source
 table: source
 fields:
   target: Target?, relation
           ''',
-        ).build(),
-      ];
+      ).build(),
+    ];
 
-      var collector = CodeGenerationCollector();
-      var analyzer =
-          StatefulAnalyzer(config, models, onErrorsCollector(collector));
-      var definitions = analyzer.validateAll();
-      expect(collector.errors, isEmpty);
-
-      targetDefinition = createDatabaseDefinitionFromModels(
-        definitions,
-        'example',
-        [],
-      );
-    }
+    var (:sourceDefinition, :targetDefinition) = databaseDefinitionsFromModels(
+      sourceModels,
+      targetModels,
+    );
 
     var migration = generateDatabaseMigration(
       databaseSource: sourceDefinition,
@@ -109,74 +80,49 @@ fields:
   test(
       'Given a table that is optionally referenced by another one, when it is renamed, then the migration code should drop both tables and recreate them in a working order',
       () {
-    DatabaseDefinition sourceDefinition;
-    {
-      var models = [
-        ModelSourceBuilder().withFileName('target').withYaml(
-          '''
+    var sourceModels = [
+      ModelSourceBuilder().withFileName('target').withYaml(
+        '''
 class: Target
 table: target
 fields:
   name: String
           ''',
-        ).build(),
-        ModelSourceBuilder().withFileName('source').withYaml(
-          '''
+      ).build(),
+      ModelSourceBuilder().withFileName('source').withYaml(
+        '''
 class: Source
 table: source
 fields:
   target: Target?, relation(optional)
           ''',
-        ).build(),
-      ];
+      ).build(),
+    ];
 
-      var collector = CodeGenerationCollector();
-      var analyzer =
-          StatefulAnalyzer(config, models, onErrorsCollector(collector));
-      var definitions = analyzer.validateAll();
-      expect(collector.errors, isEmpty);
-
-      sourceDefinition = createDatabaseDefinitionFromModels(
-        definitions,
-        'example',
-        [],
-      );
-    }
-
-    DatabaseDefinition
-        targetDefinition; // renames table `target` to `target_new`
-    {
-      var models = [
-        ModelSourceBuilder().withFileName('target').withYaml(
-          '''
+    var targetModels = [
+      // renames table `target` to `target_new`
+      ModelSourceBuilder().withFileName('target').withYaml(
+        '''
 class: Target
 table: target_new
 fields:
   name: String
           ''',
-        ).build(),
-        ModelSourceBuilder().withFileName('source').withYaml(
-          '''
+      ).build(),
+      ModelSourceBuilder().withFileName('source').withYaml(
+        '''
 class: Source
 table: source
 fields:
   target: Target?, relation(optional)
           ''',
-        ).build(),
-      ];
+      ).build(),
+    ];
 
-      var collector = CodeGenerationCollector();
-      var analyzer =
-          StatefulAnalyzer(config, models, onErrorsCollector(collector));
-      var definitions = analyzer.validateAll();
-      expect(collector.errors, isEmpty);
-
-      targetDefinition = createDatabaseDefinitionFromModels(
-        definitions,
-        'example',
-        [],
-      );
-    }
+    var (:sourceDefinition, :targetDefinition) = databaseDefinitionsFromModels(
+      sourceModels,
+      targetModels,
+    );
 
     var migration = generateDatabaseMigration(
       databaseSource: sourceDefinition,
@@ -206,74 +152,49 @@ fields:
   test(
       'Given two tables that reference each other, when one is renamed, then the migration code should drop both tables and recreate them in a working order',
       () {
-    DatabaseDefinition sourceDefinition;
-    {
-      var models = [
-        ModelSourceBuilder().withFileName('a').withYaml(
-          '''
+    var sourceModels = [
+      ModelSourceBuilder().withFileName('a').withYaml(
+        '''
 class: A
 table: a
 fields:
   b: B?, relation
           ''',
-        ).build(),
-        ModelSourceBuilder().withFileName('b').withYaml(
-          '''
+      ).build(),
+      ModelSourceBuilder().withFileName('b').withYaml(
+        '''
 class: B
 table: b
 fields:
   a: A?, relation
           ''',
-        ).build(),
-      ];
+      ).build(),
+    ];
 
-      var collector = CodeGenerationCollector();
-      var analyzer =
-          StatefulAnalyzer(config, models, onErrorsCollector(collector));
-      var definitions = analyzer.validateAll();
-      expect(collector.errors, isEmpty);
-
-      sourceDefinition = createDatabaseDefinitionFromModels(
-        definitions,
-        'example',
-        [],
-      );
-    }
-
-    // renames table `target` to `target_new`
-    DatabaseDefinition targetDefinition;
-    {
-      var models = [
-        ModelSourceBuilder().withFileName('a').withYaml(
-          '''
+    var targetModels = [
+      // renames table `target` to `target_new`
+      ModelSourceBuilder().withFileName('a').withYaml(
+        '''
 class: A
 table: a_new
 fields:
   b: B?, relation
           ''',
-        ).build(),
-        ModelSourceBuilder().withFileName('b').withYaml(
-          '''
+      ).build(),
+      ModelSourceBuilder().withFileName('b').withYaml(
+        '''
 class: B
 table: b
 fields:
   a: A?, relation
           ''',
-        ).build(),
-      ];
+      ).build(),
+    ];
 
-      var collector = CodeGenerationCollector();
-      var analyzer =
-          StatefulAnalyzer(config, models, onErrorsCollector(collector));
-      var definitions = analyzer.validateAll();
-      expect(collector.errors, isEmpty);
-
-      targetDefinition = createDatabaseDefinitionFromModels(
-        definitions,
-        'example',
-        [],
-      );
-    }
+    var (:sourceDefinition, :targetDefinition) = databaseDefinitionsFromModels(
+      sourceModels,
+      targetModels,
+    );
 
     var migration = generateDatabaseMigration(
       databaseSource: sourceDefinition,
@@ -306,90 +227,65 @@ fields:
   test(
       'Given two tables that reference each other, when one is renamed, then the migration code should not mention an unrelated table',
       () {
-    DatabaseDefinition sourceDefinition;
-    {
-      var models = [
-        ModelSourceBuilder().withFileName('a').withYaml(
-          '''
+    var sourceModels = [
+      ModelSourceBuilder().withFileName('a').withYaml(
+        '''
 class: A
 table: a
 fields:
   b: B?, relation
           ''',
-        ).build(),
-        ModelSourceBuilder().withFileName('b').withYaml(
-          '''
+      ).build(),
+      ModelSourceBuilder().withFileName('b').withYaml(
+        '''
 class: B
 table: b
 fields:
   a: A?, relation
           ''',
-        ).build(),
-        ModelSourceBuilder().withFileName('c').withYaml(
-          '''
+      ).build(),
+      ModelSourceBuilder().withFileName('c').withYaml(
+        '''
 class: C
 table: c
 fields:
   name: String?
           ''',
-        ).build(),
-      ];
+      ).build(),
+    ];
 
-      var collector = CodeGenerationCollector();
-      var analyzer =
-          StatefulAnalyzer(config, models, onErrorsCollector(collector));
-      var definitions = analyzer.validateAll();
-      expect(collector.errors, isEmpty);
-
-      sourceDefinition = createDatabaseDefinitionFromModels(
-        definitions,
-        'example',
-        [],
-      );
-    }
-
-    // renames table `target` to `target_new`
-    DatabaseDefinition targetDefinition;
-    {
-      var models = [
-        ModelSourceBuilder().withFileName('a').withYaml(
-          '''
+    var targetModels = [
+      // renames table `target` to `target_new`
+      ModelSourceBuilder().withFileName('a').withYaml(
+        '''
 class: A
 table: a_new
 fields:
   b: B?, relation
           ''',
-        ).build(),
-        ModelSourceBuilder().withFileName('b').withYaml(
-          '''
+      ).build(),
+      ModelSourceBuilder().withFileName('b').withYaml(
+        '''
 class: B
 table: b
 fields:
   a: A?, relation
           ''',
-        ).build(),
-        ModelSourceBuilder().withFileName('c').withYaml(
-          '''
+      ).build(),
+      ModelSourceBuilder().withFileName('c').withYaml(
+        '''
 class: C
 table: c
 fields:
   name: String?
           ''',
-        ).build(),
-      ];
+      ).build(),
+    ];
 
-      var collector = CodeGenerationCollector();
-      var analyzer =
-          StatefulAnalyzer(config, models, onErrorsCollector(collector));
-      var definitions = analyzer.validateAll();
-      expect(collector.errors, isEmpty);
-
-      targetDefinition = createDatabaseDefinitionFromModels(
-        definitions,
-        'example',
-        [],
-      );
-    }
+    var (:sourceDefinition, :targetDefinition) = databaseDefinitionsFromModels(
+      sourceModels,
+      targetModels,
+    );
 
     var migration = generateDatabaseMigration(
       databaseSource: sourceDefinition,
@@ -404,75 +300,50 @@ fields:
   test(
       'Given a table that is referenced by another one, when it is renamed while the pointing table is dropping the reference column, then the migration code should only drop and recreate the renamed table and drop just the column on the "pointing" one',
       () {
-    DatabaseDefinition sourceDefinition;
-    {
-      var models = [
-        ModelSourceBuilder().withFileName('target').withYaml(
-          '''
+    var sourceModels = [
+      ModelSourceBuilder().withFileName('target').withYaml(
+        '''
 class: Target
 table: target
 fields:
   name: String
           ''',
-        ).build(),
-        ModelSourceBuilder().withFileName('source').withYaml(
-          '''
+      ).build(),
+      ModelSourceBuilder().withFileName('source').withYaml(
+        '''
 class: Source
 table: source
 fields:
   name: String
   target: Target?, relation
           ''',
-        ).build(),
-      ];
+      ).build(),
+    ];
 
-      var collector = CodeGenerationCollector();
-      var analyzer =
-          StatefulAnalyzer(config, models, onErrorsCollector(collector));
-      var definitions = analyzer.validateAll();
-      expect(collector.errors, isEmpty);
-
-      sourceDefinition = createDatabaseDefinitionFromModels(
-        definitions,
-        'example',
-        [],
-      );
-    }
-
-    DatabaseDefinition
-        targetDefinition; // renames table `target` to `target_new` and `Source` drops the reference to `Target`
-    {
-      var models = [
-        ModelSourceBuilder().withFileName('target').withYaml(
-          '''
+    var targetModels = [
+      // renames table `target` to `target_new` and `Source` drops the reference to `Target`
+      ModelSourceBuilder().withFileName('target').withYaml(
+        '''
 class: Target
 table: target_new
 fields:
   name: String
           ''',
-        ).build(),
-        ModelSourceBuilder().withFileName('source').withYaml(
-          '''
+      ).build(),
+      ModelSourceBuilder().withFileName('source').withYaml(
+        '''
 class: Source
 table: source
 fields:
   name: String
           ''',
-        ).build(),
-      ];
+      ).build(),
+    ];
 
-      var collector = CodeGenerationCollector();
-      var analyzer =
-          StatefulAnalyzer(config, models, onErrorsCollector(collector));
-      var definitions = analyzer.validateAll();
-      expect(collector.errors, isEmpty);
-
-      targetDefinition = createDatabaseDefinitionFromModels(
-        definitions,
-        'example',
-        [],
-      );
-    }
+    var (:sourceDefinition, :targetDefinition) = databaseDefinitionsFromModels(
+      sourceModels,
+      targetModels,
+    );
 
     var migration = generateDatabaseMigration(
       databaseSource: sourceDefinition,

--- a/tools/serverpod_cli/test/test_util/database_definition_helpers.dart
+++ b/tools/serverpod_cli/test/test_util/database_definition_helpers.dart
@@ -1,0 +1,33 @@
+import 'package:serverpod_cli/src/analyzer/models/stateful_analyzer.dart';
+import 'package:serverpod_cli/src/database/create_definition.dart';
+import 'package:serverpod_cli/src/generator/code_generation_collector.dart';
+import 'package:serverpod_cli/src/util/model_helper.dart';
+import 'package:serverpod_service_client/serverpod_service_client.dart';
+
+import '../generator/dart/client_code_generator/class_constructors_test.dart';
+
+({DatabaseDefinition sourceDefinition, DatabaseDefinition targetDefinition})
+    databaseDefinitionsFromModels(
+  List<ModelSource> sourceModels,
+  List<ModelSource> targetModels,
+) {
+  DatabaseDefinition createDefinition(models) {
+    var collector = CodeGenerationCollector();
+    var analyzer =
+        StatefulAnalyzer(config, models, onErrorsCollector(collector));
+    var definitions = analyzer.validateAll();
+    assert(collector.errors.isEmpty,
+        'Errors found during analysis: ${collector.errors}');
+
+    return createDatabaseDefinitionFromModels(
+      definitions,
+      'example',
+      [],
+    );
+  }
+
+  return (
+    sourceDefinition: createDefinition(sourceModels),
+    targetDefinition: createDefinition(targetModels)
+  );
+}


### PR DESCRIPTION
Fixes: #3503 

When foreign keys where created as part of altering migrations in the migration system these where placed together with the other alterations to the table and not last in the file.

This caused an issue when a new table was referenced from an old table, but the creation of the new table was placed after the alterations to the old table in the migration file.

More concrete examples of the issue are included in the tests.

**Additional question**

The helper introduced in `migration_pgsql_code_generation_test.dart` could be extracted and used in `migration_with_many_to_many_relation_pgsql_code_generation_test.dart`. This would significantly reduce the footprint of that file while abstracting away non-essential boilerplate.

Should I migrate the old file?

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None - Simply fixes a bug in the migration system