### PR TITLE
fix(auth2): Retain Apple refresh token source for later requests

### DIFF
--- a/modules/new_serverpod_auth/serverpod_auth_apple/serverpod_auth_apple_client/lib/src/protocol/client.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_apple/serverpod_auth_apple_client/lib/src/protocol/client.dart
@@ -7,6 +7,7 @@
 // ignore_for_file: public_member_api_docs
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
+// ignore_for_file: invalid_use_of_internal_member
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;

--- a/modules/new_serverpod_auth/serverpod_auth_apple/serverpod_auth_apple_client/lib/src/protocol/protocol.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_apple/serverpod_auth_apple_client/lib/src/protocol/protocol.dart
@@ -7,6 +7,7 @@
 // ignore_for_file: public_member_api_docs
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
+// ignore_for_file: invalid_use_of_internal_member
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;

--- a/modules/new_serverpod_auth/serverpod_auth_apple/serverpod_auth_apple_server/lib/src/generated/endpoints.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_apple/serverpod_auth_apple_server/lib/src/generated/endpoints.dart
@@ -7,6 +7,7 @@
 // ignore_for_file: public_member_api_docs
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
+// ignore_for_file: invalid_use_of_internal_member
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/modules/new_serverpod_auth/serverpod_auth_apple/serverpod_auth_apple_server/lib/src/generated/protocol.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_apple/serverpod_auth_apple_server/lib/src/generated/protocol.dart
@@ -7,6 +7,7 @@
 // ignore_for_file: public_member_api_docs
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
+// ignore_for_file: invalid_use_of_internal_member
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/modules/new_serverpod_auth/serverpod_auth_apple/serverpod_auth_apple_server/migrations/20250716140001984/definition.json
+++ b/modules/new_serverpod_auth/serverpod_auth_apple/serverpod_auth_apple_server/migrations/20250716140001984/definition.json
@@ -1,124 +1,6 @@
 {
-  "moduleName": "serverpod_auth_apple_account",
+  "moduleName": "serverpod_auth_apple",
   "tables": [
-    {
-      "name": "serverpod_auth_apple_account",
-      "dartName": "AppleAccount",
-      "module": "serverpod_auth_apple_account",
-      "schema": "public",
-      "columns": [
-        {
-          "name": "id",
-          "columnType": 7,
-          "isNullable": false,
-          "columnDefault": "gen_random_uuid()",
-          "dartType": "UuidValue?"
-        },
-        {
-          "name": "userIdentifier",
-          "columnType": 0,
-          "isNullable": false,
-          "dartType": "String"
-        },
-        {
-          "name": "refreshToken",
-          "columnType": 0,
-          "isNullable": false,
-          "dartType": "String"
-        },
-        {
-          "name": "lastRefreshed",
-          "columnType": 4,
-          "isNullable": false,
-          "columnDefault": "CURRENT_TIMESTAMP",
-          "dartType": "DateTime"
-        },
-        {
-          "name": "authUserId",
-          "columnType": 7,
-          "isNullable": false,
-          "dartType": "UuidValue"
-        },
-        {
-          "name": "created",
-          "columnType": 4,
-          "isNullable": false,
-          "dartType": "DateTime"
-        },
-        {
-          "name": "email",
-          "columnType": 0,
-          "isNullable": true,
-          "dartType": "String?"
-        },
-        {
-          "name": "isEmailVerified",
-          "columnType": 1,
-          "isNullable": true,
-          "dartType": "bool?"
-        },
-        {
-          "name": "isPrivateEmail",
-          "columnType": 1,
-          "isNullable": true,
-          "dartType": "bool?"
-        },
-        {
-          "name": "firstName",
-          "columnType": 0,
-          "isNullable": true,
-          "dartType": "String?"
-        },
-        {
-          "name": "lastName",
-          "columnType": 0,
-          "isNullable": true,
-          "dartType": "String?"
-        }
-      ],
-      "foreignKeys": [
-        {
-          "constraintName": "serverpod_auth_apple_account_fk_0",
-          "columns": [
-            "authUserId"
-          ],
-          "referenceTable": "serverpod_auth_user",
-          "referenceTableSchema": "public",
-          "referenceColumns": [
-            "id"
-          ],
-          "onUpdate": 3,
-          "onDelete": 4
-        }
-      ],
-      "indexes": [
-        {
-          "indexName": "serverpod_auth_apple_account_pkey",
-          "elements": [
-            {
-              "type": 0,
-              "definition": "id"
-            }
-          ],
-          "type": "btree",
-          "isUnique": true,
-          "isPrimary": true
-        },
-        {
-          "indexName": "serverpod_auth_apple_account_identifier",
-          "elements": [
-            {
-              "type": 0,
-              "definition": "userIdentifier"
-            }
-          ],
-          "type": "btree",
-          "isUnique": true,
-          "isPrimary": false
-        }
-      ],
-      "managed": true
-    },
     {
       "name": "serverpod_cloud_storage",
       "dartName": "CloudStorageEntry",
@@ -1257,6 +1139,414 @@
       "managed": true
     },
     {
+      "name": "serverpod_auth_apple_account",
+      "dartName": "AppleAccount",
+      "module": "serverpod_auth_apple_account",
+      "schema": "public",
+      "columns": [
+        {
+          "name": "id",
+          "columnType": 7,
+          "isNullable": false,
+          "columnDefault": "gen_random_uuid()",
+          "dartType": "UuidValue?"
+        },
+        {
+          "name": "userIdentifier",
+          "columnType": 0,
+          "isNullable": false,
+          "dartType": "String"
+        },
+        {
+          "name": "refreshToken",
+          "columnType": 0,
+          "isNullable": false,
+          "dartType": "String"
+        },
+        {
+          "name": "refreshTokenRequestedWithBundleIdentifier",
+          "columnType": 1,
+          "isNullable": false,
+          "dartType": "bool"
+        },
+        {
+          "name": "lastRefreshed",
+          "columnType": 4,
+          "isNullable": false,
+          "columnDefault": "CURRENT_TIMESTAMP",
+          "dartType": "DateTime"
+        },
+        {
+          "name": "authUserId",
+          "columnType": 7,
+          "isNullable": false,
+          "dartType": "UuidValue"
+        },
+        {
+          "name": "created",
+          "columnType": 4,
+          "isNullable": false,
+          "dartType": "DateTime"
+        },
+        {
+          "name": "email",
+          "columnType": 0,
+          "isNullable": true,
+          "dartType": "String?"
+        },
+        {
+          "name": "isEmailVerified",
+          "columnType": 1,
+          "isNullable": true,
+          "dartType": "bool?"
+        },
+        {
+          "name": "isPrivateEmail",
+          "columnType": 1,
+          "isNullable": true,
+          "dartType": "bool?"
+        },
+        {
+          "name": "firstName",
+          "columnType": 0,
+          "isNullable": true,
+          "dartType": "String?"
+        },
+        {
+          "name": "lastName",
+          "columnType": 0,
+          "isNullable": true,
+          "dartType": "String?"
+        }
+      ],
+      "foreignKeys": [
+        {
+          "constraintName": "serverpod_auth_apple_account_fk_0",
+          "columns": [
+            "authUserId"
+          ],
+          "referenceTable": "serverpod_auth_user",
+          "referenceTableSchema": "public",
+          "referenceColumns": [
+            "id"
+          ],
+          "onUpdate": 3,
+          "onDelete": 4
+        }
+      ],
+      "indexes": [
+        {
+          "indexName": "serverpod_auth_apple_account_pkey",
+          "elements": [
+            {
+              "type": 0,
+              "definition": "id"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": true
+        },
+        {
+          "indexName": "serverpod_auth_apple_account_identifier",
+          "elements": [
+            {
+              "type": 0,
+              "definition": "userIdentifier"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": false
+        }
+      ],
+      "managed": true
+    },
+    {
+      "name": "serverpod_auth_profile_user_profile",
+      "dartName": "UserProfile",
+      "module": "serverpod_auth_profile",
+      "schema": "public",
+      "columns": [
+        {
+          "name": "id",
+          "columnType": 7,
+          "isNullable": false,
+          "columnDefault": "gen_random_uuid()",
+          "dartType": "UuidValue?"
+        },
+        {
+          "name": "authUserId",
+          "columnType": 7,
+          "isNullable": false,
+          "dartType": "UuidValue"
+        },
+        {
+          "name": "userName",
+          "columnType": 0,
+          "isNullable": true,
+          "dartType": "String?"
+        },
+        {
+          "name": "fullName",
+          "columnType": 0,
+          "isNullable": true,
+          "dartType": "String?"
+        },
+        {
+          "name": "email",
+          "columnType": 0,
+          "isNullable": true,
+          "dartType": "String?"
+        },
+        {
+          "name": "created",
+          "columnType": 4,
+          "isNullable": false,
+          "columnDefault": "CURRENT_TIMESTAMP",
+          "dartType": "DateTime"
+        },
+        {
+          "name": "imageId",
+          "columnType": 7,
+          "isNullable": true,
+          "dartType": "UuidValue?"
+        }
+      ],
+      "foreignKeys": [
+        {
+          "constraintName": "serverpod_auth_profile_user_profile_fk_0",
+          "columns": [
+            "authUserId"
+          ],
+          "referenceTable": "serverpod_auth_user",
+          "referenceTableSchema": "public",
+          "referenceColumns": [
+            "id"
+          ],
+          "onUpdate": 3,
+          "onDelete": 4
+        },
+        {
+          "constraintName": "serverpod_auth_profile_user_profile_fk_1",
+          "columns": [
+            "imageId"
+          ],
+          "referenceTable": "serverpod_auth_profile_user_profile_image",
+          "referenceTableSchema": "public",
+          "referenceColumns": [
+            "id"
+          ],
+          "onUpdate": 3,
+          "onDelete": 3
+        }
+      ],
+      "indexes": [
+        {
+          "indexName": "serverpod_auth_profile_user_profile_pkey",
+          "elements": [
+            {
+              "type": 0,
+              "definition": "id"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": true
+        },
+        {
+          "indexName": "serverpod_auth_profile_user_profile_email_auth_user_id",
+          "elements": [
+            {
+              "type": 0,
+              "definition": "authUserId"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": false
+        }
+      ],
+      "managed": true
+    },
+    {
+      "name": "serverpod_auth_profile_user_profile_image",
+      "dartName": "UserProfileImage",
+      "module": "serverpod_auth_profile",
+      "schema": "public",
+      "columns": [
+        {
+          "name": "id",
+          "columnType": 7,
+          "isNullable": false,
+          "columnDefault": "gen_random_uuid()",
+          "dartType": "UuidValue?"
+        },
+        {
+          "name": "userProfileId",
+          "columnType": 7,
+          "isNullable": false,
+          "dartType": "UuidValue"
+        },
+        {
+          "name": "created",
+          "columnType": 4,
+          "isNullable": false,
+          "columnDefault": "CURRENT_TIMESTAMP",
+          "dartType": "DateTime"
+        },
+        {
+          "name": "storageId",
+          "columnType": 0,
+          "isNullable": false,
+          "dartType": "String"
+        },
+        {
+          "name": "path",
+          "columnType": 0,
+          "isNullable": false,
+          "dartType": "String"
+        },
+        {
+          "name": "url",
+          "columnType": 0,
+          "isNullable": false,
+          "dartType": "Uri"
+        }
+      ],
+      "foreignKeys": [
+        {
+          "constraintName": "serverpod_auth_profile_user_profile_image_fk_0",
+          "columns": [
+            "userProfileId"
+          ],
+          "referenceTable": "serverpod_auth_profile_user_profile",
+          "referenceTableSchema": "public",
+          "referenceColumns": [
+            "id"
+          ],
+          "onUpdate": 3,
+          "onDelete": 4
+        }
+      ],
+      "indexes": [
+        {
+          "indexName": "serverpod_auth_profile_user_profile_image_pkey",
+          "elements": [
+            {
+              "type": 0,
+              "definition": "id"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": true
+        }
+      ],
+      "managed": true
+    },
+    {
+      "name": "serverpod_auth_session",
+      "dartName": "AuthSession",
+      "module": "serverpod_auth_session",
+      "schema": "public",
+      "columns": [
+        {
+          "name": "id",
+          "columnType": 7,
+          "isNullable": false,
+          "columnDefault": "gen_random_uuid()",
+          "dartType": "UuidValue?"
+        },
+        {
+          "name": "authUserId",
+          "columnType": 7,
+          "isNullable": false,
+          "dartType": "UuidValue"
+        },
+        {
+          "name": "scopeNames",
+          "columnType": 8,
+          "isNullable": false,
+          "dartType": "Set<String>"
+        },
+        {
+          "name": "created",
+          "columnType": 4,
+          "isNullable": false,
+          "columnDefault": "CURRENT_TIMESTAMP",
+          "dartType": "DateTime"
+        },
+        {
+          "name": "lastUsed",
+          "columnType": 4,
+          "isNullable": false,
+          "columnDefault": "CURRENT_TIMESTAMP",
+          "dartType": "DateTime"
+        },
+        {
+          "name": "expiresAt",
+          "columnType": 4,
+          "isNullable": true,
+          "dartType": "DateTime?"
+        },
+        {
+          "name": "expireAfterUnusedFor",
+          "columnType": 6,
+          "isNullable": true,
+          "dartType": "Duration?"
+        },
+        {
+          "name": "sessionKeyHash",
+          "columnType": 5,
+          "isNullable": false,
+          "dartType": "dart:typed_data:ByteData"
+        },
+        {
+          "name": "sessionKeySalt",
+          "columnType": 5,
+          "isNullable": false,
+          "dartType": "dart:typed_data:ByteData"
+        },
+        {
+          "name": "method",
+          "columnType": 0,
+          "isNullable": false,
+          "dartType": "String"
+        }
+      ],
+      "foreignKeys": [
+        {
+          "constraintName": "serverpod_auth_session_fk_0",
+          "columns": [
+            "authUserId"
+          ],
+          "referenceTable": "serverpod_auth_user",
+          "referenceTableSchema": "public",
+          "referenceColumns": [
+            "id"
+          ],
+          "onUpdate": 3,
+          "onDelete": 4
+        }
+      ],
+      "indexes": [
+        {
+          "indexName": "serverpod_auth_session_pkey",
+          "elements": [
+            {
+              "type": 0,
+              "definition": "id"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": true
+        }
+      ],
+      "managed": true
+    },
+    {
       "name": "serverpod_auth_user",
       "dartName": "AuthUser",
       "module": "serverpod_auth_user",
@@ -1308,12 +1598,24 @@
   ],
   "installedModules": [
     {
-      "module": "serverpod_auth_apple_account",
-      "version": "20250715133410884"
+      "module": "serverpod_auth_apple",
+      "version": "20250716140001984"
     },
     {
       "module": "serverpod",
       "version": "20240516151843329"
+    },
+    {
+      "module": "serverpod_auth_apple_account",
+      "version": "20250716135530275"
+    },
+    {
+      "module": "serverpod_auth_profile",
+      "version": "20250519092101868"
+    },
+    {
+      "module": "serverpod_auth_session",
+      "version": "20250611085050241"
     },
     {
       "module": "serverpod_auth_user",

--- a/modules/new_serverpod_auth/serverpod_auth_apple/serverpod_auth_apple_server/migrations/20250716140001984/definition.sql
+++ b/modules/new_serverpod_auth/serverpod_auth_apple/serverpod_auth_apple_server/migrations/20250716140001984/definition.sql
@@ -1,27 +1,7 @@
 BEGIN;
 
 --
--- ACTION CREATE TABLE
---
-CREATE TABLE "serverpod_auth_apple_account" (
-    "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-    "userIdentifier" text NOT NULL,
-    "refreshToken" text NOT NULL,
-    "lastRefreshed" timestamp without time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    "authUserId" uuid NOT NULL,
-    "created" timestamp without time zone NOT NULL,
-    "email" text,
-    "isEmailVerified" boolean,
-    "isPrivateEmail" boolean,
-    "firstName" text,
-    "lastName" text
-);
-
--- Indexes
-CREATE UNIQUE INDEX "serverpod_auth_apple_account_identifier" ON "serverpod_auth_apple_account" USING btree ("userIdentifier");
-
---
--- ACTION CREATE TABLE
+-- Class CloudStorageEntry as table serverpod_cloud_storage
 --
 CREATE TABLE "serverpod_cloud_storage" (
     "id" bigserial PRIMARY KEY,
@@ -38,7 +18,7 @@ CREATE UNIQUE INDEX "serverpod_cloud_storage_path_idx" ON "serverpod_cloud_stora
 CREATE INDEX "serverpod_cloud_storage_expiration" ON "serverpod_cloud_storage" USING btree ("expiration");
 
 --
--- ACTION CREATE TABLE
+-- Class CloudStorageDirectUploadEntry as table serverpod_cloud_storage_direct_upload
 --
 CREATE TABLE "serverpod_cloud_storage_direct_upload" (
     "id" bigserial PRIMARY KEY,
@@ -52,7 +32,7 @@ CREATE TABLE "serverpod_cloud_storage_direct_upload" (
 CREATE UNIQUE INDEX "serverpod_cloud_storage_direct_upload_storage_path" ON "serverpod_cloud_storage_direct_upload" USING btree ("storageId", "path");
 
 --
--- ACTION CREATE TABLE
+-- Class FutureCallEntry as table serverpod_future_call
 --
 CREATE TABLE "serverpod_future_call" (
     "id" bigserial PRIMARY KEY,
@@ -69,7 +49,7 @@ CREATE INDEX "serverpod_future_call_serverId_idx" ON "serverpod_future_call" USI
 CREATE INDEX "serverpod_future_call_identifier_idx" ON "serverpod_future_call" USING btree ("identifier");
 
 --
--- ACTION CREATE TABLE
+-- Class ServerHealthConnectionInfo as table serverpod_health_connection_info
 --
 CREATE TABLE "serverpod_health_connection_info" (
     "id" bigserial PRIMARY KEY,
@@ -85,7 +65,7 @@ CREATE TABLE "serverpod_health_connection_info" (
 CREATE UNIQUE INDEX "serverpod_health_connection_info_timestamp_idx" ON "serverpod_health_connection_info" USING btree ("timestamp", "serverId", "granularity");
 
 --
--- ACTION CREATE TABLE
+-- Class ServerHealthMetric as table serverpod_health_metric
 --
 CREATE TABLE "serverpod_health_metric" (
     "id" bigserial PRIMARY KEY,
@@ -101,7 +81,7 @@ CREATE TABLE "serverpod_health_metric" (
 CREATE UNIQUE INDEX "serverpod_health_metric_timestamp_idx" ON "serverpod_health_metric" USING btree ("timestamp", "serverId", "name", "granularity");
 
 --
--- ACTION CREATE TABLE
+-- Class LogEntry as table serverpod_log
 --
 CREATE TABLE "serverpod_log" (
     "id" bigserial PRIMARY KEY,
@@ -121,7 +101,7 @@ CREATE TABLE "serverpod_log" (
 CREATE INDEX "serverpod_log_sessionLogId_idx" ON "serverpod_log" USING btree ("sessionLogId");
 
 --
--- ACTION CREATE TABLE
+-- Class MessageLogEntry as table serverpod_message_log
 --
 CREATE TABLE "serverpod_message_log" (
     "id" bigserial PRIMARY KEY,
@@ -138,7 +118,7 @@ CREATE TABLE "serverpod_message_log" (
 );
 
 --
--- ACTION CREATE TABLE
+-- Class MethodInfo as table serverpod_method
 --
 CREATE TABLE "serverpod_method" (
     "id" bigserial PRIMARY KEY,
@@ -150,7 +130,7 @@ CREATE TABLE "serverpod_method" (
 CREATE UNIQUE INDEX "serverpod_method_endpoint_method_idx" ON "serverpod_method" USING btree ("endpoint", "method");
 
 --
--- ACTION CREATE TABLE
+-- Class DatabaseMigrationVersion as table serverpod_migrations
 --
 CREATE TABLE "serverpod_migrations" (
     "id" bigserial PRIMARY KEY,
@@ -163,7 +143,7 @@ CREATE TABLE "serverpod_migrations" (
 CREATE UNIQUE INDEX "serverpod_migrations_ids" ON "serverpod_migrations" USING btree ("module");
 
 --
--- ACTION CREATE TABLE
+-- Class QueryLogEntry as table serverpod_query_log
 --
 CREATE TABLE "serverpod_query_log" (
     "id" bigserial PRIMARY KEY,
@@ -183,7 +163,7 @@ CREATE TABLE "serverpod_query_log" (
 CREATE INDEX "serverpod_query_log_sessionLogId_idx" ON "serverpod_query_log" USING btree ("sessionLogId");
 
 --
--- ACTION CREATE TABLE
+-- Class ReadWriteTestEntry as table serverpod_readwrite_test
 --
 CREATE TABLE "serverpod_readwrite_test" (
     "id" bigserial PRIMARY KEY,
@@ -191,7 +171,7 @@ CREATE TABLE "serverpod_readwrite_test" (
 );
 
 --
--- ACTION CREATE TABLE
+-- Class RuntimeSettings as table serverpod_runtime_settings
 --
 CREATE TABLE "serverpod_runtime_settings" (
     "id" bigserial PRIMARY KEY,
@@ -202,7 +182,7 @@ CREATE TABLE "serverpod_runtime_settings" (
 );
 
 --
--- ACTION CREATE TABLE
+-- Class SessionLogEntry as table serverpod_session_log
 --
 CREATE TABLE "serverpod_session_log" (
     "id" bigserial PRIMARY KEY,
@@ -227,7 +207,72 @@ CREATE INDEX "serverpod_session_log_touched_idx" ON "serverpod_session_log" USIN
 CREATE INDEX "serverpod_session_log_isopen_idx" ON "serverpod_session_log" USING btree ("isOpen");
 
 --
--- ACTION CREATE TABLE
+-- Class AppleAccount as table serverpod_auth_apple_account
+--
+CREATE TABLE "serverpod_auth_apple_account" (
+    "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    "userIdentifier" text NOT NULL,
+    "refreshToken" text NOT NULL,
+    "refreshTokenRequestedWithBundleIdentifier" boolean NOT NULL,
+    "lastRefreshed" timestamp without time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "authUserId" uuid NOT NULL,
+    "created" timestamp without time zone NOT NULL,
+    "email" text,
+    "isEmailVerified" boolean,
+    "isPrivateEmail" boolean,
+    "firstName" text,
+    "lastName" text
+);
+
+-- Indexes
+CREATE UNIQUE INDEX "serverpod_auth_apple_account_identifier" ON "serverpod_auth_apple_account" USING btree ("userIdentifier");
+
+--
+-- Class UserProfile as table serverpod_auth_profile_user_profile
+--
+CREATE TABLE "serverpod_auth_profile_user_profile" (
+    "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    "authUserId" uuid NOT NULL,
+    "userName" text,
+    "fullName" text,
+    "email" text,
+    "created" timestamp without time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "imageId" uuid
+);
+
+-- Indexes
+CREATE UNIQUE INDEX "serverpod_auth_profile_user_profile_email_auth_user_id" ON "serverpod_auth_profile_user_profile" USING btree ("authUserId");
+
+--
+-- Class UserProfileImage as table serverpod_auth_profile_user_profile_image
+--
+CREATE TABLE "serverpod_auth_profile_user_profile_image" (
+    "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    "userProfileId" uuid NOT NULL,
+    "created" timestamp without time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "storageId" text NOT NULL,
+    "path" text NOT NULL,
+    "url" text NOT NULL
+);
+
+--
+-- Class AuthSession as table serverpod_auth_session
+--
+CREATE TABLE "serverpod_auth_session" (
+    "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    "authUserId" uuid NOT NULL,
+    "scopeNames" json NOT NULL,
+    "created" timestamp without time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "lastUsed" timestamp without time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "expiresAt" timestamp without time zone,
+    "expireAfterUnusedFor" bigint,
+    "sessionKeyHash" bytea NOT NULL,
+    "sessionKeySalt" bytea NOT NULL,
+    "method" text NOT NULL
+);
+
+--
+-- Class AuthUser as table serverpod_auth_user
 --
 CREATE TABLE "serverpod_auth_user" (
     "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -237,17 +282,7 @@ CREATE TABLE "serverpod_auth_user" (
 );
 
 --
--- ACTION CREATE FOREIGN KEY
---
-ALTER TABLE ONLY "serverpod_auth_apple_account"
-    ADD CONSTRAINT "serverpod_auth_apple_account_fk_0"
-    FOREIGN KEY("authUserId")
-    REFERENCES "serverpod_auth_user"("id")
-    ON DELETE CASCADE
-    ON UPDATE NO ACTION;
-
---
--- ACTION CREATE FOREIGN KEY
+-- Foreign relations for "serverpod_log" table
 --
 ALTER TABLE ONLY "serverpod_log"
     ADD CONSTRAINT "serverpod_log_fk_0"
@@ -257,7 +292,7 @@ ALTER TABLE ONLY "serverpod_log"
     ON UPDATE NO ACTION;
 
 --
--- ACTION CREATE FOREIGN KEY
+-- Foreign relations for "serverpod_message_log" table
 --
 ALTER TABLE ONLY "serverpod_message_log"
     ADD CONSTRAINT "serverpod_message_log_fk_0"
@@ -267,7 +302,7 @@ ALTER TABLE ONLY "serverpod_message_log"
     ON UPDATE NO ACTION;
 
 --
--- ACTION CREATE FOREIGN KEY
+-- Foreign relations for "serverpod_query_log" table
 --
 ALTER TABLE ONLY "serverpod_query_log"
     ADD CONSTRAINT "serverpod_query_log_fk_0"
@@ -276,14 +311,60 @@ ALTER TABLE ONLY "serverpod_query_log"
     ON DELETE CASCADE
     ON UPDATE NO ACTION;
 
+--
+-- Foreign relations for "serverpod_auth_apple_account" table
+--
+ALTER TABLE ONLY "serverpod_auth_apple_account"
+    ADD CONSTRAINT "serverpod_auth_apple_account_fk_0"
+    FOREIGN KEY("authUserId")
+    REFERENCES "serverpod_auth_user"("id")
+    ON DELETE CASCADE
+    ON UPDATE NO ACTION;
 
 --
--- MIGRATION VERSION FOR serverpod_auth_apple_account
+-- Foreign relations for "serverpod_auth_profile_user_profile" table
+--
+ALTER TABLE ONLY "serverpod_auth_profile_user_profile"
+    ADD CONSTRAINT "serverpod_auth_profile_user_profile_fk_0"
+    FOREIGN KEY("authUserId")
+    REFERENCES "serverpod_auth_user"("id")
+    ON DELETE CASCADE
+    ON UPDATE NO ACTION;
+ALTER TABLE ONLY "serverpod_auth_profile_user_profile"
+    ADD CONSTRAINT "serverpod_auth_profile_user_profile_fk_1"
+    FOREIGN KEY("imageId")
+    REFERENCES "serverpod_auth_profile_user_profile_image"("id")
+    ON DELETE NO ACTION
+    ON UPDATE NO ACTION;
+
+--
+-- Foreign relations for "serverpod_auth_profile_user_profile_image" table
+--
+ALTER TABLE ONLY "serverpod_auth_profile_user_profile_image"
+    ADD CONSTRAINT "serverpod_auth_profile_user_profile_image_fk_0"
+    FOREIGN KEY("userProfileId")
+    REFERENCES "serverpod_auth_profile_user_profile"("id")
+    ON DELETE CASCADE
+    ON UPDATE NO ACTION;
+
+--
+-- Foreign relations for "serverpod_auth_session" table
+--
+ALTER TABLE ONLY "serverpod_auth_session"
+    ADD CONSTRAINT "serverpod_auth_session_fk_0"
+    FOREIGN KEY("authUserId")
+    REFERENCES "serverpod_auth_user"("id")
+    ON DELETE CASCADE
+    ON UPDATE NO ACTION;
+
+
+--
+-- MIGRATION VERSION FOR serverpod_auth_apple
 --
 INSERT INTO "serverpod_migrations" ("module", "version", "timestamp")
-    VALUES ('serverpod_auth_apple_account', '20250715133410884', now())
+    VALUES ('serverpod_auth_apple', '20250716140001984', now())
     ON CONFLICT ("module")
-    DO UPDATE SET "version" = '20250715133410884', "timestamp" = now();
+    DO UPDATE SET "version" = '20250716140001984', "timestamp" = now();
 
 --
 -- MIGRATION VERSION FOR serverpod
@@ -292,6 +373,30 @@ INSERT INTO "serverpod_migrations" ("module", "version", "timestamp")
     VALUES ('serverpod', '20240516151843329', now())
     ON CONFLICT ("module")
     DO UPDATE SET "version" = '20240516151843329', "timestamp" = now();
+
+--
+-- MIGRATION VERSION FOR serverpod_auth_apple_account
+--
+INSERT INTO "serverpod_migrations" ("module", "version", "timestamp")
+    VALUES ('serverpod_auth_apple_account', '20250716135530275', now())
+    ON CONFLICT ("module")
+    DO UPDATE SET "version" = '20250716135530275', "timestamp" = now();
+
+--
+-- MIGRATION VERSION FOR serverpod_auth_profile
+--
+INSERT INTO "serverpod_migrations" ("module", "version", "timestamp")
+    VALUES ('serverpod_auth_profile', '20250519092101868', now())
+    ON CONFLICT ("module")
+    DO UPDATE SET "version" = '20250519092101868', "timestamp" = now();
+
+--
+-- MIGRATION VERSION FOR serverpod_auth_session
+--
+INSERT INTO "serverpod_migrations" ("module", "version", "timestamp")
+    VALUES ('serverpod_auth_session', '20250611085050241', now())
+    ON CONFLICT ("module")
+    DO UPDATE SET "version" = '20250611085050241', "timestamp" = now();
 
 --
 -- MIGRATION VERSION FOR serverpod_auth_user

--- a/modules/new_serverpod_auth/serverpod_auth_apple/serverpod_auth_apple_server/migrations/20250716140001984/definition_project.json
+++ b/modules/new_serverpod_auth/serverpod_auth_apple/serverpod_auth_apple_server/migrations/20250716140001984/definition_project.json
@@ -8,7 +8,7 @@
     },
     {
       "module": "serverpod_auth_apple_account",
-      "version": "20250715133410884"
+      "version": "20250716135530275"
     },
     {
       "module": "serverpod_auth_profile",

--- a/modules/new_serverpod_auth/serverpod_auth_apple/serverpod_auth_apple_server/migrations/20250716140001984/migration.json
+++ b/modules/new_serverpod_auth/serverpod_auth_apple/serverpod_auth_apple_server/migrations/20250716140001984/migration.json
@@ -1204,6 +1204,12 @@
             "dartType": "String"
           },
           {
+            "name": "refreshTokenRequestedWithBundleIdentifier",
+            "columnType": 1,
+            "isNullable": false,
+            "dartType": "bool"
+          },
+          {
             "name": "lastRefreshed",
             "columnType": 4,
             "isNullable": false,

--- a/modules/new_serverpod_auth/serverpod_auth_apple/serverpod_auth_apple_server/migrations/20250716140001984/migration.sql
+++ b/modules/new_serverpod_auth/serverpod_auth_apple/serverpod_auth_apple_server/migrations/20250716140001984/migration.sql
@@ -1,27 +1,7 @@
 BEGIN;
 
 --
--- Class AppleAccount as table serverpod_auth_apple_account
---
-CREATE TABLE "serverpod_auth_apple_account" (
-    "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-    "userIdentifier" text NOT NULL,
-    "refreshToken" text NOT NULL,
-    "lastRefreshed" timestamp without time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    "authUserId" uuid NOT NULL,
-    "created" timestamp without time zone NOT NULL,
-    "email" text,
-    "isEmailVerified" boolean,
-    "isPrivateEmail" boolean,
-    "firstName" text,
-    "lastName" text
-);
-
--- Indexes
-CREATE UNIQUE INDEX "serverpod_auth_apple_account_identifier" ON "serverpod_auth_apple_account" USING btree ("userIdentifier");
-
---
--- Class CloudStorageEntry as table serverpod_cloud_storage
+-- ACTION CREATE TABLE
 --
 CREATE TABLE "serverpod_cloud_storage" (
     "id" bigserial PRIMARY KEY,
@@ -38,7 +18,7 @@ CREATE UNIQUE INDEX "serverpod_cloud_storage_path_idx" ON "serverpod_cloud_stora
 CREATE INDEX "serverpod_cloud_storage_expiration" ON "serverpod_cloud_storage" USING btree ("expiration");
 
 --
--- Class CloudStorageDirectUploadEntry as table serverpod_cloud_storage_direct_upload
+-- ACTION CREATE TABLE
 --
 CREATE TABLE "serverpod_cloud_storage_direct_upload" (
     "id" bigserial PRIMARY KEY,
@@ -52,7 +32,7 @@ CREATE TABLE "serverpod_cloud_storage_direct_upload" (
 CREATE UNIQUE INDEX "serverpod_cloud_storage_direct_upload_storage_path" ON "serverpod_cloud_storage_direct_upload" USING btree ("storageId", "path");
 
 --
--- Class FutureCallEntry as table serverpod_future_call
+-- ACTION CREATE TABLE
 --
 CREATE TABLE "serverpod_future_call" (
     "id" bigserial PRIMARY KEY,
@@ -69,7 +49,7 @@ CREATE INDEX "serverpod_future_call_serverId_idx" ON "serverpod_future_call" USI
 CREATE INDEX "serverpod_future_call_identifier_idx" ON "serverpod_future_call" USING btree ("identifier");
 
 --
--- Class ServerHealthConnectionInfo as table serverpod_health_connection_info
+-- ACTION CREATE TABLE
 --
 CREATE TABLE "serverpod_health_connection_info" (
     "id" bigserial PRIMARY KEY,
@@ -85,7 +65,7 @@ CREATE TABLE "serverpod_health_connection_info" (
 CREATE UNIQUE INDEX "serverpod_health_connection_info_timestamp_idx" ON "serverpod_health_connection_info" USING btree ("timestamp", "serverId", "granularity");
 
 --
--- Class ServerHealthMetric as table serverpod_health_metric
+-- ACTION CREATE TABLE
 --
 CREATE TABLE "serverpod_health_metric" (
     "id" bigserial PRIMARY KEY,
@@ -101,7 +81,7 @@ CREATE TABLE "serverpod_health_metric" (
 CREATE UNIQUE INDEX "serverpod_health_metric_timestamp_idx" ON "serverpod_health_metric" USING btree ("timestamp", "serverId", "name", "granularity");
 
 --
--- Class LogEntry as table serverpod_log
+-- ACTION CREATE TABLE
 --
 CREATE TABLE "serverpod_log" (
     "id" bigserial PRIMARY KEY,
@@ -121,7 +101,7 @@ CREATE TABLE "serverpod_log" (
 CREATE INDEX "serverpod_log_sessionLogId_idx" ON "serverpod_log" USING btree ("sessionLogId");
 
 --
--- Class MessageLogEntry as table serverpod_message_log
+-- ACTION CREATE TABLE
 --
 CREATE TABLE "serverpod_message_log" (
     "id" bigserial PRIMARY KEY,
@@ -138,7 +118,7 @@ CREATE TABLE "serverpod_message_log" (
 );
 
 --
--- Class MethodInfo as table serverpod_method
+-- ACTION CREATE TABLE
 --
 CREATE TABLE "serverpod_method" (
     "id" bigserial PRIMARY KEY,
@@ -150,7 +130,7 @@ CREATE TABLE "serverpod_method" (
 CREATE UNIQUE INDEX "serverpod_method_endpoint_method_idx" ON "serverpod_method" USING btree ("endpoint", "method");
 
 --
--- Class DatabaseMigrationVersion as table serverpod_migrations
+-- ACTION CREATE TABLE
 --
 CREATE TABLE "serverpod_migrations" (
     "id" bigserial PRIMARY KEY,
@@ -163,7 +143,7 @@ CREATE TABLE "serverpod_migrations" (
 CREATE UNIQUE INDEX "serverpod_migrations_ids" ON "serverpod_migrations" USING btree ("module");
 
 --
--- Class QueryLogEntry as table serverpod_query_log
+-- ACTION CREATE TABLE
 --
 CREATE TABLE "serverpod_query_log" (
     "id" bigserial PRIMARY KEY,
@@ -183,7 +163,7 @@ CREATE TABLE "serverpod_query_log" (
 CREATE INDEX "serverpod_query_log_sessionLogId_idx" ON "serverpod_query_log" USING btree ("sessionLogId");
 
 --
--- Class ReadWriteTestEntry as table serverpod_readwrite_test
+-- ACTION CREATE TABLE
 --
 CREATE TABLE "serverpod_readwrite_test" (
     "id" bigserial PRIMARY KEY,
@@ -191,7 +171,7 @@ CREATE TABLE "serverpod_readwrite_test" (
 );
 
 --
--- Class RuntimeSettings as table serverpod_runtime_settings
+-- ACTION CREATE TABLE
 --
 CREATE TABLE "serverpod_runtime_settings" (
     "id" bigserial PRIMARY KEY,
@@ -202,7 +182,7 @@ CREATE TABLE "serverpod_runtime_settings" (
 );
 
 --
--- Class SessionLogEntry as table serverpod_session_log
+-- ACTION CREATE TABLE
 --
 CREATE TABLE "serverpod_session_log" (
     "id" bigserial PRIMARY KEY,
@@ -227,7 +207,72 @@ CREATE INDEX "serverpod_session_log_touched_idx" ON "serverpod_session_log" USIN
 CREATE INDEX "serverpod_session_log_isopen_idx" ON "serverpod_session_log" USING btree ("isOpen");
 
 --
--- Class AuthUser as table serverpod_auth_user
+-- ACTION CREATE TABLE
+--
+CREATE TABLE "serverpod_auth_apple_account" (
+    "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    "userIdentifier" text NOT NULL,
+    "refreshToken" text NOT NULL,
+    "refreshTokenRequestedWithBundleIdentifier" boolean NOT NULL,
+    "lastRefreshed" timestamp without time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "authUserId" uuid NOT NULL,
+    "created" timestamp without time zone NOT NULL,
+    "email" text,
+    "isEmailVerified" boolean,
+    "isPrivateEmail" boolean,
+    "firstName" text,
+    "lastName" text
+);
+
+-- Indexes
+CREATE UNIQUE INDEX "serverpod_auth_apple_account_identifier" ON "serverpod_auth_apple_account" USING btree ("userIdentifier");
+
+--
+-- ACTION CREATE TABLE
+--
+CREATE TABLE "serverpod_auth_profile_user_profile" (
+    "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    "authUserId" uuid NOT NULL,
+    "userName" text,
+    "fullName" text,
+    "email" text,
+    "created" timestamp without time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "imageId" uuid
+);
+
+-- Indexes
+CREATE UNIQUE INDEX "serverpod_auth_profile_user_profile_email_auth_user_id" ON "serverpod_auth_profile_user_profile" USING btree ("authUserId");
+
+--
+-- ACTION CREATE TABLE
+--
+CREATE TABLE "serverpod_auth_profile_user_profile_image" (
+    "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    "userProfileId" uuid NOT NULL,
+    "created" timestamp without time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "storageId" text NOT NULL,
+    "path" text NOT NULL,
+    "url" text NOT NULL
+);
+
+--
+-- ACTION CREATE TABLE
+--
+CREATE TABLE "serverpod_auth_session" (
+    "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    "authUserId" uuid NOT NULL,
+    "scopeNames" json NOT NULL,
+    "created" timestamp without time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "lastUsed" timestamp without time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "expiresAt" timestamp without time zone,
+    "expireAfterUnusedFor" bigint,
+    "sessionKeyHash" bytea NOT NULL,
+    "sessionKeySalt" bytea NOT NULL,
+    "method" text NOT NULL
+);
+
+--
+-- ACTION CREATE TABLE
 --
 CREATE TABLE "serverpod_auth_user" (
     "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -237,17 +282,7 @@ CREATE TABLE "serverpod_auth_user" (
 );
 
 --
--- Foreign relations for "serverpod_auth_apple_account" table
---
-ALTER TABLE ONLY "serverpod_auth_apple_account"
-    ADD CONSTRAINT "serverpod_auth_apple_account_fk_0"
-    FOREIGN KEY("authUserId")
-    REFERENCES "serverpod_auth_user"("id")
-    ON DELETE CASCADE
-    ON UPDATE NO ACTION;
-
---
--- Foreign relations for "serverpod_log" table
+-- ACTION CREATE FOREIGN KEY
 --
 ALTER TABLE ONLY "serverpod_log"
     ADD CONSTRAINT "serverpod_log_fk_0"
@@ -257,7 +292,7 @@ ALTER TABLE ONLY "serverpod_log"
     ON UPDATE NO ACTION;
 
 --
--- Foreign relations for "serverpod_message_log" table
+-- ACTION CREATE FOREIGN KEY
 --
 ALTER TABLE ONLY "serverpod_message_log"
     ADD CONSTRAINT "serverpod_message_log_fk_0"
@@ -267,7 +302,7 @@ ALTER TABLE ONLY "serverpod_message_log"
     ON UPDATE NO ACTION;
 
 --
--- Foreign relations for "serverpod_query_log" table
+-- ACTION CREATE FOREIGN KEY
 --
 ALTER TABLE ONLY "serverpod_query_log"
     ADD CONSTRAINT "serverpod_query_log_fk_0"
@@ -276,14 +311,60 @@ ALTER TABLE ONLY "serverpod_query_log"
     ON DELETE CASCADE
     ON UPDATE NO ACTION;
 
+--
+-- ACTION CREATE FOREIGN KEY
+--
+ALTER TABLE ONLY "serverpod_auth_apple_account"
+    ADD CONSTRAINT "serverpod_auth_apple_account_fk_0"
+    FOREIGN KEY("authUserId")
+    REFERENCES "serverpod_auth_user"("id")
+    ON DELETE CASCADE
+    ON UPDATE NO ACTION;
 
 --
--- MIGRATION VERSION FOR serverpod_auth_apple_account
+-- ACTION CREATE FOREIGN KEY
+--
+ALTER TABLE ONLY "serverpod_auth_profile_user_profile"
+    ADD CONSTRAINT "serverpod_auth_profile_user_profile_fk_0"
+    FOREIGN KEY("authUserId")
+    REFERENCES "serverpod_auth_user"("id")
+    ON DELETE CASCADE
+    ON UPDATE NO ACTION;
+ALTER TABLE ONLY "serverpod_auth_profile_user_profile"
+    ADD CONSTRAINT "serverpod_auth_profile_user_profile_fk_1"
+    FOREIGN KEY("imageId")
+    REFERENCES "serverpod_auth_profile_user_profile_image"("id")
+    ON DELETE NO ACTION
+    ON UPDATE NO ACTION;
+
+--
+-- ACTION CREATE FOREIGN KEY
+--
+ALTER TABLE ONLY "serverpod_auth_profile_user_profile_image"
+    ADD CONSTRAINT "serverpod_auth_profile_user_profile_image_fk_0"
+    FOREIGN KEY("userProfileId")
+    REFERENCES "serverpod_auth_profile_user_profile"("id")
+    ON DELETE CASCADE
+    ON UPDATE NO ACTION;
+
+--
+-- ACTION CREATE FOREIGN KEY
+--
+ALTER TABLE ONLY "serverpod_auth_session"
+    ADD CONSTRAINT "serverpod_auth_session_fk_0"
+    FOREIGN KEY("authUserId")
+    REFERENCES "serverpod_auth_user"("id")
+    ON DELETE CASCADE
+    ON UPDATE NO ACTION;
+
+
+--
+-- MIGRATION VERSION FOR serverpod_auth_apple
 --
 INSERT INTO "serverpod_migrations" ("module", "version", "timestamp")
-    VALUES ('serverpod_auth_apple_account', '20250715133410884', now())
+    VALUES ('serverpod_auth_apple', '20250716140001984', now())
     ON CONFLICT ("module")
-    DO UPDATE SET "version" = '20250715133410884', "timestamp" = now();
+    DO UPDATE SET "version" = '20250716140001984', "timestamp" = now();
 
 --
 -- MIGRATION VERSION FOR serverpod
@@ -292,6 +373,30 @@ INSERT INTO "serverpod_migrations" ("module", "version", "timestamp")
     VALUES ('serverpod', '20240516151843329', now())
     ON CONFLICT ("module")
     DO UPDATE SET "version" = '20240516151843329', "timestamp" = now();
+
+--
+-- MIGRATION VERSION FOR serverpod_auth_apple_account
+--
+INSERT INTO "serverpod_migrations" ("module", "version", "timestamp")
+    VALUES ('serverpod_auth_apple_account', '20250716135530275', now())
+    ON CONFLICT ("module")
+    DO UPDATE SET "version" = '20250716135530275', "timestamp" = now();
+
+--
+-- MIGRATION VERSION FOR serverpod_auth_profile
+--
+INSERT INTO "serverpod_migrations" ("module", "version", "timestamp")
+    VALUES ('serverpod_auth_profile', '20250519092101868', now())
+    ON CONFLICT ("module")
+    DO UPDATE SET "version" = '20250519092101868', "timestamp" = now();
+
+--
+-- MIGRATION VERSION FOR serverpod_auth_session
+--
+INSERT INTO "serverpod_migrations" ("module", "version", "timestamp")
+    VALUES ('serverpod_auth_session', '20250611085050241', now())
+    ON CONFLICT ("module")
+    DO UPDATE SET "version" = '20250611085050241', "timestamp" = now();
 
 --
 -- MIGRATION VERSION FOR serverpod_auth_user

--- a/modules/new_serverpod_auth/serverpod_auth_apple/serverpod_auth_apple_server/migrations/migration_registry.txt
+++ b/modules/new_serverpod_auth/serverpod_auth_apple/serverpod_auth_apple_server/migrations/migration_registry.txt
@@ -4,4 +4,4 @@
 ### manually. If a collision is detected in this file when doing a code merge, resolve
 ### the conflict by removing and recreating the conflicting migration.
 
-20250715133534148
+20250716140001984

--- a/modules/new_serverpod_auth/serverpod_auth_apple/serverpod_auth_apple_server/test/integration/test_tools/serverpod_test_tools.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_apple/serverpod_auth_apple_server/test/integration/test_tools/serverpod_test_tools.dart
@@ -7,6 +7,7 @@
 // ignore_for_file: public_member_api_docs
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
+// ignore_for_file: invalid_use_of_internal_member
 
 // ignore_for_file: no_leading_underscores_for_local_identifiers
 

--- a/modules/new_serverpod_auth/serverpod_auth_apple_account/serverpod_auth_apple_account_client/lib/src/protocol/client.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_apple_account/serverpod_auth_apple_account_client/lib/src/protocol/client.dart
@@ -7,6 +7,7 @@
 // ignore_for_file: public_member_api_docs
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
+// ignore_for_file: invalid_use_of_internal_member
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;

--- a/modules/new_serverpod_auth/serverpod_auth_apple_account/serverpod_auth_apple_account_client/lib/src/protocol/protocol.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_apple_account/serverpod_auth_apple_account_client/lib/src/protocol/protocol.dart
@@ -7,6 +7,7 @@
 // ignore_for_file: public_member_api_docs
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
+// ignore_for_file: invalid_use_of_internal_member
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;

--- a/modules/new_serverpod_auth/serverpod_auth_apple_account/serverpod_auth_apple_account_server/lib/src/business/apple_accounts_admin.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_apple_account/serverpod_auth_apple_account_server/lib/src/business/apple_accounts_admin.dart
@@ -46,9 +46,12 @@ final class AppleAccountsAdmin {
 
       for (final appleAccount in appleAccounts) {
         try {
-          // TODO: Get proper status from library in error cases.
-          await _siwa.validateRefreshToken(appleAccount.refreshToken);
-        } catch (_) {
+          await _siwa.validateRefreshToken(
+            appleAccount.refreshToken,
+            useBundleIdentifier:
+                appleAccount.refreshTokenRequestedWithBundleIdentifier,
+          );
+        } on RevokedTokenException catch (_) {
           expiredUserAuthenticationCallback(appleAccount.authUserId);
         }
 

--- a/modules/new_serverpod_auth/serverpod_auth_apple_account/serverpod_auth_apple_account_server/lib/src/generated/apple_account.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_apple_account/serverpod_auth_apple_account_server/lib/src/generated/apple_account.dart
@@ -7,6 +7,7 @@
 // ignore_for_file: public_member_api_docs
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
+// ignore_for_file: invalid_use_of_internal_member
 
 // ignore_for_file: unnecessary_null_comparison
 
@@ -22,6 +23,7 @@ abstract class AppleAccount
     this.id,
     required this.userIdentifier,
     required this.refreshToken,
+    required this.refreshTokenRequestedWithBundleIdentifier,
     DateTime? lastRefreshed,
     required this.authUserId,
     this.authUser,
@@ -38,6 +40,7 @@ abstract class AppleAccount
     _i1.UuidValue? id,
     required String userIdentifier,
     required String refreshToken,
+    required bool refreshTokenRequestedWithBundleIdentifier,
     DateTime? lastRefreshed,
     required _i1.UuidValue authUserId,
     _i2.AuthUser? authUser,
@@ -56,6 +59,9 @@ abstract class AppleAccount
           : _i1.UuidValueJsonExtension.fromJson(jsonSerialization['id']),
       userIdentifier: jsonSerialization['userIdentifier'] as String,
       refreshToken: jsonSerialization['refreshToken'] as String,
+      refreshTokenRequestedWithBundleIdentifier:
+          jsonSerialization['refreshTokenRequestedWithBundleIdentifier']
+              as bool,
       lastRefreshed: _i1.DateTimeJsonExtension.fromJson(
           jsonSerialization['lastRefreshed']),
       authUserId:
@@ -87,6 +93,12 @@ abstract class AppleAccount
   ///
   /// Only the first one is stored per user.
   String refreshToken;
+
+  /// Whether the refresh token was created on an Apple OS.
+  ///
+  /// The source of the initial registration needs to be retained throughout
+  /// the lifecycle of the account.
+  bool refreshTokenRequestedWithBundleIdentifier;
 
   /// Time when the account data was last received from Apple's servers.
   DateTime lastRefreshed;
@@ -136,6 +148,7 @@ abstract class AppleAccount
     _i1.UuidValue? id,
     String? userIdentifier,
     String? refreshToken,
+    bool? refreshTokenRequestedWithBundleIdentifier,
     DateTime? lastRefreshed,
     _i1.UuidValue? authUserId,
     _i2.AuthUser? authUser,
@@ -152,6 +165,8 @@ abstract class AppleAccount
       if (id != null) 'id': id?.toJson(),
       'userIdentifier': userIdentifier,
       'refreshToken': refreshToken,
+      'refreshTokenRequestedWithBundleIdentifier':
+          refreshTokenRequestedWithBundleIdentifier,
       'lastRefreshed': lastRefreshed.toJson(),
       'authUserId': authUserId.toJson(),
       if (authUser != null) 'authUser': authUser?.toJson(),
@@ -206,6 +221,7 @@ class _AppleAccountImpl extends AppleAccount {
     _i1.UuidValue? id,
     required String userIdentifier,
     required String refreshToken,
+    required bool refreshTokenRequestedWithBundleIdentifier,
     DateTime? lastRefreshed,
     required _i1.UuidValue authUserId,
     _i2.AuthUser? authUser,
@@ -219,6 +235,8 @@ class _AppleAccountImpl extends AppleAccount {
           id: id,
           userIdentifier: userIdentifier,
           refreshToken: refreshToken,
+          refreshTokenRequestedWithBundleIdentifier:
+              refreshTokenRequestedWithBundleIdentifier,
           lastRefreshed: lastRefreshed,
           authUserId: authUserId,
           authUser: authUser,
@@ -238,6 +256,7 @@ class _AppleAccountImpl extends AppleAccount {
     Object? id = _Undefined,
     String? userIdentifier,
     String? refreshToken,
+    bool? refreshTokenRequestedWithBundleIdentifier,
     DateTime? lastRefreshed,
     _i1.UuidValue? authUserId,
     Object? authUser = _Undefined,
@@ -252,6 +271,9 @@ class _AppleAccountImpl extends AppleAccount {
       id: id is _i1.UuidValue? ? id : this.id,
       userIdentifier: userIdentifier ?? this.userIdentifier,
       refreshToken: refreshToken ?? this.refreshToken,
+      refreshTokenRequestedWithBundleIdentifier:
+          refreshTokenRequestedWithBundleIdentifier ??
+              this.refreshTokenRequestedWithBundleIdentifier,
       lastRefreshed: lastRefreshed ?? this.lastRefreshed,
       authUserId: authUserId ?? this.authUserId,
       authUser:
@@ -277,6 +299,10 @@ class AppleAccountTable extends _i1.Table<_i1.UuidValue?> {
     );
     refreshToken = _i1.ColumnString(
       'refreshToken',
+      this,
+    );
+    refreshTokenRequestedWithBundleIdentifier = _i1.ColumnBool(
+      'refreshTokenRequestedWithBundleIdentifier',
       this,
     );
     lastRefreshed = _i1.ColumnDateTime(
@@ -321,6 +347,12 @@ class AppleAccountTable extends _i1.Table<_i1.UuidValue?> {
   ///
   /// Only the first one is stored per user.
   late final _i1.ColumnString refreshToken;
+
+  /// Whether the refresh token was created on an Apple OS.
+  ///
+  /// The source of the initial registration needs to be retained throughout
+  /// the lifecycle of the account.
+  late final _i1.ColumnBool refreshTokenRequestedWithBundleIdentifier;
 
   /// Time when the account data was last received from Apple's servers.
   late final _i1.ColumnDateTime lastRefreshed;
@@ -378,6 +410,7 @@ class AppleAccountTable extends _i1.Table<_i1.UuidValue?> {
         id,
         userIdentifier,
         refreshToken,
+        refreshTokenRequestedWithBundleIdentifier,
         lastRefreshed,
         authUserId,
         created,

--- a/modules/new_serverpod_auth/serverpod_auth_apple_account/serverpod_auth_apple_account_server/lib/src/generated/endpoints.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_apple_account/serverpod_auth_apple_account_server/lib/src/generated/endpoints.dart
@@ -7,6 +7,7 @@
 // ignore_for_file: public_member_api_docs
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
+// ignore_for_file: invalid_use_of_internal_member
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/modules/new_serverpod_auth/serverpod_auth_apple_account/serverpod_auth_apple_account_server/lib/src/generated/protocol.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_apple_account/serverpod_auth_apple_account_server/lib/src/generated/protocol.dart
@@ -7,6 +7,7 @@
 // ignore_for_file: public_member_api_docs
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
+// ignore_for_file: invalid_use_of_internal_member
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
@@ -48,6 +49,12 @@ class Protocol extends _i1.SerializationManagerServer {
           columnType: _i2.ColumnType.text,
           isNullable: false,
           dartType: 'String',
+        ),
+        _i2.ColumnDefinition(
+          name: 'refreshTokenRequestedWithBundleIdentifier',
+          columnType: _i2.ColumnType.boolean,
+          isNullable: false,
+          dartType: 'bool',
         ),
         _i2.ColumnDefinition(
           name: 'lastRefreshed',

--- a/modules/new_serverpod_auth/serverpod_auth_apple_account/serverpod_auth_apple_account_server/lib/src/models/apple_account.spy.yaml
+++ b/modules/new_serverpod_auth/serverpod_auth_apple_account/serverpod_auth_apple_account_server/lib/src/models/apple_account.spy.yaml
@@ -13,6 +13,12 @@ fields:
   ### Only the first one is stored per user.
   refreshToken: String
 
+  ### Whether the refresh token was created on an Apple OS.
+  ###
+  ### The source of the initial registration needs to be retained throughout
+  ### the lifecycle of the account.
+  refreshTokenRequestedWithBundleIdentifier: bool
+
   ### Time when the account data was last received from Apple's servers.
   lastRefreshed: DateTime, default=now
 

--- a/modules/new_serverpod_auth/serverpod_auth_apple_account/serverpod_auth_apple_account_server/migrations/20250716135530275/definition.json
+++ b/modules/new_serverpod_auth/serverpod_auth_apple_account/serverpod_auth_apple_account_server/migrations/20250716135530275/definition.json
@@ -1,6 +1,130 @@
 {
-  "moduleName": "serverpod_auth_apple",
+  "moduleName": "serverpod_auth_apple_account",
   "tables": [
+    {
+      "name": "serverpod_auth_apple_account",
+      "dartName": "AppleAccount",
+      "module": "serverpod_auth_apple_account",
+      "schema": "public",
+      "columns": [
+        {
+          "name": "id",
+          "columnType": 7,
+          "isNullable": false,
+          "columnDefault": "gen_random_uuid()",
+          "dartType": "UuidValue?"
+        },
+        {
+          "name": "userIdentifier",
+          "columnType": 0,
+          "isNullable": false,
+          "dartType": "String"
+        },
+        {
+          "name": "refreshToken",
+          "columnType": 0,
+          "isNullable": false,
+          "dartType": "String"
+        },
+        {
+          "name": "refreshTokenRequestedWithBundleIdentifier",
+          "columnType": 1,
+          "isNullable": false,
+          "dartType": "bool"
+        },
+        {
+          "name": "lastRefreshed",
+          "columnType": 4,
+          "isNullable": false,
+          "columnDefault": "CURRENT_TIMESTAMP",
+          "dartType": "DateTime"
+        },
+        {
+          "name": "authUserId",
+          "columnType": 7,
+          "isNullable": false,
+          "dartType": "UuidValue"
+        },
+        {
+          "name": "created",
+          "columnType": 4,
+          "isNullable": false,
+          "dartType": "DateTime"
+        },
+        {
+          "name": "email",
+          "columnType": 0,
+          "isNullable": true,
+          "dartType": "String?"
+        },
+        {
+          "name": "isEmailVerified",
+          "columnType": 1,
+          "isNullable": true,
+          "dartType": "bool?"
+        },
+        {
+          "name": "isPrivateEmail",
+          "columnType": 1,
+          "isNullable": true,
+          "dartType": "bool?"
+        },
+        {
+          "name": "firstName",
+          "columnType": 0,
+          "isNullable": true,
+          "dartType": "String?"
+        },
+        {
+          "name": "lastName",
+          "columnType": 0,
+          "isNullable": true,
+          "dartType": "String?"
+        }
+      ],
+      "foreignKeys": [
+        {
+          "constraintName": "serverpod_auth_apple_account_fk_0",
+          "columns": [
+            "authUserId"
+          ],
+          "referenceTable": "serverpod_auth_user",
+          "referenceTableSchema": "public",
+          "referenceColumns": [
+            "id"
+          ],
+          "onUpdate": 3,
+          "onDelete": 4
+        }
+      ],
+      "indexes": [
+        {
+          "indexName": "serverpod_auth_apple_account_pkey",
+          "elements": [
+            {
+              "type": 0,
+              "definition": "id"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": true
+        },
+        {
+          "indexName": "serverpod_auth_apple_account_identifier",
+          "elements": [
+            {
+              "type": 0,
+              "definition": "userIdentifier"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": false
+        }
+      ],
+      "managed": true
+    },
     {
       "name": "serverpod_cloud_storage",
       "dartName": "CloudStorageEntry",
@@ -1139,408 +1263,6 @@
       "managed": true
     },
     {
-      "name": "serverpod_auth_apple_account",
-      "dartName": "AppleAccount",
-      "module": "serverpod_auth_apple_account",
-      "schema": "public",
-      "columns": [
-        {
-          "name": "id",
-          "columnType": 7,
-          "isNullable": false,
-          "columnDefault": "gen_random_uuid()",
-          "dartType": "UuidValue?"
-        },
-        {
-          "name": "userIdentifier",
-          "columnType": 0,
-          "isNullable": false,
-          "dartType": "String"
-        },
-        {
-          "name": "refreshToken",
-          "columnType": 0,
-          "isNullable": false,
-          "dartType": "String"
-        },
-        {
-          "name": "lastRefreshed",
-          "columnType": 4,
-          "isNullable": false,
-          "columnDefault": "CURRENT_TIMESTAMP",
-          "dartType": "DateTime"
-        },
-        {
-          "name": "authUserId",
-          "columnType": 7,
-          "isNullable": false,
-          "dartType": "UuidValue"
-        },
-        {
-          "name": "created",
-          "columnType": 4,
-          "isNullable": false,
-          "dartType": "DateTime"
-        },
-        {
-          "name": "email",
-          "columnType": 0,
-          "isNullable": true,
-          "dartType": "String?"
-        },
-        {
-          "name": "isEmailVerified",
-          "columnType": 1,
-          "isNullable": true,
-          "dartType": "bool?"
-        },
-        {
-          "name": "isPrivateEmail",
-          "columnType": 1,
-          "isNullable": true,
-          "dartType": "bool?"
-        },
-        {
-          "name": "firstName",
-          "columnType": 0,
-          "isNullable": true,
-          "dartType": "String?"
-        },
-        {
-          "name": "lastName",
-          "columnType": 0,
-          "isNullable": true,
-          "dartType": "String?"
-        }
-      ],
-      "foreignKeys": [
-        {
-          "constraintName": "serverpod_auth_apple_account_fk_0",
-          "columns": [
-            "authUserId"
-          ],
-          "referenceTable": "serverpod_auth_user",
-          "referenceTableSchema": "public",
-          "referenceColumns": [
-            "id"
-          ],
-          "onUpdate": 3,
-          "onDelete": 4
-        }
-      ],
-      "indexes": [
-        {
-          "indexName": "serverpod_auth_apple_account_pkey",
-          "elements": [
-            {
-              "type": 0,
-              "definition": "id"
-            }
-          ],
-          "type": "btree",
-          "isUnique": true,
-          "isPrimary": true
-        },
-        {
-          "indexName": "serverpod_auth_apple_account_identifier",
-          "elements": [
-            {
-              "type": 0,
-              "definition": "userIdentifier"
-            }
-          ],
-          "type": "btree",
-          "isUnique": true,
-          "isPrimary": false
-        }
-      ],
-      "managed": true
-    },
-    {
-      "name": "serverpod_auth_profile_user_profile",
-      "dartName": "UserProfile",
-      "module": "serverpod_auth_profile",
-      "schema": "public",
-      "columns": [
-        {
-          "name": "id",
-          "columnType": 7,
-          "isNullable": false,
-          "columnDefault": "gen_random_uuid()",
-          "dartType": "UuidValue?"
-        },
-        {
-          "name": "authUserId",
-          "columnType": 7,
-          "isNullable": false,
-          "dartType": "UuidValue"
-        },
-        {
-          "name": "userName",
-          "columnType": 0,
-          "isNullable": true,
-          "dartType": "String?"
-        },
-        {
-          "name": "fullName",
-          "columnType": 0,
-          "isNullable": true,
-          "dartType": "String?"
-        },
-        {
-          "name": "email",
-          "columnType": 0,
-          "isNullable": true,
-          "dartType": "String?"
-        },
-        {
-          "name": "created",
-          "columnType": 4,
-          "isNullable": false,
-          "columnDefault": "CURRENT_TIMESTAMP",
-          "dartType": "DateTime"
-        },
-        {
-          "name": "imageId",
-          "columnType": 7,
-          "isNullable": true,
-          "dartType": "UuidValue?"
-        }
-      ],
-      "foreignKeys": [
-        {
-          "constraintName": "serverpod_auth_profile_user_profile_fk_0",
-          "columns": [
-            "authUserId"
-          ],
-          "referenceTable": "serverpod_auth_user",
-          "referenceTableSchema": "public",
-          "referenceColumns": [
-            "id"
-          ],
-          "onUpdate": 3,
-          "onDelete": 4
-        },
-        {
-          "constraintName": "serverpod_auth_profile_user_profile_fk_1",
-          "columns": [
-            "imageId"
-          ],
-          "referenceTable": "serverpod_auth_profile_user_profile_image",
-          "referenceTableSchema": "public",
-          "referenceColumns": [
-            "id"
-          ],
-          "onUpdate": 3,
-          "onDelete": 3
-        }
-      ],
-      "indexes": [
-        {
-          "indexName": "serverpod_auth_profile_user_profile_pkey",
-          "elements": [
-            {
-              "type": 0,
-              "definition": "id"
-            }
-          ],
-          "type": "btree",
-          "isUnique": true,
-          "isPrimary": true
-        },
-        {
-          "indexName": "serverpod_auth_profile_user_profile_email_auth_user_id",
-          "elements": [
-            {
-              "type": 0,
-              "definition": "authUserId"
-            }
-          ],
-          "type": "btree",
-          "isUnique": true,
-          "isPrimary": false
-        }
-      ],
-      "managed": true
-    },
-    {
-      "name": "serverpod_auth_profile_user_profile_image",
-      "dartName": "UserProfileImage",
-      "module": "serverpod_auth_profile",
-      "schema": "public",
-      "columns": [
-        {
-          "name": "id",
-          "columnType": 7,
-          "isNullable": false,
-          "columnDefault": "gen_random_uuid()",
-          "dartType": "UuidValue?"
-        },
-        {
-          "name": "userProfileId",
-          "columnType": 7,
-          "isNullable": false,
-          "dartType": "UuidValue"
-        },
-        {
-          "name": "created",
-          "columnType": 4,
-          "isNullable": false,
-          "columnDefault": "CURRENT_TIMESTAMP",
-          "dartType": "DateTime"
-        },
-        {
-          "name": "storageId",
-          "columnType": 0,
-          "isNullable": false,
-          "dartType": "String"
-        },
-        {
-          "name": "path",
-          "columnType": 0,
-          "isNullable": false,
-          "dartType": "String"
-        },
-        {
-          "name": "url",
-          "columnType": 0,
-          "isNullable": false,
-          "dartType": "Uri"
-        }
-      ],
-      "foreignKeys": [
-        {
-          "constraintName": "serverpod_auth_profile_user_profile_image_fk_0",
-          "columns": [
-            "userProfileId"
-          ],
-          "referenceTable": "serverpod_auth_profile_user_profile",
-          "referenceTableSchema": "public",
-          "referenceColumns": [
-            "id"
-          ],
-          "onUpdate": 3,
-          "onDelete": 4
-        }
-      ],
-      "indexes": [
-        {
-          "indexName": "serverpod_auth_profile_user_profile_image_pkey",
-          "elements": [
-            {
-              "type": 0,
-              "definition": "id"
-            }
-          ],
-          "type": "btree",
-          "isUnique": true,
-          "isPrimary": true
-        }
-      ],
-      "managed": true
-    },
-    {
-      "name": "serverpod_auth_session",
-      "dartName": "AuthSession",
-      "module": "serverpod_auth_session",
-      "schema": "public",
-      "columns": [
-        {
-          "name": "id",
-          "columnType": 7,
-          "isNullable": false,
-          "columnDefault": "gen_random_uuid()",
-          "dartType": "UuidValue?"
-        },
-        {
-          "name": "authUserId",
-          "columnType": 7,
-          "isNullable": false,
-          "dartType": "UuidValue"
-        },
-        {
-          "name": "scopeNames",
-          "columnType": 8,
-          "isNullable": false,
-          "dartType": "Set<String>"
-        },
-        {
-          "name": "created",
-          "columnType": 4,
-          "isNullable": false,
-          "columnDefault": "CURRENT_TIMESTAMP",
-          "dartType": "DateTime"
-        },
-        {
-          "name": "lastUsed",
-          "columnType": 4,
-          "isNullable": false,
-          "columnDefault": "CURRENT_TIMESTAMP",
-          "dartType": "DateTime"
-        },
-        {
-          "name": "expiresAt",
-          "columnType": 4,
-          "isNullable": true,
-          "dartType": "DateTime?"
-        },
-        {
-          "name": "expireAfterUnusedFor",
-          "columnType": 6,
-          "isNullable": true,
-          "dartType": "Duration?"
-        },
-        {
-          "name": "sessionKeyHash",
-          "columnType": 5,
-          "isNullable": false,
-          "dartType": "dart:typed_data:ByteData"
-        },
-        {
-          "name": "sessionKeySalt",
-          "columnType": 5,
-          "isNullable": false,
-          "dartType": "dart:typed_data:ByteData"
-        },
-        {
-          "name": "method",
-          "columnType": 0,
-          "isNullable": false,
-          "dartType": "String"
-        }
-      ],
-      "foreignKeys": [
-        {
-          "constraintName": "serverpod_auth_session_fk_0",
-          "columns": [
-            "authUserId"
-          ],
-          "referenceTable": "serverpod_auth_user",
-          "referenceTableSchema": "public",
-          "referenceColumns": [
-            "id"
-          ],
-          "onUpdate": 3,
-          "onDelete": 4
-        }
-      ],
-      "indexes": [
-        {
-          "indexName": "serverpod_auth_session_pkey",
-          "elements": [
-            {
-              "type": 0,
-              "definition": "id"
-            }
-          ],
-          "type": "btree",
-          "isUnique": true,
-          "isPrimary": true
-        }
-      ],
-      "managed": true
-    },
-    {
       "name": "serverpod_auth_user",
       "dartName": "AuthUser",
       "module": "serverpod_auth_user",
@@ -1592,24 +1314,12 @@
   ],
   "installedModules": [
     {
-      "module": "serverpod_auth_apple",
-      "version": "20250715133534148"
+      "module": "serverpod_auth_apple_account",
+      "version": "20250716135530275"
     },
     {
       "module": "serverpod",
       "version": "20240516151843329"
-    },
-    {
-      "module": "serverpod_auth_apple_account",
-      "version": "20250715133410884"
-    },
-    {
-      "module": "serverpod_auth_profile",
-      "version": "20250519092101868"
-    },
-    {
-      "module": "serverpod_auth_session",
-      "version": "20250611085050241"
     },
     {
       "module": "serverpod_auth_user",

--- a/modules/new_serverpod_auth/serverpod_auth_apple_account/serverpod_auth_apple_account_server/migrations/20250716135530275/definition.sql
+++ b/modules/new_serverpod_auth/serverpod_auth_apple_account/serverpod_auth_apple_account_server/migrations/20250716135530275/definition.sql
@@ -1,6 +1,27 @@
 BEGIN;
 
 --
+-- Class AppleAccount as table serverpod_auth_apple_account
+--
+CREATE TABLE "serverpod_auth_apple_account" (
+    "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    "userIdentifier" text NOT NULL,
+    "refreshToken" text NOT NULL,
+    "refreshTokenRequestedWithBundleIdentifier" boolean NOT NULL,
+    "lastRefreshed" timestamp without time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "authUserId" uuid NOT NULL,
+    "created" timestamp without time zone NOT NULL,
+    "email" text,
+    "isEmailVerified" boolean,
+    "isPrivateEmail" boolean,
+    "firstName" text,
+    "lastName" text
+);
+
+-- Indexes
+CREATE UNIQUE INDEX "serverpod_auth_apple_account_identifier" ON "serverpod_auth_apple_account" USING btree ("userIdentifier");
+
+--
 -- Class CloudStorageEntry as table serverpod_cloud_storage
 --
 CREATE TABLE "serverpod_cloud_storage" (
@@ -207,70 +228,6 @@ CREATE INDEX "serverpod_session_log_touched_idx" ON "serverpod_session_log" USIN
 CREATE INDEX "serverpod_session_log_isopen_idx" ON "serverpod_session_log" USING btree ("isOpen");
 
 --
--- Class AppleAccount as table serverpod_auth_apple_account
---
-CREATE TABLE "serverpod_auth_apple_account" (
-    "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-    "userIdentifier" text NOT NULL,
-    "refreshToken" text NOT NULL,
-    "lastRefreshed" timestamp without time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    "authUserId" uuid NOT NULL,
-    "created" timestamp without time zone NOT NULL,
-    "email" text,
-    "isEmailVerified" boolean,
-    "isPrivateEmail" boolean,
-    "firstName" text,
-    "lastName" text
-);
-
--- Indexes
-CREATE UNIQUE INDEX "serverpod_auth_apple_account_identifier" ON "serverpod_auth_apple_account" USING btree ("userIdentifier");
-
---
--- Class UserProfile as table serverpod_auth_profile_user_profile
---
-CREATE TABLE "serverpod_auth_profile_user_profile" (
-    "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-    "authUserId" uuid NOT NULL,
-    "userName" text,
-    "fullName" text,
-    "email" text,
-    "created" timestamp without time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    "imageId" uuid
-);
-
--- Indexes
-CREATE UNIQUE INDEX "serverpod_auth_profile_user_profile_email_auth_user_id" ON "serverpod_auth_profile_user_profile" USING btree ("authUserId");
-
---
--- Class UserProfileImage as table serverpod_auth_profile_user_profile_image
---
-CREATE TABLE "serverpod_auth_profile_user_profile_image" (
-    "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-    "userProfileId" uuid NOT NULL,
-    "created" timestamp without time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    "storageId" text NOT NULL,
-    "path" text NOT NULL,
-    "url" text NOT NULL
-);
-
---
--- Class AuthSession as table serverpod_auth_session
---
-CREATE TABLE "serverpod_auth_session" (
-    "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-    "authUserId" uuid NOT NULL,
-    "scopeNames" json NOT NULL,
-    "created" timestamp without time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    "lastUsed" timestamp without time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    "expiresAt" timestamp without time zone,
-    "expireAfterUnusedFor" bigint,
-    "sessionKeyHash" bytea NOT NULL,
-    "sessionKeySalt" bytea NOT NULL,
-    "method" text NOT NULL
-);
-
---
 -- Class AuthUser as table serverpod_auth_user
 --
 CREATE TABLE "serverpod_auth_user" (
@@ -279,6 +236,16 @@ CREATE TABLE "serverpod_auth_user" (
     "scopeNames" json NOT NULL,
     "blocked" boolean NOT NULL
 );
+
+--
+-- Foreign relations for "serverpod_auth_apple_account" table
+--
+ALTER TABLE ONLY "serverpod_auth_apple_account"
+    ADD CONSTRAINT "serverpod_auth_apple_account_fk_0"
+    FOREIGN KEY("authUserId")
+    REFERENCES "serverpod_auth_user"("id")
+    ON DELETE CASCADE
+    ON UPDATE NO ACTION;
 
 --
 -- Foreign relations for "serverpod_log" table
@@ -310,60 +277,14 @@ ALTER TABLE ONLY "serverpod_query_log"
     ON DELETE CASCADE
     ON UPDATE NO ACTION;
 
---
--- Foreign relations for "serverpod_auth_apple_account" table
---
-ALTER TABLE ONLY "serverpod_auth_apple_account"
-    ADD CONSTRAINT "serverpod_auth_apple_account_fk_0"
-    FOREIGN KEY("authUserId")
-    REFERENCES "serverpod_auth_user"("id")
-    ON DELETE CASCADE
-    ON UPDATE NO ACTION;
 
 --
--- Foreign relations for "serverpod_auth_profile_user_profile" table
---
-ALTER TABLE ONLY "serverpod_auth_profile_user_profile"
-    ADD CONSTRAINT "serverpod_auth_profile_user_profile_fk_0"
-    FOREIGN KEY("authUserId")
-    REFERENCES "serverpod_auth_user"("id")
-    ON DELETE CASCADE
-    ON UPDATE NO ACTION;
-ALTER TABLE ONLY "serverpod_auth_profile_user_profile"
-    ADD CONSTRAINT "serverpod_auth_profile_user_profile_fk_1"
-    FOREIGN KEY("imageId")
-    REFERENCES "serverpod_auth_profile_user_profile_image"("id")
-    ON DELETE NO ACTION
-    ON UPDATE NO ACTION;
-
---
--- Foreign relations for "serverpod_auth_profile_user_profile_image" table
---
-ALTER TABLE ONLY "serverpod_auth_profile_user_profile_image"
-    ADD CONSTRAINT "serverpod_auth_profile_user_profile_image_fk_0"
-    FOREIGN KEY("userProfileId")
-    REFERENCES "serverpod_auth_profile_user_profile"("id")
-    ON DELETE CASCADE
-    ON UPDATE NO ACTION;
-
---
--- Foreign relations for "serverpod_auth_session" table
---
-ALTER TABLE ONLY "serverpod_auth_session"
-    ADD CONSTRAINT "serverpod_auth_session_fk_0"
-    FOREIGN KEY("authUserId")
-    REFERENCES "serverpod_auth_user"("id")
-    ON DELETE CASCADE
-    ON UPDATE NO ACTION;
-
-
---
--- MIGRATION VERSION FOR serverpod_auth_apple
+-- MIGRATION VERSION FOR serverpod_auth_apple_account
 --
 INSERT INTO "serverpod_migrations" ("module", "version", "timestamp")
-    VALUES ('serverpod_auth_apple', '20250715133534148', now())
+    VALUES ('serverpod_auth_apple_account', '20250716135530275', now())
     ON CONFLICT ("module")
-    DO UPDATE SET "version" = '20250715133534148', "timestamp" = now();
+    DO UPDATE SET "version" = '20250716135530275', "timestamp" = now();
 
 --
 -- MIGRATION VERSION FOR serverpod
@@ -372,30 +293,6 @@ INSERT INTO "serverpod_migrations" ("module", "version", "timestamp")
     VALUES ('serverpod', '20240516151843329', now())
     ON CONFLICT ("module")
     DO UPDATE SET "version" = '20240516151843329', "timestamp" = now();
-
---
--- MIGRATION VERSION FOR serverpod_auth_apple_account
---
-INSERT INTO "serverpod_migrations" ("module", "version", "timestamp")
-    VALUES ('serverpod_auth_apple_account', '20250715133410884', now())
-    ON CONFLICT ("module")
-    DO UPDATE SET "version" = '20250715133410884', "timestamp" = now();
-
---
--- MIGRATION VERSION FOR serverpod_auth_profile
---
-INSERT INTO "serverpod_migrations" ("module", "version", "timestamp")
-    VALUES ('serverpod_auth_profile', '20250519092101868', now())
-    ON CONFLICT ("module")
-    DO UPDATE SET "version" = '20250519092101868', "timestamp" = now();
-
---
--- MIGRATION VERSION FOR serverpod_auth_session
---
-INSERT INTO "serverpod_migrations" ("module", "version", "timestamp")
-    VALUES ('serverpod_auth_session', '20250611085050241', now())
-    ON CONFLICT ("module")
-    DO UPDATE SET "version" = '20250611085050241', "timestamp" = now();
 
 --
 -- MIGRATION VERSION FOR serverpod_auth_user

--- a/modules/new_serverpod_auth/serverpod_auth_apple_account/serverpod_auth_apple_account_server/migrations/20250716135530275/definition_project.json
+++ b/modules/new_serverpod_auth/serverpod_auth_apple_account/serverpod_auth_apple_account_server/migrations/20250716135530275/definition_project.json
@@ -27,6 +27,12 @@
           "dartType": "String"
         },
         {
+          "name": "refreshTokenRequestedWithBundleIdentifier",
+          "columnType": 1,
+          "isNullable": false,
+          "dartType": "bool"
+        },
+        {
           "name": "lastRefreshed",
           "columnType": 4,
           "isNullable": false,

--- a/modules/new_serverpod_auth/serverpod_auth_apple_account/serverpod_auth_apple_account_server/migrations/20250716135530275/migration.json
+++ b/modules/new_serverpod_auth/serverpod_auth_apple_account/serverpod_auth_apple_account_server/migrations/20250716135530275/migration.json
@@ -28,6 +28,12 @@
             "dartType": "String"
           },
           {
+            "name": "refreshTokenRequestedWithBundleIdentifier",
+            "columnType": 1,
+            "isNullable": false,
+            "dartType": "bool"
+          },
+          {
             "name": "lastRefreshed",
             "columnType": 4,
             "isNullable": false,

--- a/modules/new_serverpod_auth/serverpod_auth_apple_account/serverpod_auth_apple_account_server/migrations/20250716135530275/migration.sql
+++ b/modules/new_serverpod_auth/serverpod_auth_apple_account/serverpod_auth_apple_account_server/migrations/20250716135530275/migration.sql
@@ -3,6 +3,27 @@ BEGIN;
 --
 -- ACTION CREATE TABLE
 --
+CREATE TABLE "serverpod_auth_apple_account" (
+    "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    "userIdentifier" text NOT NULL,
+    "refreshToken" text NOT NULL,
+    "refreshTokenRequestedWithBundleIdentifier" boolean NOT NULL,
+    "lastRefreshed" timestamp without time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "authUserId" uuid NOT NULL,
+    "created" timestamp without time zone NOT NULL,
+    "email" text,
+    "isEmailVerified" boolean,
+    "isPrivateEmail" boolean,
+    "firstName" text,
+    "lastName" text
+);
+
+-- Indexes
+CREATE UNIQUE INDEX "serverpod_auth_apple_account_identifier" ON "serverpod_auth_apple_account" USING btree ("userIdentifier");
+
+--
+-- ACTION CREATE TABLE
+--
 CREATE TABLE "serverpod_cloud_storage" (
     "id" bigserial PRIMARY KEY,
     "storageId" text NOT NULL,
@@ -209,76 +230,22 @@ CREATE INDEX "serverpod_session_log_isopen_idx" ON "serverpod_session_log" USING
 --
 -- ACTION CREATE TABLE
 --
-CREATE TABLE "serverpod_auth_apple_account" (
-    "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-    "userIdentifier" text NOT NULL,
-    "refreshToken" text NOT NULL,
-    "lastRefreshed" timestamp without time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    "authUserId" uuid NOT NULL,
-    "created" timestamp without time zone NOT NULL,
-    "email" text,
-    "isEmailVerified" boolean,
-    "isPrivateEmail" boolean,
-    "firstName" text,
-    "lastName" text
-);
-
--- Indexes
-CREATE UNIQUE INDEX "serverpod_auth_apple_account_identifier" ON "serverpod_auth_apple_account" USING btree ("userIdentifier");
-
---
--- ACTION CREATE TABLE
---
-CREATE TABLE "serverpod_auth_profile_user_profile" (
-    "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-    "authUserId" uuid NOT NULL,
-    "userName" text,
-    "fullName" text,
-    "email" text,
-    "created" timestamp without time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    "imageId" uuid
-);
-
--- Indexes
-CREATE UNIQUE INDEX "serverpod_auth_profile_user_profile_email_auth_user_id" ON "serverpod_auth_profile_user_profile" USING btree ("authUserId");
-
---
--- ACTION CREATE TABLE
---
-CREATE TABLE "serverpod_auth_profile_user_profile_image" (
-    "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-    "userProfileId" uuid NOT NULL,
-    "created" timestamp without time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    "storageId" text NOT NULL,
-    "path" text NOT NULL,
-    "url" text NOT NULL
-);
-
---
--- ACTION CREATE TABLE
---
-CREATE TABLE "serverpod_auth_session" (
-    "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-    "authUserId" uuid NOT NULL,
-    "scopeNames" json NOT NULL,
-    "created" timestamp without time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    "lastUsed" timestamp without time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    "expiresAt" timestamp without time zone,
-    "expireAfterUnusedFor" bigint,
-    "sessionKeyHash" bytea NOT NULL,
-    "sessionKeySalt" bytea NOT NULL,
-    "method" text NOT NULL
-);
-
---
--- ACTION CREATE TABLE
---
 CREATE TABLE "serverpod_auth_user" (
     "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
     "created" timestamp without time zone NOT NULL,
     "scopeNames" json NOT NULL,
     "blocked" boolean NOT NULL
 );
+
+--
+-- ACTION CREATE FOREIGN KEY
+--
+ALTER TABLE ONLY "serverpod_auth_apple_account"
+    ADD CONSTRAINT "serverpod_auth_apple_account_fk_0"
+    FOREIGN KEY("authUserId")
+    REFERENCES "serverpod_auth_user"("id")
+    ON DELETE CASCADE
+    ON UPDATE NO ACTION;
 
 --
 -- ACTION CREATE FOREIGN KEY
@@ -310,60 +277,14 @@ ALTER TABLE ONLY "serverpod_query_log"
     ON DELETE CASCADE
     ON UPDATE NO ACTION;
 
---
--- ACTION CREATE FOREIGN KEY
---
-ALTER TABLE ONLY "serverpod_auth_apple_account"
-    ADD CONSTRAINT "serverpod_auth_apple_account_fk_0"
-    FOREIGN KEY("authUserId")
-    REFERENCES "serverpod_auth_user"("id")
-    ON DELETE CASCADE
-    ON UPDATE NO ACTION;
 
 --
--- ACTION CREATE FOREIGN KEY
---
-ALTER TABLE ONLY "serverpod_auth_profile_user_profile"
-    ADD CONSTRAINT "serverpod_auth_profile_user_profile_fk_0"
-    FOREIGN KEY("authUserId")
-    REFERENCES "serverpod_auth_user"("id")
-    ON DELETE CASCADE
-    ON UPDATE NO ACTION;
-ALTER TABLE ONLY "serverpod_auth_profile_user_profile"
-    ADD CONSTRAINT "serverpod_auth_profile_user_profile_fk_1"
-    FOREIGN KEY("imageId")
-    REFERENCES "serverpod_auth_profile_user_profile_image"("id")
-    ON DELETE NO ACTION
-    ON UPDATE NO ACTION;
-
---
--- ACTION CREATE FOREIGN KEY
---
-ALTER TABLE ONLY "serverpod_auth_profile_user_profile_image"
-    ADD CONSTRAINT "serverpod_auth_profile_user_profile_image_fk_0"
-    FOREIGN KEY("userProfileId")
-    REFERENCES "serverpod_auth_profile_user_profile"("id")
-    ON DELETE CASCADE
-    ON UPDATE NO ACTION;
-
---
--- ACTION CREATE FOREIGN KEY
---
-ALTER TABLE ONLY "serverpod_auth_session"
-    ADD CONSTRAINT "serverpod_auth_session_fk_0"
-    FOREIGN KEY("authUserId")
-    REFERENCES "serverpod_auth_user"("id")
-    ON DELETE CASCADE
-    ON UPDATE NO ACTION;
-
-
---
--- MIGRATION VERSION FOR serverpod_auth_apple
+-- MIGRATION VERSION FOR serverpod_auth_apple_account
 --
 INSERT INTO "serverpod_migrations" ("module", "version", "timestamp")
-    VALUES ('serverpod_auth_apple', '20250715133534148', now())
+    VALUES ('serverpod_auth_apple_account', '20250716135530275', now())
     ON CONFLICT ("module")
-    DO UPDATE SET "version" = '20250715133534148', "timestamp" = now();
+    DO UPDATE SET "version" = '20250716135530275', "timestamp" = now();
 
 --
 -- MIGRATION VERSION FOR serverpod
@@ -372,30 +293,6 @@ INSERT INTO "serverpod_migrations" ("module", "version", "timestamp")
     VALUES ('serverpod', '20240516151843329', now())
     ON CONFLICT ("module")
     DO UPDATE SET "version" = '20240516151843329', "timestamp" = now();
-
---
--- MIGRATION VERSION FOR serverpod_auth_apple_account
---
-INSERT INTO "serverpod_migrations" ("module", "version", "timestamp")
-    VALUES ('serverpod_auth_apple_account', '20250715133410884', now())
-    ON CONFLICT ("module")
-    DO UPDATE SET "version" = '20250715133410884', "timestamp" = now();
-
---
--- MIGRATION VERSION FOR serverpod_auth_profile
---
-INSERT INTO "serverpod_migrations" ("module", "version", "timestamp")
-    VALUES ('serverpod_auth_profile', '20250519092101868', now())
-    ON CONFLICT ("module")
-    DO UPDATE SET "version" = '20250519092101868', "timestamp" = now();
-
---
--- MIGRATION VERSION FOR serverpod_auth_session
---
-INSERT INTO "serverpod_migrations" ("module", "version", "timestamp")
-    VALUES ('serverpod_auth_session', '20250611085050241', now())
-    ON CONFLICT ("module")
-    DO UPDATE SET "version" = '20250611085050241', "timestamp" = now();
 
 --
 -- MIGRATION VERSION FOR serverpod_auth_user

--- a/modules/new_serverpod_auth/serverpod_auth_apple_account/serverpod_auth_apple_account_server/migrations/migration_registry.txt
+++ b/modules/new_serverpod_auth/serverpod_auth_apple_account/serverpod_auth_apple_account_server/migrations/migration_registry.txt
@@ -4,4 +4,4 @@
 ### manually. If a collision is detected in this file when doing a code merge, resolve
 ### the conflict by removing and recreating the conflicting migration.
 
-20250715133410884
+20250716135530275

--- a/modules/new_serverpod_auth/serverpod_auth_apple_account/serverpod_auth_apple_account_server/pubspec.yaml
+++ b/modules/new_serverpod_auth/serverpod_auth_apple_account/serverpod_auth_apple_account_server/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   serverpod: 2.9.1
   serverpod_auth_user_server: 2.9.1
   serverpod_shared: 2.9.1
-  sign_in_with_apple_server: ^0.1.0
+  sign_in_with_apple_server: ^0.3.0
 
 dev_dependencies:
   serverpod_lints: 2.9.1

--- a/modules/new_serverpod_auth/serverpod_auth_apple_account/serverpod_auth_apple_account_server/test/integration/test_tools/serverpod_test_tools.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_apple_account/serverpod_auth_apple_account_server/test/integration/test_tools/serverpod_test_tools.dart
@@ -7,6 +7,7 @@
 // ignore_for_file: public_member_api_docs
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
+// ignore_for_file: invalid_use_of_internal_member
 
 // ignore_for_file: no_leading_underscores_for_local_identifiers
 

--- a/templates/pubspecs/modules/new_serverpod_auth/serverpod_auth_apple_account/serverpod_auth_apple_account_server/pubspec.yaml
+++ b/templates/pubspecs/modules/new_serverpod_auth/serverpod_auth_apple_account/serverpod_auth_apple_account_server/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   serverpod: SERVERPOD_VERSION
   serverpod_auth_user_server: SERVERPOD_VERSION
   serverpod_shared: SERVERPOD_VERSION
-  sign_in_with_apple_server: ^0.1.0
+  sign_in_with_apple_server: ^0.3.0
 
 dev_dependencies:
   serverpod_lints: SERVERPOD_VERSION


### PR DESCRIPTION
Fixes later operations for web and Android logins.

Relates to https://github.com/serverpod/serverpod/issues/3453