### PR TITLE
feat(auth2): Implement Sign in with Apple base endpoint

### DIFF
--- a/modules/new_serverpod_auth/serverpod_auth_apple/serverpod_auth_apple_server/lib/src/endpoints/apple_account_base_endpoint.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_apple/serverpod_auth_apple_server/lib/src/endpoints/apple_account_base_endpoint.dart
@@ -1,0 +1,93 @@
+import 'package:serverpod/serverpod.dart';
+import 'package:serverpod_auth_apple_account_server/serverpod_auth_apple_account_server.dart';
+import 'package:serverpod_auth_profile_server/serverpod_auth_profile_server.dart';
+import 'package:serverpod_auth_session_server/serverpod_auth_session_server.dart';
+import 'package:serverpod_auth_user_server/serverpod_auth_user_server.dart';
+
+/// Endpoint for handling Sign in with Apple.
+abstract class AppleAccountBaseEndpoint extends Endpoint {
+  static const String _method = 'apple';
+
+  /// Signs in a user with their Apple account.
+  ///
+  /// If no user exists yet linked to the Apple-provided identifier, a new one
+  /// will be created (without any `Scope`s). Further their provided name and
+  /// email (if any) will be used for the `UserProfile` which will be linked to
+  /// their `AuthUser`.
+  ///
+  /// Returns a session for the user upon successful login.
+  Future<AuthSuccess> signIn(
+    final Session session, {
+    required final String identityToken,
+    required final String authorizationCode,
+
+    /// Whether the sign-in was triggered from a native Apple platform app.
+    ///
+    /// Pass `false` for web sign-ins or 3rd party platforms like Android.
+    required final bool isNativeApplePlatformSignIn,
+    final String? firstName,
+    final String? lastName,
+  }) async {
+    return session.db.transaction((final transaction) async {
+      final account = await AppleAccounts.signIn(
+        session,
+        identityToken: identityToken,
+        authorizationCode: authorizationCode,
+        isNativeApplePlatformSignIn: isNativeApplePlatformSignIn,
+        firstName: firstName,
+        lastName: lastName,
+        transaction: transaction,
+      );
+
+      if (account.authUserNewlyCreated) {
+        await UserProfiles.createUserProfile(
+          session,
+          account.authUserId,
+          UserProfileData(
+            fullName: [account.details.firstName, account.details.lastName]
+                .nonNulls
+                .map((final n) => n.trim())
+                .where((final n) => n.isNotEmpty)
+                .join(' '),
+            email: account.details.isVerifiedEmail == true
+                ? account.details.email
+                : null,
+          ),
+          transaction: transaction,
+        );
+      }
+
+      return _createSession(
+        session,
+        account.authUserId,
+        transaction: transaction,
+      );
+    });
+  }
+
+  Future<AuthSuccess> _createSession(
+    final Session session,
+    final UuidValue authUserId, {
+    final Transaction? transaction,
+  }) async {
+    final authUser = await AuthUsers.get(
+      session,
+      authUserId: authUserId,
+      transaction: transaction,
+    );
+
+    if (authUser.blocked) {
+      throw AuthUserBlockedException();
+    }
+
+    final sessionKey = await AuthSessions.createSession(
+      session,
+      authUserId: authUserId,
+      method: _method,
+      scopes: authUser.scopes,
+      transaction: transaction,
+    );
+
+    return sessionKey;
+  }
+}

--- a/modules/new_serverpod_auth/serverpod_auth_apple_account/serverpod_auth_apple_account_server/lib/src/business/apple_accounts_admin.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_apple_account/serverpod_auth_apple_account_server/lib/src/business/apple_accounts_admin.dart
@@ -44,6 +44,10 @@ final class AppleAccountsAdmin {
         transaction: transaction,
       );
 
+      if (appleAccounts.isEmpty) {
+        break;
+      }
+
       for (final appleAccount in appleAccounts) {
         try {
           // TODO: Get proper status from library in error cases.


### PR DESCRIPTION
Relates to https://github.com/serverpod/serverpod/issues/3453

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced support for Sign in with Apple, allowing users to authenticate or create accounts using their Apple credentials.
  * User profiles are now automatically created for new users signing in with Apple, utilizing provided names and verified email addresses when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->