### PR TITLE
feat(auth2): Add method to list authentication tokens in `AuthenticationTokens`

### DIFF
--- a/modules/new_serverpod_auth/serverpod_auth_jwt/serverpod_auth_jwt_client/lib/src/protocol/authentication_token_info.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_jwt/serverpod_auth_jwt_client/lib/src/protocol/authentication_token_info.dart
@@ -16,7 +16,7 @@ abstract class AuthenticationTokenInfo implements _i1.SerializableModel {
     required this.id,
     required this.authUserId,
     required this.scopeNames,
-    this.extraClaims,
+    this.extraClaimsJSON,
     required this.lastUpdated,
     required this.created,
   });
@@ -25,7 +25,7 @@ abstract class AuthenticationTokenInfo implements _i1.SerializableModel {
     required _i1.UuidValue id,
     required _i1.UuidValue authUserId,
     required Set<String> scopeNames,
-    String? extraClaims,
+    String? extraClaimsJSON,
     required DateTime lastUpdated,
     required DateTime created,
   }) = _AuthenticationTokenInfoImpl;
@@ -39,7 +39,7 @@ abstract class AuthenticationTokenInfo implements _i1.SerializableModel {
       scopeNames: _i1.SetJsonExtension.fromJson(
           (jsonSerialization['scopeNames'] as List),
           itemFromJson: (e) => e as String)!,
-      extraClaims: jsonSerialization['extraClaims'] as String?,
+      extraClaimsJSON: jsonSerialization['extraClaimsJSON'] as String?,
       lastUpdated:
           _i1.DateTimeJsonExtension.fromJson(jsonSerialization['lastUpdated']),
       created: _i1.DateTimeJsonExtension.fromJson(jsonSerialization['created']),
@@ -57,7 +57,7 @@ abstract class AuthenticationTokenInfo implements _i1.SerializableModel {
   /// Extra claims set on this session.
   ///
   /// Stored as JSON encoded `Map<String, dynamic>`
-  String? extraClaims;
+  String? extraClaimsJSON;
 
   /// The last time when a new token pair was created for this session.
   DateTime lastUpdated;
@@ -72,7 +72,7 @@ abstract class AuthenticationTokenInfo implements _i1.SerializableModel {
     _i1.UuidValue? id,
     _i1.UuidValue? authUserId,
     Set<String>? scopeNames,
-    String? extraClaims,
+    String? extraClaimsJSON,
     DateTime? lastUpdated,
     DateTime? created,
   });
@@ -82,7 +82,7 @@ abstract class AuthenticationTokenInfo implements _i1.SerializableModel {
       'id': id.toJson(),
       'authUserId': authUserId.toJson(),
       'scopeNames': scopeNames.toJson(),
-      if (extraClaims != null) 'extraClaims': extraClaims,
+      if (extraClaimsJSON != null) 'extraClaimsJSON': extraClaimsJSON,
       'lastUpdated': lastUpdated.toJson(),
       'created': created.toJson(),
     };
@@ -101,14 +101,14 @@ class _AuthenticationTokenInfoImpl extends AuthenticationTokenInfo {
     required _i1.UuidValue id,
     required _i1.UuidValue authUserId,
     required Set<String> scopeNames,
-    String? extraClaims,
+    String? extraClaimsJSON,
     required DateTime lastUpdated,
     required DateTime created,
   }) : super._(
           id: id,
           authUserId: authUserId,
           scopeNames: scopeNames,
-          extraClaims: extraClaims,
+          extraClaimsJSON: extraClaimsJSON,
           lastUpdated: lastUpdated,
           created: created,
         );
@@ -121,7 +121,7 @@ class _AuthenticationTokenInfoImpl extends AuthenticationTokenInfo {
     _i1.UuidValue? id,
     _i1.UuidValue? authUserId,
     Set<String>? scopeNames,
-    Object? extraClaims = _Undefined,
+    Object? extraClaimsJSON = _Undefined,
     DateTime? lastUpdated,
     DateTime? created,
   }) {
@@ -129,7 +129,8 @@ class _AuthenticationTokenInfoImpl extends AuthenticationTokenInfo {
       id: id ?? this.id,
       authUserId: authUserId ?? this.authUserId,
       scopeNames: scopeNames ?? this.scopeNames.map((e0) => e0).toSet(),
-      extraClaims: extraClaims is String? ? extraClaims : this.extraClaims,
+      extraClaimsJSON:
+          extraClaimsJSON is String? ? extraClaimsJSON : this.extraClaimsJSON,
       lastUpdated: lastUpdated ?? this.lastUpdated,
       created: created ?? this.created,
     );

--- a/modules/new_serverpod_auth/serverpod_auth_jwt/serverpod_auth_jwt_client/lib/src/protocol/authentication_token_info.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_jwt/serverpod_auth_jwt_client/lib/src/protocol/authentication_token_info.dart
@@ -1,0 +1,137 @@
+/* AUTOMATICALLY GENERATED CODE DO NOT MODIFY */
+/*   To generate run: "serverpod generate"    */
+
+// ignore_for_file: implementation_imports
+// ignore_for_file: library_private_types_in_public_api
+// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: public_member_api_docs
+// ignore_for_file: type_literal_in_constant_pattern
+// ignore_for_file: use_super_parameters
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:serverpod_client/serverpod_client.dart' as _i1;
+
+abstract class AuthenticationTokenInfo implements _i1.SerializableModel {
+  AuthenticationTokenInfo._({
+    required this.id,
+    required this.authUserId,
+    required this.scopeNames,
+    this.extraClaims,
+    required this.lastUpdated,
+    required this.created,
+  });
+
+  factory AuthenticationTokenInfo({
+    required _i1.UuidValue id,
+    required _i1.UuidValue authUserId,
+    required Set<String> scopeNames,
+    String? extraClaims,
+    required DateTime lastUpdated,
+    required DateTime created,
+  }) = _AuthenticationTokenInfoImpl;
+
+  factory AuthenticationTokenInfo.fromJson(
+      Map<String, dynamic> jsonSerialization) {
+    return AuthenticationTokenInfo(
+      id: _i1.UuidValueJsonExtension.fromJson(jsonSerialization['id']),
+      authUserId:
+          _i1.UuidValueJsonExtension.fromJson(jsonSerialization['authUserId']),
+      scopeNames: _i1.SetJsonExtension.fromJson(
+          (jsonSerialization['scopeNames'] as List),
+          itemFromJson: (e) => e as String)!,
+      extraClaims: jsonSerialization['extraClaims'] as String?,
+      lastUpdated:
+          _i1.DateTimeJsonExtension.fromJson(jsonSerialization['lastUpdated']),
+      created: _i1.DateTimeJsonExtension.fromJson(jsonSerialization['created']),
+    );
+  }
+
+  _i1.UuidValue id;
+
+  /// The [AuthUser] this refresh token belongs to.
+  _i1.UuidValue authUserId;
+
+  /// The scopes given to this session.
+  Set<String> scopeNames;
+
+  /// Extra claims set on this session.
+  ///
+  /// Stored as JSON encoded `Map<String, dynamic>`
+  String? extraClaims;
+
+  /// The last time when a new token pair was created for this session.
+  DateTime lastUpdated;
+
+  /// The time when this session was initially created.
+  DateTime created;
+
+  /// Returns a shallow copy of this [AuthenticationTokenInfo]
+  /// with some or all fields replaced by the given arguments.
+  @_i1.useResult
+  AuthenticationTokenInfo copyWith({
+    _i1.UuidValue? id,
+    _i1.UuidValue? authUserId,
+    Set<String>? scopeNames,
+    String? extraClaims,
+    DateTime? lastUpdated,
+    DateTime? created,
+  });
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id.toJson(),
+      'authUserId': authUserId.toJson(),
+      'scopeNames': scopeNames.toJson(),
+      if (extraClaims != null) 'extraClaims': extraClaims,
+      'lastUpdated': lastUpdated.toJson(),
+      'created': created.toJson(),
+    };
+  }
+
+  @override
+  String toString() {
+    return _i1.SerializationManager.encode(this);
+  }
+}
+
+class _Undefined {}
+
+class _AuthenticationTokenInfoImpl extends AuthenticationTokenInfo {
+  _AuthenticationTokenInfoImpl({
+    required _i1.UuidValue id,
+    required _i1.UuidValue authUserId,
+    required Set<String> scopeNames,
+    String? extraClaims,
+    required DateTime lastUpdated,
+    required DateTime created,
+  }) : super._(
+          id: id,
+          authUserId: authUserId,
+          scopeNames: scopeNames,
+          extraClaims: extraClaims,
+          lastUpdated: lastUpdated,
+          created: created,
+        );
+
+  /// Returns a shallow copy of this [AuthenticationTokenInfo]
+  /// with some or all fields replaced by the given arguments.
+  @_i1.useResult
+  @override
+  AuthenticationTokenInfo copyWith({
+    _i1.UuidValue? id,
+    _i1.UuidValue? authUserId,
+    Set<String>? scopeNames,
+    Object? extraClaims = _Undefined,
+    DateTime? lastUpdated,
+    DateTime? created,
+  }) {
+    return AuthenticationTokenInfo(
+      id: id ?? this.id,
+      authUserId: authUserId ?? this.authUserId,
+      scopeNames: scopeNames ?? this.scopeNames.map((e0) => e0).toSet(),
+      extraClaims: extraClaims is String? ? extraClaims : this.extraClaims,
+      lastUpdated: lastUpdated ?? this.lastUpdated,
+      created: created ?? this.created,
+    );
+  }
+}

--- a/modules/new_serverpod_auth/serverpod_auth_jwt/serverpod_auth_jwt_client/lib/src/protocol/protocol.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_jwt/serverpod_auth_jwt_client/lib/src/protocol/protocol.dart
@@ -10,13 +10,15 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
-import 'refresh_token_expired_exception.dart' as _i2;
-import 'refresh_token_invalid_secret_exception.dart' as _i3;
-import 'refresh_token_malformed_exception.dart' as _i4;
-import 'refresh_token_not_found_exception.dart' as _i5;
-import 'token_pair.dart' as _i6;
+import 'authentication_token_info.dart' as _i2;
+import 'refresh_token_expired_exception.dart' as _i3;
+import 'refresh_token_invalid_secret_exception.dart' as _i4;
+import 'refresh_token_malformed_exception.dart' as _i5;
+import 'refresh_token_not_found_exception.dart' as _i6;
+import 'token_pair.dart' as _i7;
 import 'package:serverpod_auth_user_client/serverpod_auth_user_client.dart'
-    as _i7;
+    as _i8;
+export 'authentication_token_info.dart';
 export 'refresh_token_expired_exception.dart';
 export 'refresh_token_invalid_secret_exception.dart';
 export 'refresh_token_malformed_exception.dart';
@@ -37,46 +39,56 @@ class Protocol extends _i1.SerializationManager {
     Type? t,
   ]) {
     t ??= T;
-    if (t == _i2.RefreshTokenExpiredException) {
-      return _i2.RefreshTokenExpiredException.fromJson(data) as T;
+    if (t == _i2.AuthenticationTokenInfo) {
+      return _i2.AuthenticationTokenInfo.fromJson(data) as T;
     }
-    if (t == _i3.RefreshTokenInvalidSecretException) {
-      return _i3.RefreshTokenInvalidSecretException.fromJson(data) as T;
+    if (t == _i3.RefreshTokenExpiredException) {
+      return _i3.RefreshTokenExpiredException.fromJson(data) as T;
     }
-    if (t == _i4.RefreshTokenMalformedException) {
-      return _i4.RefreshTokenMalformedException.fromJson(data) as T;
+    if (t == _i4.RefreshTokenInvalidSecretException) {
+      return _i4.RefreshTokenInvalidSecretException.fromJson(data) as T;
     }
-    if (t == _i5.RefreshTokenNotFoundException) {
-      return _i5.RefreshTokenNotFoundException.fromJson(data) as T;
+    if (t == _i5.RefreshTokenMalformedException) {
+      return _i5.RefreshTokenMalformedException.fromJson(data) as T;
     }
-    if (t == _i6.TokenPair) {
-      return _i6.TokenPair.fromJson(data) as T;
+    if (t == _i6.RefreshTokenNotFoundException) {
+      return _i6.RefreshTokenNotFoundException.fromJson(data) as T;
     }
-    if (t == _i1.getType<_i2.RefreshTokenExpiredException?>()) {
+    if (t == _i7.TokenPair) {
+      return _i7.TokenPair.fromJson(data) as T;
+    }
+    if (t == _i1.getType<_i2.AuthenticationTokenInfo?>()) {
+      return (data != null ? _i2.AuthenticationTokenInfo.fromJson(data) : null)
+          as T;
+    }
+    if (t == _i1.getType<_i3.RefreshTokenExpiredException?>()) {
       return (data != null
-          ? _i2.RefreshTokenExpiredException.fromJson(data)
+          ? _i3.RefreshTokenExpiredException.fromJson(data)
           : null) as T;
     }
-    if (t == _i1.getType<_i3.RefreshTokenInvalidSecretException?>()) {
+    if (t == _i1.getType<_i4.RefreshTokenInvalidSecretException?>()) {
       return (data != null
-          ? _i3.RefreshTokenInvalidSecretException.fromJson(data)
+          ? _i4.RefreshTokenInvalidSecretException.fromJson(data)
           : null) as T;
     }
-    if (t == _i1.getType<_i4.RefreshTokenMalformedException?>()) {
+    if (t == _i1.getType<_i5.RefreshTokenMalformedException?>()) {
       return (data != null
-          ? _i4.RefreshTokenMalformedException.fromJson(data)
+          ? _i5.RefreshTokenMalformedException.fromJson(data)
           : null) as T;
     }
-    if (t == _i1.getType<_i5.RefreshTokenNotFoundException?>()) {
+    if (t == _i1.getType<_i6.RefreshTokenNotFoundException?>()) {
       return (data != null
-          ? _i5.RefreshTokenNotFoundException.fromJson(data)
+          ? _i6.RefreshTokenNotFoundException.fromJson(data)
           : null) as T;
     }
-    if (t == _i1.getType<_i6.TokenPair?>()) {
-      return (data != null ? _i6.TokenPair.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i7.TokenPair?>()) {
+      return (data != null ? _i7.TokenPair.fromJson(data) : null) as T;
+    }
+    if (t == Set<String>) {
+      return (data as List).map((e) => deserialize<String>(e)).toSet() as T;
     }
     try {
-      return _i7.Protocol().deserialize<T>(data, t);
+      return _i8.Protocol().deserialize<T>(data, t);
     } on _i1.DeserializationTypeNotFoundException catch (_) {}
     return super.deserialize<T>(data, t);
   }
@@ -85,22 +97,25 @@ class Protocol extends _i1.SerializationManager {
   String? getClassNameForObject(Object? data) {
     String? className = super.getClassNameForObject(data);
     if (className != null) return className;
-    if (data is _i2.RefreshTokenExpiredException) {
+    if (data is _i2.AuthenticationTokenInfo) {
+      return 'AuthenticationTokenInfo';
+    }
+    if (data is _i3.RefreshTokenExpiredException) {
       return 'RefreshTokenExpiredException';
     }
-    if (data is _i3.RefreshTokenInvalidSecretException) {
+    if (data is _i4.RefreshTokenInvalidSecretException) {
       return 'RefreshTokenInvalidSecretException';
     }
-    if (data is _i4.RefreshTokenMalformedException) {
+    if (data is _i5.RefreshTokenMalformedException) {
       return 'RefreshTokenMalformedException';
     }
-    if (data is _i5.RefreshTokenNotFoundException) {
+    if (data is _i6.RefreshTokenNotFoundException) {
       return 'RefreshTokenNotFoundException';
     }
-    if (data is _i6.TokenPair) {
+    if (data is _i7.TokenPair) {
       return 'TokenPair';
     }
-    className = _i7.Protocol().getClassNameForObject(data);
+    className = _i8.Protocol().getClassNameForObject(data);
     if (className != null) {
       return 'serverpod_auth_user.$className';
     }
@@ -113,24 +128,27 @@ class Protocol extends _i1.SerializationManager {
     if (dataClassName is! String) {
       return super.deserializeByClassName(data);
     }
+    if (dataClassName == 'AuthenticationTokenInfo') {
+      return deserialize<_i2.AuthenticationTokenInfo>(data['data']);
+    }
     if (dataClassName == 'RefreshTokenExpiredException') {
-      return deserialize<_i2.RefreshTokenExpiredException>(data['data']);
+      return deserialize<_i3.RefreshTokenExpiredException>(data['data']);
     }
     if (dataClassName == 'RefreshTokenInvalidSecretException') {
-      return deserialize<_i3.RefreshTokenInvalidSecretException>(data['data']);
+      return deserialize<_i4.RefreshTokenInvalidSecretException>(data['data']);
     }
     if (dataClassName == 'RefreshTokenMalformedException') {
-      return deserialize<_i4.RefreshTokenMalformedException>(data['data']);
+      return deserialize<_i5.RefreshTokenMalformedException>(data['data']);
     }
     if (dataClassName == 'RefreshTokenNotFoundException') {
-      return deserialize<_i5.RefreshTokenNotFoundException>(data['data']);
+      return deserialize<_i6.RefreshTokenNotFoundException>(data['data']);
     }
     if (dataClassName == 'TokenPair') {
-      return deserialize<_i6.TokenPair>(data['data']);
+      return deserialize<_i7.TokenPair>(data['data']);
     }
     if (dataClassName.startsWith('serverpod_auth_user.')) {
       data['className'] = dataClassName.substring(20);
-      return _i7.Protocol().deserializeByClassName(data);
+      return _i8.Protocol().deserializeByClassName(data);
     }
     return super.deserializeByClassName(data);
   }

--- a/modules/new_serverpod_auth/serverpod_auth_jwt/serverpod_auth_jwt_server/lib/serverpod_auth_jwt_server.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_jwt/serverpod_auth_jwt_server/lib/serverpod_auth_jwt_server.dart
@@ -6,3 +6,5 @@ export 'src/business/authentication_tokens_admin.dart'
     show AuthenticationTokensAdmin;
 export 'src/generated/endpoints.dart';
 export 'src/generated/protocol.dart' hide RefreshToken, RefreshTokenRepository;
+export 'src/util/authentication_token_info_extension.dart'
+    show AuthenticationTokenInfoExtension;

--- a/modules/new_serverpod_auth/serverpod_auth_jwt/serverpod_auth_jwt_server/lib/src/business/authentication_tokens.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_jwt/serverpod_auth_jwt_server/lib/src/business/authentication_tokens.dart
@@ -172,7 +172,7 @@ abstract final class AuthenticationTokens {
       refreshTokenRow.copyWith(
         rotatingSecretHash: ByteData.sublistView(newHash.hash),
         rotatingSecretSalt: ByteData.sublistView(newHash.salt),
-        lastUpdated: DateTime.now(),
+        lastUpdated: clock.now(),
       ),
       transaction: transaction,
     );
@@ -287,8 +287,8 @@ extension on Set<Scope> {
 
 extension on RefreshToken {
   bool get isExpired {
-    final oldestAcceptedRefreshTokenDate = DateTime.now()
-        .subtract(AuthenticationTokens.config.refreshTokenLifetime);
+    final oldestAcceptedRefreshTokenDate =
+        clock.now().subtract(AuthenticationTokens.config.refreshTokenLifetime);
 
     return lastUpdated.isBefore(oldestAcceptedRefreshTokenDate);
   }

--- a/modules/new_serverpod_auth/serverpod_auth_jwt/serverpod_auth_jwt_server/lib/src/business/authentication_tokens.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_jwt/serverpod_auth_jwt_server/lib/src/business/authentication_tokens.dart
@@ -244,7 +244,7 @@ abstract final class AuthenticationTokens {
     required final UuidValue authUserId,
     final Transaction? transaction,
   }) async {
-    return admin.findAuthenticationTokens(
+    return admin.listAuthenticationTokens(
       session,
       authUserId: authUserId,
       transaction: transaction,

--- a/modules/new_serverpod_auth/serverpod_auth_jwt/serverpod_auth_jwt_server/lib/src/business/authentication_tokens.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_jwt/serverpod_auth_jwt_server/lib/src/business/authentication_tokens.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:typed_data';
 
+import 'package:clock/clock.dart';
 import 'package:dart_jsonwebtoken/dart_jsonwebtoken.dart';
 import 'package:meta/meta.dart';
 import 'package:serverpod/protocol.dart';
@@ -82,6 +83,8 @@ abstract final class AuthenticationTokens {
         rotatingSecretSalt: ByteData.sublistView(newHash.salt),
         scopeNames: scopes.names,
         extraClaims: extraClaims != null ? jsonEncode(extraClaims) : null,
+        created: clock.now(),
+        lastUpdated: clock.now(),
       ),
       transaction: transaction,
     );
@@ -232,6 +235,19 @@ abstract final class AuthenticationTokens {
     await session.messages.authenticationRevoked(
       refreshToken.authUserId,
       RevokedAuthenticationAuthId(authId: refreshTokenId.toString()),
+    );
+  }
+
+  /// List all authentication tokens belonging to the given [authUserId].
+  static Future<List<AuthenticationTokenInfo>> listAuthenticationTokens(
+    final Session session, {
+    required final UuidValue authUserId,
+    final Transaction? transaction,
+  }) async {
+    return admin.findAuthenticationTokens(
+      session,
+      authUserId: authUserId,
+      transaction: transaction,
     );
   }
 

--- a/modules/new_serverpod_auth/serverpod_auth_jwt/serverpod_auth_jwt_server/lib/src/business/authentication_tokens_admin.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_jwt/serverpod_auth_jwt_server/lib/src/business/authentication_tokens_admin.dart
@@ -30,9 +30,18 @@ final class AuthenticationTokensAdmin {
     final Session session, {
     final UuidValue? authUserId,
     final Transaction? transaction,
+
+    /// How many items to return at maximum. Must be <= 1000.
     final int limit = 100,
     final int offset = 0,
   }) async {
+    if (limit <= 0 || limit > 1000) {
+      throw ArgumentError.value(limit, 'limit', 'Must be between 1 and 1000');
+    }
+    if (offset < 0) {
+      throw ArgumentError.value(offset, 'offset', 'Must be >= 0');
+    }
+
     final refreshTokens = await RefreshToken.db.find(
       session,
       where: (final t) => (authUserId != null

--- a/modules/new_serverpod_auth/serverpod_auth_jwt/serverpod_auth_jwt_server/lib/src/business/authentication_tokens_admin.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_jwt/serverpod_auth_jwt_server/lib/src/business/authentication_tokens_admin.dart
@@ -26,7 +26,7 @@ final class AuthenticationTokensAdmin {
   }
 
   /// List all authentication tokens matching the given filters.
-  Future<List<AuthenticationTokenInfo>> findAuthenticationTokens(
+  Future<List<AuthenticationTokenInfo>> listAuthenticationTokens(
     final Session session, {
     final UuidValue? authUserId,
     final Transaction? transaction,

--- a/modules/new_serverpod_auth/serverpod_auth_jwt/serverpod_auth_jwt_server/lib/src/business/authentication_tokens_admin.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_jwt/serverpod_auth_jwt_server/lib/src/business/authentication_tokens_admin.dart
@@ -52,7 +52,7 @@ final class AuthenticationTokensAdmin {
           scopeNames: refreshToken.scopeNames,
           created: refreshToken.created,
           lastUpdated: refreshToken.lastUpdated,
-          extraClaims: refreshToken.extraClaims,
+          extraClaimsJSON: refreshToken.extraClaims,
         ),
     ];
 

--- a/modules/new_serverpod_auth/serverpod_auth_jwt/serverpod_auth_jwt_server/lib/src/business/authentication_tokens_admin.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_jwt/serverpod_auth_jwt_server/lib/src/business/authentication_tokens_admin.dart
@@ -1,3 +1,4 @@
+import 'package:clock/clock.dart';
 import 'package:meta/meta.dart';
 import 'package:serverpod/serverpod.dart';
 import 'package:serverpod_auth_jwt_server/serverpod_auth_jwt_server.dart';
@@ -14,8 +15,8 @@ final class AuthenticationTokensAdmin {
     final Session session, {
     final Transaction? transaction,
   }) async {
-    final oldestValidRefreshTokenDate = DateTime.now()
-        .subtract(AuthenticationTokens.config.refreshTokenLifetime);
+    final oldestValidRefreshTokenDate =
+        clock.now().subtract(AuthenticationTokens.config.refreshTokenLifetime);
 
     await RefreshToken.db.deleteWhere(
       session,

--- a/modules/new_serverpod_auth/serverpod_auth_jwt/serverpod_auth_jwt_server/lib/src/business/authentication_tokens_admin.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_jwt/serverpod_auth_jwt_server/lib/src/business/authentication_tokens_admin.dart
@@ -30,12 +30,17 @@ final class AuthenticationTokensAdmin {
     final Session session, {
     final UuidValue? authUserId,
     final Transaction? transaction,
+    final int limit = 100,
+    final int offset = 0,
   }) async {
     final refreshTokens = await RefreshToken.db.find(
       session,
       where: (final t) => (authUserId != null
           ? t.authUserId.equals(authUserId)
           : Constant.bool(true)),
+      limit: limit,
+      offset: offset,
+      orderBy: (final t) => t.id,
       transaction: transaction,
     );
 

--- a/modules/new_serverpod_auth/serverpod_auth_jwt/serverpod_auth_jwt_server/lib/src/generated/authentication_token_info.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_jwt/serverpod_auth_jwt_server/lib/src/generated/authentication_token_info.dart
@@ -17,7 +17,7 @@ abstract class AuthenticationTokenInfo
     required this.id,
     required this.authUserId,
     required this.scopeNames,
-    this.extraClaims,
+    this.extraClaimsJSON,
     required this.lastUpdated,
     required this.created,
   });
@@ -26,7 +26,7 @@ abstract class AuthenticationTokenInfo
     required _i1.UuidValue id,
     required _i1.UuidValue authUserId,
     required Set<String> scopeNames,
-    String? extraClaims,
+    String? extraClaimsJSON,
     required DateTime lastUpdated,
     required DateTime created,
   }) = _AuthenticationTokenInfoImpl;
@@ -40,7 +40,7 @@ abstract class AuthenticationTokenInfo
       scopeNames: _i1.SetJsonExtension.fromJson(
           (jsonSerialization['scopeNames'] as List),
           itemFromJson: (e) => e as String)!,
-      extraClaims: jsonSerialization['extraClaims'] as String?,
+      extraClaimsJSON: jsonSerialization['extraClaimsJSON'] as String?,
       lastUpdated:
           _i1.DateTimeJsonExtension.fromJson(jsonSerialization['lastUpdated']),
       created: _i1.DateTimeJsonExtension.fromJson(jsonSerialization['created']),
@@ -58,7 +58,7 @@ abstract class AuthenticationTokenInfo
   /// Extra claims set on this session.
   ///
   /// Stored as JSON encoded `Map<String, dynamic>`
-  String? extraClaims;
+  String? extraClaimsJSON;
 
   /// The last time when a new token pair was created for this session.
   DateTime lastUpdated;
@@ -73,7 +73,7 @@ abstract class AuthenticationTokenInfo
     _i1.UuidValue? id,
     _i1.UuidValue? authUserId,
     Set<String>? scopeNames,
-    String? extraClaims,
+    String? extraClaimsJSON,
     DateTime? lastUpdated,
     DateTime? created,
   });
@@ -83,7 +83,7 @@ abstract class AuthenticationTokenInfo
       'id': id.toJson(),
       'authUserId': authUserId.toJson(),
       'scopeNames': scopeNames.toJson(),
-      if (extraClaims != null) 'extraClaims': extraClaims,
+      if (extraClaimsJSON != null) 'extraClaimsJSON': extraClaimsJSON,
       'lastUpdated': lastUpdated.toJson(),
       'created': created.toJson(),
     };
@@ -95,7 +95,7 @@ abstract class AuthenticationTokenInfo
       'id': id.toJson(),
       'authUserId': authUserId.toJson(),
       'scopeNames': scopeNames.toJson(),
-      if (extraClaims != null) 'extraClaims': extraClaims,
+      if (extraClaimsJSON != null) 'extraClaimsJSON': extraClaimsJSON,
       'lastUpdated': lastUpdated.toJson(),
       'created': created.toJson(),
     };
@@ -114,14 +114,14 @@ class _AuthenticationTokenInfoImpl extends AuthenticationTokenInfo {
     required _i1.UuidValue id,
     required _i1.UuidValue authUserId,
     required Set<String> scopeNames,
-    String? extraClaims,
+    String? extraClaimsJSON,
     required DateTime lastUpdated,
     required DateTime created,
   }) : super._(
           id: id,
           authUserId: authUserId,
           scopeNames: scopeNames,
-          extraClaims: extraClaims,
+          extraClaimsJSON: extraClaimsJSON,
           lastUpdated: lastUpdated,
           created: created,
         );
@@ -134,7 +134,7 @@ class _AuthenticationTokenInfoImpl extends AuthenticationTokenInfo {
     _i1.UuidValue? id,
     _i1.UuidValue? authUserId,
     Set<String>? scopeNames,
-    Object? extraClaims = _Undefined,
+    Object? extraClaimsJSON = _Undefined,
     DateTime? lastUpdated,
     DateTime? created,
   }) {
@@ -142,7 +142,8 @@ class _AuthenticationTokenInfoImpl extends AuthenticationTokenInfo {
       id: id ?? this.id,
       authUserId: authUserId ?? this.authUserId,
       scopeNames: scopeNames ?? this.scopeNames.map((e0) => e0).toSet(),
-      extraClaims: extraClaims is String? ? extraClaims : this.extraClaims,
+      extraClaimsJSON:
+          extraClaimsJSON is String? ? extraClaimsJSON : this.extraClaimsJSON,
       lastUpdated: lastUpdated ?? this.lastUpdated,
       created: created ?? this.created,
     );

--- a/modules/new_serverpod_auth/serverpod_auth_jwt/serverpod_auth_jwt_server/lib/src/generated/authentication_token_info.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_jwt/serverpod_auth_jwt_server/lib/src/generated/authentication_token_info.dart
@@ -1,0 +1,150 @@
+/* AUTOMATICALLY GENERATED CODE DO NOT MODIFY */
+/*   To generate run: "serverpod generate"    */
+
+// ignore_for_file: implementation_imports
+// ignore_for_file: library_private_types_in_public_api
+// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: public_member_api_docs
+// ignore_for_file: type_literal_in_constant_pattern
+// ignore_for_file: use_super_parameters
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:serverpod/serverpod.dart' as _i1;
+
+abstract class AuthenticationTokenInfo
+    implements _i1.SerializableModel, _i1.ProtocolSerialization {
+  AuthenticationTokenInfo._({
+    required this.id,
+    required this.authUserId,
+    required this.scopeNames,
+    this.extraClaims,
+    required this.lastUpdated,
+    required this.created,
+  });
+
+  factory AuthenticationTokenInfo({
+    required _i1.UuidValue id,
+    required _i1.UuidValue authUserId,
+    required Set<String> scopeNames,
+    String? extraClaims,
+    required DateTime lastUpdated,
+    required DateTime created,
+  }) = _AuthenticationTokenInfoImpl;
+
+  factory AuthenticationTokenInfo.fromJson(
+      Map<String, dynamic> jsonSerialization) {
+    return AuthenticationTokenInfo(
+      id: _i1.UuidValueJsonExtension.fromJson(jsonSerialization['id']),
+      authUserId:
+          _i1.UuidValueJsonExtension.fromJson(jsonSerialization['authUserId']),
+      scopeNames: _i1.SetJsonExtension.fromJson(
+          (jsonSerialization['scopeNames'] as List),
+          itemFromJson: (e) => e as String)!,
+      extraClaims: jsonSerialization['extraClaims'] as String?,
+      lastUpdated:
+          _i1.DateTimeJsonExtension.fromJson(jsonSerialization['lastUpdated']),
+      created: _i1.DateTimeJsonExtension.fromJson(jsonSerialization['created']),
+    );
+  }
+
+  _i1.UuidValue id;
+
+  /// The [AuthUser] this refresh token belongs to.
+  _i1.UuidValue authUserId;
+
+  /// The scopes given to this session.
+  Set<String> scopeNames;
+
+  /// Extra claims set on this session.
+  ///
+  /// Stored as JSON encoded `Map<String, dynamic>`
+  String? extraClaims;
+
+  /// The last time when a new token pair was created for this session.
+  DateTime lastUpdated;
+
+  /// The time when this session was initially created.
+  DateTime created;
+
+  /// Returns a shallow copy of this [AuthenticationTokenInfo]
+  /// with some or all fields replaced by the given arguments.
+  @_i1.useResult
+  AuthenticationTokenInfo copyWith({
+    _i1.UuidValue? id,
+    _i1.UuidValue? authUserId,
+    Set<String>? scopeNames,
+    String? extraClaims,
+    DateTime? lastUpdated,
+    DateTime? created,
+  });
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id.toJson(),
+      'authUserId': authUserId.toJson(),
+      'scopeNames': scopeNames.toJson(),
+      if (extraClaims != null) 'extraClaims': extraClaims,
+      'lastUpdated': lastUpdated.toJson(),
+      'created': created.toJson(),
+    };
+  }
+
+  @override
+  Map<String, dynamic> toJsonForProtocol() {
+    return {
+      'id': id.toJson(),
+      'authUserId': authUserId.toJson(),
+      'scopeNames': scopeNames.toJson(),
+      if (extraClaims != null) 'extraClaims': extraClaims,
+      'lastUpdated': lastUpdated.toJson(),
+      'created': created.toJson(),
+    };
+  }
+
+  @override
+  String toString() {
+    return _i1.SerializationManager.encode(this);
+  }
+}
+
+class _Undefined {}
+
+class _AuthenticationTokenInfoImpl extends AuthenticationTokenInfo {
+  _AuthenticationTokenInfoImpl({
+    required _i1.UuidValue id,
+    required _i1.UuidValue authUserId,
+    required Set<String> scopeNames,
+    String? extraClaims,
+    required DateTime lastUpdated,
+    required DateTime created,
+  }) : super._(
+          id: id,
+          authUserId: authUserId,
+          scopeNames: scopeNames,
+          extraClaims: extraClaims,
+          lastUpdated: lastUpdated,
+          created: created,
+        );
+
+  /// Returns a shallow copy of this [AuthenticationTokenInfo]
+  /// with some or all fields replaced by the given arguments.
+  @_i1.useResult
+  @override
+  AuthenticationTokenInfo copyWith({
+    _i1.UuidValue? id,
+    _i1.UuidValue? authUserId,
+    Set<String>? scopeNames,
+    Object? extraClaims = _Undefined,
+    DateTime? lastUpdated,
+    DateTime? created,
+  }) {
+    return AuthenticationTokenInfo(
+      id: id ?? this.id,
+      authUserId: authUserId ?? this.authUserId,
+      scopeNames: scopeNames ?? this.scopeNames.map((e0) => e0).toSet(),
+      extraClaims: extraClaims is String? ? extraClaims : this.extraClaims,
+      lastUpdated: lastUpdated ?? this.lastUpdated,
+      created: created ?? this.created,
+    );
+  }
+}

--- a/modules/new_serverpod_auth/serverpod_auth_jwt/serverpod_auth_jwt_server/lib/src/generated/protocol.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_jwt/serverpod_auth_jwt_server/lib/src/generated/protocol.dart
@@ -47,7 +47,7 @@ class Protocol extends _i1.SerializationManagerServer {
           columnType: _i2.ColumnType.uuid,
           isNullable: false,
           dartType: 'UuidValue?',
-          columnDefault: 'gen_random_uuid()',
+          columnDefault: 'gen_random_uuid_v7()',
         ),
         _i2.ColumnDefinition(
           name: 'authUserId',

--- a/modules/new_serverpod_auth/serverpod_auth_jwt/serverpod_auth_jwt_server/lib/src/generated/protocol.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_jwt/serverpod_auth_jwt_server/lib/src/generated/protocol.dart
@@ -13,12 +13,14 @@ import 'package:serverpod/serverpod.dart' as _i1;
 import 'package:serverpod/protocol.dart' as _i2;
 import 'package:serverpod_auth_user_server/serverpod_auth_user_server.dart'
     as _i3;
-import 'refresh_token.dart' as _i4;
-import 'refresh_token_expired_exception.dart' as _i5;
-import 'refresh_token_invalid_secret_exception.dart' as _i6;
-import 'refresh_token_malformed_exception.dart' as _i7;
-import 'refresh_token_not_found_exception.dart' as _i8;
-import 'token_pair.dart' as _i9;
+import 'authentication_token_info.dart' as _i4;
+import 'refresh_token.dart' as _i5;
+import 'refresh_token_expired_exception.dart' as _i6;
+import 'refresh_token_invalid_secret_exception.dart' as _i7;
+import 'refresh_token_malformed_exception.dart' as _i8;
+import 'refresh_token_not_found_exception.dart' as _i9;
+import 'token_pair.dart' as _i10;
+export 'authentication_token_info.dart';
 export 'refresh_token.dart';
 export 'refresh_token_expired_exception.dart';
 export 'refresh_token_invalid_secret_exception.dart';
@@ -149,49 +151,56 @@ class Protocol extends _i1.SerializationManagerServer {
     Type? t,
   ]) {
     t ??= T;
-    if (t == _i4.RefreshToken) {
-      return _i4.RefreshToken.fromJson(data) as T;
+    if (t == _i4.AuthenticationTokenInfo) {
+      return _i4.AuthenticationTokenInfo.fromJson(data) as T;
     }
-    if (t == _i5.RefreshTokenExpiredException) {
-      return _i5.RefreshTokenExpiredException.fromJson(data) as T;
+    if (t == _i5.RefreshToken) {
+      return _i5.RefreshToken.fromJson(data) as T;
     }
-    if (t == _i6.RefreshTokenInvalidSecretException) {
-      return _i6.RefreshTokenInvalidSecretException.fromJson(data) as T;
+    if (t == _i6.RefreshTokenExpiredException) {
+      return _i6.RefreshTokenExpiredException.fromJson(data) as T;
     }
-    if (t == _i7.RefreshTokenMalformedException) {
-      return _i7.RefreshTokenMalformedException.fromJson(data) as T;
+    if (t == _i7.RefreshTokenInvalidSecretException) {
+      return _i7.RefreshTokenInvalidSecretException.fromJson(data) as T;
     }
-    if (t == _i8.RefreshTokenNotFoundException) {
-      return _i8.RefreshTokenNotFoundException.fromJson(data) as T;
+    if (t == _i8.RefreshTokenMalformedException) {
+      return _i8.RefreshTokenMalformedException.fromJson(data) as T;
     }
-    if (t == _i9.TokenPair) {
-      return _i9.TokenPair.fromJson(data) as T;
+    if (t == _i9.RefreshTokenNotFoundException) {
+      return _i9.RefreshTokenNotFoundException.fromJson(data) as T;
     }
-    if (t == _i1.getType<_i4.RefreshToken?>()) {
-      return (data != null ? _i4.RefreshToken.fromJson(data) : null) as T;
+    if (t == _i10.TokenPair) {
+      return _i10.TokenPair.fromJson(data) as T;
     }
-    if (t == _i1.getType<_i5.RefreshTokenExpiredException?>()) {
+    if (t == _i1.getType<_i4.AuthenticationTokenInfo?>()) {
+      return (data != null ? _i4.AuthenticationTokenInfo.fromJson(data) : null)
+          as T;
+    }
+    if (t == _i1.getType<_i5.RefreshToken?>()) {
+      return (data != null ? _i5.RefreshToken.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i6.RefreshTokenExpiredException?>()) {
       return (data != null
-          ? _i5.RefreshTokenExpiredException.fromJson(data)
+          ? _i6.RefreshTokenExpiredException.fromJson(data)
           : null) as T;
     }
-    if (t == _i1.getType<_i6.RefreshTokenInvalidSecretException?>()) {
+    if (t == _i1.getType<_i7.RefreshTokenInvalidSecretException?>()) {
       return (data != null
-          ? _i6.RefreshTokenInvalidSecretException.fromJson(data)
+          ? _i7.RefreshTokenInvalidSecretException.fromJson(data)
           : null) as T;
     }
-    if (t == _i1.getType<_i7.RefreshTokenMalformedException?>()) {
+    if (t == _i1.getType<_i8.RefreshTokenMalformedException?>()) {
       return (data != null
-          ? _i7.RefreshTokenMalformedException.fromJson(data)
+          ? _i8.RefreshTokenMalformedException.fromJson(data)
           : null) as T;
     }
-    if (t == _i1.getType<_i8.RefreshTokenNotFoundException?>()) {
+    if (t == _i1.getType<_i9.RefreshTokenNotFoundException?>()) {
       return (data != null
-          ? _i8.RefreshTokenNotFoundException.fromJson(data)
+          ? _i9.RefreshTokenNotFoundException.fromJson(data)
           : null) as T;
     }
-    if (t == _i1.getType<_i9.TokenPair?>()) {
-      return (data != null ? _i9.TokenPair.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i10.TokenPair?>()) {
+      return (data != null ? _i10.TokenPair.fromJson(data) : null) as T;
     }
     if (t == Set<String>) {
       return (data as List).map((e) => deserialize<String>(e)).toSet() as T;
@@ -209,22 +218,25 @@ class Protocol extends _i1.SerializationManagerServer {
   String? getClassNameForObject(Object? data) {
     String? className = super.getClassNameForObject(data);
     if (className != null) return className;
-    if (data is _i4.RefreshToken) {
+    if (data is _i4.AuthenticationTokenInfo) {
+      return 'AuthenticationTokenInfo';
+    }
+    if (data is _i5.RefreshToken) {
       return 'RefreshToken';
     }
-    if (data is _i5.RefreshTokenExpiredException) {
+    if (data is _i6.RefreshTokenExpiredException) {
       return 'RefreshTokenExpiredException';
     }
-    if (data is _i6.RefreshTokenInvalidSecretException) {
+    if (data is _i7.RefreshTokenInvalidSecretException) {
       return 'RefreshTokenInvalidSecretException';
     }
-    if (data is _i7.RefreshTokenMalformedException) {
+    if (data is _i8.RefreshTokenMalformedException) {
       return 'RefreshTokenMalformedException';
     }
-    if (data is _i8.RefreshTokenNotFoundException) {
+    if (data is _i9.RefreshTokenNotFoundException) {
       return 'RefreshTokenNotFoundException';
     }
-    if (data is _i9.TokenPair) {
+    if (data is _i10.TokenPair) {
       return 'TokenPair';
     }
     className = _i2.Protocol().getClassNameForObject(data);
@@ -244,23 +256,26 @@ class Protocol extends _i1.SerializationManagerServer {
     if (dataClassName is! String) {
       return super.deserializeByClassName(data);
     }
+    if (dataClassName == 'AuthenticationTokenInfo') {
+      return deserialize<_i4.AuthenticationTokenInfo>(data['data']);
+    }
     if (dataClassName == 'RefreshToken') {
-      return deserialize<_i4.RefreshToken>(data['data']);
+      return deserialize<_i5.RefreshToken>(data['data']);
     }
     if (dataClassName == 'RefreshTokenExpiredException') {
-      return deserialize<_i5.RefreshTokenExpiredException>(data['data']);
+      return deserialize<_i6.RefreshTokenExpiredException>(data['data']);
     }
     if (dataClassName == 'RefreshTokenInvalidSecretException') {
-      return deserialize<_i6.RefreshTokenInvalidSecretException>(data['data']);
+      return deserialize<_i7.RefreshTokenInvalidSecretException>(data['data']);
     }
     if (dataClassName == 'RefreshTokenMalformedException') {
-      return deserialize<_i7.RefreshTokenMalformedException>(data['data']);
+      return deserialize<_i8.RefreshTokenMalformedException>(data['data']);
     }
     if (dataClassName == 'RefreshTokenNotFoundException') {
-      return deserialize<_i8.RefreshTokenNotFoundException>(data['data']);
+      return deserialize<_i9.RefreshTokenNotFoundException>(data['data']);
     }
     if (dataClassName == 'TokenPair') {
-      return deserialize<_i9.TokenPair>(data['data']);
+      return deserialize<_i10.TokenPair>(data['data']);
     }
     if (dataClassName.startsWith('serverpod.')) {
       data['className'] = dataClassName.substring(10);
@@ -288,8 +303,8 @@ class Protocol extends _i1.SerializationManagerServer {
       }
     }
     switch (t) {
-      case _i4.RefreshToken:
-        return _i4.RefreshToken.t;
+      case _i5.RefreshToken:
+        return _i5.RefreshToken.t;
     }
     return null;
   }

--- a/modules/new_serverpod_auth/serverpod_auth_jwt/serverpod_auth_jwt_server/lib/src/models/authentication_token_info.spy.yaml
+++ b/modules/new_serverpod_auth/serverpod_auth_jwt/serverpod_auth_jwt_server/lib/src/models/authentication_token_info.spy.yaml
@@ -11,7 +11,7 @@ fields:
   ### Extra claims set on this session.
   ###
   ### Stored as JSON encoded `Map<String, dynamic>`
-  extraClaims: String?
+  extraClaimsJSON: String?
 
   ### The last time when a new token pair was created for this session.
   lastUpdated: DateTime

--- a/modules/new_serverpod_auth/serverpod_auth_jwt/serverpod_auth_jwt_server/lib/src/models/authentication_token_info.spy.yaml
+++ b/modules/new_serverpod_auth/serverpod_auth_jwt/serverpod_auth_jwt_server/lib/src/models/authentication_token_info.spy.yaml
@@ -1,0 +1,20 @@
+class: AuthenticationTokenInfo
+fields:
+  id: UuidValue
+
+  ### The [AuthUser] this refresh token belongs to.
+  authUserId: UuidValue
+
+  ### The scopes given to this session.
+  scopeNames: Set<String>
+
+  ### Extra claims set on this session.
+  ###
+  ### Stored as JSON encoded `Map<String, dynamic>`
+  extraClaims: String?
+
+  ### The last time when a new token pair was created for this session.
+  lastUpdated: DateTime
+
+  ### The time when this session was initially created.
+  created: DateTime

--- a/modules/new_serverpod_auth/serverpod_auth_jwt/serverpod_auth_jwt_server/lib/src/models/refresh_token.spy.yaml
+++ b/modules/new_serverpod_auth/serverpod_auth_jwt/serverpod_auth_jwt_server/lib/src/models/refresh_token.spy.yaml
@@ -2,7 +2,7 @@ class: RefreshToken
 serverOnly: true
 table: serverpod_auth_jwt_refresh_token
 fields:
-  id: UuidValue?, defaultPersist=random
+  id: UuidValue?, defaultPersist=random_v7
 
   ### The [AuthUser] this refresh token belongs to.
   authUser: module:auth_user:AuthUser?, relation(onDelete=Cascade)

--- a/modules/new_serverpod_auth/serverpod_auth_jwt/serverpod_auth_jwt_server/lib/src/util/authentication_token_info_extension.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_jwt/serverpod_auth_jwt_server/lib/src/util/authentication_token_info_extension.dart
@@ -1,0 +1,22 @@
+import 'dart:convert';
+
+import 'package:serverpod/serverpod.dart';
+import 'package:serverpod_auth_jwt_server/serverpod_auth_jwt_server.dart';
+
+/// Extensions for [AuthenticationTokenInfo].
+extension AuthenticationTokenInfoExtension on AuthenticationTokenInfo {
+  /// Returns the `Scope`s for this authentication token.
+  Set<Scope> get scopes {
+    return scopeNames.map(Scope.new).toSet();
+  }
+
+  /// Returns the extra claims set on this authentication token.
+  Map<String, dynamic>? get extraClaims {
+    final extraClaims = this.extraClaims;
+    if (extraClaims == null) {
+      return null;
+    }
+
+    return (jsonDecode(extraClaims) as Map).cast<String, dynamic>();
+  }
+}

--- a/modules/new_serverpod_auth/serverpod_auth_jwt/serverpod_auth_jwt_server/lib/src/util/authentication_token_info_extension.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_jwt/serverpod_auth_jwt_server/lib/src/util/authentication_token_info_extension.dart
@@ -11,12 +11,12 @@ extension AuthenticationTokenInfoExtension on AuthenticationTokenInfo {
   }
 
   /// Returns the extra claims set on this authentication token.
-  Map<String, dynamic>? get extraClaimsMap {
-    final extraClaims = this.extraClaims;
-    if (extraClaims == null) {
+  Map<String, dynamic>? get extraClaims {
+    final extraClaimsJSON = this.extraClaimsJSON;
+    if (extraClaimsJSON == null) {
       return null;
     }
 
-    return (jsonDecode(extraClaims) as Map).cast<String, dynamic>();
+    return (jsonDecode(extraClaimsJSON) as Map).cast<String, dynamic>();
   }
 }

--- a/modules/new_serverpod_auth/serverpod_auth_jwt/serverpod_auth_jwt_server/lib/src/util/authentication_token_info_extension.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_jwt/serverpod_auth_jwt_server/lib/src/util/authentication_token_info_extension.dart
@@ -11,7 +11,7 @@ extension AuthenticationTokenInfoExtension on AuthenticationTokenInfo {
   }
 
   /// Returns the extra claims set on this authentication token.
-  Map<String, dynamic>? get extraClaims {
+  Map<String, dynamic>? get extraClaimsMap {
     final extraClaims = this.extraClaims;
     if (extraClaims == null) {
       return null;

--- a/modules/new_serverpod_auth/serverpod_auth_jwt/serverpod_auth_jwt_server/migrations/20250614085600650/definition.json
+++ b/modules/new_serverpod_auth/serverpod_auth_jwt/serverpod_auth_jwt_server/migrations/20250614085600650/definition.json
@@ -11,7 +11,7 @@
           "name": "id",
           "columnType": 7,
           "isNullable": false,
-          "columnDefault": "gen_random_uuid()",
+          "columnDefault": "gen_random_uuid_v7()",
           "dartType": "UuidValue?"
         },
         {
@@ -1298,7 +1298,7 @@
   "installedModules": [
     {
       "module": "serverpod_auth_jwt",
-      "version": "20250528131509267"
+      "version": "20250614085600650"
     },
     {
       "module": "serverpod",

--- a/modules/new_serverpod_auth/serverpod_auth_jwt/serverpod_auth_jwt_server/migrations/20250614085600650/definition.sql
+++ b/modules/new_serverpod_auth/serverpod_auth_jwt/serverpod_auth_jwt_server/migrations/20250614085600650/definition.sql
@@ -1,10 +1,39 @@
 BEGIN;
 
 --
+-- Function: gen_random_uuid_v7()
+-- Source: https://gist.github.com/kjmph/5bd772b2c2df145aa645b837da7eca74
+-- License: MIT (copyright notice included on the generator source code).
+--
+create or replace function gen_random_uuid_v7()
+returns uuid
+as $$
+begin
+  -- use random v4 uuid as starting point (which has the same variant we need)
+  -- then overlay timestamp
+  -- then set version 7 by flipping the 2 and 1 bit in the version 4 string
+  return encode(
+    set_bit(
+      set_bit(
+        overlay(uuid_send(gen_random_uuid())
+                placing substring(int8send(floor(extract(epoch from clock_timestamp()) * 1000)::bigint) from 3)
+                from 1 for 6
+        ),
+        52, 1
+      ),
+      53, 1
+    ),
+    'hex')::uuid;
+end
+$$
+language plpgsql
+volatile;
+
+--
 -- Class RefreshToken as table serverpod_auth_jwt_refresh_token
 --
 CREATE TABLE "serverpod_auth_jwt_refresh_token" (
-    "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    "id" uuid PRIMARY KEY DEFAULT gen_random_uuid_v7(),
     "authUserId" uuid NOT NULL,
     "scopeNames" json NOT NULL,
     "extraClaims" text,
@@ -279,9 +308,9 @@ ALTER TABLE ONLY "serverpod_query_log"
 -- MIGRATION VERSION FOR serverpod_auth_jwt
 --
 INSERT INTO "serverpod_migrations" ("module", "version", "timestamp")
-    VALUES ('serverpod_auth_jwt', '20250528131509267', now())
+    VALUES ('serverpod_auth_jwt', '20250614085600650', now())
     ON CONFLICT ("module")
-    DO UPDATE SET "version" = '20250528131509267', "timestamp" = now();
+    DO UPDATE SET "version" = '20250614085600650', "timestamp" = now();
 
 --
 -- MIGRATION VERSION FOR serverpod

--- a/modules/new_serverpod_auth/serverpod_auth_jwt/serverpod_auth_jwt_server/migrations/20250614085600650/definition_project.json
+++ b/modules/new_serverpod_auth/serverpod_auth_jwt/serverpod_auth_jwt_server/migrations/20250614085600650/definition_project.json
@@ -11,7 +11,7 @@
           "name": "id",
           "columnType": 7,
           "isNullable": false,
-          "columnDefault": "gen_random_uuid()",
+          "columnDefault": "gen_random_uuid_v7()",
           "dartType": "UuidValue?"
         },
         {

--- a/modules/new_serverpod_auth/serverpod_auth_jwt/serverpod_auth_jwt_server/migrations/20250614085600650/migration.json
+++ b/modules/new_serverpod_auth/serverpod_auth_jwt/serverpod_auth_jwt_server/migrations/20250614085600650/migration.json
@@ -12,7 +12,7 @@
             "name": "id",
             "columnType": 7,
             "isNullable": false,
-            "columnDefault": "gen_random_uuid()",
+            "columnDefault": "gen_random_uuid_v7()",
             "dartType": "UuidValue?"
           },
           {

--- a/modules/new_serverpod_auth/serverpod_auth_jwt/serverpod_auth_jwt_server/migrations/20250614085600650/migration.sql
+++ b/modules/new_serverpod_auth/serverpod_auth_jwt/serverpod_auth_jwt_server/migrations/20250614085600650/migration.sql
@@ -1,10 +1,39 @@
 BEGIN;
 
 --
+-- Function: gen_random_uuid_v7()
+-- Source: https://gist.github.com/kjmph/5bd772b2c2df145aa645b837da7eca74
+-- License: MIT (copyright notice included on the generator source code).
+--
+create or replace function gen_random_uuid_v7()
+returns uuid
+as $$
+begin
+  -- use random v4 uuid as starting point (which has the same variant we need)
+  -- then overlay timestamp
+  -- then set version 7 by flipping the 2 and 1 bit in the version 4 string
+  return encode(
+    set_bit(
+      set_bit(
+        overlay(uuid_send(gen_random_uuid())
+                placing substring(int8send(floor(extract(epoch from clock_timestamp()) * 1000)::bigint) from 3)
+                from 1 for 6
+        ),
+        52, 1
+      ),
+      53, 1
+    ),
+    'hex')::uuid;
+end
+$$
+language plpgsql
+volatile;
+
+--
 -- ACTION CREATE TABLE
 --
 CREATE TABLE "serverpod_auth_jwt_refresh_token" (
-    "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    "id" uuid PRIMARY KEY DEFAULT gen_random_uuid_v7(),
     "authUserId" uuid NOT NULL,
     "scopeNames" json NOT NULL,
     "extraClaims" text,
@@ -279,9 +308,9 @@ ALTER TABLE ONLY "serverpod_query_log"
 -- MIGRATION VERSION FOR serverpod_auth_jwt
 --
 INSERT INTO "serverpod_migrations" ("module", "version", "timestamp")
-    VALUES ('serverpod_auth_jwt', '20250528131509267', now())
+    VALUES ('serverpod_auth_jwt', '20250614085600650', now())
     ON CONFLICT ("module")
-    DO UPDATE SET "version" = '20250528131509267', "timestamp" = now();
+    DO UPDATE SET "version" = '20250614085600650', "timestamp" = now();
 
 --
 -- MIGRATION VERSION FOR serverpod

--- a/modules/new_serverpod_auth/serverpod_auth_jwt/serverpod_auth_jwt_server/migrations/migration_registry.txt
+++ b/modules/new_serverpod_auth/serverpod_auth_jwt/serverpod_auth_jwt_server/migrations/migration_registry.txt
@@ -4,4 +4,4 @@
 ### manually. If a collision is detected in this file when doing a code merge, resolve
 ### the conflict by removing and recreating the conflicting migration.
 
-20250528131509267
+20250614085600650

--- a/modules/new_serverpod_auth/serverpod_auth_jwt/serverpod_auth_jwt_server/pubspec.yaml
+++ b/modules/new_serverpod_auth/serverpod_auth_jwt/serverpod_auth_jwt_server/pubspec.yaml
@@ -10,6 +10,7 @@ environment:
   sdk: '>=3.5.0 <4.0.0'
 
 dependencies:
+  clock: ^1.1.1
   dart_jsonwebtoken: ^3.1.0
   meta: ^1.11.0
   pointycastle: ^3.7.4
@@ -18,10 +19,9 @@ dependencies:
   serverpod_shared: 2.8.0
 
 dev_dependencies:
-  clock: ^1.1.1
   lints: '>=3.0.0 <7.0.0'
   serverpod_test: 2.8.0
-  test: '^1.24.2'
+  test: ^1.24.2
 
 dependency_overrides:
   serverpod:

--- a/modules/new_serverpod_auth/serverpod_auth_jwt/serverpod_auth_jwt_server/test/integration/authentication_tokens_admin_test.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_jwt/serverpod_auth_jwt_server/test/integration/authentication_tokens_admin_test.dart
@@ -24,12 +24,8 @@ void main() {
     setUp(() async {
       session = sessionBuilder.build();
 
-      final authUser = await AuthUser.db.insertRow(
-        session,
-        AuthUser(created: DateTime.now(), scopeNames: {}, blocked: false),
-      );
-
-      authUserId = authUser.id!;
+      final authUser = await AuthUsers.create(session);
+      authUserId = authUser.id;
 
       await AuthenticationTokens.createTokens(
         session,
@@ -108,12 +104,10 @@ void main() {
     setUp(() async {
       session = sessionBuilder.build();
 
-      final authUser = await AuthUser.db.insertRow(
+      final authUser = await AuthUsers.create(
         session,
-        AuthUser(created: DateTime.now(), scopeNames: {}, blocked: false),
       );
-
-      authUserId = authUser.id!;
+      authUserId = authUser.id;
 
       await withClock(
           Clock.fixed(DateTime.now()

--- a/modules/new_serverpod_auth/serverpod_auth_jwt/serverpod_auth_jwt_server/test/integration/authentication_tokens_admin_test.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_jwt/serverpod_auth_jwt_server/test/integration/authentication_tokens_admin_test.dart
@@ -53,7 +53,7 @@ void main() {
     test(
         'when calling `findAuthenticationTokens` for all users, then it is returned.',
         () async {
-      final tokens = await AuthenticationTokensAdmin().findAuthenticationTokens(
+      final tokens = await AuthenticationTokensAdmin().listAuthenticationTokens(
         session,
       );
 
@@ -66,7 +66,7 @@ void main() {
     test(
         'when calling `findAuthenticationTokens` for that specific user, then it is returned.',
         () async {
-      final tokens = await AuthenticationTokensAdmin().findAuthenticationTokens(
+      final tokens = await AuthenticationTokensAdmin().listAuthenticationTokens(
         session,
         authUserId: authUserId,
       );
@@ -80,7 +80,7 @@ void main() {
     test(
         'when calling `findAuthenticationTokens` for another user, then nothing is returned.',
         () async {
-      final tokens = await AuthenticationTokensAdmin().findAuthenticationTokens(
+      final tokens = await AuthenticationTokensAdmin().listAuthenticationTokens(
         session,
         authUserId: const Uuid().v4obj(),
       );

--- a/modules/new_serverpod_auth/serverpod_auth_jwt/serverpod_auth_jwt_server/test/integration/authentication_tokens_admin_test.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_jwt/serverpod_auth_jwt_server/test/integration/authentication_tokens_admin_test.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:clock/clock.dart';
 import 'package:serverpod/serverpod.dart';
 import 'package:serverpod_auth_jwt_server/serverpod_auth_jwt_server.dart';
@@ -86,6 +88,97 @@ void main() {
       );
 
       expect(tokens, isEmpty);
+    });
+  });
+
+  withServerpod('Given two auth user with 100 authentication tokens each,',
+      (final sessionBuilder, final endpoints) {
+    late Session session;
+    late UuidValue authUserId1;
+    late UuidValue authUserId2;
+    late List<UuidValue> refreshTokenIdsInOrderOfCreation;
+
+    setUpAll(() {
+      AuthenticationTokens.secretsTestOverride =
+          AuthenticationTokenSecretsMock()
+            ..setHs512Algorithm()
+            ..refreshTokenHashPepper = 'pepper123';
+    });
+
+    setUp(() async {
+      session = sessionBuilder.build();
+
+      authUserId1 = (await AuthUsers.create(session)).id;
+      authUserId2 = (await AuthUsers.create(session)).id;
+      refreshTokenIdsInOrderOfCreation = [];
+
+      for (var i = 0; i < 100; i++) {
+        for (final authUserId in [authUserId1, authUserId2]) {
+          final tokenPair = await AuthenticationTokens.createTokens(
+            session,
+            authUserId: authUserId,
+            scopes: {},
+          );
+
+          refreshTokenIdsInOrderOfCreation.add(
+            UuidValue.fromByteList(
+              base64Decode(tokenPair.refreshToken.split(':')[1]),
+            ),
+          );
+        }
+      }
+    });
+
+    tearDownAll(() {
+      AuthenticationTokens.secretsTestOverride = null;
+    });
+
+    test(
+        'when calling `listAuthenticationTokens`, then it returns the first 100 tokens in order of creation date ASC.',
+        () async {
+      final tokens = await AuthenticationTokensAdmin().listAuthenticationTokens(
+        session,
+      );
+
+      expect(tokens, hasLength(100));
+      expect(
+        tokens.map(((final t) => t.id)),
+        refreshTokenIdsInOrderOfCreation.take(100),
+      );
+    });
+
+    test(
+        'when calling `listAuthenticationTokens(offset: 50)`, then it returns the next 100 tokens in order of creation date ASC.',
+        () async {
+      final tokens = await AuthenticationTokensAdmin().listAuthenticationTokens(
+        session,
+        offset: 50,
+      );
+
+      expect(tokens, hasLength(100));
+      expect(
+        tokens.map(((final t) => t.id)),
+        refreshTokenIdsInOrderOfCreation.skip(50).take(100),
+      );
+    });
+
+    test(
+        "when calling `listAuthenticationTokens(limit: 2)` for a specific auth user, then it returns that user's first 2 tokens in order of creation date ASC.",
+        () async {
+      final tokens = await AuthenticationTokensAdmin().listAuthenticationTokens(
+        session,
+        authUserId: authUserId1,
+        limit: 2,
+      );
+
+      expect(tokens, hasLength(2));
+      expect(
+        tokens.map(((final t) => t.id)),
+        [
+          refreshTokenIdsInOrderOfCreation[0],
+          refreshTokenIdsInOrderOfCreation[2],
+        ],
+      );
     });
   });
 

--- a/modules/new_serverpod_auth/serverpod_auth_jwt/serverpod_auth_jwt_server/test/integration/authentication_tokens_admin_test.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_jwt/serverpod_auth_jwt_server/test/integration/authentication_tokens_admin_test.dart
@@ -180,6 +180,45 @@ void main() {
         ],
       );
     });
+
+    test(
+        'when calling `listAuthenticationTokens` with `limit: 0`, then it throws.',
+        () async {
+      await expectLater(
+        () => AuthenticationTokensAdmin().listAuthenticationTokens(
+          session,
+          authUserId: authUserId1,
+          limit: 0,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test(
+        'when calling `listAuthenticationTokens` with `limit: 1001`, then it throws.',
+        () async {
+      await expectLater(
+        () => AuthenticationTokensAdmin().listAuthenticationTokens(
+          session,
+          authUserId: authUserId1,
+          limit: 1001,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test(
+        'when calling `listAuthenticationTokens` with `offset: -1`, then it throws.',
+        () async {
+      await expectLater(
+        () => AuthenticationTokensAdmin().listAuthenticationTokens(
+          session,
+          authUserId: authUserId1,
+          offset: -1,
+        ),
+        throwsArgumentError,
+      );
+    });
   });
 
   withServerpod('Given an auth user with an expired authentication token,',

--- a/modules/new_serverpod_auth/serverpod_auth_jwt/serverpod_auth_jwt_server/test/integration/authentication_tokens_admin_test.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_jwt/serverpod_auth_jwt_server/test/integration/authentication_tokens_admin_test.dart
@@ -1,0 +1,144 @@
+import 'package:clock/clock.dart';
+import 'package:serverpod/serverpod.dart';
+import 'package:serverpod_auth_jwt_server/serverpod_auth_jwt_server.dart';
+import 'package:serverpod_auth_jwt_server/src/generated/refresh_token.dart';
+import 'package:serverpod_auth_user_server/serverpod_auth_user_server.dart';
+import 'package:test/test.dart';
+
+import '../utils/authentication_token_secrets_mock.dart';
+import 'test_tools/serverpod_test_tools.dart';
+
+void main() {
+  withServerpod('Given an auth user with an authentication token,',
+      (final sessionBuilder, final endpoints) {
+    late Session session;
+    late UuidValue authUserId;
+
+    setUpAll(() {
+      AuthenticationTokens.secretsTestOverride =
+          AuthenticationTokenSecretsMock()
+            ..setHs512Algorithm()
+            ..refreshTokenHashPepper = 'pepper123';
+    });
+
+    setUp(() async {
+      session = sessionBuilder.build();
+
+      final authUser = await AuthUser.db.insertRow(
+        session,
+        AuthUser(created: DateTime.now(), scopeNames: {}, blocked: false),
+      );
+
+      authUserId = authUser.id!;
+
+      await AuthenticationTokens.createTokens(
+        session,
+        authUserId: authUserId,
+        scopes: {},
+      );
+    });
+
+    tearDownAll(() {
+      AuthenticationTokens.secretsTestOverride = null;
+    });
+
+    test('when calling `deleteExpiredRefreshTokens`, then it is unaffected.',
+        () async {
+      await AuthenticationTokensAdmin().deleteExpiredRefreshTokens(session);
+
+      final tokens = await RefreshToken.db.find(session);
+
+      expect(
+        tokens.single.authUserId,
+        authUserId,
+      );
+    });
+
+    test(
+        'when calling `findAuthenticationTokens` for all users, then it is returned.',
+        () async {
+      final tokens = await AuthenticationTokensAdmin().findAuthenticationTokens(
+        session,
+      );
+
+      expect(
+        tokens.single.authUserId,
+        authUserId,
+      );
+    });
+
+    test(
+        'when calling `findAuthenticationTokens` for that specific user, then it is returned.',
+        () async {
+      final tokens = await AuthenticationTokensAdmin().findAuthenticationTokens(
+        session,
+        authUserId: authUserId,
+      );
+
+      expect(
+        tokens.single.authUserId,
+        authUserId,
+      );
+    });
+
+    test(
+        'when calling `findAuthenticationTokens` for another user, then nothing is returned.',
+        () async {
+      final tokens = await AuthenticationTokensAdmin().findAuthenticationTokens(
+        session,
+        authUserId: const Uuid().v4obj(),
+      );
+
+      expect(tokens, isEmpty);
+    });
+  });
+
+  withServerpod('Given an auth user with an expired authentication token,',
+      (final sessionBuilder, final endpoints) {
+    late Session session;
+    late UuidValue authUserId;
+
+    setUpAll(() {
+      AuthenticationTokens.secretsTestOverride =
+          AuthenticationTokenSecretsMock()
+            ..setHs512Algorithm()
+            ..refreshTokenHashPepper = 'pepper123';
+    });
+
+    setUp(() async {
+      session = sessionBuilder.build();
+
+      final authUser = await AuthUser.db.insertRow(
+        session,
+        AuthUser(created: DateTime.now(), scopeNames: {}, blocked: false),
+      );
+
+      authUserId = authUser.id!;
+
+      await withClock(
+          Clock.fixed(DateTime.now()
+              .subtract(AuthenticationTokens.config.refreshTokenLifetime)),
+          () async {
+        await AuthenticationTokens.createTokens(
+          session,
+          authUserId: authUserId,
+          scopes: {},
+        );
+      });
+    });
+
+    tearDownAll(() {
+      AuthenticationTokens.secretsTestOverride = null;
+    });
+
+    test(
+        'when calling `deleteExpiredRefreshTokens`, then that token is removed.',
+        () async {
+      await AuthenticationTokensAdmin().deleteExpiredRefreshTokens(session);
+
+      final tokens = await RefreshToken.db.find(session);
+
+      expect(tokens, isEmpty);
+    });
+  });
+}

--- a/modules/new_serverpod_auth/serverpod_auth_jwt/serverpod_auth_jwt_server/test/integration/authentication_tokens_test.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_jwt/serverpod_auth_jwt_server/test/integration/authentication_tokens_test.dart
@@ -25,12 +25,8 @@ void main() {
     setUp(() async {
       session = sessionBuilder.build();
 
-      final authUser = await AuthUser.db.insertRow(
-        session,
-        AuthUser(created: DateTime.now(), scopeNames: {}, blocked: false),
-      );
-
-      authUserId = authUser.id!;
+      final authUser = await AuthUsers.create(session);
+      authUserId = authUser.id;
     });
 
     tearDownAll(() {
@@ -114,12 +110,10 @@ void main() {
 
       session = sessionBuilder.build();
 
-      final authUser = await AuthUser.db.insertRow(
+      final authUser = await AuthUsers.create(
         session,
-        AuthUser(created: DateTime.now(), scopeNames: {}, blocked: false),
       );
-
-      authUserId = authUser.id!;
+      authUserId = authUser.id;
 
       tokenPair = await AuthenticationTokens.createTokens(
         session,
@@ -275,14 +269,11 @@ void main() {
 
       session = sessionBuilder.build();
 
-      final authUser = await AuthUser.db.insertRow(
-        session,
-        AuthUser(created: DateTime.now(), scopeNames: {}, blocked: false),
-      );
+      final authUser = await AuthUsers.create(session);
 
       initialTokenPair = await AuthenticationTokens.createTokens(
         session,
-        authUserId: authUser.id!,
+        authUserId: authUser.id,
         scopes: {},
       );
 
@@ -332,12 +323,8 @@ void main() {
     setUp(() async {
       session = sessionBuilder.build();
 
-      final authUser = await AuthUser.db.insertRow(
-        session,
-        AuthUser(created: DateTime.now(), scopeNames: {}, blocked: false),
-      );
-
-      authUserId = authUser.id!;
+      final authUser = await AuthUsers.create(session);
+      authUserId = authUser.id;
 
       await AuthenticationTokens.createTokens(session,
           authUserId: authUserId, scopes: {});

--- a/modules/new_serverpod_auth/serverpod_auth_jwt/serverpod_auth_jwt_server/test/integration/authentication_tokens_test.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_jwt/serverpod_auth_jwt_server/test/integration/authentication_tokens_test.dart
@@ -247,7 +247,7 @@ void main() {
       );
 
       expect(
-        authTokensForUser.single.extraClaimsMap,
+        authTokensForUser.single.extraClaims,
         {'string': 'foo', 'int': 1},
       );
     });

--- a/modules/new_serverpod_auth/serverpod_auth_jwt/serverpod_auth_jwt_server/test/integration/authentication_tokens_test.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_jwt/serverpod_auth_jwt_server/test/integration/authentication_tokens_test.dart
@@ -242,6 +242,21 @@ void main() {
         throwsA(isA<RefreshTokenInvalidSecretException>()),
       );
     });
+
+    test(
+        'when looking at the auth token via `listAuthenticationTokens`, then the extra claims can be read as a Map.',
+        () async {
+      final authTokensForUser =
+          await AuthenticationTokens.listAuthenticationTokens(
+        session,
+        authUserId: authUserId,
+      );
+
+      expect(
+        authTokensForUser.single.extraClaimsMap,
+        {'string': 'foo', 'int': 1},
+      );
+    });
   });
 
   withServerpod('Given an initial `TokenPair` and its refreshed successor,', (

--- a/modules/new_serverpod_auth/serverpod_auth_profile/serverpod_auth_profile_server/test/integration/user_profiles_test.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_profile/serverpod_auth_profile_server/test/integration/user_profiles_test.dart
@@ -20,12 +20,8 @@ void main() {
 
         UserProfileConfig.current = UserProfileConfig();
 
-        final authUser = await AuthUser.db.insertRow(
-          session,
-          AuthUser(created: DateTime.now(), scopeNames: {}, blocked: false),
-        );
-
-        authUserId = authUser.id!;
+        final authUser = await AuthUsers.create(session);
+        authUserId = authUser.id;
       });
 
       test(
@@ -193,11 +189,8 @@ void main() {
         imageFetchFunc: (final _) => onePixelPng,
       );
 
-      final authUser = await AuthUser.db.insertRow(
-        session,
-        AuthUser(created: DateTime.now(), scopeNames: {}, blocked: false),
-      );
-      authUserId = authUser.id!;
+      final authUser = await AuthUsers.create(session);
+      authUserId = authUser.id;
 
       await UserProfiles.createUserProfile(
         session,
@@ -447,17 +440,13 @@ void main() {
   withServerpod('Given an `AuthUser` with a profile with an image,',
       (final sessionBuilder, final endpoints) {
     late Session session;
-    late AuthUser authUser;
     late UuidValue authUserId;
 
     setUp(() async {
       session = sessionBuilder.build();
 
-      authUser = await AuthUser.db.insertRow(
-        session,
-        AuthUser(created: DateTime.now(), scopeNames: {}, blocked: false),
-      );
-      authUserId = authUser.id!;
+      final authUser = await AuthUsers.create(session);
+      authUserId = authUser.id;
 
       await UserProfiles.createUserProfile(
         session,
@@ -542,7 +531,7 @@ void main() {
 
     test('when deleting the auth user, then the profile is cleaned up as well.',
         () async {
-      await AuthUser.db.deleteRow(session, authUser);
+      await AuthUsers.delete(session, authUserId: authUserId);
 
       final authUserAfterDelete = await AuthUser.db.findById(
         session,
@@ -581,21 +570,14 @@ void main() {
       setUp(() async {
         session = sessionBuilder.build();
 
-        final authUser = await AuthUser.db.insertRow(
-          session,
-          AuthUser(created: DateTime.now(), scopeNames: {}, blocked: false),
-        );
-
-        authUserId = authUser.id!;
+        final authUser = await AuthUsers.create(session);
+        authUserId = authUser.id;
       });
 
       Future<void> clearDb() async {
         final session = sessionBuilder.build();
         // also cleans up related profile and profile images
-        await AuthUser.db.deleteWhere(
-          session,
-          where: (final f) => f.id.equals(authUserId),
-        );
+        await AuthUsers.delete(session, authUserId: authUserId);
       }
 
       tearDown(clearDb);

--- a/modules/new_serverpod_auth/serverpod_auth_profile/serverpod_auth_profile_server/test/integration/user_profiles_test.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_profile/serverpod_auth_profile_server/test/integration/user_profiles_test.dart
@@ -574,13 +574,10 @@ void main() {
         authUserId = authUser.id;
       });
 
-      Future<void> clearDb() async {
-        final session = sessionBuilder.build();
+      tearDown(() async {
         // also cleans up related profile and profile images
         await AuthUsers.delete(session, authUserId: authUserId);
-      }
-
-      tearDown(clearDb);
+      });
 
       test(
           'when creating a profile and its associated image in a transaction, then there are visible in that transaction but not after a rollback.',

--- a/modules/new_serverpod_auth/serverpod_auth_session/serverpod_auth_session_server/lib/src/business/auth_sessions.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_session/serverpod_auth_session_server/lib/src/business/auth_sessions.dart
@@ -183,8 +183,13 @@ abstract final class AuthSessions {
   static Future<List<AuthSessionInfo>> listSessions(
     final Session session, {
     required final UuidValue authUserId,
+    final Transaction? transaction,
   }) async {
-    return admin.findSessions(session, authUserId: authUserId);
+    return admin.findSessions(
+      session,
+      authUserId: authUserId,
+      transaction: transaction,
+    );
   }
 
   /// Signs out a user from the server and ends all user sessions managed by this module.

--- a/templates/pubspecs/modules/new_serverpod_auth/serverpod_auth_jwt/serverpod_auth_jwt_server/pubspec.yaml
+++ b/templates/pubspecs/modules/new_serverpod_auth/serverpod_auth_jwt/serverpod_auth_jwt_server/pubspec.yaml
@@ -9,6 +9,7 @@ environment:
   sdk: DART_VERSION
 
 dependencies:
+  clock: ^1.1.1
   dart_jsonwebtoken: ^3.1.0
   meta: ^1.11.0
   pointycastle: ^3.7.4
@@ -17,10 +18,9 @@ dependencies:
   serverpod_shared: SERVERPOD_VERSION
 
 dev_dependencies:
-  clock: ^1.1.1
   lints: '>=3.0.0 <7.0.0'
   serverpod_test: SERVERPOD_VERSION
-  test: '^1.24.2'
+  test: ^1.24.2
 
 dependency_overrides:
   serverpod:


### PR DESCRIPTION
Aligning it with the new capabilities in `serverpod_auth_session`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced support for retrieving and listing authentication tokens associated with users, including detailed token metadata such as scopes and extra claims.
  - Added extension methods for easier access to token scopes and extra claims in a typed format.

- **Bug Fixes**
  - Improved consistency of token creation and update timestamps by using a unified time source.

- **Tests**
  - Added integration tests to verify listing and deletion of authentication tokens, including handling of expired tokens.
  - Enhanced test setup by using helper methods for user creation and deletion.

- **Chores**
  - Updated dependency management for the clock package.
  - Changed default UUID persistence strategy for refresh tokens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->