### PR TITLE
feat: Set module integration test concurrency to 1

### DIFF
--- a/.github/workflows/dart-tests.yaml
+++ b/.github/workflows/dart-tests.yaml
@@ -261,11 +261,11 @@ jobs:
           ./wait-for-it.sh localhost:9091 -t 60 -- echo "### Redis is UP at :9091"
         working-directory: tests/docker/tests_integration
       - name: Run integration tests
-        run: dart test -t integration
+        run: dart test -t integration --concurrency=1
         working-directory: ${{ matrix.module }}
       - name: Stop containers
         if: always()
-        run: docker compose down
+        run: docker compose down -v
         working-directory: ${{ matrix.module }}
 
   integration_test_server:


### PR DESCRIPTION
Because the DB setup/migrations across `withServerpod` calls in multiple test files are not synchronized, so they can create conflicts when using 2 or more such calls.

As these are modules, there is no `--apply-migrations` to be done outside the tests (as far as I can see).

Further this removes the test volumes from Docker after a test completed. (This was not an issue in practice, but seems cleaner.)

This change fixes the previously broken module test in https://github.com/serverpod/serverpod/actions/runs/14883049192?pr=3441, which was using 2 `withServerpod` calls.