### PR TITLE
feat(auth2): Add `deleteEmailAccountRequestById` method on `EmailAccountsAdmin`

### DIFF
--- a/modules/new_serverpod_auth/serverpod_auth_email_account/serverpod_auth_email_account_server/lib/src/business/email_accounts_admin.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_email_account/serverpod_auth_email_account_server/lib/src/business/email_accounts_admin.dart
@@ -114,8 +114,8 @@ final class EmailAccountsAdmin {
     );
   }
 
-  /// Checks whether the registration request is still pending, and if so
-  /// returns the associated email.
+  /// Checks whether an email account request is still pending, and if so
+  /// returns the associated email and verification status.
   ///
   /// In case the registration has been completed or the request is expired this
   /// returns `null`.
@@ -123,7 +123,7 @@ final class EmailAccountsAdmin {
       ({
         String email,
         bool isVerified,
-      })?> findRegistrationRequest(
+      })?> findEmailAccountRequest(
     final Session session, {
     required final UuidValue accountRequestId,
     final Transaction? transaction,
@@ -144,8 +144,8 @@ final class EmailAccountsAdmin {
     );
   }
 
-  /// Deletes a registration request by its ID.
-  Future<void> deleteRegistrationRequestById(
+  /// Deletes an account request by its ID.
+  Future<void> deleteEmailAccountRequestById(
     final Session session,
     final UuidValue accountRequestId, {
     final Transaction? transaction,

--- a/modules/new_serverpod_auth/serverpod_auth_email_account/serverpod_auth_email_account_server/test/integration/email_accounts_account_creation_test.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_email_account/serverpod_auth_email_account_server/test/integration/email_accounts_account_creation_test.dart
@@ -237,9 +237,9 @@ void main() {
       });
 
       test(
-          'when looking up the request using `EmailAccountsAdmin.findRegistrationRequest`, then the associated email is returned.',
+          'when looking up the request using `EmailAccountsAdmin.findEmailAccountRequest`, then the associated email is returned.',
           () async {
-        final requestInfo = await EmailAccounts.admin.findRegistrationRequest(
+        final requestInfo = await EmailAccounts.admin.findEmailAccountRequest(
           session,
           accountRequestId: pendingAccountRequestId,
         );
@@ -251,9 +251,9 @@ void main() {
       });
 
       test(
-          'when looking up the request using `EmailAccountsAdmin.findRegistrationRequest`, then it is not verified.',
+          'when looking up the request using `EmailAccountsAdmin.findEmailAccountRequest`, then it is not verified.',
           () async {
-        final requestInfo = await EmailAccounts.admin.findRegistrationRequest(
+        final requestInfo = await EmailAccounts.admin.findEmailAccountRequest(
           session,
           accountRequestId: pendingAccountRequestId,
         );
@@ -265,12 +265,12 @@ void main() {
       });
 
       test(
-          'when looking up the request using `EmailAccountsAdmin.findRegistrationRequest` after it has expired, then it returns `null`.',
+          'when looking up the request using `EmailAccountsAdmin.findEmailAccountRequest` after it has expired, then it returns `null`.',
           () async {
         final requestInfo = await withClock(
           Clock.fixed(DateTime.now()
               .add(EmailAccounts.config.registrationVerificationCodeLifetime)),
-          () => EmailAccounts.admin.findRegistrationRequest(
+          () => EmailAccounts.admin.findEmailAccountRequest(
             session,
             accountRequestId: pendingAccountRequestId,
           ),
@@ -341,9 +341,9 @@ void main() {
       });
 
       test(
-          'when looking up the request using `EmailAccountsAdmin.findRegistrationRequest`, then it is verified.',
+          'when looking up the request using `EmailAccountsAdmin.findEmailAccountRequest`, then it is verified.',
           () async {
-        final requestInfo = await EmailAccounts.admin.findRegistrationRequest(
+        final requestInfo = await EmailAccounts.admin.findEmailAccountRequest(
           session,
           accountRequestId: pendingAccountRequestId,
         );
@@ -418,9 +418,9 @@ void main() {
       });
 
       test(
-          'when looking up the request using `EmailAccountsAdmin.findRegistrationRequest`, then it returns `null`.',
+          'when looking up the request using `EmailAccountsAdmin.findEmailAccountRequest`, then it returns `null`.',
           () async {
-        final requestInfo = await EmailAccounts.admin.findRegistrationRequest(
+        final requestInfo = await EmailAccounts.admin.findEmailAccountRequest(
           session,
           accountRequestId: accountCreationParameters.accountRequestId,
         );

--- a/modules/new_serverpod_auth/serverpod_auth_email_account/serverpod_auth_email_account_server/test/integration/email_accounts_admin_test.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_email_account/serverpod_auth_email_account_server/test/integration/email_accounts_admin_test.dart
@@ -40,9 +40,9 @@ void main() {
     });
 
     test(
-        'when `deleteRegistrationRequestById` is called, '
+        'when `deleteEmailAccountRequestById` is called, '
         'then the account request is removed.', () async {
-      await EmailAccounts.admin.deleteRegistrationRequestById(
+      await EmailAccounts.admin.deleteEmailAccountRequestById(
         session,
         accountCreationResult.accountRequestId!,
       );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to delete email account requests by ID in the admin interface.

* **Bug Fixes**
  * Improved clarity in method naming and documentation for finding email account requests.

* **Tests**
  * Updated test cases to use the new method name for finding email account requests.
  * Added tests to verify deletion of email account requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->