### PR TITLE
fix: Always print when closing the log.

### DIFF
--- a/packages/serverpod/lib/src/server/log_manager/log_writers.dart
+++ b/packages/serverpod/lib/src/server/log_manager/log_writers.dart
@@ -164,8 +164,6 @@ class DatabaseLogWriter extends LogWriter {
 class StdOutLogWriter extends LogWriter {
   final int _logId;
 
-  SessionLogEntry? _entry;
-
   StdOutLogWriter(Session session) : _logId = session.sessionId.hashCode;
 
   @override
@@ -206,7 +204,6 @@ class StdOutLogWriter extends LogWriter {
   @override
   Future<void> openLog(SessionLogEntry entry) async {
     entry.id = _logId;
-    _entry = entry;
 
     if (entry.error != null) {
       stderr.writeln(entry);
@@ -217,8 +214,6 @@ class StdOutLogWriter extends LogWriter {
 
   @override
   Future<int> closeLog(SessionLogEntry entry) async {
-    if (_entry != null) return _logId;
-
     entry.id = _logId;
 
     if (entry.error != null) {


### PR DESCRIPTION
Closes: #3535 

Fixes an issue where we would not print the duration of request when doing console logging.

This was found when prepping the "pretty print" logging that is part of #3510.
## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None, simple additional log entry.