### PR TITLE
fix: Fix project name replacement when creating modules.

### DIFF
--- a/modules/new_serverpod_auth/serverpod_auth_jwt/serverpod_auth_jwt_server/config/test.yaml
+++ b/modules/new_serverpod_auth/serverpod_auth_jwt/serverpod_auth_jwt_server/config/test.yaml
@@ -32,7 +32,7 @@ webServer:
 database:
   host: localhost
   port: 9090
-  name: projectname_test
+  name: serverpod_auth_jwt_test
   user: postgres
 
 # This is the setup for your Redis test instance.

--- a/modules/new_serverpod_auth/serverpod_auth_jwt/serverpod_auth_jwt_server/docker-compose.yaml
+++ b/modules/new_serverpod_auth/serverpod_auth_jwt/serverpod_auth_jwt_server/docker-compose.yaml
@@ -6,10 +6,10 @@ services:
       - '9090:5432'
     environment:
       POSTGRES_USER: postgres
-      POSTGRES_DB: projectname_test
+      POSTGRES_DB: serverpod_auth_jwt_test
       POSTGRES_PASSWORD: "DB_TEST_PASSWORD"
     volumes:
-      - projectname_test_data:/var/lib/postgresql/data
+      - serverpod_auth_jwt_test_data:/var/lib/postgresql/data
   redis_test:
     image: redis:6.2.6
     ports:
@@ -19,4 +19,4 @@ services:
       - REDIS_REPLICATION_MODE=master
 
 volumes:
-  projectname_test_data:
+  serverpod_auth_jwt_test_data:

--- a/modules/new_serverpod_auth/serverpod_auth_profile/serverpod_auth_profile_server/config/test.yaml
+++ b/modules/new_serverpod_auth/serverpod_auth_profile/serverpod_auth_profile_server/config/test.yaml
@@ -32,7 +32,7 @@ webServer:
 database:
   host: localhost
   port: 9090
-  name: projectname_test
+  name: serverpod_auth_profile_test
   user: postgres
 
 # This is the setup for your Redis test instance.

--- a/modules/new_serverpod_auth/serverpod_auth_profile/serverpod_auth_profile_server/docker-compose.yaml
+++ b/modules/new_serverpod_auth/serverpod_auth_profile/serverpod_auth_profile_server/docker-compose.yaml
@@ -6,10 +6,10 @@ services:
       - '9090:5432'
     environment:
       POSTGRES_USER: postgres
-      POSTGRES_DB: projectname_test
+      POSTGRES_DB: serverpod_auth_profile_test
       POSTGRES_PASSWORD: "DB_TEST_PASSWORD"
     volumes:
-      - projectname_test_data:/var/lib/postgresql/data
+      - serverpod_auth_profile_test_data:/var/lib/postgresql/data
   redis_test:
     image: redis:6.2.6
     ports:
@@ -19,4 +19,4 @@ services:
       - REDIS_REPLICATION_MODE=master
 
 volumes:
-  projectname_test_data:
+  serverpod_auth_profile_test_data:

--- a/modules/new_serverpod_auth/serverpod_auth_session/serverpod_auth_session_server/config/test.yaml
+++ b/modules/new_serverpod_auth/serverpod_auth_session/serverpod_auth_session_server/config/test.yaml
@@ -32,7 +32,7 @@ webServer:
 database:
   host: localhost
   port: 9090
-  name: projectname_test
+  name: serverpod_auth_session_test
   user: postgres
 
 # This is the setup for your Redis test instance.

--- a/modules/new_serverpod_auth/serverpod_auth_session/serverpod_auth_session_server/docker-compose.yaml
+++ b/modules/new_serverpod_auth/serverpod_auth_session/serverpod_auth_session_server/docker-compose.yaml
@@ -6,10 +6,10 @@ services:
       - '9090:5432'
     environment:
       POSTGRES_USER: postgres
-      POSTGRES_DB: projectname_test
+      POSTGRES_DB: serverpod_auth_session_test
       POSTGRES_PASSWORD: "DB_TEST_PASSWORD"
     volumes:
-      - projectname_test_data:/var/lib/postgresql/data
+      - serverpod_auth_session_test_data:/var/lib/postgresql/data
   redis_test:
     image: redis:6.2.6
     ports:
@@ -19,4 +19,4 @@ services:
       - REDIS_REPLICATION_MODE=master
 
 volumes:
-  projectname_test_data:
+  serverpod_auth_session_test_data:

--- a/modules/new_serverpod_auth/serverpod_auth_user/serverpod_auth_user_server/config/test.yaml
+++ b/modules/new_serverpod_auth/serverpod_auth_user/serverpod_auth_user_server/config/test.yaml
@@ -32,7 +32,7 @@ webServer:
 database:
   host: localhost
   port: 9090
-  name: projectname_test
+  name: serverpod_auth_user_test
   user: postgres
 
 # This is the setup for your Redis test instance.

--- a/modules/new_serverpod_auth/serverpod_auth_user/serverpod_auth_user_server/docker-compose.yaml
+++ b/modules/new_serverpod_auth/serverpod_auth_user/serverpod_auth_user_server/docker-compose.yaml
@@ -6,10 +6,10 @@ services:
       - '9090:5432'
     environment:
       POSTGRES_USER: postgres
-      POSTGRES_DB: projectname_test
+      POSTGRES_DB: serverpod_auth_user_test
       POSTGRES_PASSWORD: "DB_TEST_PASSWORD"
     volumes:
-      - projectname_test_data:/var/lib/postgresql/data
+      - serverpod_auth_user_test_data:/var/lib/postgresql/data
   redis_test:
     image: redis:6.2.6
     ports:
@@ -19,4 +19,4 @@ services:
       - REDIS_REPLICATION_MODE=master
 
 volumes:
-  projectname_test_data:
+  serverpod_auth_user_test_data:

--- a/modules/serverpod_auth/serverpod_auth_server/config/test.yaml
+++ b/modules/serverpod_auth/serverpod_auth_server/config/test.yaml
@@ -32,7 +32,7 @@ webServer:
 database:
   host: localhost
   port: 9090
-  name: projectname_test
+  name: serverpod_auth_test
   user: postgres
 
 # This is the setup for your Redis test instance.

--- a/modules/serverpod_auth/serverpod_auth_server/docker-compose.yaml
+++ b/modules/serverpod_auth/serverpod_auth_server/docker-compose.yaml
@@ -6,10 +6,10 @@ services:
       - '9090:5432'
     environment:
       POSTGRES_USER: postgres
-      POSTGRES_DB: projectname_test
+      POSTGRES_DB: serverpod_auth_test
       POSTGRES_PASSWORD: "DB_TEST_PASSWORD"
     volumes:
-      - projectname_test_data:/var/lib/postgresql/data
+      - serverpod_auth_test_data:/var/lib/postgresql/data
   redis_test:
     image: redis:6.2.6
     ports:
@@ -19,4 +19,4 @@ services:
       - REDIS_REPLICATION_MODE=master
 
 volumes:
-  projectname_test_data:
+  serverpod_auth_test_data:

--- a/templates/serverpod_templates/modulename_server/config/test.yaml
+++ b/templates/serverpod_templates/modulename_server/config/test.yaml
@@ -32,7 +32,7 @@ webServer:
 database:
   host: localhost
   port: 9090
-  name: projectname_test
+  name: modulename_test
   user: postgres
 
 # This is the setup for your Redis test instance.

--- a/templates/serverpod_templates/modulename_server/docker-compose.yaml
+++ b/templates/serverpod_templates/modulename_server/docker-compose.yaml
@@ -6,10 +6,10 @@ services:
       - '9090:5432'
     environment:
       POSTGRES_USER: postgres
-      POSTGRES_DB: projectname_test
+      POSTGRES_DB: modulename_test
       POSTGRES_PASSWORD: "DB_TEST_PASSWORD"
     volumes:
-      - projectname_test_data:/var/lib/postgresql/data
+      - modulename_test_data:/var/lib/postgresql/data
   redis_test:
     image: redis:6.2.6
     ports:
@@ -19,4 +19,4 @@ services:
       - REDIS_REPLICATION_MODE=master
 
 volumes:
-  projectname_test_data:
+  modulename_test_data:

--- a/tests/bootstrap_project/test/module_test.dart
+++ b/tests/bootstrap_project/test/module_test.dart
@@ -6,6 +6,7 @@ import 'package:path/path.dart' as path;
 import 'package:test/test.dart';
 
 import '../lib/src/util.dart';
+import '../../serverpod_test_server/lib/test_util/custom_matcher.dart';
 
 const tempDirName = 'temp';
 
@@ -176,6 +177,43 @@ void main() {
           )).existsSync(),
           isTrue,
           reason: 'Server migration registry does not exist.',
+        );
+      });
+
+      test(
+          'then the server projects has docker compose file with project name replaced',
+          () {
+        final dockerComposeFile = File(
+          path.join(tempPath, serverDir, 'docker-compose.yaml'),
+        );
+        expect(
+          dockerComposeFile.existsSync(),
+          isTrue,
+          reason: 'Server docker compose file does not exist.',
+        );
+        expect(
+          dockerComposeFile.readAsStringSync(),
+          containsCount('${projectName}_test', 3),
+          reason: 'Server docker compose data volume name does not match.',
+        );
+      });
+
+      test(
+          'then the server project has test configuration with project name replaced',
+          () {
+        final testConfigFile = File(
+          path.join(tempPath, serverDir, 'config', 'test.yaml'),
+        );
+
+        expect(
+          testConfigFile.existsSync(),
+          isTrue,
+          reason: 'Server test configuration file does not exist.',
+        );
+        expect(
+          testConfigFile.readAsStringSync(),
+          contains('name: ${projectName}_test'),
+          reason: 'Server test configuration database name does not match.',
         );
       });
 

--- a/tests/bootstrap_project/test/module_test.dart
+++ b/tests/bootstrap_project/test/module_test.dart
@@ -27,7 +27,7 @@ void main() {
 
   tearDownAll(() async {
     try {
-      Directory(tempDirName).deleteSync(recursive: true);
+      Directory(tempPath).deleteSync(recursive: true);
     } catch (e) {}
   });
 

--- a/tests/serverpod_test_module/serverpod_test_module_server/config/test.yaml
+++ b/tests/serverpod_test_module/serverpod_test_module_server/config/test.yaml
@@ -19,7 +19,7 @@ webServer:
 database:
   host: localhost
   port: 9090
-  name: projectname_test
+  name: serverpod_test_module_test
   user: postgres
 
 redis:

--- a/tests/serverpod_test_module/serverpod_test_module_server/docker-compose.yaml
+++ b/tests/serverpod_test_module/serverpod_test_module_server/docker-compose.yaml
@@ -6,10 +6,10 @@ services:
       - '9090:5432'
     environment:
       POSTGRES_USER: postgres
-      POSTGRES_DB: projectname_test
+      POSTGRES_DB: serverpod_test_module_test
       POSTGRES_PASSWORD: "DB_TEST_PASSWORD"
     volumes:
-      - projectname_test_data:/var/lib/postgresql/data
+      - serverpod_test_module_test_data:/var/lib/postgresql/data
   redis_test:
     image: redis:6.2.6
     ports:
@@ -19,4 +19,4 @@ services:
       - REDIS_REPLICATION_MODE=master
 
 volumes:
-  projectname_test_data:
+  serverpod_test_module_test_data:


### PR DESCRIPTION
Closes: #3611 

The config templates for modules incorrectly used `projectname_test` instead of `modulename_test` which is what our search and replace algorithm looks for when copying over the template files.

This made the database and data volume of all modules to resolve to the same name.

I also patched this in all existing modules in the project.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None - This will only influence new modules created.