### PR TITLE
fix(test): Clear caches in between test runs

### DIFF
--- a/packages/serverpod/lib/src/cache/caches.dart
+++ b/packages/serverpod/lib/src/cache/caches.dart
@@ -53,4 +53,11 @@ class Caches {
 
   /// Cache used to automatically save cachable database queries.
   LocalCache get query => _query;
+
+  /// Clears all caches.
+  Future<void> clear() async {
+    await _local.clear();
+    await _localPrio.clear();
+    await _query.clear();
+  }
 }

--- a/packages/serverpod_test/lib/src/with_serverpod.dart
+++ b/packages/serverpod_test/lib/src/with_serverpod.dart
@@ -157,6 +157,10 @@ void Function(TestClosure<T>)
             await localTransactionManager.addSavepoint();
           }
 
+          await mainServerpodSession.caches.local.clear();
+          await mainServerpodSession.caches.localPrio.clear();
+          await mainServerpodSession.caches.query.clear();
+
           await GlobalStreamManager.closeAllStreams();
         });
 

--- a/packages/serverpod_test/lib/src/with_serverpod.dart
+++ b/packages/serverpod_test/lib/src/with_serverpod.dart
@@ -157,9 +157,7 @@ void Function(TestClosure<T>)
             await localTransactionManager.addSavepoint();
           }
 
-          await mainServerpodSession.caches.local.clear();
-          await mainServerpodSession.caches.localPrio.clear();
-          await mainServerpodSession.caches.query.clear();
+          await mainServerpodSession.caches.clear();
 
           await GlobalStreamManager.closeAllStreams();
         });

--- a/tests/serverpod_test_client/lib/src/protocol/client.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/client.dart
@@ -3507,6 +3507,81 @@ class EndpointTestTools extends _i1.EndpointRef {
         {},
         {},
       );
+
+  _i2.Future<void> putInLocalCache(
+    String key,
+    _i10.SimpleData data,
+  ) =>
+      caller.callServerEndpoint<void>(
+        'testTools',
+        'putInLocalCache',
+        {
+          'key': key,
+          'data': data,
+        },
+      );
+
+  _i2.Future<_i10.SimpleData?> getFromLocalCache(String key) =>
+      caller.callServerEndpoint<_i10.SimpleData?>(
+        'testTools',
+        'getFromLocalCache',
+        {'key': key},
+      );
+
+  _i2.Future<void> putInLocalPrioCache(
+    String key,
+    _i10.SimpleData data,
+  ) =>
+      caller.callServerEndpoint<void>(
+        'testTools',
+        'putInLocalPrioCache',
+        {
+          'key': key,
+          'data': data,
+        },
+      );
+
+  _i2.Future<_i10.SimpleData?> getFromLocalPrioCache(String key) =>
+      caller.callServerEndpoint<_i10.SimpleData?>(
+        'testTools',
+        'getFromLocalPrioCache',
+        {'key': key},
+      );
+
+  _i2.Future<void> putInQueryCache(
+    String key,
+    _i10.SimpleData data,
+  ) =>
+      caller.callServerEndpoint<void>(
+        'testTools',
+        'putInQueryCache',
+        {
+          'key': key,
+          'data': data,
+        },
+      );
+
+  _i2.Future<_i10.SimpleData?> getFromQueryCache(String key) =>
+      caller.callServerEndpoint<_i10.SimpleData?>(
+        'testTools',
+        'getFromQueryCache',
+        {'key': key},
+      );
+
+  _i2.Future<void> putInLocalCacheWithGroup(
+    String key,
+    _i10.SimpleData data,
+    String group,
+  ) =>
+      caller.callServerEndpoint<void>(
+        'testTools',
+        'putInLocalCacheWithGroup',
+        {
+          'key': key,
+          'data': data,
+          'group': group,
+        },
+      );
 }
 
 /// {@category Endpoint}

--- a/tests/serverpod_test_server/lib/src/endpoints/test_tools.dart
+++ b/tests/serverpod_test_server/lib/src/endpoints/test_tools.dart
@@ -342,6 +342,39 @@ class TestToolsEndpoint extends Endpoint {
 
     throw Exception();
   }
+
+  // Cache testing methods
+  Future<void> putInLocalCache(
+      Session session, String key, SimpleData data) async {
+    await session.caches.local.put(key, data);
+  }
+
+  Future<SimpleData?> getFromLocalCache(Session session, String key) async {
+    return await session.caches.local.get<SimpleData>(key);
+  }
+
+  Future<void> putInLocalPrioCache(
+      Session session, String key, SimpleData data) async {
+    await session.caches.localPrio.put(key, data);
+  }
+
+  Future<SimpleData?> getFromLocalPrioCache(Session session, String key) async {
+    return await session.caches.localPrio.get<SimpleData>(key);
+  }
+
+  Future<void> putInQueryCache(
+      Session session, String key, SimpleData data) async {
+    await session.caches.query.put(key, data);
+  }
+
+  Future<SimpleData?> getFromQueryCache(Session session, String key) async {
+    return await session.caches.query.get<SimpleData>(key);
+  }
+
+  Future<void> putInLocalCacheWithGroup(
+      Session session, String key, SimpleData data, String group) async {
+    await session.caches.local.put(key, data, group: group);
+  }
 }
 
 class AuthenticatedTestToolsEndpoint extends Endpoint {

--- a/tests/serverpod_test_server/lib/src/generated/endpoints.dart
+++ b/tests/serverpod_test_server/lib/src/generated/endpoints.dart
@@ -7291,6 +7291,169 @@ class Endpoints extends _i1.EndpointDispatch {
               (endpoints['testTools'] as _i42.TestToolsEndpoint)
                   .addWillCloseListenerToSessionAndThrow(session),
         ),
+        'putInLocalCache': _i1.MethodConnector(
+          name: 'putInLocalCache',
+          params: {
+            'key': _i1.ParameterDescription(
+              name: 'key',
+              type: _i1.getType<String>(),
+              nullable: false,
+            ),
+            'data': _i1.ParameterDescription(
+              name: 'data',
+              type: _i1.getType<_i50.SimpleData>(),
+              nullable: false,
+            ),
+          },
+          call: (
+            _i1.Session session,
+            Map<String, dynamic> params,
+          ) async =>
+              (endpoints['testTools'] as _i42.TestToolsEndpoint)
+                  .putInLocalCache(
+            session,
+            params['key'],
+            params['data'],
+          ),
+        ),
+        'getFromLocalCache': _i1.MethodConnector(
+          name: 'getFromLocalCache',
+          params: {
+            'key': _i1.ParameterDescription(
+              name: 'key',
+              type: _i1.getType<String>(),
+              nullable: false,
+            )
+          },
+          call: (
+            _i1.Session session,
+            Map<String, dynamic> params,
+          ) async =>
+              (endpoints['testTools'] as _i42.TestToolsEndpoint)
+                  .getFromLocalCache(
+            session,
+            params['key'],
+          ),
+        ),
+        'putInLocalPrioCache': _i1.MethodConnector(
+          name: 'putInLocalPrioCache',
+          params: {
+            'key': _i1.ParameterDescription(
+              name: 'key',
+              type: _i1.getType<String>(),
+              nullable: false,
+            ),
+            'data': _i1.ParameterDescription(
+              name: 'data',
+              type: _i1.getType<_i50.SimpleData>(),
+              nullable: false,
+            ),
+          },
+          call: (
+            _i1.Session session,
+            Map<String, dynamic> params,
+          ) async =>
+              (endpoints['testTools'] as _i42.TestToolsEndpoint)
+                  .putInLocalPrioCache(
+            session,
+            params['key'],
+            params['data'],
+          ),
+        ),
+        'getFromLocalPrioCache': _i1.MethodConnector(
+          name: 'getFromLocalPrioCache',
+          params: {
+            'key': _i1.ParameterDescription(
+              name: 'key',
+              type: _i1.getType<String>(),
+              nullable: false,
+            )
+          },
+          call: (
+            _i1.Session session,
+            Map<String, dynamic> params,
+          ) async =>
+              (endpoints['testTools'] as _i42.TestToolsEndpoint)
+                  .getFromLocalPrioCache(
+            session,
+            params['key'],
+          ),
+        ),
+        'putInQueryCache': _i1.MethodConnector(
+          name: 'putInQueryCache',
+          params: {
+            'key': _i1.ParameterDescription(
+              name: 'key',
+              type: _i1.getType<String>(),
+              nullable: false,
+            ),
+            'data': _i1.ParameterDescription(
+              name: 'data',
+              type: _i1.getType<_i50.SimpleData>(),
+              nullable: false,
+            ),
+          },
+          call: (
+            _i1.Session session,
+            Map<String, dynamic> params,
+          ) async =>
+              (endpoints['testTools'] as _i42.TestToolsEndpoint)
+                  .putInQueryCache(
+            session,
+            params['key'],
+            params['data'],
+          ),
+        ),
+        'getFromQueryCache': _i1.MethodConnector(
+          name: 'getFromQueryCache',
+          params: {
+            'key': _i1.ParameterDescription(
+              name: 'key',
+              type: _i1.getType<String>(),
+              nullable: false,
+            )
+          },
+          call: (
+            _i1.Session session,
+            Map<String, dynamic> params,
+          ) async =>
+              (endpoints['testTools'] as _i42.TestToolsEndpoint)
+                  .getFromQueryCache(
+            session,
+            params['key'],
+          ),
+        ),
+        'putInLocalCacheWithGroup': _i1.MethodConnector(
+          name: 'putInLocalCacheWithGroup',
+          params: {
+            'key': _i1.ParameterDescription(
+              name: 'key',
+              type: _i1.getType<String>(),
+              nullable: false,
+            ),
+            'data': _i1.ParameterDescription(
+              name: 'data',
+              type: _i1.getType<_i50.SimpleData>(),
+              nullable: false,
+            ),
+            'group': _i1.ParameterDescription(
+              name: 'group',
+              type: _i1.getType<String>(),
+              nullable: false,
+            ),
+          },
+          call: (
+            _i1.Session session,
+            Map<String, dynamic> params,
+          ) async =>
+              (endpoints['testTools'] as _i42.TestToolsEndpoint)
+                  .putInLocalCacheWithGroup(
+            session,
+            params['key'],
+            params['data'],
+            params['group'],
+          ),
+        ),
         'returnsSessionIdFromStream': _i1.MethodStreamConnector(
           name: 'returnsSessionIdFromStream',
           params: {},

--- a/tests/serverpod_test_server/lib/src/generated/protocol.yaml
+++ b/tests/serverpod_test_server/lib/src/generated/protocol.yaml
@@ -417,6 +417,13 @@ testTools:
   - logMessageWithSession:
   - addWillCloseListenerToSessionAndThrow:
   - addWillCloseListenerToSessionIntStreamMethodAndThrow:
+  - putInLocalCache:
+  - getFromLocalCache:
+  - putInLocalPrioCache:
+  - getFromLocalPrioCache:
+  - putInQueryCache:
+  - getFromQueryCache:
+  - putInLocalCacheWithGroup:
 authenticatedTestTools:
   - returnsString:
   - returnsStream:

--- a/tests/serverpod_test_server/test_integration/test_tools/cache_isolation_test.dart
+++ b/tests/serverpod_test_server/test_integration/test_tools/cache_isolation_test.dart
@@ -8,7 +8,7 @@ void main() {
     'Given withServerpod with cache operations',
     (sessionBuilder, endpoints) {
       group('when tests store data in local cache', () {
-        test('then local cache should be empty in subsequent tests', () async {
+        test('then the value is retrieved.', () async {
           // First test stores data
           final testData = SimpleData(num: 42);
           await endpoints.testTools
@@ -31,8 +31,7 @@ void main() {
       });
 
       group('when tests store data in localPrio cache', () {
-        test('then localPrio cache should be empty in subsequent tests',
-            () async {
+        test('then the value is retrieved.', () async {
           // First test stores data
           final testData = SimpleData(num: 84);
           await endpoints.testTools
@@ -56,7 +55,7 @@ void main() {
       });
 
       group('when tests store data in query cache', () {
-        test('then query cache should be empty in subsequent tests', () async {
+        test('then the value is retrieved.', () async {
           // First test stores data
           final testData = SimpleData(num: 168);
           await endpoints.testTools
@@ -79,7 +78,7 @@ void main() {
       });
 
       group('when tests store data with cache groups', () {
-        test('then cache groups should be cleared between tests', () async {
+        test('then the value is retrieved.', () async {
           // Store data with group
           final testData1 = SimpleData(num: 100);
           final testData2 = SimpleData(num: 200);
@@ -112,8 +111,7 @@ void main() {
       });
 
       group('when tests store data with different keys', () {
-        test('then multiple cache entries should be stored correctly',
-            () async {
+        test('then the value is retrieved.', () async {
           // Store multiple entries
           await endpoints.testTools
               .putInLocalCache(sessionBuilder, 'multi-1', SimpleData(num: 1));
@@ -150,6 +148,31 @@ void main() {
               reason: 'Multiple cache entry 2 should be cleared');
           expect(cached3, isNull,
               reason: 'Multiple cache entry 3 should be cleared');
+        });
+      });
+
+      group('when cache data is set in setUp', () {
+        setUp(() async {
+          final sharedData = SimpleData(num: 999);
+          await endpoints.testTools
+              .putInLocalCache(sessionBuilder, 'setup-key', sharedData);
+        });
+
+        test('then setup cache data should be available in first test',
+            () async {
+          final cached = await endpoints.testTools
+              .getFromLocalCache(sessionBuilder, 'setup-key');
+          expect(cached, isNotNull);
+          expect(cached!.num, equals(999));
+        });
+
+        test('then setup cache data should still be available in second test',
+            () async {
+          final cached = await endpoints.testTools
+              .getFromLocalCache(sessionBuilder, 'setup-key');
+          expect(cached, isNotNull,
+              reason: 'Cache data from setUpAll should persist across tests');
+          expect(cached!.num, equals(999));
         });
       });
     },

--- a/tests/serverpod_test_server/test_integration/test_tools/cache_isolation_test.dart
+++ b/tests/serverpod_test_server/test_integration/test_tools/cache_isolation_test.dart
@@ -1,0 +1,157 @@
+import 'package:serverpod_test_server/src/generated/protocol.dart';
+import 'package:test/test.dart';
+
+import 'serverpod_test_tools.dart';
+
+void main() {
+  withServerpod(
+    'Given withServerpod with cache operations',
+    (sessionBuilder, endpoints) {
+      group('when tests store data in local cache', () {
+        test('then local cache should be empty in subsequent tests', () async {
+          // First test stores data
+          final testData = SimpleData(num: 42);
+          await endpoints.testTools
+              .putInLocalCache(sessionBuilder, 'test-key', testData);
+
+          // Verify data was stored
+          final cached1 = await endpoints.testTools
+              .getFromLocalCache(sessionBuilder, 'test-key');
+          expect(cached1, isNotNull);
+          expect(cached1!.num, equals(42));
+        });
+
+        test('then local cache should be empty from previous test', () async {
+          // This test should find cache empty due to automatic cleanup
+          final cached = await endpoints.testTools
+              .getFromLocalCache(sessionBuilder, 'test-key');
+          expect(cached, isNull,
+              reason: 'Local cache should be cleared between tests');
+        });
+      });
+
+      group('when tests store data in localPrio cache', () {
+        test('then localPrio cache should be empty in subsequent tests',
+            () async {
+          // First test stores data
+          final testData = SimpleData(num: 84);
+          await endpoints.testTools
+              .putInLocalPrioCache(sessionBuilder, 'prio-key', testData);
+
+          // Verify data was stored
+          final cached1 = await endpoints.testTools
+              .getFromLocalPrioCache(sessionBuilder, 'prio-key');
+          expect(cached1, isNotNull);
+          expect(cached1!.num, equals(84));
+        });
+
+        test('then localPrio cache should be empty from previous test',
+            () async {
+          // This test should find cache empty due to automatic cleanup
+          final cached = await endpoints.testTools
+              .getFromLocalPrioCache(sessionBuilder, 'prio-key');
+          expect(cached, isNull,
+              reason: 'LocalPrio cache should be cleared between tests');
+        });
+      });
+
+      group('when tests store data in query cache', () {
+        test('then query cache should be empty in subsequent tests', () async {
+          // First test stores data
+          final testData = SimpleData(num: 168);
+          await endpoints.testTools
+              .putInQueryCache(sessionBuilder, 'query-key', testData);
+
+          // Verify data was stored
+          final cached1 = await endpoints.testTools
+              .getFromQueryCache(sessionBuilder, 'query-key');
+          expect(cached1, isNotNull);
+          expect(cached1!.num, equals(168));
+        });
+
+        test('then query cache should be empty from previous test', () async {
+          // This test should find cache empty due to automatic cleanup
+          final cached = await endpoints.testTools
+              .getFromQueryCache(sessionBuilder, 'query-key');
+          expect(cached, isNull,
+              reason: 'Query cache should be cleared between tests');
+        });
+      });
+
+      group('when tests store data with cache groups', () {
+        test('then cache groups should be cleared between tests', () async {
+          // Store data with group
+          final testData1 = SimpleData(num: 100);
+          final testData2 = SimpleData(num: 200);
+
+          await endpoints.testTools.putInLocalCacheWithGroup(
+              sessionBuilder, 'group-key-1', testData1, 'test-group');
+          await endpoints.testTools.putInLocalCacheWithGroup(
+              sessionBuilder, 'group-key-2', testData2, 'test-group');
+
+          // Verify both items are cached
+          final cached1 = await endpoints.testTools
+              .getFromLocalCache(sessionBuilder, 'group-key-1');
+          final cached2 = await endpoints.testTools
+              .getFromLocalCache(sessionBuilder, 'group-key-2');
+          expect(cached1?.num, equals(100));
+          expect(cached2?.num, equals(200));
+        });
+
+        test('then grouped cache should be empty from previous test', () async {
+          // Both grouped items should be cleared
+          final cached1 = await endpoints.testTools
+              .getFromLocalCache(sessionBuilder, 'group-key-1');
+          final cached2 = await endpoints.testTools
+              .getFromLocalCache(sessionBuilder, 'group-key-2');
+          expect(cached1, isNull,
+              reason: 'Grouped cache item 1 should be cleared');
+          expect(cached2, isNull,
+              reason: 'Grouped cache item 2 should be cleared');
+        });
+      });
+
+      group('when tests store data with different keys', () {
+        test('then multiple cache entries should be stored correctly',
+            () async {
+          // Store multiple entries
+          await endpoints.testTools
+              .putInLocalCache(sessionBuilder, 'multi-1', SimpleData(num: 1));
+          await endpoints.testTools
+              .putInLocalCache(sessionBuilder, 'multi-2', SimpleData(num: 2));
+          await endpoints.testTools
+              .putInLocalCache(sessionBuilder, 'multi-3', SimpleData(num: 3));
+
+          // Verify all are cached
+          final cached1 = await endpoints.testTools
+              .getFromLocalCache(sessionBuilder, 'multi-1');
+          final cached2 = await endpoints.testTools
+              .getFromLocalCache(sessionBuilder, 'multi-2');
+          final cached3 = await endpoints.testTools
+              .getFromLocalCache(sessionBuilder, 'multi-3');
+
+          expect(cached1?.num, equals(1));
+          expect(cached2?.num, equals(2));
+          expect(cached3?.num, equals(3));
+        });
+
+        test('then all multiple cache entries should be cleared', () async {
+          // All entries should be cleared
+          final cached1 = await endpoints.testTools
+              .getFromLocalCache(sessionBuilder, 'multi-1');
+          final cached2 = await endpoints.testTools
+              .getFromLocalCache(sessionBuilder, 'multi-2');
+          final cached3 = await endpoints.testTools
+              .getFromLocalCache(sessionBuilder, 'multi-3');
+
+          expect(cached1, isNull,
+              reason: 'Multiple cache entry 1 should be cleared');
+          expect(cached2, isNull,
+              reason: 'Multiple cache entry 2 should be cleared');
+          expect(cached3, isNull,
+              reason: 'Multiple cache entry 3 should be cleared');
+        });
+      });
+    },
+  );
+}

--- a/tests/serverpod_test_server/test_integration/test_tools/serverpod_test_tools.dart
+++ b/tests/serverpod_test_server/test_integration/test_tools/serverpod_test_tools.dart
@@ -12094,6 +12094,227 @@ class _TestToolsEndpoint {
     );
     return _localTestStreamManager.outputStreamController.stream;
   }
+
+  _i3.Future<void> putInLocalCache(
+    _i1.TestSessionBuilder sessionBuilder,
+    String key,
+    _i11.SimpleData data,
+  ) async {
+    return _i1.callAwaitableFunctionAndHandleExceptions(() async {
+      var _localUniqueSession =
+          (sessionBuilder as _i1.InternalTestSessionBuilder).internalBuild(
+        endpoint: 'testTools',
+        method: 'putInLocalCache',
+      );
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'testTools',
+          methodName: 'putInLocalCache',
+          parameters: _i1.testObjectToJson({
+            'key': key,
+            'data': data,
+          }),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<void>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
+    });
+  }
+
+  _i3.Future<_i11.SimpleData?> getFromLocalCache(
+    _i1.TestSessionBuilder sessionBuilder,
+    String key,
+  ) async {
+    return _i1.callAwaitableFunctionAndHandleExceptions(() async {
+      var _localUniqueSession =
+          (sessionBuilder as _i1.InternalTestSessionBuilder).internalBuild(
+        endpoint: 'testTools',
+        method: 'getFromLocalCache',
+      );
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'testTools',
+          methodName: 'getFromLocalCache',
+          parameters: _i1.testObjectToJson({'key': key}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<_i11.SimpleData?>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
+    });
+  }
+
+  _i3.Future<void> putInLocalPrioCache(
+    _i1.TestSessionBuilder sessionBuilder,
+    String key,
+    _i11.SimpleData data,
+  ) async {
+    return _i1.callAwaitableFunctionAndHandleExceptions(() async {
+      var _localUniqueSession =
+          (sessionBuilder as _i1.InternalTestSessionBuilder).internalBuild(
+        endpoint: 'testTools',
+        method: 'putInLocalPrioCache',
+      );
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'testTools',
+          methodName: 'putInLocalPrioCache',
+          parameters: _i1.testObjectToJson({
+            'key': key,
+            'data': data,
+          }),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<void>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
+    });
+  }
+
+  _i3.Future<_i11.SimpleData?> getFromLocalPrioCache(
+    _i1.TestSessionBuilder sessionBuilder,
+    String key,
+  ) async {
+    return _i1.callAwaitableFunctionAndHandleExceptions(() async {
+      var _localUniqueSession =
+          (sessionBuilder as _i1.InternalTestSessionBuilder).internalBuild(
+        endpoint: 'testTools',
+        method: 'getFromLocalPrioCache',
+      );
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'testTools',
+          methodName: 'getFromLocalPrioCache',
+          parameters: _i1.testObjectToJson({'key': key}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<_i11.SimpleData?>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
+    });
+  }
+
+  _i3.Future<void> putInQueryCache(
+    _i1.TestSessionBuilder sessionBuilder,
+    String key,
+    _i11.SimpleData data,
+  ) async {
+    return _i1.callAwaitableFunctionAndHandleExceptions(() async {
+      var _localUniqueSession =
+          (sessionBuilder as _i1.InternalTestSessionBuilder).internalBuild(
+        endpoint: 'testTools',
+        method: 'putInQueryCache',
+      );
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'testTools',
+          methodName: 'putInQueryCache',
+          parameters: _i1.testObjectToJson({
+            'key': key,
+            'data': data,
+          }),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<void>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
+    });
+  }
+
+  _i3.Future<_i11.SimpleData?> getFromQueryCache(
+    _i1.TestSessionBuilder sessionBuilder,
+    String key,
+  ) async {
+    return _i1.callAwaitableFunctionAndHandleExceptions(() async {
+      var _localUniqueSession =
+          (sessionBuilder as _i1.InternalTestSessionBuilder).internalBuild(
+        endpoint: 'testTools',
+        method: 'getFromQueryCache',
+      );
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'testTools',
+          methodName: 'getFromQueryCache',
+          parameters: _i1.testObjectToJson({'key': key}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<_i11.SimpleData?>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
+    });
+  }
+
+  _i3.Future<void> putInLocalCacheWithGroup(
+    _i1.TestSessionBuilder sessionBuilder,
+    String key,
+    _i11.SimpleData data,
+    String group,
+  ) async {
+    return _i1.callAwaitableFunctionAndHandleExceptions(() async {
+      var _localUniqueSession =
+          (sessionBuilder as _i1.InternalTestSessionBuilder).internalBuild(
+        endpoint: 'testTools',
+        method: 'putInLocalCacheWithGroup',
+      );
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'testTools',
+          methodName: 'putInLocalCacheWithGroup',
+          parameters: _i1.testObjectToJson({
+            'key': key,
+            'data': data,
+            'group': group,
+          }),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<void>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
+    });
+  }
 }
 
 class _AuthenticatedTestToolsEndpoint {


### PR DESCRIPTION
This PR aims to fix an issue where caches are not cleared in between different tests.

Fixes #3567

## Pre-launch Checklist

- [X] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [X] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [X] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [X] I added new tests to check the change I am making.
- [X] All existing and new tests are passing.
- [X] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new methods for testing cache operations, including storing and retrieving data from various cache types.
  * Introduced integration tests to verify cache isolation and automatic cache cleanup between tests.
* **Tests**
  * Implemented comprehensive test suites to ensure proper cache behavior and isolation across different cache types and scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->