### PR TITLE
fix: Remove "cannot find templates" log on every command

### DIFF
--- a/tools/serverpod_cli/lib/src/runner/serverpod_command_runner.dart
+++ b/tools/serverpod_cli/lib/src/runner/serverpod_command_runner.dart
@@ -53,10 +53,6 @@ Future<void> _preCommandPrints(ServerpodCommandRunner runner) async {
       'Development mode. Using templates from: ${resourceManager.templateDirectory.path}',
     );
     log.debug('SERVERPOD_HOME is set to $serverpodHome');
-
-    if (!resourceManager.isTemplatesInstalled) {
-      log.warning('Could not find templates.');
-    }
   }
 }
 


### PR DESCRIPTION
Since we merged in https://github.com/serverpod/serverpod/pull/3781, we don't need to log out that templates don't exist as this would be handled by the create command.

## Pre-launch Checklist

- [X] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [X] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [X] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [X] I added new tests to check the change I am making.
- [X] All existing and new tests are passing.
- [X] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

