### PR TITLE
feat(auth2): Add E2E test for new `SessionManager` and `serverpod_new_auth_test_server`

### DIFF
--- a/.github/workflows/dart-tests.yaml
+++ b/.github/workflows/dart-tests.yaml
@@ -287,6 +287,47 @@ jobs:
         run: docker compose down -v
         working-directory: ${{ matrix.module }}
 
+  module_e2e_tests:
+    name: Module E2E tests in ${{ matrix.module }} with Flutter ${{ matrix.flutter-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        flutter-version: ['3.24.0', '3.32.1']
+        module:
+          - server: tests/serverpod_new_auth_test/serverpod_new_auth_test_server
+            client: tests/serverpod_new_auth_test/serverpod_new_auth_test_flutter
+    steps:
+      - uses: actions/checkout@v3
+      - uses: subosito/flutter-action@v2
+        with:
+          flutter-version: ${{ matrix.flutter-version }}
+          cache: true
+      - name: Start containers
+        run: docker compose up --build -V -d
+        working-directory: ${{ matrix.module.server }}
+      - name: Wait for services to be ready
+        run: |
+          ./wait-for-it.sh localhost:9090 -t 60 -- echo "### Postgres is UP at :9090"
+          ./wait-for-it.sh localhost:9091 -t 60 -- echo "### Redis is UP at :9091"
+        working-directory: tests/docker/tests_integration
+      - name: Install dependencies
+        run: dart pub get
+        working-directory: ${{ matrix.module.server }}
+      - name: Start server
+        run: dart run bin/main.dart --apply-migrations &
+        working-directory: ${{ matrix.module.server }}
+      - name: Wait for services to be ready
+        run: |
+          ./wait-for-it.sh localhost:8080 -t 60 -- echo "### Serverpod backend is UP at :8080"
+        working-directory: tests/docker/tests_integration
+      - name: Run E2E tests (concurrently)
+        run: flutter test --reporter=failures-only
+        working-directory: ${{ matrix.module.client }}
+      - name: Stop containers
+        if: always()
+        run: docker compose down -v
+        working-directory: ${{ matrix.module.server }}
+
   integration_test_server:
     name: Serverpod integration tests (server)
     runs-on: ubuntu-latest

--- a/tests/serverpod_new_auth_test/serverpod_new_auth_test_client/lib/src/protocol/client.dart
+++ b/tests/serverpod_new_auth_test/serverpod_new_auth_test_client/lib/src/protocol/client.dart
@@ -109,6 +109,35 @@ class EndpointEmailAccount extends _i1.EndpointRef {
       );
 }
 
+/// {@category Endpoint}
+class EndpointSessionTest extends _i1.EndpointRef {
+  EndpointSessionTest(_i1.EndpointCaller caller) : super(caller);
+
+  @override
+  String get name => 'sessionTest';
+
+  _i2.Future<_i4.UuidValue> createTestUser() =>
+      caller.callServerEndpoint<_i4.UuidValue>(
+        'sessionTest',
+        'createTestUser',
+        {},
+      );
+
+  _i2.Future<_i3.AuthSuccess> createSession(_i4.UuidValue authUserId) =>
+      caller.callServerEndpoint<_i3.AuthSuccess>(
+        'sessionTest',
+        'createSession',
+        {'authUserId': authUserId},
+      );
+
+  _i2.Future<bool> checkSession(_i4.UuidValue authUserId) =>
+      caller.callServerEndpoint<bool>(
+        'sessionTest',
+        'checkSession',
+        {'authUserId': authUserId},
+      );
+}
+
 /// Endpoint to view and edit one's profile.
 /// {@category Endpoint}
 class EndpointUserProfile extends _i1.EndpointRef {
@@ -206,11 +235,14 @@ class Client extends _i1.ServerpodClientShared {
               disconnectStreamsOnLostInternetConnection,
         ) {
     emailAccount = EndpointEmailAccount(this);
+    sessionTest = EndpointSessionTest(this);
     userProfile = EndpointUserProfile(this);
     modules = Modules(this);
   }
 
   late final EndpointEmailAccount emailAccount;
+
+  late final EndpointSessionTest sessionTest;
 
   late final EndpointUserProfile userProfile;
 
@@ -219,6 +251,7 @@ class Client extends _i1.ServerpodClientShared {
   @override
   Map<String, _i1.EndpointRef> get endpointRefLookup => {
         'emailAccount': emailAccount,
+        'sessionTest': sessionTest,
         'userProfile': userProfile,
       };
 

--- a/tests/serverpod_new_auth_test/serverpod_new_auth_test_flutter/.gitignore
+++ b/tests/serverpod_new_auth_test/serverpod_new_auth_test_flutter/.gitignore
@@ -1,0 +1,29 @@
+# Miscellaneous
+*.class
+*.log
+*.pyc
+*.swp
+.DS_Store
+.atom/
+.buildlog/
+.history
+.svn/
+migrate_working_dir/
+
+# IntelliJ related
+*.iml
+*.ipr
+*.iws
+.idea/
+
+# The .vscode folder contains launch configuration and tasks you configure in
+# VS Code which you may wish to be included in version control, so this line
+# is commented out by default.
+#.vscode/
+
+# Flutter/Dart/Pub related
+# Libraries should not include pubspec.lock, per https://dart.dev/guides/libraries/private-files#pubspeclock.
+/pubspec.lock
+**/doc/api/
+.dart_tool/
+build/

--- a/tests/serverpod_new_auth_test/serverpod_new_auth_test_flutter/.metadata
+++ b/tests/serverpod_new_auth_test/serverpod_new_auth_test_flutter/.metadata
@@ -1,0 +1,10 @@
+# This file tracks properties of this Flutter project.
+# Used by Flutter tool to assess capabilities and perform upgrades etc.
+#
+# This file should be version controlled and should not be manually edited.
+
+version:
+  revision: "dec2ee5c1f98f8e84a7d5380c05eb8a3d0a81668"
+  channel: "stable"
+
+project_type: package

--- a/tests/serverpod_new_auth_test/serverpod_new_auth_test_flutter/analysis_options.yaml
+++ b/tests/serverpod_new_auth_test/serverpod_new_auth_test_flutter/analysis_options.yaml
@@ -1,0 +1,4 @@
+include: package:flutter_lints/flutter.yaml
+
+# Additional information about this file can be found at
+# https://dart.dev/guides/language/analysis-options

--- a/tests/serverpod_new_auth_test/serverpod_new_auth_test_flutter/lib/serverpod_new_auth_test_flutter.dart
+++ b/tests/serverpod_new_auth_test/serverpod_new_auth_test_flutter/lib/serverpod_new_auth_test_flutter.dart
@@ -1,0 +1,1 @@
+library serverpod_new_auth_test_flutter;

--- a/tests/serverpod_new_auth_test/serverpod_new_auth_test_flutter/pubspec.yaml
+++ b/tests/serverpod_new_auth_test/serverpod_new_auth_test_flutter/pubspec.yaml
@@ -1,0 +1,42 @@
+publish_to: none
+
+name: serverpod_new_auth_test_flutter
+description: Auth module client-side tests.
+version: 0.0.1
+
+environment:
+  sdk: ">=3.5.0 <4.0.0"
+  flutter: ">=3.24.0"
+
+dependencies:
+  flutter:
+    sdk: flutter
+
+  serverpod_auth_session_flutter:
+    path: ../../../modules/new_serverpod_auth/serverpod_auth_session/serverpod_auth_session_flutter
+
+  serverpod_new_auth_test_client:
+    path: ../serverpod_new_auth_test_client
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_lints: ">=3.0.0 <7.0.0"
+
+dependency_overrides:
+  serverpod_client:
+    path: ../../../packages/serverpod_client
+  serverpod_auth_session_client:
+    path: ../../../modules/new_serverpod_auth/serverpod_auth_session/serverpod_auth_session_client
+  serverpod_auth_user_client:
+    path: ../../../modules/new_serverpod_auth/serverpod_auth_user/serverpod_auth_user_client
+  serverpod_auth_profile_client:
+    path: ../../../modules/new_serverpod_auth/serverpod_auth_profile/serverpod_auth_profile_client
+  serverpod_auth_email_client:
+    path: ../../../modules/new_serverpod_auth/serverpod_auth_email/serverpod_auth_email_client
+  serverpod_auth_email_account_client:
+    path: ../../../modules/new_serverpod_auth/serverpod_auth_email_account/serverpod_auth_email_account_client
+  serverpod_lints:
+    path: ../../../packages/serverpod_lints
+  serverpod_serialization:
+    path: ../../../packages/serverpod_serialization

--- a/tests/serverpod_new_auth_test/serverpod_new_auth_test_flutter/test/serverpod_new_auth_test_flutter_test.dart
+++ b/tests/serverpod_new_auth_test/serverpod_new_auth_test_flutter/test/serverpod_new_auth_test_flutter_test.dart
@@ -1,0 +1,37 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:serverpod_auth_session_flutter/serverpod_auth_session_flutter.dart';
+import 'package:serverpod_new_auth_test_client/serverpod_new_auth_test_server_client.dart';
+
+import 'utils/test_storage.dart';
+
+void main() {
+  test(
+    'Given a session, when setting it on the `SessionManager`, then the server recognizes the user correctly.',
+    () async {
+      final sessionManager = SessionManager(
+        storage: TestStorage(),
+      );
+
+      final client = Client(
+        'http://localhost:8080/',
+        authenticationKeyManager: sessionManager,
+      );
+
+      final testUser = await client.sessionTest.createTestUser();
+
+      final authentication = await client.sessionTest.createSession(testUser);
+
+      expect(
+        await client.sessionTest.checkSession(testUser),
+        isFalse,
+      );
+
+      await sessionManager.setLoggedIn(authentication);
+
+      expect(
+        await client.sessionTest.checkSession(testUser),
+        isTrue,
+      );
+    },
+  );
+}

--- a/tests/serverpod_new_auth_test/serverpod_new_auth_test_flutter/test/utils/test_storage.dart
+++ b/tests/serverpod_new_auth_test/serverpod_new_auth_test_flutter/test/utils/test_storage.dart
@@ -1,0 +1,21 @@
+import 'package:serverpod_auth_session_flutter/serverpod_auth_session_flutter.dart';
+
+class TestStorage extends KeyValueStorage {
+  final values = <String, String>{};
+
+  @override
+  Future<String?> get(String key) async {
+    return values[key];
+  }
+
+  @override
+  Future<void> set(String key, String? value) async {
+    await Future.delayed(const Duration(microseconds: 1));
+
+    if (value == null) {
+      values.remove(key);
+    } else {
+      values[key] = value;
+    }
+  }
+}

--- a/tests/serverpod_new_auth_test/serverpod_new_auth_test_server/config/passwords.yaml
+++ b/tests/serverpod_new_auth_test/serverpod_new_auth_test_server/config/passwords.yaml
@@ -11,30 +11,33 @@
 
 # Save passwords used across all configurations here.
 shared:
-  mySharedPassword: 'my password'
+  mySharedPassword: "my password"
 
 # These are passwords used when running the server locally in development mode
 development:
-  database: 'YPCt48nqsQkrL1JeQmBIW2n4Z795zn16'
-  redis: '_qyA_jg_0wOZONp1WrEF7CfJVv6Lc2Ce'
+  database: "YPCt48nqsQkrL1JeQmBIW2n4Z795zn16"
+  redis: "_qyA_jg_0wOZONp1WrEF7CfJVv6Lc2Ce"
 
   # The service secret is used to communicate between servers and to access the
   # service protocol.
-  serviceSecret: 'kYhQvD7M8ye1B2Z0kNymKFl_dzdAdrtu'
+  serviceSecret: "kYhQvD7M8ye1B2Z0kNymKFl_dzdAdrtu"
+
+  serverpod_auth_email_account_passwordHashPepper: "emailPepper!"
+  serverpod_auth_session_sessionKeyHashPepper: "sessionPepper!"
 
 test:
-  database: 'A0EV-ij7y7e639gg0PrH5IYphMqAXVAE'
-  redis: 'xBjXhPyFVTSFrOuGNq1GDi564623qEGU'
-  serverpod_auth_email_account_passwordHashPepper: 'emailPepper!'
-  serverpod_auth_session_sessionKeyHashPepper: 'sessionPepper!'
+  database: "A0EV-ij7y7e639gg0PrH5IYphMqAXVAE"
+  redis: "xBjXhPyFVTSFrOuGNq1GDi564623qEGU"
+  serverpod_auth_email_account_passwordHashPepper: "emailPepper!"
+  serverpod_auth_session_sessionKeyHashPepper: "sessionPepper!"
 
 # Passwords used in your staging environment if you use one. The default setup
 # use a password for Redis.
 staging:
-  database: 'u2WVfkMEVp_Qwq3VICBj4HK49cAmG-mV'
-  serviceSecret: 'XTmnQW1t2dvgToQ9qPhHEhqTcxjNYI3m'
+  database: "u2WVfkMEVp_Qwq3VICBj4HK49cAmG-mV"
+  serviceSecret: "XTmnQW1t2dvgToQ9qPhHEhqTcxjNYI3m"
 
 # Passwords used in production mode.
 production:
-  database: 'Nqp5Vg3DhKiPxse2urqcDjFBd1zE3gMg'
-  serviceSecret: 'DS7e5uXbx42zHW3ppxFDUA__U0utE4dz'
+  database: "Nqp5Vg3DhKiPxse2urqcDjFBd1zE3gMg"
+  serviceSecret: "DS7e5uXbx42zHW3ppxFDUA__U0utE4dz"

--- a/tests/serverpod_new_auth_test/serverpod_new_auth_test_server/lib/server.dart
+++ b/tests/serverpod_new_auth_test/serverpod_new_auth_test_server/lib/server.dart
@@ -1,4 +1,6 @@
 import 'package:serverpod/serverpod.dart';
+import 'package:serverpod_auth_email_server/serverpod_auth_email_server.dart'
+    show AuthSessions;
 import 'package:serverpod_new_auth_test_server/src/web/routes/root.dart';
 
 import 'src/generated/endpoints.dart';
@@ -14,6 +16,7 @@ void run(final List<String> args) async {
     args,
     Protocol(),
     Endpoints(),
+    authenticationHandler: AuthSessions.authenticationHandler,
   );
 
   // Setup a default page at the web root.

--- a/tests/serverpod_new_auth_test/serverpod_new_auth_test_server/lib/src/endpoints/session_test_endpoint.dart
+++ b/tests/serverpod_new_auth_test/serverpod_new_auth_test_server/lib/src/endpoints/session_test_endpoint.dart
@@ -1,0 +1,29 @@
+import 'package:serverpod/serverpod.dart';
+import 'package:serverpod_auth_email_server/serverpod_auth_email_server.dart';
+
+class SessionTestEndpoint extends Endpoint {
+  Future<UuidValue> createTestUser(final Session session) async {
+    final authUser = await AuthUsers.create(session);
+
+    return authUser.id;
+  }
+
+  Future<AuthSuccess> createSession(
+    final Session session,
+    final UuidValue authUserId,
+  ) async {
+    return AuthSessions.createSession(
+      session,
+      authUserId: authUserId,
+      method: 'test',
+      scopes: {},
+    );
+  }
+
+  Future<bool> checkSession(
+    final Session session,
+    final UuidValue authUserId,
+  ) async {
+    return (await session.authenticated)?.userUuid == authUserId;
+  }
+}

--- a/tests/serverpod_new_auth_test/serverpod_new_auth_test_server/lib/src/generated/endpoints.dart
+++ b/tests/serverpod_new_auth_test/serverpod_new_auth_test_server/lib/src/generated/endpoints.dart
@@ -11,19 +11,20 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../endpoints/email_account_endpoint.dart' as _i2;
-import '../endpoints/user_profile_endpoint.dart' as _i3;
-import 'package:uuid/uuid_value.dart' as _i4;
-import 'dart:typed_data' as _i5;
+import '../endpoints/session_test_endpoint.dart' as _i3;
+import '../endpoints/user_profile_endpoint.dart' as _i4;
+import 'package:uuid/uuid_value.dart' as _i5;
+import 'dart:typed_data' as _i6;
 import 'package:serverpod_auth_email_server/serverpod_auth_email_server.dart'
-    as _i6;
-import 'package:serverpod_auth_profile_server/serverpod_auth_profile_server.dart'
     as _i7;
-import 'package:serverpod_auth_email_account_server/serverpod_auth_email_account_server.dart'
+import 'package:serverpod_auth_profile_server/serverpod_auth_profile_server.dart'
     as _i8;
-import 'package:serverpod_auth_session_server/serverpod_auth_session_server.dart'
+import 'package:serverpod_auth_email_account_server/serverpod_auth_email_account_server.dart'
     as _i9;
-import 'package:serverpod_auth_user_server/serverpod_auth_user_server.dart'
+import 'package:serverpod_auth_session_server/serverpod_auth_session_server.dart'
     as _i10;
+import 'package:serverpod_auth_user_server/serverpod_auth_user_server.dart'
+    as _i11;
 
 class Endpoints extends _i1.EndpointDispatch {
   @override
@@ -35,7 +36,13 @@ class Endpoints extends _i1.EndpointDispatch {
           'emailAccount',
           null,
         ),
-      'userProfile': _i3.UserProfileEndpoint()
+      'sessionTest': _i3.SessionTestEndpoint()
+        ..initialize(
+          server,
+          'sessionTest',
+          null,
+        ),
+      'userProfile': _i4.UserProfileEndpoint()
         ..initialize(
           server,
           'userProfile',
@@ -100,7 +107,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'accountRequestId': _i1.ParameterDescription(
               name: 'accountRequestId',
-              type: _i1.getType<_i4.UuidValue>(),
+              type: _i1.getType<_i5.UuidValue>(),
               nullable: false,
             ),
             'verificationCode': _i1.ParameterDescription(
@@ -144,7 +151,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'passwordResetRequestId': _i1.ParameterDescription(
               name: 'passwordResetRequestId',
-              type: _i1.getType<_i4.UuidValue>(),
+              type: _i1.getType<_i5.UuidValue>(),
               nullable: false,
             ),
             'verificationCode': _i1.ParameterDescription(
@@ -172,6 +179,60 @@ class Endpoints extends _i1.EndpointDispatch {
         ),
       },
     );
+    connectors['sessionTest'] = _i1.EndpointConnector(
+      name: 'sessionTest',
+      endpoint: endpoints['sessionTest']!,
+      methodConnectors: {
+        'createTestUser': _i1.MethodConnector(
+          name: 'createTestUser',
+          params: {},
+          call: (
+            _i1.Session session,
+            Map<String, dynamic> params,
+          ) async =>
+              (endpoints['sessionTest'] as _i3.SessionTestEndpoint)
+                  .createTestUser(session),
+        ),
+        'createSession': _i1.MethodConnector(
+          name: 'createSession',
+          params: {
+            'authUserId': _i1.ParameterDescription(
+              name: 'authUserId',
+              type: _i1.getType<_i5.UuidValue>(),
+              nullable: false,
+            )
+          },
+          call: (
+            _i1.Session session,
+            Map<String, dynamic> params,
+          ) async =>
+              (endpoints['sessionTest'] as _i3.SessionTestEndpoint)
+                  .createSession(
+            session,
+            params['authUserId'],
+          ),
+        ),
+        'checkSession': _i1.MethodConnector(
+          name: 'checkSession',
+          params: {
+            'authUserId': _i1.ParameterDescription(
+              name: 'authUserId',
+              type: _i1.getType<_i5.UuidValue>(),
+              nullable: false,
+            )
+          },
+          call: (
+            _i1.Session session,
+            Map<String, dynamic> params,
+          ) async =>
+              (endpoints['sessionTest'] as _i3.SessionTestEndpoint)
+                  .checkSession(
+            session,
+            params['authUserId'],
+          ),
+        ),
+      },
+    );
     connectors['userProfile'] = _i1.EndpointConnector(
       name: 'userProfile',
       endpoint: endpoints['userProfile']!,
@@ -183,7 +244,7 @@ class Endpoints extends _i1.EndpointDispatch {
             _i1.Session session,
             Map<String, dynamic> params,
           ) async =>
-              (endpoints['userProfile'] as _i3.UserProfileEndpoint)
+              (endpoints['userProfile'] as _i4.UserProfileEndpoint)
                   .get(session),
         ),
         'removeUserImage': _i1.MethodConnector(
@@ -193,7 +254,7 @@ class Endpoints extends _i1.EndpointDispatch {
             _i1.Session session,
             Map<String, dynamic> params,
           ) async =>
-              (endpoints['userProfile'] as _i3.UserProfileEndpoint)
+              (endpoints['userProfile'] as _i4.UserProfileEndpoint)
                   .removeUserImage(session),
         ),
         'setUserImage': _i1.MethodConnector(
@@ -201,7 +262,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'image': _i1.ParameterDescription(
               name: 'image',
-              type: _i1.getType<_i5.ByteData>(),
+              type: _i1.getType<_i6.ByteData>(),
               nullable: false,
             )
           },
@@ -209,7 +270,7 @@ class Endpoints extends _i1.EndpointDispatch {
             _i1.Session session,
             Map<String, dynamic> params,
           ) async =>
-              (endpoints['userProfile'] as _i3.UserProfileEndpoint)
+              (endpoints['userProfile'] as _i4.UserProfileEndpoint)
                   .setUserImage(
             session,
             params['image'],
@@ -228,7 +289,7 @@ class Endpoints extends _i1.EndpointDispatch {
             _i1.Session session,
             Map<String, dynamic> params,
           ) async =>
-              (endpoints['userProfile'] as _i3.UserProfileEndpoint)
+              (endpoints['userProfile'] as _i4.UserProfileEndpoint)
                   .changeUserName(
             session,
             params['userName'],
@@ -247,7 +308,7 @@ class Endpoints extends _i1.EndpointDispatch {
             _i1.Session session,
             Map<String, dynamic> params,
           ) async =>
-              (endpoints['userProfile'] as _i3.UserProfileEndpoint)
+              (endpoints['userProfile'] as _i4.UserProfileEndpoint)
                   .changeFullName(
             session,
             params['fullName'],
@@ -255,15 +316,15 @@ class Endpoints extends _i1.EndpointDispatch {
         ),
       },
     );
-    modules['serverpod_auth_email'] = _i6.Endpoints()
+    modules['serverpod_auth_email'] = _i7.Endpoints()
       ..initializeEndpoints(server);
-    modules['serverpod_auth_profile'] = _i7.Endpoints()
+    modules['serverpod_auth_profile'] = _i8.Endpoints()
       ..initializeEndpoints(server);
-    modules['serverpod_auth_email_account'] = _i8.Endpoints()
+    modules['serverpod_auth_email_account'] = _i9.Endpoints()
       ..initializeEndpoints(server);
-    modules['serverpod_auth_session'] = _i9.Endpoints()
+    modules['serverpod_auth_session'] = _i10.Endpoints()
       ..initializeEndpoints(server);
-    modules['serverpod_auth_user'] = _i10.Endpoints()
+    modules['serverpod_auth_user'] = _i11.Endpoints()
       ..initializeEndpoints(server);
   }
 }

--- a/tests/serverpod_new_auth_test/serverpod_new_auth_test_server/lib/src/generated/protocol.yaml
+++ b/tests/serverpod_new_auth_test/serverpod_new_auth_test_server/lib/src/generated/protocol.yaml
@@ -4,6 +4,10 @@ emailAccount:
   - finishRegistration:
   - startPasswordReset:
   - finishPasswordReset:
+sessionTest:
+  - createTestUser:
+  - createSession:
+  - checkSession:
 userProfile:
   - get:
   - removeUserImage:

--- a/tests/serverpod_new_auth_test/serverpod_new_auth_test_server/test/integration/test_tools/serverpod_test_tools.dart
+++ b/tests/serverpod_new_auth_test/serverpod_new_auth_test_server/test/integration/test_tools/serverpod_test_tools.dart
@@ -108,6 +108,8 @@ void withServerpod(
 class TestEndpoints {
   late final _EmailAccountEndpoint emailAccount;
 
+  late final _SessionTestEndpoint sessionTest;
+
   late final _UserProfileEndpoint userProfile;
 }
 
@@ -119,6 +121,10 @@ class _InternalTestEndpoints extends TestEndpoints
     _i2.EndpointDispatch endpoints,
   ) {
     emailAccount = _EmailAccountEndpoint(
+      endpoints,
+      serializationManager,
+    );
+    sessionTest = _SessionTestEndpoint(
       endpoints,
       serializationManager,
     );
@@ -295,6 +301,102 @@ class _EmailAccountEndpoint {
           _localUniqueSession,
           _localCallContext.arguments,
         ) as _i3.Future<_i4.AuthSuccess>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
+    });
+  }
+}
+
+class _SessionTestEndpoint {
+  _SessionTestEndpoint(
+    this._endpointDispatch,
+    this._serializationManager,
+  );
+
+  final _i2.EndpointDispatch _endpointDispatch;
+
+  final _i2.SerializationManager _serializationManager;
+
+  _i3.Future<_i5.UuidValue> createTestUser(
+      _i1.TestSessionBuilder sessionBuilder) async {
+    return _i1.callAwaitableFunctionAndHandleExceptions(() async {
+      var _localUniqueSession =
+          (sessionBuilder as _i1.InternalTestSessionBuilder).internalBuild(
+        endpoint: 'sessionTest',
+        method: 'createTestUser',
+      );
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'sessionTest',
+          methodName: 'createTestUser',
+          parameters: _i1.testObjectToJson({}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<_i5.UuidValue>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
+    });
+  }
+
+  _i3.Future<_i4.AuthSuccess> createSession(
+    _i1.TestSessionBuilder sessionBuilder,
+    _i5.UuidValue authUserId,
+  ) async {
+    return _i1.callAwaitableFunctionAndHandleExceptions(() async {
+      var _localUniqueSession =
+          (sessionBuilder as _i1.InternalTestSessionBuilder).internalBuild(
+        endpoint: 'sessionTest',
+        method: 'createSession',
+      );
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'sessionTest',
+          methodName: 'createSession',
+          parameters: _i1.testObjectToJson({'authUserId': authUserId}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<_i4.AuthSuccess>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
+    });
+  }
+
+  _i3.Future<bool> checkSession(
+    _i1.TestSessionBuilder sessionBuilder,
+    _i5.UuidValue authUserId,
+  ) async {
+    return _i1.callAwaitableFunctionAndHandleExceptions(() async {
+      var _localUniqueSession =
+          (sessionBuilder as _i1.InternalTestSessionBuilder).internalBuild(
+        endpoint: 'sessionTest',
+        method: 'checkSession',
+      );
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'sessionTest',
+          methodName: 'checkSession',
+          parameters: _i1.testObjectToJson({'authUserId': authUserId}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<bool>);
         return _localReturnValue;
       } finally {
         await _localUniqueSession.close();


### PR DESCRIPTION
Add the capability to have modules tested E2E with a ("Flutter") client and adds a first test for the client-side `SessionManager` class.

Successful run @ https://github.com/serverpod/serverpod/actions/runs/15974292177/job/45052592539?pr=3725

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new Flutter test module for session authentication, including configuration and test files.
  * Added a server endpoint for creating test users, managing authentication sessions, and verifying session status.
  * Enhanced integration test tools with support for session-related testing.
* **Chores**
  * Updated configuration files and added a workflow for end-to-end testing across multiple Flutter versions.
  * Improved password configuration management for development and test environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->