### PR TITLE
fix: Remove database write from read/write test.

### DIFF
--- a/packages/serverpod/lib/src/server/health_check.dart
+++ b/packages/serverpod/lib/src/server/health_check.dart
@@ -1,5 +1,3 @@
-import 'dart:math';
-
 import 'package:serverpod/src/server/features.dart';
 import 'package:serverpod/src/server/serverpod.dart';
 import 'package:serverpod/src/server/diagnostic_events/diagnostic_events.dart';
@@ -46,17 +44,8 @@ Future<ServerHealthResult> defaultHealthCheckMetrics(
   if (Features.enableDatabase) {
     try {
       var startTime = DateTime.now();
-      var rnd = Random().nextInt(1000000);
 
-      // Write entry
-      ReadWriteTestEntry? entry = ReadWriteTestEntry(
-        number: rnd,
-      );
-
-      entry = await ReadWriteTestEntry.db.insertRow(pod.internalSession, entry);
-
-      // Verify random number
-      dbHealthy = entry.number == rnd;
+      dbHealthy = await pod.internalSession.db.testConnection();
 
       dbResponseTime =
           DateTime.now().difference(startTime).inMicroseconds / 1000000.0;


### PR DESCRIPTION
This PR removes actually creating an entry in the database as part of the read-write test and instead simply tests the connection using a select query.

Continuously testing the possibility of performing a write is redundant. The latency of the connection can be measured with the select statement.

Closes: #3548

### Additional consideration

If this PR is merged, an issue should be created to remove the `ReadWriteTestEntry` model and associated table in some major release.

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None - simply stops populating an internal table.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified the database health check process, resulting in a more efficient and direct check of database connectivity. No visible changes to end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->