### PR TITLE
fix(auth2): Use validating UUID parsers in extensions methods

### DIFF
--- a/modules/new_serverpod_auth/serverpod_auth_session/serverpod_auth_session_server/lib/src/util/authentication_info_extension.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_session/serverpod_auth_session_server/lib/src/util/authentication_info_extension.dart
@@ -6,6 +6,6 @@ extension AuthenticationInfoUserId on AuthenticationInfo {
   ///
   /// Assumes that the `authId` is set and the system uses `Uuid` auth session IDs, otherwise throws.
   UuidValue get authSessionId {
-    return UuidValue.fromString(authId!);
+    return UuidValue.withValidation(authId!);
   }
 }

--- a/modules/new_serverpod_auth/serverpod_auth_session/serverpod_auth_session_server/test/authentication_info_extension_test.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_session/serverpod_auth_session_server/test/authentication_info_extension_test.dart
@@ -1,0 +1,52 @@
+import 'package:serverpod/serverpod.dart';
+import 'package:serverpod_auth_session_server/serverpod_auth_session_server.dart';
+import 'package:test/test.dart';
+
+void main() {
+  final authUserId = const Uuid().v4obj();
+
+  group('Given an `AuthenticationInfo` with a UUID `authId`', () {
+    final authId = const Uuid().v4obj();
+
+    final authenticationInfo = AuthenticationInfo(
+      authUserId,
+      {},
+      authId: authId.uuid,
+    );
+
+    test('when reading the `authSessionId` field, then the UUID is returned.',
+        () {
+      expect(authenticationInfo.authSessionId, authId);
+    });
+  });
+
+  group('Given an `AuthenticationInfo` with a `null` `authId`', () {
+    final authenticationInfo = AuthenticationInfo(
+      authUserId,
+      {},
+      authId: null,
+    );
+
+    test('when reading the `authSessionId` field, then it throws.', () {
+      expect(
+        () => authenticationInfo.authSessionId,
+        throwsA(isA<TypeError>()),
+      );
+    });
+  });
+
+  group('Given an `AuthenticationInfo` with a non-UUID `authId`', () {
+    final authenticationInfo = AuthenticationInfo(
+      123,
+      {},
+      authId: 'foo-bar',
+    );
+
+    test('when reading the `authSessionId` field, then it throws.', () {
+      expect(
+        () => authenticationInfo.authSessionId,
+        throwsFormatException,
+      );
+    });
+  });
+}

--- a/modules/new_serverpod_auth/serverpod_auth_user/serverpod_auth_user_server/lib/src/util/authentication_info_extension.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_user/serverpod_auth_user_server/lib/src/util/authentication_info_extension.dart
@@ -6,6 +6,6 @@ extension AuthenticationInfoUserId on AuthenticationInfo {
   ///
   /// Assumes that the system uses `Uuid` user IDs, otherwise throws.
   UuidValue get userUuid {
-    return UuidValue.fromString(userIdentifier);
+    return UuidValue.withValidation(userIdentifier);
   }
 }

--- a/modules/new_serverpod_auth/serverpod_auth_user/serverpod_auth_user_server/test/authentication_info_extension_test.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_user/serverpod_auth_user_server/test/authentication_info_extension_test.dart
@@ -1,0 +1,26 @@
+import 'package:serverpod/serverpod.dart';
+import 'package:serverpod_auth_user_server/serverpod_auth_user_server.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Given an `AuthenticationInfo` with a UUID `userIdentifier`', () {
+    final authUserId = const Uuid().v4obj();
+
+    final authenticationInfo = AuthenticationInfo(authUserId, {});
+
+    test('when reading the `userUuid` field, then the UUID is returned.', () {
+      expect(authenticationInfo.userUuid, authUserId);
+    });
+  });
+
+  group('Given an `AuthenticationInfo` with a non-UUID `userIdentifier`', () {
+    final authenticationInfo = AuthenticationInfo(123, {});
+
+    test('when reading the `userUuid` field, then it throws.', () {
+      expect(
+        () => authenticationInfo.userUuid,
+        throwsFormatException,
+      );
+    });
+  });
+}


### PR DESCRIPTION
As otherwise any string generates some "UUID value".


Gleamed from https://github.com/serverpod/serverpod/pull/3721 which exposed the same issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation when accessing user session and identifier properties to ensure only valid UUIDs are accepted, resulting in clearer error handling for invalid or missing values.

* **Tests**
  * Added new tests to verify correct behavior and error handling when accessing user session and identifier properties with various types of input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->