### PR TITLE
fix: Avoid generating random UUIDv7 function when not used in migrations

### DIFF
--- a/tools/serverpod_cli/lib/src/database/extensions.dart
+++ b/tools/serverpod_cli/lib/src/database/extensions.dart
@@ -449,8 +449,19 @@ extension DatabaseMigrationPgSqlGenerator on DatabaseMigration {
     out += '\n';
 
     // Must be declared at the beginning for the function to be available.
-    out += _sqlUuidGenerateV7FunctionDeclaration();
-    out += '\n';
+    // Only add the function if it is used by any column on the migration.
+    if (actions.any((e) =>
+        (e.createTable != null &&
+            e.createTable!.columns
+                .any((c) => c.columnDefault == pgsqlFunctionRandomUuidV7)) ||
+        (e.alterTable != null &&
+            (e.alterTable!.addColumns
+                    .any((c) => c.columnDefault == pgsqlFunctionRandomUuidV7) ||
+                e.alterTable!.modifyColumns
+                    .any((c) => c.newDefault == pgsqlFunctionRandomUuidV7))))) {
+      out += _sqlUuidGenerateV7FunctionDeclaration();
+      out += '\n';
+    }
 
     var foreignKeyActions = '';
     for (var action in actions) {


### PR DESCRIPTION
On #3473, the declaration of the UUIDv7 generation function on the `definitions.sql` happens only when any table uses it, but the `migration.sql` was having it included always. This PR fixes it, making the declaration on the `migration.sql` to also be conditional to the function usage as default on any table.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

No breaking changes.