### PR TITLE
fix: Correctly generate code for `scope=serverOnly` fields with a `default` value

### DIFF
--- a/tools/serverpod_cli/lib/src/generator/dart/library_generators/model_library_generator.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart/library_generators/model_library_generator.dart
@@ -1415,17 +1415,20 @@ class SerializableModelLibraryGenerator {
 
       var defaultValueFields = classFields.where((field) => field.hasDefaults);
       for (var field in defaultValueFields) {
-        Code? defaultCode = _getDefaultValue(
-          field,
-          subDirParts: subDirParts,
-        );
-        if (defaultCode == null) continue;
+        if (field.shouldIncludeField(serverCode)) {
+          Code? defaultCode = _getDefaultValue(
+            field,
+            subDirParts: subDirParts,
+          );
 
-        c.initializers.add(Block.of([
-          refer(field.name).code,
-          const Code('='),
-          refer(field.name).ifNullThen(CodeExpression(defaultCode)).code,
-        ]));
+          if (defaultCode == null) continue;
+
+          c.initializers.add(Block.of([
+            refer(field.name).code,
+            const Code('='),
+            refer(field.name).ifNullThen(CodeExpression(defaultCode)).code,
+          ]));
+        }
       }
 
       var implicitFields = classFields.where(


### PR DESCRIPTION
recheck
### 🔧 Fix: Prevent invalid client codegen for `serverOnly` fields with default values

#### 📌 Related Issue: [[#3424](https://github.com/serverpod/serverpod/issues/3424)](https://github.com/serverpod/serverpod/issues/3424)

When a field in a model is marked with both `scope=serverOnly` and `default`, the generated client constructor incorrectly tries to access the field — resulting in a Dart compilation error.

---

### 🐞 Problem Summary

Given the following model:

```yaml
class: FavouriteRecipe
table: favourite_recipe
fields:
  recipe: Recipe
  userId: int?, scope=serverOnly, default=-1
```

The generated **client model** includes:

```dart
FavouriteRecipe._({
  this.id,
  required this.recipe,
}) : userId = userId ?? -1; // ❌ Compilation Error
```

Which leads to:

```
Compiler Error:
'userId' isn't a field in the enclosing class.
Undefined name 'userId'.
```

---

### ✅ Fix Summary

This PR ensures that default value initializers are only added to the constructor **if the field is included in the current codegen scope** (i.e., not `serverOnly` during client model generation).

**Modified logic:**

```dart
for (var field in defaultValueFields) {
  if (field.shouldIncludeField(serverCode)) {
    Code? defaultCode = _getDefaultValue(
      field,
      subDirParts: subDirParts,
    );

    if (defaultCode == null) continue;

    c.initializers.add(Block.of([
      refer(field.name).code,
      const Code('='),
      refer(field.name).ifNullThen(CodeExpression(defaultCode)).code,
    ]));
  }
}
```

---

### 🔬 Testing

* ✅ Generated code using a sample project with `serverOnly` + `default` field
* ✅ Confirmed client code no longer contains invalid constructor initializer
* ✅ Dart compiler no longer throws error
* ✅ Regenerated models and verified unaffected behavior on server side

---



### 🧪 Suggested Future Improvement

Consider extending test coverage for codegen to catch issues where:

* Fields marked `serverOnly` are incorrectly referenced in client models
* Default values are mishandled across scopes

---

### 🙋‍♂️ About Me

I’m a Flutter + Node.js developer actively exploring server-side Dart. I came across this issue while working with `serverpod` in a full-stack Flutter app. I'd love to continue contributing!

---

### ✅ Checklist

* [x] Fix applied only where needed
* [x] Verified backward compatibility
* [x] Manual testing done via sample project
* [x] Linked related issue (#3424)

---

Let me know if you'd like me to add a test case — happy to contribute more 🚀

---
