### PR TITLE
fix: Default log to console in development mode.

### DIFF
--- a/packages/serverpod_shared/lib/src/config.dart
+++ b/packages/serverpod_shared/lib/src/config.dart
@@ -69,12 +69,9 @@ class ServerpodConfig {
     this.futureCall = const FutureCallConfig(),
     this.futureCallExecutionEnabled = true,
   }) : sessionLogs = sessionLogs ??
-            SessionLogConfig(
-              persistentEnabled: database != null,
-              consoleEnabled: database == null,
-              consoleLogFormat: runMode == _developmentRunMode
-                  ? ConsoleLogFormat.text
-                  : ConsoleLogFormat.defaultFormat,
+            SessionLogConfig.buildDefault(
+              databaseEnabled: database != null,
+              runMode: runMode,
             ) {
     apiServer._name = 'api';
     insightsServer?._name = 'insights';
@@ -571,6 +568,21 @@ class SessionLogConfig {
     required this.consoleEnabled,
     ConsoleLogFormat? consoleLogFormat,
   }) : consoleLogFormat = consoleLogFormat ?? ConsoleLogFormat.defaultFormat;
+
+  /// Creates a new default [SessionLogConfig] based on the run mode and
+  /// whether the database is enabled.
+  factory SessionLogConfig.buildDefault({
+    required bool databaseEnabled,
+    required String runMode,
+  }) {
+    return SessionLogConfig(
+      persistentEnabled: databaseEnabled,
+      consoleEnabled: !databaseEnabled || runMode == _developmentRunMode,
+      consoleLogFormat: runMode == _developmentRunMode
+          ? ConsoleLogFormat.text
+          : ConsoleLogFormat.defaultFormat,
+    );
+  }
 
   factory SessionLogConfig._fromJson(
     Map sessionLogConfigJson,

--- a/packages/serverpod_shared/lib/src/config.dart
+++ b/packages/serverpod_shared/lib/src/config.dart
@@ -589,15 +589,6 @@ class SessionLogConfig {
     String name, {
     required bool databaseEnabled,
   }) {
-    _validateJsonConfig(
-      {
-        ServerpodEnv.sessionPersistentLogEnabled.configKey: bool,
-        ServerpodEnv.sessionConsoleLogEnabled.configKey: bool,
-      },
-      sessionLogConfigJson,
-      name,
-    );
-
     var configuredLogFormat =
         sessionLogConfigJson[ServerpodEnv.sessionConsoleLogFormat.configKey];
 

--- a/packages/serverpod_shared/test/session_logs_config_test.dart
+++ b/packages/serverpod_shared/test/session_logs_config_test.dart
@@ -66,7 +66,7 @@ apiServer:
   );
 
   test(
-    'Given a Serverpod config missing sessionLogs configuration and a database when loading from Map then sessionLogs defaults to persistent logging enabled and console logging disabled',
+    'Given a Serverpod config with "development" run mode missing sessionLogs configuration and a database when loading from Map then sessionLogs defaults to persistent logging enabled and console text logging is enabled',
     () {
       var serverpodConfig = '''
 apiServer:
@@ -89,7 +89,43 @@ database:
       );
 
       expect(config.sessionLogs.persistentEnabled, isTrue);
+      expect(config.sessionLogs.consoleEnabled, isTrue);
+      expect(
+        config.sessionLogs.consoleLogFormat,
+        ConsoleLogFormat.text,
+      );
+    },
+  );
+
+  test(
+    'Given a Serverpod config with "production" run mode missing sessionLogs configuration and a database when loading from Map then sessionLogs defaults to persistent logging enabled and json console logging disabled',
+    () {
+      var serverpodConfig = '''
+apiServer:
+  port: 8080
+  publicHost: localhost
+  publicPort: 8080
+  publicScheme: http
+database:
+  host: localhost
+  port: 5432
+  name: testDb
+  user: testUser
+''';
+
+      var config = ServerpodConfig.loadFromMap(
+        productionRunMode,
+        serverId,
+        passwords,
+        loadYaml(serverpodConfig),
+      );
+
+      expect(config.sessionLogs.persistentEnabled, isTrue);
       expect(config.sessionLogs.consoleEnabled, isFalse);
+      expect(
+        config.sessionLogs.consoleLogFormat,
+        ConsoleLogFormat.json,
+      );
     },
   );
 

--- a/packages/serverpod_shared/test/session_logs_config_test.dart
+++ b/packages/serverpod_shared/test/session_logs_config_test.dart
@@ -140,7 +140,6 @@ apiServer:
   publicScheme: http
 sessionLogs:
   persistentEnabled: true
-  consoleEnabled: false
 ''';
 
       expect(
@@ -174,7 +173,6 @@ apiServer:
   publicScheme: http
 sessionLogs:
   persistentEnabled: false
-  consoleEnabled: true
 ''';
 
       var config = ServerpodConfig.loadFromMap(
@@ -186,7 +184,6 @@ sessionLogs:
       );
 
       expect(config.sessionLogs.persistentEnabled, isFalse);
-      expect(config.sessionLogs.consoleEnabled, isTrue);
     },
   );
 
@@ -206,7 +203,6 @@ database:
   user: testUser
 sessionLogs:
   persistentEnabled: true
-  consoleEnabled: false
 ''';
 
       var config = ServerpodConfig.loadFromMap(
@@ -217,7 +213,30 @@ sessionLogs:
       );
 
       expect(config.sessionLogs.persistentEnabled, isTrue);
-      expect(config.sessionLogs.consoleEnabled, isFalse);
+    },
+  );
+
+  test(
+    'Given a Serverpod config with sessionLogs when consoleEnabled is true then consoleEnabled remains true',
+    () {
+      var serverpodConfig = '''
+apiServer:
+  port: 8080
+  publicHost: localhost
+  publicPort: 8080
+  publicScheme: http
+sessionLogs:
+  consoleEnabled: true
+''';
+
+      var config = ServerpodConfig.loadFromMap(
+        developmentRunMode,
+        serverId,
+        passwords,
+        loadYaml(serverpodConfig),
+      );
+
+      expect(config.sessionLogs.consoleEnabled, isTrue);
     },
   );
 


### PR DESCRIPTION
When the configuration file does not specify anything, Serverpod will now always log to the console with `text` output when run mode is set to `development`.

This ensures that older upgraded projects still have logging in their console.

### Additional fix
- Makes it possible to configure session logs options in isolation from the configuration file.

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

_If you have done any breaking changes, make sure to outline them here, so that they can be included in the notes for the next release._