### PR TITLE
fix: Prevent possibility of multiple migrations being applied at the same time.

### DIFF
--- a/.github/workflows/dart-tests.yaml
+++ b/.github/workflows/dart-tests.yaml
@@ -264,7 +264,7 @@ jobs:
           ./wait-for-it.sh localhost:9091 -t 60 -- echo "### Redis is UP at :9091"
         working-directory: tests/docker/tests_integration
       - name: Run integration tests
-        run: dart test -t integration --concurrency=1
+        run: dart test -t integration
         working-directory: ${{ matrix.module }}
       - name: Stop containers
         if: always()

--- a/packages/serverpod/lib/src/database/migrations/migration_manager.dart
+++ b/packages/serverpod/lib/src/database/migrations/migration_manager.dart
@@ -200,7 +200,9 @@ class MigrationManager {
     availableVersions.clear();
     var warnings = <String>[];
     try {
-      availableVersions.addAll(MigrationVersions.listVersions());
+      availableVersions.addAll(MigrationVersions.listVersions(
+        projectDirectory: _projectDirectory,
+      ));
     } catch (e) {
       warnings.add(
           'Failed to determine migration versions for project: ${e.toString()}');

--- a/packages/serverpod/lib/src/database/migrations/migration_manager.dart
+++ b/packages/serverpod/lib/src/database/migrations/migration_manager.dart
@@ -52,7 +52,7 @@ class MigrationManager {
 
   /// Returns true if the database structure is up to date. If not, it will
   /// print a warning to stderr.
-  Future<bool> verifyDatabaseIntegrity(Session session) async {
+  static Future<bool> verifyDatabaseIntegrity(Session session) async {
     var warnings = <String>[];
 
     var liveDatabase = await DatabaseAnalyzer.analyze(session.db);

--- a/packages/serverpod/lib/src/database/migrations/migration_manager.dart
+++ b/packages/serverpod/lib/src/database/migrations/migration_manager.dart
@@ -21,9 +21,9 @@ class MigrationManager {
   /// directory. Available after [initialize] has been called.
   final List<String> availableVersions = [];
 
-  /// Initializing the [MigrationManager] by loading the current version
+  /// Updates the state of the [MigrationManager] by loading the current version
   /// from the database and available migrations.
-  Future<void> _initialize(Session session) async {
+  Future<void> _updateState(Session session) async {
     installedVersions.clear();
     try {
       installedVersions.addAll(await DatabaseMigrationVersion.db.find(session));
@@ -158,7 +158,7 @@ class MigrationManager {
         repairMigration.sqlMigration,
       );
 
-      await _initialize(session);
+      await _updateState(session);
     });
 
     return appliedVersionName;
@@ -172,7 +172,7 @@ class MigrationManager {
     List<String>? migrationsApplied = [];
 
     await _withMigrationLock(session, () async {
-      await _initialize(session);
+      await _updateState(session);
       var latestVersion = getLatestVersion();
 
       var moduleName = session.serverpod.serializationManager.getModuleName();
@@ -189,7 +189,7 @@ class MigrationManager {
         latestVersion: latestVersion,
         fromVersion: installedVersion,
       );
-      await _initialize(session);
+      await _updateState(session);
     });
 
     return migrationsApplied;

--- a/packages/serverpod/lib/src/database/migrations/migration_manager.dart
+++ b/packages/serverpod/lib/src/database/migrations/migration_manager.dart
@@ -53,7 +53,7 @@ class MigrationManager {
 
   /// Returns the installed version of the given module, or null if no version
   /// is installed.
-  String? getInstalledVersion(String module) {
+  String? _getInstalledVersion(String module) {
     var installed = installedVersions.firstWhereOrNull(
       (element) => element.module == module,
     );
@@ -64,20 +64,15 @@ class MigrationManager {
   }
 
   /// Returns the latest version of the given module from available migrations.
-  String getLatestVersion() {
+  String _getLatestVersion() {
     if (availableVersions.isEmpty) {
       throw Exception('No migrations found in project.');
     }
     return availableVersions.last;
   }
 
-  /// Returns true if any version of the given module is installed.
-  bool isAnyInstalled(String module) {
-    return getInstalledVersion(module) != null;
-  }
-
   /// Returns true if the latest version of a module is installed.
-  bool isVersionInstalled(String module, String version) {
+  bool _isVersionInstalled(String module, String version) {
     var installed = installedVersions.firstWhereOrNull(
       (element) => element.module == module,
     );
@@ -96,16 +91,16 @@ class MigrationManager {
 
     await _withMigrationLock(session, () async {
       await _updateState(session);
-      var latestVersion = getLatestVersion();
+      var latestVersion = _getLatestVersion();
 
       var moduleName = session.serverpod.serializationManager.getModuleName();
 
-      if (isVersionInstalled(moduleName, latestVersion)) {
+      if (_isVersionInstalled(moduleName, latestVersion)) {
         migrationsApplied = null;
         return;
       }
 
-      var installedVersion = getInstalledVersion(moduleName);
+      var installedVersion = _getInstalledVersion(moduleName);
 
       migrationsApplied = await _migrateToLatestModule(
         session,

--- a/packages/serverpod/lib/src/database/migrations/migration_manager.dart
+++ b/packages/serverpod/lib/src/database/migrations/migration_manager.dart
@@ -51,37 +51,6 @@ class MigrationManager {
     return appliedVersionName;
   }
 
-  /// Returns the installed version of the given module, or null if no version
-  /// is installed.
-  String? _getInstalledVersion(String module) {
-    var installed = installedVersions.firstWhereOrNull(
-      (element) => element.module == module,
-    );
-    if (installed == null) {
-      return null;
-    }
-    return installed.version;
-  }
-
-  /// Returns the latest version of the given module from available migrations.
-  String _getLatestVersion() {
-    if (availableVersions.isEmpty) {
-      throw Exception('No migrations found in project.');
-    }
-    return availableVersions.last;
-  }
-
-  /// Returns true if the latest version of a module is installed.
-  bool _isVersionInstalled(String module, String version) {
-    var installed = installedVersions.firstWhereOrNull(
-      (element) => element.module == module,
-    );
-    if (installed == null) {
-      return false;
-    }
-    return version == installed.version;
-  }
-
   /// Migrates all modules to the latest version.
   ///
   /// Returns the migrations applied.
@@ -113,6 +82,26 @@ class MigrationManager {
     return migrationsApplied;
   }
 
+  /// Returns the installed version of the given module, or null if no version
+  /// is installed.
+  String? _getInstalledVersion(String module) {
+    var installed = installedVersions.firstWhereOrNull(
+      (element) => element.module == module,
+    );
+    if (installed == null) {
+      return null;
+    }
+    return installed.version;
+  }
+
+  /// Returns the latest version of the given module from available migrations.
+  String _getLatestVersion() {
+    if (availableVersions.isEmpty) {
+      throw Exception('No migrations found in project.');
+    }
+    return availableVersions.last;
+  }
+
   /// Lists all versions newer than the given version for the given module.
   List<String> _getVersionsToApply(String fromVersion) {
     if (availableVersions.isEmpty) return [];
@@ -122,6 +111,17 @@ class MigrationManager {
       throw Exception('Version $fromVersion not found in project.');
     }
     return availableVersions.sublist(index + 1);
+  }
+
+  /// Returns true if the latest version of a module is installed.
+  bool _isVersionInstalled(String module, String version) {
+    var installed = installedVersions.firstWhereOrNull(
+      (element) => element.module == module,
+    );
+    if (installed == null) {
+      return false;
+    }
+    return version == installed.version;
   }
 
   Future<List<({String version, String sql})>> _loadMigrationSQL(

--- a/packages/serverpod/lib/src/database/migrations/migration_manager.dart
+++ b/packages/serverpod/lib/src/database/migrations/migration_manager.dart
@@ -13,6 +13,8 @@ import '../extensions.dart';
 
 /// The migration manager handles migrations of the database.
 class MigrationManager {
+  final Directory _projectDirectory;
+
   /// List of installed migration versions. Available after [initialize] has
   /// been called.
   final List<DatabaseMigrationVersion> installedVersions = [];
@@ -21,9 +23,14 @@ class MigrationManager {
   /// directory. Available after [initialize] has been called.
   final List<String> availableVersions = [];
 
+  /// Creates a new migration manager.
+  ///
+  /// The [projectDirectory] is the directory where the project is located.
+  MigrationManager(this._projectDirectory);
+
   /// Applies the repair migration to the database.
   Future<String?> applyRepairMigration(Session session) async {
-    var repairMigration = RepairMigration.load(Directory.current);
+    var repairMigration = RepairMigration.load(_projectDirectory);
     if (repairMigration == null) {
       return null;
     }
@@ -132,7 +139,7 @@ class MigrationManager {
 
     if (fromVersion == null) {
       var definitionSqlFile = MigrationConstants.databaseDefinitionSQLPath(
-        Directory.current,
+        _projectDirectory,
         latestVersion,
       );
       var sqlDefinition = await definitionSqlFile.readAsString();
@@ -143,7 +150,7 @@ class MigrationManager {
 
       for (var version in newerVersions) {
         var migrationSqlFile = MigrationConstants.databaseMigrationSQLPath(
-          Directory.current,
+          _projectDirectory,
           version,
         );
         var sqlMigration = await migrationSqlFile.readAsString();

--- a/packages/serverpod/lib/src/database/migrations/migration_manager.dart
+++ b/packages/serverpod/lib/src/database/migrations/migration_manager.dart
@@ -210,7 +210,7 @@ class MigrationManager {
     /// The transaction is thus only used to get the desired behavior from
     /// the database driver, and does not have any effect on the Postgres level.
     ///
-    /// This ensures that we are only running migrations once at a time.
+    /// This ensures that we are only running migrations one at a time.
     await session.db.transaction((transaction) async {
       await session.db.unsafeExecute(
         "SELECT pg_advisory_lock(hashtext('$lockName'));",

--- a/packages/serverpod/lib/src/database/migrations/migration_manager.dart
+++ b/packages/serverpod/lib/src/database/migrations/migration_manager.dart
@@ -204,6 +204,12 @@ class MigrationManager {
     /// Use a transaction to ensure that the advisory lock is retained
     /// until the transaction is completed.
     ///
+    /// The transaction ensures that the session used for acquiring the
+    /// lock is kept alive in the underlying connection pool, and that we
+    /// can later use that exact same session for releasing the lock.
+    /// The transaction is thus only used to get the desired behavior from
+    /// the database driver, and does not have any effect on the Postgres level.
+    ///
     /// This ensures that we are only running migrations once at a time.
     await session.db.transaction((transaction) async {
       await session.db.unsafeExecute(

--- a/packages/serverpod/lib/src/database/migrations/migrations.dart
+++ b/packages/serverpod/lib/src/database/migrations/migrations.dart
@@ -9,9 +9,10 @@ class MigrationVersions {
   /// Returns an empty list if no migrations are available or if the module
   /// directory does not exist.
   static List<String> listVersions({
-    Directory? directory,
+    required Directory projectDirectory,
   }) {
-    directory ??= defaultMigrationsDirectory;
+    var directory =
+        MigrationConstants.migrationsBaseDirectory(projectDirectory);
 
     var moduleDirectory = Directory(path.join(
       directory.path,
@@ -28,8 +29,4 @@ class MigrationVersions {
 
     return migrationVersions;
   }
-
-  /// Gets the default migrations directory.
-  static Directory get defaultMigrationsDirectory =>
-      MigrationConstants.migrationsBaseDirectory(Directory.current);
 }

--- a/packages/serverpod/lib/src/endpoints/insights.dart
+++ b/packages/serverpod/lib/src/endpoints/insights.dart
@@ -212,9 +212,6 @@ class InsightsEndpoint extends Endpoint {
     // Get database definition of the live database.
     var databaseDefinition = await DatabaseAnalyzer.analyze(session.db);
 
-    // Make sure that the migration manager is up-to-date.
-    await session.serverpod.migrationManager.initialize(session);
-
     return databaseDefinition;
   }
 

--- a/packages/serverpod/lib/src/endpoints/insights.dart
+++ b/packages/serverpod/lib/src/endpoints/insights.dart
@@ -224,7 +224,9 @@ class InsightsEndpoint extends Endpoint {
     var installedMigrations =
         await DatabaseAnalyzer.getInstalledMigrationVersions(session);
 
-    var versions = MigrationVersions.listVersions();
+    var versions = MigrationVersions.listVersions(
+      projectDirectory: Directory.current,
+    );
 
     var latestAvailableMigrations = <DatabaseMigrationVersion>[];
     if (versions.isNotEmpty) {

--- a/packages/serverpod/lib/src/server/serverpod.dart
+++ b/packages/serverpod/lib/src/server/serverpod.dart
@@ -548,6 +548,8 @@ class Serverpod {
         applyRepairMigration: commandLineArgs.applyRepairMigration,
         applyMigrations: commandLineArgs.applyMigrations,
       );
+
+      await _loadRuntimeSettings();
     } else if (commandLineArgs.applyMigrations ||
         commandLineArgs.applyRepairMigration) {
       stderr.writeln(
@@ -694,8 +696,6 @@ class Serverpod {
       const message = 'Failed to apply database migrations.';
       _reportException(e, stackTrace, message: message);
     }
-
-    await _loadRuntimeSettings();
   }
 
   Future<void> _loadRuntimeSettings() async {

--- a/packages/serverpod/lib/src/server/serverpod.dart
+++ b/packages/serverpod/lib/src/server/serverpod.dart
@@ -637,7 +637,7 @@ class Serverpod {
   }) async {
     try {
       logVerbose('Initializing migration manager.');
-      var migrationManager = MigrationManager();
+      var migrationManager = MigrationManager(Directory.current);
 
       if (applyRepairMigration) {
         logVerbose('Applying database repair migration');

--- a/packages/serverpod/lib/src/server/serverpod.dart
+++ b/packages/serverpod/lib/src/server/serverpod.dart
@@ -638,7 +638,6 @@ class Serverpod {
     try {
       logVerbose('Initializing migration manager.');
       var migrationManager = MigrationManager();
-      await migrationManager.initialize(internalSession);
 
       if (applyRepairMigration) {
         logVerbose('Applying database repair migration');
@@ -650,7 +649,6 @@ class Serverpod {
           stdout.writeln(
               'Database repair migration "$appliedRepairMigration" applied.');
         }
-        await migrationManager.initialize(internalSession);
       }
 
       if (applyMigrations) {
@@ -667,8 +665,6 @@ class Serverpod {
             stdout.writeln(' - $migration');
           }
         }
-
-        await migrationManager.initialize(internalSession);
       }
 
       logVerbose('Verifying database integrity.');

--- a/packages/serverpod/lib/src/server/serverpod.dart
+++ b/packages/serverpod/lib/src/server/serverpod.dart
@@ -526,10 +526,6 @@ class Serverpod {
     // attempting to connect to the database.
     _databasePoolManager?.start();
 
-    if (_databasePoolManager == null) {
-      _runtimeSettings = _defaultRuntimeSettings;
-    }
-
     if (Features.enableMigrations) {
       int? maxAttempts =
           commandLineArgs.role == ServerpodRole.maintenance ? 6 : null;

--- a/packages/serverpod/lib/src/server/serverpod.dart
+++ b/packages/serverpod/lib/src/server/serverpod.dart
@@ -142,20 +142,6 @@ class Serverpod {
     return server;
   }
 
-  MigrationManager? _migrationManager;
-
-  /// The migration manager used by this [Serverpod].
-  MigrationManager get migrationManager {
-    var manager = _migrationManager;
-    if (manager == null) {
-      throw StateError(
-        'Migrations are disabled, supply a database configuration '
-        'to enable this feature.',
-      );
-    }
-    return manager;
-  }
-
   late LogManager _logManager;
 
   /// The [LogManager] of the Serverpod, its typically only used internally
@@ -651,7 +637,7 @@ class Serverpod {
   }) async {
     try {
       logVerbose('Initializing migration manager.');
-      _migrationManager = MigrationManager();
+      var migrationManager = MigrationManager();
       await migrationManager.initialize(internalSession);
 
       if (applyRepairMigration) {

--- a/packages/serverpod/lib/src/server/serverpod.dart
+++ b/packages/serverpod/lib/src/server/serverpod.dart
@@ -690,6 +690,10 @@ class Serverpod {
       _reportException(e, stackTrace, message: message);
     }
 
+    await _loadRuntimeSettings();
+  }
+
+  Future<void> _loadRuntimeSettings() async {
     logVerbose('Loading runtime settings.');
     try {
       _runtimeSettings =

--- a/packages/serverpod/lib/src/server/serverpod.dart
+++ b/packages/serverpod/lib/src/server/serverpod.dart
@@ -672,7 +672,7 @@ class Serverpod {
       }
 
       logVerbose('Verifying database integrity.');
-      await migrationManager.verifyDatabaseIntegrity(internalSession);
+      await MigrationManager.verifyDatabaseIntegrity(internalSession);
     } catch (e, stackTrace) {
       _exitCode = 1;
       const message = 'Failed to apply database migrations.';

--- a/templates/pubspecs/tests/serverpod_test_server/pubspec.yaml
+++ b/templates/pubspecs/tests/serverpod_test_server/pubspec.yaml
@@ -25,6 +25,7 @@ dev_dependencies:
   lints: '>=3.0.0 <6.0.0'
   test: ^1.24.2
   path: ^1.8.2
+  test_descriptor: ^2.0.2
   serverpod_cli: SERVERPOD_VERSION
   serverpod_service_client: SERVERPOD_VERSION
   serverpod_test_client:

--- a/tests/serverpod_test_server/pubspec.yaml
+++ b/tests/serverpod_test_server/pubspec.yaml
@@ -26,6 +26,7 @@ dev_dependencies:
   lints: '>=3.0.0 <6.0.0'
   test: ^1.24.2
   path: ^1.8.2
+  test_descriptor: ^2.0.2
   serverpod_cli: 2.6.0
   serverpod_service_client: 2.6.0
   serverpod_test_client:

--- a/tests/serverpod_test_server/test_integration/migration_manager/concurrent_migration_test.dart
+++ b/tests/serverpod_test_server/test_integration/migration_manager/concurrent_migration_test.dart
@@ -1,0 +1,98 @@
+import 'dart:io';
+
+import 'package:serverpod_test_server/test_util/test_tags.dart';
+import 'package:test/test.dart';
+import 'package:uuid/uuid.dart';
+
+import '../test_tools/serverpod_test_tools.dart';
+import 'package:test_descriptor/test_descriptor.dart' as d;
+import 'package:serverpod/src/database/migrations/migration_manager.dart';
+import 'package:serverpod/src/database/migrations/migrations.dart';
+import 'package:serverpod_cli/src/migrations/generator.dart';
+
+void main() {
+  final existingMigrations = MigrationVersions.listVersions(
+    projectDirectory: Directory.current,
+  );
+
+  withServerpod(
+      rollbackDatabase: RollbackDatabase.disabled,
+      testGroupTagsOverride: [TestTags.concurrencyOneTestTag],
+      'Given unapplied migration that errors if applied multiple times',
+      (sessionBuilder, _) async {
+    final migrationName = MigrationGenerator.createVersionName(null);
+    final migrationRegistryContents =
+        [...existingMigrations, migrationName].join('\n');
+    final testTableName = 'test_table_${const Uuid().v4().replaceAll('-', '')}';
+    final sqlThatThrowsIfAppliedMultipleTimes = '''
+      BEGIN;
+
+      CREATE TABLE ${testTableName} (
+        id INT PRIMARY KEY,
+        name VARCHAR(255) NOT NULL
+      );
+
+      -- Sleep for 1 second to ensure multiple concurrent migrations
+      -- are triggered at the same time
+      SELECT pg_sleep(1);
+
+      --
+      -- MIGRATION VERSION FOR serverpod_test
+      --
+      INSERT INTO "serverpod_migrations" ("module", "version", "timestamp")
+          VALUES ('serverpod_test', '${migrationName}', now())
+          ON CONFLICT ("module")
+          DO UPDATE SET "version" = '${migrationName}', "timestamp" = now();
+
+      COMMIT;
+    ''';
+
+    setUp(() async {
+      await d.dir('migrations', [
+        d.file('migration_registry.txt', migrationRegistryContents),
+        for (var version in existingMigrations) d.dir(version, []),
+        d.dir(migrationName, [
+          d.file('definition_project.json', ''),
+          d.file('definition.json', ''),
+          d.file('migration.json', ''),
+          d.file('migration.sql', sqlThatThrowsIfAppliedMultipleTimes),
+          d.file('definition.sql', sqlThatThrowsIfAppliedMultipleTimes),
+        ])
+      ]).create();
+    });
+
+    tearDown(() async {
+      var session = sessionBuilder.build();
+      await session.db.unsafeExecute('''
+        BEGIN; 
+
+        DROP TABLE IF EXISTS ${testTableName};
+
+        --
+        -- MIGRATION VERSION FOR serverpod_test
+        --
+        INSERT INTO "serverpod_migrations" ("module", "version", "timestamp")
+            VALUES ('serverpod_test', '${existingMigrations.last}', now())
+            ON CONFLICT ("module")
+            DO UPDATE SET "version" = '${existingMigrations.last}', "timestamp" = now();
+
+        COMMIT;
+      ''');
+    });
+
+    test(
+        'when triggering multiple concurrent then migration is successfully applied once',
+        () async {
+      var migrationManager = MigrationManager(
+        Directory(d.sandbox),
+      );
+
+      var concurrentMigrations = Future.wait([
+        migrationManager.migrateToLatest(sessionBuilder.build()),
+        migrationManager.migrateToLatest(sessionBuilder.build()),
+      ]);
+
+      expect(concurrentMigrations, completes);
+    });
+  });
+}

--- a/tests/serverpod_test_server/test_integration/migration_manager/concurrent_repair_migration_test.dart
+++ b/tests/serverpod_test_server/test_integration/migration_manager/concurrent_repair_migration_test.dart
@@ -1,0 +1,83 @@
+import 'dart:io';
+
+import 'package:serverpod_test_server/test_util/test_tags.dart';
+import 'package:test/test.dart';
+import 'package:uuid/uuid.dart';
+
+import '../test_tools/serverpod_test_tools.dart';
+import 'package:test_descriptor/test_descriptor.dart' as d;
+import 'package:serverpod/src/database/migrations/migration_manager.dart';
+import 'package:serverpod_cli/src/migrations/generator.dart';
+
+void main() {
+  withServerpod(
+      rollbackDatabase: RollbackDatabase.disabled,
+      testGroupTagsOverride: [TestTags.concurrencyOneTestTag],
+      'Given unapplied repair migration that errors if applied multiple times',
+      (sessionBuilder, _) async {
+    final migrationName = MigrationGenerator.createVersionName(null);
+    final testTableName = 'test_table_${const Uuid().v4().replaceAll('-', '')}';
+    final sqlThatThrowsIfAppliedMultipleTimes = '''
+      BEGIN;
+
+      CREATE TABLE ${testTableName} (
+        id INT PRIMARY KEY,
+        name VARCHAR(255) NOT NULL
+      );
+
+      -- Sleep for 1 second to ensure multiple concurrent migrations
+      -- are triggered at the same time
+      SELECT pg_sleep(1);
+
+      --
+      -- MIGRATION VERSION FOR _repair
+      --
+      INSERT INTO "serverpod_migrations" ("module", "version", "timestamp")
+          VALUES ('_repair', '${migrationName}', now())
+          ON CONFLICT ("module")
+          DO UPDATE SET "version" = '${migrationName}', "timestamp" = now();
+
+
+      COMMIT;
+    ''';
+
+    setUp(() async {
+      await d.dir('repair-migration', [
+        d.file('${migrationName}.sql', sqlThatThrowsIfAppliedMultipleTimes),
+      ]).create();
+    });
+
+    tearDown(() async {
+      var session = sessionBuilder.build();
+      await session.db.unsafeExecute('''
+        BEGIN; 
+
+        DROP TABLE IF EXISTS ${testTableName};
+
+        --
+        -- MIGRATION VERSION FOR serverpod_test
+        --
+        DELETE FROM "serverpod_migrations"
+          WHERE "module" = '_repair'
+          AND "version" = '${migrationName}';
+
+        COMMIT;
+      ''');
+    });
+
+    test(
+        'when triggering multiple concurrent repair migrations then migration is successfully applied once',
+        () async {
+      var migrationManager = MigrationManager(
+        Directory(d.sandbox),
+      );
+
+      var concurrentMigrations = Future.wait([
+        migrationManager.applyRepairMigration(sessionBuilder.build()),
+        migrationManager.applyRepairMigration(sessionBuilder.build()),
+      ]);
+
+      expect(concurrentMigrations, completes);
+    });
+  });
+}


### PR DESCRIPTION
Closes: #3504 

This PR introduces an advisory lock that is used whenever migrations towards the database are applied.

This ensures that even in an environment where mutliple servers have the `--apply-migration` flag turned on, only one of them will make modifications to the database at the same time.

This makes the full migration script atomic.

This issue was encountered when running integration tests using the test framework since that would spawn multiple isolates that each would start a Serverpod server, resulting in a race condition when applying the migrations.

### Additional changes
- Makes the MigrationManager private on Serverpod. This is technically a breaking change, but it should never be used by external users.
- Removes updating the state of the MigrationManager when fetching the live database definition. Since the migrations are only run on Server start, updating the state is redundant.
- Refactor Serverpod startup to isolate applying the migration from other database operations. This allows us to easily expose running the migrations at a later step.

### Test question

I'm not sure how to reliably test this. The last commit enables tests that would otherwise fail if the initialization did not work as expected.

But I think that any test we could create would have the chance of producing false positives without a complicated test setup (custom migrations with delays).

I have manually validated the changes to ensure they work as expected.

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None - this should simply be a bug fix.