### PR TITLE
feat(auth): Add ability to prevent new registration/login in `serverpod_auth` endpoints

### DIFF
--- a/modules/serverpod_auth/serverpod_auth_client/lib/src/protocol/endpoint_disabled_exception.dart
+++ b/modules/serverpod_auth/serverpod_auth_client/lib/src/protocol/endpoint_disabled_exception.dart
@@ -1,0 +1,50 @@
+/* AUTOMATICALLY GENERATED CODE DO NOT MODIFY */
+/*   To generate run: "serverpod generate"    */
+
+// ignore_for_file: implementation_imports
+// ignore_for_file: library_private_types_in_public_api
+// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: public_member_api_docs
+// ignore_for_file: type_literal_in_constant_pattern
+// ignore_for_file: use_super_parameters
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:serverpod_client/serverpod_client.dart' as _i1;
+
+abstract class EndpointDisabledException
+    implements _i1.SerializableException, _i1.SerializableModel {
+  EndpointDisabledException._();
+
+  factory EndpointDisabledException() = _EndpointDisabledExceptionImpl;
+
+  factory EndpointDisabledException.fromJson(
+      Map<String, dynamic> jsonSerialization) {
+    return EndpointDisabledException();
+  }
+
+  /// Returns a shallow copy of this [EndpointDisabledException]
+  /// with some or all fields replaced by the given arguments.
+  @_i1.useResult
+  EndpointDisabledException copyWith();
+  @override
+  Map<String, dynamic> toJson() {
+    return {};
+  }
+
+  @override
+  String toString() {
+    return _i1.SerializationManager.encode(this);
+  }
+}
+
+class _EndpointDisabledExceptionImpl extends EndpointDisabledException {
+  _EndpointDisabledExceptionImpl() : super._();
+
+  /// Returns a shallow copy of this [EndpointDisabledException]
+  /// with some or all fields replaced by the given arguments.
+  @_i1.useResult
+  @override
+  EndpointDisabledException copyWith() {
+    return EndpointDisabledException();
+  }
+}

--- a/modules/serverpod_auth/serverpod_auth_client/lib/src/protocol/protocol.dart
+++ b/modules/serverpod_auth/serverpod_auth_client/lib/src/protocol/protocol.dart
@@ -19,11 +19,12 @@ import 'email_create_account_request.dart' as _i7;
 import 'email_failed_sign_in.dart' as _i8;
 import 'email_password_reset.dart' as _i9;
 import 'email_reset.dart' as _i10;
-import 'google_refresh_token.dart' as _i11;
-import 'user_image.dart' as _i12;
-import 'user_info.dart' as _i13;
-import 'user_info_public.dart' as _i14;
-import 'user_settings_config.dart' as _i15;
+import 'endpoint_disabled_exception.dart' as _i11;
+import 'google_refresh_token.dart' as _i12;
+import 'user_image.dart' as _i13;
+import 'user_info.dart' as _i14;
+import 'user_info_public.dart' as _i15;
+import 'user_settings_config.dart' as _i16;
 export 'apple_auth_info.dart';
 export 'auth_key.dart';
 export 'authentication_fail_reason.dart';
@@ -33,6 +34,7 @@ export 'email_create_account_request.dart';
 export 'email_failed_sign_in.dart';
 export 'email_password_reset.dart';
 export 'email_reset.dart';
+export 'endpoint_disabled_exception.dart';
 export 'google_refresh_token.dart';
 export 'user_image.dart';
 export 'user_info.dart';
@@ -80,20 +82,23 @@ class Protocol extends _i1.SerializationManager {
     if (t == _i10.EmailReset) {
       return _i10.EmailReset.fromJson(data) as T;
     }
-    if (t == _i11.GoogleRefreshToken) {
-      return _i11.GoogleRefreshToken.fromJson(data) as T;
+    if (t == _i11.EndpointDisabledException) {
+      return _i11.EndpointDisabledException.fromJson(data) as T;
     }
-    if (t == _i12.UserImage) {
-      return _i12.UserImage.fromJson(data) as T;
+    if (t == _i12.GoogleRefreshToken) {
+      return _i12.GoogleRefreshToken.fromJson(data) as T;
     }
-    if (t == _i13.UserInfo) {
-      return _i13.UserInfo.fromJson(data) as T;
+    if (t == _i13.UserImage) {
+      return _i13.UserImage.fromJson(data) as T;
     }
-    if (t == _i14.UserInfoPublic) {
-      return _i14.UserInfoPublic.fromJson(data) as T;
+    if (t == _i14.UserInfo) {
+      return _i14.UserInfo.fromJson(data) as T;
     }
-    if (t == _i15.UserSettingsConfig) {
-      return _i15.UserSettingsConfig.fromJson(data) as T;
+    if (t == _i15.UserInfoPublic) {
+      return _i15.UserInfoPublic.fromJson(data) as T;
+    }
+    if (t == _i16.UserSettingsConfig) {
+      return _i16.UserSettingsConfig.fromJson(data) as T;
     }
     if (t == _i1.getType<_i2.AppleAuthInfo?>()) {
       return (data != null ? _i2.AppleAuthInfo.fromJson(data) : null) as T;
@@ -126,21 +131,26 @@ class Protocol extends _i1.SerializationManager {
     if (t == _i1.getType<_i10.EmailReset?>()) {
       return (data != null ? _i10.EmailReset.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i11.GoogleRefreshToken?>()) {
-      return (data != null ? _i11.GoogleRefreshToken.fromJson(data) : null)
+    if (t == _i1.getType<_i11.EndpointDisabledException?>()) {
+      return (data != null
+          ? _i11.EndpointDisabledException.fromJson(data)
+          : null) as T;
+    }
+    if (t == _i1.getType<_i12.GoogleRefreshToken?>()) {
+      return (data != null ? _i12.GoogleRefreshToken.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i12.UserImage?>()) {
-      return (data != null ? _i12.UserImage.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i13.UserImage?>()) {
+      return (data != null ? _i13.UserImage.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i13.UserInfo?>()) {
-      return (data != null ? _i13.UserInfo.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i14.UserInfo?>()) {
+      return (data != null ? _i14.UserInfo.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i14.UserInfoPublic?>()) {
-      return (data != null ? _i14.UserInfoPublic.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i15.UserInfoPublic?>()) {
+      return (data != null ? _i15.UserInfoPublic.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i15.UserSettingsConfig?>()) {
-      return (data != null ? _i15.UserSettingsConfig.fromJson(data) : null)
+    if (t == _i1.getType<_i16.UserSettingsConfig?>()) {
+      return (data != null ? _i16.UserSettingsConfig.fromJson(data) : null)
           as T;
     }
     if (t == List<String>) {
@@ -172,15 +182,17 @@ class Protocol extends _i1.SerializationManager {
         return 'EmailPasswordReset';
       case _i10.EmailReset():
         return 'EmailReset';
-      case _i11.GoogleRefreshToken():
+      case _i11.EndpointDisabledException():
+        return 'EndpointDisabledException';
+      case _i12.GoogleRefreshToken():
         return 'GoogleRefreshToken';
-      case _i12.UserImage():
+      case _i13.UserImage():
         return 'UserImage';
-      case _i13.UserInfo():
+      case _i14.UserInfo():
         return 'UserInfo';
-      case _i14.UserInfoPublic():
+      case _i15.UserInfoPublic():
         return 'UserInfoPublic';
-      case _i15.UserSettingsConfig():
+      case _i16.UserSettingsConfig():
         return 'UserSettingsConfig';
     }
     return null;
@@ -219,20 +231,23 @@ class Protocol extends _i1.SerializationManager {
     if (dataClassName == 'EmailReset') {
       return deserialize<_i10.EmailReset>(data['data']);
     }
+    if (dataClassName == 'EndpointDisabledException') {
+      return deserialize<_i11.EndpointDisabledException>(data['data']);
+    }
     if (dataClassName == 'GoogleRefreshToken') {
-      return deserialize<_i11.GoogleRefreshToken>(data['data']);
+      return deserialize<_i12.GoogleRefreshToken>(data['data']);
     }
     if (dataClassName == 'UserImage') {
-      return deserialize<_i12.UserImage>(data['data']);
+      return deserialize<_i13.UserImage>(data['data']);
     }
     if (dataClassName == 'UserInfo') {
-      return deserialize<_i13.UserInfo>(data['data']);
+      return deserialize<_i14.UserInfo>(data['data']);
     }
     if (dataClassName == 'UserInfoPublic') {
-      return deserialize<_i14.UserInfoPublic>(data['data']);
+      return deserialize<_i15.UserInfoPublic>(data['data']);
     }
     if (dataClassName == 'UserSettingsConfig') {
-      return deserialize<_i15.UserSettingsConfig>(data['data']);
+      return deserialize<_i16.UserSettingsConfig>(data['data']);
     }
     return super.deserializeByClassName(data);
   }

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/business/config.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/business/config.dart
@@ -173,6 +173,17 @@ class AuthConfig {
   /// - [SignOutBehavior.currentDevice]: Users will be signed out from the current device only.
   final SignOutBehavior legacyUserSignOutBehavior;
 
+  /// Whether to disable all account creation and update endpoints.
+  ///
+  /// Settings this to `true` blocks all further logins and registrations,
+  /// as well as password changes.
+  ///
+  /// Since this package's endpoints can not be hidden, this can be used to at
+  /// least mark them inactive.
+  ///
+  /// Defaults to `false`.
+  final bool disableAccountEndpoints;
+
   /// Creates a new Auth configuration. Use the [set] method to replace the
   /// default settings. Defaults to `config/firebase_service_account_key.json`.
   AuthConfig({
@@ -206,6 +217,7 @@ class AuthConfig {
     this.passwordHashGenerator = defaultGeneratePasswordHash,
     this.passwordHashValidator = defaultValidatePasswordHash,
     this.legacyUserSignOutBehavior = SignOutBehavior.allDevices,
+    this.disableAccountEndpoints = false,
   }) {
     if (validationCodeLength < 8) {
       stderr.writeln(

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/endpoints/email_endpoint.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/endpoints/email_endpoint.dart
@@ -16,12 +16,23 @@ class EmailEndpoint extends Endpoint {
     String email,
     String password,
   ) async {
+    if (AuthConfig.current.disableAccountEndpoints) {
+      throw EndpointDisabledException();
+    }
+
     return Emails.authenticate(session, email, password);
   }
 
   /// Changes a users password.
   Future<bool> changePassword(
-      Session session, String oldPassword, String newPassword) async {
+    Session session,
+    String oldPassword,
+    String newPassword,
+  ) async {
+    if (AuthConfig.current.disableAccountEndpoints) {
+      throw EndpointDisabledException();
+    }
+
     var userId = (await session.authenticated)?.userId;
     if (userId == null) return false;
 
@@ -31,12 +42,23 @@ class EmailEndpoint extends Endpoint {
   /// Initiates a password reset and sends an email with the reset code to the
   /// user.
   Future<bool> initiatePasswordReset(Session session, String email) {
+    if (AuthConfig.current.disableAccountEndpoints) {
+      throw EndpointDisabledException();
+    }
+
     return Emails.initiatePasswordReset(session, email);
   }
 
   /// Resets a users password using the reset code.
   Future<bool> resetPassword(
-      Session session, String verificationCode, String password) {
+    Session session,
+    String verificationCode,
+    String password,
+  ) {
+    if (AuthConfig.current.disableAccountEndpoints) {
+      throw EndpointDisabledException();
+    }
+
     return Emails.resetPassword(session, verificationCode, password);
   }
 
@@ -48,6 +70,10 @@ class EmailEndpoint extends Endpoint {
     String email,
     String password,
   ) async {
+    if (AuthConfig.current.disableAccountEndpoints) {
+      throw EndpointDisabledException();
+    }
+
     return await Emails.createAccountRequest(
       session,
       userName,
@@ -62,6 +88,10 @@ class EmailEndpoint extends Endpoint {
     String email,
     String verificationCode,
   ) async {
+    if (AuthConfig.current.disableAccountEndpoints) {
+      throw EndpointDisabledException();
+    }
+
     return await Emails.tryCreateAccount(
       session,
       email: email,

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/endpoints/firebase_endpoint.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/endpoints/firebase_endpoint.dart
@@ -12,6 +12,10 @@ class FirebaseEndpoint extends Endpoint {
     Session session,
     String idToken,
   ) async {
+    if (AuthConfig.current.disableAccountEndpoints) {
+      throw EndpointDisabledException();
+    }
+
     FirebaseAuthManager authManager;
     session.log('Firebase authenticate', level: LogLevel.debug);
     try {

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/endpoints/google_endpoint.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/endpoints/google_endpoint.dart
@@ -28,6 +28,10 @@ class GoogleEndpoint extends Endpoint {
     String authenticationCode,
     String? redirectUri,
   ) async {
+    if (AuthConfig.current.disableAccountEndpoints) {
+      throw EndpointDisabledException();
+    }
+
     var clientSecret = GoogleAuth.clientSecret;
 
     if (clientSecret == null) {
@@ -127,7 +131,13 @@ class GoogleEndpoint extends Endpoint {
 
   /// Authenticates a user using an id token.
   Future<AuthenticationResponse> authenticateWithIdToken(
-      Session session, String idToken) async {
+    Session session,
+    String idToken,
+  ) async {
+    if (AuthConfig.current.disableAccountEndpoints) {
+      throw EndpointDisabledException();
+    }
+
     var clientSecret = GoogleAuth.clientSecret;
     if (clientSecret == null) {
       throw StateError('The server side Google client secret is not loaded.');

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/endpoint_disabled_exception.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/endpoint_disabled_exception.dart
@@ -1,0 +1,58 @@
+/* AUTOMATICALLY GENERATED CODE DO NOT MODIFY */
+/*   To generate run: "serverpod generate"    */
+
+// ignore_for_file: implementation_imports
+// ignore_for_file: library_private_types_in_public_api
+// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: public_member_api_docs
+// ignore_for_file: type_literal_in_constant_pattern
+// ignore_for_file: use_super_parameters
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:serverpod/serverpod.dart' as _i1;
+
+abstract class EndpointDisabledException
+    implements
+        _i1.SerializableException,
+        _i1.SerializableModel,
+        _i1.ProtocolSerialization {
+  EndpointDisabledException._();
+
+  factory EndpointDisabledException() = _EndpointDisabledExceptionImpl;
+
+  factory EndpointDisabledException.fromJson(
+      Map<String, dynamic> jsonSerialization) {
+    return EndpointDisabledException();
+  }
+
+  /// Returns a shallow copy of this [EndpointDisabledException]
+  /// with some or all fields replaced by the given arguments.
+  @_i1.useResult
+  EndpointDisabledException copyWith();
+  @override
+  Map<String, dynamic> toJson() {
+    return {};
+  }
+
+  @override
+  Map<String, dynamic> toJsonForProtocol() {
+    return {};
+  }
+
+  @override
+  String toString() {
+    return _i1.SerializationManager.encode(this);
+  }
+}
+
+class _EndpointDisabledExceptionImpl extends EndpointDisabledException {
+  _EndpointDisabledExceptionImpl() : super._();
+
+  /// Returns a shallow copy of this [EndpointDisabledException]
+  /// with some or all fields replaced by the given arguments.
+  @_i1.useResult
+  @override
+  EndpointDisabledException copyWith() {
+    return EndpointDisabledException();
+  }
+}

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/protocol.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/protocol.dart
@@ -20,11 +20,12 @@ import 'email_create_account_request.dart' as _i8;
 import 'email_failed_sign_in.dart' as _i9;
 import 'email_password_reset.dart' as _i10;
 import 'email_reset.dart' as _i11;
-import 'google_refresh_token.dart' as _i12;
-import 'user_image.dart' as _i13;
-import 'user_info.dart' as _i14;
-import 'user_info_public.dart' as _i15;
-import 'user_settings_config.dart' as _i16;
+import 'endpoint_disabled_exception.dart' as _i12;
+import 'google_refresh_token.dart' as _i13;
+import 'user_image.dart' as _i14;
+import 'user_info.dart' as _i15;
+import 'user_info_public.dart' as _i16;
+import 'user_settings_config.dart' as _i17;
 export 'apple_auth_info.dart';
 export 'auth_key.dart';
 export 'authentication_fail_reason.dart';
@@ -34,6 +35,7 @@ export 'email_create_account_request.dart';
 export 'email_failed_sign_in.dart';
 export 'email_password_reset.dart';
 export 'email_reset.dart';
+export 'endpoint_disabled_exception.dart';
 export 'google_refresh_token.dart';
 export 'user_image.dart';
 export 'user_info.dart';
@@ -656,20 +658,23 @@ class Protocol extends _i1.SerializationManagerServer {
     if (t == _i11.EmailReset) {
       return _i11.EmailReset.fromJson(data) as T;
     }
-    if (t == _i12.GoogleRefreshToken) {
-      return _i12.GoogleRefreshToken.fromJson(data) as T;
+    if (t == _i12.EndpointDisabledException) {
+      return _i12.EndpointDisabledException.fromJson(data) as T;
     }
-    if (t == _i13.UserImage) {
-      return _i13.UserImage.fromJson(data) as T;
+    if (t == _i13.GoogleRefreshToken) {
+      return _i13.GoogleRefreshToken.fromJson(data) as T;
     }
-    if (t == _i14.UserInfo) {
-      return _i14.UserInfo.fromJson(data) as T;
+    if (t == _i14.UserImage) {
+      return _i14.UserImage.fromJson(data) as T;
     }
-    if (t == _i15.UserInfoPublic) {
-      return _i15.UserInfoPublic.fromJson(data) as T;
+    if (t == _i15.UserInfo) {
+      return _i15.UserInfo.fromJson(data) as T;
     }
-    if (t == _i16.UserSettingsConfig) {
-      return _i16.UserSettingsConfig.fromJson(data) as T;
+    if (t == _i16.UserInfoPublic) {
+      return _i16.UserInfoPublic.fromJson(data) as T;
+    }
+    if (t == _i17.UserSettingsConfig) {
+      return _i17.UserSettingsConfig.fromJson(data) as T;
     }
     if (t == _i1.getType<_i3.AppleAuthInfo?>()) {
       return (data != null ? _i3.AppleAuthInfo.fromJson(data) : null) as T;
@@ -703,21 +708,26 @@ class Protocol extends _i1.SerializationManagerServer {
     if (t == _i1.getType<_i11.EmailReset?>()) {
       return (data != null ? _i11.EmailReset.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i12.GoogleRefreshToken?>()) {
-      return (data != null ? _i12.GoogleRefreshToken.fromJson(data) : null)
+    if (t == _i1.getType<_i12.EndpointDisabledException?>()) {
+      return (data != null
+          ? _i12.EndpointDisabledException.fromJson(data)
+          : null) as T;
+    }
+    if (t == _i1.getType<_i13.GoogleRefreshToken?>()) {
+      return (data != null ? _i13.GoogleRefreshToken.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i13.UserImage?>()) {
-      return (data != null ? _i13.UserImage.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i14.UserImage?>()) {
+      return (data != null ? _i14.UserImage.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i14.UserInfo?>()) {
-      return (data != null ? _i14.UserInfo.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i15.UserInfo?>()) {
+      return (data != null ? _i15.UserInfo.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i15.UserInfoPublic?>()) {
-      return (data != null ? _i15.UserInfoPublic.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i16.UserInfoPublic?>()) {
+      return (data != null ? _i16.UserInfoPublic.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i16.UserSettingsConfig?>()) {
-      return (data != null ? _i16.UserSettingsConfig.fromJson(data) : null)
+    if (t == _i1.getType<_i17.UserSettingsConfig?>()) {
+      return (data != null ? _i17.UserSettingsConfig.fromJson(data) : null)
           as T;
     }
     if (t == List<String>) {
@@ -752,15 +762,17 @@ class Protocol extends _i1.SerializationManagerServer {
         return 'EmailPasswordReset';
       case _i11.EmailReset():
         return 'EmailReset';
-      case _i12.GoogleRefreshToken():
+      case _i12.EndpointDisabledException():
+        return 'EndpointDisabledException';
+      case _i13.GoogleRefreshToken():
         return 'GoogleRefreshToken';
-      case _i13.UserImage():
+      case _i14.UserImage():
         return 'UserImage';
-      case _i14.UserInfo():
+      case _i15.UserInfo():
         return 'UserInfo';
-      case _i15.UserInfoPublic():
+      case _i16.UserInfoPublic():
         return 'UserInfoPublic';
-      case _i16.UserSettingsConfig():
+      case _i17.UserSettingsConfig():
         return 'UserSettingsConfig';
     }
     className = _i2.Protocol().getClassNameForObject(data);
@@ -803,20 +815,23 @@ class Protocol extends _i1.SerializationManagerServer {
     if (dataClassName == 'EmailReset') {
       return deserialize<_i11.EmailReset>(data['data']);
     }
+    if (dataClassName == 'EndpointDisabledException') {
+      return deserialize<_i12.EndpointDisabledException>(data['data']);
+    }
     if (dataClassName == 'GoogleRefreshToken') {
-      return deserialize<_i12.GoogleRefreshToken>(data['data']);
+      return deserialize<_i13.GoogleRefreshToken>(data['data']);
     }
     if (dataClassName == 'UserImage') {
-      return deserialize<_i13.UserImage>(data['data']);
+      return deserialize<_i14.UserImage>(data['data']);
     }
     if (dataClassName == 'UserInfo') {
-      return deserialize<_i14.UserInfo>(data['data']);
+      return deserialize<_i15.UserInfo>(data['data']);
     }
     if (dataClassName == 'UserInfoPublic') {
-      return deserialize<_i15.UserInfoPublic>(data['data']);
+      return deserialize<_i16.UserInfoPublic>(data['data']);
     }
     if (dataClassName == 'UserSettingsConfig') {
-      return deserialize<_i16.UserSettingsConfig>(data['data']);
+      return deserialize<_i17.UserSettingsConfig>(data['data']);
     }
     if (dataClassName.startsWith('serverpod.')) {
       data['className'] = dataClassName.substring(10);
@@ -844,12 +859,12 @@ class Protocol extends _i1.SerializationManagerServer {
         return _i9.EmailFailedSignIn.t;
       case _i11.EmailReset:
         return _i11.EmailReset.t;
-      case _i12.GoogleRefreshToken:
-        return _i12.GoogleRefreshToken.t;
-      case _i13.UserImage:
-        return _i13.UserImage.t;
-      case _i14.UserInfo:
-        return _i14.UserInfo.t;
+      case _i13.GoogleRefreshToken:
+        return _i13.GoogleRefreshToken.t;
+      case _i14.UserImage:
+        return _i14.UserImage.t;
+      case _i15.UserInfo:
+        return _i15.UserInfo.t;
     }
     return null;
   }

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/models/endpoint_disabled_exception.spy.yaml
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/models/endpoint_disabled_exception.spy.yaml
@@ -1,0 +1,1 @@
+exception: EndpointDisabledException


### PR DESCRIPTION
So during a migration (which should only last a few seconds, but the deployment can live a bit longer) we can prevent new sign-ups/sign-ins.
This prevents issues with the post-migration deploy when the database schema is updated again to expect new the UUID user ids.