### PR TITLE
feat: Exit on database integrity failure

### DIFF
--- a/packages/serverpod/lib/src/server/serverpod.dart
+++ b/packages/serverpod/lib/src/server/serverpod.dart
@@ -712,7 +712,7 @@ class Serverpod {
     required bool applyRepairMigration,
     required bool applyMigrations,
   }) async {
-    bool verified = true;
+    bool verified;
 
     try {
       logVerbose('Initializing migration manager.');

--- a/packages/serverpod/lib/src/server/serverpod.dart
+++ b/packages/serverpod/lib/src/server/serverpod.dart
@@ -712,6 +712,8 @@ class Serverpod {
     required bool applyRepairMigration,
     required bool applyMigrations,
   }) async {
+    bool verified = true;
+
     try {
       logVerbose('Initializing migration manager.');
       var migrationManager = MigrationManager(Directory.current);
@@ -745,20 +747,19 @@ class Serverpod {
       }
 
       logVerbose('Verifying database integrity.');
-      final verified =
+      verified =
           await MigrationManager.verifyDatabaseIntegrity(internalSession);
-      if (!verified) {
-        logVerbose('Database integrity verification failed.');
-        throw ExitException(1);
-      }
     } catch (e, stackTrace) {
-      if (e is ExitException) {
-        rethrow;
-      }
+      verified = false;
 
       _exitCode = 1;
       const message = 'Failed to apply database migrations.';
       _reportException(e, stackTrace, message: message);
+    }
+
+    if (!verified) {
+      logVerbose('Database integrity verification failed.');
+      throw ExitException(1);
     }
   }
 

--- a/packages/serverpod/lib/src/server/serverpod.dart
+++ b/packages/serverpod/lib/src/server/serverpod.dart
@@ -745,8 +745,17 @@ class Serverpod {
       }
 
       logVerbose('Verifying database integrity.');
-      await MigrationManager.verifyDatabaseIntegrity(internalSession);
+      final verified =
+          await MigrationManager.verifyDatabaseIntegrity(internalSession);
+      if (!verified) {
+        logVerbose('Database integrity verification failed.');
+        throw ExitException(1);
+      }
     } catch (e, stackTrace) {
+      if (e is ExitException) {
+        rethrow;
+      }
+
       _exitCode = 1;
       const message = 'Failed to apply database migrations.';
       _reportException(e, stackTrace, message: message);

--- a/packages/serverpod/lib/src/server/serverpod.dart
+++ b/packages/serverpod/lib/src/server/serverpod.dart
@@ -752,7 +752,6 @@ class Serverpod {
     } catch (e, stackTrace) {
       verified = false;
 
-      _exitCode = 1;
       const message = 'Failed to apply database migrations.';
       _reportException(e, stackTrace, message: message);
     }


### PR DESCRIPTION
This PR changes the code flow to exit early when encountering a database integity failure to clean up the error messages logged to the user

Closes #3683

## Pre-launch Checklist

- [X] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [X] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [X] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [X] I added new tests to check the change I am making.
- [X] All existing and new tests are passing.
- [X] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of database integrity verification failures during migrations, providing clearer error logging and proper exit behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->