### PR TITLE
docs: Add unit to future call scan interval config example.

### DIFF
--- a/templates/serverpod_templates/projectname_server_upgrade/config/development.yaml
+++ b/templates/serverpod_templates/projectname_server_upgrade/config/development.yaml
@@ -53,4 +53,4 @@ sessionLogs:
 
 #futureCall:
 #  concurrencyLimit: 1 # Defaults to 1, a negative or null value removes the limit
-#  scanInterval: 5000 # Defaults to 5000
+#  scanInterval: 5000 # Unit in milliseconds, defaults to 5000ms

--- a/templates/serverpod_templates/projectname_server_upgrade/config/production.yaml
+++ b/templates/serverpod_templates/projectname_server_upgrade/config/production.yaml
@@ -57,4 +57,4 @@ sessionLogs:
 
 #futureCall:
 #  concurrencyLimit: 1 # Defaults to 1, a negative or null value removes the limit
-#  scanInterval: 5000 # Defaults to 5000
+#  scanInterval: 5000 # Unit in milliseconds, defaults to 5000ms

--- a/templates/serverpod_templates/projectname_server_upgrade/config/staging.yaml
+++ b/templates/serverpod_templates/projectname_server_upgrade/config/staging.yaml
@@ -61,4 +61,4 @@ sessionLogs:
 
 #futureCall:
 #  concurrencyLimit: 1 # Defaults to 1, a negative or null value removes the limit
-#  scanInterval: 5000 # Defaults to 5000
+#  scanInterval: 5000 # Unit in milliseconds, defaults to 5000ms

--- a/templates/serverpod_templates/projectname_server_upgrade/config/test.yaml
+++ b/templates/serverpod_templates/projectname_server_upgrade/config/test.yaml
@@ -49,4 +49,4 @@ sessionLogs:
 
 #futureCall:
 #  concurrencyLimit: 1 # Defaults to 1, a negative or null value removes the limit
-#  scanInterval: 5000 # Defaults to 5000
+#  scanInterval: 5000 # Unit in milliseconds, defaults to 5000ms


### PR DESCRIPTION
Adds the time unit to the scan interfal config example.

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

_If you have done any breaking changes, make sure to outline them here, so that they can be included in the notes for the next release._