### PR TITLE
chore: Bumps the version to match the rest.

### DIFF
--- a/modules/new_serverpod_auth/serverpod_auth_user/serverpod_auth_user_server/pubspec.yaml
+++ b/modules/new_serverpod_auth/serverpod_auth_user/serverpod_auth_user_server/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   serverpod: 2.7.0
 
 dev_dependencies:
-  lints: ">=3.0.0 <6.0.0"
+  lints: '>=3.0.0 <7.0.0'
   serverpod_test: 2.7.0
   test: "^1.24.2"
 

--- a/templates/pubspecs/modules/new_serverpod_auth/serverpod_auth_user/serverpod_auth_user_server/pubspec.yaml
+++ b/templates/pubspecs/modules/new_serverpod_auth/serverpod_auth_user/serverpod_auth_user_server/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   serverpod: SERVERPOD_VERSION
 
 dev_dependencies:
-  lints: ">=3.0.0 <6.0.0"
+  lints: '>=3.0.0 <7.0.0'
   serverpod_test: SERVERPOD_VERSION
   test: "^1.24.2"
 

--- a/tools/serverpod_cli/test/util/pubspec_plus_test.dart
+++ b/tools/serverpod_cli/test/util/pubspec_plus_test.dart
@@ -52,7 +52,7 @@ dev_dependencies:
         var lintsDep = depsByName['lints']!;
         expect(
           (lintsDep as HostedDep).dependency.version,
-          VersionConstraint.parse('>=3.0.0 <6.0.0'),
+          VersionConstraint.parse('>=3.0.0 <7.0.0'),
         );
       });
 
@@ -97,7 +97,7 @@ dev_dependencies:
         expect(lintsSpan.start.column, 9);
         expect(lintsSpan.end.line, 8);
         expect(lintsSpan.end.column, 25);
-        expect(lintsSpan.text, "'>=3.0.0 <6.0.0'");
+        expect(lintsSpan.text, "'>=3.0.0 <7.0.0'");
         expect(
           lintsSpan.message('<the message>'),
           'line 9, column 10: <the message>\n' // 1-based

--- a/util/pub_get_all
+++ b/util/pub_get_all
@@ -41,6 +41,7 @@ declare -a dart_paths=(
   "tests/serverpod_test_shared"
   "tests/serverpod_test_module/serverpod_test_module_client"
   "tests/serverpod_test_module/serverpod_test_module_server"
+  "tests/serverpod_test_nonvector/serverpod_test_nonvector_client"
   "tests/serverpod_test_nonvector/serverpod_test_nonvector_server"
   "tests/bootstrap_project"
   "tests/serverpod_cli_e2e_test"


### PR DESCRIPTION
An accidentally invalid merge to main broke the CI suite in main. This PR fixes this by ensuring that all lint packages have the same version.

** Additional fix **
Adds a newly introduced test package to the `pub_get_all` script.

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

_If you have done any breaking changes, make sure to outline them here, so that they can be included in the notes for the next release._