### PR TITLE
fix: Update Redis configuration handling to respect enabled flag and add tests

### DIFF
--- a/packages/serverpod_shared/lib/src/config.dart
+++ b/packages/serverpod_shared/lib/src/config.dart
@@ -177,7 +177,9 @@ class ServerpodConfig {
         : null;
 
     var redisConfig = _redisConfigMap(configMap, environment);
-    var redis = redisConfig != null
+    var redisEnabled = redisConfig != null &&
+        (redisConfig[ServerpodEnv.redisEnabled.configKey] ?? true);
+    var redis = redisEnabled
         ? RedisConfig._fromJson(
             redisConfig,
             passwords,
@@ -520,7 +522,7 @@ class RedisConfig {
     }
 
     return RedisConfig(
-      enabled: redisSetup[ServerpodEnv.redisEnabled.configKey] ?? false,
+      enabled: redisSetup[ServerpodEnv.redisEnabled.configKey] ?? true,
       host: redisSetup[ServerpodEnv.redisHost.configKey],
       port: redisSetup[ServerpodEnv.redisPort.configKey],
       user: redisSetup[ServerpodEnv.redisUser.configKey],

--- a/packages/serverpod_shared/test/config_test.dart
+++ b/packages/serverpod_shared/test/config_test.dart
@@ -267,7 +267,7 @@ redis:
     expect(config.redis?.host, 'localhost');
     expect(config.redis?.port, 6379);
     expect(config.redis?.password, 'password');
-    expect(config.redis?.enabled, isFalse);
+    expect(config.redis?.enabled, isTrue);
     expect(config.redis?.requireSsl, isTrue);
   });
 

--- a/packages/serverpod_shared/test/redis_config_test.dart
+++ b/packages/serverpod_shared/test/redis_config_test.dart
@@ -125,7 +125,7 @@ redis:
     expect(config.redis?.password, 'password');
     expect(config.redis?.user, isNull);
     expect(config.redis?.requireSsl, isFalse);
-    expect(config.redis?.enabled, isFalse);
+    expect(config.redis?.enabled, isTrue);
   });
 
   test(
@@ -390,6 +390,139 @@ redis:
 
     expect(config.redis?.user, equals('envuser'));
     expect(config.redis?.requireSsl, isTrue);
+    expect(config.redis?.enabled, isTrue);
+  });
+
+  test(
+      'Given a Serverpod config with redis configuration where enabled=false when loading from Map then redis configuration is null.',
+      () {
+    var serverpodConfig = '''
+apiServer:
+  port: 8080
+  publicHost: localhost
+  publicPort: 8080
+  publicScheme: http
+redis:
+  host: localhost
+  port: 6379
+  enabled: false
+''';
+
+    var config = ServerpodConfig.loadFromMap(
+      runMode,
+      serverId,
+      {...passwords, 'redis': 'password'},
+      loadYaml(serverpodConfig),
+    );
+
+    expect(config.redis, isNull);
+  });
+
+  test(
+      'Given a Serverpod config with redis configuration but SERVERPOD_REDIS_ENABLED=false in environment when loading from Map then redis configuration is null.',
+      () {
+    var serverpodConfig = '''
+apiServer:
+  port: 8080
+  publicHost: localhost
+  publicPort: 8080
+  publicScheme: http
+redis:
+  host: localhost
+  port: 6379
+  enabled: true
+''';
+
+    var config = ServerpodConfig.loadFromMap(
+      runMode,
+      serverId,
+      {...passwords, 'redis': 'password'},
+      loadYaml(serverpodConfig),
+      environment: {
+        'SERVERPOD_REDIS_ENABLED': 'false',
+      },
+    );
+
+    expect(config.redis, isNull);
+  });
+
+  test(
+      'Given a Serverpod config with redis configuration without the enabled field when loading from Map then redis configuration defaults to enabled.',
+      () {
+    var serverpodConfig = '''
+apiServer:
+  port: 8080
+  publicHost: localhost
+  publicPort: 8080
+  publicScheme: http
+redis:
+  host: localhost
+  port: 6379
+''';
+
+    var config = ServerpodConfig.loadFromMap(
+      runMode,
+      serverId,
+      {...passwords, 'redis': 'password'},
+      loadYaml(serverpodConfig),
+    );
+
+    expect(config.redis, isNotNull);
+    expect(config.redis?.enabled, isTrue);
+  });
+
+  test(
+      'Given a Serverpod config with redis configuration where enabled=false and no password provided when loading from Map then no PasswordMissingException is thrown and redis configuration is null.',
+      () {
+    var serverpodConfig = '''
+apiServer:
+  port: 8080
+  publicHost: localhost
+  publicPort: 8080
+  publicScheme: http
+redis:
+  host: localhost
+  port: 6379
+  enabled: false
+''';
+
+    // This should not throw a PasswordMissingException
+    var config = ServerpodConfig.loadFromMap(
+      runMode,
+      serverId,
+      passwords, // No redis password provided
+      loadYaml(serverpodConfig),
+    );
+
+    expect(config.redis, isNull);
+  });
+
+  test(
+      'Given a Serverpod config with redis configuration where enabled=true explicitly when loading from Map then redis configuration is created normally.',
+      () {
+    var serverpodConfig = '''
+apiServer:
+  port: 8080
+  publicHost: localhost
+  publicPort: 8080
+  publicScheme: http
+redis:
+  host: localhost
+  port: 6379
+  enabled: true
+''';
+
+    var config = ServerpodConfig.loadFromMap(
+      runMode,
+      serverId,
+      {...passwords, 'redis': 'password'},
+      loadYaml(serverpodConfig),
+    );
+
+    expect(config.redis, isNotNull);
+    expect(config.redis?.host, 'localhost');
+    expect(config.redis?.port, 6379);
+    expect(config.redis?.password, 'password');
     expect(config.redis?.enabled, isTrue);
   });
 }


### PR DESCRIPTION
The redis configuration should now respect the `enabled` flag when configuring redis

## Pre-launch Checklist

- [X] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [X] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [X] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [X] I added new tests to check the change I am making.
- [X] All existing and new tests are passing.
- [X] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

