### PR TITLE
fix(auth2): Remove `.` from password variable names

### DIFF
--- a/modules/new_serverpod_auth/serverpod_auth_email_account/serverpod_auth_email_account_server/config/passwords.yaml
+++ b/modules/new_serverpod_auth/serverpod_auth_email_account/serverpod_auth_email_account_server/config/passwords.yaml
@@ -12,4 +12,4 @@
 test:
   database: 'DB_TEST_PASSWORD'
   redis: 'REDIS_TEST_PASSWORD'
-  serverpod_auth_email_account.passwordHashPepper: 'pepper!'
+  serverpod_auth_email_account_passwordHashPepper: 'pepper!'

--- a/modules/new_serverpod_auth/serverpod_auth_email_account/serverpod_auth_email_account_server/lib/src/business/email_account_secrets.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_email_account/serverpod_auth_email_account_server/lib/src/business/email_account_secrets.dart
@@ -4,7 +4,7 @@ import 'package:serverpod/serverpod.dart';
 abstract class EmailAccountSecrets {
   /// The configuration key for the password hash pepper.
   static const String passwordHashPepperConfigurationKey =
-      'serverpod_auth_email_account.passwordHashPepper';
+      'serverpod_auth_email_account_passwordHashPepper';
 
   /// The pepper used for hashing passwords.
   ///

--- a/modules/new_serverpod_auth/serverpod_auth_session/serverpod_auth_session_server/config/passwords.yaml
+++ b/modules/new_serverpod_auth/serverpod_auth_session/serverpod_auth_session_server/config/passwords.yaml
@@ -12,4 +12,4 @@
 test:
   database: 'DB_TEST_PASSWORD'
   redis: 'REDIS_TEST_PASSWORD'
-  serverpod_auth_session.sessionKeyHashPepper: 'test_session_key_pepper'
+  serverpod_auth_session_sessionKeyHashPepper: 'test_session_key_pepper'

--- a/modules/new_serverpod_auth/serverpod_auth_session/serverpod_auth_session_server/lib/src/business/auth_session_secrets.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_session/serverpod_auth_session_server/lib/src/business/auth_session_secrets.dart
@@ -12,7 +12,7 @@ class AuthSessionSecrets {
 
   /// The configuration key for the session key pepper entry.
   static const String sessionKeyHashPepperConfigurationKey =
-      'serverpod_auth_session.sessionKeyHashPepper';
+      'serverpod_auth_session_sessionKeyHashPepper';
 
   /// The pepper used for hashing authentication session keys.
   ///

--- a/tests/serverpod_new_auth_test/serverpod_new_auth_test_server/config/passwords.yaml
+++ b/tests/serverpod_new_auth_test/serverpod_new_auth_test_server/config/passwords.yaml
@@ -25,8 +25,8 @@ development:
 test:
   database: 'A0EV-ij7y7e639gg0PrH5IYphMqAXVAE'
   redis: 'xBjXhPyFVTSFrOuGNq1GDi564623qEGU'
-  serverpod_auth_email_account.passwordHashPepper: 'emailPepper!'
-  serverpod_auth_session.sessionKeyHashPepper: 'sessionPepper!'
+  serverpod_auth_email_account_passwordHashPepper: 'emailPepper!'
+  serverpod_auth_session_sessionKeyHashPepper: 'sessionPepper!'
 
 # Passwords used in your staging environment if you use one. The default setup
 # use a password for Redis.


### PR DESCRIPTION
So that they can be set as ENV variables

Closes #3680

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Renamed configuration keys by replacing dots with underscores for improved clarity and consistency across environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->