### PR TITLE
chore: Don't use fixed version for cli_tools

### DIFF
--- a/templates/pubspecs/tools/serverpod_cli/pubspec.yaml
+++ b/templates/pubspecs/tools/serverpod_cli/pubspec.yaml
@@ -37,7 +37,7 @@ dependencies:
   stream_channel: ^2.1.1
   lsp_server: ^0.3.0
   pub_semver: ^2.1.4
-  cli_tools: 0.5.0
+  cli_tools: ^0.5.0
 
 dev_dependencies:
   serverpod_lints: SERVERPOD_VERSION

--- a/tools/serverpod_cli/pubspec.yaml
+++ b/tools/serverpod_cli/pubspec.yaml
@@ -38,7 +38,7 @@ dependencies:
   stream_channel: ^2.1.1
   lsp_server: ^0.3.0
   pub_semver: ^2.1.4
-  cli_tools: 0.5.0
+  cli_tools: ^0.5.0
 
 dev_dependencies:
   serverpod_lints: 2.7.0


### PR DESCRIPTION
Uses a minimum version for `cli_tools` instead of a fixed version.

No changes.

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

_If you have done any breaking changes, make sure to outline them here, so that they can be included in the notes for the next release._