### PR TITLE
fix: Attempting to fix flaky shutdown test

### DIFF
--- a/tests/serverpod_test_server/test_integration/shutdown_test.dart
+++ b/tests/serverpod_test_server/test_integration/shutdown_test.dart
@@ -45,7 +45,7 @@ void main() {
 
     var exitCode = await processOutput.process.exitCode;
     expect(exitCode, 0);
-  }, timeout: const Timeout(Duration(seconds: 60)));
+  }, timeout: const Timeout(Duration(seconds: 120)));
 
   group('Given a running serverpod server', () {
     test(


### PR DESCRIPTION
The 'then it automatically exits' test case occasionally timed out. This doubles the timeout to 120s.

(The health-checker is likely at fault for the automatic shutdown being slow, as well as being irregular. It needs an overhaul but that is beyond the scope of this fix.)

Closes #3431 

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

n/a