### PR TITLE
fix: Separate configuring and starting insights.

### DIFF
--- a/packages/serverpod/lib/src/server/serverpod.dart
+++ b/packages/serverpod/lib/src/server/serverpod.dart
@@ -579,13 +579,7 @@ class Serverpod {
 
       // Serverpod Insights.
       if (Features.enableInsights) {
-        if (_isValidSecret(config.serviceSecret)) {
-          serversStarted &= await _serviceServer?.start() ?? true;
-        } else {
-          stderr.write(
-            'Invalid serviceSecret in password file, Insights server disabled.',
-          );
-        }
+        serversStarted &= await _serviceServer?.start() ?? true;
       }
 
       // Main API server.

--- a/packages/serverpod/lib/src/server/serverpod.dart
+++ b/packages/serverpod/lib/src/server/serverpod.dart
@@ -117,11 +117,11 @@ class Serverpod {
   /// The main server managed by this [Serverpod].
   late Server server;
 
-  Server? _serviceServer;
+  Server? _insightsServer;
 
   /// The service server managed by this [Serverpod].
   Server get serviceServer {
-    var service = _serviceServer;
+    var service = _insightsServer;
     if (service == null) {
       throw StateError(
         'Insights server is disabled, supply a Insights configuration '
@@ -469,7 +469,7 @@ class Serverpod {
 
     if (Features.enableInsights) {
       if (_isValidSecret(config.serviceSecret)) {
-        _serviceServer = _configureInsightsServer();
+        _insightsServer = _configureInsightsServer();
       } else {
         stderr.write(
           'Invalid serviceSecret in password file, Insights server disabled.',
@@ -579,7 +579,7 @@ class Serverpod {
 
       // Serverpod Insights.
       if (Features.enableInsights) {
-        serversStarted &= await _serviceServer?.start() ?? true;
+        serversStarted &= await _insightsServer?.start() ?? true;
       }
 
       // Main API server.
@@ -925,7 +925,7 @@ class Serverpod {
       redisController?.stop(),
       server.shutdown(),
       _webServer?.stop(),
-      _serviceServer?.shutdown(),
+      _insightsServer?.shutdown(),
       _futureCallManager?.stop(),
       _healthCheckManager?.stop(),
     ].nonNulls;

--- a/packages/serverpod/lib/src/server/serverpod.dart
+++ b/packages/serverpod/lib/src/server/serverpod.dart
@@ -466,6 +466,16 @@ class Serverpod {
         securityContext: _securityContextConfig?.webServer,
       );
     }
+
+    if (Features.enableInsights) {
+      if (_isValidSecret(config.serviceSecret)) {
+        _serviceServer = _configureInsightsServer();
+      } else {
+        stderr.write(
+          'Invalid serviceSecret in password file, Insights server disabled.',
+        );
+      }
+    }
   }
 
   int _exitCode = 0;
@@ -570,7 +580,7 @@ class Serverpod {
       // Serverpod Insights.
       if (Features.enableInsights) {
         if (_isValidSecret(config.serviceSecret)) {
-          serversStarted &= await _startInsightsServer();
+          serversStarted &= await _serviceServer?.start() ?? true;
         } else {
           stderr.write(
             'Invalid serviceSecret in password file, Insights server disabled.',
@@ -779,10 +789,10 @@ class Serverpod {
     shutdown(exitProcess: true, signalNumber: signal.signalNumber);
   }
 
-  Future<bool> _startInsightsServer() async {
+  Server _configureInsightsServer() {
     var endpoints = internal.Endpoints();
 
-    _serviceServer = Server(
+    var insightsServer = Server(
       serverpod: this,
       serverId: serverId,
       port: config.insightsServer!.port,
@@ -798,11 +808,9 @@ class Serverpod {
       httpOptionsResponseHeaders: httpOptionsResponseHeaders,
       securityContext: _securityContextConfig?.insightsServer,
     );
-    endpoints.initializeEndpoints(_serviceServer!);
+    endpoints.initializeEndpoints(insightsServer);
 
-    var success = await _serviceServer!.start();
-
-    return success;
+    return insightsServer;
   }
 
   /// Registers a [FutureCall] with the [Serverpod] and associates it with


### PR DESCRIPTION
When building tests for Serverpod I noticed that that inisights server was not configured when constructing the Serverpod instance.

This moves the initialization of the insights server to the same place as all other servers are initialized.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None - should give the same flow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **Refactor**
  - Improved the startup process for the Insights server, resulting in clearer separation between configuration and server start-up phases.
  - Enhanced error handling when the service secret is invalid, ensuring clearer messaging and more predictable server behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->