### PR TITLE
fix: Attempting to fix flaky shutdown test

### DIFF
--- a/tests/serverpod_test_server/test_integration/shutdown_test.dart
+++ b/tests/serverpod_test_server/test_integration/shutdown_test.dart
@@ -1,15 +1,14 @@
 // ignore_for_file: dead_code
 
 @Timeout(Duration(minutes: 1))
-@Skip('This is skipped due to flaky tests, issue to resolve this is tracked in '
-    'https://github.com/serverpod/serverpod/issues/3431')
+// Note, this test shall run non-concurrently,
+// which means the test tag 'integration' is not used.
 
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
 import 'package:http/http.dart';
-import 'package:serverpod_test/serverpod_test.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -46,9 +45,7 @@ void main() {
 
     var exitCode = await processOutput.process.exitCode;
     expect(exitCode, 0);
-  },
-      timeout: const Timeout(Duration(seconds: 60)),
-      tags: [defaultIntegrationTestTag]);
+  }, timeout: const Timeout(Duration(seconds: 60)));
 
   group('Given a running serverpod server', () {
     test(
@@ -221,7 +218,7 @@ void main() {
       );
       expect(exitCode, 130);
     }, skip: 'Dart HTTP server does not support this graceful shutdown');
-  }, tags: [defaultIntegrationTestTag]);
+  });
 }
 
 typedef ProcessOutput = ({


### PR DESCRIPTION
Previous attempt in PR #3652 didn't work. In this PR we are reclassifying this test to run non-concurrently, hopefully that fixes the flakyness.

Closes #3431 

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

n/a