### PR TITLE
fix: Improve duration print for human readable logs.

### DIFF
--- a/packages/serverpod/lib/src/server/log_manager/log_writers.dart
+++ b/packages/serverpod/lib/src/server/log_manager/log_writers.dart
@@ -235,6 +235,9 @@ class TextStdOutLogWriter extends LogWriter {
     if (milliseconds == null) return 'n/a';
     var micros = (milliseconds * Duration.microsecondsPerMillisecond).round();
     if (micros < 1000) {
+      // Ignore required because dart does not understand that "µ" is a valid
+      // character in a string.
+      // ignore: unnecessary_brace_in_string_interps
       return '${micros}µs';
     }
     if (micros < Duration.microsecondsPerSecond) {

--- a/packages/serverpod/lib/src/server/log_manager/log_writers.dart
+++ b/packages/serverpod/lib/src/server/log_manager/log_writers.dart
@@ -228,6 +228,40 @@ class JsonStdOutLogWriter extends LogWriter {
 class TextStdOutLogWriter extends LogWriter {
   static bool headersWritten = false;
 
+  /// Formats a duration value expressed in milliseconds so that it is easy to
+  /// read in logs. Very short durations will be printed using microseconds
+  /// while longer ones will switch to milliseconds or seconds.
+  static String _printDuration(double? milliseconds) {
+    if (milliseconds == null) return 'n/a';
+    var micros = (milliseconds * Duration.microsecondsPerMillisecond).round();
+    if (micros < 1000) {
+      return '${micros}µs';
+    }
+    if (micros < Duration.microsecondsPerSecond) {
+      var ms = micros / 1000;
+      return _formatNumber(ms, 'ms');
+    }
+    var s = micros / Duration.microsecondsPerSecond;
+    return _formatNumber(s, 's');
+  }
+
+  static String _formatNumber(double value, String suffix) {
+    String formatted;
+    if (value >= 100) {
+      formatted = value.toStringAsFixed(0);
+    } else if (value >= 10) {
+      formatted = value.toStringAsFixed(1);
+    } else {
+      formatted = value.toStringAsFixed(2);
+    }
+    if (formatted.contains('.')) {
+      formatted = formatted
+          .replaceFirst(RegExp(r'0+\$'), '')
+          .replaceFirst(RegExp(r'\.\$'), '');
+    }
+    return '$formatted$suffix';
+  }
+
   static void writeHeadersIfNeeded() {
     if (!headersWritten) {
       _writeFormatHeaders();
@@ -280,7 +314,7 @@ class TextStdOutLogWriter extends LogWriter {
       id: _logId,
       fields: {
         'id': entry.id,
-        'time': '${entry.duration}ms',
+        'duration': _printDuration(entry.duration),
         'query': entry.query,
       },
       error: entry.error,
@@ -318,7 +352,7 @@ class TextStdOutLogWriter extends LogWriter {
           fields: {
             'user': entry.authenticatedUserId,
             'queries': entry.numQueries,
-            'time': entry.duration,
+            'duration': _printDuration(entry.duration),
           },
           error: entry.error,
           stackTrace: entry.stackTrace,
@@ -331,7 +365,7 @@ class TextStdOutLogWriter extends LogWriter {
           id: _logId,
           fields: {
             'queries': entry.numQueries,
-            'time': entry.duration,
+            'duration': _printDuration(entry.duration),
           },
           error: entry.error,
           stackTrace: entry.stackTrace,
@@ -345,7 +379,7 @@ class TextStdOutLogWriter extends LogWriter {
           fields: {
             'user': entry.authenticatedUserId,
             'queries': entry.numQueries,
-            'time': entry.duration,
+            'duration': _printDuration(entry.duration),
           },
           error: entry.error,
           stackTrace: entry.stackTrace,
@@ -360,7 +394,7 @@ class TextStdOutLogWriter extends LogWriter {
           fields: {
             'user': entry.authenticatedUserId,
             'queries': entry.numQueries,
-            'time': entry.duration,
+            'duration': _printDuration(entry.duration),
           },
           error: entry.error,
           stackTrace: entry.stackTrace,
@@ -373,7 +407,7 @@ class TextStdOutLogWriter extends LogWriter {
           id: _logId,
           fields: {
             'queries': entry.numQueries,
-            'time': entry.duration,
+            'duration': _printDuration(entry.duration),
           },
           error: entry.error,
           stackTrace: entry.stackTrace,
@@ -388,7 +422,7 @@ class TextStdOutLogWriter extends LogWriter {
           fields: {
             'sessionType': _session.runtimeType.toString(),
             'queries': entry.numQueries,
-            'time': entry.duration,
+            'duration': _printDuration(entry.duration),
           },
           error: entry.error,
           stackTrace: entry.stackTrace,


### PR DESCRIPTION
Small improvement to the text logging output that I wanted to add.

## Summary
- add a helper to format durations for the TextStdOutLogWriter
- rename the `time` field in text logs to `duration`
- show durations using a readable unit (µs, ms, s)
- fix `_printDuration` to interpret millisecond input

## Examples

### All formatting types:
<img width="1007" alt="Screenshot 2025-06-04 at 14 42 49" src="https://github.com/user-attachments/assets/5944fc82-19a8-4f5a-9e44-09d3023659cb" />

### All message types:
<img width="1239" alt="Screenshot 2025-06-04 at 14 43 07" src="https://github.com/user-attachments/assets/abcf0323-659b-4eb6-8e45-40b1254123c6" />