### PR TITLE
feat(auth2): Rename extension method for getting the `AuthUser`'s id from an `AuthenticationInfo` instance to `authUserId`

### DIFF
--- a/modules/new_serverpod_auth/serverpod_auth_jwt/serverpod_auth_jwt_server/test/integration/authentication_handler_test.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_jwt/serverpod_auth_jwt_server/test/integration/authentication_handler_test.dart
@@ -92,7 +92,7 @@ void main() {
       );
 
       expect(authInfo, isNotNull);
-      expect(authInfo!.userUuid, authUserId);
+      expect(authInfo!.authUserId, authUserId);
       expect(authInfo.scopes, {const Scope(scopeName)});
     });
 

--- a/modules/new_serverpod_auth/serverpod_auth_profile/serverpod_auth_profile_server/lib/src/endpoints/user_profile_endpoint.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_profile/serverpod_auth_profile_server/lib/src/endpoints/user_profile_endpoint.dart
@@ -11,7 +11,7 @@ abstract class UserProfileEndpoint extends Endpoint {
 
   /// Returns the user profile of the current user.
   Future<UserProfileModel> get(final Session session) async {
-    final authUserId = (await session.authenticated)!.userUuid;
+    final authUserId = (await session.authenticated)!.authUserId;
 
     final profile = await UserProfiles.findUserProfileByUserId(
       session,
@@ -24,7 +24,7 @@ abstract class UserProfileEndpoint extends Endpoint {
   /// Removes the users uploaded image, replacing it with the default user
   /// image.
   Future<UserProfileModel> removeUserImage(final Session session) async {
-    final userId = (await session.authenticated)!.userUuid;
+    final userId = (await session.authenticated)!.authUserId;
 
     return UserProfiles.setDefaultUserImage(session, userId);
   }
@@ -34,7 +34,7 @@ abstract class UserProfileEndpoint extends Endpoint {
     final Session session,
     final ByteData image,
   ) async {
-    final userId = (await session.authenticated)!.userUuid;
+    final userId = (await session.authenticated)!.authUserId;
 
     return UserProfiles.setUserImageFromBytes(
       session,
@@ -48,7 +48,7 @@ abstract class UserProfileEndpoint extends Endpoint {
     final Session session,
     final String? userName,
   ) async {
-    final userId = (await session.authenticated)!.userUuid;
+    final userId = (await session.authenticated)!.authUserId;
 
     return UserProfiles.changeUserName(session, userId, userName);
   }
@@ -58,7 +58,7 @@ abstract class UserProfileEndpoint extends Endpoint {
     final Session session,
     final String? fullName,
   ) async {
-    final userId = (await session.authenticated)!.userUuid;
+    final userId = (await session.authenticated)!.authUserId;
 
     return UserProfiles.changeFullName(session, userId, fullName);
   }

--- a/modules/new_serverpod_auth/serverpod_auth_session/serverpod_auth_session_server/test/integration/auth_sessions_authentication_handler_test.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_session/serverpod_auth_session_server/test/integration/auth_sessions_authentication_handler_test.dart
@@ -72,7 +72,7 @@ void main() {
         );
 
         expect(
-          authInfo?.userUuid,
+          authInfo?.authUserId,
           authUserId,
         );
       },
@@ -188,7 +188,7 @@ void main() {
           );
 
           expect(
-            authInfo?.userUuid,
+            authInfo?.authUserId,
             authUserId,
           );
         },
@@ -245,7 +245,7 @@ void main() {
         );
 
         expect(
-          authInfo?.userUuid,
+          authInfo?.authUserId,
           authUserId,
         );
       },
@@ -265,7 +265,7 @@ void main() {
         );
 
         expect(
-          authInfoBeforeInitialExpiration?.userUuid,
+          authInfoBeforeInitialExpiration?.authUserId,
           authUserId,
         );
 
@@ -280,7 +280,7 @@ void main() {
         );
 
         expect(
-          authInfoAfterExtension?.userUuid,
+          authInfoAfterExtension?.authUserId,
           authUserId,
         );
       },

--- a/modules/new_serverpod_auth/serverpod_auth_user/serverpod_auth_user_server/lib/serverpod_auth_user_server.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_user/serverpod_auth_user_server/lib/serverpod_auth_user_server.dart
@@ -3,4 +3,4 @@ export 'src/generated/endpoints.dart' show Endpoints;
 export 'src/generated/protocol.dart';
 export 'src/util/auth_user_scopes_extension.dart' show AuthUserScopes;
 export 'src/util/authentication_info_extension.dart'
-    show AuthenticationInfoUserId;
+    show AuthenticationInfoAuthUserId;

--- a/modules/new_serverpod_auth/serverpod_auth_user/serverpod_auth_user_server/lib/src/util/authentication_info_extension.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_user/serverpod_auth_user_server/lib/src/util/authentication_info_extension.dart
@@ -1,11 +1,11 @@
 import 'package:serverpod/serverpod.dart';
 
-/// User ID extension for `AuthenticationInfo`
-extension AuthenticationInfoUserId on AuthenticationInfo {
+/// `AuthUser` ID extension for `AuthenticationInfo`
+extension AuthenticationInfoAuthUserId on AuthenticationInfo {
   /// Returns the `Uuid` user ID of the authenticated user.
   ///
   /// Assumes that the system uses `Uuid` user IDs, otherwise throws.
-  UuidValue get userUuid {
+  UuidValue get authUserId {
     return UuidValue.withValidation(userIdentifier);
   }
 }

--- a/modules/new_serverpod_auth/serverpod_auth_user/serverpod_auth_user_server/test/authentication_info_extension_test.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_user/serverpod_auth_user_server/test/authentication_info_extension_test.dart
@@ -9,7 +9,7 @@ void main() {
     final authenticationInfo = AuthenticationInfo(authUserId, {});
 
     test('when reading the `userUuid` field, then the UUID is returned.', () {
-      expect(authenticationInfo.userUuid, authUserId);
+      expect(authenticationInfo.authUserId, authUserId);
     });
   });
 
@@ -18,7 +18,7 @@ void main() {
 
     test('when reading the `userUuid` field, then it throws.', () {
       expect(
-        () => authenticationInfo.userUuid,
+        () => authenticationInfo.authUserId,
         throwsFormatException,
       );
     });

--- a/tests/serverpod_new_auth_test/serverpod_new_auth_test_server/lib/src/endpoints/session_test_endpoint.dart
+++ b/tests/serverpod_new_auth_test/serverpod_new_auth_test_server/lib/src/endpoints/session_test_endpoint.dart
@@ -24,6 +24,6 @@ class SessionTestEndpoint extends Endpoint {
     final Session session,
     final UuidValue authUserId,
   ) async {
-    return (await session.authenticated)?.userUuid == authUserId;
+    return (await session.authenticated)?.authUserId == authUserId;
   }
 }

--- a/tests/serverpod_new_auth_test/serverpod_new_auth_test_server/test/integration/email_account_endpoint_test.dart
+++ b/tests/serverpod_new_auth_test/serverpod_new_auth_test_server/test/integration/email_account_endpoint_test.dart
@@ -300,7 +300,7 @@ void main() {
             authSuccess.sessionKey,
           );
 
-          expect(authInfo?.userUuid, authUserId);
+          expect(authInfo?.authUserId, authUserId);
         },
       );
     },
@@ -400,7 +400,7 @@ void main() {
             passwordResetSessionKey,
           );
 
-          expect(authInfo?.userUuid, authUserId);
+          expect(authInfo?.authUserId, authUserId);
         },
       );
     },
@@ -447,7 +447,10 @@ extension on TestEndpoints {
       authSuccess.sessionKey,
     );
 
-    return (sessionKey: authSuccess.sessionKey, authUserId: authInfo!.userUuid);
+    return (
+      sessionKey: authSuccess.sessionKey,
+      authUserId: authInfo!.authUserId
+    );
   }
 
   Future<


### PR DESCRIPTION
Matching the parameter name used throughout the new auth packages.
