### PR TITLE
feat(auth2): Update documentation for `EmailAccountsAdmin` and export its type

### DIFF
--- a/modules/new_serverpod_auth/serverpod_auth_email_account/serverpod_auth_email_account_server/lib/serverpod_auth_email_account_server.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_email_account/serverpod_auth_email_account_server/lib/serverpod_auth_email_account_server.dart
@@ -1,7 +1,11 @@
 export 'src/business/email_account_config.dart';
 export 'src/business/email_account_not_found_exception.dart';
 export 'src/business/email_accounts.dart'
-    show EmailAccounts, EmailAccountRequestResult, PasswordResetResult;
+    show
+        EmailAccounts,
+        EmailAccountsAdmin,
+        EmailAccountRequestResult,
+        PasswordResetResult;
 export 'src/generated/endpoints.dart';
 export 'src/generated/protocol.dart'
     show

--- a/modules/new_serverpod_auth/serverpod_auth_email_account/serverpod_auth_email_account_server/lib/src/business/email_accounts.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_email_account/serverpod_auth_email_account_server/lib/src/business/email_accounts.dart
@@ -4,10 +4,11 @@ import 'package:clock/clock.dart';
 import 'package:serverpod/serverpod.dart';
 import 'package:serverpod_auth_email_account_server/serverpod_auth_email_account_server.dart';
 import 'package:serverpod_auth_email_account_server/src/business/email_account_secret_hash.dart';
-import 'package:serverpod_auth_email_account_server/src/business/email_accounts_admin.dart';
 import 'package:serverpod_auth_email_account_server/src/generated/protocol.dart';
 import 'package:serverpod_auth_email_account_server/src/util/byte_data_extension.dart';
 import 'package:serverpod_auth_email_account_server/src/util/uint8list_extension.dart';
+
+part 'email_accounts_admin.dart';
 
 /// Email account management functions.
 abstract final class EmailAccounts {
@@ -15,7 +16,7 @@ abstract final class EmailAccounts {
   static EmailAccountConfig config = EmailAccountConfig();
 
   /// Collection of admin-related functions.
-  static final admin = EmailAccountsAdmin();
+  static final admin = EmailAccountsAdmin._();
 
   /// Returns the [AuthUser]'s ID upon successful login.
   ///

--- a/modules/new_serverpod_auth/serverpod_auth_email_account/serverpod_auth_email_account_server/lib/src/business/email_accounts_admin.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_email_account/serverpod_auth_email_account_server/lib/src/business/email_accounts_admin.dart
@@ -1,15 +1,14 @@
-import 'dart:typed_data';
+part of 'email_accounts.dart';
 
-import 'package:clock/clock.dart';
-import 'package:meta/meta.dart';
-import 'package:serverpod/serverpod.dart';
-import 'package:serverpod_auth_email_account_server/serverpod_auth_email_account_server.dart';
-import 'package:serverpod_auth_email_account_server/src/business/email_account_secret_hash.dart';
-import 'package:serverpod_auth_email_account_server/src/generated/protocol.dart';
-import 'package:serverpod_auth_email_account_server/src/util/uint8list_extension.dart';
-
-@internal
+/// Administrative email account management functions.
+///
+/// These should generally not be exposed to clients, but might be useful for
+/// internal tasks or an admin dashboard.
+///
+/// An instance of this class is available at [EmailAccounts.admin].
 final class EmailAccountsAdmin {
+  EmailAccountsAdmin._();
+
   /// Cleans up the log of failed password reset attempts older than
   /// [olderThan].
   ///


### PR DESCRIPTION
While keeping the constructor internal, so the package stays in control of when and how to create it.