### PR TITLE
feat(auth2): Add `list` method for `UserProfile`s as an admin function

### DIFF
--- a/modules/new_serverpod_auth/serverpod_auth_profile/serverpod_auth_profile_server/lib/src/business/user_profiles.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_profile/serverpod_auth_profile_server/lib/src/business/user_profiles.dart
@@ -8,8 +8,13 @@ import 'package:serverpod_auth_profile_server/src/generated/protocol.dart';
 import 'package:serverpod_auth_profile_server/src/util/user_profile_extension.dart';
 import 'package:serverpod_shared/serverpod_shared.dart';
 
+part 'user_profiles_admin.dart';
+
 /// Business logic for handling user profiles
 abstract final class UserProfiles {
+  /// Collection of admin-related functions.
+  static final UserProfilesAdmin admin = UserProfilesAdmin._();
+
   /// Creates a new user profile and stores it in the database.
   static Future<UserProfileModel> createUserProfile(
     final Session session,

--- a/modules/new_serverpod_auth/serverpod_auth_profile/serverpod_auth_profile_server/lib/src/business/user_profiles_admin.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_profile/serverpod_auth_profile_server/lib/src/business/user_profiles_admin.dart
@@ -1,0 +1,57 @@
+part of 'user_profiles.dart';
+
+/// Admin operations complementing the end-user [UserProfilesAdmin] functionality.
+///
+/// An instance of this class is available at [UserProfiles.admin].
+final class UserProfilesAdmin {
+  UserProfilesAdmin._();
+
+  /// Returns all user profiles that match the specified criteria.
+  ///
+  /// For a direct look-up by auth user ID use [findUserProfileByUserId].
+  Future<List<UserProfileModel>> listUserProfiles(
+    final Session session, {
+    final String? email,
+    final String? userName,
+    final String? fullName,
+
+    /// How many items to return at most. Must be <= 1000.
+    final int limit = 100,
+    final int offset = 0,
+    final Transaction? transaction,
+  }) async {
+    if (limit <= 0 || limit > 1000) {
+      throw ArgumentError.value(limit, 'limit', 'Must be between 1 and 1000');
+    }
+    if (offset < 0) {
+      throw ArgumentError.value(offset, 'offset', 'Must be >= 0');
+    }
+
+    final profiles = await UserProfile.db.find(
+      session,
+      where: (final t) {
+        Expression<dynamic> expression = Constant.bool(true);
+
+        if (email != null) {
+          expression &= t.email.equals(email);
+        }
+
+        if (userName != null) {
+          expression &= t.userName.equals(userName);
+        }
+
+        if (fullName != null) {
+          expression &= t.fullName.equals(fullName);
+        }
+
+        return expression;
+      },
+      limit: limit,
+      offset: offset,
+      orderBy: (final t) => t.id,
+      transaction: transaction,
+    );
+
+    return profiles.map((final p) => p.toModel()).toList();
+  }
+}

--- a/modules/new_serverpod_auth/serverpod_auth_profile/serverpod_auth_profile_server/test/integration/user_profiles_admin_test.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_profile/serverpod_auth_profile_server/test/integration/user_profiles_admin_test.dart
@@ -1,0 +1,224 @@
+import 'package:serverpod/serverpod.dart';
+import 'package:serverpod_auth_profile_server/serverpod_auth_profile_server.dart';
+import 'package:serverpod_auth_user_server/serverpod_auth_user_server.dart';
+import 'package:test/test.dart';
+
+import 'test_tools/serverpod_test_tools.dart';
+
+void main() {
+  withServerpod(
+    'Given an `AuthUser` with a `UserProfile`,',
+    (final sessionBuilder, final endpoints) {
+      final profileData = UserProfileData(
+        userName: 'username',
+        fullName: 'Full Name',
+        email: 'test@serverpod.dev',
+      );
+
+      late Session session;
+      late UuidValue authUserId;
+
+      setUp(() async {
+        session = sessionBuilder.build();
+
+        final user1 = await AuthUsers.create(session);
+        authUserId = user1.id;
+
+        await UserProfiles.createUserProfile(session, authUserId, profileData);
+      });
+
+      test(
+        'when listing without any criteria, then the profile with data is returned.',
+        () async {
+          final profiles = await UserProfiles.admin.listUserProfiles(
+            session,
+          );
+
+          expect(profiles, hasLength(1));
+          expect(profiles.single.authUserId, authUserId);
+          expect(profiles.single.userName, profileData.userName);
+          expect(profiles.single.fullName, profileData.fullName);
+          expect(profiles.single.email, profileData.email);
+        },
+      );
+
+      test(
+        'when listing with the matching `email` parameter, then the profile is returned.',
+        () async {
+          final profiles = await UserProfiles.admin.listUserProfiles(
+            session,
+            email: profileData.email,
+          );
+
+          expect(profiles, hasLength(1));
+        },
+      );
+
+      test(
+        'when listing with the matching `username` parameter, then the profile is returned.',
+        () async {
+          final profiles = await UserProfiles.admin.listUserProfiles(
+            session,
+            userName: profileData.userName,
+          );
+
+          expect(profiles, hasLength(1));
+        },
+      );
+
+      test(
+        'when listing with the matching `fullName` parameter, then the profile is returned.',
+        () async {
+          final profiles = await UserProfiles.admin.listUserProfiles(
+            session,
+            fullName: profileData.fullName,
+          );
+
+          expect(profiles, hasLength(1));
+        },
+      );
+
+      test(
+        'when listing with no matching criteria, then no profiles are returned.',
+        () async {
+          final profiles = await UserProfiles.admin.listUserProfiles(
+            session,
+            email: 'does-not-match',
+          );
+
+          expect(profiles, isEmpty);
+        },
+      );
+
+      test(
+        'when listing with one matching and one non-matching criteria, then no profiles are returned.',
+        () async {
+          final profiles = await UserProfiles.admin.listUserProfiles(
+            session,
+            email: profileData.email,
+            userName: 'does-not-match',
+          );
+
+          expect(profiles, isEmpty);
+        },
+      );
+    },
+  );
+
+  withServerpod(
+    'Given two `AuthUser`s with identical `UserProfile`s,',
+    (final sessionBuilder, final endpoints) {
+      final profileData = UserProfileData(
+        userName: 'username',
+        fullName: 'Full Name',
+        email: 'test@serverpod.dev',
+      );
+
+      late Session session;
+      late UuidValue authUserId1;
+      late UuidValue authUserId2;
+
+      setUp(() async {
+        session = sessionBuilder.build();
+
+        final user1 = await AuthUsers.create(session);
+        authUserId1 = user1.id;
+        final user2 = await AuthUsers.create(session);
+        authUserId2 = user2.id;
+
+        await UserProfiles.createUserProfile(session, user1.id, profileData);
+        await UserProfiles.createUserProfile(session, user2.id, profileData);
+      });
+
+      test(
+        'when listing without any criteria, then all users are returned.',
+        () async {
+          final profiles = await UserProfiles.admin.listUserProfiles(
+            session,
+          );
+
+          expect(profiles, hasLength(2));
+          expect(
+            profiles.authUserIds,
+            unorderedEquals([authUserId1, authUserId2]),
+          );
+        },
+      );
+    },
+  );
+
+  withServerpod(
+    'Given two `AuthUser`s with unique `UserProfile`s,',
+    (final sessionBuilder, final endpoints) {
+      final profileData1 = UserProfileData(
+        userName: 'user1',
+        fullName: 'Full Name One',
+        email: 'one@serverpod.dev',
+      );
+      final profileData2 = UserProfileData(
+        userName: 'user2',
+        fullName: 'Full Name Two',
+        email: 'two@serverpod.dev',
+      );
+
+      late Session session;
+      late UuidValue authUserId1;
+      late UuidValue authUserId2;
+
+      setUp(() async {
+        session = sessionBuilder.build();
+
+        final user1 = await AuthUsers.create(session);
+        authUserId1 = user1.id;
+        final user2 = await AuthUsers.create(session);
+        authUserId2 = user2.id;
+
+        await UserProfiles.createUserProfile(session, user1.id, profileData1);
+        await UserProfiles.createUserProfile(session, user2.id, profileData2);
+      });
+
+      test(
+        'when listing with a criteria for user1, then only that one is returned.',
+        () async {
+          final profiles = await UserProfiles.admin.listUserProfiles(
+            session,
+            email: profileData1.email,
+          );
+
+          expect(profiles, hasLength(1));
+          expect(profiles.single.authUserId, authUserId1);
+        },
+      );
+
+      test(
+        'when listing with a criteria for user2, then only that one is returned.',
+        () async {
+          final profiles = await UserProfiles.admin.listUserProfiles(
+            session,
+            userName: profileData2.userName,
+          );
+
+          expect(profiles, hasLength(1));
+          expect(profiles.single.authUserId, authUserId2);
+        },
+      );
+
+      test(
+        'when listing with a criteria for user1 combined with one for user2, then no profiles are returned.',
+        () async {
+          final profiles = await UserProfiles.admin.listUserProfiles(
+            session,
+            email: profileData1.email,
+            userName: profileData2.userName,
+          );
+
+          expect(profiles, isEmpty);
+        },
+      );
+    },
+  );
+}
+
+extension on Iterable<UserProfileModel> {
+  Set<UuidValue> get authUserIds => {...map((final p) => p.authUserId)};
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced an administrative interface for user profiles, allowing admins to list user profiles with advanced filtering by email, username, and full name, as well as pagination options.
* **Tests**
  * Added comprehensive integration tests to ensure correct behavior of user profile listing and filtering under various scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->