### PR TITLE
fix: Only download templates on `create` command

### DIFF
--- a/tools/serverpod_cli/lib/src/commands/create.dart
+++ b/tools/serverpod_cli/lib/src/commands/create.dart
@@ -1,5 +1,6 @@
 import 'package:cli_tools/cli_tools.dart';
 import 'package:serverpod_cli/src/create/create.dart';
+import 'package:serverpod_cli/src/downloads/resource_manager.dart';
 import 'package:serverpod_cli/src/runner/serverpod_command.dart';
 import 'package:serverpod_cli/src/util/serverpod_cli_logger.dart';
 
@@ -87,6 +88,22 @@ class CreateCommand extends ServerpodCommand<CreateOption> {
         'Use the --${CreateOption.force.option.argName} flag to force creation.',
       );
       throw ExitException.error();
+    }
+
+    // Make sure all necessary downloads are installed
+    if (!resourceManager.isTemplatesInstalled) {
+      try {
+        await resourceManager.installTemplates();
+      } catch (e) {
+        log.error('Failed to download templates.');
+        throw ExitException.error();
+      }
+
+      if (!resourceManager.isTemplatesInstalled) {
+        log.error(
+            'Could not download the required resources for Serverpod. Make sure that you are connected to the internet and that you are using the latest version of Serverpod.');
+        throw ExitException.error();
+      }
     }
 
     if (!await performCreate(name, template, force)) {

--- a/tools/serverpod_cli/lib/src/runner/serverpod_command_runner.dart
+++ b/tools/serverpod_cli/lib/src/runner/serverpod_command_runner.dart
@@ -27,22 +27,6 @@ Future<void> _preCommandEnvironmentChecks() async {
   if (!loadEnvironmentVars()) {
     throw ExitException.error();
   }
-
-  // Make sure all necessary downloads are installed
-  if (!resourceManager.isTemplatesInstalled) {
-    try {
-      await resourceManager.installTemplates();
-    } catch (e) {
-      log.error('Failed to download templates.');
-      throw ExitException.error();
-    }
-
-    if (!resourceManager.isTemplatesInstalled) {
-      log.error(
-          'Could not download the required resources for Serverpod. Make sure that you are connected to the internet and that you are using the latest version of Serverpod.');
-      throw ExitException.error();
-    }
-  }
 }
 
 Future<void> _preCommandPrints(ServerpodCommandRunner runner) async {


### PR DESCRIPTION
Previously we downloaded all templates regardless of which command was run. This caused unecessary time to be wasted if all the user wanted to do is run `serverpod version` for example. This PR moves the template downloading logic to the `create` command specifically.

Fixes #3770

## Pre-launch Checklist

- [X] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [X] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [X] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [X] I added new tests to check the change I am making.
- [X] All existing and new tests are passing.
- [X] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

