### PR TITLE
feat(auth2): Create `AuthEmailAdmin` helper with `createUser` helper

### DIFF
--- a/modules/new_serverpod_auth/serverpod_auth_email/serverpod_auth_email_server/config/passwords.yaml
+++ b/modules/new_serverpod_auth/serverpod_auth_email/serverpod_auth_email_server/config/passwords.yaml
@@ -12,3 +12,4 @@
 test:
   database: 'DB_TEST_PASSWORD'
   redis: 'REDIS_TEST_PASSWORD'
+  serverpod_auth_email_account_passwordHashPepper: 'pepper!'

--- a/modules/new_serverpod_auth/serverpod_auth_email/serverpod_auth_email_server/lib/src/business/auth_email.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_email/serverpod_auth_email_server/lib/src/business/auth_email.dart
@@ -4,6 +4,8 @@ import 'package:serverpod_auth_profile_server/serverpod_auth_profile_server.dart
 import 'package:serverpod_auth_session_server/serverpod_auth_session_server.dart';
 import 'package:serverpod_auth_user_server/serverpod_auth_user_server.dart';
 
+part 'auth_email_admin.dart';
+
 /// The default implementation for the email account endpoint methods.
 ///
 /// All public methods in here can be safely exposed to end-user clients.
@@ -11,7 +13,8 @@ import 'package:serverpod_auth_user_server/serverpod_auth_user_server.dart';
 /// Uses `serverpod_auth_session` for session management and
 /// `serverpod_auth_profile` for user profiles.
 abstract class AuthEmail {
-  static const String _method = 'email';
+  /// Collection of admin-related functions.
+  static final AuthEmailAdmin admin = AuthEmailAdmin._();
 
   /// {@macro email_account_base_endpoint.login}
   static Future<AuthSuccess> login(
@@ -31,7 +34,11 @@ abstract class AuthEmail {
           transaction: transaction,
         );
 
-        return _createSession(session, authUserId, transaction: transaction);
+        return admin.createSession(
+          session,
+          authUserId,
+          transaction: transaction,
+        );
       },
     );
   }
@@ -101,7 +108,11 @@ abstract class AuthEmail {
           transaction: transaction,
         );
 
-        return _createSession(session, authUserId, transaction: transaction);
+        return admin.createSession(
+          session,
+          authUserId,
+          transaction: transaction,
+        );
       },
     );
   }
@@ -154,25 +165,12 @@ abstract class AuthEmail {
           transaction: transaction,
         );
 
-        return _createSession(
+        return admin.createSession(
           session,
           authUserId,
           transaction: transaction,
         );
       },
-    );
-  }
-
-  static Future<AuthSuccess> _createSession(
-    final Session session,
-    final UuidValue authUserId, {
-    required final Transaction transaction,
-  }) async {
-    return AuthSessions.createSession(
-      session,
-      authUserId: authUserId,
-      method: _method,
-      transaction: transaction,
     );
   }
 }

--- a/modules/new_serverpod_auth/serverpod_auth_email/serverpod_auth_email_server/lib/src/business/auth_email_admin.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_email/serverpod_auth_email_server/lib/src/business/auth_email_admin.dart
@@ -1,0 +1,72 @@
+part of 'auth_email.dart';
+
+/// Admin operations complementing the end-user [AuthEmail] functionality.
+///
+/// An instance of this class is available at [AuthEmail.admin].
+final class AuthEmailAdmin {
+  AuthEmailAdmin._();
+
+  static const String _method = 'email';
+
+  /// Creates a user with an email-based authentication and the associated
+  /// profile.
+  ///
+  /// The end result is identical to the combination of
+  /// [AuthEmail.startRegistration] and [AuthEmail.finishRegistration].
+  /// The [email] is considered verified by default.
+  ///
+  /// Returns the newly created [AuthUser]'s id.
+  Future<UuidValue> createUser(
+    final Session session, {
+    required final String email,
+    required final String password,
+    final Transaction? transaction,
+  }) async {
+    return DatabaseUtil.runInTransactionOrSavepoint(
+      session.db,
+      transaction,
+      (final transaction) async {
+        final newUser = await AuthUsers.create(
+          session,
+          transaction: transaction,
+        );
+        final authUserId = newUser.id;
+
+        await UserProfiles.createUserProfile(
+          session,
+          authUserId,
+          UserProfileData(
+            email: email,
+          ),
+          transaction: transaction,
+        );
+
+        await EmailAccounts.admin.createEmailAuthentication(
+          session,
+          authUserId: authUserId,
+          email: email,
+          password: password,
+          transaction: transaction,
+        );
+
+        return authUserId;
+      },
+    );
+  }
+
+  /// Create a session for the given auth user.
+  ///
+  /// The session is marked as originating from the `email` provider.
+  Future<AuthSuccess> createSession(
+    final Session session,
+    final UuidValue authUserId, {
+    required final Transaction? transaction,
+  }) async {
+    return AuthSessions.createSession(
+      session,
+      authUserId: authUserId,
+      method: _method,
+      transaction: transaction,
+    );
+  }
+}

--- a/modules/new_serverpod_auth/serverpod_auth_email/serverpod_auth_email_server/test/integration/auth_email_admin_test.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_email/serverpod_auth_email_server/test/integration/auth_email_admin_test.dart
@@ -1,0 +1,58 @@
+import 'package:serverpod/serverpod.dart';
+import 'package:serverpod_auth_email_server/serverpod_auth_email_server.dart';
+import 'package:test/test.dart';
+
+import './test_tools/serverpod_test_tools.dart';
+
+void main() {
+  withServerpod(
+    'Given a user created through `AuthEmail.admin.create`,',
+    (final sessionBuilder, final endpoints) {
+      const email = 'test@serverpod.dev';
+      const password = 'Abcdef123!!!';
+
+      late Session session;
+      late UuidValue authUserId;
+
+      setUp(() async {
+        session = sessionBuilder.build();
+
+        authUserId = await AuthEmail.admin.createUser(
+          session,
+          email: email,
+          password: password,
+        );
+      });
+
+      test(
+          "when getting the user's profile, then it is found and the email set.",
+          () async {
+        final profile = await UserProfiles.findUserProfileByUserId(
+          session,
+          authUserId,
+        );
+
+        expect(
+          profile.email,
+          email,
+        );
+      });
+
+      test(
+        'when using the credentials, then they work.',
+        () async {
+          final authenticatedUserId = await EmailAccounts.authenticate(
+            session,
+            email: email,
+            password: password,
+          );
+
+          expect(
+            authenticatedUserId,
+            authUserId,
+          );
+        },
+      );
+    },
+  );
+}


### PR DESCRIPTION
Which creates a full auth user + email authentication + user profile, just like the 2 step login process


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced administrative operations for email-based authentication, including user and session creation, accessible via a new admin interface.
* **Refactor**
  * Centralized session creation logic under the new admin interface for improved maintainability.
* **Tests**
  * Added integration tests to verify user creation and authentication using the new administrative features.
* **Chores**
  * Updated configuration to include a new password pepper value for enhanced test environment security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->