### PR TITLE
feat: Upgrade to `actions/checkout` `v4`

### DIFF
--- a/.github/workflows/dart-tests.yaml
+++ b/.github/workflows/dart-tests.yaml
@@ -25,7 +25,7 @@ jobs:
       matrix:
         dart-version: ['3.5.0']
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dart-lang/setup-dart@v1.3
         with:
           sdk: ${{ matrix.dart-version }}
@@ -41,7 +41,7 @@ jobs:
         flutter-version: ['3.24.0']
         os: [windows-latest, ubuntu-latest]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: subosito/flutter-action@v2
         with:
           flutter-version: ${{ matrix.flutter-version }}
@@ -61,7 +61,7 @@ jobs:
         flutter-version: ['3.32.1']
         os: [windows-latest, ubuntu-latest]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: subosito/flutter-action@v2
         with:
           flutter-version: ${{ matrix.flutter-version }}
@@ -81,7 +81,7 @@ jobs:
         flutter-version: ['3.24.0', '3.32.1']
         os: [windows-latest, ubuntu-latest]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: subosito/flutter-action@v2
         with:
           flutter-version: ${{ matrix.flutter-version }}
@@ -102,7 +102,7 @@ jobs:
       matrix:
         flutter-version: ['3.24.0', '3.32.1']
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: subosito/flutter-action@v2
         with:
           flutter-version: ${{ matrix.flutter-version }}
@@ -119,7 +119,7 @@ jobs:
       matrix:
         flutter-version: ['3.24.0', '3.32.1']
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: subosito/flutter-action@v2
         with:
           flutter-version: ${{ matrix.flutter-version }}
@@ -135,7 +135,7 @@ jobs:
         flutter-version: ['3.24.0', '3.32.1']
         os: [windows-latest, ubuntu-latest]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: subosito/flutter-action@v2
         with:
           flutter-version: ${{ matrix.flutter-version }}
@@ -162,7 +162,7 @@ jobs:
             compiler: dart2wasm
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: subosito/flutter-action@v2
         with:
           flutter-version: ${{ matrix.flutter-version }}
@@ -185,7 +185,7 @@ jobs:
         os: [windows-latest, ubuntu-latest]
         path: ['packages/serverpod_flutter']
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: subosito/flutter-action@v2
         with:
           flutter-version: ${{ matrix.flutter-version }}
@@ -201,7 +201,7 @@ jobs:
       matrix:
         flutter-version: ['3.24.0', '3.32.1']
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: subosito/flutter-action@v2
         with:
           flutter-version: ${{ matrix.flutter-version }}
@@ -216,7 +216,7 @@ jobs:
       matrix:
         flutter-version: ['3.24.0', '3.32.1']
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: subosito/flutter-action@v2
         with:
           flutter-version: ${{ matrix.flutter-version }}
@@ -232,7 +232,7 @@ jobs:
         flutter-version: ['3.24.0', '3.32.1']
         path: ['packages/serverpod_shared']
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: subosito/flutter-action@v2
         with:
           flutter-version: ${{ matrix.flutter-version }}
@@ -261,7 +261,7 @@ jobs:
             'modules/serverpod_auth/serverpod_auth_server',
           ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: subosito/flutter-action@v2
         with:
           flutter-version: ${{ matrix.flutter-version }}
@@ -297,7 +297,7 @@ jobs:
           - server: tests/serverpod_new_auth_test/serverpod_new_auth_test_server
             client: tests/serverpod_new_auth_test/serverpod_new_auth_test_flutter
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: subosito/flutter-action@v2
         with:
           flutter-version: ${{ matrix.flutter-version }}
@@ -335,7 +335,7 @@ jobs:
       matrix:
         flutter-version: ['3.24.0', '3.32.1']
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: subosito/flutter-action@v2
         with:
           flutter-version: ${{ matrix.flutter-version }}
@@ -350,7 +350,7 @@ jobs:
       matrix:
         flutter-version: ['3.24.0', '3.32.1']
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: subosito/flutter-action@v2
         with:
           flutter-version: ${{ matrix.flutter-version }}
@@ -368,7 +368,7 @@ jobs:
         os: [windows-latest, ubuntu-latest]
         path: ['tests/bootstrap_project']
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: subosito/flutter-action@v2
         with:
           flutter-version: ${{ matrix.flutter-version }}
@@ -394,7 +394,7 @@ jobs:
       matrix:
         flutter-version: ['3.24.0', '3.32.1']
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: subosito/flutter-action@v2
         with:
           flutter-version: ${{ matrix.flutter-version }}
@@ -412,7 +412,7 @@ jobs:
         os: [ubuntu-latest]
         path: ['tests/serverpod_cli_e2e_test']
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: subosito/flutter-action@v2
         with:
           flutter-version: ${{ matrix.flutter-version }}
@@ -435,7 +435,7 @@ jobs:
     name: Serverpod integration tests (flutter)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Run integration tests in Docker
         run: util/run_tests_flutter_integration
 
@@ -443,7 +443,7 @@ jobs:
     name: Version change test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: subosito/flutter-action@v2
         with:
           flutter-version: '3.24.0'

--- a/templates/serverpod_templates/github/workflows/deployment-gcp.yml
+++ b/templates/serverpod_templates/github/workflows/deployment-gcp.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 


### PR DESCRIPTION
In our GitHub actions and the default GCP deployment template.

Closes #3733
