### PR TITLE
Support redis tls connection

### DIFF
--- a/packages/serverpod/lib/src/server/serverpod.dart
+++ b/packages/serverpod/lib/src/server/serverpod.dart
@@ -393,6 +393,7 @@ class Serverpod {
         port: redis.port,
         user: redis.user,
         password: redis.password,
+        requireSsl: redis.requireSsl,
       );
     }
 

--- a/packages/serverpod_shared/lib/src/config.dart
+++ b/packages/serverpod_shared/lib/src/config.dart
@@ -409,6 +409,9 @@ class RedisConfig {
   /// Redis password (optional, but recommended).
   final String? password;
 
+  /// True if Redis requires an SSL connection.
+  final bool requireSsl;
+
   /// Creates a new [RedisConfig].
   RedisConfig({
     required this.enabled,
@@ -416,6 +419,7 @@ class RedisConfig {
     required this.port,
     this.user,
     this.password,
+    this.requireSsl = false,
   });
 
   factory RedisConfig._fromJson(Map redisSetup, Map passwords, String name) {
@@ -434,6 +438,7 @@ class RedisConfig {
       port: redisSetup[ServerpodEnv.redisPort.configKey],
       user: redisSetup[ServerpodEnv.redisUser.configKey],
       password: passwords[ServerpodPassword.redisPassword.configKey],
+      requireSsl: redisSetup[ServerpodEnv.redisRequireSsl.configKey] ?? false,
     );
   }
 
@@ -448,6 +453,7 @@ class RedisConfig {
     if (password != null) {
       str += 'redis pass: ********\n';
     }
+    str += 'redis require SSL: $requireSsl\n';
     return str;
   }
 }
@@ -634,6 +640,7 @@ Map? _redisConfigMap(Map configMap, Map<String, String> environment) {
     (ServerpodEnv.redisPort, int.parse),
     (ServerpodEnv.redisUser, null),
     (ServerpodEnv.redisEnabled, bool.parse),
+    (ServerpodEnv.redisRequireSsl, bool.parse),
   ]);
 }
 

--- a/packages/serverpod_shared/lib/src/environment_variables.dart
+++ b/packages/serverpod_shared/lib/src/environment_variables.dart
@@ -81,6 +81,9 @@ enum ServerpodEnv {
   /// Toggle to enable the redis broker.
   redisEnabled,
 
+  /// Toggle to require SSL for the redis broker.
+  redisRequireSsl,
+
   /// The local port for the api server.
   apiPort,
 
@@ -152,6 +155,7 @@ enum ServerpodEnv {
       (ServerpodEnv.redisPort) => 'port',
       (ServerpodEnv.redisUser) => 'user',
       (ServerpodEnv.redisEnabled) => 'enabled',
+      (ServerpodEnv.redisRequireSsl) => 'requireSsl',
       (ServerpodEnv.apiPort) => ServerpodServerConfigMap.port,
       (ServerpodEnv.apiPublicHost) => ServerpodServerConfigMap.publicHost,
       (ServerpodEnv.apiPublicPort) => ServerpodServerConfigMap.publicPort,
@@ -192,6 +196,7 @@ enum ServerpodEnv {
       (ServerpodEnv.redisPort) => 'SERVERPOD_REDIS_PORT',
       (ServerpodEnv.redisUser) => 'SERVERPOD_REDIS_USER',
       (ServerpodEnv.redisEnabled) => 'SERVERPOD_REDIS_ENABLED',
+      (ServerpodEnv.redisRequireSsl) => 'SERVERPOD_REDIS_REQUIRE_SSL',
       (ServerpodEnv.apiPort) => 'SERVERPOD_API_SERVER_PORT',
       (ServerpodEnv.apiPublicHost) => 'SERVERPOD_API_SERVER_PUBLIC_HOST',
       (ServerpodEnv.apiPublicPort) => 'SERVERPOD_API_SERVER_PUBLIC_PORT',

--- a/packages/serverpod_shared/test/config_test.dart
+++ b/packages/serverpod_shared/test/config_test.dart
@@ -641,6 +641,66 @@ redis:
     expect(config.redis?.host, 'localhost');
     expect(config.redis?.port, 6379);
     expect(config.redis?.user, 'default');
+    expect(config.redis?.requireSsl, false);
+  });
+
+  test(
+      'Given a Serverpod config with only the api server configuration but the environment variables containing the config for the redis with a required tls connection when loading from Map then the redis config is created.',
+      () {
+    var config = ServerpodConfig.loadFromMap(
+      runMode,
+      serverId,
+      {...passwords, 'redis': 'password'},
+      {
+        'apiServer': {
+          'port': 8080,
+          'publicHost': 'localhost',
+          'publicPort': 8080,
+          'publicScheme': 'http',
+        },
+      },
+      environment: {
+        'SERVERPOD_REDIS_HOST': 'localhost',
+        'SERVERPOD_REDIS_PORT': '6379',
+        'SERVERPOD_REDIS_USER': 'default',
+        'SERVERPOD_REDIS_REQUIRE_SSL': 'true',
+      },
+    );
+
+    expect(config.redis?.host, 'localhost');
+    expect(config.redis?.port, 6379);
+    expect(config.redis?.user, 'default');
+    expect(config.redis?.requireSsl, true);
+  });
+  test(
+      'Given a Serverpod config with only the api server configuration but the environment variables containing the config for the redis with a invalid value for require ssl when loading from Map then an exception is thrown',
+      () {
+    expect(
+        () => ServerpodConfig.loadFromMap(
+              runMode,
+              serverId,
+              {...passwords, 'redis': 'password'},
+              {
+                'apiServer': {
+                  'port': 8080,
+                  'publicHost': 'localhost',
+                  'publicPort': 8080,
+                  'publicScheme': 'http',
+                },
+              },
+              environment: {
+                'SERVERPOD_REDIS_HOST': 'localhost',
+                'SERVERPOD_REDIS_PORT': '6379',
+                'SERVERPOD_REDIS_USER': 'default',
+                'SERVERPOD_REDIS_REQUIRE_SSL': 'INVALID',
+              },
+            ),
+        throwsA(isA<Exception>().having(
+          (e) => e.toString(),
+          'message',
+          equals(
+              'Exception: Invalid value (INVALID) for SERVERPOD_REDIS_REQUIRE_SSL.'),
+        )));
   });
 
   test(
@@ -670,6 +730,7 @@ redis:
     expect(config.redis?.host, 'localhost');
     expect(config.redis?.port, 6379);
     expect(config.redis?.user, 'default');
+    expect(config.redis?.requireSsl, false);
   });
 
   test(


### PR DESCRIPTION
This PR adds support for connecting to Redis SSL

_List which issues are fixed by this PR. You must list at least one issue._
 #3529

## Pre-launch Checklist

- [ X] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [X ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ X] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [X ] I listed at least one issue that this PR fixes in the description above.
- [X ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ X] I added new tests to check the change I am making.
- [ X] All existing and new tests are passing.
- [ X] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes
none