### PR TITLE
fix: Add missing `public` parameter to file upload description

### DIFF
--- a/integrations/serverpod_cloud_storage_s3/lib/src/cloud_storage.dart/s3_cloud_storage.dart
+++ b/integrations/serverpod_cloud_storage_s3/lib/src/cloud_storage.dart/s3_cloud_storage.dart
@@ -128,6 +128,7 @@ class S3CloudStorage extends CloudStorage {
       uploadDst: path,
       expires: expirationDuration,
       maxFileSize: maxFileSize,
+      public: public,
     );
   }
 


### PR DESCRIPTION
What this PR does
This PR fixes an issue in the createDirectFileUploadDescription method where the public parameter was not passed to AwsS3Uploader.getDirectUploadDescription. This caused incorrect headers to be generated for private S3 buckets, resulting in failed uploads.

The public parameter is now correctly forwarded, ensuring proper upload behavior for both public and private buckets.

Issues fixed by this PR
Fixes [#2655](https://github.com/serverpod/serverpod/issues/2655)