### PR TITLE
feat(auth2): Add `serverpod_lints` under`dev_dependencies` in every new auth server package

### DIFF
--- a/modules/new_serverpod_auth/serverpod_auth_apple/serverpod_auth_apple_server/pubspec.yaml
+++ b/modules/new_serverpod_auth/serverpod_auth_apple/serverpod_auth_apple_server/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   serverpod_auth_user_server: 2.9.1
 
 dev_dependencies:
-  lints: ">=3.0.0 <7.0.0"
+  serverpod_lints: 2.9.1
   serverpod_test: 2.9.1
   test: "^1.24.2"
 

--- a/modules/new_serverpod_auth/serverpod_auth_apple_account/serverpod_auth_apple_account_server/pubspec.yaml
+++ b/modules/new_serverpod_auth/serverpod_auth_apple_account/serverpod_auth_apple_account_server/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   serverpod_shared: 2.9.1
 
 dev_dependencies:
-  lints: ">=3.0.0 <7.0.0"
+  serverpod_lints: 2.9.1
   serverpod_test: 2.9.1
   test: "^1.24.2"
 

--- a/modules/new_serverpod_auth/serverpod_auth_backwards_compatibility/serverpod_auth_backwards_compatibility_server/pubspec.yaml
+++ b/modules/new_serverpod_auth/serverpod_auth_backwards_compatibility/serverpod_auth_backwards_compatibility_server/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   serverpod_shared: 2.9.1
 
 dev_dependencies:
-  lints: ">=3.0.0 <7.0.0"
+  serverpod_lints: 2.9.1
   serverpod_test: 2.9.1
   test: ^1.24.2
 

--- a/modules/new_serverpod_auth/serverpod_auth_email/serverpod_auth_email_server/pubspec.yaml
+++ b/modules/new_serverpod_auth/serverpod_auth_email/serverpod_auth_email_server/pubspec.yaml
@@ -17,9 +17,9 @@ dependencies:
   serverpod_auth_user_server: 2.9.1
 
 dev_dependencies:
-  lints: '>=3.0.0 <7.0.0'
+  serverpod_lints: 2.9.1
   serverpod_test: 2.9.1
-  test: '^1.24.2'
+  test: "^1.24.2"
 
 dependency_overrides:
   serverpod:

--- a/modules/new_serverpod_auth/serverpod_auth_email_account/serverpod_auth_email_account_server/pubspec.yaml
+++ b/modules/new_serverpod_auth/serverpod_auth_email_account/serverpod_auth_email_account_server/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 
 dependencies:
   clock: ^1.1.1
-  email_validator: '>=2.1.17 <4.0.0'
+  email_validator: ">=2.1.17 <4.0.0"
   meta: ^1.11.0
   pointycastle: ^3.7.4
   serverpod: 2.9.1
@@ -19,9 +19,9 @@ dependencies:
   serverpod_shared: 2.9.1
 
 dev_dependencies:
-  lints: '>=3.0.0 <7.0.0'
+  serverpod_lints: 2.9.1
   serverpod_test: 2.9.1
-  test: '^1.24.2'
+  test: "^1.24.2"
 
 dependency_overrides:
   serverpod:

--- a/modules/new_serverpod_auth/serverpod_auth_google_account/serverpod_auth_google_account_server/pubspec.yaml
+++ b/modules/new_serverpod_auth/serverpod_auth_google_account/serverpod_auth_google_account_server/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   serverpod_shared: 2.9.1
 
 dev_dependencies:
-  lints: ">=3.0.0 <7.0.0"
+  serverpod_lints: 2.9.1
   serverpod_test: 2.9.1
   test: ^1.24.2
 

--- a/modules/new_serverpod_auth/serverpod_auth_jwt/serverpod_auth_jwt_server/pubspec.yaml
+++ b/modules/new_serverpod_auth/serverpod_auth_jwt/serverpod_auth_jwt_server/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   serverpod_shared: 2.9.1
 
 dev_dependencies:
-  lints: '>=3.0.0 <7.0.0'
+  serverpod_lints: 2.9.1
   serverpod_test: 2.9.1
   test: ^1.24.2
 

--- a/modules/new_serverpod_auth/serverpod_auth_migration/serverpod_auth_migration_server/pubspec.yaml
+++ b/modules/new_serverpod_auth/serverpod_auth_migration/serverpod_auth_migration_server/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
   serverpod_shared: 2.9.1
 
 dev_dependencies:
-  lints: ">=3.0.0 <7.0.0"
+  serverpod_lints: 2.9.1
   serverpod_test: 2.9.1
   test: ^1.24.2
 

--- a/modules/new_serverpod_auth/serverpod_auth_profile/serverpod_auth_profile_server/pubspec.yaml
+++ b/modules/new_serverpod_auth/serverpod_auth_profile/serverpod_auth_profile_server/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: '>=3.5.0 <4.0.0'
 
 dependencies:
-  http: '>=1.1.0 <2.0.0'
+  http: ">=1.1.0 <2.0.0"
   image: ^4.0.15
   serverpod: 2.9.1
   serverpod_auth_user_server: 2.9.1
@@ -18,9 +18,9 @@ dependencies:
   uuid: ^4.1.0
 
 dev_dependencies:
-  lints: '>=3.0.0 <7.0.0'
+  serverpod_lints: 2.9.1
   serverpod_test: 2.9.1
-  test: '^1.24.2'
+  test: "^1.24.2"
 
 dependency_overrides:
   serverpod:

--- a/modules/new_serverpod_auth/serverpod_auth_session/serverpod_auth_session_server/pubspec.yaml
+++ b/modules/new_serverpod_auth/serverpod_auth_session/serverpod_auth_session_server/pubspec.yaml
@@ -15,9 +15,9 @@ dependencies:
   serverpod_shared: 2.9.1
 
 dev_dependencies:
-  lints: '>=3.0.0 <7.0.0'
+  serverpod_lints: 2.9.1
   serverpod_test: 2.9.1
-  test: '^1.24.2'
+  test: "^1.24.2"
 
 dependency_overrides:
   serverpod:

--- a/modules/new_serverpod_auth/serverpod_auth_user/serverpod_auth_user_server/pubspec.yaml
+++ b/modules/new_serverpod_auth/serverpod_auth_user/serverpod_auth_user_server/pubspec.yaml
@@ -14,8 +14,8 @@ dependencies:
   serverpod: 2.9.1
 
 dev_dependencies:
-  lints: '>=3.0.0 <7.0.0'
   meta: ^1.11.0
+  serverpod_lints: 2.9.1
   serverpod_test: 2.9.1
   test: ^1.24.2
 

--- a/templates/pubspecs/modules/new_serverpod_auth/serverpod_auth_apple/serverpod_auth_apple_server/pubspec.yaml
+++ b/templates/pubspecs/modules/new_serverpod_auth/serverpod_auth_apple/serverpod_auth_apple_server/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   serverpod_auth_user_server: SERVERPOD_VERSION
 
 dev_dependencies:
-  lints: ">=3.0.0 <7.0.0"
+  serverpod_lints: SERVERPOD_VERSION
   serverpod_test: SERVERPOD_VERSION
   test: "^1.24.2"
 

--- a/templates/pubspecs/modules/new_serverpod_auth/serverpod_auth_apple_account/serverpod_auth_apple_account_server/pubspec.yaml
+++ b/templates/pubspecs/modules/new_serverpod_auth/serverpod_auth_apple_account/serverpod_auth_apple_account_server/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   serverpod_shared: SERVERPOD_VERSION
 
 dev_dependencies:
-  lints: ">=3.0.0 <7.0.0"
+  serverpod_lints: SERVERPOD_VERSION
   serverpod_test: SERVERPOD_VERSION
   test: "^1.24.2"
 

--- a/templates/pubspecs/modules/new_serverpod_auth/serverpod_auth_backwards_compatibility/serverpod_auth_backwards_compatibility_server/pubspec.yaml
+++ b/templates/pubspecs/modules/new_serverpod_auth/serverpod_auth_backwards_compatibility/serverpod_auth_backwards_compatibility_server/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   serverpod_shared: SERVERPOD_VERSION
 
 dev_dependencies:
-  lints: ">=3.0.0 <7.0.0"
+  serverpod_lints: SERVERPOD_VERSION
   serverpod_test: SERVERPOD_VERSION
   test: ^1.24.2
 

--- a/templates/pubspecs/modules/new_serverpod_auth/serverpod_auth_email/serverpod_auth_email_server/pubspec.yaml
+++ b/templates/pubspecs/modules/new_serverpod_auth/serverpod_auth_email/serverpod_auth_email_server/pubspec.yaml
@@ -16,9 +16,9 @@ dependencies:
   serverpod_auth_user_server: SERVERPOD_VERSION
 
 dev_dependencies:
-  lints: '>=3.0.0 <7.0.0'
+  serverpod_lints: SERVERPOD_VERSION
   serverpod_test: SERVERPOD_VERSION
-  test: '^1.24.2'
+  test: "^1.24.2"
 
 dependency_overrides:
   serverpod:

--- a/templates/pubspecs/modules/new_serverpod_auth/serverpod_auth_email_account/serverpod_auth_email_account_server/pubspec.yaml
+++ b/templates/pubspecs/modules/new_serverpod_auth/serverpod_auth_email_account/serverpod_auth_email_account_server/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 
 dependencies:
   clock: ^1.1.1
-  email_validator: '>=2.1.17 <4.0.0'
+  email_validator: ">=2.1.17 <4.0.0"
   meta: ^1.11.0
   pointycastle: ^3.7.4
   serverpod: SERVERPOD_VERSION
@@ -18,9 +18,9 @@ dependencies:
   serverpod_shared: SERVERPOD_VERSION
 
 dev_dependencies:
-  lints: '>=3.0.0 <7.0.0'
+  serverpod_lints: SERVERPOD_VERSION
   serverpod_test: SERVERPOD_VERSION
-  test: '^1.24.2'
+  test: "^1.24.2"
 
 dependency_overrides:
   serverpod:

--- a/templates/pubspecs/modules/new_serverpod_auth/serverpod_auth_google_account/serverpod_auth_google_account_server/pubspec.yaml
+++ b/templates/pubspecs/modules/new_serverpod_auth/serverpod_auth_google_account/serverpod_auth_google_account_server/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   serverpod_shared: SERVERPOD_VERSION
 
 dev_dependencies:
-  lints: ">=3.0.0 <7.0.0"
+  serverpod_lints: SERVERPOD_VERSION
   serverpod_test: SERVERPOD_VERSION
   test: ^1.24.2
 

--- a/templates/pubspecs/modules/new_serverpod_auth/serverpod_auth_jwt/serverpod_auth_jwt_server/pubspec.yaml
+++ b/templates/pubspecs/modules/new_serverpod_auth/serverpod_auth_jwt/serverpod_auth_jwt_server/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   serverpod_shared: SERVERPOD_VERSION
 
 dev_dependencies:
-  lints: '>=3.0.0 <7.0.0'
+  serverpod_lints: SERVERPOD_VERSION
   serverpod_test: SERVERPOD_VERSION
   test: ^1.24.2
 

--- a/templates/pubspecs/modules/new_serverpod_auth/serverpod_auth_migration/serverpod_auth_migration_server/pubspec.yaml
+++ b/templates/pubspecs/modules/new_serverpod_auth/serverpod_auth_migration/serverpod_auth_migration_server/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
   serverpod_shared: SERVERPOD_VERSION
 
 dev_dependencies:
-  lints: ">=3.0.0 <7.0.0"
+  serverpod_lints: SERVERPOD_VERSION
   serverpod_test: SERVERPOD_VERSION
   test: ^1.24.2
 

--- a/templates/pubspecs/modules/new_serverpod_auth/serverpod_auth_profile/serverpod_auth_profile_server/pubspec.yaml
+++ b/templates/pubspecs/modules/new_serverpod_auth/serverpod_auth_profile/serverpod_auth_profile_server/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: DART_VERSION
 
 dependencies:
-  http: '>=1.1.0 <2.0.0'
+  http: ">=1.1.0 <2.0.0"
   image: ^4.0.15
   serverpod: SERVERPOD_VERSION
   serverpod_auth_user_server: SERVERPOD_VERSION
@@ -17,9 +17,9 @@ dependencies:
   uuid: ^4.1.0
 
 dev_dependencies:
-  lints: '>=3.0.0 <7.0.0'
+  serverpod_lints: SERVERPOD_VERSION
   serverpod_test: SERVERPOD_VERSION
-  test: '^1.24.2'
+  test: "^1.24.2"
 
 dependency_overrides:
   serverpod:

--- a/templates/pubspecs/modules/new_serverpod_auth/serverpod_auth_session/serverpod_auth_session_server/pubspec.yaml
+++ b/templates/pubspecs/modules/new_serverpod_auth/serverpod_auth_session/serverpod_auth_session_server/pubspec.yaml
@@ -15,9 +15,9 @@ dependencies:
   serverpod_shared: SERVERPOD_VERSION
 
 dev_dependencies:
-  lints: '>=3.0.0 <7.0.0'
+  serverpod_lints: SERVERPOD_VERSION
   serverpod_test: SERVERPOD_VERSION
-  test: '^1.24.2'
+  test: "^1.24.2"
 
 dependency_overrides:
   serverpod:

--- a/templates/pubspecs/modules/new_serverpod_auth/serverpod_auth_user/serverpod_auth_user_server/pubspec.yaml
+++ b/templates/pubspecs/modules/new_serverpod_auth/serverpod_auth_user/serverpod_auth_user_server/pubspec.yaml
@@ -13,8 +13,8 @@ dependencies:
   serverpod: SERVERPOD_VERSION
 
 dev_dependencies:
-  lints: '>=3.0.0 <7.0.0'
   meta: ^1.11.0
+  serverpod_lints: SERVERPOD_VERSION
   serverpod_test: SERVERPOD_VERSION
   test: ^1.24.2
 


### PR DESCRIPTION
As the server's analysis options rely on it. Before it was always implicitly included and the analysis working without error, but now it's properly mentioned.