### PR TITLE
chore: Add missing dependency override in serverpod_auth_user_server.

### DIFF
--- a/modules/new_serverpod_auth/serverpod_auth_user/serverpod_auth_user_server/pubspec.yaml
+++ b/modules/new_serverpod_auth/serverpod_auth_user/serverpod_auth_user_server/pubspec.yaml
@@ -24,5 +24,7 @@ dependency_overrides:
     path: ../../../../packages/serverpod_lints
   serverpod_serialization:
     path: ../../../../packages/serverpod_serialization
+  serverpod_shared:
+    path: ../../../../packages/serverpod_shared
   serverpod_test:
     path: ../../../../packages/serverpod_test

--- a/templates/pubspecs/modules/new_serverpod_auth/serverpod_auth_user/serverpod_auth_user_server/pubspec.yaml
+++ b/templates/pubspecs/modules/new_serverpod_auth/serverpod_auth_user/serverpod_auth_user_server/pubspec.yaml
@@ -23,5 +23,7 @@ dependency_overrides:
     path: ../../../../packages/serverpod_lints
   serverpod_serialization:
     path: ../../../../packages/serverpod_serialization
+  serverpod_shared:
+    path: ../../../../packages/serverpod_shared
   serverpod_test:
     path: ../../../../packages/serverpod_test


### PR DESCRIPTION
Noticed a missed dependency override when creating the 2.7.0 release.

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None - simple dev override addition.