### PR TITLE
feat(auth2): Re-export email account and session packages from email endpoint package

### DIFF
--- a/modules/new_serverpod_auth/serverpod_auth_email/serverpod_auth_email_server/lib/serverpod_auth_email_server.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_email/serverpod_auth_email_server/lib/serverpod_auth_email_server.dart
@@ -1,3 +1,12 @@
+export 'package:serverpod_auth_email_account_server/serverpod_auth_email_account_server.dart'
+    hide Endpoints, Protocol;
+export 'package:serverpod_auth_profile_server/serverpod_auth_profile_server.dart'
+    hide Endpoints, Protocol;
+export 'package:serverpod_auth_session_server/serverpod_auth_session_server.dart'
+    hide Endpoints, Protocol;
+export 'package:serverpod_auth_user_server/serverpod_auth_user_server.dart'
+    hide Endpoints, Protocol;
+
 export 'src/endpoints/email_account_endpoint.dart' show EmailAccountEndpoint;
 export 'src/generated/endpoints.dart';
 export 'src/generated/protocol.dart';

--- a/modules/new_serverpod_auth/serverpod_auth_session/serverpod_auth_session_server/lib/serverpod_auth_session_server.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_session/serverpod_auth_session_server/lib/serverpod_auth_session_server.dart
@@ -5,4 +5,4 @@ export 'src/generated/endpoints.dart';
 export 'src/generated/protocol.dart'
     show Protocol, AuthSessionInfo, AuthSuccess;
 export 'src/util/authentication_info_extension.dart'
-    show AuthenticationInfoUserId;
+    show AuthenticationInfoAuthSessionId;

--- a/modules/new_serverpod_auth/serverpod_auth_session/serverpod_auth_session_server/lib/src/util/authentication_info_extension.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_session/serverpod_auth_session_server/lib/src/util/authentication_info_extension.dart
@@ -1,10 +1,11 @@
 import 'package:serverpod/serverpod.dart';
 
-/// User session ID extension for `AuthenticationInfo`.
-extension AuthenticationInfoUserId on AuthenticationInfo {
+/// Authentication session ID extension for `AuthenticationInfo`.
+extension AuthenticationInfoAuthSessionId on AuthenticationInfo {
   /// Returns the auth session ID of the authenticated user.
   ///
-  /// Assumes that the `authId` is set and the system uses `Uuid` auth session IDs, otherwise throws.
+  /// Assumes that the `authId` is set and the system uses `Uuid` auth session
+  /// IDs, otherwise throws.
   UuidValue get authSessionId {
     return UuidValue.withValidation(authId!);
   }


### PR DESCRIPTION
So consumer only have to add 1 dependency to their pubspec and can use and configure the underlying packages.

For example, a developer wanting to add email accounts to their app can now just add `serverpod_auth_email` to their pubspec.yaml, but then gets accounts to `EmailsAccounts.config`, `AuthSessions.config`, and `UserProfiles.config` to configure them all without having to add a package for each of them.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded authentication module API by making additional authentication-related features available for integration.

* **Documentation**
  * Updated documentation comments to clarify usage related to authentication session IDs.

* **Refactor**
  * Renamed an extension to better reflect its association with authentication session IDs.
  * Adjusted exported symbols to prevent naming conflicts and improve clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->