### PR TITLE
fix: Respons with 503 when server is unhealthy

### DIFF
--- a/packages/serverpod/lib/src/server/server.dart
+++ b/packages/serverpod/lib/src/server/server.dart
@@ -245,6 +245,7 @@ class Server {
       if (allOk) {
         request.response.writeln('OK ${DateTime.now().toUtc()}');
       } else {
+        request.response.statusCode = HttpStatus.serviceUnavailable;
         request.response.writeln('SADNESS ${DateTime.now().toUtc()}');
       }
       for (var issue in issues) {


### PR DESCRIPTION
# Changes

Previously, the health check responded with status code 200 even when the services was unhealthy. This will be interpreted as healthy by other systems such as when a loadbalancer checks if the server is available. 

To make sure traffic is not routed to unhealthy instances we now give back 503 instead.

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

## Breaking changes

None