### PR TITLE
feat: WebServer port getter reflects actual port

### DIFF
--- a/packages/serverpod/lib/src/web_server/web_server.dart
+++ b/packages/serverpod/lib/src/web_server/web_server.dart
@@ -15,11 +15,11 @@ class WebServer {
   /// The server id of this server.
   final String serverId;
 
-  /// The port the webserver is configured to run on.
-  late final int port;
+  /// The configuration for this web server.
+  late final ServerConfig _config;
 
-  /// The actual port the webserver is listening on, or null if not started.
-  int? get actualPort => _actualPort;
+  /// The port the webserver is listening on, or null if not started.
+  int? get port => _actualPort;
 
   int? _actualPort;
 
@@ -45,7 +45,7 @@ class WebServer {
       );
     }
 
-    port = config.port;
+    _config = config;
   }
 
   bool _running = false;
@@ -75,7 +75,7 @@ class WebServer {
       final server = await serve(
         _handleRequest,
         InternetAddress.anyIPv6,
-        port,
+        _config.port,
         context: context,
       );
       _server = server;


### PR DESCRIPTION
Code using the new WebServer of a Serverpod server needs to be able to get the actual port number the web server listens on, which is randomly allocated by the OS if it is configured as 0.

This is needed for Serverpod Cloud.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

n/a