### PR TITLE
fix(codegen): Fix `getClassNameForObject` for subclasses

### DIFF
--- a/packages/serverpod/lib/src/generated/protocol.dart
+++ b/packages/serverpod/lib/src/generated/protocol.dart
@@ -11,7 +11,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'package:serverpod/protocol.dart' as _i2;
-import 'authentication/revoked_authentication_auth_id.dart' as _i3;
+import 'database/database_migration_action_type.dart' as _i3;
 import 'authentication/revoked_authentication_scope.dart' as _i4;
 import 'authentication/revoked_authentication_user.dart' as _i5;
 import 'cache_info.dart' as _i6;
@@ -31,7 +31,7 @@ import 'database/database_definition.dart' as _i19;
 import 'database/database_definitions.dart' as _i20;
 import 'database/database_migration.dart' as _i21;
 import 'database/database_migration_action.dart' as _i22;
-import 'database/database_migration_action_type.dart' as _i23;
+import 'authentication/revoked_authentication_auth_id.dart' as _i23;
 import 'database/database_migration_version.dart' as _i24;
 import 'database/database_migration_warning.dart' as _i25;
 import 'database/database_migration_warning_type.dart' as _i26;
@@ -49,7 +49,7 @@ import 'database/table_definition.dart' as _i37;
 import 'database/table_migration.dart' as _i38;
 import 'database/vector_distance_function.dart' as _i39;
 import 'distributed_cache_entry.dart' as _i40;
-import 'exceptions/access_denied.dart' as _i41;
+import 'session_log_result.dart' as _i41;
 import 'exceptions/file_not_found.dart' as _i42;
 import 'future_call_entry.dart' as _i43;
 import 'log_entry.dart' as _i44;
@@ -69,7 +69,7 @@ import 'serverpod_sql_exception.dart' as _i57;
 import 'session_log_entry.dart' as _i58;
 import 'session_log_filter.dart' as _i59;
 import 'session_log_info.dart' as _i60;
-import 'session_log_result.dart' as _i61;
+import 'exceptions/access_denied.dart' as _i61;
 import 'package:serverpod/src/generated/database/table_definition.dart' as _i62;
 export 'authentication/revoked_authentication_auth_id.dart';
 export 'authentication/revoked_authentication_scope.dart';
@@ -1309,8 +1309,8 @@ class Protocol extends _i1.SerializationManagerServer {
     Type? t,
   ]) {
     t ??= T;
-    if (t == _i3.RevokedAuthenticationAuthId) {
-      return _i3.RevokedAuthenticationAuthId.fromJson(data) as T;
+    if (t == _i3.DatabaseMigrationActionType) {
+      return _i3.DatabaseMigrationActionType.fromJson(data) as T;
     }
     if (t == _i4.RevokedAuthenticationScope) {
       return _i4.RevokedAuthenticationScope.fromJson(data) as T;
@@ -1369,8 +1369,8 @@ class Protocol extends _i1.SerializationManagerServer {
     if (t == _i22.DatabaseMigrationAction) {
       return _i22.DatabaseMigrationAction.fromJson(data) as T;
     }
-    if (t == _i23.DatabaseMigrationActionType) {
-      return _i23.DatabaseMigrationActionType.fromJson(data) as T;
+    if (t == _i23.RevokedAuthenticationAuthId) {
+      return _i23.RevokedAuthenticationAuthId.fromJson(data) as T;
     }
     if (t == _i24.DatabaseMigrationVersion) {
       return _i24.DatabaseMigrationVersion.fromJson(data) as T;
@@ -1423,8 +1423,8 @@ class Protocol extends _i1.SerializationManagerServer {
     if (t == _i40.DistributedCacheEntry) {
       return _i40.DistributedCacheEntry.fromJson(data) as T;
     }
-    if (t == _i41.AccessDeniedException) {
-      return _i41.AccessDeniedException.fromJson(data) as T;
+    if (t == _i41.SessionLogResult) {
+      return _i41.SessionLogResult.fromJson(data) as T;
     }
     if (t == _i42.FileNotFoundException) {
       return _i42.FileNotFoundException.fromJson(data) as T;
@@ -1483,12 +1483,12 @@ class Protocol extends _i1.SerializationManagerServer {
     if (t == _i60.SessionLogInfo) {
       return _i60.SessionLogInfo.fromJson(data) as T;
     }
-    if (t == _i61.SessionLogResult) {
-      return _i61.SessionLogResult.fromJson(data) as T;
+    if (t == _i61.AccessDeniedException) {
+      return _i61.AccessDeniedException.fromJson(data) as T;
     }
-    if (t == _i1.getType<_i3.RevokedAuthenticationAuthId?>()) {
+    if (t == _i1.getType<_i3.DatabaseMigrationActionType?>()) {
       return (data != null
-          ? _i3.RevokedAuthenticationAuthId.fromJson(data)
+          ? _i3.DatabaseMigrationActionType.fromJson(data)
           : null) as T;
     }
     if (t == _i1.getType<_i4.RevokedAuthenticationScope?>()) {
@@ -1559,9 +1559,9 @@ class Protocol extends _i1.SerializationManagerServer {
       return (data != null ? _i22.DatabaseMigrationAction.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i23.DatabaseMigrationActionType?>()) {
+    if (t == _i1.getType<_i23.RevokedAuthenticationAuthId?>()) {
       return (data != null
-          ? _i23.DatabaseMigrationActionType.fromJson(data)
+          ? _i23.RevokedAuthenticationAuthId.fromJson(data)
           : null) as T;
     }
     if (t == _i1.getType<_i24.DatabaseMigrationVersion?>()) {
@@ -1629,9 +1629,8 @@ class Protocol extends _i1.SerializationManagerServer {
       return (data != null ? _i40.DistributedCacheEntry.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i41.AccessDeniedException?>()) {
-      return (data != null ? _i41.AccessDeniedException.fromJson(data) : null)
-          as T;
+    if (t == _i1.getType<_i41.SessionLogResult?>()) {
+      return (data != null ? _i41.SessionLogResult.fromJson(data) : null) as T;
     }
     if (t == _i1.getType<_i42.FileNotFoundException?>()) {
       return (data != null ? _i42.FileNotFoundException.fromJson(data) : null)
@@ -1698,8 +1697,9 @@ class Protocol extends _i1.SerializationManagerServer {
     if (t == _i1.getType<_i60.SessionLogInfo?>()) {
       return (data != null ? _i60.SessionLogInfo.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i61.SessionLogResult?>()) {
-      return (data != null ? _i61.SessionLogResult.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i61.AccessDeniedException?>()) {
+      return (data != null ? _i61.AccessDeniedException.fromJson(data) : null)
+          as T;
     }
     if (t == List<String>) {
       return (data as List).map((e) => deserialize<String>(e)).toList() as T;
@@ -1775,6 +1775,11 @@ class Protocol extends _i1.SerializationManagerServer {
           .map((e) => deserialize<_i17.ColumnMigration>(e))
           .toList() as T;
     }
+    if (t == List<_i60.SessionLogInfo>) {
+      return (data as List)
+          .map((e) => deserialize<_i60.SessionLogInfo>(e))
+          .toList() as T;
+    }
     if (t == List<_i44.LogEntry>) {
       return (data as List).map((e) => deserialize<_i44.LogEntry>(e)).toList()
           as T;
@@ -1804,11 +1809,6 @@ class Protocol extends _i1.SerializationManagerServer {
           .map((e) => deserialize<_i49.MessageLogEntry>(e))
           .toList() as T;
     }
-    if (t == List<_i60.SessionLogInfo>) {
-      return (data as List)
-          .map((e) => deserialize<_i60.SessionLogInfo>(e))
-          .toList() as T;
-    }
     if (t == List<_i62.TableDefinition>) {
       return (data as List)
           .map((e) => deserialize<_i62.TableDefinition>(e))
@@ -1824,8 +1824,8 @@ class Protocol extends _i1.SerializationManagerServer {
   String? getClassNameForObject(Object? data) {
     String? className = super.getClassNameForObject(data);
     if (className != null) return className;
-    if (data is _i3.RevokedAuthenticationAuthId) {
-      return 'RevokedAuthenticationAuthId';
+    if (data is _i3.DatabaseMigrationActionType) {
+      return 'DatabaseMigrationActionType';
     }
     if (data is _i4.RevokedAuthenticationScope) {
       return 'RevokedAuthenticationScope';
@@ -1884,8 +1884,8 @@ class Protocol extends _i1.SerializationManagerServer {
     if (data is _i22.DatabaseMigrationAction) {
       return 'DatabaseMigrationAction';
     }
-    if (data is _i23.DatabaseMigrationActionType) {
-      return 'DatabaseMigrationActionType';
+    if (data is _i23.RevokedAuthenticationAuthId) {
+      return 'RevokedAuthenticationAuthId';
     }
     if (data is _i24.DatabaseMigrationVersion) {
       return 'DatabaseMigrationVersion';
@@ -1938,8 +1938,8 @@ class Protocol extends _i1.SerializationManagerServer {
     if (data is _i40.DistributedCacheEntry) {
       return 'DistributedCacheEntry';
     }
-    if (data is _i41.AccessDeniedException) {
-      return 'AccessDeniedException';
+    if (data is _i41.SessionLogResult) {
+      return 'SessionLogResult';
     }
     if (data is _i42.FileNotFoundException) {
       return 'FileNotFoundException';
@@ -1998,8 +1998,8 @@ class Protocol extends _i1.SerializationManagerServer {
     if (data is _i60.SessionLogInfo) {
       return 'SessionLogInfo';
     }
-    if (data is _i61.SessionLogResult) {
-      return 'SessionLogResult';
+    if (data is _i61.AccessDeniedException) {
+      return 'AccessDeniedException';
     }
     return null;
   }
@@ -2010,8 +2010,8 @@ class Protocol extends _i1.SerializationManagerServer {
     if (dataClassName is! String) {
       return super.deserializeByClassName(data);
     }
-    if (dataClassName == 'RevokedAuthenticationAuthId') {
-      return deserialize<_i3.RevokedAuthenticationAuthId>(data['data']);
+    if (dataClassName == 'DatabaseMigrationActionType') {
+      return deserialize<_i3.DatabaseMigrationActionType>(data['data']);
     }
     if (dataClassName == 'RevokedAuthenticationScope') {
       return deserialize<_i4.RevokedAuthenticationScope>(data['data']);
@@ -2070,8 +2070,8 @@ class Protocol extends _i1.SerializationManagerServer {
     if (dataClassName == 'DatabaseMigrationAction') {
       return deserialize<_i22.DatabaseMigrationAction>(data['data']);
     }
-    if (dataClassName == 'DatabaseMigrationActionType') {
-      return deserialize<_i23.DatabaseMigrationActionType>(data['data']);
+    if (dataClassName == 'RevokedAuthenticationAuthId') {
+      return deserialize<_i23.RevokedAuthenticationAuthId>(data['data']);
     }
     if (dataClassName == 'DatabaseMigrationVersion') {
       return deserialize<_i24.DatabaseMigrationVersion>(data['data']);
@@ -2124,8 +2124,8 @@ class Protocol extends _i1.SerializationManagerServer {
     if (dataClassName == 'DistributedCacheEntry') {
       return deserialize<_i40.DistributedCacheEntry>(data['data']);
     }
-    if (dataClassName == 'AccessDeniedException') {
-      return deserialize<_i41.AccessDeniedException>(data['data']);
+    if (dataClassName == 'SessionLogResult') {
+      return deserialize<_i41.SessionLogResult>(data['data']);
     }
     if (dataClassName == 'FileNotFoundException') {
       return deserialize<_i42.FileNotFoundException>(data['data']);
@@ -2184,8 +2184,8 @@ class Protocol extends _i1.SerializationManagerServer {
     if (dataClassName == 'SessionLogInfo') {
       return deserialize<_i60.SessionLogInfo>(data['data']);
     }
-    if (dataClassName == 'SessionLogResult') {
-      return deserialize<_i61.SessionLogResult>(data['data']);
+    if (dataClassName == 'AccessDeniedException') {
+      return deserialize<_i61.AccessDeniedException>(data['data']);
     }
     return super.deserializeByClassName(data);
   }

--- a/packages/serverpod_service_client/lib/src/protocol/protocol.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/protocol.dart
@@ -10,7 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
-import 'cache_info.dart' as _i2;
+import 'database/database_migration_version.dart' as _i2;
 import 'caches_info.dart' as _i3;
 import 'cloud_storage.dart' as _i4;
 import 'cloud_storage_direct_upload.dart' as _i5;
@@ -28,7 +28,7 @@ import 'database/database_definitions.dart' as _i16;
 import 'database/database_migration.dart' as _i17;
 import 'database/database_migration_action.dart' as _i18;
 import 'database/database_migration_action_type.dart' as _i19;
-import 'database/database_migration_version.dart' as _i20;
+import 'cache_info.dart' as _i20;
 import 'database/database_migration_warning.dart' as _i21;
 import 'database/database_migration_warning_type.dart' as _i22;
 import 'database/enum_serialization.dart' as _i23;
@@ -46,7 +46,7 @@ import 'database/table_migration.dart' as _i34;
 import 'database/vector_distance_function.dart' as _i35;
 import 'distributed_cache_entry.dart' as _i36;
 import 'exceptions/access_denied.dart' as _i37;
-import 'exceptions/file_not_found.dart' as _i38;
+import 'session_log_result.dart' as _i38;
 import 'future_call_entry.dart' as _i39;
 import 'log_entry.dart' as _i40;
 import 'log_level.dart' as _i41;
@@ -65,7 +65,7 @@ import 'serverpod_sql_exception.dart' as _i53;
 import 'session_log_entry.dart' as _i54;
 import 'session_log_filter.dart' as _i55;
 import 'session_log_info.dart' as _i56;
-import 'session_log_result.dart' as _i57;
+import 'exceptions/file_not_found.dart' as _i57;
 import 'package:serverpod_service_client/src/protocol/database/table_definition.dart'
     as _i58;
 export 'cache_info.dart';
@@ -139,8 +139,8 @@ class Protocol extends _i1.SerializationManager {
     Type? t,
   ]) {
     t ??= T;
-    if (t == _i2.CacheInfo) {
-      return _i2.CacheInfo.fromJson(data) as T;
+    if (t == _i2.DatabaseMigrationVersion) {
+      return _i2.DatabaseMigrationVersion.fromJson(data) as T;
     }
     if (t == _i3.CachesInfo) {
       return _i3.CachesInfo.fromJson(data) as T;
@@ -193,8 +193,8 @@ class Protocol extends _i1.SerializationManager {
     if (t == _i19.DatabaseMigrationActionType) {
       return _i19.DatabaseMigrationActionType.fromJson(data) as T;
     }
-    if (t == _i20.DatabaseMigrationVersion) {
-      return _i20.DatabaseMigrationVersion.fromJson(data) as T;
+    if (t == _i20.CacheInfo) {
+      return _i20.CacheInfo.fromJson(data) as T;
     }
     if (t == _i21.DatabaseMigrationWarning) {
       return _i21.DatabaseMigrationWarning.fromJson(data) as T;
@@ -247,8 +247,8 @@ class Protocol extends _i1.SerializationManager {
     if (t == _i37.AccessDeniedException) {
       return _i37.AccessDeniedException.fromJson(data) as T;
     }
-    if (t == _i38.FileNotFoundException) {
-      return _i38.FileNotFoundException.fromJson(data) as T;
+    if (t == _i38.SessionLogResult) {
+      return _i38.SessionLogResult.fromJson(data) as T;
     }
     if (t == _i39.FutureCallEntry) {
       return _i39.FutureCallEntry.fromJson(data) as T;
@@ -304,11 +304,12 @@ class Protocol extends _i1.SerializationManager {
     if (t == _i56.SessionLogInfo) {
       return _i56.SessionLogInfo.fromJson(data) as T;
     }
-    if (t == _i57.SessionLogResult) {
-      return _i57.SessionLogResult.fromJson(data) as T;
+    if (t == _i57.FileNotFoundException) {
+      return _i57.FileNotFoundException.fromJson(data) as T;
     }
-    if (t == _i1.getType<_i2.CacheInfo?>()) {
-      return (data != null ? _i2.CacheInfo.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i2.DatabaseMigrationVersion?>()) {
+      return (data != null ? _i2.DatabaseMigrationVersion.fromJson(data) : null)
+          as T;
     }
     if (t == _i1.getType<_i3.CachesInfo?>()) {
       return (data != null ? _i3.CachesInfo.fromJson(data) : null) as T;
@@ -370,10 +371,8 @@ class Protocol extends _i1.SerializationManager {
           ? _i19.DatabaseMigrationActionType.fromJson(data)
           : null) as T;
     }
-    if (t == _i1.getType<_i20.DatabaseMigrationVersion?>()) {
-      return (data != null
-          ? _i20.DatabaseMigrationVersion.fromJson(data)
-          : null) as T;
+    if (t == _i1.getType<_i20.CacheInfo?>()) {
+      return (data != null ? _i20.CacheInfo.fromJson(data) : null) as T;
     }
     if (t == _i1.getType<_i21.DatabaseMigrationWarning?>()) {
       return (data != null
@@ -439,9 +438,8 @@ class Protocol extends _i1.SerializationManager {
       return (data != null ? _i37.AccessDeniedException.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i38.FileNotFoundException?>()) {
-      return (data != null ? _i38.FileNotFoundException.fromJson(data) : null)
-          as T;
+    if (t == _i1.getType<_i38.SessionLogResult?>()) {
+      return (data != null ? _i38.SessionLogResult.fromJson(data) : null) as T;
     }
     if (t == _i1.getType<_i39.FutureCallEntry?>()) {
       return (data != null ? _i39.FutureCallEntry.fromJson(data) : null) as T;
@@ -504,13 +502,9 @@ class Protocol extends _i1.SerializationManager {
     if (t == _i1.getType<_i56.SessionLogInfo?>()) {
       return (data != null ? _i56.SessionLogInfo.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i57.SessionLogResult?>()) {
-      return (data != null ? _i57.SessionLogResult.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<List<String>?>()) {
-      return (data != null
-          ? (data as List).map((e) => deserialize<String>(e)).toList()
-          : null) as T;
+    if (t == _i1.getType<_i57.FileNotFoundException?>()) {
+      return (data != null ? _i57.FileNotFoundException.fromJson(data) : null)
+          as T;
     }
     if (t == List<_i7.ClusterServerInfo>) {
       return (data as List)
@@ -527,9 +521,9 @@ class Protocol extends _i1.SerializationManager {
           .map((e) => deserialize<_i33.TableDefinition>(e))
           .toList() as T;
     }
-    if (t == List<_i20.DatabaseMigrationVersion>) {
+    if (t == List<_i2.DatabaseMigrationVersion>) {
       return (data as List)
-          .map((e) => deserialize<_i20.DatabaseMigrationVersion>(e))
+          .map((e) => deserialize<_i2.DatabaseMigrationVersion>(e))
           .toList() as T;
     }
     if (t == List<_i18.DatabaseMigrationAction>) {
@@ -541,6 +535,11 @@ class Protocol extends _i1.SerializationManager {
       return (data as List)
           .map((e) => deserialize<_i21.DatabaseMigrationWarning>(e))
           .toList() as T;
+    }
+    if (t == _i1.getType<List<String>?>()) {
+      return (data != null
+          ? (data as List).map((e) => deserialize<String>(e)).toList()
+          : null) as T;
     }
     if (t == List<String>) {
       return (data as List).map((e) => deserialize<String>(e)).toList() as T;
@@ -581,6 +580,11 @@ class Protocol extends _i1.SerializationManager {
           .map((e) => deserialize<_i13.ColumnMigration>(e))
           .toList() as T;
     }
+    if (t == List<_i56.SessionLogInfo>) {
+      return (data as List)
+          .map((e) => deserialize<_i56.SessionLogInfo>(e))
+          .toList() as T;
+    }
     if (t == List<_i40.LogEntry>) {
       return (data as List).map((e) => deserialize<_i40.LogEntry>(e)).toList()
           as T;
@@ -610,11 +614,6 @@ class Protocol extends _i1.SerializationManager {
           .map((e) => deserialize<_i45.MessageLogEntry>(e))
           .toList() as T;
     }
-    if (t == List<_i56.SessionLogInfo>) {
-      return (data as List)
-          .map((e) => deserialize<_i56.SessionLogInfo>(e))
-          .toList() as T;
-    }
     if (t == List<_i58.TableDefinition>) {
       return (data as List)
           .map((e) => deserialize<_i58.TableDefinition>(e))
@@ -630,8 +629,8 @@ class Protocol extends _i1.SerializationManager {
   String? getClassNameForObject(Object? data) {
     String? className = super.getClassNameForObject(data);
     if (className != null) return className;
-    if (data is _i2.CacheInfo) {
-      return 'CacheInfo';
+    if (data is _i2.DatabaseMigrationVersion) {
+      return 'DatabaseMigrationVersion';
     }
     if (data is _i3.CachesInfo) {
       return 'CachesInfo';
@@ -684,8 +683,8 @@ class Protocol extends _i1.SerializationManager {
     if (data is _i19.DatabaseMigrationActionType) {
       return 'DatabaseMigrationActionType';
     }
-    if (data is _i20.DatabaseMigrationVersion) {
-      return 'DatabaseMigrationVersion';
+    if (data is _i20.CacheInfo) {
+      return 'CacheInfo';
     }
     if (data is _i21.DatabaseMigrationWarning) {
       return 'DatabaseMigrationWarning';
@@ -738,8 +737,8 @@ class Protocol extends _i1.SerializationManager {
     if (data is _i37.AccessDeniedException) {
       return 'AccessDeniedException';
     }
-    if (data is _i38.FileNotFoundException) {
-      return 'FileNotFoundException';
+    if (data is _i38.SessionLogResult) {
+      return 'SessionLogResult';
     }
     if (data is _i39.FutureCallEntry) {
       return 'FutureCallEntry';
@@ -795,8 +794,8 @@ class Protocol extends _i1.SerializationManager {
     if (data is _i56.SessionLogInfo) {
       return 'SessionLogInfo';
     }
-    if (data is _i57.SessionLogResult) {
-      return 'SessionLogResult';
+    if (data is _i57.FileNotFoundException) {
+      return 'FileNotFoundException';
     }
     return null;
   }
@@ -807,8 +806,8 @@ class Protocol extends _i1.SerializationManager {
     if (dataClassName is! String) {
       return super.deserializeByClassName(data);
     }
-    if (dataClassName == 'CacheInfo') {
-      return deserialize<_i2.CacheInfo>(data['data']);
+    if (dataClassName == 'DatabaseMigrationVersion') {
+      return deserialize<_i2.DatabaseMigrationVersion>(data['data']);
     }
     if (dataClassName == 'CachesInfo') {
       return deserialize<_i3.CachesInfo>(data['data']);
@@ -861,8 +860,8 @@ class Protocol extends _i1.SerializationManager {
     if (dataClassName == 'DatabaseMigrationActionType') {
       return deserialize<_i19.DatabaseMigrationActionType>(data['data']);
     }
-    if (dataClassName == 'DatabaseMigrationVersion') {
-      return deserialize<_i20.DatabaseMigrationVersion>(data['data']);
+    if (dataClassName == 'CacheInfo') {
+      return deserialize<_i20.CacheInfo>(data['data']);
     }
     if (dataClassName == 'DatabaseMigrationWarning') {
       return deserialize<_i21.DatabaseMigrationWarning>(data['data']);
@@ -915,8 +914,8 @@ class Protocol extends _i1.SerializationManager {
     if (dataClassName == 'AccessDeniedException') {
       return deserialize<_i37.AccessDeniedException>(data['data']);
     }
-    if (dataClassName == 'FileNotFoundException') {
-      return deserialize<_i38.FileNotFoundException>(data['data']);
+    if (dataClassName == 'SessionLogResult') {
+      return deserialize<_i38.SessionLogResult>(data['data']);
     }
     if (dataClassName == 'FutureCallEntry') {
       return deserialize<_i39.FutureCallEntry>(data['data']);
@@ -972,8 +971,8 @@ class Protocol extends _i1.SerializationManager {
     if (dataClassName == 'SessionLogInfo') {
       return deserialize<_i56.SessionLogInfo>(data['data']);
     }
-    if (dataClassName == 'SessionLogResult') {
-      return deserialize<_i57.SessionLogResult>(data['data']);
+    if (dataClassName == 'FileNotFoundException') {
+      return deserialize<_i57.FileNotFoundException>(data['data']);
     }
     return super.deserializeByClassName(data);
   }

--- a/tests/serverpod_test_client/lib/src/protocol/protocol.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/protocol.dart
@@ -10,77 +10,77 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
-import 'by_index_enum_with_name_value.dart' as _i2;
-import 'by_name_enum_with_name_value.dart' as _i3;
-import 'changed_id_type/many_to_many/course.dart' as _i4;
-import 'changed_id_type/many_to_many/enrollment.dart' as _i5;
-import 'changed_id_type/many_to_many/student.dart' as _i6;
-import 'changed_id_type/nested_one_to_many/arena.dart' as _i7;
-import 'changed_id_type/nested_one_to_many/player.dart' as _i8;
-import 'changed_id_type/nested_one_to_many/team.dart' as _i9;
-import 'changed_id_type/one_to_many/comment.dart' as _i10;
-import 'changed_id_type/one_to_many/customer.dart' as _i11;
-import 'changed_id_type/one_to_many/order.dart' as _i12;
-import 'changed_id_type/one_to_one/address.dart' as _i13;
-import 'changed_id_type/one_to_one/citizen.dart' as _i14;
-import 'changed_id_type/one_to_one/company.dart' as _i15;
-import 'changed_id_type/one_to_one/town.dart' as _i16;
-import 'changed_id_type/self.dart' as _i17;
-import 'defaults/bigint/bigint_default.dart' as _i18;
-import 'defaults/bigint/bigint_default_mix.dart' as _i19;
-import 'defaults/bigint/bigint_default_model.dart' as _i20;
-import 'defaults/bigint/bigint_default_persist.dart' as _i21;
-import 'defaults/boolean/bool_default.dart' as _i22;
-import 'defaults/boolean/bool_default_mix.dart' as _i23;
-import 'defaults/boolean/bool_default_model.dart' as _i24;
-import 'defaults/boolean/bool_default_persist.dart' as _i25;
-import 'defaults/datetime/datetime_default.dart' as _i26;
-import 'defaults/datetime/datetime_default_mix.dart' as _i27;
-import 'defaults/datetime/datetime_default_model.dart' as _i28;
-import 'defaults/datetime/datetime_default_persist.dart' as _i29;
-import 'defaults/double/double_default.dart' as _i30;
-import 'defaults/double/double_default_mix.dart' as _i31;
-import 'defaults/double/double_default_model.dart' as _i32;
-import 'defaults/double/double_default_persist.dart' as _i33;
-import 'defaults/duration/duration_default.dart' as _i34;
-import 'defaults/duration/duration_default_mix.dart' as _i35;
-import 'defaults/duration/duration_default_model.dart' as _i36;
-import 'defaults/duration/duration_default_persist.dart' as _i37;
-import 'defaults/enum/enum_default.dart' as _i38;
-import 'defaults/enum/enum_default_mix.dart' as _i39;
-import 'defaults/enum/enum_default_model.dart' as _i40;
-import 'defaults/enum/enum_default_persist.dart' as _i41;
-import 'defaults/enum/enums/by_index_enum.dart' as _i42;
-import 'defaults/enum/enums/by_name_enum.dart' as _i43;
-import 'defaults/enum/enums/default_value_enum.dart' as _i44;
-import 'defaults/exception/default_exception.dart' as _i45;
-import 'defaults/integer/int_default.dart' as _i46;
-import 'defaults/integer/int_default_mix.dart' as _i47;
-import 'defaults/integer/int_default_model.dart' as _i48;
-import 'defaults/integer/int_default_persist.dart' as _i49;
-import 'defaults/string/string_default.dart' as _i50;
-import 'defaults/string/string_default_mix.dart' as _i51;
-import 'defaults/string/string_default_model.dart' as _i52;
-import 'defaults/string/string_default_persist.dart' as _i53;
-import 'defaults/uri/uri_default.dart' as _i54;
-import 'defaults/uri/uri_default_mix.dart' as _i55;
-import 'defaults/uri/uri_default_model.dart' as _i56;
-import 'defaults/uri/uri_default_persist.dart' as _i57;
-import 'defaults/uuid/uuid_default.dart' as _i58;
-import 'defaults/uuid/uuid_default_mix.dart' as _i59;
-import 'defaults/uuid/uuid_default_model.dart' as _i60;
-import 'defaults/uuid/uuid_default_persist.dart' as _i61;
-import 'empty_model/empty_model.dart' as _i62;
-import 'empty_model/empty_model_relation_item.dart' as _i63;
-import 'empty_model/empty_model_with_table.dart' as _i64;
-import 'empty_model/relation_empy_model.dart' as _i65;
-import 'exception_with_data.dart' as _i66;
-import 'inheritance/child_class.dart' as _i67;
-import 'inheritance/child_with_default.dart' as _i68;
-import 'inheritance/grandparent_class.dart' as _i69;
-import 'inheritance/parent_class.dart' as _i70;
-import 'inheritance/parent_with_default.dart' as _i71;
-import 'inheritance/sealed_parent.dart' as _i72;
+import 'scopes/scope_server_only_field_child.dart' as _i2;
+import 'inheritance/child_class.dart' as _i3;
+import 'inheritance/child_with_default.dart' as _i4;
+import 'inheritance/parent_class.dart' as _i5;
+import 'inheritance/sealed_parent.dart' as _i6;
+import 'defaults/string/string_default_persist.dart' as _i7;
+import 'changed_id_type/one_to_many/comment.dart' as _i8;
+import 'changed_id_type/one_to_many/customer.dart' as _i9;
+import 'changed_id_type/one_to_many/order.dart' as _i10;
+import 'changed_id_type/one_to_one/address.dart' as _i11;
+import 'changed_id_type/one_to_one/citizen.dart' as _i12;
+import 'changed_id_type/one_to_one/company.dart' as _i13;
+import 'changed_id_type/one_to_one/town.dart' as _i14;
+import 'changed_id_type/self.dart' as _i15;
+import 'defaults/bigint/bigint_default.dart' as _i16;
+import 'defaults/bigint/bigint_default_mix.dart' as _i17;
+import 'defaults/bigint/bigint_default_model.dart' as _i18;
+import 'defaults/bigint/bigint_default_persist.dart' as _i19;
+import 'defaults/boolean/bool_default.dart' as _i20;
+import 'defaults/boolean/bool_default_mix.dart' as _i21;
+import 'defaults/boolean/bool_default_model.dart' as _i22;
+import 'defaults/boolean/bool_default_persist.dart' as _i23;
+import 'defaults/datetime/datetime_default.dart' as _i24;
+import 'defaults/datetime/datetime_default_mix.dart' as _i25;
+import 'defaults/datetime/datetime_default_model.dart' as _i26;
+import 'defaults/datetime/datetime_default_persist.dart' as _i27;
+import 'defaults/double/double_default.dart' as _i28;
+import 'defaults/double/double_default_mix.dart' as _i29;
+import 'defaults/double/double_default_model.dart' as _i30;
+import 'defaults/double/double_default_persist.dart' as _i31;
+import 'defaults/duration/duration_default.dart' as _i32;
+import 'defaults/duration/duration_default_mix.dart' as _i33;
+import 'defaults/duration/duration_default_model.dart' as _i34;
+import 'defaults/duration/duration_default_persist.dart' as _i35;
+import 'defaults/enum/enum_default.dart' as _i36;
+import 'defaults/enum/enum_default_mix.dart' as _i37;
+import 'defaults/enum/enum_default_model.dart' as _i38;
+import 'defaults/enum/enum_default_persist.dart' as _i39;
+import 'defaults/enum/enums/by_index_enum.dart' as _i40;
+import 'defaults/enum/enums/by_name_enum.dart' as _i41;
+import 'defaults/enum/enums/default_value_enum.dart' as _i42;
+import 'defaults/exception/default_exception.dart' as _i43;
+import 'defaults/integer/int_default.dart' as _i44;
+import 'defaults/integer/int_default_mix.dart' as _i45;
+import 'defaults/integer/int_default_model.dart' as _i46;
+import 'defaults/integer/int_default_persist.dart' as _i47;
+import 'defaults/string/string_default.dart' as _i48;
+import 'defaults/string/string_default_mix.dart' as _i49;
+import 'defaults/string/string_default_model.dart' as _i50;
+import 'by_index_enum_with_name_value.dart' as _i51;
+import 'defaults/uri/uri_default.dart' as _i52;
+import 'defaults/uri/uri_default_mix.dart' as _i53;
+import 'defaults/uri/uri_default_model.dart' as _i54;
+import 'defaults/uri/uri_default_persist.dart' as _i55;
+import 'defaults/uuid/uuid_default.dart' as _i56;
+import 'defaults/uuid/uuid_default_mix.dart' as _i57;
+import 'defaults/uuid/uuid_default_model.dart' as _i58;
+import 'defaults/uuid/uuid_default_persist.dart' as _i59;
+import 'empty_model/empty_model.dart' as _i60;
+import 'empty_model/empty_model_relation_item.dart' as _i61;
+import 'empty_model/empty_model_with_table.dart' as _i62;
+import 'empty_model/relation_empy_model.dart' as _i63;
+import 'exception_with_data.dart' as _i64;
+import 'by_name_enum_with_name_value.dart' as _i65;
+import 'changed_id_type/many_to_many/course.dart' as _i66;
+import 'inheritance/grandparent_class.dart' as _i67;
+import 'changed_id_type/many_to_many/enrollment.dart' as _i68;
+import 'inheritance/parent_with_default.dart' as _i69;
+import 'changed_id_type/many_to_many/student.dart' as _i70;
+import 'changed_id_type/nested_one_to_many/arena.dart' as _i71;
+import 'changed_id_type/nested_one_to_many/player.dart' as _i72;
 import 'long_identifiers/deep_includes/city_with_long_table_name.dart' as _i73;
 import 'long_identifiers/deep_includes/organization_with_long_table_name.dart'
     as _i74;
@@ -117,7 +117,7 @@ import 'models_with_relations/one_to_many/customer.dart' as _i97;
 import 'models_with_relations/one_to_many/implicit/book.dart' as _i98;
 import 'models_with_relations/one_to_many/implicit/chapter.dart' as _i99;
 import 'models_with_relations/one_to_many/order.dart' as _i100;
-import 'models_with_relations/one_to_one/address.dart' as _i101;
+import 'my_feature/models/my_feature_model.dart' as _i101;
 import 'models_with_relations/one_to_one/citizen.dart' as _i102;
 import 'models_with_relations/one_to_one/company.dart' as _i103;
 import 'models_with_relations/one_to_one/town.dart' as _i104;
@@ -148,7 +148,7 @@ import 'record.dart' as _i127;
 import 'related_unique_data.dart' as _i128;
 import 'scopes/scope_none_fields.dart' as _i129;
 import 'scopes/scope_server_only_field.dart' as _i130;
-import 'scopes/scope_server_only_field_child.dart' as _i131;
+import 'changed_id_type/nested_one_to_many/team.dart' as _i131;
 import 'scopes/serverOnly/default_server_only_class.dart' as _i132;
 import 'scopes/serverOnly/default_server_only_enum.dart' as _i133;
 import 'scopes/serverOnly/not_server_only_class.dart' as _i134;
@@ -169,7 +169,7 @@ import 'types_record.dart' as _i148;
 import 'types_set.dart' as _i149;
 import 'types_set_required.dart' as _i150;
 import 'unique_data.dart' as _i151;
-import 'my_feature/models/my_feature_model.dart' as _i152;
+import 'models_with_relations/one_to_one/address.dart' as _i152;
 import 'package:serverpod_test_module_client/serverpod_test_module_client.dart'
     as _i153;
 import 'dart:typed_data' as _i154;
@@ -345,224 +345,224 @@ class Protocol extends _i1.SerializationManager {
     Type? t,
   ]) {
     t ??= T;
-    if (t == _i2.ByIndexEnumWithNameValue) {
-      return _i2.ByIndexEnumWithNameValue.fromJson(data) as T;
+    if (t == _i2.ScopeServerOnlyFieldChild) {
+      return _i2.ScopeServerOnlyFieldChild.fromJson(data) as T;
     }
-    if (t == _i3.ByNameEnumWithNameValue) {
-      return _i3.ByNameEnumWithNameValue.fromJson(data) as T;
+    if (t == _i3.ChildClass) {
+      return _i3.ChildClass.fromJson(data) as T;
     }
-    if (t == _i4.CourseUuid) {
-      return _i4.CourseUuid.fromJson(data) as T;
+    if (t == _i4.ChildWithDefault) {
+      return _i4.ChildWithDefault.fromJson(data) as T;
     }
-    if (t == _i5.EnrollmentInt) {
-      return _i5.EnrollmentInt.fromJson(data) as T;
+    if (t == _i5.ParentClass) {
+      return _i5.ParentClass.fromJson(data) as T;
     }
-    if (t == _i6.StudentUuid) {
-      return _i6.StudentUuid.fromJson(data) as T;
+    if (t == _i6.SealedGrandChild) {
+      return _i6.SealedGrandChild.fromJson(data) as T;
     }
-    if (t == _i7.ArenaUuid) {
-      return _i7.ArenaUuid.fromJson(data) as T;
+    if (t == _i6.SealedChild) {
+      return _i6.SealedChild.fromJson(data) as T;
     }
-    if (t == _i8.PlayerUuid) {
-      return _i8.PlayerUuid.fromJson(data) as T;
+    if (t == _i6.SealedOtherChild) {
+      return _i6.SealedOtherChild.fromJson(data) as T;
     }
-    if (t == _i9.TeamInt) {
-      return _i9.TeamInt.fromJson(data) as T;
+    if (t == _i7.StringDefaultPersist) {
+      return _i7.StringDefaultPersist.fromJson(data) as T;
     }
-    if (t == _i10.CommentInt) {
-      return _i10.CommentInt.fromJson(data) as T;
+    if (t == _i8.CommentInt) {
+      return _i8.CommentInt.fromJson(data) as T;
     }
-    if (t == _i11.CustomerInt) {
-      return _i11.CustomerInt.fromJson(data) as T;
+    if (t == _i9.CustomerInt) {
+      return _i9.CustomerInt.fromJson(data) as T;
     }
-    if (t == _i12.OrderUuid) {
-      return _i12.OrderUuid.fromJson(data) as T;
+    if (t == _i10.OrderUuid) {
+      return _i10.OrderUuid.fromJson(data) as T;
     }
-    if (t == _i13.AddressUuid) {
-      return _i13.AddressUuid.fromJson(data) as T;
+    if (t == _i11.AddressUuid) {
+      return _i11.AddressUuid.fromJson(data) as T;
     }
-    if (t == _i14.CitizenInt) {
-      return _i14.CitizenInt.fromJson(data) as T;
+    if (t == _i12.CitizenInt) {
+      return _i12.CitizenInt.fromJson(data) as T;
     }
-    if (t == _i15.CompanyUuid) {
-      return _i15.CompanyUuid.fromJson(data) as T;
+    if (t == _i13.CompanyUuid) {
+      return _i13.CompanyUuid.fromJson(data) as T;
     }
-    if (t == _i16.TownInt) {
-      return _i16.TownInt.fromJson(data) as T;
+    if (t == _i14.TownInt) {
+      return _i14.TownInt.fromJson(data) as T;
     }
-    if (t == _i17.ChangedIdTypeSelf) {
-      return _i17.ChangedIdTypeSelf.fromJson(data) as T;
+    if (t == _i15.ChangedIdTypeSelf) {
+      return _i15.ChangedIdTypeSelf.fromJson(data) as T;
     }
-    if (t == _i18.BigIntDefault) {
-      return _i18.BigIntDefault.fromJson(data) as T;
+    if (t == _i16.BigIntDefault) {
+      return _i16.BigIntDefault.fromJson(data) as T;
     }
-    if (t == _i19.BigIntDefaultMix) {
-      return _i19.BigIntDefaultMix.fromJson(data) as T;
+    if (t == _i17.BigIntDefaultMix) {
+      return _i17.BigIntDefaultMix.fromJson(data) as T;
     }
-    if (t == _i20.BigIntDefaultModel) {
-      return _i20.BigIntDefaultModel.fromJson(data) as T;
+    if (t == _i18.BigIntDefaultModel) {
+      return _i18.BigIntDefaultModel.fromJson(data) as T;
     }
-    if (t == _i21.BigIntDefaultPersist) {
-      return _i21.BigIntDefaultPersist.fromJson(data) as T;
+    if (t == _i19.BigIntDefaultPersist) {
+      return _i19.BigIntDefaultPersist.fromJson(data) as T;
     }
-    if (t == _i22.BoolDefault) {
-      return _i22.BoolDefault.fromJson(data) as T;
+    if (t == _i20.BoolDefault) {
+      return _i20.BoolDefault.fromJson(data) as T;
     }
-    if (t == _i23.BoolDefaultMix) {
-      return _i23.BoolDefaultMix.fromJson(data) as T;
+    if (t == _i21.BoolDefaultMix) {
+      return _i21.BoolDefaultMix.fromJson(data) as T;
     }
-    if (t == _i24.BoolDefaultModel) {
-      return _i24.BoolDefaultModel.fromJson(data) as T;
+    if (t == _i22.BoolDefaultModel) {
+      return _i22.BoolDefaultModel.fromJson(data) as T;
     }
-    if (t == _i25.BoolDefaultPersist) {
-      return _i25.BoolDefaultPersist.fromJson(data) as T;
+    if (t == _i23.BoolDefaultPersist) {
+      return _i23.BoolDefaultPersist.fromJson(data) as T;
     }
-    if (t == _i26.DateTimeDefault) {
-      return _i26.DateTimeDefault.fromJson(data) as T;
+    if (t == _i24.DateTimeDefault) {
+      return _i24.DateTimeDefault.fromJson(data) as T;
     }
-    if (t == _i27.DateTimeDefaultMix) {
-      return _i27.DateTimeDefaultMix.fromJson(data) as T;
+    if (t == _i25.DateTimeDefaultMix) {
+      return _i25.DateTimeDefaultMix.fromJson(data) as T;
     }
-    if (t == _i28.DateTimeDefaultModel) {
-      return _i28.DateTimeDefaultModel.fromJson(data) as T;
+    if (t == _i26.DateTimeDefaultModel) {
+      return _i26.DateTimeDefaultModel.fromJson(data) as T;
     }
-    if (t == _i29.DateTimeDefaultPersist) {
-      return _i29.DateTimeDefaultPersist.fromJson(data) as T;
+    if (t == _i27.DateTimeDefaultPersist) {
+      return _i27.DateTimeDefaultPersist.fromJson(data) as T;
     }
-    if (t == _i30.DoubleDefault) {
-      return _i30.DoubleDefault.fromJson(data) as T;
+    if (t == _i28.DoubleDefault) {
+      return _i28.DoubleDefault.fromJson(data) as T;
     }
-    if (t == _i31.DoubleDefaultMix) {
-      return _i31.DoubleDefaultMix.fromJson(data) as T;
+    if (t == _i29.DoubleDefaultMix) {
+      return _i29.DoubleDefaultMix.fromJson(data) as T;
     }
-    if (t == _i32.DoubleDefaultModel) {
-      return _i32.DoubleDefaultModel.fromJson(data) as T;
+    if (t == _i30.DoubleDefaultModel) {
+      return _i30.DoubleDefaultModel.fromJson(data) as T;
     }
-    if (t == _i33.DoubleDefaultPersist) {
-      return _i33.DoubleDefaultPersist.fromJson(data) as T;
+    if (t == _i31.DoubleDefaultPersist) {
+      return _i31.DoubleDefaultPersist.fromJson(data) as T;
     }
-    if (t == _i34.DurationDefault) {
-      return _i34.DurationDefault.fromJson(data) as T;
+    if (t == _i32.DurationDefault) {
+      return _i32.DurationDefault.fromJson(data) as T;
     }
-    if (t == _i35.DurationDefaultMix) {
-      return _i35.DurationDefaultMix.fromJson(data) as T;
+    if (t == _i33.DurationDefaultMix) {
+      return _i33.DurationDefaultMix.fromJson(data) as T;
     }
-    if (t == _i36.DurationDefaultModel) {
-      return _i36.DurationDefaultModel.fromJson(data) as T;
+    if (t == _i34.DurationDefaultModel) {
+      return _i34.DurationDefaultModel.fromJson(data) as T;
     }
-    if (t == _i37.DurationDefaultPersist) {
-      return _i37.DurationDefaultPersist.fromJson(data) as T;
+    if (t == _i35.DurationDefaultPersist) {
+      return _i35.DurationDefaultPersist.fromJson(data) as T;
     }
-    if (t == _i38.EnumDefault) {
-      return _i38.EnumDefault.fromJson(data) as T;
+    if (t == _i36.EnumDefault) {
+      return _i36.EnumDefault.fromJson(data) as T;
     }
-    if (t == _i39.EnumDefaultMix) {
-      return _i39.EnumDefaultMix.fromJson(data) as T;
+    if (t == _i37.EnumDefaultMix) {
+      return _i37.EnumDefaultMix.fromJson(data) as T;
     }
-    if (t == _i40.EnumDefaultModel) {
-      return _i40.EnumDefaultModel.fromJson(data) as T;
+    if (t == _i38.EnumDefaultModel) {
+      return _i38.EnumDefaultModel.fromJson(data) as T;
     }
-    if (t == _i41.EnumDefaultPersist) {
-      return _i41.EnumDefaultPersist.fromJson(data) as T;
+    if (t == _i39.EnumDefaultPersist) {
+      return _i39.EnumDefaultPersist.fromJson(data) as T;
     }
-    if (t == _i42.ByIndexEnum) {
-      return _i42.ByIndexEnum.fromJson(data) as T;
+    if (t == _i40.ByIndexEnum) {
+      return _i40.ByIndexEnum.fromJson(data) as T;
     }
-    if (t == _i43.ByNameEnum) {
-      return _i43.ByNameEnum.fromJson(data) as T;
+    if (t == _i41.ByNameEnum) {
+      return _i41.ByNameEnum.fromJson(data) as T;
     }
-    if (t == _i44.DefaultValueEnum) {
-      return _i44.DefaultValueEnum.fromJson(data) as T;
+    if (t == _i42.DefaultValueEnum) {
+      return _i42.DefaultValueEnum.fromJson(data) as T;
     }
-    if (t == _i45.DefaultException) {
-      return _i45.DefaultException.fromJson(data) as T;
+    if (t == _i43.DefaultException) {
+      return _i43.DefaultException.fromJson(data) as T;
     }
-    if (t == _i46.IntDefault) {
-      return _i46.IntDefault.fromJson(data) as T;
+    if (t == _i44.IntDefault) {
+      return _i44.IntDefault.fromJson(data) as T;
     }
-    if (t == _i47.IntDefaultMix) {
-      return _i47.IntDefaultMix.fromJson(data) as T;
+    if (t == _i45.IntDefaultMix) {
+      return _i45.IntDefaultMix.fromJson(data) as T;
     }
-    if (t == _i48.IntDefaultModel) {
-      return _i48.IntDefaultModel.fromJson(data) as T;
+    if (t == _i46.IntDefaultModel) {
+      return _i46.IntDefaultModel.fromJson(data) as T;
     }
-    if (t == _i49.IntDefaultPersist) {
-      return _i49.IntDefaultPersist.fromJson(data) as T;
+    if (t == _i47.IntDefaultPersist) {
+      return _i47.IntDefaultPersist.fromJson(data) as T;
     }
-    if (t == _i50.StringDefault) {
-      return _i50.StringDefault.fromJson(data) as T;
+    if (t == _i48.StringDefault) {
+      return _i48.StringDefault.fromJson(data) as T;
     }
-    if (t == _i51.StringDefaultMix) {
-      return _i51.StringDefaultMix.fromJson(data) as T;
+    if (t == _i49.StringDefaultMix) {
+      return _i49.StringDefaultMix.fromJson(data) as T;
     }
-    if (t == _i52.StringDefaultModel) {
-      return _i52.StringDefaultModel.fromJson(data) as T;
+    if (t == _i50.StringDefaultModel) {
+      return _i50.StringDefaultModel.fromJson(data) as T;
     }
-    if (t == _i53.StringDefaultPersist) {
-      return _i53.StringDefaultPersist.fromJson(data) as T;
+    if (t == _i51.ByIndexEnumWithNameValue) {
+      return _i51.ByIndexEnumWithNameValue.fromJson(data) as T;
     }
-    if (t == _i54.UriDefault) {
-      return _i54.UriDefault.fromJson(data) as T;
+    if (t == _i52.UriDefault) {
+      return _i52.UriDefault.fromJson(data) as T;
     }
-    if (t == _i55.UriDefaultMix) {
-      return _i55.UriDefaultMix.fromJson(data) as T;
+    if (t == _i53.UriDefaultMix) {
+      return _i53.UriDefaultMix.fromJson(data) as T;
     }
-    if (t == _i56.UriDefaultModel) {
-      return _i56.UriDefaultModel.fromJson(data) as T;
+    if (t == _i54.UriDefaultModel) {
+      return _i54.UriDefaultModel.fromJson(data) as T;
     }
-    if (t == _i57.UriDefaultPersist) {
-      return _i57.UriDefaultPersist.fromJson(data) as T;
+    if (t == _i55.UriDefaultPersist) {
+      return _i55.UriDefaultPersist.fromJson(data) as T;
     }
-    if (t == _i58.UuidDefault) {
-      return _i58.UuidDefault.fromJson(data) as T;
+    if (t == _i56.UuidDefault) {
+      return _i56.UuidDefault.fromJson(data) as T;
     }
-    if (t == _i59.UuidDefaultMix) {
-      return _i59.UuidDefaultMix.fromJson(data) as T;
+    if (t == _i57.UuidDefaultMix) {
+      return _i57.UuidDefaultMix.fromJson(data) as T;
     }
-    if (t == _i60.UuidDefaultModel) {
-      return _i60.UuidDefaultModel.fromJson(data) as T;
+    if (t == _i58.UuidDefaultModel) {
+      return _i58.UuidDefaultModel.fromJson(data) as T;
     }
-    if (t == _i61.UuidDefaultPersist) {
-      return _i61.UuidDefaultPersist.fromJson(data) as T;
+    if (t == _i59.UuidDefaultPersist) {
+      return _i59.UuidDefaultPersist.fromJson(data) as T;
     }
-    if (t == _i62.EmptyModel) {
-      return _i62.EmptyModel.fromJson(data) as T;
+    if (t == _i60.EmptyModel) {
+      return _i60.EmptyModel.fromJson(data) as T;
     }
-    if (t == _i63.EmptyModelRelationItem) {
-      return _i63.EmptyModelRelationItem.fromJson(data) as T;
+    if (t == _i61.EmptyModelRelationItem) {
+      return _i61.EmptyModelRelationItem.fromJson(data) as T;
     }
-    if (t == _i64.EmptyModelWithTable) {
-      return _i64.EmptyModelWithTable.fromJson(data) as T;
+    if (t == _i62.EmptyModelWithTable) {
+      return _i62.EmptyModelWithTable.fromJson(data) as T;
     }
-    if (t == _i65.RelationEmptyModel) {
-      return _i65.RelationEmptyModel.fromJson(data) as T;
+    if (t == _i63.RelationEmptyModel) {
+      return _i63.RelationEmptyModel.fromJson(data) as T;
     }
-    if (t == _i66.ExceptionWithData) {
-      return _i66.ExceptionWithData.fromJson(data) as T;
+    if (t == _i64.ExceptionWithData) {
+      return _i64.ExceptionWithData.fromJson(data) as T;
     }
-    if (t == _i67.ChildClass) {
-      return _i67.ChildClass.fromJson(data) as T;
+    if (t == _i65.ByNameEnumWithNameValue) {
+      return _i65.ByNameEnumWithNameValue.fromJson(data) as T;
     }
-    if (t == _i68.ChildWithDefault) {
-      return _i68.ChildWithDefault.fromJson(data) as T;
+    if (t == _i66.CourseUuid) {
+      return _i66.CourseUuid.fromJson(data) as T;
     }
-    if (t == _i69.GrandparentClass) {
-      return _i69.GrandparentClass.fromJson(data) as T;
+    if (t == _i67.GrandparentClass) {
+      return _i67.GrandparentClass.fromJson(data) as T;
     }
-    if (t == _i70.ParentClass) {
-      return _i70.ParentClass.fromJson(data) as T;
+    if (t == _i68.EnrollmentInt) {
+      return _i68.EnrollmentInt.fromJson(data) as T;
     }
-    if (t == _i71.ParentWithDefault) {
-      return _i71.ParentWithDefault.fromJson(data) as T;
+    if (t == _i69.ParentWithDefault) {
+      return _i69.ParentWithDefault.fromJson(data) as T;
     }
-    if (t == _i72.SealedChild) {
-      return _i72.SealedChild.fromJson(data) as T;
+    if (t == _i70.StudentUuid) {
+      return _i70.StudentUuid.fromJson(data) as T;
     }
-    if (t == _i72.SealedGrandChild) {
-      return _i72.SealedGrandChild.fromJson(data) as T;
+    if (t == _i71.ArenaUuid) {
+      return _i71.ArenaUuid.fromJson(data) as T;
     }
-    if (t == _i72.SealedOtherChild) {
-      return _i72.SealedOtherChild.fromJson(data) as T;
+    if (t == _i72.PlayerUuid) {
+      return _i72.PlayerUuid.fromJson(data) as T;
     }
     if (t == _i73.CityWithLongTableName) {
       return _i73.CityWithLongTableName.fromJson(data) as T;
@@ -648,8 +648,8 @@ class Protocol extends _i1.SerializationManager {
     if (t == _i100.Order) {
       return _i100.Order.fromJson(data) as T;
     }
-    if (t == _i101.Address) {
-      return _i101.Address.fromJson(data) as T;
+    if (t == _i101.MyFeatureModel) {
+      return _i101.MyFeatureModel.fromJson(data) as T;
     }
     if (t == _i102.Citizen) {
       return _i102.Citizen.fromJson(data) as T;
@@ -738,8 +738,8 @@ class Protocol extends _i1.SerializationManager {
     if (t == _i130.ScopeServerOnlyField) {
       return _i130.ScopeServerOnlyField.fromJson(data) as T;
     }
-    if (t == _i131.ScopeServerOnlyFieldChild) {
-      return _i131.ScopeServerOnlyFieldChild.fromJson(data) as T;
+    if (t == _i131.TeamInt) {
+      return _i131.TeamInt.fromJson(data) as T;
     }
     if (t == _i132.DefaultServerOnlyClass) {
       return _i132.DefaultServerOnlyClass.fromJson(data) as T;
@@ -801,247 +801,250 @@ class Protocol extends _i1.SerializationManager {
     if (t == _i151.UniqueData) {
       return _i151.UniqueData.fromJson(data) as T;
     }
-    if (t == _i152.MyFeatureModel) {
-      return _i152.MyFeatureModel.fromJson(data) as T;
+    if (t == _i152.Address) {
+      return _i152.Address.fromJson(data) as T;
     }
-    if (t == _i1.getType<_i2.ByIndexEnumWithNameValue?>()) {
-      return (data != null ? _i2.ByIndexEnumWithNameValue.fromJson(data) : null)
+    if (t == _i1.getType<_i2.ScopeServerOnlyFieldChild?>()) {
+      return (data != null
+          ? _i2.ScopeServerOnlyFieldChild.fromJson(data)
+          : null) as T;
+    }
+    if (t == _i1.getType<_i3.ChildClass?>()) {
+      return (data != null ? _i3.ChildClass.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i4.ChildWithDefault?>()) {
+      return (data != null ? _i4.ChildWithDefault.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i5.ParentClass?>()) {
+      return (data != null ? _i5.ParentClass.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i6.SealedGrandChild?>()) {
+      return (data != null ? _i6.SealedGrandChild.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i6.SealedChild?>()) {
+      return (data != null ? _i6.SealedChild.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i6.SealedOtherChild?>()) {
+      return (data != null ? _i6.SealedOtherChild.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i7.StringDefaultPersist?>()) {
+      return (data != null ? _i7.StringDefaultPersist.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i3.ByNameEnumWithNameValue?>()) {
-      return (data != null ? _i3.ByNameEnumWithNameValue.fromJson(data) : null)
+    if (t == _i1.getType<_i8.CommentInt?>()) {
+      return (data != null ? _i8.CommentInt.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i9.CustomerInt?>()) {
+      return (data != null ? _i9.CustomerInt.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i10.OrderUuid?>()) {
+      return (data != null ? _i10.OrderUuid.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i11.AddressUuid?>()) {
+      return (data != null ? _i11.AddressUuid.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i12.CitizenInt?>()) {
+      return (data != null ? _i12.CitizenInt.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i13.CompanyUuid?>()) {
+      return (data != null ? _i13.CompanyUuid.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i14.TownInt?>()) {
+      return (data != null ? _i14.TownInt.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i15.ChangedIdTypeSelf?>()) {
+      return (data != null ? _i15.ChangedIdTypeSelf.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i16.BigIntDefault?>()) {
+      return (data != null ? _i16.BigIntDefault.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i17.BigIntDefaultMix?>()) {
+      return (data != null ? _i17.BigIntDefaultMix.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i18.BigIntDefaultModel?>()) {
+      return (data != null ? _i18.BigIntDefaultModel.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i4.CourseUuid?>()) {
-      return (data != null ? _i4.CourseUuid.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i5.EnrollmentInt?>()) {
-      return (data != null ? _i5.EnrollmentInt.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i6.StudentUuid?>()) {
-      return (data != null ? _i6.StudentUuid.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i7.ArenaUuid?>()) {
-      return (data != null ? _i7.ArenaUuid.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i8.PlayerUuid?>()) {
-      return (data != null ? _i8.PlayerUuid.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i9.TeamInt?>()) {
-      return (data != null ? _i9.TeamInt.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i10.CommentInt?>()) {
-      return (data != null ? _i10.CommentInt.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i11.CustomerInt?>()) {
-      return (data != null ? _i11.CustomerInt.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i12.OrderUuid?>()) {
-      return (data != null ? _i12.OrderUuid.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i13.AddressUuid?>()) {
-      return (data != null ? _i13.AddressUuid.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i14.CitizenInt?>()) {
-      return (data != null ? _i14.CitizenInt.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i15.CompanyUuid?>()) {
-      return (data != null ? _i15.CompanyUuid.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i16.TownInt?>()) {
-      return (data != null ? _i16.TownInt.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i17.ChangedIdTypeSelf?>()) {
-      return (data != null ? _i17.ChangedIdTypeSelf.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i18.BigIntDefault?>()) {
-      return (data != null ? _i18.BigIntDefault.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i19.BigIntDefaultMix?>()) {
-      return (data != null ? _i19.BigIntDefaultMix.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i20.BigIntDefaultModel?>()) {
-      return (data != null ? _i20.BigIntDefaultModel.fromJson(data) : null)
+    if (t == _i1.getType<_i19.BigIntDefaultPersist?>()) {
+      return (data != null ? _i19.BigIntDefaultPersist.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i21.BigIntDefaultPersist?>()) {
-      return (data != null ? _i21.BigIntDefaultPersist.fromJson(data) : null)
+    if (t == _i1.getType<_i20.BoolDefault?>()) {
+      return (data != null ? _i20.BoolDefault.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i21.BoolDefaultMix?>()) {
+      return (data != null ? _i21.BoolDefaultMix.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i22.BoolDefaultModel?>()) {
+      return (data != null ? _i22.BoolDefaultModel.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i23.BoolDefaultPersist?>()) {
+      return (data != null ? _i23.BoolDefaultPersist.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i22.BoolDefault?>()) {
-      return (data != null ? _i22.BoolDefault.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i24.DateTimeDefault?>()) {
+      return (data != null ? _i24.DateTimeDefault.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i23.BoolDefaultMix?>()) {
-      return (data != null ? _i23.BoolDefaultMix.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i24.BoolDefaultModel?>()) {
-      return (data != null ? _i24.BoolDefaultModel.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i25.BoolDefaultPersist?>()) {
-      return (data != null ? _i25.BoolDefaultPersist.fromJson(data) : null)
+    if (t == _i1.getType<_i25.DateTimeDefaultMix?>()) {
+      return (data != null ? _i25.DateTimeDefaultMix.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i26.DateTimeDefault?>()) {
-      return (data != null ? _i26.DateTimeDefault.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i27.DateTimeDefaultMix?>()) {
-      return (data != null ? _i27.DateTimeDefaultMix.fromJson(data) : null)
+    if (t == _i1.getType<_i26.DateTimeDefaultModel?>()) {
+      return (data != null ? _i26.DateTimeDefaultModel.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i28.DateTimeDefaultModel?>()) {
-      return (data != null ? _i28.DateTimeDefaultModel.fromJson(data) : null)
+    if (t == _i1.getType<_i27.DateTimeDefaultPersist?>()) {
+      return (data != null ? _i27.DateTimeDefaultPersist.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i29.DateTimeDefaultPersist?>()) {
-      return (data != null ? _i29.DateTimeDefaultPersist.fromJson(data) : null)
+    if (t == _i1.getType<_i28.DoubleDefault?>()) {
+      return (data != null ? _i28.DoubleDefault.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i29.DoubleDefaultMix?>()) {
+      return (data != null ? _i29.DoubleDefaultMix.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i30.DoubleDefaultModel?>()) {
+      return (data != null ? _i30.DoubleDefaultModel.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i30.DoubleDefault?>()) {
-      return (data != null ? _i30.DoubleDefault.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i31.DoubleDefaultMix?>()) {
-      return (data != null ? _i31.DoubleDefaultMix.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i32.DoubleDefaultModel?>()) {
-      return (data != null ? _i32.DoubleDefaultModel.fromJson(data) : null)
+    if (t == _i1.getType<_i31.DoubleDefaultPersist?>()) {
+      return (data != null ? _i31.DoubleDefaultPersist.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i33.DoubleDefaultPersist?>()) {
-      return (data != null ? _i33.DoubleDefaultPersist.fromJson(data) : null)
+    if (t == _i1.getType<_i32.DurationDefault?>()) {
+      return (data != null ? _i32.DurationDefault.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i33.DurationDefaultMix?>()) {
+      return (data != null ? _i33.DurationDefaultMix.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i34.DurationDefault?>()) {
-      return (data != null ? _i34.DurationDefault.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i35.DurationDefaultMix?>()) {
-      return (data != null ? _i35.DurationDefaultMix.fromJson(data) : null)
+    if (t == _i1.getType<_i34.DurationDefaultModel?>()) {
+      return (data != null ? _i34.DurationDefaultModel.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i36.DurationDefaultModel?>()) {
-      return (data != null ? _i36.DurationDefaultModel.fromJson(data) : null)
+    if (t == _i1.getType<_i35.DurationDefaultPersist?>()) {
+      return (data != null ? _i35.DurationDefaultPersist.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i37.DurationDefaultPersist?>()) {
-      return (data != null ? _i37.DurationDefaultPersist.fromJson(data) : null)
+    if (t == _i1.getType<_i36.EnumDefault?>()) {
+      return (data != null ? _i36.EnumDefault.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i37.EnumDefaultMix?>()) {
+      return (data != null ? _i37.EnumDefaultMix.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i38.EnumDefaultModel?>()) {
+      return (data != null ? _i38.EnumDefaultModel.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i39.EnumDefaultPersist?>()) {
+      return (data != null ? _i39.EnumDefaultPersist.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i38.EnumDefault?>()) {
-      return (data != null ? _i38.EnumDefault.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i40.ByIndexEnum?>()) {
+      return (data != null ? _i40.ByIndexEnum.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i39.EnumDefaultMix?>()) {
-      return (data != null ? _i39.EnumDefaultMix.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i41.ByNameEnum?>()) {
+      return (data != null ? _i41.ByNameEnum.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i40.EnumDefaultModel?>()) {
-      return (data != null ? _i40.EnumDefaultModel.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i42.DefaultValueEnum?>()) {
+      return (data != null ? _i42.DefaultValueEnum.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i41.EnumDefaultPersist?>()) {
-      return (data != null ? _i41.EnumDefaultPersist.fromJson(data) : null)
+    if (t == _i1.getType<_i43.DefaultException?>()) {
+      return (data != null ? _i43.DefaultException.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i44.IntDefault?>()) {
+      return (data != null ? _i44.IntDefault.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i45.IntDefaultMix?>()) {
+      return (data != null ? _i45.IntDefaultMix.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i46.IntDefaultModel?>()) {
+      return (data != null ? _i46.IntDefaultModel.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i47.IntDefaultPersist?>()) {
+      return (data != null ? _i47.IntDefaultPersist.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i48.StringDefault?>()) {
+      return (data != null ? _i48.StringDefault.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i49.StringDefaultMix?>()) {
+      return (data != null ? _i49.StringDefaultMix.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i50.StringDefaultModel?>()) {
+      return (data != null ? _i50.StringDefaultModel.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i42.ByIndexEnum?>()) {
-      return (data != null ? _i42.ByIndexEnum.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i51.ByIndexEnumWithNameValue?>()) {
+      return (data != null
+          ? _i51.ByIndexEnumWithNameValue.fromJson(data)
+          : null) as T;
     }
-    if (t == _i1.getType<_i43.ByNameEnum?>()) {
-      return (data != null ? _i43.ByNameEnum.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i52.UriDefault?>()) {
+      return (data != null ? _i52.UriDefault.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i44.DefaultValueEnum?>()) {
-      return (data != null ? _i44.DefaultValueEnum.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i53.UriDefaultMix?>()) {
+      return (data != null ? _i53.UriDefaultMix.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i45.DefaultException?>()) {
-      return (data != null ? _i45.DefaultException.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i54.UriDefaultModel?>()) {
+      return (data != null ? _i54.UriDefaultModel.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i46.IntDefault?>()) {
-      return (data != null ? _i46.IntDefault.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i55.UriDefaultPersist?>()) {
+      return (data != null ? _i55.UriDefaultPersist.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i47.IntDefaultMix?>()) {
-      return (data != null ? _i47.IntDefaultMix.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i56.UuidDefault?>()) {
+      return (data != null ? _i56.UuidDefault.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i48.IntDefaultModel?>()) {
-      return (data != null ? _i48.IntDefaultModel.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i57.UuidDefaultMix?>()) {
+      return (data != null ? _i57.UuidDefaultMix.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i49.IntDefaultPersist?>()) {
-      return (data != null ? _i49.IntDefaultPersist.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i58.UuidDefaultModel?>()) {
+      return (data != null ? _i58.UuidDefaultModel.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i50.StringDefault?>()) {
-      return (data != null ? _i50.StringDefault.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i51.StringDefaultMix?>()) {
-      return (data != null ? _i51.StringDefaultMix.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i52.StringDefaultModel?>()) {
-      return (data != null ? _i52.StringDefaultModel.fromJson(data) : null)
+    if (t == _i1.getType<_i59.UuidDefaultPersist?>()) {
+      return (data != null ? _i59.UuidDefaultPersist.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i53.StringDefaultPersist?>()) {
-      return (data != null ? _i53.StringDefaultPersist.fromJson(data) : null)
+    if (t == _i1.getType<_i60.EmptyModel?>()) {
+      return (data != null ? _i60.EmptyModel.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i61.EmptyModelRelationItem?>()) {
+      return (data != null ? _i61.EmptyModelRelationItem.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i54.UriDefault?>()) {
-      return (data != null ? _i54.UriDefault.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i55.UriDefaultMix?>()) {
-      return (data != null ? _i55.UriDefaultMix.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i56.UriDefaultModel?>()) {
-      return (data != null ? _i56.UriDefaultModel.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i57.UriDefaultPersist?>()) {
-      return (data != null ? _i57.UriDefaultPersist.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i58.UuidDefault?>()) {
-      return (data != null ? _i58.UuidDefault.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i59.UuidDefaultMix?>()) {
-      return (data != null ? _i59.UuidDefaultMix.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i60.UuidDefaultModel?>()) {
-      return (data != null ? _i60.UuidDefaultModel.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i61.UuidDefaultPersist?>()) {
-      return (data != null ? _i61.UuidDefaultPersist.fromJson(data) : null)
+    if (t == _i1.getType<_i62.EmptyModelWithTable?>()) {
+      return (data != null ? _i62.EmptyModelWithTable.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i62.EmptyModel?>()) {
-      return (data != null ? _i62.EmptyModel.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i63.EmptyModelRelationItem?>()) {
-      return (data != null ? _i63.EmptyModelRelationItem.fromJson(data) : null)
+    if (t == _i1.getType<_i63.RelationEmptyModel?>()) {
+      return (data != null ? _i63.RelationEmptyModel.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i64.EmptyModelWithTable?>()) {
-      return (data != null ? _i64.EmptyModelWithTable.fromJson(data) : null)
+    if (t == _i1.getType<_i64.ExceptionWithData?>()) {
+      return (data != null ? _i64.ExceptionWithData.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i65.ByNameEnumWithNameValue?>()) {
+      return (data != null ? _i65.ByNameEnumWithNameValue.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i65.RelationEmptyModel?>()) {
-      return (data != null ? _i65.RelationEmptyModel.fromJson(data) : null)
-          as T;
+    if (t == _i1.getType<_i66.CourseUuid?>()) {
+      return (data != null ? _i66.CourseUuid.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i66.ExceptionWithData?>()) {
-      return (data != null ? _i66.ExceptionWithData.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i67.GrandparentClass?>()) {
+      return (data != null ? _i67.GrandparentClass.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i67.ChildClass?>()) {
-      return (data != null ? _i67.ChildClass.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i68.EnrollmentInt?>()) {
+      return (data != null ? _i68.EnrollmentInt.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i68.ChildWithDefault?>()) {
-      return (data != null ? _i68.ChildWithDefault.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i69.ParentWithDefault?>()) {
+      return (data != null ? _i69.ParentWithDefault.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i69.GrandparentClass?>()) {
-      return (data != null ? _i69.GrandparentClass.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i70.StudentUuid?>()) {
+      return (data != null ? _i70.StudentUuid.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i70.ParentClass?>()) {
-      return (data != null ? _i70.ParentClass.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i71.ArenaUuid?>()) {
+      return (data != null ? _i71.ArenaUuid.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i71.ParentWithDefault?>()) {
-      return (data != null ? _i71.ParentWithDefault.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i72.SealedChild?>()) {
-      return (data != null ? _i72.SealedChild.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i72.SealedGrandChild?>()) {
-      return (data != null ? _i72.SealedGrandChild.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i72.SealedOtherChild?>()) {
-      return (data != null ? _i72.SealedOtherChild.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i72.PlayerUuid?>()) {
+      return (data != null ? _i72.PlayerUuid.fromJson(data) : null) as T;
     }
     if (t == _i1.getType<_i73.CityWithLongTableName?>()) {
       return (data != null ? _i73.CityWithLongTableName.fromJson(data) : null)
@@ -1141,8 +1144,8 @@ class Protocol extends _i1.SerializationManager {
     if (t == _i1.getType<_i100.Order?>()) {
       return (data != null ? _i100.Order.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i101.Address?>()) {
-      return (data != null ? _i101.Address.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i101.MyFeatureModel?>()) {
+      return (data != null ? _i101.MyFeatureModel.fromJson(data) : null) as T;
     }
     if (t == _i1.getType<_i102.Citizen?>()) {
       return (data != null ? _i102.Citizen.fromJson(data) : null) as T;
@@ -1241,10 +1244,8 @@ class Protocol extends _i1.SerializationManager {
       return (data != null ? _i130.ScopeServerOnlyField.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i131.ScopeServerOnlyFieldChild?>()) {
-      return (data != null
-          ? _i131.ScopeServerOnlyFieldChild.fromJson(data)
-          : null) as T;
+    if (t == _i1.getType<_i131.TeamInt?>()) {
+      return (data != null ? _i131.TeamInt.fromJson(data) : null) as T;
     }
     if (t == _i1.getType<_i132.DefaultServerOnlyClass?>()) {
       return (data != null ? _i132.DefaultServerOnlyClass.fromJson(data) : null)
@@ -1312,54 +1313,49 @@ class Protocol extends _i1.SerializationManager {
     if (t == _i1.getType<_i151.UniqueData?>()) {
       return (data != null ? _i151.UniqueData.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i152.MyFeatureModel?>()) {
-      return (data != null ? _i152.MyFeatureModel.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i152.Address?>()) {
+      return (data != null ? _i152.Address.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<List<_i5.EnrollmentInt>?>()) {
+    if (t == _i1.getType<List<_i10.OrderUuid>?>()) {
+      return (data != null
+          ? (data as List).map((e) => deserialize<_i10.OrderUuid>(e)).toList()
+          : null) as T;
+    }
+    if (t == _i1.getType<List<_i8.CommentInt>?>()) {
+      return (data != null
+          ? (data as List).map((e) => deserialize<_i8.CommentInt>(e)).toList()
+          : null) as T;
+    }
+    if (t == _i1.getType<List<_i15.ChangedIdTypeSelf>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i5.EnrollmentInt>(e))
+              .map((e) => deserialize<_i15.ChangedIdTypeSelf>(e))
               .toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i5.EnrollmentInt>?>()) {
+    if (t == _i1.getType<List<_i61.EmptyModelRelationItem>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i5.EnrollmentInt>(e))
-              .toList()
-          : null) as T;
-    }
-    if (t == _i1.getType<List<_i8.PlayerUuid>?>()) {
-      return (data != null
-          ? (data as List).map((e) => deserialize<_i8.PlayerUuid>(e)).toList()
-          : null) as T;
-    }
-    if (t == _i1.getType<List<_i12.OrderUuid>?>()) {
-      return (data != null
-          ? (data as List).map((e) => deserialize<_i12.OrderUuid>(e)).toList()
-          : null) as T;
-    }
-    if (t == _i1.getType<List<_i10.CommentInt>?>()) {
-      return (data != null
-          ? (data as List).map((e) => deserialize<_i10.CommentInt>(e)).toList()
-          : null) as T;
-    }
-    if (t == _i1.getType<List<_i17.ChangedIdTypeSelf>?>()) {
-      return (data != null
-          ? (data as List)
-              .map((e) => deserialize<_i17.ChangedIdTypeSelf>(e))
-              .toList()
-          : null) as T;
-    }
-    if (t == _i1.getType<List<_i63.EmptyModelRelationItem>?>()) {
-      return (data != null
-          ? (data as List)
-              .map((e) => deserialize<_i63.EmptyModelRelationItem>(e))
+              .map((e) => deserialize<_i61.EmptyModelRelationItem>(e))
               .toList()
           : null) as T;
     }
     if (t == List<String>) {
       return (data as List).map((e) => deserialize<String>(e)).toList() as T;
+    }
+    if (t == _i1.getType<List<_i68.EnrollmentInt>?>()) {
+      return (data != null
+          ? (data as List)
+              .map((e) => deserialize<_i68.EnrollmentInt>(e))
+              .toList()
+          : null) as T;
+    }
+    if (t == _i1.getType<List<_i68.EnrollmentInt>?>()) {
+      return (data != null
+          ? (data as List)
+              .map((e) => deserialize<_i68.EnrollmentInt>(e))
+              .toList()
+          : null) as T;
     }
     if (t == _i1.getType<List<_i75.PersonWithLongTableName>?>()) {
       return (data != null
@@ -1743,6 +1739,11 @@ class Protocol extends _i1.SerializationManager {
       return (data == null)
           ? null as T
           : (deserialize<bool>(((data as Map)['p'] as List)[0]),) as T;
+    }
+    if (t == _i1.getType<List<_i72.PlayerUuid>?>()) {
+      return (data != null
+          ? (data as List).map((e) => deserialize<_i72.PlayerUuid>(e)).toList()
+          : null) as T;
     }
     if (t == _i1.getType<List<_i144.TestEnumStringified>?>()) {
       return (data != null
@@ -3694,224 +3695,224 @@ class Protocol extends _i1.SerializationManager {
     if (data is _i155.FreezedCustomClass) {
       return 'FreezedCustomClass';
     }
-    if (data is _i2.ByIndexEnumWithNameValue) {
-      return 'ByIndexEnumWithNameValue';
+    if (data is _i2.ScopeServerOnlyFieldChild) {
+      return 'ScopeServerOnlyFieldChild';
     }
-    if (data is _i3.ByNameEnumWithNameValue) {
-      return 'ByNameEnumWithNameValue';
-    }
-    if (data is _i4.CourseUuid) {
-      return 'CourseUuid';
-    }
-    if (data is _i5.EnrollmentInt) {
-      return 'EnrollmentInt';
-    }
-    if (data is _i6.StudentUuid) {
-      return 'StudentUuid';
-    }
-    if (data is _i7.ArenaUuid) {
-      return 'ArenaUuid';
-    }
-    if (data is _i8.PlayerUuid) {
-      return 'PlayerUuid';
-    }
-    if (data is _i9.TeamInt) {
-      return 'TeamInt';
-    }
-    if (data is _i10.CommentInt) {
-      return 'CommentInt';
-    }
-    if (data is _i11.CustomerInt) {
-      return 'CustomerInt';
-    }
-    if (data is _i12.OrderUuid) {
-      return 'OrderUuid';
-    }
-    if (data is _i13.AddressUuid) {
-      return 'AddressUuid';
-    }
-    if (data is _i14.CitizenInt) {
-      return 'CitizenInt';
-    }
-    if (data is _i15.CompanyUuid) {
-      return 'CompanyUuid';
-    }
-    if (data is _i16.TownInt) {
-      return 'TownInt';
-    }
-    if (data is _i17.ChangedIdTypeSelf) {
-      return 'ChangedIdTypeSelf';
-    }
-    if (data is _i18.BigIntDefault) {
-      return 'BigIntDefault';
-    }
-    if (data is _i19.BigIntDefaultMix) {
-      return 'BigIntDefaultMix';
-    }
-    if (data is _i20.BigIntDefaultModel) {
-      return 'BigIntDefaultModel';
-    }
-    if (data is _i21.BigIntDefaultPersist) {
-      return 'BigIntDefaultPersist';
-    }
-    if (data is _i22.BoolDefault) {
-      return 'BoolDefault';
-    }
-    if (data is _i23.BoolDefaultMix) {
-      return 'BoolDefaultMix';
-    }
-    if (data is _i24.BoolDefaultModel) {
-      return 'BoolDefaultModel';
-    }
-    if (data is _i25.BoolDefaultPersist) {
-      return 'BoolDefaultPersist';
-    }
-    if (data is _i26.DateTimeDefault) {
-      return 'DateTimeDefault';
-    }
-    if (data is _i27.DateTimeDefaultMix) {
-      return 'DateTimeDefaultMix';
-    }
-    if (data is _i28.DateTimeDefaultModel) {
-      return 'DateTimeDefaultModel';
-    }
-    if (data is _i29.DateTimeDefaultPersist) {
-      return 'DateTimeDefaultPersist';
-    }
-    if (data is _i30.DoubleDefault) {
-      return 'DoubleDefault';
-    }
-    if (data is _i31.DoubleDefaultMix) {
-      return 'DoubleDefaultMix';
-    }
-    if (data is _i32.DoubleDefaultModel) {
-      return 'DoubleDefaultModel';
-    }
-    if (data is _i33.DoubleDefaultPersist) {
-      return 'DoubleDefaultPersist';
-    }
-    if (data is _i34.DurationDefault) {
-      return 'DurationDefault';
-    }
-    if (data is _i35.DurationDefaultMix) {
-      return 'DurationDefaultMix';
-    }
-    if (data is _i36.DurationDefaultModel) {
-      return 'DurationDefaultModel';
-    }
-    if (data is _i37.DurationDefaultPersist) {
-      return 'DurationDefaultPersist';
-    }
-    if (data is _i38.EnumDefault) {
-      return 'EnumDefault';
-    }
-    if (data is _i39.EnumDefaultMix) {
-      return 'EnumDefaultMix';
-    }
-    if (data is _i40.EnumDefaultModel) {
-      return 'EnumDefaultModel';
-    }
-    if (data is _i41.EnumDefaultPersist) {
-      return 'EnumDefaultPersist';
-    }
-    if (data is _i42.ByIndexEnum) {
-      return 'ByIndexEnum';
-    }
-    if (data is _i43.ByNameEnum) {
-      return 'ByNameEnum';
-    }
-    if (data is _i44.DefaultValueEnum) {
-      return 'DefaultValueEnum';
-    }
-    if (data is _i45.DefaultException) {
-      return 'DefaultException';
-    }
-    if (data is _i46.IntDefault) {
-      return 'IntDefault';
-    }
-    if (data is _i47.IntDefaultMix) {
-      return 'IntDefaultMix';
-    }
-    if (data is _i48.IntDefaultModel) {
-      return 'IntDefaultModel';
-    }
-    if (data is _i49.IntDefaultPersist) {
-      return 'IntDefaultPersist';
-    }
-    if (data is _i50.StringDefault) {
-      return 'StringDefault';
-    }
-    if (data is _i51.StringDefaultMix) {
-      return 'StringDefaultMix';
-    }
-    if (data is _i52.StringDefaultModel) {
-      return 'StringDefaultModel';
-    }
-    if (data is _i53.StringDefaultPersist) {
-      return 'StringDefaultPersist';
-    }
-    if (data is _i54.UriDefault) {
-      return 'UriDefault';
-    }
-    if (data is _i55.UriDefaultMix) {
-      return 'UriDefaultMix';
-    }
-    if (data is _i56.UriDefaultModel) {
-      return 'UriDefaultModel';
-    }
-    if (data is _i57.UriDefaultPersist) {
-      return 'UriDefaultPersist';
-    }
-    if (data is _i58.UuidDefault) {
-      return 'UuidDefault';
-    }
-    if (data is _i59.UuidDefaultMix) {
-      return 'UuidDefaultMix';
-    }
-    if (data is _i60.UuidDefaultModel) {
-      return 'UuidDefaultModel';
-    }
-    if (data is _i61.UuidDefaultPersist) {
-      return 'UuidDefaultPersist';
-    }
-    if (data is _i62.EmptyModel) {
-      return 'EmptyModel';
-    }
-    if (data is _i63.EmptyModelRelationItem) {
-      return 'EmptyModelRelationItem';
-    }
-    if (data is _i64.EmptyModelWithTable) {
-      return 'EmptyModelWithTable';
-    }
-    if (data is _i65.RelationEmptyModel) {
-      return 'RelationEmptyModel';
-    }
-    if (data is _i66.ExceptionWithData) {
-      return 'ExceptionWithData';
-    }
-    if (data is _i67.ChildClass) {
+    if (data is _i3.ChildClass) {
       return 'ChildClass';
     }
-    if (data is _i68.ChildWithDefault) {
+    if (data is _i4.ChildWithDefault) {
       return 'ChildWithDefault';
     }
-    if (data is _i69.GrandparentClass) {
-      return 'GrandparentClass';
-    }
-    if (data is _i70.ParentClass) {
+    if (data is _i5.ParentClass) {
       return 'ParentClass';
     }
-    if (data is _i71.ParentWithDefault) {
-      return 'ParentWithDefault';
-    }
-    if (data is _i72.SealedChild) {
-      return 'SealedChild';
-    }
-    if (data is _i72.SealedGrandChild) {
+    if (data is _i6.SealedGrandChild) {
       return 'SealedGrandChild';
     }
-    if (data is _i72.SealedOtherChild) {
+    if (data is _i6.SealedChild) {
+      return 'SealedChild';
+    }
+    if (data is _i6.SealedOtherChild) {
       return 'SealedOtherChild';
+    }
+    if (data is _i7.StringDefaultPersist) {
+      return 'StringDefaultPersist';
+    }
+    if (data is _i8.CommentInt) {
+      return 'CommentInt';
+    }
+    if (data is _i9.CustomerInt) {
+      return 'CustomerInt';
+    }
+    if (data is _i10.OrderUuid) {
+      return 'OrderUuid';
+    }
+    if (data is _i11.AddressUuid) {
+      return 'AddressUuid';
+    }
+    if (data is _i12.CitizenInt) {
+      return 'CitizenInt';
+    }
+    if (data is _i13.CompanyUuid) {
+      return 'CompanyUuid';
+    }
+    if (data is _i14.TownInt) {
+      return 'TownInt';
+    }
+    if (data is _i15.ChangedIdTypeSelf) {
+      return 'ChangedIdTypeSelf';
+    }
+    if (data is _i16.BigIntDefault) {
+      return 'BigIntDefault';
+    }
+    if (data is _i17.BigIntDefaultMix) {
+      return 'BigIntDefaultMix';
+    }
+    if (data is _i18.BigIntDefaultModel) {
+      return 'BigIntDefaultModel';
+    }
+    if (data is _i19.BigIntDefaultPersist) {
+      return 'BigIntDefaultPersist';
+    }
+    if (data is _i20.BoolDefault) {
+      return 'BoolDefault';
+    }
+    if (data is _i21.BoolDefaultMix) {
+      return 'BoolDefaultMix';
+    }
+    if (data is _i22.BoolDefaultModel) {
+      return 'BoolDefaultModel';
+    }
+    if (data is _i23.BoolDefaultPersist) {
+      return 'BoolDefaultPersist';
+    }
+    if (data is _i24.DateTimeDefault) {
+      return 'DateTimeDefault';
+    }
+    if (data is _i25.DateTimeDefaultMix) {
+      return 'DateTimeDefaultMix';
+    }
+    if (data is _i26.DateTimeDefaultModel) {
+      return 'DateTimeDefaultModel';
+    }
+    if (data is _i27.DateTimeDefaultPersist) {
+      return 'DateTimeDefaultPersist';
+    }
+    if (data is _i28.DoubleDefault) {
+      return 'DoubleDefault';
+    }
+    if (data is _i29.DoubleDefaultMix) {
+      return 'DoubleDefaultMix';
+    }
+    if (data is _i30.DoubleDefaultModel) {
+      return 'DoubleDefaultModel';
+    }
+    if (data is _i31.DoubleDefaultPersist) {
+      return 'DoubleDefaultPersist';
+    }
+    if (data is _i32.DurationDefault) {
+      return 'DurationDefault';
+    }
+    if (data is _i33.DurationDefaultMix) {
+      return 'DurationDefaultMix';
+    }
+    if (data is _i34.DurationDefaultModel) {
+      return 'DurationDefaultModel';
+    }
+    if (data is _i35.DurationDefaultPersist) {
+      return 'DurationDefaultPersist';
+    }
+    if (data is _i36.EnumDefault) {
+      return 'EnumDefault';
+    }
+    if (data is _i37.EnumDefaultMix) {
+      return 'EnumDefaultMix';
+    }
+    if (data is _i38.EnumDefaultModel) {
+      return 'EnumDefaultModel';
+    }
+    if (data is _i39.EnumDefaultPersist) {
+      return 'EnumDefaultPersist';
+    }
+    if (data is _i40.ByIndexEnum) {
+      return 'ByIndexEnum';
+    }
+    if (data is _i41.ByNameEnum) {
+      return 'ByNameEnum';
+    }
+    if (data is _i42.DefaultValueEnum) {
+      return 'DefaultValueEnum';
+    }
+    if (data is _i43.DefaultException) {
+      return 'DefaultException';
+    }
+    if (data is _i44.IntDefault) {
+      return 'IntDefault';
+    }
+    if (data is _i45.IntDefaultMix) {
+      return 'IntDefaultMix';
+    }
+    if (data is _i46.IntDefaultModel) {
+      return 'IntDefaultModel';
+    }
+    if (data is _i47.IntDefaultPersist) {
+      return 'IntDefaultPersist';
+    }
+    if (data is _i48.StringDefault) {
+      return 'StringDefault';
+    }
+    if (data is _i49.StringDefaultMix) {
+      return 'StringDefaultMix';
+    }
+    if (data is _i50.StringDefaultModel) {
+      return 'StringDefaultModel';
+    }
+    if (data is _i51.ByIndexEnumWithNameValue) {
+      return 'ByIndexEnumWithNameValue';
+    }
+    if (data is _i52.UriDefault) {
+      return 'UriDefault';
+    }
+    if (data is _i53.UriDefaultMix) {
+      return 'UriDefaultMix';
+    }
+    if (data is _i54.UriDefaultModel) {
+      return 'UriDefaultModel';
+    }
+    if (data is _i55.UriDefaultPersist) {
+      return 'UriDefaultPersist';
+    }
+    if (data is _i56.UuidDefault) {
+      return 'UuidDefault';
+    }
+    if (data is _i57.UuidDefaultMix) {
+      return 'UuidDefaultMix';
+    }
+    if (data is _i58.UuidDefaultModel) {
+      return 'UuidDefaultModel';
+    }
+    if (data is _i59.UuidDefaultPersist) {
+      return 'UuidDefaultPersist';
+    }
+    if (data is _i60.EmptyModel) {
+      return 'EmptyModel';
+    }
+    if (data is _i61.EmptyModelRelationItem) {
+      return 'EmptyModelRelationItem';
+    }
+    if (data is _i62.EmptyModelWithTable) {
+      return 'EmptyModelWithTable';
+    }
+    if (data is _i63.RelationEmptyModel) {
+      return 'RelationEmptyModel';
+    }
+    if (data is _i64.ExceptionWithData) {
+      return 'ExceptionWithData';
+    }
+    if (data is _i65.ByNameEnumWithNameValue) {
+      return 'ByNameEnumWithNameValue';
+    }
+    if (data is _i66.CourseUuid) {
+      return 'CourseUuid';
+    }
+    if (data is _i67.GrandparentClass) {
+      return 'GrandparentClass';
+    }
+    if (data is _i68.EnrollmentInt) {
+      return 'EnrollmentInt';
+    }
+    if (data is _i69.ParentWithDefault) {
+      return 'ParentWithDefault';
+    }
+    if (data is _i70.StudentUuid) {
+      return 'StudentUuid';
+    }
+    if (data is _i71.ArenaUuid) {
+      return 'ArenaUuid';
+    }
+    if (data is _i72.PlayerUuid) {
+      return 'PlayerUuid';
     }
     if (data is _i73.CityWithLongTableName) {
       return 'CityWithLongTableName';
@@ -3997,8 +3998,8 @@ class Protocol extends _i1.SerializationManager {
     if (data is _i100.Order) {
       return 'Order';
     }
-    if (data is _i101.Address) {
-      return 'Address';
+    if (data is _i101.MyFeatureModel) {
+      return 'MyFeatureModel';
     }
     if (data is _i102.Citizen) {
       return 'Citizen';
@@ -4087,8 +4088,8 @@ class Protocol extends _i1.SerializationManager {
     if (data is _i130.ScopeServerOnlyField) {
       return 'ScopeServerOnlyField';
     }
-    if (data is _i131.ScopeServerOnlyFieldChild) {
-      return 'ScopeServerOnlyFieldChild';
+    if (data is _i131.TeamInt) {
+      return 'TeamInt';
     }
     if (data is _i132.DefaultServerOnlyClass) {
       return 'DefaultServerOnlyClass';
@@ -4150,8 +4151,8 @@ class Protocol extends _i1.SerializationManager {
     if (data is _i151.UniqueData) {
       return 'UniqueData';
     }
-    if (data is _i152.MyFeatureModel) {
-      return 'MyFeatureModel';
+    if (data is _i152.Address) {
+      return 'Address';
     }
     className = _i158.Protocol().getClassNameForObject(data);
     if (className != null) {
@@ -4246,224 +4247,224 @@ class Protocol extends _i1.SerializationManager {
     if (dataClassName == 'FreezedCustomClass') {
       return deserialize<_i155.FreezedCustomClass>(data['data']);
     }
-    if (dataClassName == 'ByIndexEnumWithNameValue') {
-      return deserialize<_i2.ByIndexEnumWithNameValue>(data['data']);
-    }
-    if (dataClassName == 'ByNameEnumWithNameValue') {
-      return deserialize<_i3.ByNameEnumWithNameValue>(data['data']);
-    }
-    if (dataClassName == 'CourseUuid') {
-      return deserialize<_i4.CourseUuid>(data['data']);
-    }
-    if (dataClassName == 'EnrollmentInt') {
-      return deserialize<_i5.EnrollmentInt>(data['data']);
-    }
-    if (dataClassName == 'StudentUuid') {
-      return deserialize<_i6.StudentUuid>(data['data']);
-    }
-    if (dataClassName == 'ArenaUuid') {
-      return deserialize<_i7.ArenaUuid>(data['data']);
-    }
-    if (dataClassName == 'PlayerUuid') {
-      return deserialize<_i8.PlayerUuid>(data['data']);
-    }
-    if (dataClassName == 'TeamInt') {
-      return deserialize<_i9.TeamInt>(data['data']);
-    }
-    if (dataClassName == 'CommentInt') {
-      return deserialize<_i10.CommentInt>(data['data']);
-    }
-    if (dataClassName == 'CustomerInt') {
-      return deserialize<_i11.CustomerInt>(data['data']);
-    }
-    if (dataClassName == 'OrderUuid') {
-      return deserialize<_i12.OrderUuid>(data['data']);
-    }
-    if (dataClassName == 'AddressUuid') {
-      return deserialize<_i13.AddressUuid>(data['data']);
-    }
-    if (dataClassName == 'CitizenInt') {
-      return deserialize<_i14.CitizenInt>(data['data']);
-    }
-    if (dataClassName == 'CompanyUuid') {
-      return deserialize<_i15.CompanyUuid>(data['data']);
-    }
-    if (dataClassName == 'TownInt') {
-      return deserialize<_i16.TownInt>(data['data']);
-    }
-    if (dataClassName == 'ChangedIdTypeSelf') {
-      return deserialize<_i17.ChangedIdTypeSelf>(data['data']);
-    }
-    if (dataClassName == 'BigIntDefault') {
-      return deserialize<_i18.BigIntDefault>(data['data']);
-    }
-    if (dataClassName == 'BigIntDefaultMix') {
-      return deserialize<_i19.BigIntDefaultMix>(data['data']);
-    }
-    if (dataClassName == 'BigIntDefaultModel') {
-      return deserialize<_i20.BigIntDefaultModel>(data['data']);
-    }
-    if (dataClassName == 'BigIntDefaultPersist') {
-      return deserialize<_i21.BigIntDefaultPersist>(data['data']);
-    }
-    if (dataClassName == 'BoolDefault') {
-      return deserialize<_i22.BoolDefault>(data['data']);
-    }
-    if (dataClassName == 'BoolDefaultMix') {
-      return deserialize<_i23.BoolDefaultMix>(data['data']);
-    }
-    if (dataClassName == 'BoolDefaultModel') {
-      return deserialize<_i24.BoolDefaultModel>(data['data']);
-    }
-    if (dataClassName == 'BoolDefaultPersist') {
-      return deserialize<_i25.BoolDefaultPersist>(data['data']);
-    }
-    if (dataClassName == 'DateTimeDefault') {
-      return deserialize<_i26.DateTimeDefault>(data['data']);
-    }
-    if (dataClassName == 'DateTimeDefaultMix') {
-      return deserialize<_i27.DateTimeDefaultMix>(data['data']);
-    }
-    if (dataClassName == 'DateTimeDefaultModel') {
-      return deserialize<_i28.DateTimeDefaultModel>(data['data']);
-    }
-    if (dataClassName == 'DateTimeDefaultPersist') {
-      return deserialize<_i29.DateTimeDefaultPersist>(data['data']);
-    }
-    if (dataClassName == 'DoubleDefault') {
-      return deserialize<_i30.DoubleDefault>(data['data']);
-    }
-    if (dataClassName == 'DoubleDefaultMix') {
-      return deserialize<_i31.DoubleDefaultMix>(data['data']);
-    }
-    if (dataClassName == 'DoubleDefaultModel') {
-      return deserialize<_i32.DoubleDefaultModel>(data['data']);
-    }
-    if (dataClassName == 'DoubleDefaultPersist') {
-      return deserialize<_i33.DoubleDefaultPersist>(data['data']);
-    }
-    if (dataClassName == 'DurationDefault') {
-      return deserialize<_i34.DurationDefault>(data['data']);
-    }
-    if (dataClassName == 'DurationDefaultMix') {
-      return deserialize<_i35.DurationDefaultMix>(data['data']);
-    }
-    if (dataClassName == 'DurationDefaultModel') {
-      return deserialize<_i36.DurationDefaultModel>(data['data']);
-    }
-    if (dataClassName == 'DurationDefaultPersist') {
-      return deserialize<_i37.DurationDefaultPersist>(data['data']);
-    }
-    if (dataClassName == 'EnumDefault') {
-      return deserialize<_i38.EnumDefault>(data['data']);
-    }
-    if (dataClassName == 'EnumDefaultMix') {
-      return deserialize<_i39.EnumDefaultMix>(data['data']);
-    }
-    if (dataClassName == 'EnumDefaultModel') {
-      return deserialize<_i40.EnumDefaultModel>(data['data']);
-    }
-    if (dataClassName == 'EnumDefaultPersist') {
-      return deserialize<_i41.EnumDefaultPersist>(data['data']);
-    }
-    if (dataClassName == 'ByIndexEnum') {
-      return deserialize<_i42.ByIndexEnum>(data['data']);
-    }
-    if (dataClassName == 'ByNameEnum') {
-      return deserialize<_i43.ByNameEnum>(data['data']);
-    }
-    if (dataClassName == 'DefaultValueEnum') {
-      return deserialize<_i44.DefaultValueEnum>(data['data']);
-    }
-    if (dataClassName == 'DefaultException') {
-      return deserialize<_i45.DefaultException>(data['data']);
-    }
-    if (dataClassName == 'IntDefault') {
-      return deserialize<_i46.IntDefault>(data['data']);
-    }
-    if (dataClassName == 'IntDefaultMix') {
-      return deserialize<_i47.IntDefaultMix>(data['data']);
-    }
-    if (dataClassName == 'IntDefaultModel') {
-      return deserialize<_i48.IntDefaultModel>(data['data']);
-    }
-    if (dataClassName == 'IntDefaultPersist') {
-      return deserialize<_i49.IntDefaultPersist>(data['data']);
-    }
-    if (dataClassName == 'StringDefault') {
-      return deserialize<_i50.StringDefault>(data['data']);
-    }
-    if (dataClassName == 'StringDefaultMix') {
-      return deserialize<_i51.StringDefaultMix>(data['data']);
-    }
-    if (dataClassName == 'StringDefaultModel') {
-      return deserialize<_i52.StringDefaultModel>(data['data']);
-    }
-    if (dataClassName == 'StringDefaultPersist') {
-      return deserialize<_i53.StringDefaultPersist>(data['data']);
-    }
-    if (dataClassName == 'UriDefault') {
-      return deserialize<_i54.UriDefault>(data['data']);
-    }
-    if (dataClassName == 'UriDefaultMix') {
-      return deserialize<_i55.UriDefaultMix>(data['data']);
-    }
-    if (dataClassName == 'UriDefaultModel') {
-      return deserialize<_i56.UriDefaultModel>(data['data']);
-    }
-    if (dataClassName == 'UriDefaultPersist') {
-      return deserialize<_i57.UriDefaultPersist>(data['data']);
-    }
-    if (dataClassName == 'UuidDefault') {
-      return deserialize<_i58.UuidDefault>(data['data']);
-    }
-    if (dataClassName == 'UuidDefaultMix') {
-      return deserialize<_i59.UuidDefaultMix>(data['data']);
-    }
-    if (dataClassName == 'UuidDefaultModel') {
-      return deserialize<_i60.UuidDefaultModel>(data['data']);
-    }
-    if (dataClassName == 'UuidDefaultPersist') {
-      return deserialize<_i61.UuidDefaultPersist>(data['data']);
-    }
-    if (dataClassName == 'EmptyModel') {
-      return deserialize<_i62.EmptyModel>(data['data']);
-    }
-    if (dataClassName == 'EmptyModelRelationItem') {
-      return deserialize<_i63.EmptyModelRelationItem>(data['data']);
-    }
-    if (dataClassName == 'EmptyModelWithTable') {
-      return deserialize<_i64.EmptyModelWithTable>(data['data']);
-    }
-    if (dataClassName == 'RelationEmptyModel') {
-      return deserialize<_i65.RelationEmptyModel>(data['data']);
-    }
-    if (dataClassName == 'ExceptionWithData') {
-      return deserialize<_i66.ExceptionWithData>(data['data']);
+    if (dataClassName == 'ScopeServerOnlyFieldChild') {
+      return deserialize<_i2.ScopeServerOnlyFieldChild>(data['data']);
     }
     if (dataClassName == 'ChildClass') {
-      return deserialize<_i67.ChildClass>(data['data']);
+      return deserialize<_i3.ChildClass>(data['data']);
     }
     if (dataClassName == 'ChildWithDefault') {
-      return deserialize<_i68.ChildWithDefault>(data['data']);
-    }
-    if (dataClassName == 'GrandparentClass') {
-      return deserialize<_i69.GrandparentClass>(data['data']);
+      return deserialize<_i4.ChildWithDefault>(data['data']);
     }
     if (dataClassName == 'ParentClass') {
-      return deserialize<_i70.ParentClass>(data['data']);
-    }
-    if (dataClassName == 'ParentWithDefault') {
-      return deserialize<_i71.ParentWithDefault>(data['data']);
-    }
-    if (dataClassName == 'SealedChild') {
-      return deserialize<_i72.SealedChild>(data['data']);
+      return deserialize<_i5.ParentClass>(data['data']);
     }
     if (dataClassName == 'SealedGrandChild') {
-      return deserialize<_i72.SealedGrandChild>(data['data']);
+      return deserialize<_i6.SealedGrandChild>(data['data']);
+    }
+    if (dataClassName == 'SealedChild') {
+      return deserialize<_i6.SealedChild>(data['data']);
     }
     if (dataClassName == 'SealedOtherChild') {
-      return deserialize<_i72.SealedOtherChild>(data['data']);
+      return deserialize<_i6.SealedOtherChild>(data['data']);
+    }
+    if (dataClassName == 'StringDefaultPersist') {
+      return deserialize<_i7.StringDefaultPersist>(data['data']);
+    }
+    if (dataClassName == 'CommentInt') {
+      return deserialize<_i8.CommentInt>(data['data']);
+    }
+    if (dataClassName == 'CustomerInt') {
+      return deserialize<_i9.CustomerInt>(data['data']);
+    }
+    if (dataClassName == 'OrderUuid') {
+      return deserialize<_i10.OrderUuid>(data['data']);
+    }
+    if (dataClassName == 'AddressUuid') {
+      return deserialize<_i11.AddressUuid>(data['data']);
+    }
+    if (dataClassName == 'CitizenInt') {
+      return deserialize<_i12.CitizenInt>(data['data']);
+    }
+    if (dataClassName == 'CompanyUuid') {
+      return deserialize<_i13.CompanyUuid>(data['data']);
+    }
+    if (dataClassName == 'TownInt') {
+      return deserialize<_i14.TownInt>(data['data']);
+    }
+    if (dataClassName == 'ChangedIdTypeSelf') {
+      return deserialize<_i15.ChangedIdTypeSelf>(data['data']);
+    }
+    if (dataClassName == 'BigIntDefault') {
+      return deserialize<_i16.BigIntDefault>(data['data']);
+    }
+    if (dataClassName == 'BigIntDefaultMix') {
+      return deserialize<_i17.BigIntDefaultMix>(data['data']);
+    }
+    if (dataClassName == 'BigIntDefaultModel') {
+      return deserialize<_i18.BigIntDefaultModel>(data['data']);
+    }
+    if (dataClassName == 'BigIntDefaultPersist') {
+      return deserialize<_i19.BigIntDefaultPersist>(data['data']);
+    }
+    if (dataClassName == 'BoolDefault') {
+      return deserialize<_i20.BoolDefault>(data['data']);
+    }
+    if (dataClassName == 'BoolDefaultMix') {
+      return deserialize<_i21.BoolDefaultMix>(data['data']);
+    }
+    if (dataClassName == 'BoolDefaultModel') {
+      return deserialize<_i22.BoolDefaultModel>(data['data']);
+    }
+    if (dataClassName == 'BoolDefaultPersist') {
+      return deserialize<_i23.BoolDefaultPersist>(data['data']);
+    }
+    if (dataClassName == 'DateTimeDefault') {
+      return deserialize<_i24.DateTimeDefault>(data['data']);
+    }
+    if (dataClassName == 'DateTimeDefaultMix') {
+      return deserialize<_i25.DateTimeDefaultMix>(data['data']);
+    }
+    if (dataClassName == 'DateTimeDefaultModel') {
+      return deserialize<_i26.DateTimeDefaultModel>(data['data']);
+    }
+    if (dataClassName == 'DateTimeDefaultPersist') {
+      return deserialize<_i27.DateTimeDefaultPersist>(data['data']);
+    }
+    if (dataClassName == 'DoubleDefault') {
+      return deserialize<_i28.DoubleDefault>(data['data']);
+    }
+    if (dataClassName == 'DoubleDefaultMix') {
+      return deserialize<_i29.DoubleDefaultMix>(data['data']);
+    }
+    if (dataClassName == 'DoubleDefaultModel') {
+      return deserialize<_i30.DoubleDefaultModel>(data['data']);
+    }
+    if (dataClassName == 'DoubleDefaultPersist') {
+      return deserialize<_i31.DoubleDefaultPersist>(data['data']);
+    }
+    if (dataClassName == 'DurationDefault') {
+      return deserialize<_i32.DurationDefault>(data['data']);
+    }
+    if (dataClassName == 'DurationDefaultMix') {
+      return deserialize<_i33.DurationDefaultMix>(data['data']);
+    }
+    if (dataClassName == 'DurationDefaultModel') {
+      return deserialize<_i34.DurationDefaultModel>(data['data']);
+    }
+    if (dataClassName == 'DurationDefaultPersist') {
+      return deserialize<_i35.DurationDefaultPersist>(data['data']);
+    }
+    if (dataClassName == 'EnumDefault') {
+      return deserialize<_i36.EnumDefault>(data['data']);
+    }
+    if (dataClassName == 'EnumDefaultMix') {
+      return deserialize<_i37.EnumDefaultMix>(data['data']);
+    }
+    if (dataClassName == 'EnumDefaultModel') {
+      return deserialize<_i38.EnumDefaultModel>(data['data']);
+    }
+    if (dataClassName == 'EnumDefaultPersist') {
+      return deserialize<_i39.EnumDefaultPersist>(data['data']);
+    }
+    if (dataClassName == 'ByIndexEnum') {
+      return deserialize<_i40.ByIndexEnum>(data['data']);
+    }
+    if (dataClassName == 'ByNameEnum') {
+      return deserialize<_i41.ByNameEnum>(data['data']);
+    }
+    if (dataClassName == 'DefaultValueEnum') {
+      return deserialize<_i42.DefaultValueEnum>(data['data']);
+    }
+    if (dataClassName == 'DefaultException') {
+      return deserialize<_i43.DefaultException>(data['data']);
+    }
+    if (dataClassName == 'IntDefault') {
+      return deserialize<_i44.IntDefault>(data['data']);
+    }
+    if (dataClassName == 'IntDefaultMix') {
+      return deserialize<_i45.IntDefaultMix>(data['data']);
+    }
+    if (dataClassName == 'IntDefaultModel') {
+      return deserialize<_i46.IntDefaultModel>(data['data']);
+    }
+    if (dataClassName == 'IntDefaultPersist') {
+      return deserialize<_i47.IntDefaultPersist>(data['data']);
+    }
+    if (dataClassName == 'StringDefault') {
+      return deserialize<_i48.StringDefault>(data['data']);
+    }
+    if (dataClassName == 'StringDefaultMix') {
+      return deserialize<_i49.StringDefaultMix>(data['data']);
+    }
+    if (dataClassName == 'StringDefaultModel') {
+      return deserialize<_i50.StringDefaultModel>(data['data']);
+    }
+    if (dataClassName == 'ByIndexEnumWithNameValue') {
+      return deserialize<_i51.ByIndexEnumWithNameValue>(data['data']);
+    }
+    if (dataClassName == 'UriDefault') {
+      return deserialize<_i52.UriDefault>(data['data']);
+    }
+    if (dataClassName == 'UriDefaultMix') {
+      return deserialize<_i53.UriDefaultMix>(data['data']);
+    }
+    if (dataClassName == 'UriDefaultModel') {
+      return deserialize<_i54.UriDefaultModel>(data['data']);
+    }
+    if (dataClassName == 'UriDefaultPersist') {
+      return deserialize<_i55.UriDefaultPersist>(data['data']);
+    }
+    if (dataClassName == 'UuidDefault') {
+      return deserialize<_i56.UuidDefault>(data['data']);
+    }
+    if (dataClassName == 'UuidDefaultMix') {
+      return deserialize<_i57.UuidDefaultMix>(data['data']);
+    }
+    if (dataClassName == 'UuidDefaultModel') {
+      return deserialize<_i58.UuidDefaultModel>(data['data']);
+    }
+    if (dataClassName == 'UuidDefaultPersist') {
+      return deserialize<_i59.UuidDefaultPersist>(data['data']);
+    }
+    if (dataClassName == 'EmptyModel') {
+      return deserialize<_i60.EmptyModel>(data['data']);
+    }
+    if (dataClassName == 'EmptyModelRelationItem') {
+      return deserialize<_i61.EmptyModelRelationItem>(data['data']);
+    }
+    if (dataClassName == 'EmptyModelWithTable') {
+      return deserialize<_i62.EmptyModelWithTable>(data['data']);
+    }
+    if (dataClassName == 'RelationEmptyModel') {
+      return deserialize<_i63.RelationEmptyModel>(data['data']);
+    }
+    if (dataClassName == 'ExceptionWithData') {
+      return deserialize<_i64.ExceptionWithData>(data['data']);
+    }
+    if (dataClassName == 'ByNameEnumWithNameValue') {
+      return deserialize<_i65.ByNameEnumWithNameValue>(data['data']);
+    }
+    if (dataClassName == 'CourseUuid') {
+      return deserialize<_i66.CourseUuid>(data['data']);
+    }
+    if (dataClassName == 'GrandparentClass') {
+      return deserialize<_i67.GrandparentClass>(data['data']);
+    }
+    if (dataClassName == 'EnrollmentInt') {
+      return deserialize<_i68.EnrollmentInt>(data['data']);
+    }
+    if (dataClassName == 'ParentWithDefault') {
+      return deserialize<_i69.ParentWithDefault>(data['data']);
+    }
+    if (dataClassName == 'StudentUuid') {
+      return deserialize<_i70.StudentUuid>(data['data']);
+    }
+    if (dataClassName == 'ArenaUuid') {
+      return deserialize<_i71.ArenaUuid>(data['data']);
+    }
+    if (dataClassName == 'PlayerUuid') {
+      return deserialize<_i72.PlayerUuid>(data['data']);
     }
     if (dataClassName == 'CityWithLongTableName') {
       return deserialize<_i73.CityWithLongTableName>(data['data']);
@@ -4549,8 +4550,8 @@ class Protocol extends _i1.SerializationManager {
     if (dataClassName == 'Order') {
       return deserialize<_i100.Order>(data['data']);
     }
-    if (dataClassName == 'Address') {
-      return deserialize<_i101.Address>(data['data']);
+    if (dataClassName == 'MyFeatureModel') {
+      return deserialize<_i101.MyFeatureModel>(data['data']);
     }
     if (dataClassName == 'Citizen') {
       return deserialize<_i102.Citizen>(data['data']);
@@ -4639,8 +4640,8 @@ class Protocol extends _i1.SerializationManager {
     if (dataClassName == 'ScopeServerOnlyField') {
       return deserialize<_i130.ScopeServerOnlyField>(data['data']);
     }
-    if (dataClassName == 'ScopeServerOnlyFieldChild') {
-      return deserialize<_i131.ScopeServerOnlyFieldChild>(data['data']);
+    if (dataClassName == 'TeamInt') {
+      return deserialize<_i131.TeamInt>(data['data']);
     }
     if (dataClassName == 'DefaultServerOnlyClass') {
       return deserialize<_i132.DefaultServerOnlyClass>(data['data']);
@@ -4702,8 +4703,8 @@ class Protocol extends _i1.SerializationManager {
     if (dataClassName == 'UniqueData') {
       return deserialize<_i151.UniqueData>(data['data']);
     }
-    if (dataClassName == 'MyFeatureModel') {
-      return deserialize<_i152.MyFeatureModel>(data['data']);
+    if (dataClassName == 'Address') {
+      return deserialize<_i152.Address>(data['data']);
     }
     if (dataClassName.startsWith('serverpod_auth.')) {
       data['className'] = dataClassName.substring(15);

--- a/tests/serverpod_test_server/lib/src/generated/protocol.dart
+++ b/tests/serverpod_test_server/lib/src/generated/protocol.dart
@@ -14,77 +14,77 @@ import 'package:serverpod/protocol.dart' as _i2;
 import 'package:serverpod_auth_server/serverpod_auth_server.dart' as _i3;
 import 'package:serverpod_test_module_server/serverpod_test_module_server.dart'
     as _i4;
-import 'by_index_enum_with_name_value.dart' as _i5;
-import 'by_name_enum_with_name_value.dart' as _i6;
-import 'changed_id_type/many_to_many/course.dart' as _i7;
-import 'changed_id_type/many_to_many/enrollment.dart' as _i8;
-import 'changed_id_type/many_to_many/student.dart' as _i9;
-import 'changed_id_type/nested_one_to_many/arena.dart' as _i10;
-import 'changed_id_type/nested_one_to_many/player.dart' as _i11;
-import 'changed_id_type/nested_one_to_many/team.dart' as _i12;
-import 'changed_id_type/one_to_many/comment.dart' as _i13;
-import 'changed_id_type/one_to_many/customer.dart' as _i14;
-import 'changed_id_type/one_to_many/order.dart' as _i15;
-import 'changed_id_type/one_to_one/address.dart' as _i16;
-import 'changed_id_type/one_to_one/citizen.dart' as _i17;
-import 'changed_id_type/one_to_one/company.dart' as _i18;
-import 'changed_id_type/one_to_one/town.dart' as _i19;
-import 'changed_id_type/self.dart' as _i20;
-import 'defaults/bigint/bigint_default.dart' as _i21;
-import 'defaults/bigint/bigint_default_mix.dart' as _i22;
-import 'defaults/bigint/bigint_default_model.dart' as _i23;
-import 'defaults/bigint/bigint_default_persist.dart' as _i24;
-import 'defaults/boolean/bool_default.dart' as _i25;
-import 'defaults/boolean/bool_default_mix.dart' as _i26;
-import 'defaults/boolean/bool_default_model.dart' as _i27;
-import 'defaults/boolean/bool_default_persist.dart' as _i28;
-import 'defaults/datetime/datetime_default.dart' as _i29;
-import 'defaults/datetime/datetime_default_mix.dart' as _i30;
-import 'defaults/datetime/datetime_default_model.dart' as _i31;
-import 'defaults/datetime/datetime_default_persist.dart' as _i32;
-import 'defaults/double/double_default.dart' as _i33;
-import 'defaults/double/double_default_mix.dart' as _i34;
-import 'defaults/double/double_default_model.dart' as _i35;
-import 'defaults/double/double_default_persist.dart' as _i36;
-import 'defaults/duration/duration_default.dart' as _i37;
-import 'defaults/duration/duration_default_mix.dart' as _i38;
-import 'defaults/duration/duration_default_model.dart' as _i39;
-import 'defaults/duration/duration_default_persist.dart' as _i40;
-import 'defaults/enum/enum_default.dart' as _i41;
-import 'defaults/enum/enum_default_mix.dart' as _i42;
-import 'defaults/enum/enum_default_model.dart' as _i43;
-import 'defaults/enum/enum_default_persist.dart' as _i44;
-import 'defaults/enum/enums/by_index_enum.dart' as _i45;
-import 'defaults/enum/enums/by_name_enum.dart' as _i46;
-import 'defaults/enum/enums/default_value_enum.dart' as _i47;
-import 'defaults/exception/default_exception.dart' as _i48;
-import 'defaults/integer/int_default.dart' as _i49;
-import 'defaults/integer/int_default_mix.dart' as _i50;
-import 'defaults/integer/int_default_model.dart' as _i51;
-import 'defaults/integer/int_default_persist.dart' as _i52;
-import 'defaults/string/string_default.dart' as _i53;
-import 'defaults/string/string_default_mix.dart' as _i54;
-import 'defaults/string/string_default_model.dart' as _i55;
-import 'defaults/string/string_default_persist.dart' as _i56;
-import 'defaults/uri/uri_default.dart' as _i57;
-import 'defaults/uri/uri_default_mix.dart' as _i58;
-import 'defaults/uri/uri_default_model.dart' as _i59;
-import 'defaults/uri/uri_default_persist.dart' as _i60;
-import 'defaults/uuid/uuid_default.dart' as _i61;
-import 'defaults/uuid/uuid_default_mix.dart' as _i62;
-import 'defaults/uuid/uuid_default_model.dart' as _i63;
-import 'defaults/uuid/uuid_default_persist.dart' as _i64;
-import 'empty_model/empty_model.dart' as _i65;
-import 'empty_model/empty_model_relation_item.dart' as _i66;
-import 'empty_model/empty_model_with_table.dart' as _i67;
-import 'empty_model/relation_empy_model.dart' as _i68;
-import 'exception_with_data.dart' as _i69;
-import 'inheritance/child_class.dart' as _i70;
-import 'inheritance/child_with_default.dart' as _i71;
-import 'inheritance/grandparent_class.dart' as _i72;
-import 'inheritance/parent_class.dart' as _i73;
-import 'inheritance/parent_with_default.dart' as _i74;
-import 'inheritance/sealed_parent.dart' as _i75;
+import 'scopes/scope_server_only_field_child.dart' as _i5;
+import 'inheritance/child_class.dart' as _i6;
+import 'inheritance/child_with_default.dart' as _i7;
+import 'inheritance/parent_class.dart' as _i8;
+import 'inheritance/sealed_parent.dart' as _i9;
+import 'defaults/uri/uri_default.dart' as _i10;
+import 'changed_id_type/one_to_many/comment.dart' as _i11;
+import 'changed_id_type/one_to_many/customer.dart' as _i12;
+import 'changed_id_type/one_to_many/order.dart' as _i13;
+import 'changed_id_type/one_to_one/address.dart' as _i14;
+import 'changed_id_type/one_to_one/citizen.dart' as _i15;
+import 'changed_id_type/one_to_one/company.dart' as _i16;
+import 'changed_id_type/one_to_one/town.dart' as _i17;
+import 'changed_id_type/self.dart' as _i18;
+import 'defaults/bigint/bigint_default.dart' as _i19;
+import 'defaults/bigint/bigint_default_mix.dart' as _i20;
+import 'defaults/bigint/bigint_default_model.dart' as _i21;
+import 'defaults/bigint/bigint_default_persist.dart' as _i22;
+import 'defaults/boolean/bool_default.dart' as _i23;
+import 'defaults/boolean/bool_default_mix.dart' as _i24;
+import 'defaults/boolean/bool_default_model.dart' as _i25;
+import 'defaults/boolean/bool_default_persist.dart' as _i26;
+import 'defaults/datetime/datetime_default.dart' as _i27;
+import 'defaults/datetime/datetime_default_mix.dart' as _i28;
+import 'defaults/datetime/datetime_default_model.dart' as _i29;
+import 'defaults/datetime/datetime_default_persist.dart' as _i30;
+import 'defaults/double/double_default.dart' as _i31;
+import 'defaults/double/double_default_mix.dart' as _i32;
+import 'defaults/double/double_default_model.dart' as _i33;
+import 'defaults/double/double_default_persist.dart' as _i34;
+import 'defaults/duration/duration_default.dart' as _i35;
+import 'defaults/duration/duration_default_mix.dart' as _i36;
+import 'defaults/duration/duration_default_model.dart' as _i37;
+import 'defaults/duration/duration_default_persist.dart' as _i38;
+import 'defaults/enum/enum_default.dart' as _i39;
+import 'defaults/enum/enum_default_mix.dart' as _i40;
+import 'defaults/enum/enum_default_model.dart' as _i41;
+import 'defaults/enum/enum_default_persist.dart' as _i42;
+import 'defaults/enum/enums/by_index_enum.dart' as _i43;
+import 'defaults/enum/enums/by_name_enum.dart' as _i44;
+import 'defaults/enum/enums/default_value_enum.dart' as _i45;
+import 'defaults/exception/default_exception.dart' as _i46;
+import 'defaults/integer/int_default.dart' as _i47;
+import 'defaults/integer/int_default_mix.dart' as _i48;
+import 'defaults/integer/int_default_model.dart' as _i49;
+import 'defaults/integer/int_default_persist.dart' as _i50;
+import 'defaults/string/string_default.dart' as _i51;
+import 'defaults/string/string_default_mix.dart' as _i52;
+import 'defaults/string/string_default_model.dart' as _i53;
+import 'defaults/string/string_default_persist.dart' as _i54;
+import 'by_index_enum_with_name_value.dart' as _i55;
+import 'defaults/uri/uri_default_mix.dart' as _i56;
+import 'defaults/uri/uri_default_model.dart' as _i57;
+import 'defaults/uri/uri_default_persist.dart' as _i58;
+import 'defaults/uuid/uuid_default.dart' as _i59;
+import 'defaults/uuid/uuid_default_mix.dart' as _i60;
+import 'defaults/uuid/uuid_default_model.dart' as _i61;
+import 'defaults/uuid/uuid_default_persist.dart' as _i62;
+import 'empty_model/empty_model.dart' as _i63;
+import 'empty_model/empty_model_relation_item.dart' as _i64;
+import 'empty_model/empty_model_with_table.dart' as _i65;
+import 'empty_model/relation_empy_model.dart' as _i66;
+import 'exception_with_data.dart' as _i67;
+import 'by_name_enum_with_name_value.dart' as _i68;
+import 'changed_id_type/many_to_many/course.dart' as _i69;
+import 'inheritance/grandparent_class.dart' as _i70;
+import 'changed_id_type/many_to_many/enrollment.dart' as _i71;
+import 'inheritance/parent_with_default.dart' as _i72;
+import 'changed_id_type/many_to_many/student.dart' as _i73;
+import 'changed_id_type/nested_one_to_many/arena.dart' as _i74;
+import 'changed_id_type/nested_one_to_many/player.dart' as _i75;
 import 'long_identifiers/deep_includes/city_with_long_table_name.dart' as _i76;
 import 'long_identifiers/deep_includes/organization_with_long_table_name.dart'
     as _i77;
@@ -122,7 +122,7 @@ import 'models_with_relations/one_to_many/implicit/book.dart' as _i101;
 import 'models_with_relations/one_to_many/implicit/chapter.dart' as _i102;
 import 'models_with_relations/one_to_many/order.dart' as _i103;
 import 'models_with_relations/one_to_one/address.dart' as _i104;
-import 'models_with_relations/one_to_one/citizen.dart' as _i105;
+import 'my_feature/models/my_feature_model.dart' as _i105;
 import 'models_with_relations/one_to_one/company.dart' as _i106;
 import 'models_with_relations/one_to_one/town.dart' as _i107;
 import 'models_with_relations/self_relation/many_to_many/blocking.dart'
@@ -152,7 +152,7 @@ import 'record.dart' as _i130;
 import 'related_unique_data.dart' as _i131;
 import 'scopes/scope_none_fields.dart' as _i132;
 import 'scopes/scope_server_only_field.dart' as _i133;
-import 'scopes/scope_server_only_field_child.dart' as _i134;
+import 'changed_id_type/nested_one_to_many/team.dart' as _i134;
 import 'scopes/serverOnly/default_server_only_class.dart' as _i135;
 import 'scopes/serverOnly/default_server_only_enum.dart' as _i136;
 import 'scopes/serverOnly/not_server_only_class.dart' as _i137;
@@ -175,7 +175,7 @@ import 'types_record.dart' as _i153;
 import 'types_set.dart' as _i154;
 import 'types_set_required.dart' as _i155;
 import 'unique_data.dart' as _i156;
-import 'my_feature/models/my_feature_model.dart' as _i157;
+import 'models_with_relations/one_to_one/citizen.dart' as _i157;
 import 'dart:typed_data' as _i158;
 import 'package:serverpod_test_shared/serverpod_test_shared.dart' as _i159;
 import 'package:serverpod_test_server/src/generated/simple_data.dart' as _i160;
@@ -6728,224 +6728,224 @@ class Protocol extends _i1.SerializationManagerServer {
     Type? t,
   ]) {
     t ??= T;
-    if (t == _i5.ByIndexEnumWithNameValue) {
-      return _i5.ByIndexEnumWithNameValue.fromJson(data) as T;
+    if (t == _i5.ScopeServerOnlyFieldChild) {
+      return _i5.ScopeServerOnlyFieldChild.fromJson(data) as T;
     }
-    if (t == _i6.ByNameEnumWithNameValue) {
-      return _i6.ByNameEnumWithNameValue.fromJson(data) as T;
+    if (t == _i6.ChildClass) {
+      return _i6.ChildClass.fromJson(data) as T;
     }
-    if (t == _i7.CourseUuid) {
-      return _i7.CourseUuid.fromJson(data) as T;
+    if (t == _i7.ChildWithDefault) {
+      return _i7.ChildWithDefault.fromJson(data) as T;
     }
-    if (t == _i8.EnrollmentInt) {
-      return _i8.EnrollmentInt.fromJson(data) as T;
+    if (t == _i8.ParentClass) {
+      return _i8.ParentClass.fromJson(data) as T;
     }
-    if (t == _i9.StudentUuid) {
-      return _i9.StudentUuid.fromJson(data) as T;
+    if (t == _i9.SealedGrandChild) {
+      return _i9.SealedGrandChild.fromJson(data) as T;
     }
-    if (t == _i10.ArenaUuid) {
-      return _i10.ArenaUuid.fromJson(data) as T;
+    if (t == _i9.SealedChild) {
+      return _i9.SealedChild.fromJson(data) as T;
     }
-    if (t == _i11.PlayerUuid) {
-      return _i11.PlayerUuid.fromJson(data) as T;
+    if (t == _i9.SealedOtherChild) {
+      return _i9.SealedOtherChild.fromJson(data) as T;
     }
-    if (t == _i12.TeamInt) {
-      return _i12.TeamInt.fromJson(data) as T;
+    if (t == _i10.UriDefault) {
+      return _i10.UriDefault.fromJson(data) as T;
     }
-    if (t == _i13.CommentInt) {
-      return _i13.CommentInt.fromJson(data) as T;
+    if (t == _i11.CommentInt) {
+      return _i11.CommentInt.fromJson(data) as T;
     }
-    if (t == _i14.CustomerInt) {
-      return _i14.CustomerInt.fromJson(data) as T;
+    if (t == _i12.CustomerInt) {
+      return _i12.CustomerInt.fromJson(data) as T;
     }
-    if (t == _i15.OrderUuid) {
-      return _i15.OrderUuid.fromJson(data) as T;
+    if (t == _i13.OrderUuid) {
+      return _i13.OrderUuid.fromJson(data) as T;
     }
-    if (t == _i16.AddressUuid) {
-      return _i16.AddressUuid.fromJson(data) as T;
+    if (t == _i14.AddressUuid) {
+      return _i14.AddressUuid.fromJson(data) as T;
     }
-    if (t == _i17.CitizenInt) {
-      return _i17.CitizenInt.fromJson(data) as T;
+    if (t == _i15.CitizenInt) {
+      return _i15.CitizenInt.fromJson(data) as T;
     }
-    if (t == _i18.CompanyUuid) {
-      return _i18.CompanyUuid.fromJson(data) as T;
+    if (t == _i16.CompanyUuid) {
+      return _i16.CompanyUuid.fromJson(data) as T;
     }
-    if (t == _i19.TownInt) {
-      return _i19.TownInt.fromJson(data) as T;
+    if (t == _i17.TownInt) {
+      return _i17.TownInt.fromJson(data) as T;
     }
-    if (t == _i20.ChangedIdTypeSelf) {
-      return _i20.ChangedIdTypeSelf.fromJson(data) as T;
+    if (t == _i18.ChangedIdTypeSelf) {
+      return _i18.ChangedIdTypeSelf.fromJson(data) as T;
     }
-    if (t == _i21.BigIntDefault) {
-      return _i21.BigIntDefault.fromJson(data) as T;
+    if (t == _i19.BigIntDefault) {
+      return _i19.BigIntDefault.fromJson(data) as T;
     }
-    if (t == _i22.BigIntDefaultMix) {
-      return _i22.BigIntDefaultMix.fromJson(data) as T;
+    if (t == _i20.BigIntDefaultMix) {
+      return _i20.BigIntDefaultMix.fromJson(data) as T;
     }
-    if (t == _i23.BigIntDefaultModel) {
-      return _i23.BigIntDefaultModel.fromJson(data) as T;
+    if (t == _i21.BigIntDefaultModel) {
+      return _i21.BigIntDefaultModel.fromJson(data) as T;
     }
-    if (t == _i24.BigIntDefaultPersist) {
-      return _i24.BigIntDefaultPersist.fromJson(data) as T;
+    if (t == _i22.BigIntDefaultPersist) {
+      return _i22.BigIntDefaultPersist.fromJson(data) as T;
     }
-    if (t == _i25.BoolDefault) {
-      return _i25.BoolDefault.fromJson(data) as T;
+    if (t == _i23.BoolDefault) {
+      return _i23.BoolDefault.fromJson(data) as T;
     }
-    if (t == _i26.BoolDefaultMix) {
-      return _i26.BoolDefaultMix.fromJson(data) as T;
+    if (t == _i24.BoolDefaultMix) {
+      return _i24.BoolDefaultMix.fromJson(data) as T;
     }
-    if (t == _i27.BoolDefaultModel) {
-      return _i27.BoolDefaultModel.fromJson(data) as T;
+    if (t == _i25.BoolDefaultModel) {
+      return _i25.BoolDefaultModel.fromJson(data) as T;
     }
-    if (t == _i28.BoolDefaultPersist) {
-      return _i28.BoolDefaultPersist.fromJson(data) as T;
+    if (t == _i26.BoolDefaultPersist) {
+      return _i26.BoolDefaultPersist.fromJson(data) as T;
     }
-    if (t == _i29.DateTimeDefault) {
-      return _i29.DateTimeDefault.fromJson(data) as T;
+    if (t == _i27.DateTimeDefault) {
+      return _i27.DateTimeDefault.fromJson(data) as T;
     }
-    if (t == _i30.DateTimeDefaultMix) {
-      return _i30.DateTimeDefaultMix.fromJson(data) as T;
+    if (t == _i28.DateTimeDefaultMix) {
+      return _i28.DateTimeDefaultMix.fromJson(data) as T;
     }
-    if (t == _i31.DateTimeDefaultModel) {
-      return _i31.DateTimeDefaultModel.fromJson(data) as T;
+    if (t == _i29.DateTimeDefaultModel) {
+      return _i29.DateTimeDefaultModel.fromJson(data) as T;
     }
-    if (t == _i32.DateTimeDefaultPersist) {
-      return _i32.DateTimeDefaultPersist.fromJson(data) as T;
+    if (t == _i30.DateTimeDefaultPersist) {
+      return _i30.DateTimeDefaultPersist.fromJson(data) as T;
     }
-    if (t == _i33.DoubleDefault) {
-      return _i33.DoubleDefault.fromJson(data) as T;
+    if (t == _i31.DoubleDefault) {
+      return _i31.DoubleDefault.fromJson(data) as T;
     }
-    if (t == _i34.DoubleDefaultMix) {
-      return _i34.DoubleDefaultMix.fromJson(data) as T;
+    if (t == _i32.DoubleDefaultMix) {
+      return _i32.DoubleDefaultMix.fromJson(data) as T;
     }
-    if (t == _i35.DoubleDefaultModel) {
-      return _i35.DoubleDefaultModel.fromJson(data) as T;
+    if (t == _i33.DoubleDefaultModel) {
+      return _i33.DoubleDefaultModel.fromJson(data) as T;
     }
-    if (t == _i36.DoubleDefaultPersist) {
-      return _i36.DoubleDefaultPersist.fromJson(data) as T;
+    if (t == _i34.DoubleDefaultPersist) {
+      return _i34.DoubleDefaultPersist.fromJson(data) as T;
     }
-    if (t == _i37.DurationDefault) {
-      return _i37.DurationDefault.fromJson(data) as T;
+    if (t == _i35.DurationDefault) {
+      return _i35.DurationDefault.fromJson(data) as T;
     }
-    if (t == _i38.DurationDefaultMix) {
-      return _i38.DurationDefaultMix.fromJson(data) as T;
+    if (t == _i36.DurationDefaultMix) {
+      return _i36.DurationDefaultMix.fromJson(data) as T;
     }
-    if (t == _i39.DurationDefaultModel) {
-      return _i39.DurationDefaultModel.fromJson(data) as T;
+    if (t == _i37.DurationDefaultModel) {
+      return _i37.DurationDefaultModel.fromJson(data) as T;
     }
-    if (t == _i40.DurationDefaultPersist) {
-      return _i40.DurationDefaultPersist.fromJson(data) as T;
+    if (t == _i38.DurationDefaultPersist) {
+      return _i38.DurationDefaultPersist.fromJson(data) as T;
     }
-    if (t == _i41.EnumDefault) {
-      return _i41.EnumDefault.fromJson(data) as T;
+    if (t == _i39.EnumDefault) {
+      return _i39.EnumDefault.fromJson(data) as T;
     }
-    if (t == _i42.EnumDefaultMix) {
-      return _i42.EnumDefaultMix.fromJson(data) as T;
+    if (t == _i40.EnumDefaultMix) {
+      return _i40.EnumDefaultMix.fromJson(data) as T;
     }
-    if (t == _i43.EnumDefaultModel) {
-      return _i43.EnumDefaultModel.fromJson(data) as T;
+    if (t == _i41.EnumDefaultModel) {
+      return _i41.EnumDefaultModel.fromJson(data) as T;
     }
-    if (t == _i44.EnumDefaultPersist) {
-      return _i44.EnumDefaultPersist.fromJson(data) as T;
+    if (t == _i42.EnumDefaultPersist) {
+      return _i42.EnumDefaultPersist.fromJson(data) as T;
     }
-    if (t == _i45.ByIndexEnum) {
-      return _i45.ByIndexEnum.fromJson(data) as T;
+    if (t == _i43.ByIndexEnum) {
+      return _i43.ByIndexEnum.fromJson(data) as T;
     }
-    if (t == _i46.ByNameEnum) {
-      return _i46.ByNameEnum.fromJson(data) as T;
+    if (t == _i44.ByNameEnum) {
+      return _i44.ByNameEnum.fromJson(data) as T;
     }
-    if (t == _i47.DefaultValueEnum) {
-      return _i47.DefaultValueEnum.fromJson(data) as T;
+    if (t == _i45.DefaultValueEnum) {
+      return _i45.DefaultValueEnum.fromJson(data) as T;
     }
-    if (t == _i48.DefaultException) {
-      return _i48.DefaultException.fromJson(data) as T;
+    if (t == _i46.DefaultException) {
+      return _i46.DefaultException.fromJson(data) as T;
     }
-    if (t == _i49.IntDefault) {
-      return _i49.IntDefault.fromJson(data) as T;
+    if (t == _i47.IntDefault) {
+      return _i47.IntDefault.fromJson(data) as T;
     }
-    if (t == _i50.IntDefaultMix) {
-      return _i50.IntDefaultMix.fromJson(data) as T;
+    if (t == _i48.IntDefaultMix) {
+      return _i48.IntDefaultMix.fromJson(data) as T;
     }
-    if (t == _i51.IntDefaultModel) {
-      return _i51.IntDefaultModel.fromJson(data) as T;
+    if (t == _i49.IntDefaultModel) {
+      return _i49.IntDefaultModel.fromJson(data) as T;
     }
-    if (t == _i52.IntDefaultPersist) {
-      return _i52.IntDefaultPersist.fromJson(data) as T;
+    if (t == _i50.IntDefaultPersist) {
+      return _i50.IntDefaultPersist.fromJson(data) as T;
     }
-    if (t == _i53.StringDefault) {
-      return _i53.StringDefault.fromJson(data) as T;
+    if (t == _i51.StringDefault) {
+      return _i51.StringDefault.fromJson(data) as T;
     }
-    if (t == _i54.StringDefaultMix) {
-      return _i54.StringDefaultMix.fromJson(data) as T;
+    if (t == _i52.StringDefaultMix) {
+      return _i52.StringDefaultMix.fromJson(data) as T;
     }
-    if (t == _i55.StringDefaultModel) {
-      return _i55.StringDefaultModel.fromJson(data) as T;
+    if (t == _i53.StringDefaultModel) {
+      return _i53.StringDefaultModel.fromJson(data) as T;
     }
-    if (t == _i56.StringDefaultPersist) {
-      return _i56.StringDefaultPersist.fromJson(data) as T;
+    if (t == _i54.StringDefaultPersist) {
+      return _i54.StringDefaultPersist.fromJson(data) as T;
     }
-    if (t == _i57.UriDefault) {
-      return _i57.UriDefault.fromJson(data) as T;
+    if (t == _i55.ByIndexEnumWithNameValue) {
+      return _i55.ByIndexEnumWithNameValue.fromJson(data) as T;
     }
-    if (t == _i58.UriDefaultMix) {
-      return _i58.UriDefaultMix.fromJson(data) as T;
+    if (t == _i56.UriDefaultMix) {
+      return _i56.UriDefaultMix.fromJson(data) as T;
     }
-    if (t == _i59.UriDefaultModel) {
-      return _i59.UriDefaultModel.fromJson(data) as T;
+    if (t == _i57.UriDefaultModel) {
+      return _i57.UriDefaultModel.fromJson(data) as T;
     }
-    if (t == _i60.UriDefaultPersist) {
-      return _i60.UriDefaultPersist.fromJson(data) as T;
+    if (t == _i58.UriDefaultPersist) {
+      return _i58.UriDefaultPersist.fromJson(data) as T;
     }
-    if (t == _i61.UuidDefault) {
-      return _i61.UuidDefault.fromJson(data) as T;
+    if (t == _i59.UuidDefault) {
+      return _i59.UuidDefault.fromJson(data) as T;
     }
-    if (t == _i62.UuidDefaultMix) {
-      return _i62.UuidDefaultMix.fromJson(data) as T;
+    if (t == _i60.UuidDefaultMix) {
+      return _i60.UuidDefaultMix.fromJson(data) as T;
     }
-    if (t == _i63.UuidDefaultModel) {
-      return _i63.UuidDefaultModel.fromJson(data) as T;
+    if (t == _i61.UuidDefaultModel) {
+      return _i61.UuidDefaultModel.fromJson(data) as T;
     }
-    if (t == _i64.UuidDefaultPersist) {
-      return _i64.UuidDefaultPersist.fromJson(data) as T;
+    if (t == _i62.UuidDefaultPersist) {
+      return _i62.UuidDefaultPersist.fromJson(data) as T;
     }
-    if (t == _i65.EmptyModel) {
-      return _i65.EmptyModel.fromJson(data) as T;
+    if (t == _i63.EmptyModel) {
+      return _i63.EmptyModel.fromJson(data) as T;
     }
-    if (t == _i66.EmptyModelRelationItem) {
-      return _i66.EmptyModelRelationItem.fromJson(data) as T;
+    if (t == _i64.EmptyModelRelationItem) {
+      return _i64.EmptyModelRelationItem.fromJson(data) as T;
     }
-    if (t == _i67.EmptyModelWithTable) {
-      return _i67.EmptyModelWithTable.fromJson(data) as T;
+    if (t == _i65.EmptyModelWithTable) {
+      return _i65.EmptyModelWithTable.fromJson(data) as T;
     }
-    if (t == _i68.RelationEmptyModel) {
-      return _i68.RelationEmptyModel.fromJson(data) as T;
+    if (t == _i66.RelationEmptyModel) {
+      return _i66.RelationEmptyModel.fromJson(data) as T;
     }
-    if (t == _i69.ExceptionWithData) {
-      return _i69.ExceptionWithData.fromJson(data) as T;
+    if (t == _i67.ExceptionWithData) {
+      return _i67.ExceptionWithData.fromJson(data) as T;
     }
-    if (t == _i70.ChildClass) {
-      return _i70.ChildClass.fromJson(data) as T;
+    if (t == _i68.ByNameEnumWithNameValue) {
+      return _i68.ByNameEnumWithNameValue.fromJson(data) as T;
     }
-    if (t == _i71.ChildWithDefault) {
-      return _i71.ChildWithDefault.fromJson(data) as T;
+    if (t == _i69.CourseUuid) {
+      return _i69.CourseUuid.fromJson(data) as T;
     }
-    if (t == _i72.GrandparentClass) {
-      return _i72.GrandparentClass.fromJson(data) as T;
+    if (t == _i70.GrandparentClass) {
+      return _i70.GrandparentClass.fromJson(data) as T;
     }
-    if (t == _i73.ParentClass) {
-      return _i73.ParentClass.fromJson(data) as T;
+    if (t == _i71.EnrollmentInt) {
+      return _i71.EnrollmentInt.fromJson(data) as T;
     }
-    if (t == _i74.ParentWithDefault) {
-      return _i74.ParentWithDefault.fromJson(data) as T;
+    if (t == _i72.ParentWithDefault) {
+      return _i72.ParentWithDefault.fromJson(data) as T;
     }
-    if (t == _i75.SealedChild) {
-      return _i75.SealedChild.fromJson(data) as T;
+    if (t == _i73.StudentUuid) {
+      return _i73.StudentUuid.fromJson(data) as T;
     }
-    if (t == _i75.SealedGrandChild) {
-      return _i75.SealedGrandChild.fromJson(data) as T;
+    if (t == _i74.ArenaUuid) {
+      return _i74.ArenaUuid.fromJson(data) as T;
     }
-    if (t == _i75.SealedOtherChild) {
-      return _i75.SealedOtherChild.fromJson(data) as T;
+    if (t == _i75.PlayerUuid) {
+      return _i75.PlayerUuid.fromJson(data) as T;
     }
     if (t == _i76.CityWithLongTableName) {
       return _i76.CityWithLongTableName.fromJson(data) as T;
@@ -7034,8 +7034,8 @@ class Protocol extends _i1.SerializationManagerServer {
     if (t == _i104.Address) {
       return _i104.Address.fromJson(data) as T;
     }
-    if (t == _i105.Citizen) {
-      return _i105.Citizen.fromJson(data) as T;
+    if (t == _i105.MyFeatureModel) {
+      return _i105.MyFeatureModel.fromJson(data) as T;
     }
     if (t == _i106.Company) {
       return _i106.Company.fromJson(data) as T;
@@ -7121,8 +7121,8 @@ class Protocol extends _i1.SerializationManagerServer {
     if (t == _i133.ScopeServerOnlyField) {
       return _i133.ScopeServerOnlyField.fromJson(data) as T;
     }
-    if (t == _i134.ScopeServerOnlyFieldChild) {
-      return _i134.ScopeServerOnlyFieldChild.fromJson(data) as T;
+    if (t == _i134.TeamInt) {
+      return _i134.TeamInt.fromJson(data) as T;
     }
     if (t == _i135.DefaultServerOnlyClass) {
       return _i135.DefaultServerOnlyClass.fromJson(data) as T;
@@ -7190,247 +7190,250 @@ class Protocol extends _i1.SerializationManagerServer {
     if (t == _i156.UniqueData) {
       return _i156.UniqueData.fromJson(data) as T;
     }
-    if (t == _i157.MyFeatureModel) {
-      return _i157.MyFeatureModel.fromJson(data) as T;
+    if (t == _i157.Citizen) {
+      return _i157.Citizen.fromJson(data) as T;
     }
-    if (t == _i1.getType<_i5.ByIndexEnumWithNameValue?>()) {
-      return (data != null ? _i5.ByIndexEnumWithNameValue.fromJson(data) : null)
+    if (t == _i1.getType<_i5.ScopeServerOnlyFieldChild?>()) {
+      return (data != null
+          ? _i5.ScopeServerOnlyFieldChild.fromJson(data)
+          : null) as T;
+    }
+    if (t == _i1.getType<_i6.ChildClass?>()) {
+      return (data != null ? _i6.ChildClass.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i7.ChildWithDefault?>()) {
+      return (data != null ? _i7.ChildWithDefault.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i8.ParentClass?>()) {
+      return (data != null ? _i8.ParentClass.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i9.SealedGrandChild?>()) {
+      return (data != null ? _i9.SealedGrandChild.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i9.SealedChild?>()) {
+      return (data != null ? _i9.SealedChild.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i9.SealedOtherChild?>()) {
+      return (data != null ? _i9.SealedOtherChild.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i10.UriDefault?>()) {
+      return (data != null ? _i10.UriDefault.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i11.CommentInt?>()) {
+      return (data != null ? _i11.CommentInt.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i12.CustomerInt?>()) {
+      return (data != null ? _i12.CustomerInt.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i13.OrderUuid?>()) {
+      return (data != null ? _i13.OrderUuid.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i14.AddressUuid?>()) {
+      return (data != null ? _i14.AddressUuid.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i15.CitizenInt?>()) {
+      return (data != null ? _i15.CitizenInt.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i16.CompanyUuid?>()) {
+      return (data != null ? _i16.CompanyUuid.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i17.TownInt?>()) {
+      return (data != null ? _i17.TownInt.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i18.ChangedIdTypeSelf?>()) {
+      return (data != null ? _i18.ChangedIdTypeSelf.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i19.BigIntDefault?>()) {
+      return (data != null ? _i19.BigIntDefault.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i20.BigIntDefaultMix?>()) {
+      return (data != null ? _i20.BigIntDefaultMix.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i21.BigIntDefaultModel?>()) {
+      return (data != null ? _i21.BigIntDefaultModel.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i6.ByNameEnumWithNameValue?>()) {
-      return (data != null ? _i6.ByNameEnumWithNameValue.fromJson(data) : null)
+    if (t == _i1.getType<_i22.BigIntDefaultPersist?>()) {
+      return (data != null ? _i22.BigIntDefaultPersist.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i7.CourseUuid?>()) {
-      return (data != null ? _i7.CourseUuid.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i23.BoolDefault?>()) {
+      return (data != null ? _i23.BoolDefault.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i8.EnrollmentInt?>()) {
-      return (data != null ? _i8.EnrollmentInt.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i24.BoolDefaultMix?>()) {
+      return (data != null ? _i24.BoolDefaultMix.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i9.StudentUuid?>()) {
-      return (data != null ? _i9.StudentUuid.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i25.BoolDefaultModel?>()) {
+      return (data != null ? _i25.BoolDefaultModel.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i10.ArenaUuid?>()) {
-      return (data != null ? _i10.ArenaUuid.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i11.PlayerUuid?>()) {
-      return (data != null ? _i11.PlayerUuid.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i12.TeamInt?>()) {
-      return (data != null ? _i12.TeamInt.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i13.CommentInt?>()) {
-      return (data != null ? _i13.CommentInt.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i14.CustomerInt?>()) {
-      return (data != null ? _i14.CustomerInt.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i15.OrderUuid?>()) {
-      return (data != null ? _i15.OrderUuid.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i16.AddressUuid?>()) {
-      return (data != null ? _i16.AddressUuid.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i17.CitizenInt?>()) {
-      return (data != null ? _i17.CitizenInt.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i18.CompanyUuid?>()) {
-      return (data != null ? _i18.CompanyUuid.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i19.TownInt?>()) {
-      return (data != null ? _i19.TownInt.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i20.ChangedIdTypeSelf?>()) {
-      return (data != null ? _i20.ChangedIdTypeSelf.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i21.BigIntDefault?>()) {
-      return (data != null ? _i21.BigIntDefault.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i22.BigIntDefaultMix?>()) {
-      return (data != null ? _i22.BigIntDefaultMix.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i23.BigIntDefaultModel?>()) {
-      return (data != null ? _i23.BigIntDefaultModel.fromJson(data) : null)
+    if (t == _i1.getType<_i26.BoolDefaultPersist?>()) {
+      return (data != null ? _i26.BoolDefaultPersist.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i24.BigIntDefaultPersist?>()) {
-      return (data != null ? _i24.BigIntDefaultPersist.fromJson(data) : null)
+    if (t == _i1.getType<_i27.DateTimeDefault?>()) {
+      return (data != null ? _i27.DateTimeDefault.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i28.DateTimeDefaultMix?>()) {
+      return (data != null ? _i28.DateTimeDefaultMix.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i25.BoolDefault?>()) {
-      return (data != null ? _i25.BoolDefault.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i26.BoolDefaultMix?>()) {
-      return (data != null ? _i26.BoolDefaultMix.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i27.BoolDefaultModel?>()) {
-      return (data != null ? _i27.BoolDefaultModel.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i28.BoolDefaultPersist?>()) {
-      return (data != null ? _i28.BoolDefaultPersist.fromJson(data) : null)
+    if (t == _i1.getType<_i29.DateTimeDefaultModel?>()) {
+      return (data != null ? _i29.DateTimeDefaultModel.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i29.DateTimeDefault?>()) {
-      return (data != null ? _i29.DateTimeDefault.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i30.DateTimeDefaultMix?>()) {
-      return (data != null ? _i30.DateTimeDefaultMix.fromJson(data) : null)
+    if (t == _i1.getType<_i30.DateTimeDefaultPersist?>()) {
+      return (data != null ? _i30.DateTimeDefaultPersist.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i31.DateTimeDefaultModel?>()) {
-      return (data != null ? _i31.DateTimeDefaultModel.fromJson(data) : null)
+    if (t == _i1.getType<_i31.DoubleDefault?>()) {
+      return (data != null ? _i31.DoubleDefault.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i32.DoubleDefaultMix?>()) {
+      return (data != null ? _i32.DoubleDefaultMix.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i33.DoubleDefaultModel?>()) {
+      return (data != null ? _i33.DoubleDefaultModel.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i32.DateTimeDefaultPersist?>()) {
-      return (data != null ? _i32.DateTimeDefaultPersist.fromJson(data) : null)
+    if (t == _i1.getType<_i34.DoubleDefaultPersist?>()) {
+      return (data != null ? _i34.DoubleDefaultPersist.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i33.DoubleDefault?>()) {
-      return (data != null ? _i33.DoubleDefault.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i35.DurationDefault?>()) {
+      return (data != null ? _i35.DurationDefault.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i34.DoubleDefaultMix?>()) {
-      return (data != null ? _i34.DoubleDefaultMix.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i35.DoubleDefaultModel?>()) {
-      return (data != null ? _i35.DoubleDefaultModel.fromJson(data) : null)
+    if (t == _i1.getType<_i36.DurationDefaultMix?>()) {
+      return (data != null ? _i36.DurationDefaultMix.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i36.DoubleDefaultPersist?>()) {
-      return (data != null ? _i36.DoubleDefaultPersist.fromJson(data) : null)
+    if (t == _i1.getType<_i37.DurationDefaultModel?>()) {
+      return (data != null ? _i37.DurationDefaultModel.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i37.DurationDefault?>()) {
-      return (data != null ? _i37.DurationDefault.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i38.DurationDefaultMix?>()) {
-      return (data != null ? _i38.DurationDefaultMix.fromJson(data) : null)
+    if (t == _i1.getType<_i38.DurationDefaultPersist?>()) {
+      return (data != null ? _i38.DurationDefaultPersist.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i39.DurationDefaultModel?>()) {
-      return (data != null ? _i39.DurationDefaultModel.fromJson(data) : null)
+    if (t == _i1.getType<_i39.EnumDefault?>()) {
+      return (data != null ? _i39.EnumDefault.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i40.EnumDefaultMix?>()) {
+      return (data != null ? _i40.EnumDefaultMix.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i41.EnumDefaultModel?>()) {
+      return (data != null ? _i41.EnumDefaultModel.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i42.EnumDefaultPersist?>()) {
+      return (data != null ? _i42.EnumDefaultPersist.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i40.DurationDefaultPersist?>()) {
-      return (data != null ? _i40.DurationDefaultPersist.fromJson(data) : null)
+    if (t == _i1.getType<_i43.ByIndexEnum?>()) {
+      return (data != null ? _i43.ByIndexEnum.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i44.ByNameEnum?>()) {
+      return (data != null ? _i44.ByNameEnum.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i45.DefaultValueEnum?>()) {
+      return (data != null ? _i45.DefaultValueEnum.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i46.DefaultException?>()) {
+      return (data != null ? _i46.DefaultException.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i47.IntDefault?>()) {
+      return (data != null ? _i47.IntDefault.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i48.IntDefaultMix?>()) {
+      return (data != null ? _i48.IntDefaultMix.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i49.IntDefaultModel?>()) {
+      return (data != null ? _i49.IntDefaultModel.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i50.IntDefaultPersist?>()) {
+      return (data != null ? _i50.IntDefaultPersist.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i51.StringDefault?>()) {
+      return (data != null ? _i51.StringDefault.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i52.StringDefaultMix?>()) {
+      return (data != null ? _i52.StringDefaultMix.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i53.StringDefaultModel?>()) {
+      return (data != null ? _i53.StringDefaultModel.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i41.EnumDefault?>()) {
-      return (data != null ? _i41.EnumDefault.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i42.EnumDefaultMix?>()) {
-      return (data != null ? _i42.EnumDefaultMix.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i43.EnumDefaultModel?>()) {
-      return (data != null ? _i43.EnumDefaultModel.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i44.EnumDefaultPersist?>()) {
-      return (data != null ? _i44.EnumDefaultPersist.fromJson(data) : null)
+    if (t == _i1.getType<_i54.StringDefaultPersist?>()) {
+      return (data != null ? _i54.StringDefaultPersist.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i45.ByIndexEnum?>()) {
-      return (data != null ? _i45.ByIndexEnum.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i55.ByIndexEnumWithNameValue?>()) {
+      return (data != null
+          ? _i55.ByIndexEnumWithNameValue.fromJson(data)
+          : null) as T;
     }
-    if (t == _i1.getType<_i46.ByNameEnum?>()) {
-      return (data != null ? _i46.ByNameEnum.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i56.UriDefaultMix?>()) {
+      return (data != null ? _i56.UriDefaultMix.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i47.DefaultValueEnum?>()) {
-      return (data != null ? _i47.DefaultValueEnum.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i57.UriDefaultModel?>()) {
+      return (data != null ? _i57.UriDefaultModel.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i48.DefaultException?>()) {
-      return (data != null ? _i48.DefaultException.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i58.UriDefaultPersist?>()) {
+      return (data != null ? _i58.UriDefaultPersist.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i49.IntDefault?>()) {
-      return (data != null ? _i49.IntDefault.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i59.UuidDefault?>()) {
+      return (data != null ? _i59.UuidDefault.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i50.IntDefaultMix?>()) {
-      return (data != null ? _i50.IntDefaultMix.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i60.UuidDefaultMix?>()) {
+      return (data != null ? _i60.UuidDefaultMix.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i51.IntDefaultModel?>()) {
-      return (data != null ? _i51.IntDefaultModel.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i61.UuidDefaultModel?>()) {
+      return (data != null ? _i61.UuidDefaultModel.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i52.IntDefaultPersist?>()) {
-      return (data != null ? _i52.IntDefaultPersist.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i53.StringDefault?>()) {
-      return (data != null ? _i53.StringDefault.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i54.StringDefaultMix?>()) {
-      return (data != null ? _i54.StringDefaultMix.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i55.StringDefaultModel?>()) {
-      return (data != null ? _i55.StringDefaultModel.fromJson(data) : null)
+    if (t == _i1.getType<_i62.UuidDefaultPersist?>()) {
+      return (data != null ? _i62.UuidDefaultPersist.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i56.StringDefaultPersist?>()) {
-      return (data != null ? _i56.StringDefaultPersist.fromJson(data) : null)
+    if (t == _i1.getType<_i63.EmptyModel?>()) {
+      return (data != null ? _i63.EmptyModel.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i64.EmptyModelRelationItem?>()) {
+      return (data != null ? _i64.EmptyModelRelationItem.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i57.UriDefault?>()) {
-      return (data != null ? _i57.UriDefault.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i58.UriDefaultMix?>()) {
-      return (data != null ? _i58.UriDefaultMix.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i59.UriDefaultModel?>()) {
-      return (data != null ? _i59.UriDefaultModel.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i60.UriDefaultPersist?>()) {
-      return (data != null ? _i60.UriDefaultPersist.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i61.UuidDefault?>()) {
-      return (data != null ? _i61.UuidDefault.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i62.UuidDefaultMix?>()) {
-      return (data != null ? _i62.UuidDefaultMix.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i63.UuidDefaultModel?>()) {
-      return (data != null ? _i63.UuidDefaultModel.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i64.UuidDefaultPersist?>()) {
-      return (data != null ? _i64.UuidDefaultPersist.fromJson(data) : null)
+    if (t == _i1.getType<_i65.EmptyModelWithTable?>()) {
+      return (data != null ? _i65.EmptyModelWithTable.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i65.EmptyModel?>()) {
-      return (data != null ? _i65.EmptyModel.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i66.EmptyModelRelationItem?>()) {
-      return (data != null ? _i66.EmptyModelRelationItem.fromJson(data) : null)
+    if (t == _i1.getType<_i66.RelationEmptyModel?>()) {
+      return (data != null ? _i66.RelationEmptyModel.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i67.EmptyModelWithTable?>()) {
-      return (data != null ? _i67.EmptyModelWithTable.fromJson(data) : null)
+    if (t == _i1.getType<_i67.ExceptionWithData?>()) {
+      return (data != null ? _i67.ExceptionWithData.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i68.ByNameEnumWithNameValue?>()) {
+      return (data != null ? _i68.ByNameEnumWithNameValue.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i68.RelationEmptyModel?>()) {
-      return (data != null ? _i68.RelationEmptyModel.fromJson(data) : null)
-          as T;
+    if (t == _i1.getType<_i69.CourseUuid?>()) {
+      return (data != null ? _i69.CourseUuid.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i69.ExceptionWithData?>()) {
-      return (data != null ? _i69.ExceptionWithData.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i70.GrandparentClass?>()) {
+      return (data != null ? _i70.GrandparentClass.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i70.ChildClass?>()) {
-      return (data != null ? _i70.ChildClass.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i71.EnrollmentInt?>()) {
+      return (data != null ? _i71.EnrollmentInt.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i71.ChildWithDefault?>()) {
-      return (data != null ? _i71.ChildWithDefault.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i72.ParentWithDefault?>()) {
+      return (data != null ? _i72.ParentWithDefault.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i72.GrandparentClass?>()) {
-      return (data != null ? _i72.GrandparentClass.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i73.StudentUuid?>()) {
+      return (data != null ? _i73.StudentUuid.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i73.ParentClass?>()) {
-      return (data != null ? _i73.ParentClass.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i74.ArenaUuid?>()) {
+      return (data != null ? _i74.ArenaUuid.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i74.ParentWithDefault?>()) {
-      return (data != null ? _i74.ParentWithDefault.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i75.SealedChild?>()) {
-      return (data != null ? _i75.SealedChild.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i75.SealedGrandChild?>()) {
-      return (data != null ? _i75.SealedGrandChild.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i75.SealedOtherChild?>()) {
-      return (data != null ? _i75.SealedOtherChild.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i75.PlayerUuid?>()) {
+      return (data != null ? _i75.PlayerUuid.fromJson(data) : null) as T;
     }
     if (t == _i1.getType<_i76.CityWithLongTableName?>()) {
       return (data != null ? _i76.CityWithLongTableName.fromJson(data) : null)
@@ -7533,8 +7536,8 @@ class Protocol extends _i1.SerializationManagerServer {
     if (t == _i1.getType<_i104.Address?>()) {
       return (data != null ? _i104.Address.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i105.Citizen?>()) {
-      return (data != null ? _i105.Citizen.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i105.MyFeatureModel?>()) {
+      return (data != null ? _i105.MyFeatureModel.fromJson(data) : null) as T;
     }
     if (t == _i1.getType<_i106.Company?>()) {
       return (data != null ? _i106.Company.fromJson(data) : null) as T;
@@ -7630,10 +7633,8 @@ class Protocol extends _i1.SerializationManagerServer {
       return (data != null ? _i133.ScopeServerOnlyField.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i134.ScopeServerOnlyFieldChild?>()) {
-      return (data != null
-          ? _i134.ScopeServerOnlyFieldChild.fromJson(data)
-          : null) as T;
+    if (t == _i1.getType<_i134.TeamInt?>()) {
+      return (data != null ? _i134.TeamInt.fromJson(data) : null) as T;
     }
     if (t == _i1.getType<_i135.DefaultServerOnlyClass?>()) {
       return (data != null ? _i135.DefaultServerOnlyClass.fromJson(data) : null)
@@ -7707,54 +7708,49 @@ class Protocol extends _i1.SerializationManagerServer {
     if (t == _i1.getType<_i156.UniqueData?>()) {
       return (data != null ? _i156.UniqueData.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i157.MyFeatureModel?>()) {
-      return (data != null ? _i157.MyFeatureModel.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i157.Citizen?>()) {
+      return (data != null ? _i157.Citizen.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<List<_i8.EnrollmentInt>?>()) {
+    if (t == _i1.getType<List<_i13.OrderUuid>?>()) {
+      return (data != null
+          ? (data as List).map((e) => deserialize<_i13.OrderUuid>(e)).toList()
+          : null) as T;
+    }
+    if (t == _i1.getType<List<_i11.CommentInt>?>()) {
+      return (data != null
+          ? (data as List).map((e) => deserialize<_i11.CommentInt>(e)).toList()
+          : null) as T;
+    }
+    if (t == _i1.getType<List<_i18.ChangedIdTypeSelf>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i8.EnrollmentInt>(e))
+              .map((e) => deserialize<_i18.ChangedIdTypeSelf>(e))
               .toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i8.EnrollmentInt>?>()) {
+    if (t == _i1.getType<List<_i64.EmptyModelRelationItem>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i8.EnrollmentInt>(e))
-              .toList()
-          : null) as T;
-    }
-    if (t == _i1.getType<List<_i11.PlayerUuid>?>()) {
-      return (data != null
-          ? (data as List).map((e) => deserialize<_i11.PlayerUuid>(e)).toList()
-          : null) as T;
-    }
-    if (t == _i1.getType<List<_i15.OrderUuid>?>()) {
-      return (data != null
-          ? (data as List).map((e) => deserialize<_i15.OrderUuid>(e)).toList()
-          : null) as T;
-    }
-    if (t == _i1.getType<List<_i13.CommentInt>?>()) {
-      return (data != null
-          ? (data as List).map((e) => deserialize<_i13.CommentInt>(e)).toList()
-          : null) as T;
-    }
-    if (t == _i1.getType<List<_i20.ChangedIdTypeSelf>?>()) {
-      return (data != null
-          ? (data as List)
-              .map((e) => deserialize<_i20.ChangedIdTypeSelf>(e))
-              .toList()
-          : null) as T;
-    }
-    if (t == _i1.getType<List<_i66.EmptyModelRelationItem>?>()) {
-      return (data != null
-          ? (data as List)
-              .map((e) => deserialize<_i66.EmptyModelRelationItem>(e))
+              .map((e) => deserialize<_i64.EmptyModelRelationItem>(e))
               .toList()
           : null) as T;
     }
     if (t == List<String>) {
       return (data as List).map((e) => deserialize<String>(e)).toList() as T;
+    }
+    if (t == _i1.getType<List<_i71.EnrollmentInt>?>()) {
+      return (data != null
+          ? (data as List)
+              .map((e) => deserialize<_i71.EnrollmentInt>(e))
+              .toList()
+          : null) as T;
+    }
+    if (t == _i1.getType<List<_i71.EnrollmentInt>?>()) {
+      return (data != null
+          ? (data as List)
+              .map((e) => deserialize<_i71.EnrollmentInt>(e))
+              .toList()
+          : null) as T;
     }
     if (t == _i1.getType<List<_i78.PersonWithLongTableName>?>()) {
       return (data != null
@@ -8138,6 +8134,11 @@ class Protocol extends _i1.SerializationManagerServer {
       return (data == null)
           ? null as T
           : (deserialize<bool>(((data as Map)['p'] as List)[0]),) as T;
+    }
+    if (t == _i1.getType<List<_i75.PlayerUuid>?>()) {
+      return (data != null
+          ? (data as List).map((e) => deserialize<_i75.PlayerUuid>(e)).toList()
+          : null) as T;
     }
     if (t == _i1.getType<List<_i139.ServerOnlyClass>?>()) {
       return (data != null
@@ -10105,224 +10106,224 @@ class Protocol extends _i1.SerializationManagerServer {
     if (data is _i159.FreezedCustomClass) {
       return 'FreezedCustomClass';
     }
-    if (data is _i5.ByIndexEnumWithNameValue) {
-      return 'ByIndexEnumWithNameValue';
+    if (data is _i5.ScopeServerOnlyFieldChild) {
+      return 'ScopeServerOnlyFieldChild';
     }
-    if (data is _i6.ByNameEnumWithNameValue) {
-      return 'ByNameEnumWithNameValue';
-    }
-    if (data is _i7.CourseUuid) {
-      return 'CourseUuid';
-    }
-    if (data is _i8.EnrollmentInt) {
-      return 'EnrollmentInt';
-    }
-    if (data is _i9.StudentUuid) {
-      return 'StudentUuid';
-    }
-    if (data is _i10.ArenaUuid) {
-      return 'ArenaUuid';
-    }
-    if (data is _i11.PlayerUuid) {
-      return 'PlayerUuid';
-    }
-    if (data is _i12.TeamInt) {
-      return 'TeamInt';
-    }
-    if (data is _i13.CommentInt) {
-      return 'CommentInt';
-    }
-    if (data is _i14.CustomerInt) {
-      return 'CustomerInt';
-    }
-    if (data is _i15.OrderUuid) {
-      return 'OrderUuid';
-    }
-    if (data is _i16.AddressUuid) {
-      return 'AddressUuid';
-    }
-    if (data is _i17.CitizenInt) {
-      return 'CitizenInt';
-    }
-    if (data is _i18.CompanyUuid) {
-      return 'CompanyUuid';
-    }
-    if (data is _i19.TownInt) {
-      return 'TownInt';
-    }
-    if (data is _i20.ChangedIdTypeSelf) {
-      return 'ChangedIdTypeSelf';
-    }
-    if (data is _i21.BigIntDefault) {
-      return 'BigIntDefault';
-    }
-    if (data is _i22.BigIntDefaultMix) {
-      return 'BigIntDefaultMix';
-    }
-    if (data is _i23.BigIntDefaultModel) {
-      return 'BigIntDefaultModel';
-    }
-    if (data is _i24.BigIntDefaultPersist) {
-      return 'BigIntDefaultPersist';
-    }
-    if (data is _i25.BoolDefault) {
-      return 'BoolDefault';
-    }
-    if (data is _i26.BoolDefaultMix) {
-      return 'BoolDefaultMix';
-    }
-    if (data is _i27.BoolDefaultModel) {
-      return 'BoolDefaultModel';
-    }
-    if (data is _i28.BoolDefaultPersist) {
-      return 'BoolDefaultPersist';
-    }
-    if (data is _i29.DateTimeDefault) {
-      return 'DateTimeDefault';
-    }
-    if (data is _i30.DateTimeDefaultMix) {
-      return 'DateTimeDefaultMix';
-    }
-    if (data is _i31.DateTimeDefaultModel) {
-      return 'DateTimeDefaultModel';
-    }
-    if (data is _i32.DateTimeDefaultPersist) {
-      return 'DateTimeDefaultPersist';
-    }
-    if (data is _i33.DoubleDefault) {
-      return 'DoubleDefault';
-    }
-    if (data is _i34.DoubleDefaultMix) {
-      return 'DoubleDefaultMix';
-    }
-    if (data is _i35.DoubleDefaultModel) {
-      return 'DoubleDefaultModel';
-    }
-    if (data is _i36.DoubleDefaultPersist) {
-      return 'DoubleDefaultPersist';
-    }
-    if (data is _i37.DurationDefault) {
-      return 'DurationDefault';
-    }
-    if (data is _i38.DurationDefaultMix) {
-      return 'DurationDefaultMix';
-    }
-    if (data is _i39.DurationDefaultModel) {
-      return 'DurationDefaultModel';
-    }
-    if (data is _i40.DurationDefaultPersist) {
-      return 'DurationDefaultPersist';
-    }
-    if (data is _i41.EnumDefault) {
-      return 'EnumDefault';
-    }
-    if (data is _i42.EnumDefaultMix) {
-      return 'EnumDefaultMix';
-    }
-    if (data is _i43.EnumDefaultModel) {
-      return 'EnumDefaultModel';
-    }
-    if (data is _i44.EnumDefaultPersist) {
-      return 'EnumDefaultPersist';
-    }
-    if (data is _i45.ByIndexEnum) {
-      return 'ByIndexEnum';
-    }
-    if (data is _i46.ByNameEnum) {
-      return 'ByNameEnum';
-    }
-    if (data is _i47.DefaultValueEnum) {
-      return 'DefaultValueEnum';
-    }
-    if (data is _i48.DefaultException) {
-      return 'DefaultException';
-    }
-    if (data is _i49.IntDefault) {
-      return 'IntDefault';
-    }
-    if (data is _i50.IntDefaultMix) {
-      return 'IntDefaultMix';
-    }
-    if (data is _i51.IntDefaultModel) {
-      return 'IntDefaultModel';
-    }
-    if (data is _i52.IntDefaultPersist) {
-      return 'IntDefaultPersist';
-    }
-    if (data is _i53.StringDefault) {
-      return 'StringDefault';
-    }
-    if (data is _i54.StringDefaultMix) {
-      return 'StringDefaultMix';
-    }
-    if (data is _i55.StringDefaultModel) {
-      return 'StringDefaultModel';
-    }
-    if (data is _i56.StringDefaultPersist) {
-      return 'StringDefaultPersist';
-    }
-    if (data is _i57.UriDefault) {
-      return 'UriDefault';
-    }
-    if (data is _i58.UriDefaultMix) {
-      return 'UriDefaultMix';
-    }
-    if (data is _i59.UriDefaultModel) {
-      return 'UriDefaultModel';
-    }
-    if (data is _i60.UriDefaultPersist) {
-      return 'UriDefaultPersist';
-    }
-    if (data is _i61.UuidDefault) {
-      return 'UuidDefault';
-    }
-    if (data is _i62.UuidDefaultMix) {
-      return 'UuidDefaultMix';
-    }
-    if (data is _i63.UuidDefaultModel) {
-      return 'UuidDefaultModel';
-    }
-    if (data is _i64.UuidDefaultPersist) {
-      return 'UuidDefaultPersist';
-    }
-    if (data is _i65.EmptyModel) {
-      return 'EmptyModel';
-    }
-    if (data is _i66.EmptyModelRelationItem) {
-      return 'EmptyModelRelationItem';
-    }
-    if (data is _i67.EmptyModelWithTable) {
-      return 'EmptyModelWithTable';
-    }
-    if (data is _i68.RelationEmptyModel) {
-      return 'RelationEmptyModel';
-    }
-    if (data is _i69.ExceptionWithData) {
-      return 'ExceptionWithData';
-    }
-    if (data is _i70.ChildClass) {
+    if (data is _i6.ChildClass) {
       return 'ChildClass';
     }
-    if (data is _i71.ChildWithDefault) {
+    if (data is _i7.ChildWithDefault) {
       return 'ChildWithDefault';
     }
-    if (data is _i72.GrandparentClass) {
-      return 'GrandparentClass';
-    }
-    if (data is _i73.ParentClass) {
+    if (data is _i8.ParentClass) {
       return 'ParentClass';
     }
-    if (data is _i74.ParentWithDefault) {
-      return 'ParentWithDefault';
-    }
-    if (data is _i75.SealedChild) {
-      return 'SealedChild';
-    }
-    if (data is _i75.SealedGrandChild) {
+    if (data is _i9.SealedGrandChild) {
       return 'SealedGrandChild';
     }
-    if (data is _i75.SealedOtherChild) {
+    if (data is _i9.SealedChild) {
+      return 'SealedChild';
+    }
+    if (data is _i9.SealedOtherChild) {
       return 'SealedOtherChild';
+    }
+    if (data is _i10.UriDefault) {
+      return 'UriDefault';
+    }
+    if (data is _i11.CommentInt) {
+      return 'CommentInt';
+    }
+    if (data is _i12.CustomerInt) {
+      return 'CustomerInt';
+    }
+    if (data is _i13.OrderUuid) {
+      return 'OrderUuid';
+    }
+    if (data is _i14.AddressUuid) {
+      return 'AddressUuid';
+    }
+    if (data is _i15.CitizenInt) {
+      return 'CitizenInt';
+    }
+    if (data is _i16.CompanyUuid) {
+      return 'CompanyUuid';
+    }
+    if (data is _i17.TownInt) {
+      return 'TownInt';
+    }
+    if (data is _i18.ChangedIdTypeSelf) {
+      return 'ChangedIdTypeSelf';
+    }
+    if (data is _i19.BigIntDefault) {
+      return 'BigIntDefault';
+    }
+    if (data is _i20.BigIntDefaultMix) {
+      return 'BigIntDefaultMix';
+    }
+    if (data is _i21.BigIntDefaultModel) {
+      return 'BigIntDefaultModel';
+    }
+    if (data is _i22.BigIntDefaultPersist) {
+      return 'BigIntDefaultPersist';
+    }
+    if (data is _i23.BoolDefault) {
+      return 'BoolDefault';
+    }
+    if (data is _i24.BoolDefaultMix) {
+      return 'BoolDefaultMix';
+    }
+    if (data is _i25.BoolDefaultModel) {
+      return 'BoolDefaultModel';
+    }
+    if (data is _i26.BoolDefaultPersist) {
+      return 'BoolDefaultPersist';
+    }
+    if (data is _i27.DateTimeDefault) {
+      return 'DateTimeDefault';
+    }
+    if (data is _i28.DateTimeDefaultMix) {
+      return 'DateTimeDefaultMix';
+    }
+    if (data is _i29.DateTimeDefaultModel) {
+      return 'DateTimeDefaultModel';
+    }
+    if (data is _i30.DateTimeDefaultPersist) {
+      return 'DateTimeDefaultPersist';
+    }
+    if (data is _i31.DoubleDefault) {
+      return 'DoubleDefault';
+    }
+    if (data is _i32.DoubleDefaultMix) {
+      return 'DoubleDefaultMix';
+    }
+    if (data is _i33.DoubleDefaultModel) {
+      return 'DoubleDefaultModel';
+    }
+    if (data is _i34.DoubleDefaultPersist) {
+      return 'DoubleDefaultPersist';
+    }
+    if (data is _i35.DurationDefault) {
+      return 'DurationDefault';
+    }
+    if (data is _i36.DurationDefaultMix) {
+      return 'DurationDefaultMix';
+    }
+    if (data is _i37.DurationDefaultModel) {
+      return 'DurationDefaultModel';
+    }
+    if (data is _i38.DurationDefaultPersist) {
+      return 'DurationDefaultPersist';
+    }
+    if (data is _i39.EnumDefault) {
+      return 'EnumDefault';
+    }
+    if (data is _i40.EnumDefaultMix) {
+      return 'EnumDefaultMix';
+    }
+    if (data is _i41.EnumDefaultModel) {
+      return 'EnumDefaultModel';
+    }
+    if (data is _i42.EnumDefaultPersist) {
+      return 'EnumDefaultPersist';
+    }
+    if (data is _i43.ByIndexEnum) {
+      return 'ByIndexEnum';
+    }
+    if (data is _i44.ByNameEnum) {
+      return 'ByNameEnum';
+    }
+    if (data is _i45.DefaultValueEnum) {
+      return 'DefaultValueEnum';
+    }
+    if (data is _i46.DefaultException) {
+      return 'DefaultException';
+    }
+    if (data is _i47.IntDefault) {
+      return 'IntDefault';
+    }
+    if (data is _i48.IntDefaultMix) {
+      return 'IntDefaultMix';
+    }
+    if (data is _i49.IntDefaultModel) {
+      return 'IntDefaultModel';
+    }
+    if (data is _i50.IntDefaultPersist) {
+      return 'IntDefaultPersist';
+    }
+    if (data is _i51.StringDefault) {
+      return 'StringDefault';
+    }
+    if (data is _i52.StringDefaultMix) {
+      return 'StringDefaultMix';
+    }
+    if (data is _i53.StringDefaultModel) {
+      return 'StringDefaultModel';
+    }
+    if (data is _i54.StringDefaultPersist) {
+      return 'StringDefaultPersist';
+    }
+    if (data is _i55.ByIndexEnumWithNameValue) {
+      return 'ByIndexEnumWithNameValue';
+    }
+    if (data is _i56.UriDefaultMix) {
+      return 'UriDefaultMix';
+    }
+    if (data is _i57.UriDefaultModel) {
+      return 'UriDefaultModel';
+    }
+    if (data is _i58.UriDefaultPersist) {
+      return 'UriDefaultPersist';
+    }
+    if (data is _i59.UuidDefault) {
+      return 'UuidDefault';
+    }
+    if (data is _i60.UuidDefaultMix) {
+      return 'UuidDefaultMix';
+    }
+    if (data is _i61.UuidDefaultModel) {
+      return 'UuidDefaultModel';
+    }
+    if (data is _i62.UuidDefaultPersist) {
+      return 'UuidDefaultPersist';
+    }
+    if (data is _i63.EmptyModel) {
+      return 'EmptyModel';
+    }
+    if (data is _i64.EmptyModelRelationItem) {
+      return 'EmptyModelRelationItem';
+    }
+    if (data is _i65.EmptyModelWithTable) {
+      return 'EmptyModelWithTable';
+    }
+    if (data is _i66.RelationEmptyModel) {
+      return 'RelationEmptyModel';
+    }
+    if (data is _i67.ExceptionWithData) {
+      return 'ExceptionWithData';
+    }
+    if (data is _i68.ByNameEnumWithNameValue) {
+      return 'ByNameEnumWithNameValue';
+    }
+    if (data is _i69.CourseUuid) {
+      return 'CourseUuid';
+    }
+    if (data is _i70.GrandparentClass) {
+      return 'GrandparentClass';
+    }
+    if (data is _i71.EnrollmentInt) {
+      return 'EnrollmentInt';
+    }
+    if (data is _i72.ParentWithDefault) {
+      return 'ParentWithDefault';
+    }
+    if (data is _i73.StudentUuid) {
+      return 'StudentUuid';
+    }
+    if (data is _i74.ArenaUuid) {
+      return 'ArenaUuid';
+    }
+    if (data is _i75.PlayerUuid) {
+      return 'PlayerUuid';
     }
     if (data is _i76.CityWithLongTableName) {
       return 'CityWithLongTableName';
@@ -10411,8 +10412,8 @@ class Protocol extends _i1.SerializationManagerServer {
     if (data is _i104.Address) {
       return 'Address';
     }
-    if (data is _i105.Citizen) {
-      return 'Citizen';
+    if (data is _i105.MyFeatureModel) {
+      return 'MyFeatureModel';
     }
     if (data is _i106.Company) {
       return 'Company';
@@ -10498,8 +10499,8 @@ class Protocol extends _i1.SerializationManagerServer {
     if (data is _i133.ScopeServerOnlyField) {
       return 'ScopeServerOnlyField';
     }
-    if (data is _i134.ScopeServerOnlyFieldChild) {
-      return 'ScopeServerOnlyFieldChild';
+    if (data is _i134.TeamInt) {
+      return 'TeamInt';
     }
     if (data is _i135.DefaultServerOnlyClass) {
       return 'DefaultServerOnlyClass';
@@ -10567,8 +10568,8 @@ class Protocol extends _i1.SerializationManagerServer {
     if (data is _i156.UniqueData) {
       return 'UniqueData';
     }
-    if (data is _i157.MyFeatureModel) {
-      return 'MyFeatureModel';
+    if (data is _i157.Citizen) {
+      return 'Citizen';
     }
     className = _i2.Protocol().getClassNameForObject(data);
     if (className != null) {
@@ -10667,224 +10668,224 @@ class Protocol extends _i1.SerializationManagerServer {
     if (dataClassName == 'FreezedCustomClass') {
       return deserialize<_i159.FreezedCustomClass>(data['data']);
     }
-    if (dataClassName == 'ByIndexEnumWithNameValue') {
-      return deserialize<_i5.ByIndexEnumWithNameValue>(data['data']);
-    }
-    if (dataClassName == 'ByNameEnumWithNameValue') {
-      return deserialize<_i6.ByNameEnumWithNameValue>(data['data']);
-    }
-    if (dataClassName == 'CourseUuid') {
-      return deserialize<_i7.CourseUuid>(data['data']);
-    }
-    if (dataClassName == 'EnrollmentInt') {
-      return deserialize<_i8.EnrollmentInt>(data['data']);
-    }
-    if (dataClassName == 'StudentUuid') {
-      return deserialize<_i9.StudentUuid>(data['data']);
-    }
-    if (dataClassName == 'ArenaUuid') {
-      return deserialize<_i10.ArenaUuid>(data['data']);
-    }
-    if (dataClassName == 'PlayerUuid') {
-      return deserialize<_i11.PlayerUuid>(data['data']);
-    }
-    if (dataClassName == 'TeamInt') {
-      return deserialize<_i12.TeamInt>(data['data']);
-    }
-    if (dataClassName == 'CommentInt') {
-      return deserialize<_i13.CommentInt>(data['data']);
-    }
-    if (dataClassName == 'CustomerInt') {
-      return deserialize<_i14.CustomerInt>(data['data']);
-    }
-    if (dataClassName == 'OrderUuid') {
-      return deserialize<_i15.OrderUuid>(data['data']);
-    }
-    if (dataClassName == 'AddressUuid') {
-      return deserialize<_i16.AddressUuid>(data['data']);
-    }
-    if (dataClassName == 'CitizenInt') {
-      return deserialize<_i17.CitizenInt>(data['data']);
-    }
-    if (dataClassName == 'CompanyUuid') {
-      return deserialize<_i18.CompanyUuid>(data['data']);
-    }
-    if (dataClassName == 'TownInt') {
-      return deserialize<_i19.TownInt>(data['data']);
-    }
-    if (dataClassName == 'ChangedIdTypeSelf') {
-      return deserialize<_i20.ChangedIdTypeSelf>(data['data']);
-    }
-    if (dataClassName == 'BigIntDefault') {
-      return deserialize<_i21.BigIntDefault>(data['data']);
-    }
-    if (dataClassName == 'BigIntDefaultMix') {
-      return deserialize<_i22.BigIntDefaultMix>(data['data']);
-    }
-    if (dataClassName == 'BigIntDefaultModel') {
-      return deserialize<_i23.BigIntDefaultModel>(data['data']);
-    }
-    if (dataClassName == 'BigIntDefaultPersist') {
-      return deserialize<_i24.BigIntDefaultPersist>(data['data']);
-    }
-    if (dataClassName == 'BoolDefault') {
-      return deserialize<_i25.BoolDefault>(data['data']);
-    }
-    if (dataClassName == 'BoolDefaultMix') {
-      return deserialize<_i26.BoolDefaultMix>(data['data']);
-    }
-    if (dataClassName == 'BoolDefaultModel') {
-      return deserialize<_i27.BoolDefaultModel>(data['data']);
-    }
-    if (dataClassName == 'BoolDefaultPersist') {
-      return deserialize<_i28.BoolDefaultPersist>(data['data']);
-    }
-    if (dataClassName == 'DateTimeDefault') {
-      return deserialize<_i29.DateTimeDefault>(data['data']);
-    }
-    if (dataClassName == 'DateTimeDefaultMix') {
-      return deserialize<_i30.DateTimeDefaultMix>(data['data']);
-    }
-    if (dataClassName == 'DateTimeDefaultModel') {
-      return deserialize<_i31.DateTimeDefaultModel>(data['data']);
-    }
-    if (dataClassName == 'DateTimeDefaultPersist') {
-      return deserialize<_i32.DateTimeDefaultPersist>(data['data']);
-    }
-    if (dataClassName == 'DoubleDefault') {
-      return deserialize<_i33.DoubleDefault>(data['data']);
-    }
-    if (dataClassName == 'DoubleDefaultMix') {
-      return deserialize<_i34.DoubleDefaultMix>(data['data']);
-    }
-    if (dataClassName == 'DoubleDefaultModel') {
-      return deserialize<_i35.DoubleDefaultModel>(data['data']);
-    }
-    if (dataClassName == 'DoubleDefaultPersist') {
-      return deserialize<_i36.DoubleDefaultPersist>(data['data']);
-    }
-    if (dataClassName == 'DurationDefault') {
-      return deserialize<_i37.DurationDefault>(data['data']);
-    }
-    if (dataClassName == 'DurationDefaultMix') {
-      return deserialize<_i38.DurationDefaultMix>(data['data']);
-    }
-    if (dataClassName == 'DurationDefaultModel') {
-      return deserialize<_i39.DurationDefaultModel>(data['data']);
-    }
-    if (dataClassName == 'DurationDefaultPersist') {
-      return deserialize<_i40.DurationDefaultPersist>(data['data']);
-    }
-    if (dataClassName == 'EnumDefault') {
-      return deserialize<_i41.EnumDefault>(data['data']);
-    }
-    if (dataClassName == 'EnumDefaultMix') {
-      return deserialize<_i42.EnumDefaultMix>(data['data']);
-    }
-    if (dataClassName == 'EnumDefaultModel') {
-      return deserialize<_i43.EnumDefaultModel>(data['data']);
-    }
-    if (dataClassName == 'EnumDefaultPersist') {
-      return deserialize<_i44.EnumDefaultPersist>(data['data']);
-    }
-    if (dataClassName == 'ByIndexEnum') {
-      return deserialize<_i45.ByIndexEnum>(data['data']);
-    }
-    if (dataClassName == 'ByNameEnum') {
-      return deserialize<_i46.ByNameEnum>(data['data']);
-    }
-    if (dataClassName == 'DefaultValueEnum') {
-      return deserialize<_i47.DefaultValueEnum>(data['data']);
-    }
-    if (dataClassName == 'DefaultException') {
-      return deserialize<_i48.DefaultException>(data['data']);
-    }
-    if (dataClassName == 'IntDefault') {
-      return deserialize<_i49.IntDefault>(data['data']);
-    }
-    if (dataClassName == 'IntDefaultMix') {
-      return deserialize<_i50.IntDefaultMix>(data['data']);
-    }
-    if (dataClassName == 'IntDefaultModel') {
-      return deserialize<_i51.IntDefaultModel>(data['data']);
-    }
-    if (dataClassName == 'IntDefaultPersist') {
-      return deserialize<_i52.IntDefaultPersist>(data['data']);
-    }
-    if (dataClassName == 'StringDefault') {
-      return deserialize<_i53.StringDefault>(data['data']);
-    }
-    if (dataClassName == 'StringDefaultMix') {
-      return deserialize<_i54.StringDefaultMix>(data['data']);
-    }
-    if (dataClassName == 'StringDefaultModel') {
-      return deserialize<_i55.StringDefaultModel>(data['data']);
-    }
-    if (dataClassName == 'StringDefaultPersist') {
-      return deserialize<_i56.StringDefaultPersist>(data['data']);
-    }
-    if (dataClassName == 'UriDefault') {
-      return deserialize<_i57.UriDefault>(data['data']);
-    }
-    if (dataClassName == 'UriDefaultMix') {
-      return deserialize<_i58.UriDefaultMix>(data['data']);
-    }
-    if (dataClassName == 'UriDefaultModel') {
-      return deserialize<_i59.UriDefaultModel>(data['data']);
-    }
-    if (dataClassName == 'UriDefaultPersist') {
-      return deserialize<_i60.UriDefaultPersist>(data['data']);
-    }
-    if (dataClassName == 'UuidDefault') {
-      return deserialize<_i61.UuidDefault>(data['data']);
-    }
-    if (dataClassName == 'UuidDefaultMix') {
-      return deserialize<_i62.UuidDefaultMix>(data['data']);
-    }
-    if (dataClassName == 'UuidDefaultModel') {
-      return deserialize<_i63.UuidDefaultModel>(data['data']);
-    }
-    if (dataClassName == 'UuidDefaultPersist') {
-      return deserialize<_i64.UuidDefaultPersist>(data['data']);
-    }
-    if (dataClassName == 'EmptyModel') {
-      return deserialize<_i65.EmptyModel>(data['data']);
-    }
-    if (dataClassName == 'EmptyModelRelationItem') {
-      return deserialize<_i66.EmptyModelRelationItem>(data['data']);
-    }
-    if (dataClassName == 'EmptyModelWithTable') {
-      return deserialize<_i67.EmptyModelWithTable>(data['data']);
-    }
-    if (dataClassName == 'RelationEmptyModel') {
-      return deserialize<_i68.RelationEmptyModel>(data['data']);
-    }
-    if (dataClassName == 'ExceptionWithData') {
-      return deserialize<_i69.ExceptionWithData>(data['data']);
+    if (dataClassName == 'ScopeServerOnlyFieldChild') {
+      return deserialize<_i5.ScopeServerOnlyFieldChild>(data['data']);
     }
     if (dataClassName == 'ChildClass') {
-      return deserialize<_i70.ChildClass>(data['data']);
+      return deserialize<_i6.ChildClass>(data['data']);
     }
     if (dataClassName == 'ChildWithDefault') {
-      return deserialize<_i71.ChildWithDefault>(data['data']);
-    }
-    if (dataClassName == 'GrandparentClass') {
-      return deserialize<_i72.GrandparentClass>(data['data']);
+      return deserialize<_i7.ChildWithDefault>(data['data']);
     }
     if (dataClassName == 'ParentClass') {
-      return deserialize<_i73.ParentClass>(data['data']);
-    }
-    if (dataClassName == 'ParentWithDefault') {
-      return deserialize<_i74.ParentWithDefault>(data['data']);
-    }
-    if (dataClassName == 'SealedChild') {
-      return deserialize<_i75.SealedChild>(data['data']);
+      return deserialize<_i8.ParentClass>(data['data']);
     }
     if (dataClassName == 'SealedGrandChild') {
-      return deserialize<_i75.SealedGrandChild>(data['data']);
+      return deserialize<_i9.SealedGrandChild>(data['data']);
+    }
+    if (dataClassName == 'SealedChild') {
+      return deserialize<_i9.SealedChild>(data['data']);
     }
     if (dataClassName == 'SealedOtherChild') {
-      return deserialize<_i75.SealedOtherChild>(data['data']);
+      return deserialize<_i9.SealedOtherChild>(data['data']);
+    }
+    if (dataClassName == 'UriDefault') {
+      return deserialize<_i10.UriDefault>(data['data']);
+    }
+    if (dataClassName == 'CommentInt') {
+      return deserialize<_i11.CommentInt>(data['data']);
+    }
+    if (dataClassName == 'CustomerInt') {
+      return deserialize<_i12.CustomerInt>(data['data']);
+    }
+    if (dataClassName == 'OrderUuid') {
+      return deserialize<_i13.OrderUuid>(data['data']);
+    }
+    if (dataClassName == 'AddressUuid') {
+      return deserialize<_i14.AddressUuid>(data['data']);
+    }
+    if (dataClassName == 'CitizenInt') {
+      return deserialize<_i15.CitizenInt>(data['data']);
+    }
+    if (dataClassName == 'CompanyUuid') {
+      return deserialize<_i16.CompanyUuid>(data['data']);
+    }
+    if (dataClassName == 'TownInt') {
+      return deserialize<_i17.TownInt>(data['data']);
+    }
+    if (dataClassName == 'ChangedIdTypeSelf') {
+      return deserialize<_i18.ChangedIdTypeSelf>(data['data']);
+    }
+    if (dataClassName == 'BigIntDefault') {
+      return deserialize<_i19.BigIntDefault>(data['data']);
+    }
+    if (dataClassName == 'BigIntDefaultMix') {
+      return deserialize<_i20.BigIntDefaultMix>(data['data']);
+    }
+    if (dataClassName == 'BigIntDefaultModel') {
+      return deserialize<_i21.BigIntDefaultModel>(data['data']);
+    }
+    if (dataClassName == 'BigIntDefaultPersist') {
+      return deserialize<_i22.BigIntDefaultPersist>(data['data']);
+    }
+    if (dataClassName == 'BoolDefault') {
+      return deserialize<_i23.BoolDefault>(data['data']);
+    }
+    if (dataClassName == 'BoolDefaultMix') {
+      return deserialize<_i24.BoolDefaultMix>(data['data']);
+    }
+    if (dataClassName == 'BoolDefaultModel') {
+      return deserialize<_i25.BoolDefaultModel>(data['data']);
+    }
+    if (dataClassName == 'BoolDefaultPersist') {
+      return deserialize<_i26.BoolDefaultPersist>(data['data']);
+    }
+    if (dataClassName == 'DateTimeDefault') {
+      return deserialize<_i27.DateTimeDefault>(data['data']);
+    }
+    if (dataClassName == 'DateTimeDefaultMix') {
+      return deserialize<_i28.DateTimeDefaultMix>(data['data']);
+    }
+    if (dataClassName == 'DateTimeDefaultModel') {
+      return deserialize<_i29.DateTimeDefaultModel>(data['data']);
+    }
+    if (dataClassName == 'DateTimeDefaultPersist') {
+      return deserialize<_i30.DateTimeDefaultPersist>(data['data']);
+    }
+    if (dataClassName == 'DoubleDefault') {
+      return deserialize<_i31.DoubleDefault>(data['data']);
+    }
+    if (dataClassName == 'DoubleDefaultMix') {
+      return deserialize<_i32.DoubleDefaultMix>(data['data']);
+    }
+    if (dataClassName == 'DoubleDefaultModel') {
+      return deserialize<_i33.DoubleDefaultModel>(data['data']);
+    }
+    if (dataClassName == 'DoubleDefaultPersist') {
+      return deserialize<_i34.DoubleDefaultPersist>(data['data']);
+    }
+    if (dataClassName == 'DurationDefault') {
+      return deserialize<_i35.DurationDefault>(data['data']);
+    }
+    if (dataClassName == 'DurationDefaultMix') {
+      return deserialize<_i36.DurationDefaultMix>(data['data']);
+    }
+    if (dataClassName == 'DurationDefaultModel') {
+      return deserialize<_i37.DurationDefaultModel>(data['data']);
+    }
+    if (dataClassName == 'DurationDefaultPersist') {
+      return deserialize<_i38.DurationDefaultPersist>(data['data']);
+    }
+    if (dataClassName == 'EnumDefault') {
+      return deserialize<_i39.EnumDefault>(data['data']);
+    }
+    if (dataClassName == 'EnumDefaultMix') {
+      return deserialize<_i40.EnumDefaultMix>(data['data']);
+    }
+    if (dataClassName == 'EnumDefaultModel') {
+      return deserialize<_i41.EnumDefaultModel>(data['data']);
+    }
+    if (dataClassName == 'EnumDefaultPersist') {
+      return deserialize<_i42.EnumDefaultPersist>(data['data']);
+    }
+    if (dataClassName == 'ByIndexEnum') {
+      return deserialize<_i43.ByIndexEnum>(data['data']);
+    }
+    if (dataClassName == 'ByNameEnum') {
+      return deserialize<_i44.ByNameEnum>(data['data']);
+    }
+    if (dataClassName == 'DefaultValueEnum') {
+      return deserialize<_i45.DefaultValueEnum>(data['data']);
+    }
+    if (dataClassName == 'DefaultException') {
+      return deserialize<_i46.DefaultException>(data['data']);
+    }
+    if (dataClassName == 'IntDefault') {
+      return deserialize<_i47.IntDefault>(data['data']);
+    }
+    if (dataClassName == 'IntDefaultMix') {
+      return deserialize<_i48.IntDefaultMix>(data['data']);
+    }
+    if (dataClassName == 'IntDefaultModel') {
+      return deserialize<_i49.IntDefaultModel>(data['data']);
+    }
+    if (dataClassName == 'IntDefaultPersist') {
+      return deserialize<_i50.IntDefaultPersist>(data['data']);
+    }
+    if (dataClassName == 'StringDefault') {
+      return deserialize<_i51.StringDefault>(data['data']);
+    }
+    if (dataClassName == 'StringDefaultMix') {
+      return deserialize<_i52.StringDefaultMix>(data['data']);
+    }
+    if (dataClassName == 'StringDefaultModel') {
+      return deserialize<_i53.StringDefaultModel>(data['data']);
+    }
+    if (dataClassName == 'StringDefaultPersist') {
+      return deserialize<_i54.StringDefaultPersist>(data['data']);
+    }
+    if (dataClassName == 'ByIndexEnumWithNameValue') {
+      return deserialize<_i55.ByIndexEnumWithNameValue>(data['data']);
+    }
+    if (dataClassName == 'UriDefaultMix') {
+      return deserialize<_i56.UriDefaultMix>(data['data']);
+    }
+    if (dataClassName == 'UriDefaultModel') {
+      return deserialize<_i57.UriDefaultModel>(data['data']);
+    }
+    if (dataClassName == 'UriDefaultPersist') {
+      return deserialize<_i58.UriDefaultPersist>(data['data']);
+    }
+    if (dataClassName == 'UuidDefault') {
+      return deserialize<_i59.UuidDefault>(data['data']);
+    }
+    if (dataClassName == 'UuidDefaultMix') {
+      return deserialize<_i60.UuidDefaultMix>(data['data']);
+    }
+    if (dataClassName == 'UuidDefaultModel') {
+      return deserialize<_i61.UuidDefaultModel>(data['data']);
+    }
+    if (dataClassName == 'UuidDefaultPersist') {
+      return deserialize<_i62.UuidDefaultPersist>(data['data']);
+    }
+    if (dataClassName == 'EmptyModel') {
+      return deserialize<_i63.EmptyModel>(data['data']);
+    }
+    if (dataClassName == 'EmptyModelRelationItem') {
+      return deserialize<_i64.EmptyModelRelationItem>(data['data']);
+    }
+    if (dataClassName == 'EmptyModelWithTable') {
+      return deserialize<_i65.EmptyModelWithTable>(data['data']);
+    }
+    if (dataClassName == 'RelationEmptyModel') {
+      return deserialize<_i66.RelationEmptyModel>(data['data']);
+    }
+    if (dataClassName == 'ExceptionWithData') {
+      return deserialize<_i67.ExceptionWithData>(data['data']);
+    }
+    if (dataClassName == 'ByNameEnumWithNameValue') {
+      return deserialize<_i68.ByNameEnumWithNameValue>(data['data']);
+    }
+    if (dataClassName == 'CourseUuid') {
+      return deserialize<_i69.CourseUuid>(data['data']);
+    }
+    if (dataClassName == 'GrandparentClass') {
+      return deserialize<_i70.GrandparentClass>(data['data']);
+    }
+    if (dataClassName == 'EnrollmentInt') {
+      return deserialize<_i71.EnrollmentInt>(data['data']);
+    }
+    if (dataClassName == 'ParentWithDefault') {
+      return deserialize<_i72.ParentWithDefault>(data['data']);
+    }
+    if (dataClassName == 'StudentUuid') {
+      return deserialize<_i73.StudentUuid>(data['data']);
+    }
+    if (dataClassName == 'ArenaUuid') {
+      return deserialize<_i74.ArenaUuid>(data['data']);
+    }
+    if (dataClassName == 'PlayerUuid') {
+      return deserialize<_i75.PlayerUuid>(data['data']);
     }
     if (dataClassName == 'CityWithLongTableName') {
       return deserialize<_i76.CityWithLongTableName>(data['data']);
@@ -10973,8 +10974,8 @@ class Protocol extends _i1.SerializationManagerServer {
     if (dataClassName == 'Address') {
       return deserialize<_i104.Address>(data['data']);
     }
-    if (dataClassName == 'Citizen') {
-      return deserialize<_i105.Citizen>(data['data']);
+    if (dataClassName == 'MyFeatureModel') {
+      return deserialize<_i105.MyFeatureModel>(data['data']);
     }
     if (dataClassName == 'Company') {
       return deserialize<_i106.Company>(data['data']);
@@ -11060,8 +11061,8 @@ class Protocol extends _i1.SerializationManagerServer {
     if (dataClassName == 'ScopeServerOnlyField') {
       return deserialize<_i133.ScopeServerOnlyField>(data['data']);
     }
-    if (dataClassName == 'ScopeServerOnlyFieldChild') {
-      return deserialize<_i134.ScopeServerOnlyFieldChild>(data['data']);
+    if (dataClassName == 'TeamInt') {
+      return deserialize<_i134.TeamInt>(data['data']);
     }
     if (dataClassName == 'DefaultServerOnlyClass') {
       return deserialize<_i135.DefaultServerOnlyClass>(data['data']);
@@ -11129,8 +11130,8 @@ class Protocol extends _i1.SerializationManagerServer {
     if (dataClassName == 'UniqueData') {
       return deserialize<_i156.UniqueData>(data['data']);
     }
-    if (dataClassName == 'MyFeatureModel') {
-      return deserialize<_i157.MyFeatureModel>(data['data']);
+    if (dataClassName == 'Citizen') {
+      return deserialize<_i157.Citizen>(data['data']);
     }
     if (dataClassName.startsWith('serverpod.')) {
       data['className'] = dataClassName.substring(10);
@@ -11226,122 +11227,122 @@ class Protocol extends _i1.SerializationManagerServer {
       }
     }
     switch (t) {
-      case _i7.CourseUuid:
-        return _i7.CourseUuid.t;
-      case _i8.EnrollmentInt:
-        return _i8.EnrollmentInt.t;
-      case _i9.StudentUuid:
-        return _i9.StudentUuid.t;
-      case _i10.ArenaUuid:
-        return _i10.ArenaUuid.t;
-      case _i11.PlayerUuid:
-        return _i11.PlayerUuid.t;
-      case _i12.TeamInt:
-        return _i12.TeamInt.t;
-      case _i13.CommentInt:
-        return _i13.CommentInt.t;
-      case _i14.CustomerInt:
-        return _i14.CustomerInt.t;
-      case _i15.OrderUuid:
-        return _i15.OrderUuid.t;
-      case _i16.AddressUuid:
-        return _i16.AddressUuid.t;
-      case _i17.CitizenInt:
-        return _i17.CitizenInt.t;
-      case _i18.CompanyUuid:
-        return _i18.CompanyUuid.t;
-      case _i19.TownInt:
-        return _i19.TownInt.t;
-      case _i20.ChangedIdTypeSelf:
-        return _i20.ChangedIdTypeSelf.t;
-      case _i21.BigIntDefault:
-        return _i21.BigIntDefault.t;
-      case _i22.BigIntDefaultMix:
-        return _i22.BigIntDefaultMix.t;
-      case _i23.BigIntDefaultModel:
-        return _i23.BigIntDefaultModel.t;
-      case _i24.BigIntDefaultPersist:
-        return _i24.BigIntDefaultPersist.t;
-      case _i25.BoolDefault:
-        return _i25.BoolDefault.t;
-      case _i26.BoolDefaultMix:
-        return _i26.BoolDefaultMix.t;
-      case _i27.BoolDefaultModel:
-        return _i27.BoolDefaultModel.t;
-      case _i28.BoolDefaultPersist:
-        return _i28.BoolDefaultPersist.t;
-      case _i29.DateTimeDefault:
-        return _i29.DateTimeDefault.t;
-      case _i30.DateTimeDefaultMix:
-        return _i30.DateTimeDefaultMix.t;
-      case _i31.DateTimeDefaultModel:
-        return _i31.DateTimeDefaultModel.t;
-      case _i32.DateTimeDefaultPersist:
-        return _i32.DateTimeDefaultPersist.t;
-      case _i33.DoubleDefault:
-        return _i33.DoubleDefault.t;
-      case _i34.DoubleDefaultMix:
-        return _i34.DoubleDefaultMix.t;
-      case _i35.DoubleDefaultModel:
-        return _i35.DoubleDefaultModel.t;
-      case _i36.DoubleDefaultPersist:
-        return _i36.DoubleDefaultPersist.t;
-      case _i37.DurationDefault:
-        return _i37.DurationDefault.t;
-      case _i38.DurationDefaultMix:
-        return _i38.DurationDefaultMix.t;
-      case _i39.DurationDefaultModel:
-        return _i39.DurationDefaultModel.t;
-      case _i40.DurationDefaultPersist:
-        return _i40.DurationDefaultPersist.t;
-      case _i41.EnumDefault:
-        return _i41.EnumDefault.t;
-      case _i42.EnumDefaultMix:
-        return _i42.EnumDefaultMix.t;
-      case _i43.EnumDefaultModel:
-        return _i43.EnumDefaultModel.t;
-      case _i44.EnumDefaultPersist:
-        return _i44.EnumDefaultPersist.t;
-      case _i49.IntDefault:
-        return _i49.IntDefault.t;
-      case _i50.IntDefaultMix:
-        return _i50.IntDefaultMix.t;
-      case _i51.IntDefaultModel:
-        return _i51.IntDefaultModel.t;
-      case _i52.IntDefaultPersist:
-        return _i52.IntDefaultPersist.t;
-      case _i53.StringDefault:
-        return _i53.StringDefault.t;
-      case _i54.StringDefaultMix:
-        return _i54.StringDefaultMix.t;
-      case _i55.StringDefaultModel:
-        return _i55.StringDefaultModel.t;
-      case _i56.StringDefaultPersist:
-        return _i56.StringDefaultPersist.t;
-      case _i57.UriDefault:
-        return _i57.UriDefault.t;
-      case _i58.UriDefaultMix:
-        return _i58.UriDefaultMix.t;
-      case _i59.UriDefaultModel:
-        return _i59.UriDefaultModel.t;
-      case _i60.UriDefaultPersist:
-        return _i60.UriDefaultPersist.t;
-      case _i61.UuidDefault:
-        return _i61.UuidDefault.t;
-      case _i62.UuidDefaultMix:
-        return _i62.UuidDefaultMix.t;
-      case _i63.UuidDefaultModel:
-        return _i63.UuidDefaultModel.t;
-      case _i64.UuidDefaultPersist:
-        return _i64.UuidDefaultPersist.t;
-      case _i66.EmptyModelRelationItem:
-        return _i66.EmptyModelRelationItem.t;
-      case _i67.EmptyModelWithTable:
-        return _i67.EmptyModelWithTable.t;
-      case _i68.RelationEmptyModel:
-        return _i68.RelationEmptyModel.t;
-      case _i73.ParentClass:
-        return _i73.ParentClass.t;
+      case _i69.CourseUuid:
+        return _i69.CourseUuid.t;
+      case _i71.EnrollmentInt:
+        return _i71.EnrollmentInt.t;
+      case _i73.StudentUuid:
+        return _i73.StudentUuid.t;
+      case _i74.ArenaUuid:
+        return _i74.ArenaUuid.t;
+      case _i75.PlayerUuid:
+        return _i75.PlayerUuid.t;
+      case _i134.TeamInt:
+        return _i134.TeamInt.t;
+      case _i11.CommentInt:
+        return _i11.CommentInt.t;
+      case _i12.CustomerInt:
+        return _i12.CustomerInt.t;
+      case _i13.OrderUuid:
+        return _i13.OrderUuid.t;
+      case _i14.AddressUuid:
+        return _i14.AddressUuid.t;
+      case _i15.CitizenInt:
+        return _i15.CitizenInt.t;
+      case _i16.CompanyUuid:
+        return _i16.CompanyUuid.t;
+      case _i17.TownInt:
+        return _i17.TownInt.t;
+      case _i18.ChangedIdTypeSelf:
+        return _i18.ChangedIdTypeSelf.t;
+      case _i19.BigIntDefault:
+        return _i19.BigIntDefault.t;
+      case _i20.BigIntDefaultMix:
+        return _i20.BigIntDefaultMix.t;
+      case _i21.BigIntDefaultModel:
+        return _i21.BigIntDefaultModel.t;
+      case _i22.BigIntDefaultPersist:
+        return _i22.BigIntDefaultPersist.t;
+      case _i23.BoolDefault:
+        return _i23.BoolDefault.t;
+      case _i24.BoolDefaultMix:
+        return _i24.BoolDefaultMix.t;
+      case _i25.BoolDefaultModel:
+        return _i25.BoolDefaultModel.t;
+      case _i26.BoolDefaultPersist:
+        return _i26.BoolDefaultPersist.t;
+      case _i27.DateTimeDefault:
+        return _i27.DateTimeDefault.t;
+      case _i28.DateTimeDefaultMix:
+        return _i28.DateTimeDefaultMix.t;
+      case _i29.DateTimeDefaultModel:
+        return _i29.DateTimeDefaultModel.t;
+      case _i30.DateTimeDefaultPersist:
+        return _i30.DateTimeDefaultPersist.t;
+      case _i31.DoubleDefault:
+        return _i31.DoubleDefault.t;
+      case _i32.DoubleDefaultMix:
+        return _i32.DoubleDefaultMix.t;
+      case _i33.DoubleDefaultModel:
+        return _i33.DoubleDefaultModel.t;
+      case _i34.DoubleDefaultPersist:
+        return _i34.DoubleDefaultPersist.t;
+      case _i35.DurationDefault:
+        return _i35.DurationDefault.t;
+      case _i36.DurationDefaultMix:
+        return _i36.DurationDefaultMix.t;
+      case _i37.DurationDefaultModel:
+        return _i37.DurationDefaultModel.t;
+      case _i38.DurationDefaultPersist:
+        return _i38.DurationDefaultPersist.t;
+      case _i39.EnumDefault:
+        return _i39.EnumDefault.t;
+      case _i40.EnumDefaultMix:
+        return _i40.EnumDefaultMix.t;
+      case _i41.EnumDefaultModel:
+        return _i41.EnumDefaultModel.t;
+      case _i42.EnumDefaultPersist:
+        return _i42.EnumDefaultPersist.t;
+      case _i47.IntDefault:
+        return _i47.IntDefault.t;
+      case _i48.IntDefaultMix:
+        return _i48.IntDefaultMix.t;
+      case _i49.IntDefaultModel:
+        return _i49.IntDefaultModel.t;
+      case _i50.IntDefaultPersist:
+        return _i50.IntDefaultPersist.t;
+      case _i51.StringDefault:
+        return _i51.StringDefault.t;
+      case _i52.StringDefaultMix:
+        return _i52.StringDefaultMix.t;
+      case _i53.StringDefaultModel:
+        return _i53.StringDefaultModel.t;
+      case _i54.StringDefaultPersist:
+        return _i54.StringDefaultPersist.t;
+      case _i10.UriDefault:
+        return _i10.UriDefault.t;
+      case _i56.UriDefaultMix:
+        return _i56.UriDefaultMix.t;
+      case _i57.UriDefaultModel:
+        return _i57.UriDefaultModel.t;
+      case _i58.UriDefaultPersist:
+        return _i58.UriDefaultPersist.t;
+      case _i59.UuidDefault:
+        return _i59.UuidDefault.t;
+      case _i60.UuidDefaultMix:
+        return _i60.UuidDefaultMix.t;
+      case _i61.UuidDefaultModel:
+        return _i61.UuidDefaultModel.t;
+      case _i62.UuidDefaultPersist:
+        return _i62.UuidDefaultPersist.t;
+      case _i64.EmptyModelRelationItem:
+        return _i64.EmptyModelRelationItem.t;
+      case _i65.EmptyModelWithTable:
+        return _i65.EmptyModelWithTable.t;
+      case _i66.RelationEmptyModel:
+        return _i66.RelationEmptyModel.t;
+      case _i8.ParentClass:
+        return _i8.ParentClass.t;
       case _i76.CityWithLongTableName:
         return _i76.CityWithLongTableName.t;
       case _i77.OrganizationWithLongTableName:
@@ -11400,8 +11401,8 @@ class Protocol extends _i1.SerializationManagerServer {
         return _i103.Order.t;
       case _i104.Address:
         return _i104.Address.t;
-      case _i105.Citizen:
-        return _i105.Citizen.t;
+      case _i157.Citizen:
+        return _i157.Citizen.t;
       case _i106.Company:
         return _i106.Company.t;
       case _i107.Town:

--- a/tests/serverpod_test_server/test/class_name_for_object_test.dart
+++ b/tests/serverpod_test_server/test/class_name_for_object_test.dart
@@ -1,3 +1,4 @@
+import 'package:serverpod/serverpod.dart';
 import 'package:serverpod_auth_client/serverpod_auth_client.dart'
     as auth_client;
 import 'package:serverpod_auth_server/serverpod_auth_server.dart'
@@ -72,6 +73,35 @@ void main() {
 
     expect(serverName, 'List<serverpod_auth.UserInfo>');
     expect(clientName, serverName);
+  });
+
+  test(
+      'Given a hierarchy of model classes, when "getClassNameForObject" is called, then both server and client generate the same string for each class.',
+      () {
+    final modelClassesWithname = <String,
+        (SerializableModel clientModel, SerializableModel serverModel)>{
+      'GrandparentClass': (
+        client.GrandparentClass(grandParentField: ''),
+        server.GrandparentClass(grandParentField: ''),
+      ),
+      'ParentClass': (
+        client.ParentClass(grandParentField: '', parentField: ''),
+        server.ParentClass(grandParentField: '', parentField: ''),
+      ),
+      'ChildClass': (
+        client.ChildClass(grandParentField: '', parentField: '', childField: 0),
+        server.ChildClass(grandParentField: '', parentField: '', childField: 0),
+      ),
+    };
+
+    for (final MapEntry(key: className, value: cases)
+        in modelClassesWithname.entries) {
+      var clientName = clientProtocol.getClassNameForObject(cases.$1);
+      var serverName = serverProtocol.getClassNameForObject(cases.$2);
+
+      expect(serverName, className);
+      expect(clientName, serverName);
+    }
   });
 
   test(

--- a/tests/serverpod_test_server/test/serialization_test.dart
+++ b/tests/serverpod_test_server/test/serialization_test.dart
@@ -435,4 +435,24 @@ void main() {
     // ensure this can be encoded as well
     expect(jsonEncode(jsonList), isNotEmpty);
   });
+
+  test(
+      'Given a leaf class in a hierarchy, when serializing it, then all its values are restored on decode.',
+      () {
+    final object = server.ParentClass(
+      grandParentField: 'grand parent value',
+      parentField: 'parent value',
+    );
+
+    var encodedString = server.Protocol().encodeWithType(object);
+    var decodedObject = server.Protocol().decodeWithType(encodedString);
+
+    expect(
+      decodedObject,
+      isA<server.ParentClass>()
+          .having((c) => c.grandParentField, 'grandParentField',
+              'grand parent value')
+          .having((c) => c.parentField, 'parentField', 'parent value'),
+    );
+  });
 }

--- a/tools/serverpod_cli/test/generator/dart/client_code_generator/protocol/inheritance_protocol_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/client_code_generator/protocol/inheritance_protocol_test.dart
@@ -248,6 +248,22 @@ void main() {
             isTrue,
           );
         });
+
+        test(
+            'that returns the $grandchildClassName before the $childClassName the top node alias',
+            () {
+          final getClassNameForObjectMethodSource =
+              getClassNameForObjectMethod!.toSource();
+
+          expect(
+            getClassNameForObjectMethodSource
+                .indexOf('if (data is _i2.$grandchildClassName)'),
+            lessThan(
+              getClassNameForObjectMethodSource
+                  .indexOf('if (data is _i2.$childClassName)'),
+            ),
+          );
+        });
       });
 
       group('with a deserializeByClassName method', () {


### PR DESCRIPTION
Sorts classes in a hierarchy from child to parent, such that the `getClassNameForObject` gets the name of the most specific class, not a parent.

Closes #3730
