### PR TITLE
fix: Do not strip paths starting with v in static files

### DIFF
--- a/packages/serverpod/lib/src/relic/routes/static_directory.dart
+++ b/packages/serverpod/lib/src/relic/routes/static_directory.dart
@@ -101,7 +101,7 @@ class RouteStaticDirectory extends Route {
       var extension = p.extension(path);
 
       var baseParts = base.split('@');
-      if (baseParts.last.startsWith('v')) {
+      if (baseParts.length > 1 && baseParts.last.startsWith('v')) {
         baseParts.removeLast();
       }
       base = baseParts.join('@');


### PR DESCRIPTION
Fixes a bug where paths starting with `v` always returned 404 when serving static files in the web server. 

Closes: https://github.com/serverpod/serverpod/issues/3604

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

none