### PR TITLE
feat!(relic): Rename `Widget`

### DIFF
--- a/examples/auth_example/auth_example_server/lib/src/web/routes/root.dart
+++ b/examples/auth_example/auth_example_server/lib/src/web/routes/root.dart
@@ -5,7 +5,7 @@ import 'package:serverpod/serverpod.dart';
 
 class RouteRoot extends WidgetRoute {
   @override
-  Future<Widget> build(Session session, HttpRequest request) async {
+  Future<WebWidget> build(Session session, HttpRequest request) async {
     return DefaultPageWidget();
   }
 }

--- a/examples/auth_example/auth_example_server/lib/src/web/widgets/default_page_widget.dart
+++ b/examples/auth_example/auth_example_server/lib/src/web/widgets/default_page_widget.dart
@@ -1,6 +1,6 @@
 import 'package:serverpod/serverpod.dart';
 
-class DefaultPageWidget extends Widget {
+class DefaultPageWidget extends WebWidget {
   DefaultPageWidget() : super(name: 'default') {
     values = {
       'served': DateTime.now(),

--- a/examples/chat/chat_server/lib/src/web/routes/root.dart
+++ b/examples/chat/chat_server/lib/src/web/routes/root.dart
@@ -5,7 +5,7 @@ import 'package:serverpod/serverpod.dart';
 
 class RouteRoot extends WidgetRoute {
   @override
-  Future<Widget> build(Session session, HttpRequest request) async {
+  Future<WebWidget> build(Session session, HttpRequest request) async {
     return DefaultPageWidget();
   }
 }

--- a/examples/chat/chat_server/lib/src/web/widgets/default_page_widget.dart
+++ b/examples/chat/chat_server/lib/src/web/widgets/default_page_widget.dart
@@ -1,5 +1,5 @@
 import 'package:serverpod/serverpod.dart';
 
-class DefaultPageWidget extends Widget {
+class DefaultPageWidget extends WebWidget {
   DefaultPageWidget() : super(name: 'default');
 }

--- a/packages/serverpod/lib/src/relic/web_server.dart
+++ b/packages/serverpod/lib/src/relic/web_server.dart
@@ -339,9 +339,9 @@ abstract class Route {
 }
 
 /// A [WidgetRoute] is the most convenient way to create routes in your server.
-/// Override the [build] method and return an appropriate [Widget].
+/// Override the [build] method and return an appropriate [WebWidget].
 abstract class WidgetRoute extends Route {
-  /// Override this method to build your web [Widget] from the current [session]
+  /// Override this method to build your web [WebWidget] from the current [session]
   /// and [request].
   Future<AbstractWidget> build(Session session, HttpRequest request);
 
@@ -349,9 +349,9 @@ abstract class WidgetRoute extends Route {
   Future<bool> handleCall(Session session, HttpRequest request) async {
     var widget = await build(session, request);
 
-    if (widget is WidgetJson) {
+    if (widget is WebJsonWidget) {
       request.response.headers.contentType = ContentType('application', 'json');
-    } else if (widget is WidgetRedirect) {
+    } else if (widget is WebRouteRedirect) {
       var uri = Uri.parse(widget.url);
       await request.response.redirect(uri);
       return true;

--- a/packages/serverpod/lib/src/relic/web_widget.dart
+++ b/packages/serverpod/lib/src/relic/web_widget.dart
@@ -14,8 +14,8 @@ abstract class AbstractWidget {}
 /// on the value. The templates are loaded when the server starts. If you add
 /// new templates or modify existing templates, you will need to restart the
 /// server for them to take effect.
-class Widget extends AbstractWidget {
-  /// The name of the template used by this [Widget].
+class WebWidget extends AbstractWidget {
+  /// The name of the template used by this [WebWidget].
   final String name;
 
   /// The template used by this widget.
@@ -25,8 +25,8 @@ class Widget extends AbstractWidget {
   /// strings using the toString method of the values.
   Map<String, dynamic> values = {};
 
-  /// Creates a new [Widget].
-  Widget({
+  /// Creates a new [WebWidget].
+  WebWidget({
     required this.name,
   }) {
     var cachedTemplate = templates[name];
@@ -42,13 +42,13 @@ class Widget extends AbstractWidget {
   }
 }
 
-/// Combines a List of [Widget]s into a single widget.
-class WidgetList extends AbstractWidget {
+/// Combines a List of [WebWidget]s into a single widget.
+class WebWidgetList extends AbstractWidget {
   /// List of original widgets.
-  final List<Widget> widgets;
+  final List<WebWidget> widgets;
 
   /// Creates a new widget list.
-  WidgetList({required this.widgets});
+  WebWidgetList({required this.widgets});
 
   @override
   String toString() {
@@ -62,12 +62,12 @@ class WidgetList extends AbstractWidget {
 
 /// A widget that renders JSON output. The output will be the result of passing
 /// the provided [object] to [jsonEncode].
-class WidgetJson extends AbstractWidget {
+class WebJsonWidget extends AbstractWidget {
   /// The original object to be rendered as JSON.
   final dynamic object;
 
-  /// Creates a new [WidgetJson].
-  WidgetJson({required this.object});
+  /// Creates a new [WebJsonWidget].
+  WebJsonWidget({required this.object});
 
   @override
   String toString() {
@@ -76,12 +76,12 @@ class WidgetJson extends AbstractWidget {
 }
 
 /// A widget that renders a HTTP redirect to the provided [url].
-class WidgetRedirect extends AbstractWidget {
+class WebRouteRedirect extends AbstractWidget {
   /// The [url] to redirect to.
   final String url;
 
   /// Creates a new widget that renders a redirect.
-  WidgetRedirect({required this.url});
+  WebRouteRedirect({required this.url});
 
   @override
   String toString() {

--- a/tests/serverpod_new_auth_test/serverpod_new_auth_test_server/lib/src/web/routes/root.dart
+++ b/tests/serverpod_new_auth_test/serverpod_new_auth_test_server/lib/src/web/routes/root.dart
@@ -5,7 +5,8 @@ import 'package:serverpod_new_auth_test_server/src/web/widgets/built_with_server
 
 class RouteRoot extends WidgetRoute {
   @override
-  Future<Widget> build(final Session session, final HttpRequest request) async {
+  Future<WebWidget> build(
+      final Session session, final HttpRequest request) async {
     return BuiltWithServerpodPage();
   }
 }

--- a/tests/serverpod_new_auth_test/serverpod_new_auth_test_server/lib/src/web/widgets/built_with_serverpod_page.dart
+++ b/tests/serverpod_new_auth_test/serverpod_new_auth_test_server/lib/src/web/widgets/built_with_serverpod_page.dart
@@ -4,7 +4,7 @@ import 'package:serverpod/serverpod.dart';
 /// It uses the built_with_serverpod.html template to render the page.
 /// The [name] of the template should correspond to a template file in your
 /// server's web/templates directory.
-class BuiltWithServerpodPage extends Widget {
+class BuiltWithServerpodPage extends WebWidget {
   BuiltWithServerpodPage() : super(name: 'built_with_serverpod') {
     values = {
       'served': DateTime.now(),

--- a/tests/serverpod_test_nonvector/serverpod_test_nonvector_server/lib/src/web/routes/root.dart
+++ b/tests/serverpod_test_nonvector/serverpod_test_nonvector_server/lib/src/web/routes/root.dart
@@ -5,7 +5,7 @@ import 'package:serverpod/serverpod.dart';
 
 class RouteRoot extends WidgetRoute {
   @override
-  Future<Widget> build(Session session, HttpRequest request) async {
+  Future<WebWidget> build(Session session, HttpRequest request) async {
     return BuiltWithServerpodPage();
   }
 }

--- a/tests/serverpod_test_nonvector/serverpod_test_nonvector_server/lib/src/web/widgets/built_with_serverpod_page.dart
+++ b/tests/serverpod_test_nonvector/serverpod_test_nonvector_server/lib/src/web/widgets/built_with_serverpod_page.dart
@@ -1,6 +1,6 @@
 import 'package:serverpod/serverpod.dart';
 
-class BuiltWithServerpodPage extends Widget {
+class BuiltWithServerpodPage extends WebWidget {
   BuiltWithServerpodPage() : super(name: 'built_with_serverpod') {
     values = {
       'served': DateTime.now(),

--- a/tests/serverpod_test_server/lib/src/web/routes/root.dart
+++ b/tests/serverpod_test_server/lib/src/web/routes/root.dart
@@ -7,7 +7,7 @@ import '../widgets/text.dart';
 
 class RouteRoot extends WidgetRoute {
   @override
-  Future<Widget> build(Session session, HttpRequest request) async {
+  Future<WebWidget> build(Session session, HttpRequest request) async {
     return SimplePageWidget(
       title: 'My Root Page',
       body: TextWidget(text: 'Hello world'),

--- a/tests/serverpod_test_server/lib/src/web/widgets/simple_page.dart
+++ b/tests/serverpod_test_server/lib/src/web/widgets/simple_page.dart
@@ -1,9 +1,9 @@
 import 'package:serverpod/serverpod.dart';
 
-class SimplePageWidget extends Widget {
+class SimplePageWidget extends WebWidget {
   SimplePageWidget({
     required String title,
-    required Widget body,
+    required WebWidget body,
   }) : super(name: 'simple_page') {
     values = {
       'title': title,

--- a/tests/serverpod_test_server/lib/src/web/widgets/text.dart
+++ b/tests/serverpod_test_server/lib/src/web/widgets/text.dart
@@ -1,6 +1,6 @@
 import 'package:serverpod/serverpod.dart';
 
-class TextWidget extends Widget {
+class TextWidget extends WebWidget {
   TextWidget({
     required String text,
   }) : super(name: 'text') {

--- a/tests/serverpod_test_server/test_integration/diagnostics/diagnostic_events_test.dart
+++ b/tests/serverpod_test_server/test_integration/diagnostics/diagnostic_events_test.dart
@@ -14,7 +14,7 @@ import 'test_exception_handler.dart';
 
 class ExceptionRoute extends WidgetRoute {
   @override
-  Future<Widget> build(Session session, HttpRequest request) async {
+  Future<WebWidget> build(Session session, HttpRequest request) async {
     throw UnimplementedError('ExceptionRoute not implemented');
   }
 }


### PR DESCRIPTION
We want to rename `Widget` to another name that it isn't ambigious with `Widget` from Flutter.

Closes #3467

## Pre-launch Checklist

- [X] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [X] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [X] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [X] I added new tests to check the change I am making.
- [X] All existing and new tests are passing.
- [X] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

Renaming these classes may have breaking changes if the user is referencing these classes
