### PR TITLE
fix: Patch the regex for time to remove last decimals.

### DIFF
--- a/packages/serverpod/lib/src/server/log_manager/log_writers.dart
+++ b/packages/serverpod/lib/src/server/log_manager/log_writers.dart
@@ -259,8 +259,8 @@ class TextStdOutLogWriter extends LogWriter {
     }
     if (formatted.contains('.')) {
       formatted = formatted
-          .replaceFirst(RegExp(r'0+\$'), '')
-          .replaceFirst(RegExp(r'\.\$'), '');
+          .replaceFirst(RegExp(r'0+$'), '')
+          .replaceFirst(RegExp(r'\.$'), '');
     }
     return '$formatted$suffix';
   }


### PR DESCRIPTION
Notice the milli seconds at the end.

### Before fix
<img width="1019" alt="Screenshot 2025-06-04 at 16 44 12" src="https://github.com/user-attachments/assets/9e04c32c-d1eb-404a-8fd6-a59f05b8dfba" />


### After fix
<img width="991" alt="Screenshot 2025-06-04 at 16 29 48" src="https://github.com/user-attachments/assets/9ff1be79-1255-4754-bb80-81ad55af33f0" />



## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

_If you have done any breaking changes, make sure to outline them here, so that they can be included in the notes for the next release._