### PR TITLE
test: Add ci test for upgrading Serverpod version.

### DIFF
--- a/.github/workflows/dart-tests.yaml
+++ b/.github/workflows/dart-tests.yaml
@@ -376,3 +376,14 @@ jobs:
       - uses: actions/checkout@v3
       - name: Run integration tests in Docker
         run: util/run_tests_flutter_integration
+
+  version_change_test:
+    name: Version change test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.19.0'
+      - name: Run version change test
+        run: util/run_tests_version_change

--- a/templates/pubspecs/modules/new_serverpod_auth/serverpod_auth_session/serverpod_auth_session_server/pubspec.yaml
+++ b/templates/pubspecs/modules/new_serverpod_auth/serverpod_auth_session/serverpod_auth_session_server/pubspec.yaml
@@ -27,5 +27,7 @@ dependency_overrides:
     path: ../../../../packages/serverpod_lints
   serverpod_serialization:
     path: ../../../../packages/serverpod_serialization
+  serverpod_shared:
+    path: ../../../../packages/serverpod_shared
   serverpod_test:
     path: ../../../../packages/serverpod_test

--- a/templates/pubspecs/modules/new_serverpod_auth/serverpod_auth_session/serverpod_auth_session_server/pubspec.yaml
+++ b/templates/pubspecs/modules/new_serverpod_auth/serverpod_auth_session/serverpod_auth_session_server/pubspec.yaml
@@ -27,7 +27,5 @@ dependency_overrides:
     path: ../../../../packages/serverpod_lints
   serverpod_serialization:
     path: ../../../../packages/serverpod_serialization
-  serverpod_shared:
-    path: ../../../../packages/serverpod_shared
   serverpod_test:
     path: ../../../../packages/serverpod_test

--- a/util/ensure_no_changes
+++ b/util/ensure_no_changes
@@ -2,7 +2,7 @@
 
 if [ ! -f util/.serverpod_util_root ]; then
     echo "Run this script from the root of the Serverpod repository"
-    echo "I.e. util/pub_get_all"
+    echo "I.e. util/ensure_no_changes"
     exit 1
 fi
 

--- a/util/generate_all
+++ b/util/generate_all
@@ -2,7 +2,7 @@
 
 if [ ! -f util/.serverpod_util_root ]; then
     echo "Run this script from the root of the Serverpod repository"
-    echo "I.e. util/pub_get_all"
+    echo "I.e. util/generate_all"
     exit 1
 fi
 

--- a/util/recreate_all_migrations
+++ b/util/recreate_all_migrations
@@ -2,7 +2,7 @@
 
 if [ ! -f util/.serverpod_util_root ]; then
     echo "Run this script from the root of the Serverpod repository"
-    echo "I.e. util/pub_get_all"
+    echo "I.e. util/recreate_all_migrations"
     exit 1
 fi
 
@@ -66,5 +66,3 @@ echo "examples/auth_example/auth_example_server"
 cd $BASE/examples/auth_example/auth_example_server
 rm -r $MIGRATION_DIR
 dart $CLI create-migration --no-analytics
-
-

--- a/util/run_tests_serverpod_generate
+++ b/util/run_tests_serverpod_generate
@@ -5,7 +5,7 @@ set -e
 
 echo "### Run serverpod generate test"
 echo "### If this test fails, make sure that you have run serverpod generate"
-echo "### on all packages with util/generate_all"
+echo "### on all packages with util/run_tests_serverpod_generate"
 
 # Install the serverpod command
 echo "### Installing CLI tools"

--- a/util/run_tests_unit
+++ b/util/run_tests_unit
@@ -2,7 +2,7 @@
 
 if [ ! -f util/.serverpod_util_root ]; then
     echo "Run this script from the root of the Serverpod repository"
-    echo "I.e. util/run_tests"
+    echo "I.e. util/run_tests_unit"
     exit 1
 fi
 

--- a/util/run_tests_update_pubspecs
+++ b/util/run_tests_update_pubspecs
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+if [ ! -f util/.serverpod_util_root ]; then
+    echo "Run this script from the root of the Serverpod repository"
+    echo "I.e. util/run_tests_update_pubspecs"
+    exit 1
+fi
+
 # Makes script exit on first non-zero error code
 set -e
 

--- a/util/run_tests_version_change
+++ b/util/run_tests_version_change
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+if [ ! -f util/.serverpod_util_root ]; then
+    echo "Run this script from the root of the Serverpod repository"
+    echo "I.e. util/run_tests"
+    exit 1
+fi
+
+# Makes script exit on first non-zero error code
+set -e
+
+echo "### Incrementing major version in SERVERPOD_VERSION"
+if [ ! -f SERVERPOD_VERSION ]; then
+    echo "Error: SERVERPOD_VERSION file not found in the root of the repository"
+    exit 1
+fi
+
+current_version=$(cat SERVERPOD_VERSION)
+IFS='.' read -r major minor patch <<< "$current_version"
+new_major=$((major + 1))
+new_version="${new_major}.0.0"
+echo "$new_version" > SERVERPOD_VERSION
+echo "Updated SERVERPOD_VERSION to $new_version"
+echo ""
+
+export SERVERPOD_HOME=$(pwd)
+echo "### Serverpod home: $SERVERPOD_HOME"
+
+echo "### Running update pubspecs"
+util/update_pubspecs
+
+echo "### Running pub get all"
+util/pub_get_all

--- a/util/run_tests_version_change
+++ b/util/run_tests_version_change
@@ -2,7 +2,7 @@
 
 if [ ! -f util/.serverpod_util_root ]; then
     echo "Run this script from the root of the Serverpod repository"
-    echo "I.e. util/run_tests"
+    echo "I.e. util/run_tests_version_change"
     exit 1
 fi
 

--- a/util/update_pubspecs
+++ b/util/update_pubspecs
@@ -6,6 +6,9 @@ if [ ! -f util/.serverpod_util_root ]; then
     exit 1
 fi
 
+# Makes script exit on first non-zero error code
+set -e
+
 VERSION=`cat SERVERPOD_VERSION`
 DART_VERSION=`cat DART_VERSION`
 FLUTTER_VERSION=`cat FLUTTER_VERSION`


### PR DESCRIPTION
Closes: #2871

Adds a CI test for validating that Serverpod version upgrades are ok.
This will help us catch missed dependency overrides in the project.

Commit number 4 introduces an error that was catched here: https://github.com/serverpod/serverpod/actions/runs/15021982175/job/42213207934

Removed in commit number 5.

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None - Simple CI test.