### PR TITLE
feat(auth)!: Simplify authentication key interface in Serverpod `Client`

### DIFF
--- a/examples/auth_example/auth_example_flutter/lib/src/serverpod_client.dart
+++ b/examples/auth_example/auth_example_flutter/lib/src/serverpod_client.dart
@@ -6,6 +6,11 @@ late SessionManager sessionManager;
 late Client client;
 
 Future<void> initializeServerpodClient() async {
+  // The session manager keeps track of the signed-in state of the user. You
+  // can query it to see if the user is currently signed in and get information
+  // about the user.
+  sessionManager = SessionManager();
+
   // Sets up a singleton client object that can be used to talk to the server from
   // anywhere in our app. The client is generated from your server code.
   // The client is set up to connect to a Serverpod running on a local server on
@@ -13,13 +18,9 @@ Future<void> initializeServerpodClient() async {
   // production servers.
   client = Client(
     'http://localhost:8080/',
-    authenticationKeyManager: FlutterAuthenticationKeyManager(),
+    authenticationKeyManager: sessionManager,
   )..connectivityMonitor = FlutterConnectivityMonitor();
 
-  // The session manager keeps track of the signed-in state of the user. You
-  // can query it to see if the user is currently signed in and get information
-  // about the user.
-  sessionManager = SessionManager(
-    caller: client.modules.auth,
-  );
+  // TODO: Why was this not called before in the example?
+  sessionManager.initialize(client.modules.auth);
 }

--- a/examples/chat/chat_flutter/lib/main.dart
+++ b/examples/chat/chat_flutter/lib/main.dart
@@ -1,3 +1,4 @@
+import 'package:chat_client/chat_client.dart';
 import 'package:chat_flutter/src/disconnected_page.dart';
 import 'package:chat_flutter/src/loading_page.dart';
 import 'package:chat_flutter/src/main_page.dart';
@@ -5,7 +6,6 @@ import 'package:flutter/material.dart';
 import 'package:serverpod_auth_email_flutter/serverpod_auth_email_flutter.dart';
 import 'package:serverpod_auth_shared_flutter/serverpod_auth_shared_flutter.dart';
 import 'package:serverpod_chat_flutter/serverpod_chat_flutter.dart';
-import 'package:chat_client/chat_client.dart';
 import 'package:serverpod_flutter/serverpod_flutter.dart';
 
 late SessionManager sessionManager;
@@ -17,22 +17,21 @@ void main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
   // Sets up a singleton client object that can be used to talk to the server
+  // The session manager keeps track of the signed-in state of the user. You
+  // can query it to see if the user is currently signed in and get information
+  // about the user.
+  sessionManager = SessionManager();
+
   // from anywhere in our app. The client is generated from your server code.
   // The client is set up to connect to a Serverpod running on a local server on
   // the default port. You will need to modify this to connect to staging or
   // production servers.
   client = Client(
     'http://$localhost:8080/',
-    authenticationKeyManager: FlutterAuthenticationKeyManager(),
+    authenticationKeyManager: sessionManager,
   )..connectivityMonitor = FlutterConnectivityMonitor();
 
-  // The session manager keeps track of the signed-in state of the user. You
-  // can query it to see if the user is currently signed in and get information
-  // about the user.
-  sessionManager = SessionManager(
-    caller: client.modules.auth,
-  );
-  await sessionManager.initialize();
+  await sessionManager.initialize(client.modules.auth);
 
   runApp(const MyApp());
 }

--- a/modules/new_serverpod_auth/serverpod_auth_session/serverpod_auth_session_flutter/.gitignore
+++ b/modules/new_serverpod_auth/serverpod_auth_session/serverpod_auth_session_flutter/.gitignore
@@ -1,0 +1,29 @@
+# Miscellaneous
+*.class
+*.log
+*.pyc
+*.swp
+.DS_Store
+.atom/
+.buildlog/
+.history
+.svn/
+migrate_working_dir/
+
+# IntelliJ related
+*.iml
+*.ipr
+*.iws
+.idea/
+
+# The .vscode folder contains launch configuration and tasks you configure in
+# VS Code which you may wish to be included in version control, so this line
+# is commented out by default.
+#.vscode/
+
+# Flutter/Dart/Pub related
+# Libraries should not include pubspec.lock, per https://dart.dev/guides/libraries/private-files#pubspeclock.
+/pubspec.lock
+**/doc/api/
+.dart_tool/
+build/

--- a/modules/new_serverpod_auth/serverpod_auth_session/serverpod_auth_session_flutter/.metadata
+++ b/modules/new_serverpod_auth/serverpod_auth_session/serverpod_auth_session_flutter/.metadata
@@ -1,0 +1,10 @@
+# This file tracks properties of this Flutter project.
+# Used by Flutter tool to assess capabilities and perform upgrades etc.
+#
+# This file should be version controlled and should not be manually edited.
+
+version:
+  revision: "dec2ee5c1f98f8e84a7d5380c05eb8a3d0a81668"
+  channel: "stable"
+
+project_type: package

--- a/modules/new_serverpod_auth/serverpod_auth_session/serverpod_auth_session_flutter/CHANGELOG.md
+++ b/modules/new_serverpod_auth/serverpod_auth_session/serverpod_auth_session_flutter/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 0.0.1
+
+* TODO: Describe initial release.

--- a/modules/new_serverpod_auth/serverpod_auth_session/serverpod_auth_session_flutter/README.md
+++ b/modules/new_serverpod_auth/serverpod_auth_session/serverpod_auth_session_flutter/README.md
@@ -1,0 +1,39 @@
+<!--
+This README describes the package. If you publish this package to pub.dev,
+this README's contents appear on the landing page for your package.
+
+For information about how to write a good package README, see the guide for
+[writing package pages](https://dart.dev/tools/pub/writing-package-pages).
+
+For general information about developing packages, see the Dart guide for
+[creating packages](https://dart.dev/guides/libraries/create-packages)
+and the Flutter guide for
+[developing packages and plugins](https://flutter.dev/to/develop-packages).
+-->
+
+TODO: Put a short description of the package here that helps potential users
+know whether this package might be useful for them.
+
+## Features
+
+TODO: List what your package can do. Maybe include images, gifs, or videos.
+
+## Getting started
+
+TODO: List prerequisites and provide or point to information on how to
+start using the package.
+
+## Usage
+
+TODO: Include short and useful examples for package users. Add longer examples
+to `/example` folder.
+
+```dart
+const like = 'sample';
+```
+
+## Additional information
+
+TODO: Tell users more about the package: where to find more information, how to
+contribute to the package, how to file issues, what response they can expect
+from the package authors, and more.

--- a/modules/new_serverpod_auth/serverpod_auth_session/serverpod_auth_session_flutter/analysis_options.yaml
+++ b/modules/new_serverpod_auth/serverpod_auth_session/serverpod_auth_session_flutter/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: package:serverpod_lints/public_flutter.yaml

--- a/modules/new_serverpod_auth/serverpod_auth_session/serverpod_auth_session_flutter/lib/serverpod_auth_session_flutter.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_session/serverpod_auth_session_flutter/lib/serverpod_auth_session_flutter.dart
@@ -1,0 +1,1 @@
+export './src/session_manager.dart' show SessionManager, KeyValueStorage;

--- a/modules/new_serverpod_auth/serverpod_auth_session/serverpod_auth_session_flutter/lib/src/session_manager.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_session/serverpod_auth_session_flutter/lib/src/session_manager.dart
@@ -1,0 +1,116 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+// TODO
+// ignore: depend_on_referenced_packages
+import 'package:meta/meta.dart';
+import 'package:serverpod_auth_session_client/serverpod_auth_session_client.dart';
+
+/// Session manager client a server using `serverpod_auth_session`.
+class SessionManager implements AuthenticationKeyProvider {
+  /// Creates a new session manager instance.
+  SessionManager({
+    KeyValueStorage? storage,
+  }) : _storage = storage ?? SharedPreferencesKeyValueStorage();
+
+  // TODO: Use secure and "normal"?
+  //       Or should we simplify due to the little data being stored
+  final KeyValueStorage _storage;
+
+  final _authInfo = ValueNotifier<AuthInfo?>(null);
+
+  String? _key;
+
+  static const _sessionKeyStorageKey = 'session_key'; // TODO
+  static const _userInfoStorageKey = 'userInfo'; // TODO
+
+  var _init = false;
+
+  /// Read the configuration from the storage
+  Future<void> restore() async {
+    if (_init) {
+      throw Exception('SessionManager.init must only be called once.');
+    }
+    _init = true;
+
+    final sessionKey = await _storage.get(_sessionKeyStorageKey);
+    final userInfo = await _storage.get(_userInfoStorageKey);
+
+    if (sessionKey != null) {
+      _key = sessionKey;
+
+      _authInfo.value = (
+        authUserId: UuidValue.fromString(userInfo!),
+        // TODO: Handle scopes
+        scopeNames: {},
+      );
+    }
+  }
+
+  @override
+  String? getAuthenticationKey() {
+    return _key;
+  }
+
+  @override
+  void onUnauthenticatedException(String authenticationKey) {
+    if (authenticationKey == _key) {
+      logout();
+    }
+  }
+
+  /// Set the current session to a logged-in user described by [authSuccess].
+  Future<void> setLoggedIn(AuthSuccess authSuccess) async {
+    _key = authSuccess.sessionKey;
+
+    _storage.set(_sessionKeyStorageKey, authSuccess.sessionKey);
+
+    // TODO: Scopes as well
+    _storage.set(_userInfoStorageKey, authSuccess.authUserId.uuid);
+  }
+
+  /// Drop the current user.
+  ///
+  /// This should be called after a `logout` endpoint has been called on the server.
+  void logout() {
+    _storage.set(_sessionKeyStorageKey, null);
+    _storage.set(_userInfoStorageKey, null);
+
+    _key = null;
+    _authInfo.value = null;
+  }
+}
+
+/// Info about the logged-in user.
+// TODO: Should the `Scope` class move to shared (until we can have a model?)
+// TODO: Do we already track `Scope.name` not being `null` as a breaking change for 3.0?
+typedef AuthInfo = ({UuidValue authUserId, Set<String> scopeNames});
+
+/// TODO: Will be added by https://github.com/serverpod/serverpod/pull/3712
+typedef AuthSuccess = ({
+  String sessionKey,
+  UuidValue authUserId,
+  Set<String> scopeNames
+});
+
+/// Storage interface
+abstract class KeyValueStorage {
+  /// Get
+  FutureOr<String?> get(String key);
+
+  /// Set
+  FutureOr set(String key, String? value);
+}
+
+@internal
+class SharedPreferencesKeyValueStorage implements KeyValueStorage {
+  @override
+  Future<String?> get(String key) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<void> set(String key, String? value) {
+    throw UnimplementedError();
+  }
+}

--- a/modules/new_serverpod_auth/serverpod_auth_session/serverpod_auth_session_flutter/pubspec.yaml
+++ b/modules/new_serverpod_auth/serverpod_auth_session/serverpod_auth_session_flutter/pubspec.yaml
@@ -1,0 +1,32 @@
+name: serverpod_auth_session_flutter
+description: Client-side companion for Serverpod servers using `serverpod_auth_session`.
+version: 0.0.1
+repository: https://github.com/serverpod/serverpod
+homepage: https://serverpod.dev
+issue_tracker: https://github.com/serverpod/serverpod/issues
+
+environment:
+  sdk: ^3.5.4
+  flutter: ">=1.17.0"
+
+dependencies:
+  flutter:
+    sdk: flutter
+  serverpod_auth_session_client: 2.9.0
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  serverpod_lints: 2.9.0
+
+dependency_overrides:
+  serverpod_client:
+    path: ../../../../packages/serverpod_client
+  serverpod_auth_session_client:
+    path: ../serverpod_auth_session_client
+  serverpod_auth_user_client:
+    path: ../../serverpod_auth_user/serverpod_auth_user_client
+  serverpod_lints:
+    path: ../../../../packages/serverpod_lints
+  serverpod_serialization:
+    path: ../../../../packages/serverpod_serialization

--- a/modules/new_serverpod_auth/serverpod_auth_session/serverpod_auth_session_flutter/test/serverpod_auth_session_flutter_test.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_session/serverpod_auth_session_flutter/test/serverpod_auth_session_flutter_test.dart
@@ -1,0 +1,12 @@
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test(
+      'Test that stuff is written and cleared out as expected; that async blocking is done until the storage completes',
+      () {
+    // final calculator = Calculator();
+    // expect(calculator.addOne(2), 3);
+    // expect(calculator.addOne(-7), -6);
+    // expect(calculator.addOne(0), 1);
+  });
+}

--- a/modules/serverpod_auth/serverpod_auth_shared_flutter/lib/src/authentication_key_manager.dart
+++ b/modules/serverpod_auth/serverpod_auth_shared_flutter/lib/src/authentication_key_manager.dart
@@ -1,11 +1,10 @@
-import 'package:serverpod_client/serverpod_client.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 const _prefsKey = 'serverpod_authentication_key';
 
 /// Implementation of a Serverpod [AuthenticationKeyManager] specifically for
 /// Flutter. Authentication key is stored in the [SharedPreferences].
-class FlutterAuthenticationKeyManager extends AuthenticationKeyManager {
+class FlutterAuthenticationKeyManager {
   bool _initialized = false;
   String? _authenticationKey;
 

--- a/packages/serverpod_service_client/lib/src/service_key_manager.dart
+++ b/packages/serverpod_service_client/lib/src/service_key_manager.dart
@@ -2,7 +2,7 @@ import 'package:serverpod_client/serverpod_client.dart';
 import 'package:serverpod_shared/serverpod_shared.dart';
 
 /// The key manager used for the service protocol.
-class ServiceKeyManager extends AuthenticationKeyManager {
+class ServiceKeyManager extends AuthenticationKeyProvider {
   /// Name of the client
   final String name;
 
@@ -20,12 +20,7 @@ class ServiceKeyManager extends AuthenticationKeyManager {
   );
 
   @override
-  Future<String> get() async {
+  String? getAuthenticationKey() {
     return '$name:$serviceSecret';
   }
-
-  @override
-  Future<void> put(String key) async {}
-  @override
-  Future<void> remove() async {}
 }

--- a/tests/serverpod_new_auth_test/serverpod_new_auth_test_client/lib/serverpod_new_auth_test_server_client.dart
+++ b/tests/serverpod_new_auth_test/serverpod_new_auth_test_client/lib/serverpod_new_auth_test_server_client.dart
@@ -1,2 +1,3 @@
-export 'src/protocol/protocol.dart';
 export 'package:serverpod_client/serverpod_client.dart';
+
+export 'src/protocol/protocol.dart';

--- a/tests/serverpod_test_flutter/test_integration/auth_session_manager_signout_test.dart
+++ b/tests/serverpod_test_flutter/test_integration/auth_session_manager_signout_test.dart
@@ -1,6 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:serverpod_test_client/serverpod_test_client.dart';
 import 'package:serverpod_auth_shared_flutter/serverpod_auth_shared_flutter.dart';
+import 'package:serverpod_test_client/serverpod_test_client.dart';
 
 class MockStorage implements Storage {
   final Map<String, dynamic> _values = {};
@@ -27,29 +27,23 @@ void main() {
     late SessionManager secondarySessionManager;
 
     setUp(() async {
+      primarySessionManager = SessionManager(
+        storage: MockStorage(),
+      );
       primaryClient = Client(
         serverUrl,
-        authenticationKeyManager: FlutterAuthenticationKeyManager(
-          storage: MockStorage(),
-        ),
+        authenticationKeyManager: primarySessionManager,
       );
-      primarySessionManager = SessionManager(
-        caller: primaryClient.modules.auth,
+      await primarySessionManager.initialize(primaryClient.modules.auth);
+
+      secondarySessionManager = SessionManager(
         storage: MockStorage(),
       );
-      await primarySessionManager.initialize();
-
       secondaryClient = Client(
         serverUrl,
-        authenticationKeyManager: FlutterAuthenticationKeyManager(
-          storage: MockStorage(),
-        ),
+        authenticationKeyManager: secondarySessionManager,
       );
-      secondarySessionManager = SessionManager(
-        caller: secondaryClient.modules.auth,
-        storage: MockStorage(),
-      );
-      await secondarySessionManager.initialize();
+      await secondarySessionManager.initialize(secondaryClient.modules.auth);
 
       await _authenticateClientAndSessionManager(
         primaryClient,

--- a/tests/serverpod_test_server/lib/test_util/test_key_manager.dart
+++ b/tests/serverpod_test_server/lib/test_util/test_key_manager.dart
@@ -1,18 +1,8 @@
 import 'package:serverpod_test_client/serverpod_test_client.dart';
 
-class TestAuthKeyManager extends AuthenticationKeyManager {
-  String? _key;
+class TestAuthKeyManager extends AuthenticationKeyProvider {
+  String? key;
 
   @override
-  Future<String?> get() async => _key;
-
-  @override
-  Future<void> put(String key) async {
-    _key = key;
-  }
-
-  @override
-  Future<void> remove() async {
-    _key = null;
-  }
+  String? getAuthenticationKey() => key;
 }

--- a/tests/serverpod_test_server/lib/test_util/test_service_key_manager.dart
+++ b/tests/serverpod_test_server/lib/test_util/test_service_key_manager.dart
@@ -1,19 +1,13 @@
 import 'package:serverpod_test_client/serverpod_test_client.dart';
 
-class TestServiceKeyManager extends AuthenticationKeyManager {
+class TestServiceKeyManager extends AuthenticationKeyProvider {
   final String name;
   final String serviceSecret;
 
   TestServiceKeyManager(this.name, this.serviceSecret);
 
   @override
-  Future<String> get() async {
+  Future<String?> getAuthenticationKey() async {
     return 'name:$serviceSecret';
   }
-
-  @override
-  Future<void> put(String key) async {}
-
-  @override
-  Future<void> remove() async {}
 }

--- a/tests/serverpod_test_server/test_e2e/auth_core_test.dart
+++ b/tests/serverpod_test_server/test_e2e/auth_core_test.dart
@@ -10,23 +10,28 @@ import 'package:test/scaffolding.dart';
 void main() {
   group('Given a simulated legacy client with old authorization conventions, ',
       () {
+    late TestAuthKeyManager authenticationKeyManager;
     late Client client;
     late String authKey;
 
     setUpAll(() async {
       // prepare a proper authentication key
+      authenticationKeyManager = TestAuthKeyManager();
       client = Client(
         serverUrl,
-        authenticationKeyManager: TestAuthKeyManager(),
+        authenticationKeyManager: authenticationKeyManager,
       );
-      var response =
-          await client.authentication.authenticate('test@foo.bar', 'password');
+      var response = await client.authentication.authenticate(
+        'test@foo.bar',
+        'password',
+      );
       assert(response.success, 'Authentication setup failed');
       authKey = '${response.keyId}:${response.key}';
     });
 
     tearDownAll(() async {
-      await client.authenticationKeyManager?.remove();
+      // TODO: Interestingly, this would never have been set
+      authenticationKeyManager.key = null;
       await client.authentication.removeAllUsers();
       await client.authentication.signOut();
       assert(

--- a/tests/serverpod_test_server/test_e2e/auth_module_test.dart
+++ b/tests/serverpod_test_server/test_e2e/auth_module_test.dart
@@ -5,12 +5,11 @@ import 'package:serverpod_test_server/test_util/test_key_manager.dart';
 import 'package:test/test.dart';
 
 void main() {
+  final authenticationKeyManager = TestAuthKeyManager();
   var client = Client(
     serverUrl,
-    authenticationKeyManager: TestAuthKeyManager(),
+    authenticationKeyManager: authenticationKeyManager,
   );
-
-  setUp(() {});
 
   group('Setup', () {
     test('Remove accounts', () async {
@@ -52,11 +51,12 @@ void main() {
     });
 
     test('Authenticate with correct credentials', () async {
-      var response =
-          await client.authentication.authenticate('test@foo.bar', 'password');
+      var response = await client.authentication.authenticate(
+        'test@foo.bar',
+        'password',
+      );
       if (response.success) {
-        await client.authenticationKeyManager!
-            .put('${response.keyId}:${response.key}');
+        authenticationKeyManager.key = '${response.keyId}:${response.key}';
       }
       expect(response.success, equals(true));
       expect(response.userInfo, isNotNull);
@@ -117,14 +117,13 @@ void main() {
         'password',
       );
       assert(response.success, 'Failed to authenticate user');
-      await client.authenticationKeyManager
-          ?.put('${response.keyId}:${response.key}');
+      authenticationKeyManager.key = '${response.keyId}:${response.key}';
       assert(
           await client.modules.auth.status.isSignedIn(), 'Failed to sign in');
     });
 
     tearDown(() async {
-      await client.authenticationKeyManager?.remove();
+      authenticationKeyManager.key = null;
       await client.authentication.removeAllUsers();
       await client.authentication.signOut();
       assert(
@@ -150,14 +149,13 @@ void main() {
         [Scope.admin.name!],
       );
       assert(response.success, 'Failed to authenticate user');
-      await client.authenticationKeyManager
-          ?.put('${response.keyId}:${response.key}');
+      authenticationKeyManager.key = '${response.keyId}:${response.key}';
       assert(
           await client.modules.auth.status.isSignedIn(), 'Failed to sign in');
     });
 
     tearDown(() async {
-      await client.authenticationKeyManager?.remove();
+      authenticationKeyManager.key = null;
       await client.authentication.removeAllUsers();
       await client.authentication.signOut();
       assert(
@@ -180,14 +178,13 @@ void main() {
         'password',
       );
       assert(response.success, 'Failed to authenticate user');
-      await client.authenticationKeyManager
-          ?.put('${response.keyId}:${response.key}');
+      authenticationKeyManager.key = '${response.keyId}:${response.key}';
       assert(
           await client.modules.auth.status.isSignedIn(), 'Failed to sign in');
     });
 
     tearDown(() async {
-      await client.authenticationKeyManager?.remove();
+      authenticationKeyManager.key = null;
       await client.authentication.removeAllUsers();
       await client.authentication.signOut();
       assert(

--- a/tests/serverpod_test_server/test_e2e/email_authentication_provider_test.dart
+++ b/tests/serverpod_test_server/test_e2e/email_authentication_provider_test.dart
@@ -4,9 +4,10 @@ import 'package:serverpod_test_server/test_util/test_key_manager.dart';
 import 'package:test/test.dart';
 
 void main() {
+  var authenticationKeyManager = TestAuthKeyManager();
   var client = Client(
     serverUrl,
-    authenticationKeyManager: TestAuthKeyManager(),
+    authenticationKeyManager: authenticationKeyManager,
   );
   // ".bar" is the only valid top level domain for test email addresses
   const email = 'test@serverpod.bar';
@@ -126,15 +127,17 @@ void main() {
             await client.modules.auth.email.authenticate(email, password);
         assert(authResponse.success, 'Failed to authenticate user');
         assert(authResponse.key != null, 'Failed to retrieve auth key');
-        await client.authenticationKeyManager
-            ?.put('${authResponse.keyId}:${authResponse.key}');
+        authenticationKeyManager.key =
+            ('${authResponse.keyId}:${authResponse.key}');
 
         assert(await client.modules.auth.status.isSignedIn(),
             'User not signed in');
       },
     );
 
-    tearDown(() async => await client.authenticationKeyManager?.remove());
+    tearDown(() {
+      authenticationKeyManager.key = null;
+    });
 
     test('when changing password then user can authenticate with new password',
         () async {

--- a/tests/serverpod_test_server/test_e2e/endpoint_hierarchy_test.dart
+++ b/tests/serverpod_test_server/test_e2e/endpoint_hierarchy_test.dart
@@ -5,9 +5,10 @@ import 'package:serverpod_test_server/test_util/test_key_manager.dart';
 import 'package:test/test.dart';
 
 void main() {
+  var authenticationKeyManager = TestAuthKeyManager();
   var client = Client(
     serverUrl,
-    authenticationKeyManager: TestAuthKeyManager(),
+    authenticationKeyManager: authenticationKeyManager,
   );
 
   setUp(() async {
@@ -17,7 +18,7 @@ void main() {
   });
 
   tearDown(() async {
-    await client.authenticationKeyManager?.remove();
+    authenticationKeyManager.key = null;
     await client.authentication.removeAllUsers();
     await client.authentication.signOut();
     assert(
@@ -49,8 +50,8 @@ void main() {
         'test@foo.bar',
         'password',
       );
-      await client.authenticationKeyManager!
-          .put('${loginResponse.keyId}:${loginResponse.key}');
+      authenticationKeyManager.key =
+          '${loginResponse.keyId}:${loginResponse.key}';
 
       final response = await client.myLoggedIn.echo('hello');
 
@@ -81,8 +82,8 @@ void main() {
         'test@foo.bar',
         'password',
       );
-      await client.authenticationKeyManager!
-          .put('${loginResponse.keyId}:${loginResponse.key}');
+      authenticationKeyManager.key =
+          '${loginResponse.keyId}:${loginResponse.key}';
 
       await expectLater(
         () async => await client.myAdmin.echo('hello'),
@@ -102,8 +103,8 @@ void main() {
         'password',
         [Scope.admin.name!],
       );
-      await client.authenticationKeyManager!
-          .put('${loginResponse.keyId}:${loginResponse.key}');
+      authenticationKeyManager.key =
+          '${loginResponse.keyId}:${loginResponse.key}';
 
       final response = await client.myAdmin.echo('hello');
 
@@ -134,8 +135,8 @@ void main() {
         'test@foo.bar',
         'password',
       );
-      await client.authenticationKeyManager!
-          .put('${loginResponse.keyId}:${loginResponse.key}');
+      authenticationKeyManager.key =
+          '${loginResponse.keyId}:${loginResponse.key}';
 
       await expectLater(
         () async => await client.myConcreteAdmin.echo('hello'),
@@ -155,8 +156,8 @@ void main() {
         'password',
         [Scope.admin.name!],
       );
-      await client.authenticationKeyManager!
-          .put('${loginResponse.keyId}:${loginResponse.key}');
+      authenticationKeyManager.key =
+          '${loginResponse.keyId}:${loginResponse.key}';
 
       final response = await client.myConcreteAdmin.echo('hello');
 

--- a/tests/serverpod_test_server/test_e2e/method_streaming/authenticated_streaming_method_test.dart
+++ b/tests/serverpod_test_server/test_e2e/method_streaming/authenticated_streaming_method_test.dart
@@ -9,9 +9,10 @@ import 'package:serverpod_test_server/test_util/test_key_manager.dart';
 import 'package:test/test.dart';
 
 void main() {
+  var authenticationKeyManager = TestAuthKeyManager();
   var client = Client(
     serverUrl,
-    authenticationKeyManager: TestAuthKeyManager(),
+    authenticationKeyManager: authenticationKeyManager,
   );
 
   test(
@@ -40,14 +41,13 @@ void main() {
         'password',
       );
       assert(response.success, 'Failed to authenticate user');
-      await client.authenticationKeyManager
-          ?.put('${response.keyId}:${response.key}');
+      authenticationKeyManager.key = '${response.keyId}:${response.key}';
       assert(
           await client.modules.auth.status.isSignedIn(), 'Failed to sign in');
     });
 
     tearDown(() async {
-      await client.authenticationKeyManager?.remove();
+      authenticationKeyManager.key = null;
       await client.authentication.removeAllUsers();
       await client.authentication.signOut();
       assert(
@@ -84,14 +84,13 @@ void main() {
         [Scope.admin.name!],
       );
       assert(response.success, 'Failed to authenticate user');
-      await client.authenticationKeyManager
-          ?.put('${response.keyId}:${response.key}');
+      authenticationKeyManager.key = '${response.keyId}:${response.key}';
       assert(
           await client.modules.auth.status.isSignedIn(), 'Failed to sign in');
     });
 
     tearDown(() async {
-      await client.authenticationKeyManager?.remove();
+      authenticationKeyManager.key = null;
       await client.authentication.removeAllUsers();
       await client.authentication.signOut();
       assert(
@@ -129,14 +128,13 @@ void main() {
       );
       assert(response.success, 'Failed to authenticate user');
       userId = response.userInfo!.id!;
-      await client.authenticationKeyManager
-          ?.put('${response.keyId}:${response.key}');
+      authenticationKeyManager.key = '${response.keyId}:${response.key}';
       assert(
           await client.modules.auth.status.isSignedIn(), 'Failed to sign in');
     });
 
     tearDown(() async {
-      await client.authenticationKeyManager?.remove();
+      authenticationKeyManager.key = null;
       await client.authentication.removeAllUsers();
       await client.authentication.signOut();
       assert(

--- a/tests/serverpod_test_server/test_e2e/websocket_auth_test.dart
+++ b/tests/serverpod_test_server/test_e2e/websocket_auth_test.dart
@@ -18,7 +18,7 @@ void main() {
     });
 
     tearDown(() async {
-      await client.authenticationKeyManager?.remove();
+      authKeyManager.key = null;
       await client.authentication.removeAllUsers();
       await client.authentication.signOut();
       assert(
@@ -56,7 +56,7 @@ void main() {
       expect(response.keyId, isNotNull);
 
       var key = '${response.keyId}:${response.key}';
-      await authKeyManager.put(key);
+      authKeyManager.key = key;
 
       await client.openStreamingConnection(
         disconnectOnLostInternetConnection: false,

--- a/tests/serverpod_test_server/test_e2e/websocket_test.dart
+++ b/tests/serverpod_test_server/test_e2e/websocket_test.dart
@@ -9,9 +9,10 @@ import 'package:serverpod_test_shared/serverpod_test_shared.dart';
 import 'package:test/test.dart';
 
 void main() {
+  var authenticationKeyManager = TestAuthKeyManager();
   var client = Client(
     serverUrl,
-    authenticationKeyManager: TestAuthKeyManager(),
+    authenticationKeyManager: authenticationKeyManager,
   );
 
   var streamingStream = client.streaming.stream.asBroadcastStream();
@@ -97,8 +98,7 @@ void main() {
       var response =
           await client.authentication.authenticate('test@foo.bar', 'password');
       if (response.success) {
-        await client.authenticationKeyManager!
-            .put('${response.keyId}:${response.key}');
+        authenticationKeyManager.key = '${response.keyId}:${response.key}';
       }
       expect(response.success, equals(true));
       expect(response.userInfo, isNotNull);
@@ -132,7 +132,7 @@ void main() {
     test('Upgrade streaming connection', () async {
       // Make sure we are signed out.
       await client.authentication.signOut();
-      await client.authenticationKeyManager!.remove();
+      authenticationKeyManager.key = null;
       await client.closeStreamingConnection();
       client.signInRequired.resetStream();
       await client.openStreamingConnection(
@@ -147,8 +147,7 @@ void main() {
       var response =
           await client.authentication.authenticate('test@foo.bar', 'password');
       if (response.success) {
-        await client.authenticationKeyManager!
-            .put('${response.keyId}:${response.key}');
+        authenticationKeyManager.key = '${response.keyId}:${response.key}';
       }
       expect(response.success, equals(true));
       expect(response.userInfo, isNotNull);
@@ -184,8 +183,7 @@ void main() {
           'password',
         );
         assert(response.success, 'Failed to authenticate user');
-        await client.authenticationKeyManager
-            ?.put('${response.keyId}:${response.key}');
+        authenticationKeyManager.key = '${response.keyId}:${response.key}';
         assert(
             await client.modules.auth.status.isSignedIn(), 'Failed to sign in');
         await client.openStreamingConnection(
@@ -194,7 +192,7 @@ void main() {
       });
 
       tearDown(() async {
-        await client.authenticationKeyManager?.remove();
+        authenticationKeyManager.key = null;
         await client.authentication.removeAllUsers();
         await client.authentication.signOut();
         assert(
@@ -227,8 +225,7 @@ void main() {
           [Scope.admin.name!],
         );
         assert(response.success, 'Failed to authenticate user');
-        await client.authenticationKeyManager
-            ?.put('${response.keyId}:${response.key}');
+        authenticationKeyManager.key = '${response.keyId}:${response.key}';
         assert(
             await client.modules.auth.status.isSignedIn(), 'Failed to sign in');
         await client.openStreamingConnection(
@@ -237,7 +234,7 @@ void main() {
       });
 
       tearDown(() async {
-        await client.authenticationKeyManager?.remove();
+        authenticationKeyManager.key = null;
         await client.authentication.removeAllUsers();
         await client.authentication.signOut();
         assert(

--- a/tests/serverpod_test_server/test_integration/websockets/method_websockets/method_streams/revoked_authentication_stream_test.dart
+++ b/tests/serverpod_test_server/test_integration/websockets/method_websockets/method_streams/revoked_authentication_stream_test.dart
@@ -49,7 +49,7 @@ void main() {
     late String authToken;
     setUp(() async {
       authToken = const Uuid().v4();
-      authKeyManager.put(authToken);
+      authKeyManager.key = authToken;
     });
     group('connected to an authenticated streaming method', () {
       late Completer<dynamic> streamClosedCompleter;


### PR DESCRIPTION
Change the framework's `AuthenticationKeyManager` to only handle the minimal interface, which is providing an authentication key for the next request.

The other previous methods of `put`, `remove`, etc. were never called from the framework.

Additionally, the framework can now notify the new `AuthenticationKeyProvider` in case of "unauthorized" responses, which means the key was not valid.

TODO:
- [ ] Fully update the legacy `serverpod_auth` `SessionManager` implementation
  - We could probably make do with a simplified storage interface, as both implementations use `SharedPreferences` by default. But if we want to retain the pluggability, we could have one "basic" and one "secure" storage
  - The `_initialized`/caching can probably be dropped, as current versions of `shared_preferences` should already do this (to be confirmed)
  - Otherwise, the old interface will be left mostly unchanged, but the new session manager (for `serverpod_auth_session` will provide a slimmer implementation and updated pattern for observations (`ValueListenable`)
- [ ] Update init and tests, since the `AuthenticationKeyManager` is not re-exposed from the client anymore, and thus no one can grab into it. Additionally, figure out a good way for the circular dependency between the 2 classes).
- [ ] Add tests verifying that authentication keys sent from clients < 3.0 are still working correctly on the server
- [ ] Add least write an internal example / demo showcasing how to store the auth key in https://pub.dev/packages/flutter_secure_storage (to actually make use of the basic/secure options)