### PR TITLE
test: Disable flaky shutdown tests

### DIFF
--- a/tests/serverpod_test_server/test_integration/shutdown_test.dart
+++ b/tests/serverpod_test_server/test_integration/shutdown_test.dart
@@ -1,6 +1,8 @@
 // ignore_for_file: dead_code
 
 @Timeout(Duration(minutes: 1))
+@Skip('This is skipped due to flaky tests, issue to resolve this is tracked in '
+    'https://github.com/serverpod/serverpod/issues/3431')
 
 import 'dart:async';
 import 'dart:convert';


### PR DESCRIPTION
Shutdown tests are still flaky.

This PR disables these tests again.

Issue that tracks fixing this is here: https://github.com/serverpod/serverpod/issues/3431

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None - simply disables some tests.