### PR TITLE
fix: Read rest of server configuration even if API config is missing.

### DIFF
--- a/packages/serverpod_shared/lib/src/config.dart
+++ b/packages/serverpod_shared/lib/src/config.dart
@@ -92,9 +92,6 @@ class ServerpodConfig {
   factory ServerpodConfig.defaultConfig() {
     return ServerpodConfig(
       apiServer: _defaultApiServer,
-      futureCall: const FutureCallConfig(
-        concurrencyLimit: FutureCallConfig.defaultFutureCallConcurrencyLimit,
-      ),
     );
   }
 
@@ -175,10 +172,7 @@ class ServerpodConfig {
             futureCallConfigJson,
             ServerpodConfigMap.futureCall,
           )
-        : const FutureCallConfig(
-            concurrencyLimit:
-                FutureCallConfig.defaultFutureCallConcurrencyLimit,
-          );
+        : const FutureCallConfig();
 
     var futureCallExecutionEnabled =
         _readIsFutureCallExecutionEnabled(configMap, environment);
@@ -471,7 +465,7 @@ class FutureCallConfig {
 
   /// Creates a new [FutureCallConfig].
   const FutureCallConfig({
-    this.concurrencyLimit,
+    this.concurrencyLimit = defaultFutureCallConcurrencyLimit,
     this.scanInterval =
         const Duration(milliseconds: defaultFutureCallScanIntervalMs),
   });

--- a/packages/serverpod_shared/lib/src/config.dart
+++ b/packages/serverpod_shared/lib/src/config.dart
@@ -11,12 +11,12 @@ const int _defaultMaxRequestSize = 524288;
 
 const String _developmentRunMode = 'development';
 
-final _defaultApiServer = ServerConfig(
-  port: 8080,
-  publicHost: 'localhost',
-  publicPort: 8080,
-  publicScheme: 'http',
-);
+ServerConfig _createDefaultApiServer() => ServerConfig(
+      port: 8080,
+      publicHost: 'localhost',
+      publicPort: 8080,
+      publicScheme: 'http',
+    );
 
 /// Parser for the Serverpod configuration file.
 class ServerpodConfig {
@@ -91,7 +91,7 @@ class ServerpodConfig {
   /// Creates a default bare bone configuration.
   factory ServerpodConfig.defaultConfig() {
     return ServerpodConfig(
-      apiServer: _defaultApiServer,
+      apiServer: _createDefaultApiServer(),
     );
   }
 
@@ -115,7 +115,7 @@ class ServerpodConfig {
             apiConfig,
             ServerpodConfigMap.apiServer,
           )
-        : _defaultApiServer;
+        : _createDefaultApiServer();
 
     var insightsConfig = _insightsConfigMap(configMap, environment);
     var insightsServer = insightsConfig != null

--- a/packages/serverpod_shared/test/config_test.dart
+++ b/packages/serverpod_shared/test/config_test.dart
@@ -1023,9 +1023,7 @@ futureCallExecutionEnabled: false
   });
 
   group('Given an empty Serverpod config map when loading from Map then', () {
-    test(
-        'future call config uses default concurrency limit of 1 instead of null',
-        () {
+    test('future call config uses default concurrency limit of 1', () {
       var config = ServerpodConfig.loadFromMap(
         runMode,
         serverId,
@@ -1034,8 +1032,6 @@ futureCallExecutionEnabled: false
         environment: {},
       );
 
-      // This is the key difference - when parsing an empty map, the future call config
-      // gets the default concurrency limit of 1 instead of null like defaultConfig()
       expect(config.futureCall.concurrencyLimit, 1);
       expect(config.futureCall.scanInterval.inMilliseconds, 5000);
       expect(config.apiServer.port, 8080);

--- a/packages/serverpod_shared/test/config_test.dart
+++ b/packages/serverpod_shared/test/config_test.dart
@@ -11,15 +11,13 @@ void main() {
   var passwords = {'serviceSecret': 'longpasswordthatisrequired'};
 
   test(
-      'Given a Serverpod config missing api server configuration when loading from Map then exception is thrown.',
+      'Given a Serverpod config missing api server configuration when loading from Map then default api server configuration is used.',
       () {
+    var config = ServerpodConfig.loadFromMap(runMode, serverId, passwords, {});
+    expect(config, isA<ServerpodConfig>());
     expect(
-      () => ServerpodConfig.loadFromMap(runMode, serverId, passwords, {}),
-      throwsA(isA<Exception>().having(
-        (e) => e.toString(),
-        'message',
-        equals('Serverpod API server configuration is missing.'),
-      )),
+      config.apiServer,
+      equals(ServerpodConfig.defaultConfig().apiServer),
     );
   });
 

--- a/packages/serverpod_shared/test/config_test.dart
+++ b/packages/serverpod_shared/test/config_test.dart
@@ -15,10 +15,10 @@ void main() {
       () {
     var config = ServerpodConfig.loadFromMap(runMode, serverId, passwords, {});
     expect(config, isA<ServerpodConfig>());
-    expect(
-      config.apiServer,
-      equals(ServerpodConfig.defaultConfig().apiServer),
-    );
+    expect(config.apiServer.port, 8080);
+    expect(config.apiServer.publicHost, 'localhost');
+    expect(config.apiServer.publicPort, 8080);
+    expect(config.apiServer.publicScheme, 'http');
   });
 
   test(


### PR DESCRIPTION
Due to Mini not including configuration files by default, the config is never constructed and always throws when the API config is missing. This causes a default config to be used always. Since we are refactoring config to be the source of truth for CLI args in #3619, this behaviour is a blocker as we use config's runMode, role, etc. And since we previously threw, we would never successfully construct a config from CLI args and therefore, options like `--mode`, `--role` are ignored.

## Pre-launch Checklist

- [X] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [X] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [X] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [X] I added new tests to check the change I am making.
- [X] All existing and new tests are passing.
- [X] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of missing API server configuration by automatically using default values instead of causing errors.
  - Future call concurrency limit now defaults to 1 when not specified.

- **Tests**
  - Updated and added tests to verify the use of default configuration values when loading from an empty config map or missing API server settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->