### PR TITLE
fix: Add cache invalidation for User in unblockUser

### DIFF
--- a/.github/workflows/dart-tests.yaml
+++ b/.github/workflows/dart-tests.yaml
@@ -239,7 +239,8 @@ jobs:
           'tests/serverpod_test_module/serverpod_test_module_server',
           'tests/serverpod_test_nonvector/serverpod_test_nonvector_server',
           'modules/new_serverpod_auth/serverpod_auth_session/serverpod_auth_session_server',
-          'modules/new_serverpod_auth/serverpod_auth_profile/serverpod_auth_profile_server'
+          'modules/new_serverpod_auth/serverpod_auth_profile/serverpod_auth_profile_server',
+          'modules/serverpod_auth/serverpod_auth_server'
         ]
     steps:
       - uses: actions/checkout@v3

--- a/modules/serverpod_auth/serverpod_auth_server/config/passwords.yaml
+++ b/modules/serverpod_auth/serverpod_auth_server/config/passwords.yaml
@@ -1,4 +1,15 @@
+# Use this file to store passwords to services that your server you use. When
+# the server starts, the passwords will be automatically loaded and can be
+# accessed from the `session.passwords` field. If you don't have access to a
+# session object, passwords can also be accessed from
+# `Serverpod.instance.passwords`. You can provide different passwords for
+# different run configurations. If you want the same password for any
+# configuration used, place it under `shared`.
+#
+# Note that this file should not be under version control. Store it in a safe
+# place.
+
 test:
-  database: 'password'
-  redis: 'password'
+  database: 'DB_TEST_PASSWORD'
+  redis: 'REDIS_TEST_PASSWORD'
   serviceSecret: 'super_SECRET_password'

--- a/modules/serverpod_auth/serverpod_auth_server/config/test.yaml
+++ b/modules/serverpod_auth/serverpod_auth_server/config/test.yaml
@@ -1,28 +1,46 @@
+# This is the configuration file for your test environment.
+# All ports are set to zero in this file which makes the server find the next available port.
+# This is needed to enable running tests concurrently. To set up your server, you will
+# need to add the name of the database you are connecting to and the user name.
+# The password for the database is stored in the config/passwords.yaml.
+#
+# When running your server locally, the server ports are the same as the public
+# facing ports.
+
+# Configuration for the main API test server.
 apiServer:
-  port: 8080
-  publicHost: serverpod_test_server
-  publicPort: 8080
+  port: 0
+  publicHost: localhost
+  publicPort: 0
   publicScheme: http
 
+# Configuration for the Insights test server.
 insightsServer:
-  port: 8081
-  publicHost: serverpod_test_server
-  publicPort: 8081
+  port: 0
+  publicHost: localhost
+  publicPort: 0
   publicScheme: http
 
+# Configuration for the web test server.
 webServer:
-  port: 8082
-  publicHost: serverpod_test_server
-  publicPort: 8082
+  port: 0
+  publicHost: localhost
+  publicPort: 0
   publicScheme: http
 
+# This is the database setup for your test server.
 database:
-  host: postgres
-  port: 5432
-  name: serverpod_test
+  host: localhost
+  port: 9090
+  name: projectname_test
   user: postgres
 
+# This is the setup for your Redis test instance.
 redis:
-  enabled: true
-  host: redis
-  port: 6379
+  enabled: false
+  host: localhost
+  port: 9091
+
+sessionLogs:
+  persistentEnabled: true
+  consoleEnabled: true

--- a/modules/serverpod_auth/serverpod_auth_server/docker-compose.yaml
+++ b/modules/serverpod_auth/serverpod_auth_server/docker-compose.yaml
@@ -1,0 +1,22 @@
+services:
+  # Test services
+  postgres_test:
+    image: postgres:16.3
+    ports:
+      - '9090:5432'
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_DB: projectname_test
+      POSTGRES_PASSWORD: "DB_TEST_PASSWORD"
+    volumes:
+      - projectname_test_data:/var/lib/postgresql/data
+  redis_test:
+    image: redis:6.2.6
+    ports:
+      - '9091:6379'
+    command: redis-server --requirepass "REDIS_TEST_PASSWORD"
+    environment:
+      - REDIS_REPLICATION_MODE=master
+
+volumes:
+  projectname_test_data:

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/business/users.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/business/users.dart
@@ -190,7 +190,8 @@ class Users {
     );
   }
 
-  /// Unblocks a user so that they can log in again.
+  /// Unblocks a user so that they can log in again, and invalidates the cache 
+  /// for the user so that they can be blocked again
   static Future<void> unblockUser(
     Session session,
     int userId,
@@ -203,6 +204,7 @@ class Users {
     }
     userInfo.blocked = false;
     await session.db.updateRow(userInfo);
+    await invalidateCacheForUser(session, userId);
   }
 
   /// Invalidates the cache for a user and makes sure the next time a user info

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/business/users.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/business/users.dart
@@ -190,7 +190,7 @@ class Users {
     );
   }
 
-  /// Unblocks a user so that they can log in again, and invalidates the cache 
+  /// Unblocks a user so that they can log in again, and invalidates the cache
   /// for the user so that they can be blocked again
   static Future<void> unblockUser(
     Session session,

--- a/modules/serverpod_auth/serverpod_auth_server/test/blocked_user_test.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/test/blocked_user_test.dart
@@ -1,7 +1,7 @@
 import 'package:serverpod_auth_server/serverpod_auth_server.dart';
 import 'package:test/test.dart';
 
-import '../test/integration/test_tools/serverpod_test_tools.dart';
+import 'integration/test_tools/serverpod_test_tools.dart';
 
 void main() {
   withServerpod('Given a blocked user', (sessionBuilder, _) {

--- a/modules/serverpod_auth/serverpod_auth_server/test/signout_legacy_option_test.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/test/signout_legacy_option_test.dart
@@ -1,7 +1,7 @@
 import 'package:serverpod/serverpod.dart';
 import 'package:serverpod_auth_server/serverpod_auth_server.dart';
 import 'package:test/test.dart';
-import '../../test/integration/test_tools/serverpod_test_tools.dart';
+import 'integration/test_tools/serverpod_test_tools.dart';
 
 void main() {
   var userId = 1;

--- a/modules/serverpod_auth/serverpod_auth_server/test_integration/blocked_user_test.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/test_integration/blocked_user_test.dart
@@ -1,0 +1,68 @@
+import 'package:serverpod_auth_server/serverpod_auth_server.dart';
+import 'package:test/test.dart';
+
+import '../test/integration/test_tools/serverpod_test_tools.dart';
+
+void main() {
+  withServerpod('Given a blocked user', (sessionBuilder, _) {
+    const email = 'test@serverpod.dev';
+    const password = 'password123';
+    late int userId;
+    setUp(() async {
+      var session = sessionBuilder.build();
+      var user = await Emails.createUser(
+        session,
+        'blockedUser',
+        email,
+        password,
+      );
+
+      assert(user != null, 'User should be created successfully');
+      var maybeUserId = user!.id;
+      assert(maybeUserId != null, 'User ID should not be null');
+
+      userId = maybeUserId!;
+      await Users.blockUser(session, userId);
+    });
+
+    test(
+        'when user attempts to authenticate, then authentication fails with reason "blocked"',
+        () async {
+      var session = sessionBuilder.build();
+      var result = await Emails.authenticate(session, email, password);
+
+      expect(result.success, isFalse);
+      expect(result.failReason, AuthenticationFailReason.blocked);
+    });
+  });
+
+  withServerpod('Given a previously blocked user', (sessionBuilder, _) {
+    const email = 'test@serverpod.dev';
+    const password = 'password123';
+    setUp(() async {
+      var session = sessionBuilder.build();
+      var user = await Emails.createUser(
+        session,
+        'blockedUser',
+        email,
+        password,
+      );
+
+      assert(user != null, 'User should be created successfully');
+      var maybeUserId = user!.id;
+      assert(maybeUserId != null, 'User ID should not be null');
+
+      var userId = maybeUserId!;
+      await Users.blockUser(session, userId);
+      await Users.unblockUser(session, userId);
+    });
+
+    test('when user attempts to authenticate, then authentication succeeds',
+        () async {
+      var session = sessionBuilder.build();
+      var result = await Emails.authenticate(session, email, password);
+
+      expect(result.success, isTrue);
+    });
+  });
+}


### PR DESCRIPTION
This PR adds `invalidateCacheForUser` to `unblockUser` so a user can be blocked again.

The user can not be blocked after unblocking because `blockUser` gets the cached value and throws an exception that the user is already blocked.

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None