### PR TITLE
fix: Use more efficient stream reading

### DIFF
--- a/packages/serverpod_client/lib/src/file_uploader.dart
+++ b/packages/serverpod_client/lib/src/file_uploader.dart
@@ -37,7 +37,7 @@ class FileUploader {
       try {
         var result = await http.post(
           _uploadDescription.url,
-          body: await _readStreamData(stream),
+          body: await http.ByteStream(stream).toBytes(),
           headers: {
             'Content-Type': 'application/octet-stream',
             'Accept': '*/*',
@@ -74,26 +74,6 @@ class FileUploader {
       }
     }
     throw UnimplementedError('Unknown upload type');
-  }
-
-  // Future<String?> _readBody(http.ByteStream stream) async {
-  //   // TODO: Find more efficient solution?
-  //   var len = 0;
-  //   var data = <int>[];
-  //   await for (var segment in stream) {
-  //     len += segment.length;
-  //     data += segment;
-  //   }
-  //   return Utf8Decoder().convert(data);
-  // }
-
-  Future<List<int>> _readStreamData(Stream<List<int>> stream) async {
-    // TODO: Find more efficient solution?
-    var data = <int>[];
-    await for (var segment in stream) {
-      data += segment;
-    }
-    return data;
   }
 }
 


### PR DESCRIPTION
Refactor stream data handling in `FileUploader` to use `http.ByteStream().toBytes()` directly.

Fixes: #3533

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).
