### PR TITLE
fix(auth2): Rename `attemptedAt` to `attempted` to match general pattern for `DateTimes`

### DIFF
--- a/modules/new_serverpod_auth/serverpod_auth_backwards_compatibility/serverpod_auth_backwards_compatibility_server/migrations/20250724125750464/definition.json
+++ b/modules/new_serverpod_auth/serverpod_auth_backwards_compatibility/serverpod_auth_backwards_compatibility_server/migrations/20250724125750464/definition.json
@@ -1,50 +1,106 @@
 {
-  "moduleName": "serverpod_auth_migration",
+  "moduleName": "serverpod_auth_backwards_compatibility",
   "tables": [
     {
-      "name": "serverpod_auth_migration_migrated_user",
-      "dartName": "MigratedUser",
-      "module": "serverpod_auth_migration",
+      "name": "serverpod_auth_backwards_compatibility_email_password",
+      "dartName": "LegacyEmailPassword",
+      "module": "serverpod_auth_backwards_compatibility",
       "schema": "public",
       "columns": [
         {
           "name": "id",
-          "columnType": 6,
+          "columnType": 7,
           "isNullable": false,
-          "columnDefault": "nextval('serverpod_auth_migration_migrated_user_id_seq'::regclass)",
-          "dartType": "int?"
+          "columnDefault": "gen_random_uuid()",
+          "dartType": "UuidValue?"
         },
         {
-          "name": "oldUserId",
-          "columnType": 6,
-          "isNullable": false,
-          "dartType": "int"
-        },
-        {
-          "name": "newAuthUserId",
+          "name": "emailAccountId",
           "columnType": 7,
           "isNullable": false,
           "dartType": "UuidValue"
+        },
+        {
+          "name": "hash",
+          "columnType": 0,
+          "isNullable": false,
+          "dartType": "String"
         }
       ],
       "foreignKeys": [
         {
-          "constraintName": "serverpod_auth_migration_migrated_user_fk_0",
+          "constraintName": "serverpod_auth_backwards_compatibility_email_password_fk_0",
           "columns": [
-            "oldUserId"
+            "emailAccountId"
           ],
-          "referenceTable": "serverpod_user_info",
+          "referenceTable": "serverpod_auth_email_account",
           "referenceTableSchema": "public",
           "referenceColumns": [
             "id"
           ],
           "onUpdate": 3,
           "onDelete": 4
+        }
+      ],
+      "indexes": [
+        {
+          "indexName": "serverpod_auth_backwards_compatibility_email_password_pkey",
+          "elements": [
+            {
+              "type": 0,
+              "definition": "id"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": true
         },
         {
-          "constraintName": "serverpod_auth_migration_migrated_user_fk_1",
+          "indexName": "serverpod_auth_backwards_compatibility_email_password_account",
+          "elements": [
+            {
+              "type": 0,
+              "definition": "emailAccountId"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": false
+        }
+      ],
+      "managed": true
+    },
+    {
+      "name": "serverpod_auth_backwards_compatibility_external_user_id",
+      "dartName": "LegacyExternalUserIdentifier",
+      "module": "serverpod_auth_backwards_compatibility",
+      "schema": "public",
+      "columns": [
+        {
+          "name": "id",
+          "columnType": 7,
+          "isNullable": false,
+          "columnDefault": "gen_random_uuid()",
+          "dartType": "UuidValue?"
+        },
+        {
+          "name": "authUserId",
+          "columnType": 7,
+          "isNullable": false,
+          "dartType": "UuidValue"
+        },
+        {
+          "name": "userIdentifier",
+          "columnType": 0,
+          "isNullable": false,
+          "dartType": "String"
+        }
+      ],
+      "foreignKeys": [
+        {
+          "constraintName": "serverpod_auth_backwards_compatibility_external_user_id_fk_0",
           "columns": [
-            "newAuthUserId"
+            "authUserId"
           ],
           "referenceTable": "serverpod_auth_user",
           "referenceTableSchema": "public",
@@ -57,7 +113,7 @@
       ],
       "indexes": [
         {
-          "indexName": "serverpod_auth_migration_migrated_user_pkey",
+          "indexName": "serverpod_auth_backwards_compatibility_external_user_id_pkey",
           "elements": [
             {
               "type": 0,
@@ -69,28 +125,85 @@
           "isPrimary": true
         },
         {
-          "indexName": "serverpod_auth_migration_migrated_user_old",
+          "indexName": "serverpod_auth_backwards_compatibility_external_user_id_id",
           "elements": [
             {
               "type": 0,
-              "definition": "oldUserId"
+              "definition": "userIdentifier"
             }
           ],
           "type": "btree",
           "isUnique": true,
           "isPrimary": false
+        }
+      ],
+      "managed": true
+    },
+    {
+      "name": "serverpod_auth_backwards_compatibility_session",
+      "dartName": "LegacySession",
+      "module": "serverpod_auth_backwards_compatibility",
+      "schema": "public",
+      "columns": [
+        {
+          "name": "id",
+          "columnType": 6,
+          "isNullable": false,
+          "columnDefault": "nextval('serverpod_auth_backwards_compatibility_session_id_seq'::regclass)",
+          "dartType": "int?"
         },
         {
-          "indexName": "serverpod_auth_migration_migrated_user_new",
+          "name": "authUserId",
+          "columnType": 7,
+          "isNullable": false,
+          "dartType": "UuidValue"
+        },
+        {
+          "name": "scopeNames",
+          "columnType": 8,
+          "isNullable": false,
+          "dartType": "Set<String>"
+        },
+        {
+          "name": "hash",
+          "columnType": 0,
+          "isNullable": false,
+          "dartType": "String"
+        },
+        {
+          "name": "method",
+          "columnType": 0,
+          "isNullable": false,
+          "dartType": "String"
+        }
+      ],
+      "foreignKeys": [
+        {
+          "constraintName": "serverpod_auth_backwards_compatibility_session_fk_0",
+          "columns": [
+            "authUserId"
+          ],
+          "referenceTable": "serverpod_auth_user",
+          "referenceTableSchema": "public",
+          "referenceColumns": [
+            "id"
+          ],
+          "onUpdate": 3,
+          "onDelete": 4
+        }
+      ],
+      "indexes": [
+        {
+          "indexName": "serverpod_auth_backwards_compatibility_session_pkey",
           "elements": [
             {
               "type": 0,
-              "definition": "newAuthUserId"
+              "definition": "id"
             }
           ],
           "type": "btree",
           "isUnique": true,
-          "isPrimary": false
+          "isPrimary": true
         }
       ],
       "managed": true
@@ -1233,213 +1346,6 @@
       "managed": true
     },
     {
-      "name": "serverpod_auth_backwards_compatibility_email_password",
-      "dartName": "LegacyEmailPassword",
-      "module": "serverpod_auth_backwards_compatibility",
-      "schema": "public",
-      "columns": [
-        {
-          "name": "id",
-          "columnType": 7,
-          "isNullable": false,
-          "columnDefault": "gen_random_uuid()",
-          "dartType": "UuidValue?"
-        },
-        {
-          "name": "emailAccountId",
-          "columnType": 7,
-          "isNullable": false,
-          "dartType": "UuidValue"
-        },
-        {
-          "name": "hash",
-          "columnType": 0,
-          "isNullable": false,
-          "dartType": "String"
-        }
-      ],
-      "foreignKeys": [
-        {
-          "constraintName": "serverpod_auth_backwards_compatibility_email_password_fk_0",
-          "columns": [
-            "emailAccountId"
-          ],
-          "referenceTable": "serverpod_auth_email_account",
-          "referenceTableSchema": "public",
-          "referenceColumns": [
-            "id"
-          ],
-          "onUpdate": 3,
-          "onDelete": 4
-        }
-      ],
-      "indexes": [
-        {
-          "indexName": "serverpod_auth_backwards_compatibility_email_password_pkey",
-          "elements": [
-            {
-              "type": 0,
-              "definition": "id"
-            }
-          ],
-          "type": "btree",
-          "isUnique": true,
-          "isPrimary": true
-        },
-        {
-          "indexName": "serverpod_auth_backwards_compatibility_email_password_account",
-          "elements": [
-            {
-              "type": 0,
-              "definition": "emailAccountId"
-            }
-          ],
-          "type": "btree",
-          "isUnique": true,
-          "isPrimary": false
-        }
-      ],
-      "managed": true
-    },
-    {
-      "name": "serverpod_auth_backwards_compatibility_external_user_id",
-      "dartName": "LegacyExternalUserIdentifier",
-      "module": "serverpod_auth_backwards_compatibility",
-      "schema": "public",
-      "columns": [
-        {
-          "name": "id",
-          "columnType": 7,
-          "isNullable": false,
-          "columnDefault": "gen_random_uuid()",
-          "dartType": "UuidValue?"
-        },
-        {
-          "name": "authUserId",
-          "columnType": 7,
-          "isNullable": false,
-          "dartType": "UuidValue"
-        },
-        {
-          "name": "userIdentifier",
-          "columnType": 0,
-          "isNullable": false,
-          "dartType": "String"
-        }
-      ],
-      "foreignKeys": [
-        {
-          "constraintName": "serverpod_auth_backwards_compatibility_external_user_id_fk_0",
-          "columns": [
-            "authUserId"
-          ],
-          "referenceTable": "serverpod_auth_user",
-          "referenceTableSchema": "public",
-          "referenceColumns": [
-            "id"
-          ],
-          "onUpdate": 3,
-          "onDelete": 4
-        }
-      ],
-      "indexes": [
-        {
-          "indexName": "serverpod_auth_backwards_compatibility_external_user_id_pkey",
-          "elements": [
-            {
-              "type": 0,
-              "definition": "id"
-            }
-          ],
-          "type": "btree",
-          "isUnique": true,
-          "isPrimary": true
-        },
-        {
-          "indexName": "serverpod_auth_backwards_compatibility_external_user_id_id",
-          "elements": [
-            {
-              "type": 0,
-              "definition": "userIdentifier"
-            }
-          ],
-          "type": "btree",
-          "isUnique": true,
-          "isPrimary": false
-        }
-      ],
-      "managed": true
-    },
-    {
-      "name": "serverpod_auth_backwards_compatibility_session",
-      "dartName": "LegacySession",
-      "module": "serverpod_auth_backwards_compatibility",
-      "schema": "public",
-      "columns": [
-        {
-          "name": "id",
-          "columnType": 6,
-          "isNullable": false,
-          "columnDefault": "nextval('serverpod_auth_backwards_compatibility_session_id_seq'::regclass)",
-          "dartType": "int?"
-        },
-        {
-          "name": "authUserId",
-          "columnType": 7,
-          "isNullable": false,
-          "dartType": "UuidValue"
-        },
-        {
-          "name": "scopeNames",
-          "columnType": 8,
-          "isNullable": false,
-          "dartType": "Set<String>"
-        },
-        {
-          "name": "hash",
-          "columnType": 0,
-          "isNullable": false,
-          "dartType": "String"
-        },
-        {
-          "name": "method",
-          "columnType": 0,
-          "isNullable": false,
-          "dartType": "String"
-        }
-      ],
-      "foreignKeys": [
-        {
-          "constraintName": "serverpod_auth_backwards_compatibility_session_fk_0",
-          "columns": [
-            "authUserId"
-          ],
-          "referenceTable": "serverpod_auth_user",
-          "referenceTableSchema": "public",
-          "referenceColumns": [
-            "id"
-          ],
-          "onUpdate": 3,
-          "onDelete": 4
-        }
-      ],
-      "indexes": [
-        {
-          "indexName": "serverpod_auth_backwards_compatibility_session_pkey",
-          "elements": [
-            {
-              "type": 0,
-              "definition": "id"
-            }
-          ],
-          "type": "btree",
-          "isUnique": true,
-          "isPrimary": true
-        }
-      ],
-      "managed": true
-    },
-    {
       "name": "serverpod_auth_email_account",
       "dartName": "EmailAccount",
       "module": "serverpod_auth_email_account",
@@ -1546,7 +1452,7 @@
           "dartType": "String"
         },
         {
-          "name": "attemptedAt",
+          "name": "attempted",
           "columnType": 4,
           "isNullable": false,
           "dartType": "DateTime"
@@ -1585,11 +1491,11 @@
           "isPrimary": false
         },
         {
-          "indexName": "serverpod_auth_email_account_failed_login_attempt_attempted_at",
+          "indexName": "serverpod_auth_email_account_failed_login_attempt_attempted",
           "elements": [
             {
               "type": 0,
-              "definition": "attemptedAt"
+              "definition": "attempted"
             }
           ],
           "type": "btree",
@@ -1613,7 +1519,7 @@
           "dartType": "UuidValue?"
         },
         {
-          "name": "attemptedAt",
+          "name": "attempted",
           "columnType": 4,
           "isNullable": false,
           "dartType": "DateTime"
@@ -1672,11 +1578,11 @@
           "isPrimary": false
         },
         {
-          "indexName": "serverpod_auth_email_account_password_reset_attempt_at",
+          "indexName": "serverpod_auth_email_account_password_reset_attempted",
           "elements": [
             {
               "type": 0,
-              "definition": "attemptedAt"
+              "definition": "attempted"
             }
           ],
           "type": "btree",
@@ -1776,7 +1682,7 @@
           "dartType": "String"
         },
         {
-          "name": "attemptedAt",
+          "name": "attempted",
           "columnType": 4,
           "isNullable": false,
           "dartType": "DateTime"
@@ -1827,11 +1733,11 @@
           "isPrimary": false
         },
         {
-          "indexName": "serverpod_auth_email_account_pw_reset_request_attempt_at",
+          "indexName": "serverpod_auth_email_account_pw_reset_request_attempted",
           "elements": [
             {
               "type": 0,
-              "definition": "attemptedAt"
+              "definition": "attempted"
             }
           ],
           "type": "btree",
@@ -1941,7 +1847,7 @@
           "dartType": "UuidValue?"
         },
         {
-          "name": "attemptedAt",
+          "name": "attempted",
           "columnType": 4,
           "isNullable": false,
           "dartType": "DateTime"
@@ -2000,746 +1906,11 @@
           "isPrimary": false
         },
         {
-          "indexName": "serverpod_auth_email_account_request_completion_attempt_at",
+          "indexName": "serverpod_auth_email_account_request_completion_attempted",
           "elements": [
             {
               "type": 0,
-              "definition": "attemptedAt"
-            }
-          ],
-          "type": "btree",
-          "isUnique": false,
-          "isPrimary": false
-        }
-      ],
-      "managed": true
-    },
-    {
-      "name": "serverpod_auth_profile_user_profile",
-      "dartName": "UserProfile",
-      "module": "serverpod_auth_profile",
-      "schema": "public",
-      "columns": [
-        {
-          "name": "id",
-          "columnType": 7,
-          "isNullable": false,
-          "columnDefault": "gen_random_uuid()",
-          "dartType": "UuidValue?"
-        },
-        {
-          "name": "authUserId",
-          "columnType": 7,
-          "isNullable": false,
-          "dartType": "UuidValue"
-        },
-        {
-          "name": "userName",
-          "columnType": 0,
-          "isNullable": true,
-          "dartType": "String?"
-        },
-        {
-          "name": "fullName",
-          "columnType": 0,
-          "isNullable": true,
-          "dartType": "String?"
-        },
-        {
-          "name": "email",
-          "columnType": 0,
-          "isNullable": true,
-          "dartType": "String?"
-        },
-        {
-          "name": "created",
-          "columnType": 4,
-          "isNullable": false,
-          "columnDefault": "CURRENT_TIMESTAMP",
-          "dartType": "DateTime"
-        },
-        {
-          "name": "imageId",
-          "columnType": 7,
-          "isNullable": true,
-          "dartType": "UuidValue?"
-        }
-      ],
-      "foreignKeys": [
-        {
-          "constraintName": "serverpod_auth_profile_user_profile_fk_0",
-          "columns": [
-            "authUserId"
-          ],
-          "referenceTable": "serverpod_auth_user",
-          "referenceTableSchema": "public",
-          "referenceColumns": [
-            "id"
-          ],
-          "onUpdate": 3,
-          "onDelete": 4
-        },
-        {
-          "constraintName": "serverpod_auth_profile_user_profile_fk_1",
-          "columns": [
-            "imageId"
-          ],
-          "referenceTable": "serverpod_auth_profile_user_profile_image",
-          "referenceTableSchema": "public",
-          "referenceColumns": [
-            "id"
-          ],
-          "onUpdate": 3,
-          "onDelete": 3
-        }
-      ],
-      "indexes": [
-        {
-          "indexName": "serverpod_auth_profile_user_profile_pkey",
-          "elements": [
-            {
-              "type": 0,
-              "definition": "id"
-            }
-          ],
-          "type": "btree",
-          "isUnique": true,
-          "isPrimary": true
-        },
-        {
-          "indexName": "serverpod_auth_profile_user_profile_email_auth_user_id",
-          "elements": [
-            {
-              "type": 0,
-              "definition": "authUserId"
-            }
-          ],
-          "type": "btree",
-          "isUnique": true,
-          "isPrimary": false
-        }
-      ],
-      "managed": true
-    },
-    {
-      "name": "serverpod_auth_profile_user_profile_image",
-      "dartName": "UserProfileImage",
-      "module": "serverpod_auth_profile",
-      "schema": "public",
-      "columns": [
-        {
-          "name": "id",
-          "columnType": 7,
-          "isNullable": false,
-          "columnDefault": "gen_random_uuid()",
-          "dartType": "UuidValue?"
-        },
-        {
-          "name": "userProfileId",
-          "columnType": 7,
-          "isNullable": false,
-          "dartType": "UuidValue"
-        },
-        {
-          "name": "created",
-          "columnType": 4,
-          "isNullable": false,
-          "columnDefault": "CURRENT_TIMESTAMP",
-          "dartType": "DateTime"
-        },
-        {
-          "name": "storageId",
-          "columnType": 0,
-          "isNullable": false,
-          "dartType": "String"
-        },
-        {
-          "name": "path",
-          "columnType": 0,
-          "isNullable": false,
-          "dartType": "String"
-        },
-        {
-          "name": "url",
-          "columnType": 0,
-          "isNullable": false,
-          "dartType": "Uri"
-        }
-      ],
-      "foreignKeys": [
-        {
-          "constraintName": "serverpod_auth_profile_user_profile_image_fk_0",
-          "columns": [
-            "userProfileId"
-          ],
-          "referenceTable": "serverpod_auth_profile_user_profile",
-          "referenceTableSchema": "public",
-          "referenceColumns": [
-            "id"
-          ],
-          "onUpdate": 3,
-          "onDelete": 4
-        }
-      ],
-      "indexes": [
-        {
-          "indexName": "serverpod_auth_profile_user_profile_image_pkey",
-          "elements": [
-            {
-              "type": 0,
-              "definition": "id"
-            }
-          ],
-          "type": "btree",
-          "isUnique": true,
-          "isPrimary": true
-        }
-      ],
-      "managed": true
-    },
-    {
-      "name": "serverpod_auth_key",
-      "dartName": "AuthKey",
-      "module": "serverpod_auth",
-      "schema": "public",
-      "columns": [
-        {
-          "name": "id",
-          "columnType": 6,
-          "isNullable": false,
-          "columnDefault": "nextval('serverpod_auth_key_id_seq'::regclass)",
-          "dartType": "int?"
-        },
-        {
-          "name": "userId",
-          "columnType": 6,
-          "isNullable": false,
-          "dartType": "int"
-        },
-        {
-          "name": "hash",
-          "columnType": 0,
-          "isNullable": false,
-          "dartType": "String"
-        },
-        {
-          "name": "scopeNames",
-          "columnType": 8,
-          "isNullable": false,
-          "dartType": "List<String>"
-        },
-        {
-          "name": "method",
-          "columnType": 0,
-          "isNullable": false,
-          "dartType": "String"
-        }
-      ],
-      "foreignKeys": [],
-      "indexes": [
-        {
-          "indexName": "serverpod_auth_key_pkey",
-          "elements": [
-            {
-              "type": 0,
-              "definition": "id"
-            }
-          ],
-          "type": "btree",
-          "isUnique": true,
-          "isPrimary": true
-        },
-        {
-          "indexName": "serverpod_auth_key_userId_idx",
-          "elements": [
-            {
-              "type": 0,
-              "definition": "userId"
-            }
-          ],
-          "type": "btree",
-          "isUnique": false,
-          "isPrimary": false
-        }
-      ],
-      "managed": true
-    },
-    {
-      "name": "serverpod_email_auth",
-      "dartName": "EmailAuth",
-      "module": "serverpod_auth",
-      "schema": "public",
-      "columns": [
-        {
-          "name": "id",
-          "columnType": 6,
-          "isNullable": false,
-          "columnDefault": "nextval('serverpod_email_auth_id_seq'::regclass)",
-          "dartType": "int?"
-        },
-        {
-          "name": "userId",
-          "columnType": 6,
-          "isNullable": false,
-          "dartType": "int"
-        },
-        {
-          "name": "email",
-          "columnType": 0,
-          "isNullable": false,
-          "dartType": "String"
-        },
-        {
-          "name": "hash",
-          "columnType": 0,
-          "isNullable": false,
-          "dartType": "String"
-        }
-      ],
-      "foreignKeys": [],
-      "indexes": [
-        {
-          "indexName": "serverpod_email_auth_pkey",
-          "elements": [
-            {
-              "type": 0,
-              "definition": "id"
-            }
-          ],
-          "type": "btree",
-          "isUnique": true,
-          "isPrimary": true
-        },
-        {
-          "indexName": "serverpod_email_auth_email",
-          "elements": [
-            {
-              "type": 0,
-              "definition": "email"
-            }
-          ],
-          "type": "btree",
-          "isUnique": true,
-          "isPrimary": false
-        }
-      ],
-      "managed": true
-    },
-    {
-      "name": "serverpod_email_create_request",
-      "dartName": "EmailCreateAccountRequest",
-      "module": "serverpod_auth",
-      "schema": "public",
-      "columns": [
-        {
-          "name": "id",
-          "columnType": 6,
-          "isNullable": false,
-          "columnDefault": "nextval('serverpod_email_create_request_id_seq'::regclass)",
-          "dartType": "int?"
-        },
-        {
-          "name": "userName",
-          "columnType": 0,
-          "isNullable": false,
-          "dartType": "String"
-        },
-        {
-          "name": "email",
-          "columnType": 0,
-          "isNullable": false,
-          "dartType": "String"
-        },
-        {
-          "name": "hash",
-          "columnType": 0,
-          "isNullable": false,
-          "dartType": "String"
-        },
-        {
-          "name": "verificationCode",
-          "columnType": 0,
-          "isNullable": false,
-          "dartType": "String"
-        }
-      ],
-      "foreignKeys": [],
-      "indexes": [
-        {
-          "indexName": "serverpod_email_create_request_pkey",
-          "elements": [
-            {
-              "type": 0,
-              "definition": "id"
-            }
-          ],
-          "type": "btree",
-          "isUnique": true,
-          "isPrimary": true
-        },
-        {
-          "indexName": "serverpod_email_auth_create_account_request_idx",
-          "elements": [
-            {
-              "type": 0,
-              "definition": "email"
-            }
-          ],
-          "type": "btree",
-          "isUnique": true,
-          "isPrimary": false
-        }
-      ],
-      "managed": true
-    },
-    {
-      "name": "serverpod_email_failed_sign_in",
-      "dartName": "EmailFailedSignIn",
-      "module": "serverpod_auth",
-      "schema": "public",
-      "columns": [
-        {
-          "name": "id",
-          "columnType": 6,
-          "isNullable": false,
-          "columnDefault": "nextval('serverpod_email_failed_sign_in_id_seq'::regclass)",
-          "dartType": "int?"
-        },
-        {
-          "name": "email",
-          "columnType": 0,
-          "isNullable": false,
-          "dartType": "String"
-        },
-        {
-          "name": "time",
-          "columnType": 4,
-          "isNullable": false,
-          "dartType": "DateTime"
-        },
-        {
-          "name": "ipAddress",
-          "columnType": 0,
-          "isNullable": false,
-          "dartType": "String"
-        }
-      ],
-      "foreignKeys": [],
-      "indexes": [
-        {
-          "indexName": "serverpod_email_failed_sign_in_pkey",
-          "elements": [
-            {
-              "type": 0,
-              "definition": "id"
-            }
-          ],
-          "type": "btree",
-          "isUnique": true,
-          "isPrimary": true
-        },
-        {
-          "indexName": "serverpod_email_failed_sign_in_email_idx",
-          "elements": [
-            {
-              "type": 0,
-              "definition": "email"
-            }
-          ],
-          "type": "btree",
-          "isUnique": false,
-          "isPrimary": false
-        },
-        {
-          "indexName": "serverpod_email_failed_sign_in_time_idx",
-          "elements": [
-            {
-              "type": 0,
-              "definition": "time"
-            }
-          ],
-          "type": "btree",
-          "isUnique": false,
-          "isPrimary": false
-        }
-      ],
-      "managed": true
-    },
-    {
-      "name": "serverpod_email_reset",
-      "dartName": "EmailReset",
-      "module": "serverpod_auth",
-      "schema": "public",
-      "columns": [
-        {
-          "name": "id",
-          "columnType": 6,
-          "isNullable": false,
-          "columnDefault": "nextval('serverpod_email_reset_id_seq'::regclass)",
-          "dartType": "int?"
-        },
-        {
-          "name": "userId",
-          "columnType": 6,
-          "isNullable": false,
-          "dartType": "int"
-        },
-        {
-          "name": "verificationCode",
-          "columnType": 0,
-          "isNullable": false,
-          "dartType": "String"
-        },
-        {
-          "name": "expiration",
-          "columnType": 4,
-          "isNullable": false,
-          "dartType": "DateTime"
-        }
-      ],
-      "foreignKeys": [],
-      "indexes": [
-        {
-          "indexName": "serverpod_email_reset_pkey",
-          "elements": [
-            {
-              "type": 0,
-              "definition": "id"
-            }
-          ],
-          "type": "btree",
-          "isUnique": true,
-          "isPrimary": true
-        },
-        {
-          "indexName": "serverpod_email_reset_verification_idx",
-          "elements": [
-            {
-              "type": 0,
-              "definition": "verificationCode"
-            }
-          ],
-          "type": "btree",
-          "isUnique": true,
-          "isPrimary": false
-        }
-      ],
-      "managed": true
-    },
-    {
-      "name": "serverpod_google_refresh_token",
-      "dartName": "GoogleRefreshToken",
-      "module": "serverpod_auth",
-      "schema": "public",
-      "columns": [
-        {
-          "name": "id",
-          "columnType": 6,
-          "isNullable": false,
-          "columnDefault": "nextval('serverpod_google_refresh_token_id_seq'::regclass)",
-          "dartType": "int?"
-        },
-        {
-          "name": "userId",
-          "columnType": 6,
-          "isNullable": false,
-          "dartType": "int"
-        },
-        {
-          "name": "refreshToken",
-          "columnType": 0,
-          "isNullable": false,
-          "dartType": "String"
-        }
-      ],
-      "foreignKeys": [],
-      "indexes": [
-        {
-          "indexName": "serverpod_google_refresh_token_pkey",
-          "elements": [
-            {
-              "type": 0,
-              "definition": "id"
-            }
-          ],
-          "type": "btree",
-          "isUnique": true,
-          "isPrimary": true
-        },
-        {
-          "indexName": "serverpod_google_refresh_token_userId_idx",
-          "elements": [
-            {
-              "type": 0,
-              "definition": "userId"
-            }
-          ],
-          "type": "btree",
-          "isUnique": true,
-          "isPrimary": false
-        }
-      ],
-      "managed": true
-    },
-    {
-      "name": "serverpod_user_image",
-      "dartName": "UserImage",
-      "module": "serverpod_auth",
-      "schema": "public",
-      "columns": [
-        {
-          "name": "id",
-          "columnType": 6,
-          "isNullable": false,
-          "columnDefault": "nextval('serverpod_user_image_id_seq'::regclass)",
-          "dartType": "int?"
-        },
-        {
-          "name": "userId",
-          "columnType": 6,
-          "isNullable": false,
-          "dartType": "int"
-        },
-        {
-          "name": "version",
-          "columnType": 6,
-          "isNullable": false,
-          "dartType": "int"
-        },
-        {
-          "name": "url",
-          "columnType": 0,
-          "isNullable": false,
-          "dartType": "String"
-        }
-      ],
-      "foreignKeys": [],
-      "indexes": [
-        {
-          "indexName": "serverpod_user_image_pkey",
-          "elements": [
-            {
-              "type": 0,
-              "definition": "id"
-            }
-          ],
-          "type": "btree",
-          "isUnique": true,
-          "isPrimary": true
-        },
-        {
-          "indexName": "serverpod_user_image_user_id",
-          "elements": [
-            {
-              "type": 0,
-              "definition": "userId"
-            },
-            {
-              "type": 0,
-              "definition": "version"
-            }
-          ],
-          "type": "btree",
-          "isUnique": false,
-          "isPrimary": false
-        }
-      ],
-      "managed": true
-    },
-    {
-      "name": "serverpod_user_info",
-      "dartName": "UserInfo",
-      "module": "serverpod_auth",
-      "schema": "public",
-      "columns": [
-        {
-          "name": "id",
-          "columnType": 6,
-          "isNullable": false,
-          "columnDefault": "nextval('serverpod_user_info_id_seq'::regclass)",
-          "dartType": "int?"
-        },
-        {
-          "name": "userIdentifier",
-          "columnType": 0,
-          "isNullable": false,
-          "dartType": "String"
-        },
-        {
-          "name": "userName",
-          "columnType": 0,
-          "isNullable": true,
-          "dartType": "String?"
-        },
-        {
-          "name": "fullName",
-          "columnType": 0,
-          "isNullable": true,
-          "dartType": "String?"
-        },
-        {
-          "name": "email",
-          "columnType": 0,
-          "isNullable": true,
-          "dartType": "String?"
-        },
-        {
-          "name": "created",
-          "columnType": 4,
-          "isNullable": false,
-          "dartType": "DateTime"
-        },
-        {
-          "name": "imageUrl",
-          "columnType": 0,
-          "isNullable": true,
-          "dartType": "String?"
-        },
-        {
-          "name": "scopeNames",
-          "columnType": 8,
-          "isNullable": false,
-          "dartType": "List<String>"
-        },
-        {
-          "name": "blocked",
-          "columnType": 1,
-          "isNullable": false,
-          "dartType": "bool"
-        }
-      ],
-      "foreignKeys": [],
-      "indexes": [
-        {
-          "indexName": "serverpod_user_info_pkey",
-          "elements": [
-            {
-              "type": 0,
-              "definition": "id"
-            }
-          ],
-          "type": "btree",
-          "isUnique": true,
-          "isPrimary": true
-        },
-        {
-          "indexName": "serverpod_user_info_user_identifier",
-          "elements": [
-            {
-              "type": 0,
-              "definition": "userIdentifier"
-            }
-          ],
-          "type": "btree",
-          "isUnique": true,
-          "isPrimary": false
-        },
-        {
-          "indexName": "serverpod_user_info_email",
-          "elements": [
-            {
-              "type": 0,
-              "definition": "email"
+              "definition": "attempted"
             }
           ],
           "type": "btree",
@@ -2902,32 +2073,16 @@
   ],
   "installedModules": [
     {
-      "module": "serverpod_auth_migration",
-      "version": "20250711114550334"
+      "module": "serverpod_auth_backwards_compatibility",
+      "version": "20250724125750464"
     },
     {
       "module": "serverpod",
       "version": "20240516151843329"
     },
     {
-      "module": "serverpod_auth_backwards_compatibility",
-      "version": "20250708110241098"
-    },
-    {
       "module": "serverpod_auth_email_account",
-      "version": "20250606090748154"
-    },
-    {
-      "module": "serverpod_auth_email",
-      "version": "20250611073844715"
-    },
-    {
-      "module": "serverpod_auth_profile",
-      "version": "20250519092101868"
-    },
-    {
-      "module": "serverpod_auth",
-      "version": "20240520102713718"
+      "version": "20250724100154487"
     },
     {
       "module": "serverpod_auth_session",

--- a/modules/new_serverpod_auth/serverpod_auth_backwards_compatibility/serverpod_auth_backwards_compatibility_server/migrations/20250724125750464/definition.sql
+++ b/modules/new_serverpod_auth/serverpod_auth_backwards_compatibility/serverpod_auth_backwards_compatibility_server/migrations/20250724125750464/definition.sql
@@ -1,6 +1,41 @@
 BEGIN;
 
 --
+-- Class LegacyEmailPassword as table serverpod_auth_backwards_compatibility_email_password
+--
+CREATE TABLE "serverpod_auth_backwards_compatibility_email_password" (
+    "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    "emailAccountId" uuid NOT NULL,
+    "hash" text NOT NULL
+);
+
+-- Indexes
+CREATE UNIQUE INDEX "serverpod_auth_backwards_compatibility_email_password_account" ON "serverpod_auth_backwards_compatibility_email_password" USING btree ("emailAccountId");
+
+--
+-- Class LegacyExternalUserIdentifier as table serverpod_auth_backwards_compatibility_external_user_id
+--
+CREATE TABLE "serverpod_auth_backwards_compatibility_external_user_id" (
+    "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    "authUserId" uuid NOT NULL,
+    "userIdentifier" text NOT NULL
+);
+
+-- Indexes
+CREATE UNIQUE INDEX "serverpod_auth_backwards_compatibility_external_user_id_id" ON "serverpod_auth_backwards_compatibility_external_user_id" USING btree ("userIdentifier");
+
+--
+-- Class LegacySession as table serverpod_auth_backwards_compatibility_session
+--
+CREATE TABLE "serverpod_auth_backwards_compatibility_session" (
+    "id" bigserial PRIMARY KEY,
+    "authUserId" uuid NOT NULL,
+    "scopeNames" json NOT NULL,
+    "hash" text NOT NULL,
+    "method" text NOT NULL
+);
+
+--
 -- Class CloudStorageEntry as table serverpod_cloud_storage
 --
 CREATE TABLE "serverpod_cloud_storage" (
@@ -207,194 +242,6 @@ CREATE INDEX "serverpod_session_log_touched_idx" ON "serverpod_session_log" USIN
 CREATE INDEX "serverpod_session_log_isopen_idx" ON "serverpod_session_log" USING btree ("isOpen");
 
 --
--- Class LegacyEmailPassword as table serverpod_auth_backwards_compatibility_email_password
---
-CREATE TABLE "serverpod_auth_backwards_compatibility_email_password" (
-    "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-    "emailAccountId" uuid NOT NULL,
-    "hash" text NOT NULL
-);
-
--- Indexes
-CREATE UNIQUE INDEX "serverpod_auth_backwards_compatibility_email_password_account" ON "serverpod_auth_backwards_compatibility_email_password" USING btree ("emailAccountId");
-
---
--- Class LegacyExternalUserIdentifier as table serverpod_auth_backwards_compatibility_external_user_id
---
-CREATE TABLE "serverpod_auth_backwards_compatibility_external_user_id" (
-    "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-    "authUserId" uuid NOT NULL,
-    "userIdentifier" text NOT NULL
-);
-
--- Indexes
-CREATE UNIQUE INDEX "serverpod_auth_backwards_compatibility_external_user_id_id" ON "serverpod_auth_backwards_compatibility_external_user_id" USING btree ("userIdentifier");
-
---
--- Class LegacySession as table serverpod_auth_backwards_compatibility_session
---
-CREATE TABLE "serverpod_auth_backwards_compatibility_session" (
-    "id" bigserial PRIMARY KEY,
-    "authUserId" uuid NOT NULL,
-    "scopeNames" json NOT NULL,
-    "hash" text NOT NULL,
-    "method" text NOT NULL
-);
-
---
--- Class MigratedUser as table serverpod_auth_migration_migrated_user
---
-CREATE TABLE "serverpod_auth_migration_migrated_user" (
-    "id" bigserial PRIMARY KEY,
-    "oldUserId" bigint NOT NULL,
-    "newAuthUserId" uuid NOT NULL
-);
-
--- Indexes
-CREATE UNIQUE INDEX "serverpod_auth_migration_migrated_user_old" ON "serverpod_auth_migration_migrated_user" USING btree ("oldUserId");
-CREATE UNIQUE INDEX "serverpod_auth_migration_migrated_user_new" ON "serverpod_auth_migration_migrated_user" USING btree ("newAuthUserId");
-
---
--- Class UserProfile as table serverpod_auth_profile_user_profile
---
-CREATE TABLE "serverpod_auth_profile_user_profile" (
-    "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-    "authUserId" uuid NOT NULL,
-    "userName" text,
-    "fullName" text,
-    "email" text,
-    "created" timestamp without time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    "imageId" uuid
-);
-
--- Indexes
-CREATE UNIQUE INDEX "serverpod_auth_profile_user_profile_email_auth_user_id" ON "serverpod_auth_profile_user_profile" USING btree ("authUserId");
-
---
--- Class UserProfileImage as table serverpod_auth_profile_user_profile_image
---
-CREATE TABLE "serverpod_auth_profile_user_profile_image" (
-    "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-    "userProfileId" uuid NOT NULL,
-    "created" timestamp without time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    "storageId" text NOT NULL,
-    "path" text NOT NULL,
-    "url" text NOT NULL
-);
-
---
--- Class AuthKey as table serverpod_auth_key
---
-CREATE TABLE "serverpod_auth_key" (
-    "id" bigserial PRIMARY KEY,
-    "userId" bigint NOT NULL,
-    "hash" text NOT NULL,
-    "scopeNames" json NOT NULL,
-    "method" text NOT NULL
-);
-
--- Indexes
-CREATE INDEX "serverpod_auth_key_userId_idx" ON "serverpod_auth_key" USING btree ("userId");
-
---
--- Class EmailAuth as table serverpod_email_auth
---
-CREATE TABLE "serverpod_email_auth" (
-    "id" bigserial PRIMARY KEY,
-    "userId" bigint NOT NULL,
-    "email" text NOT NULL,
-    "hash" text NOT NULL
-);
-
--- Indexes
-CREATE UNIQUE INDEX "serverpod_email_auth_email" ON "serverpod_email_auth" USING btree ("email");
-
---
--- Class EmailCreateAccountRequest as table serverpod_email_create_request
---
-CREATE TABLE "serverpod_email_create_request" (
-    "id" bigserial PRIMARY KEY,
-    "userName" text NOT NULL,
-    "email" text NOT NULL,
-    "hash" text NOT NULL,
-    "verificationCode" text NOT NULL
-);
-
--- Indexes
-CREATE UNIQUE INDEX "serverpod_email_auth_create_account_request_idx" ON "serverpod_email_create_request" USING btree ("email");
-
---
--- Class EmailFailedSignIn as table serverpod_email_failed_sign_in
---
-CREATE TABLE "serverpod_email_failed_sign_in" (
-    "id" bigserial PRIMARY KEY,
-    "email" text NOT NULL,
-    "time" timestamp without time zone NOT NULL,
-    "ipAddress" text NOT NULL
-);
-
--- Indexes
-CREATE INDEX "serverpod_email_failed_sign_in_email_idx" ON "serverpod_email_failed_sign_in" USING btree ("email");
-CREATE INDEX "serverpod_email_failed_sign_in_time_idx" ON "serverpod_email_failed_sign_in" USING btree ("time");
-
---
--- Class EmailReset as table serverpod_email_reset
---
-CREATE TABLE "serverpod_email_reset" (
-    "id" bigserial PRIMARY KEY,
-    "userId" bigint NOT NULL,
-    "verificationCode" text NOT NULL,
-    "expiration" timestamp without time zone NOT NULL
-);
-
--- Indexes
-CREATE UNIQUE INDEX "serverpod_email_reset_verification_idx" ON "serverpod_email_reset" USING btree ("verificationCode");
-
---
--- Class GoogleRefreshToken as table serverpod_google_refresh_token
---
-CREATE TABLE "serverpod_google_refresh_token" (
-    "id" bigserial PRIMARY KEY,
-    "userId" bigint NOT NULL,
-    "refreshToken" text NOT NULL
-);
-
--- Indexes
-CREATE UNIQUE INDEX "serverpod_google_refresh_token_userId_idx" ON "serverpod_google_refresh_token" USING btree ("userId");
-
---
--- Class UserImage as table serverpod_user_image
---
-CREATE TABLE "serverpod_user_image" (
-    "id" bigserial PRIMARY KEY,
-    "userId" bigint NOT NULL,
-    "version" bigint NOT NULL,
-    "url" text NOT NULL
-);
-
--- Indexes
-CREATE INDEX "serverpod_user_image_user_id" ON "serverpod_user_image" USING btree ("userId", "version");
-
---
--- Class UserInfo as table serverpod_user_info
---
-CREATE TABLE "serverpod_user_info" (
-    "id" bigserial PRIMARY KEY,
-    "userIdentifier" text NOT NULL,
-    "userName" text,
-    "fullName" text,
-    "email" text,
-    "created" timestamp without time zone NOT NULL,
-    "imageUrl" text,
-    "scopeNames" json NOT NULL,
-    "blocked" boolean NOT NULL
-);
-
--- Indexes
-CREATE UNIQUE INDEX "serverpod_user_info_user_identifier" ON "serverpod_user_info" USING btree ("userIdentifier");
-CREATE INDEX "serverpod_user_info_email" ON "serverpod_user_info" USING btree ("email");
-
---
 -- Class EmailAccount as table serverpod_auth_email_account
 --
 CREATE TABLE "serverpod_auth_email_account" (
@@ -415,27 +262,27 @@ CREATE UNIQUE INDEX "serverpod_auth_email_account_email" ON "serverpod_auth_emai
 CREATE TABLE "serverpod_auth_email_account_failed_login_attempt" (
     "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
     "email" text NOT NULL,
-    "attemptedAt" timestamp without time zone NOT NULL,
+    "attempted" timestamp without time zone NOT NULL,
     "ipAddress" text NOT NULL
 );
 
 -- Indexes
 CREATE INDEX "serverpod_auth_email_account_failed_login_attempt_email" ON "serverpod_auth_email_account_failed_login_attempt" USING btree ("email");
-CREATE INDEX "serverpod_auth_email_account_failed_login_attempt_attempted_at" ON "serverpod_auth_email_account_failed_login_attempt" USING btree ("attemptedAt");
+CREATE INDEX "serverpod_auth_email_account_failed_login_attempt_attempted" ON "serverpod_auth_email_account_failed_login_attempt" USING btree ("attempted");
 
 --
 -- Class EmailAccountPasswordResetAttempt as table serverpod_auth_email_account_password_reset_attempt
 --
 CREATE TABLE "serverpod_auth_email_account_password_reset_attempt" (
     "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-    "attemptedAt" timestamp without time zone NOT NULL,
+    "attempted" timestamp without time zone NOT NULL,
     "ipAddress" text NOT NULL,
     "passwordResetRequestId" uuid NOT NULL
 );
 
 -- Indexes
 CREATE INDEX "serverpod_auth_email_account_password_reset_attempt_ip" ON "serverpod_auth_email_account_password_reset_attempt" USING btree ("ipAddress");
-CREATE INDEX "serverpod_auth_email_account_password_reset_attempt_at" ON "serverpod_auth_email_account_password_reset_attempt" USING btree ("attemptedAt");
+CREATE INDEX "serverpod_auth_email_account_password_reset_attempted" ON "serverpod_auth_email_account_password_reset_attempt" USING btree ("attempted");
 
 --
 -- Class EmailAccountPasswordResetRequest as table serverpod_auth_email_account_password_reset_request
@@ -454,14 +301,14 @@ CREATE TABLE "serverpod_auth_email_account_password_reset_request" (
 CREATE TABLE "serverpod_auth_email_account_pw_reset_request_attempt" (
     "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
     "email" text NOT NULL,
-    "attemptedAt" timestamp without time zone NOT NULL,
+    "attempted" timestamp without time zone NOT NULL,
     "ipAddress" text NOT NULL
 );
 
 -- Indexes
 CREATE INDEX "serverpod_auth_email_account_pw_reset_request_attempt_email" ON "serverpod_auth_email_account_pw_reset_request_attempt" USING btree ("email");
 CREATE INDEX "serverpod_auth_email_account_pw_reset_request_attempt_ip" ON "serverpod_auth_email_account_pw_reset_request_attempt" USING btree ("ipAddress");
-CREATE INDEX "serverpod_auth_email_account_pw_reset_request_attempt_at" ON "serverpod_auth_email_account_pw_reset_request_attempt" USING btree ("attemptedAt");
+CREATE INDEX "serverpod_auth_email_account_pw_reset_request_attempted" ON "serverpod_auth_email_account_pw_reset_request_attempt" USING btree ("attempted");
 
 --
 -- Class EmailAccountRequest as table serverpod_auth_email_account_request
@@ -485,14 +332,14 @@ CREATE UNIQUE INDEX "serverpod_auth_email_account_request_email" ON "serverpod_a
 --
 CREATE TABLE "serverpod_auth_email_account_request_completion_attempt" (
     "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-    "attemptedAt" timestamp without time zone NOT NULL,
+    "attempted" timestamp without time zone NOT NULL,
     "ipAddress" text NOT NULL,
     "emailAccountRequestId" uuid NOT NULL
 );
 
 -- Indexes
 CREATE INDEX "serverpod_auth_email_account_request_completion_attempt_ip" ON "serverpod_auth_email_account_request_completion_attempt" USING btree ("ipAddress");
-CREATE INDEX "serverpod_auth_email_account_request_completion_attempt_at" ON "serverpod_auth_email_account_request_completion_attempt" USING btree ("attemptedAt");
+CREATE INDEX "serverpod_auth_email_account_request_completion_attempted" ON "serverpod_auth_email_account_request_completion_attempt" USING btree ("attempted");
 
 --
 -- Class AuthSession as table serverpod_auth_session
@@ -519,36 +366,6 @@ CREATE TABLE "serverpod_auth_user" (
     "scopeNames" json NOT NULL,
     "blocked" boolean NOT NULL
 );
-
---
--- Foreign relations for "serverpod_log" table
---
-ALTER TABLE ONLY "serverpod_log"
-    ADD CONSTRAINT "serverpod_log_fk_0"
-    FOREIGN KEY("sessionLogId")
-    REFERENCES "serverpod_session_log"("id")
-    ON DELETE CASCADE
-    ON UPDATE NO ACTION;
-
---
--- Foreign relations for "serverpod_message_log" table
---
-ALTER TABLE ONLY "serverpod_message_log"
-    ADD CONSTRAINT "serverpod_message_log_fk_0"
-    FOREIGN KEY("sessionLogId")
-    REFERENCES "serverpod_session_log"("id")
-    ON DELETE CASCADE
-    ON UPDATE NO ACTION;
-
---
--- Foreign relations for "serverpod_query_log" table
---
-ALTER TABLE ONLY "serverpod_query_log"
-    ADD CONSTRAINT "serverpod_query_log_fk_0"
-    FOREIGN KEY("sessionLogId")
-    REFERENCES "serverpod_session_log"("id")
-    ON DELETE CASCADE
-    ON UPDATE NO ACTION;
 
 --
 -- Foreign relations for "serverpod_auth_backwards_compatibility_email_password" table
@@ -581,44 +398,32 @@ ALTER TABLE ONLY "serverpod_auth_backwards_compatibility_session"
     ON UPDATE NO ACTION;
 
 --
--- Foreign relations for "serverpod_auth_migration_migrated_user" table
+-- Foreign relations for "serverpod_log" table
 --
-ALTER TABLE ONLY "serverpod_auth_migration_migrated_user"
-    ADD CONSTRAINT "serverpod_auth_migration_migrated_user_fk_0"
-    FOREIGN KEY("oldUserId")
-    REFERENCES "serverpod_user_info"("id")
-    ON DELETE CASCADE
-    ON UPDATE NO ACTION;
-ALTER TABLE ONLY "serverpod_auth_migration_migrated_user"
-    ADD CONSTRAINT "serverpod_auth_migration_migrated_user_fk_1"
-    FOREIGN KEY("newAuthUserId")
-    REFERENCES "serverpod_auth_user"("id")
+ALTER TABLE ONLY "serverpod_log"
+    ADD CONSTRAINT "serverpod_log_fk_0"
+    FOREIGN KEY("sessionLogId")
+    REFERENCES "serverpod_session_log"("id")
     ON DELETE CASCADE
     ON UPDATE NO ACTION;
 
 --
--- Foreign relations for "serverpod_auth_profile_user_profile" table
+-- Foreign relations for "serverpod_message_log" table
 --
-ALTER TABLE ONLY "serverpod_auth_profile_user_profile"
-    ADD CONSTRAINT "serverpod_auth_profile_user_profile_fk_0"
-    FOREIGN KEY("authUserId")
-    REFERENCES "serverpod_auth_user"("id")
+ALTER TABLE ONLY "serverpod_message_log"
+    ADD CONSTRAINT "serverpod_message_log_fk_0"
+    FOREIGN KEY("sessionLogId")
+    REFERENCES "serverpod_session_log"("id")
     ON DELETE CASCADE
-    ON UPDATE NO ACTION;
-ALTER TABLE ONLY "serverpod_auth_profile_user_profile"
-    ADD CONSTRAINT "serverpod_auth_profile_user_profile_fk_1"
-    FOREIGN KEY("imageId")
-    REFERENCES "serverpod_auth_profile_user_profile_image"("id")
-    ON DELETE NO ACTION
     ON UPDATE NO ACTION;
 
 --
--- Foreign relations for "serverpod_auth_profile_user_profile_image" table
+-- Foreign relations for "serverpod_query_log" table
 --
-ALTER TABLE ONLY "serverpod_auth_profile_user_profile_image"
-    ADD CONSTRAINT "serverpod_auth_profile_user_profile_image_fk_0"
-    FOREIGN KEY("userProfileId")
-    REFERENCES "serverpod_auth_profile_user_profile"("id")
+ALTER TABLE ONLY "serverpod_query_log"
+    ADD CONSTRAINT "serverpod_query_log_fk_0"
+    FOREIGN KEY("sessionLogId")
+    REFERENCES "serverpod_session_log"("id")
     ON DELETE CASCADE
     ON UPDATE NO ACTION;
 
@@ -674,12 +479,12 @@ ALTER TABLE ONLY "serverpod_auth_session"
 
 
 --
--- MIGRATION VERSION FOR serverpod_new_auth_test
+-- MIGRATION VERSION FOR serverpod_auth_backwards_compatibility
 --
 INSERT INTO "serverpod_migrations" ("module", "version", "timestamp")
-    VALUES ('serverpod_new_auth_test', '20250708110506342', now())
+    VALUES ('serverpod_auth_backwards_compatibility', '20250724125750464', now())
     ON CONFLICT ("module")
-    DO UPDATE SET "version" = '20250708110506342', "timestamp" = now();
+    DO UPDATE SET "version" = '20250724125750464', "timestamp" = now();
 
 --
 -- MIGRATION VERSION FOR serverpod
@@ -690,52 +495,12 @@ INSERT INTO "serverpod_migrations" ("module", "version", "timestamp")
     DO UPDATE SET "version" = '20240516151843329', "timestamp" = now();
 
 --
--- MIGRATION VERSION FOR serverpod_auth_backwards_compatibility
---
-INSERT INTO "serverpod_migrations" ("module", "version", "timestamp")
-    VALUES ('serverpod_auth_backwards_compatibility', '20250708110241098', now())
-    ON CONFLICT ("module")
-    DO UPDATE SET "version" = '20250708110241098', "timestamp" = now();
-
---
--- MIGRATION VERSION FOR serverpod_auth_email
---
-INSERT INTO "serverpod_migrations" ("module", "version", "timestamp")
-    VALUES ('serverpod_auth_email', '20250611073844715', now())
-    ON CONFLICT ("module")
-    DO UPDATE SET "version" = '20250611073844715', "timestamp" = now();
-
---
--- MIGRATION VERSION FOR serverpod_auth_migration
---
-INSERT INTO "serverpod_migrations" ("module", "version", "timestamp")
-    VALUES ('serverpod_auth_migration', '20250705132233496', now())
-    ON CONFLICT ("module")
-    DO UPDATE SET "version" = '20250705132233496', "timestamp" = now();
-
---
--- MIGRATION VERSION FOR serverpod_auth_profile
---
-INSERT INTO "serverpod_migrations" ("module", "version", "timestamp")
-    VALUES ('serverpod_auth_profile', '20250519092101868', now())
-    ON CONFLICT ("module")
-    DO UPDATE SET "version" = '20250519092101868', "timestamp" = now();
-
---
--- MIGRATION VERSION FOR serverpod_auth
---
-INSERT INTO "serverpod_migrations" ("module", "version", "timestamp")
-    VALUES ('serverpod_auth', '20240520102713718', now())
-    ON CONFLICT ("module")
-    DO UPDATE SET "version" = '20240520102713718', "timestamp" = now();
-
---
 -- MIGRATION VERSION FOR serverpod_auth_email_account
 --
 INSERT INTO "serverpod_migrations" ("module", "version", "timestamp")
-    VALUES ('serverpod_auth_email_account', '20250606090748154', now())
+    VALUES ('serverpod_auth_email_account', '20250724100154487', now())
     ON CONFLICT ("module")
-    DO UPDATE SET "version" = '20250606090748154', "timestamp" = now();
+    DO UPDATE SET "version" = '20250724100154487', "timestamp" = now();
 
 --
 -- MIGRATION VERSION FOR serverpod_auth_session

--- a/modules/new_serverpod_auth/serverpod_auth_backwards_compatibility/serverpod_auth_backwards_compatibility_server/migrations/20250724125750464/definition_project.json
+++ b/modules/new_serverpod_auth/serverpod_auth_backwards_compatibility/serverpod_auth_backwards_compatibility_server/migrations/20250724125750464/definition_project.json
@@ -216,7 +216,7 @@
     },
     {
       "module": "serverpod_auth_email_account",
-      "version": "20250606090748154"
+      "version": "20250724100154487"
     },
     {
       "module": "serverpod_auth_session",

--- a/modules/new_serverpod_auth/serverpod_auth_backwards_compatibility/serverpod_auth_backwards_compatibility_server/migrations/20250724125750464/migration.json
+++ b/modules/new_serverpod_auth/serverpod_auth_backwards_compatibility/serverpod_auth_backwards_compatibility_server/migrations/20250724125750464/migration.json
@@ -3,49 +3,108 @@
     {
       "type": "createTable",
       "createTable": {
-        "name": "serverpod_auth_migration_migrated_user",
-        "dartName": "MigratedUser",
-        "module": "serverpod_auth_migration",
+        "name": "serverpod_auth_backwards_compatibility_email_password",
+        "dartName": "LegacyEmailPassword",
+        "module": "serverpod_auth_backwards_compatibility",
         "schema": "public",
         "columns": [
           {
             "name": "id",
-            "columnType": 6,
+            "columnType": 7,
             "isNullable": false,
-            "columnDefault": "nextval('serverpod_auth_migration_migrated_user_id_seq'::regclass)",
-            "dartType": "int?"
+            "columnDefault": "gen_random_uuid()",
+            "dartType": "UuidValue?"
           },
           {
-            "name": "oldUserId",
-            "columnType": 6,
-            "isNullable": false,
-            "dartType": "int"
-          },
-          {
-            "name": "newAuthUserId",
+            "name": "emailAccountId",
             "columnType": 7,
             "isNullable": false,
             "dartType": "UuidValue"
+          },
+          {
+            "name": "hash",
+            "columnType": 0,
+            "isNullable": false,
+            "dartType": "String"
           }
         ],
         "foreignKeys": [
           {
-            "constraintName": "serverpod_auth_migration_migrated_user_fk_0",
+            "constraintName": "serverpod_auth_backwards_compatibility_email_password_fk_0",
             "columns": [
-              "oldUserId"
+              "emailAccountId"
             ],
-            "referenceTable": "serverpod_user_info",
+            "referenceTable": "serverpod_auth_email_account",
             "referenceTableSchema": "public",
             "referenceColumns": [
               "id"
             ],
             "onUpdate": 3,
             "onDelete": 4
+          }
+        ],
+        "indexes": [
+          {
+            "indexName": "serverpod_auth_backwards_compatibility_email_password_pkey",
+            "elements": [
+              {
+                "type": 0,
+                "definition": "id"
+              }
+            ],
+            "type": "btree",
+            "isUnique": true,
+            "isPrimary": true
           },
           {
-            "constraintName": "serverpod_auth_migration_migrated_user_fk_1",
+            "indexName": "serverpod_auth_backwards_compatibility_email_password_account",
+            "elements": [
+              {
+                "type": 0,
+                "definition": "emailAccountId"
+              }
+            ],
+            "type": "btree",
+            "isUnique": true,
+            "isPrimary": false
+          }
+        ],
+        "managed": true
+      }
+    },
+    {
+      "type": "createTable",
+      "createTable": {
+        "name": "serverpod_auth_backwards_compatibility_external_user_id",
+        "dartName": "LegacyExternalUserIdentifier",
+        "module": "serverpod_auth_backwards_compatibility",
+        "schema": "public",
+        "columns": [
+          {
+            "name": "id",
+            "columnType": 7,
+            "isNullable": false,
+            "columnDefault": "gen_random_uuid()",
+            "dartType": "UuidValue?"
+          },
+          {
+            "name": "authUserId",
+            "columnType": 7,
+            "isNullable": false,
+            "dartType": "UuidValue"
+          },
+          {
+            "name": "userIdentifier",
+            "columnType": 0,
+            "isNullable": false,
+            "dartType": "String"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "constraintName": "serverpod_auth_backwards_compatibility_external_user_id_fk_0",
             "columns": [
-              "newAuthUserId"
+              "authUserId"
             ],
             "referenceTable": "serverpod_auth_user",
             "referenceTableSchema": "public",
@@ -58,7 +117,7 @@
         ],
         "indexes": [
           {
-            "indexName": "serverpod_auth_migration_migrated_user_pkey",
+            "indexName": "serverpod_auth_backwards_compatibility_external_user_id_pkey",
             "elements": [
               {
                 "type": 0,
@@ -70,28 +129,88 @@
             "isPrimary": true
           },
           {
-            "indexName": "serverpod_auth_migration_migrated_user_old",
+            "indexName": "serverpod_auth_backwards_compatibility_external_user_id_id",
             "elements": [
               {
                 "type": 0,
-                "definition": "oldUserId"
+                "definition": "userIdentifier"
               }
             ],
             "type": "btree",
             "isUnique": true,
             "isPrimary": false
+          }
+        ],
+        "managed": true
+      }
+    },
+    {
+      "type": "createTable",
+      "createTable": {
+        "name": "serverpod_auth_backwards_compatibility_session",
+        "dartName": "LegacySession",
+        "module": "serverpod_auth_backwards_compatibility",
+        "schema": "public",
+        "columns": [
+          {
+            "name": "id",
+            "columnType": 6,
+            "isNullable": false,
+            "columnDefault": "nextval('serverpod_auth_backwards_compatibility_session_id_seq'::regclass)",
+            "dartType": "int?"
           },
           {
-            "indexName": "serverpod_auth_migration_migrated_user_new",
+            "name": "authUserId",
+            "columnType": 7,
+            "isNullable": false,
+            "dartType": "UuidValue"
+          },
+          {
+            "name": "scopeNames",
+            "columnType": 8,
+            "isNullable": false,
+            "dartType": "Set<String>"
+          },
+          {
+            "name": "hash",
+            "columnType": 0,
+            "isNullable": false,
+            "dartType": "String"
+          },
+          {
+            "name": "method",
+            "columnType": 0,
+            "isNullable": false,
+            "dartType": "String"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "constraintName": "serverpod_auth_backwards_compatibility_session_fk_0",
+            "columns": [
+              "authUserId"
+            ],
+            "referenceTable": "serverpod_auth_user",
+            "referenceTableSchema": "public",
+            "referenceColumns": [
+              "id"
+            ],
+            "onUpdate": 3,
+            "onDelete": 4
+          }
+        ],
+        "indexes": [
+          {
+            "indexName": "serverpod_auth_backwards_compatibility_session_pkey",
             "elements": [
               {
                 "type": 0,
-                "definition": "newAuthUserId"
+                "definition": "id"
               }
             ],
             "type": "btree",
             "isUnique": true,
-            "isPrimary": false
+            "isPrimary": true
           }
         ],
         "managed": true
@@ -1276,222 +1395,6 @@
     {
       "type": "createTable",
       "createTable": {
-        "name": "serverpod_auth_backwards_compatibility_email_password",
-        "dartName": "LegacyEmailPassword",
-        "module": "serverpod_auth_backwards_compatibility",
-        "schema": "public",
-        "columns": [
-          {
-            "name": "id",
-            "columnType": 7,
-            "isNullable": false,
-            "columnDefault": "gen_random_uuid()",
-            "dartType": "UuidValue?"
-          },
-          {
-            "name": "emailAccountId",
-            "columnType": 7,
-            "isNullable": false,
-            "dartType": "UuidValue"
-          },
-          {
-            "name": "hash",
-            "columnType": 0,
-            "isNullable": false,
-            "dartType": "String"
-          }
-        ],
-        "foreignKeys": [
-          {
-            "constraintName": "serverpod_auth_backwards_compatibility_email_password_fk_0",
-            "columns": [
-              "emailAccountId"
-            ],
-            "referenceTable": "serverpod_auth_email_account",
-            "referenceTableSchema": "public",
-            "referenceColumns": [
-              "id"
-            ],
-            "onUpdate": 3,
-            "onDelete": 4
-          }
-        ],
-        "indexes": [
-          {
-            "indexName": "serverpod_auth_backwards_compatibility_email_password_pkey",
-            "elements": [
-              {
-                "type": 0,
-                "definition": "id"
-              }
-            ],
-            "type": "btree",
-            "isUnique": true,
-            "isPrimary": true
-          },
-          {
-            "indexName": "serverpod_auth_backwards_compatibility_email_password_account",
-            "elements": [
-              {
-                "type": 0,
-                "definition": "emailAccountId"
-              }
-            ],
-            "type": "btree",
-            "isUnique": true,
-            "isPrimary": false
-          }
-        ],
-        "managed": true
-      }
-    },
-    {
-      "type": "createTable",
-      "createTable": {
-        "name": "serverpod_auth_backwards_compatibility_external_user_id",
-        "dartName": "LegacyExternalUserIdentifier",
-        "module": "serverpod_auth_backwards_compatibility",
-        "schema": "public",
-        "columns": [
-          {
-            "name": "id",
-            "columnType": 7,
-            "isNullable": false,
-            "columnDefault": "gen_random_uuid()",
-            "dartType": "UuidValue?"
-          },
-          {
-            "name": "authUserId",
-            "columnType": 7,
-            "isNullable": false,
-            "dartType": "UuidValue"
-          },
-          {
-            "name": "userIdentifier",
-            "columnType": 0,
-            "isNullable": false,
-            "dartType": "String"
-          }
-        ],
-        "foreignKeys": [
-          {
-            "constraintName": "serverpod_auth_backwards_compatibility_external_user_id_fk_0",
-            "columns": [
-              "authUserId"
-            ],
-            "referenceTable": "serverpod_auth_user",
-            "referenceTableSchema": "public",
-            "referenceColumns": [
-              "id"
-            ],
-            "onUpdate": 3,
-            "onDelete": 4
-          }
-        ],
-        "indexes": [
-          {
-            "indexName": "serverpod_auth_backwards_compatibility_external_user_id_pkey",
-            "elements": [
-              {
-                "type": 0,
-                "definition": "id"
-              }
-            ],
-            "type": "btree",
-            "isUnique": true,
-            "isPrimary": true
-          },
-          {
-            "indexName": "serverpod_auth_backwards_compatibility_external_user_id_id",
-            "elements": [
-              {
-                "type": 0,
-                "definition": "userIdentifier"
-              }
-            ],
-            "type": "btree",
-            "isUnique": true,
-            "isPrimary": false
-          }
-        ],
-        "managed": true
-      }
-    },
-    {
-      "type": "createTable",
-      "createTable": {
-        "name": "serverpod_auth_backwards_compatibility_session",
-        "dartName": "LegacySession",
-        "module": "serverpod_auth_backwards_compatibility",
-        "schema": "public",
-        "columns": [
-          {
-            "name": "id",
-            "columnType": 6,
-            "isNullable": false,
-            "columnDefault": "nextval('serverpod_auth_backwards_compatibility_session_id_seq'::regclass)",
-            "dartType": "int?"
-          },
-          {
-            "name": "authUserId",
-            "columnType": 7,
-            "isNullable": false,
-            "dartType": "UuidValue"
-          },
-          {
-            "name": "scopeNames",
-            "columnType": 8,
-            "isNullable": false,
-            "dartType": "Set<String>"
-          },
-          {
-            "name": "hash",
-            "columnType": 0,
-            "isNullable": false,
-            "dartType": "String"
-          },
-          {
-            "name": "method",
-            "columnType": 0,
-            "isNullable": false,
-            "dartType": "String"
-          }
-        ],
-        "foreignKeys": [
-          {
-            "constraintName": "serverpod_auth_backwards_compatibility_session_fk_0",
-            "columns": [
-              "authUserId"
-            ],
-            "referenceTable": "serverpod_auth_user",
-            "referenceTableSchema": "public",
-            "referenceColumns": [
-              "id"
-            ],
-            "onUpdate": 3,
-            "onDelete": 4
-          }
-        ],
-        "indexes": [
-          {
-            "indexName": "serverpod_auth_backwards_compatibility_session_pkey",
-            "elements": [
-              {
-                "type": 0,
-                "definition": "id"
-              }
-            ],
-            "type": "btree",
-            "isUnique": true,
-            "isPrimary": true
-          }
-        ],
-        "managed": true
-      }
-    },
-    {
-      "type": "createTable",
-      "createTable": {
         "name": "serverpod_auth_email_account",
         "dartName": "EmailAccount",
         "module": "serverpod_auth_email_account",
@@ -1601,7 +1504,7 @@
             "dartType": "String"
           },
           {
-            "name": "attemptedAt",
+            "name": "attempted",
             "columnType": 4,
             "isNullable": false,
             "dartType": "DateTime"
@@ -1640,11 +1543,11 @@
             "isPrimary": false
           },
           {
-            "indexName": "serverpod_auth_email_account_failed_login_attempt_attempted_at",
+            "indexName": "serverpod_auth_email_account_failed_login_attempt_attempted",
             "elements": [
               {
                 "type": 0,
-                "definition": "attemptedAt"
+                "definition": "attempted"
               }
             ],
             "type": "btree",
@@ -1671,7 +1574,7 @@
             "dartType": "UuidValue?"
           },
           {
-            "name": "attemptedAt",
+            "name": "attempted",
             "columnType": 4,
             "isNullable": false,
             "dartType": "DateTime"
@@ -1730,11 +1633,11 @@
             "isPrimary": false
           },
           {
-            "indexName": "serverpod_auth_email_account_password_reset_attempt_at",
+            "indexName": "serverpod_auth_email_account_password_reset_attempted",
             "elements": [
               {
                 "type": 0,
-                "definition": "attemptedAt"
+                "definition": "attempted"
               }
             ],
             "type": "btree",
@@ -1840,7 +1743,7 @@
             "dartType": "String"
           },
           {
-            "name": "attemptedAt",
+            "name": "attempted",
             "columnType": 4,
             "isNullable": false,
             "dartType": "DateTime"
@@ -1891,11 +1794,11 @@
             "isPrimary": false
           },
           {
-            "indexName": "serverpod_auth_email_account_pw_reset_request_attempt_at",
+            "indexName": "serverpod_auth_email_account_pw_reset_request_attempted",
             "elements": [
               {
                 "type": 0,
-                "definition": "attemptedAt"
+                "definition": "attempted"
               }
             ],
             "type": "btree",
@@ -2011,7 +1914,7 @@
             "dartType": "UuidValue?"
           },
           {
-            "name": "attemptedAt",
+            "name": "attempted",
             "columnType": 4,
             "isNullable": false,
             "dartType": "DateTime"
@@ -2070,776 +1973,11 @@
             "isPrimary": false
           },
           {
-            "indexName": "serverpod_auth_email_account_request_completion_attempt_at",
+            "indexName": "serverpod_auth_email_account_request_completion_attempted",
             "elements": [
               {
                 "type": 0,
-                "definition": "attemptedAt"
-              }
-            ],
-            "type": "btree",
-            "isUnique": false,
-            "isPrimary": false
-          }
-        ],
-        "managed": true
-      }
-    },
-    {
-      "type": "createTable",
-      "createTable": {
-        "name": "serverpod_auth_profile_user_profile",
-        "dartName": "UserProfile",
-        "module": "serverpod_auth_profile",
-        "schema": "public",
-        "columns": [
-          {
-            "name": "id",
-            "columnType": 7,
-            "isNullable": false,
-            "columnDefault": "gen_random_uuid()",
-            "dartType": "UuidValue?"
-          },
-          {
-            "name": "authUserId",
-            "columnType": 7,
-            "isNullable": false,
-            "dartType": "UuidValue"
-          },
-          {
-            "name": "userName",
-            "columnType": 0,
-            "isNullable": true,
-            "dartType": "String?"
-          },
-          {
-            "name": "fullName",
-            "columnType": 0,
-            "isNullable": true,
-            "dartType": "String?"
-          },
-          {
-            "name": "email",
-            "columnType": 0,
-            "isNullable": true,
-            "dartType": "String?"
-          },
-          {
-            "name": "created",
-            "columnType": 4,
-            "isNullable": false,
-            "columnDefault": "CURRENT_TIMESTAMP",
-            "dartType": "DateTime"
-          },
-          {
-            "name": "imageId",
-            "columnType": 7,
-            "isNullable": true,
-            "dartType": "UuidValue?"
-          }
-        ],
-        "foreignKeys": [
-          {
-            "constraintName": "serverpod_auth_profile_user_profile_fk_0",
-            "columns": [
-              "authUserId"
-            ],
-            "referenceTable": "serverpod_auth_user",
-            "referenceTableSchema": "public",
-            "referenceColumns": [
-              "id"
-            ],
-            "onUpdate": 3,
-            "onDelete": 4
-          },
-          {
-            "constraintName": "serverpod_auth_profile_user_profile_fk_1",
-            "columns": [
-              "imageId"
-            ],
-            "referenceTable": "serverpod_auth_profile_user_profile_image",
-            "referenceTableSchema": "public",
-            "referenceColumns": [
-              "id"
-            ],
-            "onUpdate": 3,
-            "onDelete": 3
-          }
-        ],
-        "indexes": [
-          {
-            "indexName": "serverpod_auth_profile_user_profile_pkey",
-            "elements": [
-              {
-                "type": 0,
-                "definition": "id"
-              }
-            ],
-            "type": "btree",
-            "isUnique": true,
-            "isPrimary": true
-          },
-          {
-            "indexName": "serverpod_auth_profile_user_profile_email_auth_user_id",
-            "elements": [
-              {
-                "type": 0,
-                "definition": "authUserId"
-              }
-            ],
-            "type": "btree",
-            "isUnique": true,
-            "isPrimary": false
-          }
-        ],
-        "managed": true
-      }
-    },
-    {
-      "type": "createTable",
-      "createTable": {
-        "name": "serverpod_auth_profile_user_profile_image",
-        "dartName": "UserProfileImage",
-        "module": "serverpod_auth_profile",
-        "schema": "public",
-        "columns": [
-          {
-            "name": "id",
-            "columnType": 7,
-            "isNullable": false,
-            "columnDefault": "gen_random_uuid()",
-            "dartType": "UuidValue?"
-          },
-          {
-            "name": "userProfileId",
-            "columnType": 7,
-            "isNullable": false,
-            "dartType": "UuidValue"
-          },
-          {
-            "name": "created",
-            "columnType": 4,
-            "isNullable": false,
-            "columnDefault": "CURRENT_TIMESTAMP",
-            "dartType": "DateTime"
-          },
-          {
-            "name": "storageId",
-            "columnType": 0,
-            "isNullable": false,
-            "dartType": "String"
-          },
-          {
-            "name": "path",
-            "columnType": 0,
-            "isNullable": false,
-            "dartType": "String"
-          },
-          {
-            "name": "url",
-            "columnType": 0,
-            "isNullable": false,
-            "dartType": "Uri"
-          }
-        ],
-        "foreignKeys": [
-          {
-            "constraintName": "serverpod_auth_profile_user_profile_image_fk_0",
-            "columns": [
-              "userProfileId"
-            ],
-            "referenceTable": "serverpod_auth_profile_user_profile",
-            "referenceTableSchema": "public",
-            "referenceColumns": [
-              "id"
-            ],
-            "onUpdate": 3,
-            "onDelete": 4
-          }
-        ],
-        "indexes": [
-          {
-            "indexName": "serverpod_auth_profile_user_profile_image_pkey",
-            "elements": [
-              {
-                "type": 0,
-                "definition": "id"
-              }
-            ],
-            "type": "btree",
-            "isUnique": true,
-            "isPrimary": true
-          }
-        ],
-        "managed": true
-      }
-    },
-    {
-      "type": "createTable",
-      "createTable": {
-        "name": "serverpod_auth_key",
-        "dartName": "AuthKey",
-        "module": "serverpod_auth",
-        "schema": "public",
-        "columns": [
-          {
-            "name": "id",
-            "columnType": 6,
-            "isNullable": false,
-            "columnDefault": "nextval('serverpod_auth_key_id_seq'::regclass)",
-            "dartType": "int?"
-          },
-          {
-            "name": "userId",
-            "columnType": 6,
-            "isNullable": false,
-            "dartType": "int"
-          },
-          {
-            "name": "hash",
-            "columnType": 0,
-            "isNullable": false,
-            "dartType": "String"
-          },
-          {
-            "name": "scopeNames",
-            "columnType": 8,
-            "isNullable": false,
-            "dartType": "List<String>"
-          },
-          {
-            "name": "method",
-            "columnType": 0,
-            "isNullable": false,
-            "dartType": "String"
-          }
-        ],
-        "foreignKeys": [],
-        "indexes": [
-          {
-            "indexName": "serverpod_auth_key_pkey",
-            "elements": [
-              {
-                "type": 0,
-                "definition": "id"
-              }
-            ],
-            "type": "btree",
-            "isUnique": true,
-            "isPrimary": true
-          },
-          {
-            "indexName": "serverpod_auth_key_userId_idx",
-            "elements": [
-              {
-                "type": 0,
-                "definition": "userId"
-              }
-            ],
-            "type": "btree",
-            "isUnique": false,
-            "isPrimary": false
-          }
-        ],
-        "managed": true
-      }
-    },
-    {
-      "type": "createTable",
-      "createTable": {
-        "name": "serverpod_email_auth",
-        "dartName": "EmailAuth",
-        "module": "serverpod_auth",
-        "schema": "public",
-        "columns": [
-          {
-            "name": "id",
-            "columnType": 6,
-            "isNullable": false,
-            "columnDefault": "nextval('serverpod_email_auth_id_seq'::regclass)",
-            "dartType": "int?"
-          },
-          {
-            "name": "userId",
-            "columnType": 6,
-            "isNullable": false,
-            "dartType": "int"
-          },
-          {
-            "name": "email",
-            "columnType": 0,
-            "isNullable": false,
-            "dartType": "String"
-          },
-          {
-            "name": "hash",
-            "columnType": 0,
-            "isNullable": false,
-            "dartType": "String"
-          }
-        ],
-        "foreignKeys": [],
-        "indexes": [
-          {
-            "indexName": "serverpod_email_auth_pkey",
-            "elements": [
-              {
-                "type": 0,
-                "definition": "id"
-              }
-            ],
-            "type": "btree",
-            "isUnique": true,
-            "isPrimary": true
-          },
-          {
-            "indexName": "serverpod_email_auth_email",
-            "elements": [
-              {
-                "type": 0,
-                "definition": "email"
-              }
-            ],
-            "type": "btree",
-            "isUnique": true,
-            "isPrimary": false
-          }
-        ],
-        "managed": true
-      }
-    },
-    {
-      "type": "createTable",
-      "createTable": {
-        "name": "serverpod_email_create_request",
-        "dartName": "EmailCreateAccountRequest",
-        "module": "serverpod_auth",
-        "schema": "public",
-        "columns": [
-          {
-            "name": "id",
-            "columnType": 6,
-            "isNullable": false,
-            "columnDefault": "nextval('serverpod_email_create_request_id_seq'::regclass)",
-            "dartType": "int?"
-          },
-          {
-            "name": "userName",
-            "columnType": 0,
-            "isNullable": false,
-            "dartType": "String"
-          },
-          {
-            "name": "email",
-            "columnType": 0,
-            "isNullable": false,
-            "dartType": "String"
-          },
-          {
-            "name": "hash",
-            "columnType": 0,
-            "isNullable": false,
-            "dartType": "String"
-          },
-          {
-            "name": "verificationCode",
-            "columnType": 0,
-            "isNullable": false,
-            "dartType": "String"
-          }
-        ],
-        "foreignKeys": [],
-        "indexes": [
-          {
-            "indexName": "serverpod_email_create_request_pkey",
-            "elements": [
-              {
-                "type": 0,
-                "definition": "id"
-              }
-            ],
-            "type": "btree",
-            "isUnique": true,
-            "isPrimary": true
-          },
-          {
-            "indexName": "serverpod_email_auth_create_account_request_idx",
-            "elements": [
-              {
-                "type": 0,
-                "definition": "email"
-              }
-            ],
-            "type": "btree",
-            "isUnique": true,
-            "isPrimary": false
-          }
-        ],
-        "managed": true
-      }
-    },
-    {
-      "type": "createTable",
-      "createTable": {
-        "name": "serverpod_email_failed_sign_in",
-        "dartName": "EmailFailedSignIn",
-        "module": "serverpod_auth",
-        "schema": "public",
-        "columns": [
-          {
-            "name": "id",
-            "columnType": 6,
-            "isNullable": false,
-            "columnDefault": "nextval('serverpod_email_failed_sign_in_id_seq'::regclass)",
-            "dartType": "int?"
-          },
-          {
-            "name": "email",
-            "columnType": 0,
-            "isNullable": false,
-            "dartType": "String"
-          },
-          {
-            "name": "time",
-            "columnType": 4,
-            "isNullable": false,
-            "dartType": "DateTime"
-          },
-          {
-            "name": "ipAddress",
-            "columnType": 0,
-            "isNullable": false,
-            "dartType": "String"
-          }
-        ],
-        "foreignKeys": [],
-        "indexes": [
-          {
-            "indexName": "serverpod_email_failed_sign_in_pkey",
-            "elements": [
-              {
-                "type": 0,
-                "definition": "id"
-              }
-            ],
-            "type": "btree",
-            "isUnique": true,
-            "isPrimary": true
-          },
-          {
-            "indexName": "serverpod_email_failed_sign_in_email_idx",
-            "elements": [
-              {
-                "type": 0,
-                "definition": "email"
-              }
-            ],
-            "type": "btree",
-            "isUnique": false,
-            "isPrimary": false
-          },
-          {
-            "indexName": "serverpod_email_failed_sign_in_time_idx",
-            "elements": [
-              {
-                "type": 0,
-                "definition": "time"
-              }
-            ],
-            "type": "btree",
-            "isUnique": false,
-            "isPrimary": false
-          }
-        ],
-        "managed": true
-      }
-    },
-    {
-      "type": "createTable",
-      "createTable": {
-        "name": "serverpod_email_reset",
-        "dartName": "EmailReset",
-        "module": "serverpod_auth",
-        "schema": "public",
-        "columns": [
-          {
-            "name": "id",
-            "columnType": 6,
-            "isNullable": false,
-            "columnDefault": "nextval('serverpod_email_reset_id_seq'::regclass)",
-            "dartType": "int?"
-          },
-          {
-            "name": "userId",
-            "columnType": 6,
-            "isNullable": false,
-            "dartType": "int"
-          },
-          {
-            "name": "verificationCode",
-            "columnType": 0,
-            "isNullable": false,
-            "dartType": "String"
-          },
-          {
-            "name": "expiration",
-            "columnType": 4,
-            "isNullable": false,
-            "dartType": "DateTime"
-          }
-        ],
-        "foreignKeys": [],
-        "indexes": [
-          {
-            "indexName": "serverpod_email_reset_pkey",
-            "elements": [
-              {
-                "type": 0,
-                "definition": "id"
-              }
-            ],
-            "type": "btree",
-            "isUnique": true,
-            "isPrimary": true
-          },
-          {
-            "indexName": "serverpod_email_reset_verification_idx",
-            "elements": [
-              {
-                "type": 0,
-                "definition": "verificationCode"
-              }
-            ],
-            "type": "btree",
-            "isUnique": true,
-            "isPrimary": false
-          }
-        ],
-        "managed": true
-      }
-    },
-    {
-      "type": "createTable",
-      "createTable": {
-        "name": "serverpod_google_refresh_token",
-        "dartName": "GoogleRefreshToken",
-        "module": "serverpod_auth",
-        "schema": "public",
-        "columns": [
-          {
-            "name": "id",
-            "columnType": 6,
-            "isNullable": false,
-            "columnDefault": "nextval('serverpod_google_refresh_token_id_seq'::regclass)",
-            "dartType": "int?"
-          },
-          {
-            "name": "userId",
-            "columnType": 6,
-            "isNullable": false,
-            "dartType": "int"
-          },
-          {
-            "name": "refreshToken",
-            "columnType": 0,
-            "isNullable": false,
-            "dartType": "String"
-          }
-        ],
-        "foreignKeys": [],
-        "indexes": [
-          {
-            "indexName": "serverpod_google_refresh_token_pkey",
-            "elements": [
-              {
-                "type": 0,
-                "definition": "id"
-              }
-            ],
-            "type": "btree",
-            "isUnique": true,
-            "isPrimary": true
-          },
-          {
-            "indexName": "serverpod_google_refresh_token_userId_idx",
-            "elements": [
-              {
-                "type": 0,
-                "definition": "userId"
-              }
-            ],
-            "type": "btree",
-            "isUnique": true,
-            "isPrimary": false
-          }
-        ],
-        "managed": true
-      }
-    },
-    {
-      "type": "createTable",
-      "createTable": {
-        "name": "serverpod_user_image",
-        "dartName": "UserImage",
-        "module": "serverpod_auth",
-        "schema": "public",
-        "columns": [
-          {
-            "name": "id",
-            "columnType": 6,
-            "isNullable": false,
-            "columnDefault": "nextval('serverpod_user_image_id_seq'::regclass)",
-            "dartType": "int?"
-          },
-          {
-            "name": "userId",
-            "columnType": 6,
-            "isNullable": false,
-            "dartType": "int"
-          },
-          {
-            "name": "version",
-            "columnType": 6,
-            "isNullable": false,
-            "dartType": "int"
-          },
-          {
-            "name": "url",
-            "columnType": 0,
-            "isNullable": false,
-            "dartType": "String"
-          }
-        ],
-        "foreignKeys": [],
-        "indexes": [
-          {
-            "indexName": "serverpod_user_image_pkey",
-            "elements": [
-              {
-                "type": 0,
-                "definition": "id"
-              }
-            ],
-            "type": "btree",
-            "isUnique": true,
-            "isPrimary": true
-          },
-          {
-            "indexName": "serverpod_user_image_user_id",
-            "elements": [
-              {
-                "type": 0,
-                "definition": "userId"
-              },
-              {
-                "type": 0,
-                "definition": "version"
-              }
-            ],
-            "type": "btree",
-            "isUnique": false,
-            "isPrimary": false
-          }
-        ],
-        "managed": true
-      }
-    },
-    {
-      "type": "createTable",
-      "createTable": {
-        "name": "serverpod_user_info",
-        "dartName": "UserInfo",
-        "module": "serverpod_auth",
-        "schema": "public",
-        "columns": [
-          {
-            "name": "id",
-            "columnType": 6,
-            "isNullable": false,
-            "columnDefault": "nextval('serverpod_user_info_id_seq'::regclass)",
-            "dartType": "int?"
-          },
-          {
-            "name": "userIdentifier",
-            "columnType": 0,
-            "isNullable": false,
-            "dartType": "String"
-          },
-          {
-            "name": "userName",
-            "columnType": 0,
-            "isNullable": true,
-            "dartType": "String?"
-          },
-          {
-            "name": "fullName",
-            "columnType": 0,
-            "isNullable": true,
-            "dartType": "String?"
-          },
-          {
-            "name": "email",
-            "columnType": 0,
-            "isNullable": true,
-            "dartType": "String?"
-          },
-          {
-            "name": "created",
-            "columnType": 4,
-            "isNullable": false,
-            "dartType": "DateTime"
-          },
-          {
-            "name": "imageUrl",
-            "columnType": 0,
-            "isNullable": true,
-            "dartType": "String?"
-          },
-          {
-            "name": "scopeNames",
-            "columnType": 8,
-            "isNullable": false,
-            "dartType": "List<String>"
-          },
-          {
-            "name": "blocked",
-            "columnType": 1,
-            "isNullable": false,
-            "dartType": "bool"
-          }
-        ],
-        "foreignKeys": [],
-        "indexes": [
-          {
-            "indexName": "serverpod_user_info_pkey",
-            "elements": [
-              {
-                "type": 0,
-                "definition": "id"
-              }
-            ],
-            "type": "btree",
-            "isUnique": true,
-            "isPrimary": true
-          },
-          {
-            "indexName": "serverpod_user_info_user_identifier",
-            "elements": [
-              {
-                "type": 0,
-                "definition": "userIdentifier"
-              }
-            ],
-            "type": "btree",
-            "isUnique": true,
-            "isPrimary": false
-          },
-          {
-            "indexName": "serverpod_user_info_email",
-            "elements": [
-              {
-                "type": 0,
-                "definition": "email"
+                "definition": "attempted"
               }
             ],
             "type": "btree",

--- a/modules/new_serverpod_auth/serverpod_auth_backwards_compatibility/serverpod_auth_backwards_compatibility_server/migrations/20250724125750464/migration.sql
+++ b/modules/new_serverpod_auth/serverpod_auth_backwards_compatibility/serverpod_auth_backwards_compatibility_server/migrations/20250724125750464/migration.sql
@@ -262,27 +262,27 @@ CREATE UNIQUE INDEX "serverpod_auth_email_account_email" ON "serverpod_auth_emai
 CREATE TABLE "serverpod_auth_email_account_failed_login_attempt" (
     "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
     "email" text NOT NULL,
-    "attemptedAt" timestamp without time zone NOT NULL,
+    "attempted" timestamp without time zone NOT NULL,
     "ipAddress" text NOT NULL
 );
 
 -- Indexes
 CREATE INDEX "serverpod_auth_email_account_failed_login_attempt_email" ON "serverpod_auth_email_account_failed_login_attempt" USING btree ("email");
-CREATE INDEX "serverpod_auth_email_account_failed_login_attempt_attempted_at" ON "serverpod_auth_email_account_failed_login_attempt" USING btree ("attemptedAt");
+CREATE INDEX "serverpod_auth_email_account_failed_login_attempt_attempted" ON "serverpod_auth_email_account_failed_login_attempt" USING btree ("attempted");
 
 --
 -- ACTION CREATE TABLE
 --
 CREATE TABLE "serverpod_auth_email_account_password_reset_attempt" (
     "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-    "attemptedAt" timestamp without time zone NOT NULL,
+    "attempted" timestamp without time zone NOT NULL,
     "ipAddress" text NOT NULL,
     "passwordResetRequestId" uuid NOT NULL
 );
 
 -- Indexes
 CREATE INDEX "serverpod_auth_email_account_password_reset_attempt_ip" ON "serverpod_auth_email_account_password_reset_attempt" USING btree ("ipAddress");
-CREATE INDEX "serverpod_auth_email_account_password_reset_attempt_at" ON "serverpod_auth_email_account_password_reset_attempt" USING btree ("attemptedAt");
+CREATE INDEX "serverpod_auth_email_account_password_reset_attempted" ON "serverpod_auth_email_account_password_reset_attempt" USING btree ("attempted");
 
 --
 -- ACTION CREATE TABLE
@@ -301,14 +301,14 @@ CREATE TABLE "serverpod_auth_email_account_password_reset_request" (
 CREATE TABLE "serverpod_auth_email_account_pw_reset_request_attempt" (
     "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
     "email" text NOT NULL,
-    "attemptedAt" timestamp without time zone NOT NULL,
+    "attempted" timestamp without time zone NOT NULL,
     "ipAddress" text NOT NULL
 );
 
 -- Indexes
 CREATE INDEX "serverpod_auth_email_account_pw_reset_request_attempt_email" ON "serverpod_auth_email_account_pw_reset_request_attempt" USING btree ("email");
 CREATE INDEX "serverpod_auth_email_account_pw_reset_request_attempt_ip" ON "serverpod_auth_email_account_pw_reset_request_attempt" USING btree ("ipAddress");
-CREATE INDEX "serverpod_auth_email_account_pw_reset_request_attempt_at" ON "serverpod_auth_email_account_pw_reset_request_attempt" USING btree ("attemptedAt");
+CREATE INDEX "serverpod_auth_email_account_pw_reset_request_attempted" ON "serverpod_auth_email_account_pw_reset_request_attempt" USING btree ("attempted");
 
 --
 -- ACTION CREATE TABLE
@@ -332,14 +332,14 @@ CREATE UNIQUE INDEX "serverpod_auth_email_account_request_email" ON "serverpod_a
 --
 CREATE TABLE "serverpod_auth_email_account_request_completion_attempt" (
     "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-    "attemptedAt" timestamp without time zone NOT NULL,
+    "attempted" timestamp without time zone NOT NULL,
     "ipAddress" text NOT NULL,
     "emailAccountRequestId" uuid NOT NULL
 );
 
 -- Indexes
 CREATE INDEX "serverpod_auth_email_account_request_completion_attempt_ip" ON "serverpod_auth_email_account_request_completion_attempt" USING btree ("ipAddress");
-CREATE INDEX "serverpod_auth_email_account_request_completion_attempt_at" ON "serverpod_auth_email_account_request_completion_attempt" USING btree ("attemptedAt");
+CREATE INDEX "serverpod_auth_email_account_request_completion_attempted" ON "serverpod_auth_email_account_request_completion_attempt" USING btree ("attempted");
 
 --
 -- ACTION CREATE TABLE
@@ -482,9 +482,9 @@ ALTER TABLE ONLY "serverpod_auth_session"
 -- MIGRATION VERSION FOR serverpod_auth_backwards_compatibility
 --
 INSERT INTO "serverpod_migrations" ("module", "version", "timestamp")
-    VALUES ('serverpod_auth_backwards_compatibility', '20250708110241098', now())
+    VALUES ('serverpod_auth_backwards_compatibility', '20250724125750464', now())
     ON CONFLICT ("module")
-    DO UPDATE SET "version" = '20250708110241098', "timestamp" = now();
+    DO UPDATE SET "version" = '20250724125750464', "timestamp" = now();
 
 --
 -- MIGRATION VERSION FOR serverpod
@@ -498,9 +498,9 @@ INSERT INTO "serverpod_migrations" ("module", "version", "timestamp")
 -- MIGRATION VERSION FOR serverpod_auth_email_account
 --
 INSERT INTO "serverpod_migrations" ("module", "version", "timestamp")
-    VALUES ('serverpod_auth_email_account', '20250606090748154', now())
+    VALUES ('serverpod_auth_email_account', '20250724100154487', now())
     ON CONFLICT ("module")
-    DO UPDATE SET "version" = '20250606090748154', "timestamp" = now();
+    DO UPDATE SET "version" = '20250724100154487', "timestamp" = now();
 
 --
 -- MIGRATION VERSION FOR serverpod_auth_session

--- a/modules/new_serverpod_auth/serverpod_auth_backwards_compatibility/serverpod_auth_backwards_compatibility_server/migrations/migration_registry.txt
+++ b/modules/new_serverpod_auth/serverpod_auth_backwards_compatibility/serverpod_auth_backwards_compatibility_server/migrations/migration_registry.txt
@@ -4,4 +4,4 @@
 ### manually. If a collision is detected in this file when doing a code merge, resolve
 ### the conflict by removing and recreating the conflicting migration.
 
-20250708110241098
+20250724125750464

--- a/modules/new_serverpod_auth/serverpod_auth_email/serverpod_auth_email_server/migrations/20250724100231671/definition.json
+++ b/modules/new_serverpod_auth/serverpod_auth_email/serverpod_auth_email_server/migrations/20250724100231671/definition.json
@@ -1,5 +1,5 @@
 {
-  "moduleName": "serverpod_new_auth_test",
+  "moduleName": "serverpod_auth_email",
   "tables": [
     {
       "name": "serverpod_cloud_storage",
@@ -1139,9 +1139,256 @@
       "managed": true
     },
     {
-      "name": "serverpod_auth_backwards_compatibility_email_password",
-      "dartName": "LegacyEmailPassword",
-      "module": "serverpod_auth_backwards_compatibility",
+      "name": "serverpod_auth_email_account",
+      "dartName": "EmailAccount",
+      "module": "serverpod_auth_email_account",
+      "schema": "public",
+      "columns": [
+        {
+          "name": "id",
+          "columnType": 7,
+          "isNullable": false,
+          "columnDefault": "gen_random_uuid()",
+          "dartType": "UuidValue?"
+        },
+        {
+          "name": "authUserId",
+          "columnType": 7,
+          "isNullable": false,
+          "dartType": "UuidValue"
+        },
+        {
+          "name": "created",
+          "columnType": 4,
+          "isNullable": false,
+          "dartType": "DateTime"
+        },
+        {
+          "name": "email",
+          "columnType": 0,
+          "isNullable": false,
+          "dartType": "String"
+        },
+        {
+          "name": "passwordHash",
+          "columnType": 5,
+          "isNullable": false,
+          "dartType": "dart:typed_data:ByteData"
+        },
+        {
+          "name": "passwordSalt",
+          "columnType": 5,
+          "isNullable": false,
+          "dartType": "dart:typed_data:ByteData"
+        }
+      ],
+      "foreignKeys": [
+        {
+          "constraintName": "serverpod_auth_email_account_fk_0",
+          "columns": [
+            "authUserId"
+          ],
+          "referenceTable": "serverpod_auth_user",
+          "referenceTableSchema": "public",
+          "referenceColumns": [
+            "id"
+          ],
+          "onUpdate": 3,
+          "onDelete": 4
+        }
+      ],
+      "indexes": [
+        {
+          "indexName": "serverpod_auth_email_account_pkey",
+          "elements": [
+            {
+              "type": 0,
+              "definition": "id"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": true
+        },
+        {
+          "indexName": "serverpod_auth_email_account_email",
+          "elements": [
+            {
+              "type": 0,
+              "definition": "email"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": false
+        }
+      ],
+      "managed": true
+    },
+    {
+      "name": "serverpod_auth_email_account_failed_login_attempt",
+      "dartName": "EmailAccountFailedLoginAttempt",
+      "module": "serverpod_auth_email_account",
+      "schema": "public",
+      "columns": [
+        {
+          "name": "id",
+          "columnType": 7,
+          "isNullable": false,
+          "columnDefault": "gen_random_uuid()",
+          "dartType": "UuidValue?"
+        },
+        {
+          "name": "email",
+          "columnType": 0,
+          "isNullable": false,
+          "dartType": "String"
+        },
+        {
+          "name": "attempted",
+          "columnType": 4,
+          "isNullable": false,
+          "dartType": "DateTime"
+        },
+        {
+          "name": "ipAddress",
+          "columnType": 0,
+          "isNullable": false,
+          "dartType": "String"
+        }
+      ],
+      "foreignKeys": [],
+      "indexes": [
+        {
+          "indexName": "serverpod_auth_email_account_failed_login_attempt_pkey",
+          "elements": [
+            {
+              "type": 0,
+              "definition": "id"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": true
+        },
+        {
+          "indexName": "serverpod_auth_email_account_failed_login_attempt_email",
+          "elements": [
+            {
+              "type": 0,
+              "definition": "email"
+            }
+          ],
+          "type": "btree",
+          "isUnique": false,
+          "isPrimary": false
+        },
+        {
+          "indexName": "serverpod_auth_email_account_failed_login_attempt_attempted",
+          "elements": [
+            {
+              "type": 0,
+              "definition": "attempted"
+            }
+          ],
+          "type": "btree",
+          "isUnique": false,
+          "isPrimary": false
+        }
+      ],
+      "managed": true
+    },
+    {
+      "name": "serverpod_auth_email_account_password_reset_attempt",
+      "dartName": "EmailAccountPasswordResetAttempt",
+      "module": "serverpod_auth_email_account",
+      "schema": "public",
+      "columns": [
+        {
+          "name": "id",
+          "columnType": 7,
+          "isNullable": false,
+          "columnDefault": "gen_random_uuid()",
+          "dartType": "UuidValue?"
+        },
+        {
+          "name": "attempted",
+          "columnType": 4,
+          "isNullable": false,
+          "dartType": "DateTime"
+        },
+        {
+          "name": "ipAddress",
+          "columnType": 0,
+          "isNullable": false,
+          "dartType": "String"
+        },
+        {
+          "name": "passwordResetRequestId",
+          "columnType": 7,
+          "isNullable": false,
+          "dartType": "UuidValue"
+        }
+      ],
+      "foreignKeys": [
+        {
+          "constraintName": "serverpod_auth_email_account_password_reset_attempt_fk_0",
+          "columns": [
+            "passwordResetRequestId"
+          ],
+          "referenceTable": "serverpod_auth_email_account_password_reset_request",
+          "referenceTableSchema": "public",
+          "referenceColumns": [
+            "id"
+          ],
+          "onUpdate": 3,
+          "onDelete": 4
+        }
+      ],
+      "indexes": [
+        {
+          "indexName": "serverpod_auth_email_account_password_reset_attempt_pkey",
+          "elements": [
+            {
+              "type": 0,
+              "definition": "id"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": true
+        },
+        {
+          "indexName": "serverpod_auth_email_account_password_reset_attempt_ip",
+          "elements": [
+            {
+              "type": 0,
+              "definition": "ipAddress"
+            }
+          ],
+          "type": "btree",
+          "isUnique": false,
+          "isPrimary": false
+        },
+        {
+          "indexName": "serverpod_auth_email_account_password_reset_attempted",
+          "elements": [
+            {
+              "type": 0,
+              "definition": "attempted"
+            }
+          ],
+          "type": "btree",
+          "isUnique": false,
+          "isPrimary": false
+        }
+      ],
+      "managed": true
+    },
+    {
+      "name": "serverpod_auth_email_account_password_reset_request",
+      "dartName": "EmailAccountPasswordResetRequest",
+      "module": "serverpod_auth_email_account",
       "schema": "public",
       "columns": [
         {
@@ -1158,15 +1405,28 @@
           "dartType": "UuidValue"
         },
         {
-          "name": "hash",
-          "columnType": 0,
+          "name": "created",
+          "columnType": 4,
           "isNullable": false,
-          "dartType": "String"
+          "columnDefault": "CURRENT_TIMESTAMP",
+          "dartType": "DateTime"
+        },
+        {
+          "name": "verificationCodeHash",
+          "columnType": 5,
+          "isNullable": false,
+          "dartType": "dart:typed_data:ByteData"
+        },
+        {
+          "name": "verificationCodeSalt",
+          "columnType": 5,
+          "isNullable": false,
+          "dartType": "dart:typed_data:ByteData"
         }
       ],
       "foreignKeys": [
         {
-          "constraintName": "serverpod_auth_backwards_compatibility_email_password_fk_0",
+          "constraintName": "serverpod_auth_email_account_password_reset_request_fk_0",
           "columns": [
             "emailAccountId"
           ],
@@ -1181,7 +1441,7 @@
       ],
       "indexes": [
         {
-          "indexName": "serverpod_auth_backwards_compatibility_email_password_pkey",
+          "indexName": "serverpod_auth_email_account_password_reset_request_pkey",
           "elements": [
             {
               "type": 0,
@@ -1191,26 +1451,14 @@
           "type": "btree",
           "isUnique": true,
           "isPrimary": true
-        },
-        {
-          "indexName": "serverpod_auth_backwards_compatibility_email_password_account",
-          "elements": [
-            {
-              "type": 0,
-              "definition": "emailAccountId"
-            }
-          ],
-          "type": "btree",
-          "isUnique": true,
-          "isPrimary": false
         }
       ],
       "managed": true
     },
     {
-      "name": "serverpod_auth_backwards_compatibility_external_user_id",
-      "dartName": "LegacyExternalUserIdentifier",
-      "module": "serverpod_auth_backwards_compatibility",
+      "name": "serverpod_auth_email_account_pw_reset_request_attempt",
+      "dartName": "EmailAccountPasswordResetRequestAttempt",
+      "module": "serverpod_auth_email_account",
       "schema": "public",
       "columns": [
         {
@@ -1221,36 +1469,28 @@
           "dartType": "UuidValue?"
         },
         {
-          "name": "authUserId",
-          "columnType": 7,
+          "name": "email",
+          "columnType": 0,
           "isNullable": false,
-          "dartType": "UuidValue"
+          "dartType": "String"
         },
         {
-          "name": "userIdentifier",
+          "name": "attempted",
+          "columnType": 4,
+          "isNullable": false,
+          "dartType": "DateTime"
+        },
+        {
+          "name": "ipAddress",
           "columnType": 0,
           "isNullable": false,
           "dartType": "String"
         }
       ],
-      "foreignKeys": [
-        {
-          "constraintName": "serverpod_auth_backwards_compatibility_external_user_id_fk_0",
-          "columns": [
-            "authUserId"
-          ],
-          "referenceTable": "serverpod_auth_user",
-          "referenceTableSchema": "public",
-          "referenceColumns": [
-            "id"
-          ],
-          "onUpdate": 3,
-          "onDelete": 4
-        }
-      ],
+      "foreignKeys": [],
       "indexes": [
         {
-          "indexName": "serverpod_auth_backwards_compatibility_external_user_id_pkey",
+          "indexName": "serverpod_auth_email_account_pw_reset_request_attempt_pkey",
           "elements": [
             {
               "type": 0,
@@ -1262,11 +1502,121 @@
           "isPrimary": true
         },
         {
-          "indexName": "serverpod_auth_backwards_compatibility_external_user_id_id",
+          "indexName": "serverpod_auth_email_account_pw_reset_request_attempt_email",
           "elements": [
             {
               "type": 0,
-              "definition": "userIdentifier"
+              "definition": "email"
+            }
+          ],
+          "type": "btree",
+          "isUnique": false,
+          "isPrimary": false
+        },
+        {
+          "indexName": "serverpod_auth_email_account_pw_reset_request_attempt_ip",
+          "elements": [
+            {
+              "type": 0,
+              "definition": "ipAddress"
+            }
+          ],
+          "type": "btree",
+          "isUnique": false,
+          "isPrimary": false
+        },
+        {
+          "indexName": "serverpod_auth_email_account_pw_reset_request_attempted",
+          "elements": [
+            {
+              "type": 0,
+              "definition": "attempted"
+            }
+          ],
+          "type": "btree",
+          "isUnique": false,
+          "isPrimary": false
+        }
+      ],
+      "managed": true
+    },
+    {
+      "name": "serverpod_auth_email_account_request",
+      "dartName": "EmailAccountRequest",
+      "module": "serverpod_auth_email_account",
+      "schema": "public",
+      "columns": [
+        {
+          "name": "id",
+          "columnType": 7,
+          "isNullable": false,
+          "columnDefault": "gen_random_uuid()",
+          "dartType": "UuidValue?"
+        },
+        {
+          "name": "created",
+          "columnType": 4,
+          "isNullable": false,
+          "columnDefault": "CURRENT_TIMESTAMP",
+          "dartType": "DateTime"
+        },
+        {
+          "name": "email",
+          "columnType": 0,
+          "isNullable": false,
+          "dartType": "String"
+        },
+        {
+          "name": "passwordHash",
+          "columnType": 5,
+          "isNullable": false,
+          "dartType": "dart:typed_data:ByteData"
+        },
+        {
+          "name": "passwordSalt",
+          "columnType": 5,
+          "isNullable": false,
+          "dartType": "dart:typed_data:ByteData"
+        },
+        {
+          "name": "verificationCodeHash",
+          "columnType": 5,
+          "isNullable": false,
+          "dartType": "dart:typed_data:ByteData"
+        },
+        {
+          "name": "verificationCodeSalt",
+          "columnType": 5,
+          "isNullable": false,
+          "dartType": "dart:typed_data:ByteData"
+        },
+        {
+          "name": "verifiedAt",
+          "columnType": 4,
+          "isNullable": true,
+          "dartType": "DateTime?"
+        }
+      ],
+      "foreignKeys": [],
+      "indexes": [
+        {
+          "indexName": "serverpod_auth_email_account_request_pkey",
+          "elements": [
+            {
+              "type": 0,
+              "definition": "id"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": true
+        },
+        {
+          "indexName": "serverpod_auth_email_account_request_email",
+          "elements": [
+            {
+              "type": 0,
+              "definition": "email"
             }
           ],
           "type": "btree",
@@ -1277,50 +1627,44 @@
       "managed": true
     },
     {
-      "name": "serverpod_auth_backwards_compatibility_session",
-      "dartName": "LegacySession",
-      "module": "serverpod_auth_backwards_compatibility",
+      "name": "serverpod_auth_email_account_request_completion_attempt",
+      "dartName": "EmailAccountRequestCompletionAttempt",
+      "module": "serverpod_auth_email_account",
       "schema": "public",
       "columns": [
         {
           "name": "id",
-          "columnType": 6,
+          "columnType": 7,
           "isNullable": false,
-          "columnDefault": "nextval('serverpod_auth_backwards_compatibility_session_id_seq'::regclass)",
-          "dartType": "int?"
+          "columnDefault": "gen_random_uuid()",
+          "dartType": "UuidValue?"
         },
         {
-          "name": "authUserId",
+          "name": "attempted",
+          "columnType": 4,
+          "isNullable": false,
+          "dartType": "DateTime"
+        },
+        {
+          "name": "ipAddress",
+          "columnType": 0,
+          "isNullable": false,
+          "dartType": "String"
+        },
+        {
+          "name": "emailAccountRequestId",
           "columnType": 7,
           "isNullable": false,
           "dartType": "UuidValue"
-        },
-        {
-          "name": "scopeNames",
-          "columnType": 8,
-          "isNullable": false,
-          "dartType": "Set<String>"
-        },
-        {
-          "name": "hash",
-          "columnType": 0,
-          "isNullable": false,
-          "dartType": "String"
-        },
-        {
-          "name": "method",
-          "columnType": 0,
-          "isNullable": false,
-          "dartType": "String"
         }
       ],
       "foreignKeys": [
         {
-          "constraintName": "serverpod_auth_backwards_compatibility_session_fk_0",
+          "constraintName": "serverpod_auth_email_account_request_completion_attempt_fk_0",
           "columns": [
-            "authUserId"
+            "emailAccountRequestId"
           ],
-          "referenceTable": "serverpod_auth_user",
+          "referenceTable": "serverpod_auth_email_account_request",
           "referenceTableSchema": "public",
           "referenceColumns": [
             "id"
@@ -1331,77 +1675,7 @@
       ],
       "indexes": [
         {
-          "indexName": "serverpod_auth_backwards_compatibility_session_pkey",
-          "elements": [
-            {
-              "type": 0,
-              "definition": "id"
-            }
-          ],
-          "type": "btree",
-          "isUnique": true,
-          "isPrimary": true
-        }
-      ],
-      "managed": true
-    },
-    {
-      "name": "serverpod_auth_migration_migrated_user",
-      "dartName": "MigratedUser",
-      "module": "serverpod_auth_migration",
-      "schema": "public",
-      "columns": [
-        {
-          "name": "id",
-          "columnType": 6,
-          "isNullable": false,
-          "columnDefault": "nextval('serverpod_auth_migration_migrated_user_id_seq'::regclass)",
-          "dartType": "int?"
-        },
-        {
-          "name": "oldUserId",
-          "columnType": 6,
-          "isNullable": false,
-          "dartType": "int"
-        },
-        {
-          "name": "newAuthUserId",
-          "columnType": 7,
-          "isNullable": false,
-          "dartType": "UuidValue"
-        }
-      ],
-      "foreignKeys": [
-        {
-          "constraintName": "serverpod_auth_migration_migrated_user_fk_0",
-          "columns": [
-            "oldUserId"
-          ],
-          "referenceTable": "serverpod_user_info",
-          "referenceTableSchema": "public",
-          "referenceColumns": [
-            "id"
-          ],
-          "onUpdate": 3,
-          "onDelete": 4
-        },
-        {
-          "constraintName": "serverpod_auth_migration_migrated_user_fk_1",
-          "columns": [
-            "newAuthUserId"
-          ],
-          "referenceTable": "serverpod_auth_user",
-          "referenceTableSchema": "public",
-          "referenceColumns": [
-            "id"
-          ],
-          "onUpdate": 3,
-          "onDelete": 4
-        }
-      ],
-      "indexes": [
-        {
-          "indexName": "serverpod_auth_migration_migrated_user_pkey",
+          "indexName": "serverpod_auth_email_account_request_completion_attempt_pkey",
           "elements": [
             {
               "type": 0,
@@ -1413,27 +1687,27 @@
           "isPrimary": true
         },
         {
-          "indexName": "serverpod_auth_migration_migrated_user_old",
+          "indexName": "serverpod_auth_email_account_request_completion_attempt_ip",
           "elements": [
             {
               "type": 0,
-              "definition": "oldUserId"
+              "definition": "ipAddress"
             }
           ],
           "type": "btree",
-          "isUnique": true,
+          "isUnique": false,
           "isPrimary": false
         },
         {
-          "indexName": "serverpod_auth_migration_migrated_user_new",
+          "indexName": "serverpod_auth_email_account_request_completion_attempted",
           "elements": [
             {
               "type": 0,
-              "definition": "newAuthUserId"
+              "definition": "attempted"
             }
           ],
           "type": "btree",
-          "isUnique": true,
+          "isUnique": false,
           "isPrimary": false
         }
       ],
@@ -1623,1133 +1897,6 @@
       "managed": true
     },
     {
-      "name": "serverpod_auth_key",
-      "dartName": "AuthKey",
-      "module": "serverpod_auth",
-      "schema": "public",
-      "columns": [
-        {
-          "name": "id",
-          "columnType": 6,
-          "isNullable": false,
-          "columnDefault": "nextval('serverpod_auth_key_id_seq'::regclass)",
-          "dartType": "int?"
-        },
-        {
-          "name": "userId",
-          "columnType": 6,
-          "isNullable": false,
-          "dartType": "int"
-        },
-        {
-          "name": "hash",
-          "columnType": 0,
-          "isNullable": false,
-          "dartType": "String"
-        },
-        {
-          "name": "scopeNames",
-          "columnType": 8,
-          "isNullable": false,
-          "dartType": "List<String>"
-        },
-        {
-          "name": "method",
-          "columnType": 0,
-          "isNullable": false,
-          "dartType": "String"
-        }
-      ],
-      "foreignKeys": [],
-      "indexes": [
-        {
-          "indexName": "serverpod_auth_key_pkey",
-          "elements": [
-            {
-              "type": 0,
-              "definition": "id"
-            }
-          ],
-          "type": "btree",
-          "isUnique": true,
-          "isPrimary": true
-        },
-        {
-          "indexName": "serverpod_auth_key_userId_idx",
-          "elements": [
-            {
-              "type": 0,
-              "definition": "userId"
-            }
-          ],
-          "type": "btree",
-          "isUnique": false,
-          "isPrimary": false
-        }
-      ],
-      "managed": true
-    },
-    {
-      "name": "serverpod_email_auth",
-      "dartName": "EmailAuth",
-      "module": "serverpod_auth",
-      "schema": "public",
-      "columns": [
-        {
-          "name": "id",
-          "columnType": 6,
-          "isNullable": false,
-          "columnDefault": "nextval('serverpod_email_auth_id_seq'::regclass)",
-          "dartType": "int?"
-        },
-        {
-          "name": "userId",
-          "columnType": 6,
-          "isNullable": false,
-          "dartType": "int"
-        },
-        {
-          "name": "email",
-          "columnType": 0,
-          "isNullable": false,
-          "dartType": "String"
-        },
-        {
-          "name": "hash",
-          "columnType": 0,
-          "isNullable": false,
-          "dartType": "String"
-        }
-      ],
-      "foreignKeys": [],
-      "indexes": [
-        {
-          "indexName": "serverpod_email_auth_pkey",
-          "elements": [
-            {
-              "type": 0,
-              "definition": "id"
-            }
-          ],
-          "type": "btree",
-          "isUnique": true,
-          "isPrimary": true
-        },
-        {
-          "indexName": "serverpod_email_auth_email",
-          "elements": [
-            {
-              "type": 0,
-              "definition": "email"
-            }
-          ],
-          "type": "btree",
-          "isUnique": true,
-          "isPrimary": false
-        }
-      ],
-      "managed": true
-    },
-    {
-      "name": "serverpod_email_create_request",
-      "dartName": "EmailCreateAccountRequest",
-      "module": "serverpod_auth",
-      "schema": "public",
-      "columns": [
-        {
-          "name": "id",
-          "columnType": 6,
-          "isNullable": false,
-          "columnDefault": "nextval('serverpod_email_create_request_id_seq'::regclass)",
-          "dartType": "int?"
-        },
-        {
-          "name": "userName",
-          "columnType": 0,
-          "isNullable": false,
-          "dartType": "String"
-        },
-        {
-          "name": "email",
-          "columnType": 0,
-          "isNullable": false,
-          "dartType": "String"
-        },
-        {
-          "name": "hash",
-          "columnType": 0,
-          "isNullable": false,
-          "dartType": "String"
-        },
-        {
-          "name": "verificationCode",
-          "columnType": 0,
-          "isNullable": false,
-          "dartType": "String"
-        }
-      ],
-      "foreignKeys": [],
-      "indexes": [
-        {
-          "indexName": "serverpod_email_create_request_pkey",
-          "elements": [
-            {
-              "type": 0,
-              "definition": "id"
-            }
-          ],
-          "type": "btree",
-          "isUnique": true,
-          "isPrimary": true
-        },
-        {
-          "indexName": "serverpod_email_auth_create_account_request_idx",
-          "elements": [
-            {
-              "type": 0,
-              "definition": "email"
-            }
-          ],
-          "type": "btree",
-          "isUnique": true,
-          "isPrimary": false
-        }
-      ],
-      "managed": true
-    },
-    {
-      "name": "serverpod_email_failed_sign_in",
-      "dartName": "EmailFailedSignIn",
-      "module": "serverpod_auth",
-      "schema": "public",
-      "columns": [
-        {
-          "name": "id",
-          "columnType": 6,
-          "isNullable": false,
-          "columnDefault": "nextval('serverpod_email_failed_sign_in_id_seq'::regclass)",
-          "dartType": "int?"
-        },
-        {
-          "name": "email",
-          "columnType": 0,
-          "isNullable": false,
-          "dartType": "String"
-        },
-        {
-          "name": "time",
-          "columnType": 4,
-          "isNullable": false,
-          "dartType": "DateTime"
-        },
-        {
-          "name": "ipAddress",
-          "columnType": 0,
-          "isNullable": false,
-          "dartType": "String"
-        }
-      ],
-      "foreignKeys": [],
-      "indexes": [
-        {
-          "indexName": "serverpod_email_failed_sign_in_pkey",
-          "elements": [
-            {
-              "type": 0,
-              "definition": "id"
-            }
-          ],
-          "type": "btree",
-          "isUnique": true,
-          "isPrimary": true
-        },
-        {
-          "indexName": "serverpod_email_failed_sign_in_email_idx",
-          "elements": [
-            {
-              "type": 0,
-              "definition": "email"
-            }
-          ],
-          "type": "btree",
-          "isUnique": false,
-          "isPrimary": false
-        },
-        {
-          "indexName": "serverpod_email_failed_sign_in_time_idx",
-          "elements": [
-            {
-              "type": 0,
-              "definition": "time"
-            }
-          ],
-          "type": "btree",
-          "isUnique": false,
-          "isPrimary": false
-        }
-      ],
-      "managed": true
-    },
-    {
-      "name": "serverpod_email_reset",
-      "dartName": "EmailReset",
-      "module": "serverpod_auth",
-      "schema": "public",
-      "columns": [
-        {
-          "name": "id",
-          "columnType": 6,
-          "isNullable": false,
-          "columnDefault": "nextval('serverpod_email_reset_id_seq'::regclass)",
-          "dartType": "int?"
-        },
-        {
-          "name": "userId",
-          "columnType": 6,
-          "isNullable": false,
-          "dartType": "int"
-        },
-        {
-          "name": "verificationCode",
-          "columnType": 0,
-          "isNullable": false,
-          "dartType": "String"
-        },
-        {
-          "name": "expiration",
-          "columnType": 4,
-          "isNullable": false,
-          "dartType": "DateTime"
-        }
-      ],
-      "foreignKeys": [],
-      "indexes": [
-        {
-          "indexName": "serverpod_email_reset_pkey",
-          "elements": [
-            {
-              "type": 0,
-              "definition": "id"
-            }
-          ],
-          "type": "btree",
-          "isUnique": true,
-          "isPrimary": true
-        },
-        {
-          "indexName": "serverpod_email_reset_verification_idx",
-          "elements": [
-            {
-              "type": 0,
-              "definition": "verificationCode"
-            }
-          ],
-          "type": "btree",
-          "isUnique": true,
-          "isPrimary": false
-        }
-      ],
-      "managed": true
-    },
-    {
-      "name": "serverpod_google_refresh_token",
-      "dartName": "GoogleRefreshToken",
-      "module": "serverpod_auth",
-      "schema": "public",
-      "columns": [
-        {
-          "name": "id",
-          "columnType": 6,
-          "isNullable": false,
-          "columnDefault": "nextval('serverpod_google_refresh_token_id_seq'::regclass)",
-          "dartType": "int?"
-        },
-        {
-          "name": "userId",
-          "columnType": 6,
-          "isNullable": false,
-          "dartType": "int"
-        },
-        {
-          "name": "refreshToken",
-          "columnType": 0,
-          "isNullable": false,
-          "dartType": "String"
-        }
-      ],
-      "foreignKeys": [],
-      "indexes": [
-        {
-          "indexName": "serverpod_google_refresh_token_pkey",
-          "elements": [
-            {
-              "type": 0,
-              "definition": "id"
-            }
-          ],
-          "type": "btree",
-          "isUnique": true,
-          "isPrimary": true
-        },
-        {
-          "indexName": "serverpod_google_refresh_token_userId_idx",
-          "elements": [
-            {
-              "type": 0,
-              "definition": "userId"
-            }
-          ],
-          "type": "btree",
-          "isUnique": true,
-          "isPrimary": false
-        }
-      ],
-      "managed": true
-    },
-    {
-      "name": "serverpod_user_image",
-      "dartName": "UserImage",
-      "module": "serverpod_auth",
-      "schema": "public",
-      "columns": [
-        {
-          "name": "id",
-          "columnType": 6,
-          "isNullable": false,
-          "columnDefault": "nextval('serverpod_user_image_id_seq'::regclass)",
-          "dartType": "int?"
-        },
-        {
-          "name": "userId",
-          "columnType": 6,
-          "isNullable": false,
-          "dartType": "int"
-        },
-        {
-          "name": "version",
-          "columnType": 6,
-          "isNullable": false,
-          "dartType": "int"
-        },
-        {
-          "name": "url",
-          "columnType": 0,
-          "isNullable": false,
-          "dartType": "String"
-        }
-      ],
-      "foreignKeys": [],
-      "indexes": [
-        {
-          "indexName": "serverpod_user_image_pkey",
-          "elements": [
-            {
-              "type": 0,
-              "definition": "id"
-            }
-          ],
-          "type": "btree",
-          "isUnique": true,
-          "isPrimary": true
-        },
-        {
-          "indexName": "serverpod_user_image_user_id",
-          "elements": [
-            {
-              "type": 0,
-              "definition": "userId"
-            },
-            {
-              "type": 0,
-              "definition": "version"
-            }
-          ],
-          "type": "btree",
-          "isUnique": false,
-          "isPrimary": false
-        }
-      ],
-      "managed": true
-    },
-    {
-      "name": "serverpod_user_info",
-      "dartName": "UserInfo",
-      "module": "serverpod_auth",
-      "schema": "public",
-      "columns": [
-        {
-          "name": "id",
-          "columnType": 6,
-          "isNullable": false,
-          "columnDefault": "nextval('serverpod_user_info_id_seq'::regclass)",
-          "dartType": "int?"
-        },
-        {
-          "name": "userIdentifier",
-          "columnType": 0,
-          "isNullable": false,
-          "dartType": "String"
-        },
-        {
-          "name": "userName",
-          "columnType": 0,
-          "isNullable": true,
-          "dartType": "String?"
-        },
-        {
-          "name": "fullName",
-          "columnType": 0,
-          "isNullable": true,
-          "dartType": "String?"
-        },
-        {
-          "name": "email",
-          "columnType": 0,
-          "isNullable": true,
-          "dartType": "String?"
-        },
-        {
-          "name": "created",
-          "columnType": 4,
-          "isNullable": false,
-          "dartType": "DateTime"
-        },
-        {
-          "name": "imageUrl",
-          "columnType": 0,
-          "isNullable": true,
-          "dartType": "String?"
-        },
-        {
-          "name": "scopeNames",
-          "columnType": 8,
-          "isNullable": false,
-          "dartType": "List<String>"
-        },
-        {
-          "name": "blocked",
-          "columnType": 1,
-          "isNullable": false,
-          "dartType": "bool"
-        }
-      ],
-      "foreignKeys": [],
-      "indexes": [
-        {
-          "indexName": "serverpod_user_info_pkey",
-          "elements": [
-            {
-              "type": 0,
-              "definition": "id"
-            }
-          ],
-          "type": "btree",
-          "isUnique": true,
-          "isPrimary": true
-        },
-        {
-          "indexName": "serverpod_user_info_user_identifier",
-          "elements": [
-            {
-              "type": 0,
-              "definition": "userIdentifier"
-            }
-          ],
-          "type": "btree",
-          "isUnique": true,
-          "isPrimary": false
-        },
-        {
-          "indexName": "serverpod_user_info_email",
-          "elements": [
-            {
-              "type": 0,
-              "definition": "email"
-            }
-          ],
-          "type": "btree",
-          "isUnique": false,
-          "isPrimary": false
-        }
-      ],
-      "managed": true
-    },
-    {
-      "name": "serverpod_auth_email_account",
-      "dartName": "EmailAccount",
-      "module": "serverpod_auth_email_account",
-      "schema": "public",
-      "columns": [
-        {
-          "name": "id",
-          "columnType": 7,
-          "isNullable": false,
-          "columnDefault": "gen_random_uuid()",
-          "dartType": "UuidValue?"
-        },
-        {
-          "name": "authUserId",
-          "columnType": 7,
-          "isNullable": false,
-          "dartType": "UuidValue"
-        },
-        {
-          "name": "created",
-          "columnType": 4,
-          "isNullable": false,
-          "dartType": "DateTime"
-        },
-        {
-          "name": "email",
-          "columnType": 0,
-          "isNullable": false,
-          "dartType": "String"
-        },
-        {
-          "name": "passwordHash",
-          "columnType": 5,
-          "isNullable": false,
-          "dartType": "dart:typed_data:ByteData"
-        },
-        {
-          "name": "passwordSalt",
-          "columnType": 5,
-          "isNullable": false,
-          "dartType": "dart:typed_data:ByteData"
-        }
-      ],
-      "foreignKeys": [
-        {
-          "constraintName": "serverpod_auth_email_account_fk_0",
-          "columns": [
-            "authUserId"
-          ],
-          "referenceTable": "serverpod_auth_user",
-          "referenceTableSchema": "public",
-          "referenceColumns": [
-            "id"
-          ],
-          "onUpdate": 3,
-          "onDelete": 4
-        }
-      ],
-      "indexes": [
-        {
-          "indexName": "serverpod_auth_email_account_pkey",
-          "elements": [
-            {
-              "type": 0,
-              "definition": "id"
-            }
-          ],
-          "type": "btree",
-          "isUnique": true,
-          "isPrimary": true
-        },
-        {
-          "indexName": "serverpod_auth_email_account_email",
-          "elements": [
-            {
-              "type": 0,
-              "definition": "email"
-            }
-          ],
-          "type": "btree",
-          "isUnique": true,
-          "isPrimary": false
-        }
-      ],
-      "managed": true
-    },
-    {
-      "name": "serverpod_auth_email_account_failed_login_attempt",
-      "dartName": "EmailAccountFailedLoginAttempt",
-      "module": "serverpod_auth_email_account",
-      "schema": "public",
-      "columns": [
-        {
-          "name": "id",
-          "columnType": 7,
-          "isNullable": false,
-          "columnDefault": "gen_random_uuid()",
-          "dartType": "UuidValue?"
-        },
-        {
-          "name": "email",
-          "columnType": 0,
-          "isNullable": false,
-          "dartType": "String"
-        },
-        {
-          "name": "attemptedAt",
-          "columnType": 4,
-          "isNullable": false,
-          "dartType": "DateTime"
-        },
-        {
-          "name": "ipAddress",
-          "columnType": 0,
-          "isNullable": false,
-          "dartType": "String"
-        }
-      ],
-      "foreignKeys": [],
-      "indexes": [
-        {
-          "indexName": "serverpod_auth_email_account_failed_login_attempt_pkey",
-          "elements": [
-            {
-              "type": 0,
-              "definition": "id"
-            }
-          ],
-          "type": "btree",
-          "isUnique": true,
-          "isPrimary": true
-        },
-        {
-          "indexName": "serverpod_auth_email_account_failed_login_attempt_email",
-          "elements": [
-            {
-              "type": 0,
-              "definition": "email"
-            }
-          ],
-          "type": "btree",
-          "isUnique": false,
-          "isPrimary": false
-        },
-        {
-          "indexName": "serverpod_auth_email_account_failed_login_attempt_attempted_at",
-          "elements": [
-            {
-              "type": 0,
-              "definition": "attemptedAt"
-            }
-          ],
-          "type": "btree",
-          "isUnique": false,
-          "isPrimary": false
-        }
-      ],
-      "managed": true
-    },
-    {
-      "name": "serverpod_auth_email_account_password_reset_attempt",
-      "dartName": "EmailAccountPasswordResetAttempt",
-      "module": "serverpod_auth_email_account",
-      "schema": "public",
-      "columns": [
-        {
-          "name": "id",
-          "columnType": 7,
-          "isNullable": false,
-          "columnDefault": "gen_random_uuid()",
-          "dartType": "UuidValue?"
-        },
-        {
-          "name": "attemptedAt",
-          "columnType": 4,
-          "isNullable": false,
-          "dartType": "DateTime"
-        },
-        {
-          "name": "ipAddress",
-          "columnType": 0,
-          "isNullable": false,
-          "dartType": "String"
-        },
-        {
-          "name": "passwordResetRequestId",
-          "columnType": 7,
-          "isNullable": false,
-          "dartType": "UuidValue"
-        }
-      ],
-      "foreignKeys": [
-        {
-          "constraintName": "serverpod_auth_email_account_password_reset_attempt_fk_0",
-          "columns": [
-            "passwordResetRequestId"
-          ],
-          "referenceTable": "serverpod_auth_email_account_password_reset_request",
-          "referenceTableSchema": "public",
-          "referenceColumns": [
-            "id"
-          ],
-          "onUpdate": 3,
-          "onDelete": 4
-        }
-      ],
-      "indexes": [
-        {
-          "indexName": "serverpod_auth_email_account_password_reset_attempt_pkey",
-          "elements": [
-            {
-              "type": 0,
-              "definition": "id"
-            }
-          ],
-          "type": "btree",
-          "isUnique": true,
-          "isPrimary": true
-        },
-        {
-          "indexName": "serverpod_auth_email_account_password_reset_attempt_ip",
-          "elements": [
-            {
-              "type": 0,
-              "definition": "ipAddress"
-            }
-          ],
-          "type": "btree",
-          "isUnique": false,
-          "isPrimary": false
-        },
-        {
-          "indexName": "serverpod_auth_email_account_password_reset_attempt_at",
-          "elements": [
-            {
-              "type": 0,
-              "definition": "attemptedAt"
-            }
-          ],
-          "type": "btree",
-          "isUnique": false,
-          "isPrimary": false
-        }
-      ],
-      "managed": true
-    },
-    {
-      "name": "serverpod_auth_email_account_password_reset_request",
-      "dartName": "EmailAccountPasswordResetRequest",
-      "module": "serverpod_auth_email_account",
-      "schema": "public",
-      "columns": [
-        {
-          "name": "id",
-          "columnType": 7,
-          "isNullable": false,
-          "columnDefault": "gen_random_uuid()",
-          "dartType": "UuidValue?"
-        },
-        {
-          "name": "emailAccountId",
-          "columnType": 7,
-          "isNullable": false,
-          "dartType": "UuidValue"
-        },
-        {
-          "name": "created",
-          "columnType": 4,
-          "isNullable": false,
-          "columnDefault": "CURRENT_TIMESTAMP",
-          "dartType": "DateTime"
-        },
-        {
-          "name": "verificationCodeHash",
-          "columnType": 5,
-          "isNullable": false,
-          "dartType": "dart:typed_data:ByteData"
-        },
-        {
-          "name": "verificationCodeSalt",
-          "columnType": 5,
-          "isNullable": false,
-          "dartType": "dart:typed_data:ByteData"
-        }
-      ],
-      "foreignKeys": [
-        {
-          "constraintName": "serverpod_auth_email_account_password_reset_request_fk_0",
-          "columns": [
-            "emailAccountId"
-          ],
-          "referenceTable": "serverpod_auth_email_account",
-          "referenceTableSchema": "public",
-          "referenceColumns": [
-            "id"
-          ],
-          "onUpdate": 3,
-          "onDelete": 4
-        }
-      ],
-      "indexes": [
-        {
-          "indexName": "serverpod_auth_email_account_password_reset_request_pkey",
-          "elements": [
-            {
-              "type": 0,
-              "definition": "id"
-            }
-          ],
-          "type": "btree",
-          "isUnique": true,
-          "isPrimary": true
-        }
-      ],
-      "managed": true
-    },
-    {
-      "name": "serverpod_auth_email_account_pw_reset_request_attempt",
-      "dartName": "EmailAccountPasswordResetRequestAttempt",
-      "module": "serverpod_auth_email_account",
-      "schema": "public",
-      "columns": [
-        {
-          "name": "id",
-          "columnType": 7,
-          "isNullable": false,
-          "columnDefault": "gen_random_uuid()",
-          "dartType": "UuidValue?"
-        },
-        {
-          "name": "email",
-          "columnType": 0,
-          "isNullable": false,
-          "dartType": "String"
-        },
-        {
-          "name": "attemptedAt",
-          "columnType": 4,
-          "isNullable": false,
-          "dartType": "DateTime"
-        },
-        {
-          "name": "ipAddress",
-          "columnType": 0,
-          "isNullable": false,
-          "dartType": "String"
-        }
-      ],
-      "foreignKeys": [],
-      "indexes": [
-        {
-          "indexName": "serverpod_auth_email_account_pw_reset_request_attempt_pkey",
-          "elements": [
-            {
-              "type": 0,
-              "definition": "id"
-            }
-          ],
-          "type": "btree",
-          "isUnique": true,
-          "isPrimary": true
-        },
-        {
-          "indexName": "serverpod_auth_email_account_pw_reset_request_attempt_email",
-          "elements": [
-            {
-              "type": 0,
-              "definition": "email"
-            }
-          ],
-          "type": "btree",
-          "isUnique": false,
-          "isPrimary": false
-        },
-        {
-          "indexName": "serverpod_auth_email_account_pw_reset_request_attempt_ip",
-          "elements": [
-            {
-              "type": 0,
-              "definition": "ipAddress"
-            }
-          ],
-          "type": "btree",
-          "isUnique": false,
-          "isPrimary": false
-        },
-        {
-          "indexName": "serverpod_auth_email_account_pw_reset_request_attempt_at",
-          "elements": [
-            {
-              "type": 0,
-              "definition": "attemptedAt"
-            }
-          ],
-          "type": "btree",
-          "isUnique": false,
-          "isPrimary": false
-        }
-      ],
-      "managed": true
-    },
-    {
-      "name": "serverpod_auth_email_account_request",
-      "dartName": "EmailAccountRequest",
-      "module": "serverpod_auth_email_account",
-      "schema": "public",
-      "columns": [
-        {
-          "name": "id",
-          "columnType": 7,
-          "isNullable": false,
-          "columnDefault": "gen_random_uuid()",
-          "dartType": "UuidValue?"
-        },
-        {
-          "name": "created",
-          "columnType": 4,
-          "isNullable": false,
-          "columnDefault": "CURRENT_TIMESTAMP",
-          "dartType": "DateTime"
-        },
-        {
-          "name": "email",
-          "columnType": 0,
-          "isNullable": false,
-          "dartType": "String"
-        },
-        {
-          "name": "passwordHash",
-          "columnType": 5,
-          "isNullable": false,
-          "dartType": "dart:typed_data:ByteData"
-        },
-        {
-          "name": "passwordSalt",
-          "columnType": 5,
-          "isNullable": false,
-          "dartType": "dart:typed_data:ByteData"
-        },
-        {
-          "name": "verificationCodeHash",
-          "columnType": 5,
-          "isNullable": false,
-          "dartType": "dart:typed_data:ByteData"
-        },
-        {
-          "name": "verificationCodeSalt",
-          "columnType": 5,
-          "isNullable": false,
-          "dartType": "dart:typed_data:ByteData"
-        },
-        {
-          "name": "verifiedAt",
-          "columnType": 4,
-          "isNullable": true,
-          "dartType": "DateTime?"
-        }
-      ],
-      "foreignKeys": [],
-      "indexes": [
-        {
-          "indexName": "serverpod_auth_email_account_request_pkey",
-          "elements": [
-            {
-              "type": 0,
-              "definition": "id"
-            }
-          ],
-          "type": "btree",
-          "isUnique": true,
-          "isPrimary": true
-        },
-        {
-          "indexName": "serverpod_auth_email_account_request_email",
-          "elements": [
-            {
-              "type": 0,
-              "definition": "email"
-            }
-          ],
-          "type": "btree",
-          "isUnique": true,
-          "isPrimary": false
-        }
-      ],
-      "managed": true
-    },
-    {
-      "name": "serverpod_auth_email_account_request_completion_attempt",
-      "dartName": "EmailAccountRequestCompletionAttempt",
-      "module": "serverpod_auth_email_account",
-      "schema": "public",
-      "columns": [
-        {
-          "name": "id",
-          "columnType": 7,
-          "isNullable": false,
-          "columnDefault": "gen_random_uuid()",
-          "dartType": "UuidValue?"
-        },
-        {
-          "name": "attemptedAt",
-          "columnType": 4,
-          "isNullable": false,
-          "dartType": "DateTime"
-        },
-        {
-          "name": "ipAddress",
-          "columnType": 0,
-          "isNullable": false,
-          "dartType": "String"
-        },
-        {
-          "name": "emailAccountRequestId",
-          "columnType": 7,
-          "isNullable": false,
-          "dartType": "UuidValue"
-        }
-      ],
-      "foreignKeys": [
-        {
-          "constraintName": "serverpod_auth_email_account_request_completion_attempt_fk_0",
-          "columns": [
-            "emailAccountRequestId"
-          ],
-          "referenceTable": "serverpod_auth_email_account_request",
-          "referenceTableSchema": "public",
-          "referenceColumns": [
-            "id"
-          ],
-          "onUpdate": 3,
-          "onDelete": 4
-        }
-      ],
-      "indexes": [
-        {
-          "indexName": "serverpod_auth_email_account_request_completion_attempt_pkey",
-          "elements": [
-            {
-              "type": 0,
-              "definition": "id"
-            }
-          ],
-          "type": "btree",
-          "isUnique": true,
-          "isPrimary": true
-        },
-        {
-          "indexName": "serverpod_auth_email_account_request_completion_attempt_ip",
-          "elements": [
-            {
-              "type": 0,
-              "definition": "ipAddress"
-            }
-          ],
-          "type": "btree",
-          "isUnique": false,
-          "isPrimary": false
-        },
-        {
-          "indexName": "serverpod_auth_email_account_request_completion_attempt_at",
-          "elements": [
-            {
-              "type": 0,
-              "definition": "attemptedAt"
-            }
-          ],
-          "type": "btree",
-          "isUnique": false,
-          "isPrimary": false
-        }
-      ],
-      "managed": true
-    },
-    {
       "name": "serverpod_auth_session",
       "dartName": "AuthSession",
       "module": "serverpod_auth_session",
@@ -2902,36 +2049,20 @@
   ],
   "installedModules": [
     {
-      "module": "serverpod_new_auth_test",
-      "version": "20250708110506342"
+      "module": "serverpod_auth_email",
+      "version": "20250724100231671"
     },
     {
       "module": "serverpod",
       "version": "20240516151843329"
     },
     {
-      "module": "serverpod_auth_backwards_compatibility",
-      "version": "20250708110241098"
-    },
-    {
-      "module": "serverpod_auth_email",
-      "version": "20250611073844715"
-    },
-    {
-      "module": "serverpod_auth_migration",
-      "version": "20250705132233496"
+      "module": "serverpod_auth_email_account",
+      "version": "20250724100154487"
     },
     {
       "module": "serverpod_auth_profile",
       "version": "20250519092101868"
-    },
-    {
-      "module": "serverpod_auth",
-      "version": "20240520102713718"
-    },
-    {
-      "module": "serverpod_auth_email_account",
-      "version": "20250606090748154"
     },
     {
       "module": "serverpod_auth_session",

--- a/modules/new_serverpod_auth/serverpod_auth_email/serverpod_auth_email_server/migrations/20250724100231671/definition.sql
+++ b/modules/new_serverpod_auth/serverpod_auth_email/serverpod_auth_email_server/migrations/20250724100231671/definition.sql
@@ -227,27 +227,27 @@ CREATE UNIQUE INDEX "serverpod_auth_email_account_email" ON "serverpod_auth_emai
 CREATE TABLE "serverpod_auth_email_account_failed_login_attempt" (
     "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
     "email" text NOT NULL,
-    "attemptedAt" timestamp without time zone NOT NULL,
+    "attempted" timestamp without time zone NOT NULL,
     "ipAddress" text NOT NULL
 );
 
 -- Indexes
 CREATE INDEX "serverpod_auth_email_account_failed_login_attempt_email" ON "serverpod_auth_email_account_failed_login_attempt" USING btree ("email");
-CREATE INDEX "serverpod_auth_email_account_failed_login_attempt_attempted_at" ON "serverpod_auth_email_account_failed_login_attempt" USING btree ("attemptedAt");
+CREATE INDEX "serverpod_auth_email_account_failed_login_attempt_attempted" ON "serverpod_auth_email_account_failed_login_attempt" USING btree ("attempted");
 
 --
 -- Class EmailAccountPasswordResetAttempt as table serverpod_auth_email_account_password_reset_attempt
 --
 CREATE TABLE "serverpod_auth_email_account_password_reset_attempt" (
     "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-    "attemptedAt" timestamp without time zone NOT NULL,
+    "attempted" timestamp without time zone NOT NULL,
     "ipAddress" text NOT NULL,
     "passwordResetRequestId" uuid NOT NULL
 );
 
 -- Indexes
 CREATE INDEX "serverpod_auth_email_account_password_reset_attempt_ip" ON "serverpod_auth_email_account_password_reset_attempt" USING btree ("ipAddress");
-CREATE INDEX "serverpod_auth_email_account_password_reset_attempt_at" ON "serverpod_auth_email_account_password_reset_attempt" USING btree ("attemptedAt");
+CREATE INDEX "serverpod_auth_email_account_password_reset_attempted" ON "serverpod_auth_email_account_password_reset_attempt" USING btree ("attempted");
 
 --
 -- Class EmailAccountPasswordResetRequest as table serverpod_auth_email_account_password_reset_request
@@ -266,14 +266,14 @@ CREATE TABLE "serverpod_auth_email_account_password_reset_request" (
 CREATE TABLE "serverpod_auth_email_account_pw_reset_request_attempt" (
     "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
     "email" text NOT NULL,
-    "attemptedAt" timestamp without time zone NOT NULL,
+    "attempted" timestamp without time zone NOT NULL,
     "ipAddress" text NOT NULL
 );
 
 -- Indexes
 CREATE INDEX "serverpod_auth_email_account_pw_reset_request_attempt_email" ON "serverpod_auth_email_account_pw_reset_request_attempt" USING btree ("email");
 CREATE INDEX "serverpod_auth_email_account_pw_reset_request_attempt_ip" ON "serverpod_auth_email_account_pw_reset_request_attempt" USING btree ("ipAddress");
-CREATE INDEX "serverpod_auth_email_account_pw_reset_request_attempt_at" ON "serverpod_auth_email_account_pw_reset_request_attempt" USING btree ("attemptedAt");
+CREATE INDEX "serverpod_auth_email_account_pw_reset_request_attempted" ON "serverpod_auth_email_account_pw_reset_request_attempt" USING btree ("attempted");
 
 --
 -- Class EmailAccountRequest as table serverpod_auth_email_account_request
@@ -297,14 +297,14 @@ CREATE UNIQUE INDEX "serverpod_auth_email_account_request_email" ON "serverpod_a
 --
 CREATE TABLE "serverpod_auth_email_account_request_completion_attempt" (
     "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-    "attemptedAt" timestamp without time zone NOT NULL,
+    "attempted" timestamp without time zone NOT NULL,
     "ipAddress" text NOT NULL,
     "emailAccountRequestId" uuid NOT NULL
 );
 
 -- Indexes
 CREATE INDEX "serverpod_auth_email_account_request_completion_attempt_ip" ON "serverpod_auth_email_account_request_completion_attempt" USING btree ("ipAddress");
-CREATE INDEX "serverpod_auth_email_account_request_completion_attempt_at" ON "serverpod_auth_email_account_request_completion_attempt" USING btree ("attemptedAt");
+CREATE INDEX "serverpod_auth_email_account_request_completion_attempted" ON "serverpod_auth_email_account_request_completion_attempt" USING btree ("attempted");
 
 --
 -- Class UserProfile as table serverpod_auth_profile_user_profile
@@ -340,8 +340,11 @@ CREATE TABLE "serverpod_auth_profile_user_profile_image" (
 CREATE TABLE "serverpod_auth_session" (
     "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
     "authUserId" uuid NOT NULL,
-    "created" timestamp without time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "scopeNames" json NOT NULL,
+    "created" timestamp without time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "lastUsed" timestamp without time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "expiresAt" timestamp without time zone,
+    "expireAfterUnusedFor" bigint,
     "sessionKeyHash" bytea NOT NULL,
     "sessionKeySalt" bytea NOT NULL,
     "method" text NOT NULL
@@ -468,9 +471,9 @@ ALTER TABLE ONLY "serverpod_auth_session"
 -- MIGRATION VERSION FOR serverpod_auth_email
 --
 INSERT INTO "serverpod_migrations" ("module", "version", "timestamp")
-    VALUES ('serverpod_auth_email', '20250611073844715', now())
+    VALUES ('serverpod_auth_email', '20250724100231671', now())
     ON CONFLICT ("module")
-    DO UPDATE SET "version" = '20250611073844715', "timestamp" = now();
+    DO UPDATE SET "version" = '20250724100231671', "timestamp" = now();
 
 --
 -- MIGRATION VERSION FOR serverpod
@@ -484,9 +487,9 @@ INSERT INTO "serverpod_migrations" ("module", "version", "timestamp")
 -- MIGRATION VERSION FOR serverpod_auth_email_account
 --
 INSERT INTO "serverpod_migrations" ("module", "version", "timestamp")
-    VALUES ('serverpod_auth_email_account', '20250606090748154', now())
+    VALUES ('serverpod_auth_email_account', '20250724100154487', now())
     ON CONFLICT ("module")
-    DO UPDATE SET "version" = '20250606090748154', "timestamp" = now();
+    DO UPDATE SET "version" = '20250724100154487', "timestamp" = now();
 
 --
 -- MIGRATION VERSION FOR serverpod_auth_profile
@@ -500,9 +503,9 @@ INSERT INTO "serverpod_migrations" ("module", "version", "timestamp")
 -- MIGRATION VERSION FOR serverpod_auth_session
 --
 INSERT INTO "serverpod_migrations" ("module", "version", "timestamp")
-    VALUES ('serverpod_auth_session', '20250607101155018', now())
+    VALUES ('serverpod_auth_session', '20250611085050241', now())
     ON CONFLICT ("module")
-    DO UPDATE SET "version" = '20250607101155018', "timestamp" = now();
+    DO UPDATE SET "version" = '20250611085050241', "timestamp" = now();
 
 --
 -- MIGRATION VERSION FOR serverpod_auth_user

--- a/modules/new_serverpod_auth/serverpod_auth_email/serverpod_auth_email_server/migrations/20250724100231671/definition_project.json
+++ b/modules/new_serverpod_auth/serverpod_auth_email/serverpod_auth_email_server/migrations/20250724100231671/definition_project.json
@@ -8,7 +8,7 @@
     },
     {
       "module": "serverpod_auth_email_account",
-      "version": "20250606090748154"
+      "version": "20250724100154487"
     },
     {
       "module": "serverpod_auth_profile",
@@ -16,7 +16,7 @@
     },
     {
       "module": "serverpod_auth_session",
-      "version": "20250607101155018"
+      "version": "20250611085050241"
     },
     {
       "module": "serverpod_auth_user",

--- a/modules/new_serverpod_auth/serverpod_auth_email/serverpod_auth_email_server/migrations/20250724100231671/migration.json
+++ b/modules/new_serverpod_auth/serverpod_auth_email/serverpod_auth_email_server/migrations/20250724100231671/migration.json
@@ -3,222 +3,6 @@
     {
       "type": "createTable",
       "createTable": {
-        "name": "serverpod_auth_backwards_compatibility_email_password",
-        "dartName": "LegacyEmailPassword",
-        "module": "serverpod_auth_backwards_compatibility",
-        "schema": "public",
-        "columns": [
-          {
-            "name": "id",
-            "columnType": 7,
-            "isNullable": false,
-            "columnDefault": "gen_random_uuid()",
-            "dartType": "UuidValue?"
-          },
-          {
-            "name": "emailAccountId",
-            "columnType": 7,
-            "isNullable": false,
-            "dartType": "UuidValue"
-          },
-          {
-            "name": "hash",
-            "columnType": 0,
-            "isNullable": false,
-            "dartType": "String"
-          }
-        ],
-        "foreignKeys": [
-          {
-            "constraintName": "serverpod_auth_backwards_compatibility_email_password_fk_0",
-            "columns": [
-              "emailAccountId"
-            ],
-            "referenceTable": "serverpod_auth_email_account",
-            "referenceTableSchema": "public",
-            "referenceColumns": [
-              "id"
-            ],
-            "onUpdate": 3,
-            "onDelete": 4
-          }
-        ],
-        "indexes": [
-          {
-            "indexName": "serverpod_auth_backwards_compatibility_email_password_pkey",
-            "elements": [
-              {
-                "type": 0,
-                "definition": "id"
-              }
-            ],
-            "type": "btree",
-            "isUnique": true,
-            "isPrimary": true
-          },
-          {
-            "indexName": "serverpod_auth_backwards_compatibility_email_password_account",
-            "elements": [
-              {
-                "type": 0,
-                "definition": "emailAccountId"
-              }
-            ],
-            "type": "btree",
-            "isUnique": true,
-            "isPrimary": false
-          }
-        ],
-        "managed": true
-      }
-    },
-    {
-      "type": "createTable",
-      "createTable": {
-        "name": "serverpod_auth_backwards_compatibility_external_user_id",
-        "dartName": "LegacyExternalUserIdentifier",
-        "module": "serverpod_auth_backwards_compatibility",
-        "schema": "public",
-        "columns": [
-          {
-            "name": "id",
-            "columnType": 7,
-            "isNullable": false,
-            "columnDefault": "gen_random_uuid()",
-            "dartType": "UuidValue?"
-          },
-          {
-            "name": "authUserId",
-            "columnType": 7,
-            "isNullable": false,
-            "dartType": "UuidValue"
-          },
-          {
-            "name": "userIdentifier",
-            "columnType": 0,
-            "isNullable": false,
-            "dartType": "String"
-          }
-        ],
-        "foreignKeys": [
-          {
-            "constraintName": "serverpod_auth_backwards_compatibility_external_user_id_fk_0",
-            "columns": [
-              "authUserId"
-            ],
-            "referenceTable": "serverpod_auth_user",
-            "referenceTableSchema": "public",
-            "referenceColumns": [
-              "id"
-            ],
-            "onUpdate": 3,
-            "onDelete": 4
-          }
-        ],
-        "indexes": [
-          {
-            "indexName": "serverpod_auth_backwards_compatibility_external_user_id_pkey",
-            "elements": [
-              {
-                "type": 0,
-                "definition": "id"
-              }
-            ],
-            "type": "btree",
-            "isUnique": true,
-            "isPrimary": true
-          },
-          {
-            "indexName": "serverpod_auth_backwards_compatibility_external_user_id_id",
-            "elements": [
-              {
-                "type": 0,
-                "definition": "userIdentifier"
-              }
-            ],
-            "type": "btree",
-            "isUnique": true,
-            "isPrimary": false
-          }
-        ],
-        "managed": true
-      }
-    },
-    {
-      "type": "createTable",
-      "createTable": {
-        "name": "serverpod_auth_backwards_compatibility_session",
-        "dartName": "LegacySession",
-        "module": "serverpod_auth_backwards_compatibility",
-        "schema": "public",
-        "columns": [
-          {
-            "name": "id",
-            "columnType": 6,
-            "isNullable": false,
-            "columnDefault": "nextval('serverpod_auth_backwards_compatibility_session_id_seq'::regclass)",
-            "dartType": "int?"
-          },
-          {
-            "name": "authUserId",
-            "columnType": 7,
-            "isNullable": false,
-            "dartType": "UuidValue"
-          },
-          {
-            "name": "scopeNames",
-            "columnType": 8,
-            "isNullable": false,
-            "dartType": "Set<String>"
-          },
-          {
-            "name": "hash",
-            "columnType": 0,
-            "isNullable": false,
-            "dartType": "String"
-          },
-          {
-            "name": "method",
-            "columnType": 0,
-            "isNullable": false,
-            "dartType": "String"
-          }
-        ],
-        "foreignKeys": [
-          {
-            "constraintName": "serverpod_auth_backwards_compatibility_session_fk_0",
-            "columns": [
-              "authUserId"
-            ],
-            "referenceTable": "serverpod_auth_user",
-            "referenceTableSchema": "public",
-            "referenceColumns": [
-              "id"
-            ],
-            "onUpdate": 3,
-            "onDelete": 4
-          }
-        ],
-        "indexes": [
-          {
-            "indexName": "serverpod_auth_backwards_compatibility_session_pkey",
-            "elements": [
-              {
-                "type": 0,
-                "definition": "id"
-              }
-            ],
-            "type": "btree",
-            "isUnique": true,
-            "isPrimary": true
-          }
-        ],
-        "managed": true
-      }
-    },
-    {
-      "type": "createTable",
-      "createTable": {
         "name": "serverpod_cloud_storage",
         "dartName": "CloudStorageEntry",
         "module": "serverpod",
@@ -1504,7 +1288,7 @@
             "dartType": "String"
           },
           {
-            "name": "attemptedAt",
+            "name": "attempted",
             "columnType": 4,
             "isNullable": false,
             "dartType": "DateTime"
@@ -1543,11 +1327,11 @@
             "isPrimary": false
           },
           {
-            "indexName": "serverpod_auth_email_account_failed_login_attempt_attempted_at",
+            "indexName": "serverpod_auth_email_account_failed_login_attempt_attempted",
             "elements": [
               {
                 "type": 0,
-                "definition": "attemptedAt"
+                "definition": "attempted"
               }
             ],
             "type": "btree",
@@ -1574,7 +1358,7 @@
             "dartType": "UuidValue?"
           },
           {
-            "name": "attemptedAt",
+            "name": "attempted",
             "columnType": 4,
             "isNullable": false,
             "dartType": "DateTime"
@@ -1633,11 +1417,11 @@
             "isPrimary": false
           },
           {
-            "indexName": "serverpod_auth_email_account_password_reset_attempt_at",
+            "indexName": "serverpod_auth_email_account_password_reset_attempted",
             "elements": [
               {
                 "type": 0,
-                "definition": "attemptedAt"
+                "definition": "attempted"
               }
             ],
             "type": "btree",
@@ -1743,7 +1527,7 @@
             "dartType": "String"
           },
           {
-            "name": "attemptedAt",
+            "name": "attempted",
             "columnType": 4,
             "isNullable": false,
             "dartType": "DateTime"
@@ -1794,11 +1578,11 @@
             "isPrimary": false
           },
           {
-            "indexName": "serverpod_auth_email_account_pw_reset_request_attempt_at",
+            "indexName": "serverpod_auth_email_account_pw_reset_request_attempted",
             "elements": [
               {
                 "type": 0,
-                "definition": "attemptedAt"
+                "definition": "attempted"
               }
             ],
             "type": "btree",
@@ -1914,7 +1698,7 @@
             "dartType": "UuidValue?"
           },
           {
-            "name": "attemptedAt",
+            "name": "attempted",
             "columnType": 4,
             "isNullable": false,
             "dartType": "DateTime"
@@ -1973,16 +1757,205 @@
             "isPrimary": false
           },
           {
-            "indexName": "serverpod_auth_email_account_request_completion_attempt_at",
+            "indexName": "serverpod_auth_email_account_request_completion_attempted",
             "elements": [
               {
                 "type": 0,
-                "definition": "attemptedAt"
+                "definition": "attempted"
               }
             ],
             "type": "btree",
             "isUnique": false,
             "isPrimary": false
+          }
+        ],
+        "managed": true
+      }
+    },
+    {
+      "type": "createTable",
+      "createTable": {
+        "name": "serverpod_auth_profile_user_profile",
+        "dartName": "UserProfile",
+        "module": "serverpod_auth_profile",
+        "schema": "public",
+        "columns": [
+          {
+            "name": "id",
+            "columnType": 7,
+            "isNullable": false,
+            "columnDefault": "gen_random_uuid()",
+            "dartType": "UuidValue?"
+          },
+          {
+            "name": "authUserId",
+            "columnType": 7,
+            "isNullable": false,
+            "dartType": "UuidValue"
+          },
+          {
+            "name": "userName",
+            "columnType": 0,
+            "isNullable": true,
+            "dartType": "String?"
+          },
+          {
+            "name": "fullName",
+            "columnType": 0,
+            "isNullable": true,
+            "dartType": "String?"
+          },
+          {
+            "name": "email",
+            "columnType": 0,
+            "isNullable": true,
+            "dartType": "String?"
+          },
+          {
+            "name": "created",
+            "columnType": 4,
+            "isNullable": false,
+            "columnDefault": "CURRENT_TIMESTAMP",
+            "dartType": "DateTime"
+          },
+          {
+            "name": "imageId",
+            "columnType": 7,
+            "isNullable": true,
+            "dartType": "UuidValue?"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "constraintName": "serverpod_auth_profile_user_profile_fk_0",
+            "columns": [
+              "authUserId"
+            ],
+            "referenceTable": "serverpod_auth_user",
+            "referenceTableSchema": "public",
+            "referenceColumns": [
+              "id"
+            ],
+            "onUpdate": 3,
+            "onDelete": 4
+          },
+          {
+            "constraintName": "serverpod_auth_profile_user_profile_fk_1",
+            "columns": [
+              "imageId"
+            ],
+            "referenceTable": "serverpod_auth_profile_user_profile_image",
+            "referenceTableSchema": "public",
+            "referenceColumns": [
+              "id"
+            ],
+            "onUpdate": 3,
+            "onDelete": 3
+          }
+        ],
+        "indexes": [
+          {
+            "indexName": "serverpod_auth_profile_user_profile_pkey",
+            "elements": [
+              {
+                "type": 0,
+                "definition": "id"
+              }
+            ],
+            "type": "btree",
+            "isUnique": true,
+            "isPrimary": true
+          },
+          {
+            "indexName": "serverpod_auth_profile_user_profile_email_auth_user_id",
+            "elements": [
+              {
+                "type": 0,
+                "definition": "authUserId"
+              }
+            ],
+            "type": "btree",
+            "isUnique": true,
+            "isPrimary": false
+          }
+        ],
+        "managed": true
+      }
+    },
+    {
+      "type": "createTable",
+      "createTable": {
+        "name": "serverpod_auth_profile_user_profile_image",
+        "dartName": "UserProfileImage",
+        "module": "serverpod_auth_profile",
+        "schema": "public",
+        "columns": [
+          {
+            "name": "id",
+            "columnType": 7,
+            "isNullable": false,
+            "columnDefault": "gen_random_uuid()",
+            "dartType": "UuidValue?"
+          },
+          {
+            "name": "userProfileId",
+            "columnType": 7,
+            "isNullable": false,
+            "dartType": "UuidValue"
+          },
+          {
+            "name": "created",
+            "columnType": 4,
+            "isNullable": false,
+            "columnDefault": "CURRENT_TIMESTAMP",
+            "dartType": "DateTime"
+          },
+          {
+            "name": "storageId",
+            "columnType": 0,
+            "isNullable": false,
+            "dartType": "String"
+          },
+          {
+            "name": "path",
+            "columnType": 0,
+            "isNullable": false,
+            "dartType": "String"
+          },
+          {
+            "name": "url",
+            "columnType": 0,
+            "isNullable": false,
+            "dartType": "Uri"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "constraintName": "serverpod_auth_profile_user_profile_image_fk_0",
+            "columns": [
+              "userProfileId"
+            ],
+            "referenceTable": "serverpod_auth_profile_user_profile",
+            "referenceTableSchema": "public",
+            "referenceColumns": [
+              "id"
+            ],
+            "onUpdate": 3,
+            "onDelete": 4
+          }
+        ],
+        "indexes": [
+          {
+            "indexName": "serverpod_auth_profile_user_profile_image_pkey",
+            "elements": [
+              {
+                "type": 0,
+                "definition": "id"
+              }
+            ],
+            "type": "btree",
+            "isUnique": true,
+            "isPrimary": true
           }
         ],
         "managed": true

--- a/modules/new_serverpod_auth/serverpod_auth_email/serverpod_auth_email_server/migrations/20250724100231671/migration.sql
+++ b/modules/new_serverpod_auth/serverpod_auth_email/serverpod_auth_email_server/migrations/20250724100231671/migration.sql
@@ -1,20 +1,7 @@
 BEGIN;
 
 --
--- Class MigratedUser as table serverpod_auth_migration_migrated_user
---
-CREATE TABLE "serverpod_auth_migration_migrated_user" (
-    "id" bigserial PRIMARY KEY,
-    "oldUserId" bigint NOT NULL,
-    "newAuthUserId" uuid NOT NULL
-);
-
--- Indexes
-CREATE UNIQUE INDEX "serverpod_auth_migration_migrated_user_old" ON "serverpod_auth_migration_migrated_user" USING btree ("oldUserId");
-CREATE UNIQUE INDEX "serverpod_auth_migration_migrated_user_new" ON "serverpod_auth_migration_migrated_user" USING btree ("newAuthUserId");
-
---
--- Class CloudStorageEntry as table serverpod_cloud_storage
+-- ACTION CREATE TABLE
 --
 CREATE TABLE "serverpod_cloud_storage" (
     "id" bigserial PRIMARY KEY,
@@ -31,7 +18,7 @@ CREATE UNIQUE INDEX "serverpod_cloud_storage_path_idx" ON "serverpod_cloud_stora
 CREATE INDEX "serverpod_cloud_storage_expiration" ON "serverpod_cloud_storage" USING btree ("expiration");
 
 --
--- Class CloudStorageDirectUploadEntry as table serverpod_cloud_storage_direct_upload
+-- ACTION CREATE TABLE
 --
 CREATE TABLE "serverpod_cloud_storage_direct_upload" (
     "id" bigserial PRIMARY KEY,
@@ -45,7 +32,7 @@ CREATE TABLE "serverpod_cloud_storage_direct_upload" (
 CREATE UNIQUE INDEX "serverpod_cloud_storage_direct_upload_storage_path" ON "serverpod_cloud_storage_direct_upload" USING btree ("storageId", "path");
 
 --
--- Class FutureCallEntry as table serverpod_future_call
+-- ACTION CREATE TABLE
 --
 CREATE TABLE "serverpod_future_call" (
     "id" bigserial PRIMARY KEY,
@@ -62,7 +49,7 @@ CREATE INDEX "serverpod_future_call_serverId_idx" ON "serverpod_future_call" USI
 CREATE INDEX "serverpod_future_call_identifier_idx" ON "serverpod_future_call" USING btree ("identifier");
 
 --
--- Class ServerHealthConnectionInfo as table serverpod_health_connection_info
+-- ACTION CREATE TABLE
 --
 CREATE TABLE "serverpod_health_connection_info" (
     "id" bigserial PRIMARY KEY,
@@ -78,7 +65,7 @@ CREATE TABLE "serverpod_health_connection_info" (
 CREATE UNIQUE INDEX "serverpod_health_connection_info_timestamp_idx" ON "serverpod_health_connection_info" USING btree ("timestamp", "serverId", "granularity");
 
 --
--- Class ServerHealthMetric as table serverpod_health_metric
+-- ACTION CREATE TABLE
 --
 CREATE TABLE "serverpod_health_metric" (
     "id" bigserial PRIMARY KEY,
@@ -94,7 +81,7 @@ CREATE TABLE "serverpod_health_metric" (
 CREATE UNIQUE INDEX "serverpod_health_metric_timestamp_idx" ON "serverpod_health_metric" USING btree ("timestamp", "serverId", "name", "granularity");
 
 --
--- Class LogEntry as table serverpod_log
+-- ACTION CREATE TABLE
 --
 CREATE TABLE "serverpod_log" (
     "id" bigserial PRIMARY KEY,
@@ -114,7 +101,7 @@ CREATE TABLE "serverpod_log" (
 CREATE INDEX "serverpod_log_sessionLogId_idx" ON "serverpod_log" USING btree ("sessionLogId");
 
 --
--- Class MessageLogEntry as table serverpod_message_log
+-- ACTION CREATE TABLE
 --
 CREATE TABLE "serverpod_message_log" (
     "id" bigserial PRIMARY KEY,
@@ -131,7 +118,7 @@ CREATE TABLE "serverpod_message_log" (
 );
 
 --
--- Class MethodInfo as table serverpod_method
+-- ACTION CREATE TABLE
 --
 CREATE TABLE "serverpod_method" (
     "id" bigserial PRIMARY KEY,
@@ -143,7 +130,7 @@ CREATE TABLE "serverpod_method" (
 CREATE UNIQUE INDEX "serverpod_method_endpoint_method_idx" ON "serverpod_method" USING btree ("endpoint", "method");
 
 --
--- Class DatabaseMigrationVersion as table serverpod_migrations
+-- ACTION CREATE TABLE
 --
 CREATE TABLE "serverpod_migrations" (
     "id" bigserial PRIMARY KEY,
@@ -156,7 +143,7 @@ CREATE TABLE "serverpod_migrations" (
 CREATE UNIQUE INDEX "serverpod_migrations_ids" ON "serverpod_migrations" USING btree ("module");
 
 --
--- Class QueryLogEntry as table serverpod_query_log
+-- ACTION CREATE TABLE
 --
 CREATE TABLE "serverpod_query_log" (
     "id" bigserial PRIMARY KEY,
@@ -176,7 +163,7 @@ CREATE TABLE "serverpod_query_log" (
 CREATE INDEX "serverpod_query_log_sessionLogId_idx" ON "serverpod_query_log" USING btree ("sessionLogId");
 
 --
--- Class ReadWriteTestEntry as table serverpod_readwrite_test
+-- ACTION CREATE TABLE
 --
 CREATE TABLE "serverpod_readwrite_test" (
     "id" bigserial PRIMARY KEY,
@@ -184,7 +171,7 @@ CREATE TABLE "serverpod_readwrite_test" (
 );
 
 --
--- Class RuntimeSettings as table serverpod_runtime_settings
+-- ACTION CREATE TABLE
 --
 CREATE TABLE "serverpod_runtime_settings" (
     "id" bigserial PRIMARY KEY,
@@ -195,7 +182,7 @@ CREATE TABLE "serverpod_runtime_settings" (
 );
 
 --
--- Class SessionLogEntry as table serverpod_session_log
+-- ACTION CREATE TABLE
 --
 CREATE TABLE "serverpod_session_log" (
     "id" bigserial PRIMARY KEY,
@@ -220,42 +207,7 @@ CREATE INDEX "serverpod_session_log_touched_idx" ON "serverpod_session_log" USIN
 CREATE INDEX "serverpod_session_log_isopen_idx" ON "serverpod_session_log" USING btree ("isOpen");
 
 --
--- Class LegacyEmailPassword as table serverpod_auth_backwards_compatibility_email_password
---
-CREATE TABLE "serverpod_auth_backwards_compatibility_email_password" (
-    "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-    "emailAccountId" uuid NOT NULL,
-    "hash" text NOT NULL
-);
-
--- Indexes
-CREATE UNIQUE INDEX "serverpod_auth_backwards_compatibility_email_password_account" ON "serverpod_auth_backwards_compatibility_email_password" USING btree ("emailAccountId");
-
---
--- Class LegacyExternalUserIdentifier as table serverpod_auth_backwards_compatibility_external_user_id
---
-CREATE TABLE "serverpod_auth_backwards_compatibility_external_user_id" (
-    "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-    "authUserId" uuid NOT NULL,
-    "userIdentifier" text NOT NULL
-);
-
--- Indexes
-CREATE UNIQUE INDEX "serverpod_auth_backwards_compatibility_external_user_id_id" ON "serverpod_auth_backwards_compatibility_external_user_id" USING btree ("userIdentifier");
-
---
--- Class LegacySession as table serverpod_auth_backwards_compatibility_session
---
-CREATE TABLE "serverpod_auth_backwards_compatibility_session" (
-    "id" bigserial PRIMARY KEY,
-    "authUserId" uuid NOT NULL,
-    "scopeNames" json NOT NULL,
-    "hash" text NOT NULL,
-    "method" text NOT NULL
-);
-
---
--- Class EmailAccount as table serverpod_auth_email_account
+-- ACTION CREATE TABLE
 --
 CREATE TABLE "serverpod_auth_email_account" (
     "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -270,35 +222,35 @@ CREATE TABLE "serverpod_auth_email_account" (
 CREATE UNIQUE INDEX "serverpod_auth_email_account_email" ON "serverpod_auth_email_account" USING btree ("email");
 
 --
--- Class EmailAccountFailedLoginAttempt as table serverpod_auth_email_account_failed_login_attempt
+-- ACTION CREATE TABLE
 --
 CREATE TABLE "serverpod_auth_email_account_failed_login_attempt" (
     "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
     "email" text NOT NULL,
-    "attemptedAt" timestamp without time zone NOT NULL,
+    "attempted" timestamp without time zone NOT NULL,
     "ipAddress" text NOT NULL
 );
 
 -- Indexes
 CREATE INDEX "serverpod_auth_email_account_failed_login_attempt_email" ON "serverpod_auth_email_account_failed_login_attempt" USING btree ("email");
-CREATE INDEX "serverpod_auth_email_account_failed_login_attempt_attempted_at" ON "serverpod_auth_email_account_failed_login_attempt" USING btree ("attemptedAt");
+CREATE INDEX "serverpod_auth_email_account_failed_login_attempt_attempted" ON "serverpod_auth_email_account_failed_login_attempt" USING btree ("attempted");
 
 --
--- Class EmailAccountPasswordResetAttempt as table serverpod_auth_email_account_password_reset_attempt
+-- ACTION CREATE TABLE
 --
 CREATE TABLE "serverpod_auth_email_account_password_reset_attempt" (
     "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-    "attemptedAt" timestamp without time zone NOT NULL,
+    "attempted" timestamp without time zone NOT NULL,
     "ipAddress" text NOT NULL,
     "passwordResetRequestId" uuid NOT NULL
 );
 
 -- Indexes
 CREATE INDEX "serverpod_auth_email_account_password_reset_attempt_ip" ON "serverpod_auth_email_account_password_reset_attempt" USING btree ("ipAddress");
-CREATE INDEX "serverpod_auth_email_account_password_reset_attempt_at" ON "serverpod_auth_email_account_password_reset_attempt" USING btree ("attemptedAt");
+CREATE INDEX "serverpod_auth_email_account_password_reset_attempted" ON "serverpod_auth_email_account_password_reset_attempt" USING btree ("attempted");
 
 --
--- Class EmailAccountPasswordResetRequest as table serverpod_auth_email_account_password_reset_request
+-- ACTION CREATE TABLE
 --
 CREATE TABLE "serverpod_auth_email_account_password_reset_request" (
     "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -309,22 +261,22 @@ CREATE TABLE "serverpod_auth_email_account_password_reset_request" (
 );
 
 --
--- Class EmailAccountPasswordResetRequestAttempt as table serverpod_auth_email_account_pw_reset_request_attempt
+-- ACTION CREATE TABLE
 --
 CREATE TABLE "serverpod_auth_email_account_pw_reset_request_attempt" (
     "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
     "email" text NOT NULL,
-    "attemptedAt" timestamp without time zone NOT NULL,
+    "attempted" timestamp without time zone NOT NULL,
     "ipAddress" text NOT NULL
 );
 
 -- Indexes
 CREATE INDEX "serverpod_auth_email_account_pw_reset_request_attempt_email" ON "serverpod_auth_email_account_pw_reset_request_attempt" USING btree ("email");
 CREATE INDEX "serverpod_auth_email_account_pw_reset_request_attempt_ip" ON "serverpod_auth_email_account_pw_reset_request_attempt" USING btree ("ipAddress");
-CREATE INDEX "serverpod_auth_email_account_pw_reset_request_attempt_at" ON "serverpod_auth_email_account_pw_reset_request_attempt" USING btree ("attemptedAt");
+CREATE INDEX "serverpod_auth_email_account_pw_reset_request_attempted" ON "serverpod_auth_email_account_pw_reset_request_attempt" USING btree ("attempted");
 
 --
--- Class EmailAccountRequest as table serverpod_auth_email_account_request
+-- ACTION CREATE TABLE
 --
 CREATE TABLE "serverpod_auth_email_account_request" (
     "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -341,21 +293,21 @@ CREATE TABLE "serverpod_auth_email_account_request" (
 CREATE UNIQUE INDEX "serverpod_auth_email_account_request_email" ON "serverpod_auth_email_account_request" USING btree ("email");
 
 --
--- Class EmailAccountRequestCompletionAttempt as table serverpod_auth_email_account_request_completion_attempt
+-- ACTION CREATE TABLE
 --
 CREATE TABLE "serverpod_auth_email_account_request_completion_attempt" (
     "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-    "attemptedAt" timestamp without time zone NOT NULL,
+    "attempted" timestamp without time zone NOT NULL,
     "ipAddress" text NOT NULL,
     "emailAccountRequestId" uuid NOT NULL
 );
 
 -- Indexes
 CREATE INDEX "serverpod_auth_email_account_request_completion_attempt_ip" ON "serverpod_auth_email_account_request_completion_attempt" USING btree ("ipAddress");
-CREATE INDEX "serverpod_auth_email_account_request_completion_attempt_at" ON "serverpod_auth_email_account_request_completion_attempt" USING btree ("attemptedAt");
+CREATE INDEX "serverpod_auth_email_account_request_completion_attempted" ON "serverpod_auth_email_account_request_completion_attempt" USING btree ("attempted");
 
 --
--- Class UserProfile as table serverpod_auth_profile_user_profile
+-- ACTION CREATE TABLE
 --
 CREATE TABLE "serverpod_auth_profile_user_profile" (
     "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -371,7 +323,7 @@ CREATE TABLE "serverpod_auth_profile_user_profile" (
 CREATE UNIQUE INDEX "serverpod_auth_profile_user_profile_email_auth_user_id" ON "serverpod_auth_profile_user_profile" USING btree ("authUserId");
 
 --
--- Class UserProfileImage as table serverpod_auth_profile_user_profile_image
+-- ACTION CREATE TABLE
 --
 CREATE TABLE "serverpod_auth_profile_user_profile_image" (
     "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -383,119 +335,7 @@ CREATE TABLE "serverpod_auth_profile_user_profile_image" (
 );
 
 --
--- Class AuthKey as table serverpod_auth_key
---
-CREATE TABLE "serverpod_auth_key" (
-    "id" bigserial PRIMARY KEY,
-    "userId" bigint NOT NULL,
-    "hash" text NOT NULL,
-    "scopeNames" json NOT NULL,
-    "method" text NOT NULL
-);
-
--- Indexes
-CREATE INDEX "serverpod_auth_key_userId_idx" ON "serverpod_auth_key" USING btree ("userId");
-
---
--- Class EmailAuth as table serverpod_email_auth
---
-CREATE TABLE "serverpod_email_auth" (
-    "id" bigserial PRIMARY KEY,
-    "userId" bigint NOT NULL,
-    "email" text NOT NULL,
-    "hash" text NOT NULL
-);
-
--- Indexes
-CREATE UNIQUE INDEX "serverpod_email_auth_email" ON "serverpod_email_auth" USING btree ("email");
-
---
--- Class EmailCreateAccountRequest as table serverpod_email_create_request
---
-CREATE TABLE "serverpod_email_create_request" (
-    "id" bigserial PRIMARY KEY,
-    "userName" text NOT NULL,
-    "email" text NOT NULL,
-    "hash" text NOT NULL,
-    "verificationCode" text NOT NULL
-);
-
--- Indexes
-CREATE UNIQUE INDEX "serverpod_email_auth_create_account_request_idx" ON "serverpod_email_create_request" USING btree ("email");
-
---
--- Class EmailFailedSignIn as table serverpod_email_failed_sign_in
---
-CREATE TABLE "serverpod_email_failed_sign_in" (
-    "id" bigserial PRIMARY KEY,
-    "email" text NOT NULL,
-    "time" timestamp without time zone NOT NULL,
-    "ipAddress" text NOT NULL
-);
-
--- Indexes
-CREATE INDEX "serverpod_email_failed_sign_in_email_idx" ON "serverpod_email_failed_sign_in" USING btree ("email");
-CREATE INDEX "serverpod_email_failed_sign_in_time_idx" ON "serverpod_email_failed_sign_in" USING btree ("time");
-
---
--- Class EmailReset as table serverpod_email_reset
---
-CREATE TABLE "serverpod_email_reset" (
-    "id" bigserial PRIMARY KEY,
-    "userId" bigint NOT NULL,
-    "verificationCode" text NOT NULL,
-    "expiration" timestamp without time zone NOT NULL
-);
-
--- Indexes
-CREATE UNIQUE INDEX "serverpod_email_reset_verification_idx" ON "serverpod_email_reset" USING btree ("verificationCode");
-
---
--- Class GoogleRefreshToken as table serverpod_google_refresh_token
---
-CREATE TABLE "serverpod_google_refresh_token" (
-    "id" bigserial PRIMARY KEY,
-    "userId" bigint NOT NULL,
-    "refreshToken" text NOT NULL
-);
-
--- Indexes
-CREATE UNIQUE INDEX "serverpod_google_refresh_token_userId_idx" ON "serverpod_google_refresh_token" USING btree ("userId");
-
---
--- Class UserImage as table serverpod_user_image
---
-CREATE TABLE "serverpod_user_image" (
-    "id" bigserial PRIMARY KEY,
-    "userId" bigint NOT NULL,
-    "version" bigint NOT NULL,
-    "url" text NOT NULL
-);
-
--- Indexes
-CREATE INDEX "serverpod_user_image_user_id" ON "serverpod_user_image" USING btree ("userId", "version");
-
---
--- Class UserInfo as table serverpod_user_info
---
-CREATE TABLE "serverpod_user_info" (
-    "id" bigserial PRIMARY KEY,
-    "userIdentifier" text NOT NULL,
-    "userName" text,
-    "fullName" text,
-    "email" text,
-    "created" timestamp without time zone NOT NULL,
-    "imageUrl" text,
-    "scopeNames" json NOT NULL,
-    "blocked" boolean NOT NULL
-);
-
--- Indexes
-CREATE UNIQUE INDEX "serverpod_user_info_user_identifier" ON "serverpod_user_info" USING btree ("userIdentifier");
-CREATE INDEX "serverpod_user_info_email" ON "serverpod_user_info" USING btree ("email");
-
---
--- Class AuthSession as table serverpod_auth_session
+-- ACTION CREATE TABLE
 --
 CREATE TABLE "serverpod_auth_session" (
     "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -511,7 +351,7 @@ CREATE TABLE "serverpod_auth_session" (
 );
 
 --
--- Class AuthUser as table serverpod_auth_user
+-- ACTION CREATE TABLE
 --
 CREATE TABLE "serverpod_auth_user" (
     "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -521,23 +361,7 @@ CREATE TABLE "serverpod_auth_user" (
 );
 
 --
--- Foreign relations for "serverpod_auth_migration_migrated_user" table
---
-ALTER TABLE ONLY "serverpod_auth_migration_migrated_user"
-    ADD CONSTRAINT "serverpod_auth_migration_migrated_user_fk_0"
-    FOREIGN KEY("oldUserId")
-    REFERENCES "serverpod_user_info"("id")
-    ON DELETE CASCADE
-    ON UPDATE NO ACTION;
-ALTER TABLE ONLY "serverpod_auth_migration_migrated_user"
-    ADD CONSTRAINT "serverpod_auth_migration_migrated_user_fk_1"
-    FOREIGN KEY("newAuthUserId")
-    REFERENCES "serverpod_auth_user"("id")
-    ON DELETE CASCADE
-    ON UPDATE NO ACTION;
-
---
--- Foreign relations for "serverpod_log" table
+-- ACTION CREATE FOREIGN KEY
 --
 ALTER TABLE ONLY "serverpod_log"
     ADD CONSTRAINT "serverpod_log_fk_0"
@@ -547,7 +371,7 @@ ALTER TABLE ONLY "serverpod_log"
     ON UPDATE NO ACTION;
 
 --
--- Foreign relations for "serverpod_message_log" table
+-- ACTION CREATE FOREIGN KEY
 --
 ALTER TABLE ONLY "serverpod_message_log"
     ADD CONSTRAINT "serverpod_message_log_fk_0"
@@ -557,7 +381,7 @@ ALTER TABLE ONLY "serverpod_message_log"
     ON UPDATE NO ACTION;
 
 --
--- Foreign relations for "serverpod_query_log" table
+-- ACTION CREATE FOREIGN KEY
 --
 ALTER TABLE ONLY "serverpod_query_log"
     ADD CONSTRAINT "serverpod_query_log_fk_0"
@@ -567,37 +391,7 @@ ALTER TABLE ONLY "serverpod_query_log"
     ON UPDATE NO ACTION;
 
 --
--- Foreign relations for "serverpod_auth_backwards_compatibility_email_password" table
---
-ALTER TABLE ONLY "serverpod_auth_backwards_compatibility_email_password"
-    ADD CONSTRAINT "serverpod_auth_backwards_compatibility_email_password_fk_0"
-    FOREIGN KEY("emailAccountId")
-    REFERENCES "serverpod_auth_email_account"("id")
-    ON DELETE CASCADE
-    ON UPDATE NO ACTION;
-
---
--- Foreign relations for "serverpod_auth_backwards_compatibility_external_user_id" table
---
-ALTER TABLE ONLY "serverpod_auth_backwards_compatibility_external_user_id"
-    ADD CONSTRAINT "serverpod_auth_backwards_compatibility_external_user_id_fk_0"
-    FOREIGN KEY("authUserId")
-    REFERENCES "serverpod_auth_user"("id")
-    ON DELETE CASCADE
-    ON UPDATE NO ACTION;
-
---
--- Foreign relations for "serverpod_auth_backwards_compatibility_session" table
---
-ALTER TABLE ONLY "serverpod_auth_backwards_compatibility_session"
-    ADD CONSTRAINT "serverpod_auth_backwards_compatibility_session_fk_0"
-    FOREIGN KEY("authUserId")
-    REFERENCES "serverpod_auth_user"("id")
-    ON DELETE CASCADE
-    ON UPDATE NO ACTION;
-
---
--- Foreign relations for "serverpod_auth_email_account" table
+-- ACTION CREATE FOREIGN KEY
 --
 ALTER TABLE ONLY "serverpod_auth_email_account"
     ADD CONSTRAINT "serverpod_auth_email_account_fk_0"
@@ -607,7 +401,7 @@ ALTER TABLE ONLY "serverpod_auth_email_account"
     ON UPDATE NO ACTION;
 
 --
--- Foreign relations for "serverpod_auth_email_account_password_reset_attempt" table
+-- ACTION CREATE FOREIGN KEY
 --
 ALTER TABLE ONLY "serverpod_auth_email_account_password_reset_attempt"
     ADD CONSTRAINT "serverpod_auth_email_account_password_reset_attempt_fk_0"
@@ -617,7 +411,7 @@ ALTER TABLE ONLY "serverpod_auth_email_account_password_reset_attempt"
     ON UPDATE NO ACTION;
 
 --
--- Foreign relations for "serverpod_auth_email_account_password_reset_request" table
+-- ACTION CREATE FOREIGN KEY
 --
 ALTER TABLE ONLY "serverpod_auth_email_account_password_reset_request"
     ADD CONSTRAINT "serverpod_auth_email_account_password_reset_request_fk_0"
@@ -627,7 +421,7 @@ ALTER TABLE ONLY "serverpod_auth_email_account_password_reset_request"
     ON UPDATE NO ACTION;
 
 --
--- Foreign relations for "serverpod_auth_email_account_request_completion_attempt" table
+-- ACTION CREATE FOREIGN KEY
 --
 ALTER TABLE ONLY "serverpod_auth_email_account_request_completion_attempt"
     ADD CONSTRAINT "serverpod_auth_email_account_request_completion_attempt_fk_0"
@@ -637,7 +431,7 @@ ALTER TABLE ONLY "serverpod_auth_email_account_request_completion_attempt"
     ON UPDATE NO ACTION;
 
 --
--- Foreign relations for "serverpod_auth_profile_user_profile" table
+-- ACTION CREATE FOREIGN KEY
 --
 ALTER TABLE ONLY "serverpod_auth_profile_user_profile"
     ADD CONSTRAINT "serverpod_auth_profile_user_profile_fk_0"
@@ -653,7 +447,7 @@ ALTER TABLE ONLY "serverpod_auth_profile_user_profile"
     ON UPDATE NO ACTION;
 
 --
--- Foreign relations for "serverpod_auth_profile_user_profile_image" table
+-- ACTION CREATE FOREIGN KEY
 --
 ALTER TABLE ONLY "serverpod_auth_profile_user_profile_image"
     ADD CONSTRAINT "serverpod_auth_profile_user_profile_image_fk_0"
@@ -663,7 +457,7 @@ ALTER TABLE ONLY "serverpod_auth_profile_user_profile_image"
     ON UPDATE NO ACTION;
 
 --
--- Foreign relations for "serverpod_auth_session" table
+-- ACTION CREATE FOREIGN KEY
 --
 ALTER TABLE ONLY "serverpod_auth_session"
     ADD CONSTRAINT "serverpod_auth_session_fk_0"
@@ -674,12 +468,12 @@ ALTER TABLE ONLY "serverpod_auth_session"
 
 
 --
--- MIGRATION VERSION FOR serverpod_auth_migration
+-- MIGRATION VERSION FOR serverpod_auth_email
 --
 INSERT INTO "serverpod_migrations" ("module", "version", "timestamp")
-    VALUES ('serverpod_auth_migration', '20250711114550334', now())
+    VALUES ('serverpod_auth_email', '20250724100231671', now())
     ON CONFLICT ("module")
-    DO UPDATE SET "version" = '20250711114550334', "timestamp" = now();
+    DO UPDATE SET "version" = '20250724100231671', "timestamp" = now();
 
 --
 -- MIGRATION VERSION FOR serverpod
@@ -690,28 +484,12 @@ INSERT INTO "serverpod_migrations" ("module", "version", "timestamp")
     DO UPDATE SET "version" = '20240516151843329', "timestamp" = now();
 
 --
--- MIGRATION VERSION FOR serverpod_auth_backwards_compatibility
---
-INSERT INTO "serverpod_migrations" ("module", "version", "timestamp")
-    VALUES ('serverpod_auth_backwards_compatibility', '20250708110241098', now())
-    ON CONFLICT ("module")
-    DO UPDATE SET "version" = '20250708110241098', "timestamp" = now();
-
---
 -- MIGRATION VERSION FOR serverpod_auth_email_account
 --
 INSERT INTO "serverpod_migrations" ("module", "version", "timestamp")
-    VALUES ('serverpod_auth_email_account', '20250606090748154', now())
+    VALUES ('serverpod_auth_email_account', '20250724100154487', now())
     ON CONFLICT ("module")
-    DO UPDATE SET "version" = '20250606090748154', "timestamp" = now();
-
---
--- MIGRATION VERSION FOR serverpod_auth_email
---
-INSERT INTO "serverpod_migrations" ("module", "version", "timestamp")
-    VALUES ('serverpod_auth_email', '20250611073844715', now())
-    ON CONFLICT ("module")
-    DO UPDATE SET "version" = '20250611073844715', "timestamp" = now();
+    DO UPDATE SET "version" = '20250724100154487', "timestamp" = now();
 
 --
 -- MIGRATION VERSION FOR serverpod_auth_profile
@@ -720,14 +498,6 @@ INSERT INTO "serverpod_migrations" ("module", "version", "timestamp")
     VALUES ('serverpod_auth_profile', '20250519092101868', now())
     ON CONFLICT ("module")
     DO UPDATE SET "version" = '20250519092101868', "timestamp" = now();
-
---
--- MIGRATION VERSION FOR serverpod_auth
---
-INSERT INTO "serverpod_migrations" ("module", "version", "timestamp")
-    VALUES ('serverpod_auth', '20240520102713718', now())
-    ON CONFLICT ("module")
-    DO UPDATE SET "version" = '20240520102713718', "timestamp" = now();
 
 --
 -- MIGRATION VERSION FOR serverpod_auth_session

--- a/modules/new_serverpod_auth/serverpod_auth_email/serverpod_auth_email_server/migrations/migration_registry.txt
+++ b/modules/new_serverpod_auth/serverpod_auth_email/serverpod_auth_email_server/migrations/migration_registry.txt
@@ -4,4 +4,4 @@
 ### manually. If a collision is detected in this file when doing a code merge, resolve
 ### the conflict by removing and recreating the conflicting migration.
 
-20250611073844715
+20250724100231671

--- a/modules/new_serverpod_auth/serverpod_auth_email_account/serverpod_auth_email_account_server/lib/src/business/email_accounts.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_email_account/serverpod_auth_email_account_server/lib/src/business/email_accounts.dart
@@ -496,7 +496,7 @@ abstract final class EmailAccounts {
       where: (final t) =>
           (t.email.equals(email) |
               t.ipAddress.equals(session.remoteIpAddress)) &
-          (t.attemptedAt > oldestRelevantAttempt),
+          (t.attempted > oldestRelevantAttempt),
       transaction: transaction,
     );
 
@@ -548,7 +548,7 @@ abstract final class EmailAccounts {
         where: (final t) =>
             (t.email.equals(email) |
                 t.ipAddress.equals(session.remoteIpAddress)) &
-            (t.attemptedAt > oldestRelevantAttemptTimestamp),
+            (t.attempted > oldestRelevantAttemptTimestamp),
         transaction: transaction,
       );
 

--- a/modules/new_serverpod_auth/serverpod_auth_email_account/serverpod_auth_email_account_server/lib/src/business/email_accounts_admin.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_email_account/serverpod_auth_email_account_server/lib/src/business/email_accounts_admin.dart
@@ -26,7 +26,7 @@ final class EmailAccountsAdmin {
 
     await EmailAccountPasswordResetAttempt.db.deleteWhere(
       session,
-      where: (final t) => t.attemptedAt < removeBefore,
+      where: (final t) => t.attempted < removeBefore,
       transaction: transaction,
     );
   }
@@ -79,7 +79,7 @@ final class EmailAccountsAdmin {
 
     await EmailAccountFailedLoginAttempt.db.deleteWhere(
       session,
-      where: (final t) => t.attemptedAt < removeBefore,
+      where: (final t) => t.attempted < removeBefore,
       transaction: transaction,
     );
   }

--- a/modules/new_serverpod_auth/serverpod_auth_email_account/serverpod_auth_email_account_server/lib/src/generated/email_account_failed_login_attempt.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_email_account/serverpod_auth_email_account_server/lib/src/generated/email_account_failed_login_attempt.dart
@@ -19,14 +19,14 @@ abstract class EmailAccountFailedLoginAttempt
   EmailAccountFailedLoginAttempt._({
     this.id,
     required this.email,
-    DateTime? attemptedAt,
+    DateTime? attempted,
     required this.ipAddress,
-  }) : attemptedAt = attemptedAt ?? DateTime.now();
+  }) : attempted = attempted ?? DateTime.now();
 
   factory EmailAccountFailedLoginAttempt({
     _i1.UuidValue? id,
     required String email,
-    DateTime? attemptedAt,
+    DateTime? attempted,
     required String ipAddress,
   }) = _EmailAccountFailedLoginAttemptImpl;
 
@@ -37,8 +37,8 @@ abstract class EmailAccountFailedLoginAttempt
           ? null
           : _i1.UuidValueJsonExtension.fromJson(jsonSerialization['id']),
       email: jsonSerialization['email'] as String,
-      attemptedAt:
-          _i1.DateTimeJsonExtension.fromJson(jsonSerialization['attemptedAt']),
+      attempted:
+          _i1.DateTimeJsonExtension.fromJson(jsonSerialization['attempted']),
       ipAddress: jsonSerialization['ipAddress'] as String,
     );
   }
@@ -56,7 +56,7 @@ abstract class EmailAccountFailedLoginAttempt
   String email;
 
   /// The time of the sign in attempt.
-  DateTime attemptedAt;
+  DateTime attempted;
 
   /// The IP address of the sign in attempt.
   String ipAddress;
@@ -70,7 +70,7 @@ abstract class EmailAccountFailedLoginAttempt
   EmailAccountFailedLoginAttempt copyWith({
     _i1.UuidValue? id,
     String? email,
-    DateTime? attemptedAt,
+    DateTime? attempted,
     String? ipAddress,
   });
   @override
@@ -78,7 +78,7 @@ abstract class EmailAccountFailedLoginAttempt
     return {
       if (id != null) 'id': id?.toJson(),
       'email': email,
-      'attemptedAt': attemptedAt.toJson(),
+      'attempted': attempted.toJson(),
       'ipAddress': ipAddress,
     };
   }
@@ -125,12 +125,12 @@ class _EmailAccountFailedLoginAttemptImpl
   _EmailAccountFailedLoginAttemptImpl({
     _i1.UuidValue? id,
     required String email,
-    DateTime? attemptedAt,
+    DateTime? attempted,
     required String ipAddress,
   }) : super._(
           id: id,
           email: email,
-          attemptedAt: attemptedAt,
+          attempted: attempted,
           ipAddress: ipAddress,
         );
 
@@ -141,13 +141,13 @@ class _EmailAccountFailedLoginAttemptImpl
   EmailAccountFailedLoginAttempt copyWith({
     Object? id = _Undefined,
     String? email,
-    DateTime? attemptedAt,
+    DateTime? attempted,
     String? ipAddress,
   }) {
     return EmailAccountFailedLoginAttempt(
       id: id is _i1.UuidValue? ? id : this.id,
       email: email ?? this.email,
-      attemptedAt: attemptedAt ?? this.attemptedAt,
+      attempted: attempted ?? this.attempted,
       ipAddress: ipAddress ?? this.ipAddress,
     );
   }
@@ -160,8 +160,8 @@ class EmailAccountFailedLoginAttemptTable extends _i1.Table<_i1.UuidValue?> {
       'email',
       this,
     );
-    attemptedAt = _i1.ColumnDateTime(
-      'attemptedAt',
+    attempted = _i1.ColumnDateTime(
+      'attempted',
       this,
     );
     ipAddress = _i1.ColumnString(
@@ -176,7 +176,7 @@ class EmailAccountFailedLoginAttemptTable extends _i1.Table<_i1.UuidValue?> {
   late final _i1.ColumnString email;
 
   /// The time of the sign in attempt.
-  late final _i1.ColumnDateTime attemptedAt;
+  late final _i1.ColumnDateTime attempted;
 
   /// The IP address of the sign in attempt.
   late final _i1.ColumnString ipAddress;
@@ -185,7 +185,7 @@ class EmailAccountFailedLoginAttemptTable extends _i1.Table<_i1.UuidValue?> {
   List<_i1.Column> get columns => [
         id,
         email,
-        attemptedAt,
+        attempted,
         ipAddress,
       ];
 }

--- a/modules/new_serverpod_auth/serverpod_auth_email_account/serverpod_auth_email_account_server/lib/src/generated/email_account_password_reset_attempt.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_email_account/serverpod_auth_email_account_server/lib/src/generated/email_account_password_reset_attempt.dart
@@ -21,15 +21,15 @@ abstract class EmailAccountPasswordResetAttempt
     implements _i1.TableRow<_i1.UuidValue?>, _i1.ProtocolSerialization {
   EmailAccountPasswordResetAttempt._({
     this.id,
-    DateTime? attemptedAt,
+    DateTime? attempted,
     required this.ipAddress,
     required this.passwordResetRequestId,
     this.passwordResetRequest,
-  }) : attemptedAt = attemptedAt ?? DateTime.now();
+  }) : attempted = attempted ?? DateTime.now();
 
   factory EmailAccountPasswordResetAttempt({
     _i1.UuidValue? id,
-    DateTime? attemptedAt,
+    DateTime? attempted,
     required String ipAddress,
     required _i1.UuidValue passwordResetRequestId,
     _i2.EmailAccountPasswordResetRequest? passwordResetRequest,
@@ -41,8 +41,8 @@ abstract class EmailAccountPasswordResetAttempt
       id: jsonSerialization['id'] == null
           ? null
           : _i1.UuidValueJsonExtension.fromJson(jsonSerialization['id']),
-      attemptedAt:
-          _i1.DateTimeJsonExtension.fromJson(jsonSerialization['attemptedAt']),
+      attempted:
+          _i1.DateTimeJsonExtension.fromJson(jsonSerialization['attempted']),
       ipAddress: jsonSerialization['ipAddress'] as String,
       passwordResetRequestId: _i1.UuidValueJsonExtension.fromJson(
           jsonSerialization['passwordResetRequestId']),
@@ -62,7 +62,7 @@ abstract class EmailAccountPasswordResetAttempt
   _i1.UuidValue? id;
 
   /// The time of the reset attempt.
-  DateTime attemptedAt;
+  DateTime attempted;
 
   /// The IP address of the sign in attempt.
   String ipAddress;
@@ -79,7 +79,7 @@ abstract class EmailAccountPasswordResetAttempt
   @_i1.useResult
   EmailAccountPasswordResetAttempt copyWith({
     _i1.UuidValue? id,
-    DateTime? attemptedAt,
+    DateTime? attempted,
     String? ipAddress,
     _i1.UuidValue? passwordResetRequestId,
     _i2.EmailAccountPasswordResetRequest? passwordResetRequest,
@@ -88,7 +88,7 @@ abstract class EmailAccountPasswordResetAttempt
   Map<String, dynamic> toJson() {
     return {
       if (id != null) 'id': id?.toJson(),
-      'attemptedAt': attemptedAt.toJson(),
+      'attempted': attempted.toJson(),
       'ipAddress': ipAddress,
       'passwordResetRequestId': passwordResetRequestId.toJson(),
       if (passwordResetRequest != null)
@@ -139,13 +139,13 @@ class _EmailAccountPasswordResetAttemptImpl
     extends EmailAccountPasswordResetAttempt {
   _EmailAccountPasswordResetAttemptImpl({
     _i1.UuidValue? id,
-    DateTime? attemptedAt,
+    DateTime? attempted,
     required String ipAddress,
     required _i1.UuidValue passwordResetRequestId,
     _i2.EmailAccountPasswordResetRequest? passwordResetRequest,
   }) : super._(
           id: id,
-          attemptedAt: attemptedAt,
+          attempted: attempted,
           ipAddress: ipAddress,
           passwordResetRequestId: passwordResetRequestId,
           passwordResetRequest: passwordResetRequest,
@@ -157,14 +157,14 @@ class _EmailAccountPasswordResetAttemptImpl
   @override
   EmailAccountPasswordResetAttempt copyWith({
     Object? id = _Undefined,
-    DateTime? attemptedAt,
+    DateTime? attempted,
     String? ipAddress,
     _i1.UuidValue? passwordResetRequestId,
     Object? passwordResetRequest = _Undefined,
   }) {
     return EmailAccountPasswordResetAttempt(
       id: id is _i1.UuidValue? ? id : this.id,
-      attemptedAt: attemptedAt ?? this.attemptedAt,
+      attempted: attempted ?? this.attempted,
       ipAddress: ipAddress ?? this.ipAddress,
       passwordResetRequestId:
           passwordResetRequestId ?? this.passwordResetRequestId,
@@ -180,8 +180,8 @@ class EmailAccountPasswordResetAttemptTable extends _i1.Table<_i1.UuidValue?> {
   EmailAccountPasswordResetAttemptTable({super.tableRelation})
       : super(
             tableName: 'serverpod_auth_email_account_password_reset_attempt') {
-    attemptedAt = _i1.ColumnDateTime(
-      'attemptedAt',
+    attempted = _i1.ColumnDateTime(
+      'attempted',
       this,
     );
     ipAddress = _i1.ColumnString(
@@ -195,7 +195,7 @@ class EmailAccountPasswordResetAttemptTable extends _i1.Table<_i1.UuidValue?> {
   }
 
   /// The time of the reset attempt.
-  late final _i1.ColumnDateTime attemptedAt;
+  late final _i1.ColumnDateTime attempted;
 
   /// The IP address of the sign in attempt.
   late final _i1.ColumnString ipAddress;
@@ -221,7 +221,7 @@ class EmailAccountPasswordResetAttemptTable extends _i1.Table<_i1.UuidValue?> {
   @override
   List<_i1.Column> get columns => [
         id,
-        attemptedAt,
+        attempted,
         ipAddress,
         passwordResetRequestId,
       ];

--- a/modules/new_serverpod_auth/serverpod_auth_email_account/serverpod_auth_email_account_server/lib/src/generated/email_account_password_reset_request_attempt.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_email_account/serverpod_auth_email_account_server/lib/src/generated/email_account_password_reset_request_attempt.dart
@@ -18,14 +18,14 @@ abstract class EmailAccountPasswordResetRequestAttempt
   EmailAccountPasswordResetRequestAttempt._({
     this.id,
     required this.email,
-    DateTime? attemptedAt,
+    DateTime? attempted,
     required this.ipAddress,
-  }) : attemptedAt = attemptedAt ?? DateTime.now();
+  }) : attempted = attempted ?? DateTime.now();
 
   factory EmailAccountPasswordResetRequestAttempt({
     _i1.UuidValue? id,
     required String email,
-    DateTime? attemptedAt,
+    DateTime? attempted,
     required String ipAddress,
   }) = _EmailAccountPasswordResetRequestAttemptImpl;
 
@@ -36,8 +36,8 @@ abstract class EmailAccountPasswordResetRequestAttempt
           ? null
           : _i1.UuidValueJsonExtension.fromJson(jsonSerialization['id']),
       email: jsonSerialization['email'] as String,
-      attemptedAt:
-          _i1.DateTimeJsonExtension.fromJson(jsonSerialization['attemptedAt']),
+      attempted:
+          _i1.DateTimeJsonExtension.fromJson(jsonSerialization['attempted']),
       ipAddress: jsonSerialization['ipAddress'] as String,
     );
   }
@@ -55,7 +55,7 @@ abstract class EmailAccountPasswordResetRequestAttempt
   String email;
 
   /// The time of the reset attempt.
-  DateTime attemptedAt;
+  DateTime attempted;
 
   /// The IP address of the sign in attempt.
   String ipAddress;
@@ -69,7 +69,7 @@ abstract class EmailAccountPasswordResetRequestAttempt
   EmailAccountPasswordResetRequestAttempt copyWith({
     _i1.UuidValue? id,
     String? email,
-    DateTime? attemptedAt,
+    DateTime? attempted,
     String? ipAddress,
   });
   @override
@@ -77,7 +77,7 @@ abstract class EmailAccountPasswordResetRequestAttempt
     return {
       if (id != null) 'id': id?.toJson(),
       'email': email,
-      'attemptedAt': attemptedAt.toJson(),
+      'attempted': attempted.toJson(),
       'ipAddress': ipAddress,
     };
   }
@@ -126,12 +126,12 @@ class _EmailAccountPasswordResetRequestAttemptImpl
   _EmailAccountPasswordResetRequestAttemptImpl({
     _i1.UuidValue? id,
     required String email,
-    DateTime? attemptedAt,
+    DateTime? attempted,
     required String ipAddress,
   }) : super._(
           id: id,
           email: email,
-          attemptedAt: attemptedAt,
+          attempted: attempted,
           ipAddress: ipAddress,
         );
 
@@ -142,13 +142,13 @@ class _EmailAccountPasswordResetRequestAttemptImpl
   EmailAccountPasswordResetRequestAttempt copyWith({
     Object? id = _Undefined,
     String? email,
-    DateTime? attemptedAt,
+    DateTime? attempted,
     String? ipAddress,
   }) {
     return EmailAccountPasswordResetRequestAttempt(
       id: id is _i1.UuidValue? ? id : this.id,
       email: email ?? this.email,
-      attemptedAt: attemptedAt ?? this.attemptedAt,
+      attempted: attempted ?? this.attempted,
       ipAddress: ipAddress ?? this.ipAddress,
     );
   }
@@ -164,8 +164,8 @@ class EmailAccountPasswordResetRequestAttemptTable
       'email',
       this,
     );
-    attemptedAt = _i1.ColumnDateTime(
-      'attemptedAt',
+    attempted = _i1.ColumnDateTime(
+      'attempted',
       this,
     );
     ipAddress = _i1.ColumnString(
@@ -180,7 +180,7 @@ class EmailAccountPasswordResetRequestAttemptTable
   late final _i1.ColumnString email;
 
   /// The time of the reset attempt.
-  late final _i1.ColumnDateTime attemptedAt;
+  late final _i1.ColumnDateTime attempted;
 
   /// The IP address of the sign in attempt.
   late final _i1.ColumnString ipAddress;
@@ -189,7 +189,7 @@ class EmailAccountPasswordResetRequestAttemptTable
   List<_i1.Column> get columns => [
         id,
         email,
-        attemptedAt,
+        attempted,
         ipAddress,
       ];
 }

--- a/modules/new_serverpod_auth/serverpod_auth_email_account/serverpod_auth_email_account_server/lib/src/generated/email_account_request_completion_attempt.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_email_account/serverpod_auth_email_account_server/lib/src/generated/email_account_request_completion_attempt.dart
@@ -21,15 +21,15 @@ abstract class EmailAccountRequestCompletionAttempt
     implements _i1.TableRow<_i1.UuidValue?>, _i1.ProtocolSerialization {
   EmailAccountRequestCompletionAttempt._({
     this.id,
-    DateTime? attemptedAt,
+    DateTime? attempted,
     required this.ipAddress,
     required this.emailAccountRequestId,
     this.emailAccountRequest,
-  }) : attemptedAt = attemptedAt ?? DateTime.now();
+  }) : attempted = attempted ?? DateTime.now();
 
   factory EmailAccountRequestCompletionAttempt({
     _i1.UuidValue? id,
-    DateTime? attemptedAt,
+    DateTime? attempted,
     required String ipAddress,
     required _i1.UuidValue emailAccountRequestId,
     _i2.EmailAccountRequest? emailAccountRequest,
@@ -41,8 +41,8 @@ abstract class EmailAccountRequestCompletionAttempt
       id: jsonSerialization['id'] == null
           ? null
           : _i1.UuidValueJsonExtension.fromJson(jsonSerialization['id']),
-      attemptedAt:
-          _i1.DateTimeJsonExtension.fromJson(jsonSerialization['attemptedAt']),
+      attempted:
+          _i1.DateTimeJsonExtension.fromJson(jsonSerialization['attempted']),
       ipAddress: jsonSerialization['ipAddress'] as String,
       emailAccountRequestId: _i1.UuidValueJsonExtension.fromJson(
           jsonSerialization['emailAccountRequestId']),
@@ -61,8 +61,8 @@ abstract class EmailAccountRequestCompletionAttempt
   @override
   _i1.UuidValue? id;
 
-  /// The time of the reset attempt.
-  DateTime attemptedAt;
+  /// The time of the reset completion attempt.
+  DateTime attempted;
 
   /// The IP address of the sign in attempt.
   String ipAddress;
@@ -79,7 +79,7 @@ abstract class EmailAccountRequestCompletionAttempt
   @_i1.useResult
   EmailAccountRequestCompletionAttempt copyWith({
     _i1.UuidValue? id,
-    DateTime? attemptedAt,
+    DateTime? attempted,
     String? ipAddress,
     _i1.UuidValue? emailAccountRequestId,
     _i2.EmailAccountRequest? emailAccountRequest,
@@ -88,7 +88,7 @@ abstract class EmailAccountRequestCompletionAttempt
   Map<String, dynamic> toJson() {
     return {
       if (id != null) 'id': id?.toJson(),
-      'attemptedAt': attemptedAt.toJson(),
+      'attempted': attempted.toJson(),
       'ipAddress': ipAddress,
       'emailAccountRequestId': emailAccountRequestId.toJson(),
       if (emailAccountRequest != null)
@@ -141,13 +141,13 @@ class _EmailAccountRequestCompletionAttemptImpl
     extends EmailAccountRequestCompletionAttempt {
   _EmailAccountRequestCompletionAttemptImpl({
     _i1.UuidValue? id,
-    DateTime? attemptedAt,
+    DateTime? attempted,
     required String ipAddress,
     required _i1.UuidValue emailAccountRequestId,
     _i2.EmailAccountRequest? emailAccountRequest,
   }) : super._(
           id: id,
-          attemptedAt: attemptedAt,
+          attempted: attempted,
           ipAddress: ipAddress,
           emailAccountRequestId: emailAccountRequestId,
           emailAccountRequest: emailAccountRequest,
@@ -159,14 +159,14 @@ class _EmailAccountRequestCompletionAttemptImpl
   @override
   EmailAccountRequestCompletionAttempt copyWith({
     Object? id = _Undefined,
-    DateTime? attemptedAt,
+    DateTime? attempted,
     String? ipAddress,
     _i1.UuidValue? emailAccountRequestId,
     Object? emailAccountRequest = _Undefined,
   }) {
     return EmailAccountRequestCompletionAttempt(
       id: id is _i1.UuidValue? ? id : this.id,
-      attemptedAt: attemptedAt ?? this.attemptedAt,
+      attempted: attempted ?? this.attempted,
       ipAddress: ipAddress ?? this.ipAddress,
       emailAccountRequestId:
           emailAccountRequestId ?? this.emailAccountRequestId,
@@ -183,8 +183,8 @@ class EmailAccountRequestCompletionAttemptTable
       : super(
             tableName:
                 'serverpod_auth_email_account_request_completion_attempt') {
-    attemptedAt = _i1.ColumnDateTime(
-      'attemptedAt',
+    attempted = _i1.ColumnDateTime(
+      'attempted',
       this,
     );
     ipAddress = _i1.ColumnString(
@@ -197,8 +197,8 @@ class EmailAccountRequestCompletionAttemptTable
     );
   }
 
-  /// The time of the reset attempt.
-  late final _i1.ColumnDateTime attemptedAt;
+  /// The time of the reset completion attempt.
+  late final _i1.ColumnDateTime attempted;
 
   /// The IP address of the sign in attempt.
   late final _i1.ColumnString ipAddress;
@@ -223,7 +223,7 @@ class EmailAccountRequestCompletionAttemptTable
   @override
   List<_i1.Column> get columns => [
         id,
-        attemptedAt,
+        attempted,
         ipAddress,
         emailAccountRequestId,
       ];

--- a/modules/new_serverpod_auth/serverpod_auth_email_account/serverpod_auth_email_account_server/lib/src/generated/protocol.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_email_account/serverpod_auth_email_account_server/lib/src/generated/protocol.dart
@@ -176,7 +176,7 @@ class Protocol extends _i1.SerializationManagerServer {
           dartType: 'String',
         ),
         _i2.ColumnDefinition(
-          name: 'attemptedAt',
+          name: 'attempted',
           columnType: _i2.ColumnType.timestampWithoutTimeZone,
           isNullable: false,
           dartType: 'DateTime',
@@ -218,12 +218,12 @@ class Protocol extends _i1.SerializationManagerServer {
         ),
         _i2.IndexDefinition(
           indexName:
-              'serverpod_auth_email_account_failed_login_attempt_attempted_at',
+              'serverpod_auth_email_account_failed_login_attempt_attempted',
           tableSpace: null,
           elements: [
             _i2.IndexElementDefinition(
               type: _i2.IndexElementDefinitionType.column,
-              definition: 'attemptedAt',
+              definition: 'attempted',
             )
           ],
           type: 'btree',
@@ -247,7 +247,7 @@ class Protocol extends _i1.SerializationManagerServer {
           columnDefault: 'gen_random_uuid()',
         ),
         _i2.ColumnDefinition(
-          name: 'attemptedAt',
+          name: 'attempted',
           columnType: _i2.ColumnType.timestampWithoutTimeZone,
           isNullable: false,
           dartType: 'DateTime',
@@ -306,12 +306,12 @@ class Protocol extends _i1.SerializationManagerServer {
           isPrimary: false,
         ),
         _i2.IndexDefinition(
-          indexName: 'serverpod_auth_email_account_password_reset_attempt_at',
+          indexName: 'serverpod_auth_email_account_password_reset_attempted',
           tableSpace: null,
           elements: [
             _i2.IndexElementDefinition(
               type: _i2.IndexElementDefinitionType.column,
-              definition: 'attemptedAt',
+              definition: 'attempted',
             )
           ],
           type: 'btree',
@@ -410,7 +410,7 @@ class Protocol extends _i1.SerializationManagerServer {
           dartType: 'String',
         ),
         _i2.ColumnDefinition(
-          name: 'attemptedAt',
+          name: 'attempted',
           columnType: _i2.ColumnType.timestampWithoutTimeZone,
           isNullable: false,
           dartType: 'DateTime',
@@ -466,12 +466,12 @@ class Protocol extends _i1.SerializationManagerServer {
           isPrimary: false,
         ),
         _i2.IndexDefinition(
-          indexName: 'serverpod_auth_email_account_pw_reset_request_attempt_at',
+          indexName: 'serverpod_auth_email_account_pw_reset_request_attempted',
           tableSpace: null,
           elements: [
             _i2.IndexElementDefinition(
               type: _i2.IndexElementDefinitionType.column,
-              definition: 'attemptedAt',
+              definition: 'attempted',
             )
           ],
           type: 'btree',
@@ -583,7 +583,7 @@ class Protocol extends _i1.SerializationManagerServer {
           columnDefault: 'gen_random_uuid()',
         ),
         _i2.ColumnDefinition(
-          name: 'attemptedAt',
+          name: 'attempted',
           columnType: _i2.ColumnType.timestampWithoutTimeZone,
           isNullable: false,
           dartType: 'DateTime',
@@ -645,12 +645,12 @@ class Protocol extends _i1.SerializationManagerServer {
         ),
         _i2.IndexDefinition(
           indexName:
-              'serverpod_auth_email_account_request_completion_attempt_at',
+              'serverpod_auth_email_account_request_completion_attempted',
           tableSpace: null,
           elements: [
             _i2.IndexElementDefinition(
               type: _i2.IndexElementDefinitionType.column,
-              definition: 'attemptedAt',
+              definition: 'attempted',
             )
           ],
           type: 'btree',

--- a/modules/new_serverpod_auth/serverpod_auth_email_account/serverpod_auth_email_account_server/lib/src/models/email_account_failed_login_attempt.spy.yaml
+++ b/modules/new_serverpod_auth/serverpod_auth_email_account/serverpod_auth_email_account_server/lib/src/models/email_account_failed_login_attempt.spy.yaml
@@ -12,7 +12,7 @@ fields:
   email: String
 
   ### The time of the sign in attempt.
-  attemptedAt: DateTime, defaultModel=now
+  attempted: DateTime, defaultModel=now
 
   ### The IP address of the sign in attempt.
   ipAddress: String
@@ -21,5 +21,5 @@ indexes:
   serverpod_auth_email_account_failed_login_attempt_email:
     fields: email
 
-  serverpod_auth_email_account_failed_login_attempt_attempted_at:
-    fields: attemptedAt
+  serverpod_auth_email_account_failed_login_attempt_attempted:
+    fields: attempted

--- a/modules/new_serverpod_auth/serverpod_auth_email_account/serverpod_auth_email_account_server/lib/src/models/email_account_password_reset_attempt.spy.yaml
+++ b/modules/new_serverpod_auth/serverpod_auth_email_account/serverpod_auth_email_account_server/lib/src/models/email_account_password_reset_attempt.spy.yaml
@@ -7,7 +7,7 @@ fields:
   id: UuidValue?, defaultPersist=random
 
   ### The time of the reset attempt.
-  attemptedAt: DateTime, defaultModel=now
+  attempted: DateTime, defaultModel=now
 
   ### The IP address of the sign in attempt.
   ipAddress: String
@@ -18,5 +18,5 @@ indexes:
   serverpod_auth_email_account_password_reset_attempt_ip:
     fields: ipAddress
 
-  serverpod_auth_email_account_password_reset_attempt_at:
-    fields: attemptedAt
+  serverpod_auth_email_account_password_reset_attempted:
+    fields: attempted

--- a/modules/new_serverpod_auth/serverpod_auth_email_account/serverpod_auth_email_account_server/lib/src/models/email_account_password_reset_request_attempt.spy.yaml
+++ b/modules/new_serverpod_auth/serverpod_auth_email_account/serverpod_auth_email_account_server/lib/src/models/email_account_password_reset_request_attempt.spy.yaml
@@ -11,7 +11,7 @@ fields:
   email: String
 
   ### The time of the reset attempt.
-  attemptedAt: DateTime, defaultModel=now
+  attempted: DateTime, defaultModel=now
 
   ### The IP address of the sign in attempt.
   ipAddress: String
@@ -23,5 +23,5 @@ indexes:
   serverpod_auth_email_account_pw_reset_request_attempt_ip:
     fields: ipAddress
 
-  serverpod_auth_email_account_pw_reset_request_attempt_at:
-    fields: attemptedAt
+  serverpod_auth_email_account_pw_reset_request_attempted:
+    fields: attempted

--- a/modules/new_serverpod_auth/serverpod_auth_email_account/serverpod_auth_email_account_server/lib/src/models/email_account_request_completion_attempt.spy.yaml
+++ b/modules/new_serverpod_auth/serverpod_auth_email_account/serverpod_auth_email_account_server/lib/src/models/email_account_request_completion_attempt.spy.yaml
@@ -6,8 +6,8 @@ table: serverpod_auth_email_account_request_completion_attempt
 fields:
   id: UuidValue?, defaultPersist=random
 
-  ### The time of the reset attempt.
-  attemptedAt: DateTime, defaultModel=now
+  ### The time of the reset completion attempt.
+  attempted: DateTime, defaultModel=now
 
   ### The IP address of the sign in attempt.
   ipAddress: String
@@ -18,5 +18,5 @@ indexes:
   serverpod_auth_email_account_request_completion_attempt_ip:
     fields: ipAddress
 
-  serverpod_auth_email_account_request_completion_attempt_at:
-    fields: attemptedAt
+  serverpod_auth_email_account_request_completion_attempted:
+    fields: attempted

--- a/modules/new_serverpod_auth/serverpod_auth_email_account/serverpod_auth_email_account_server/migrations/20250724100154487/definition.json
+++ b/modules/new_serverpod_auth/serverpod_auth_email_account/serverpod_auth_email_account_server/migrations/20250724100154487/definition.json
@@ -108,7 +108,7 @@
           "dartType": "String"
         },
         {
-          "name": "attemptedAt",
+          "name": "attempted",
           "columnType": 4,
           "isNullable": false,
           "dartType": "DateTime"
@@ -147,11 +147,11 @@
           "isPrimary": false
         },
         {
-          "indexName": "serverpod_auth_email_account_failed_login_attempt_attempted_at",
+          "indexName": "serverpod_auth_email_account_failed_login_attempt_attempted",
           "elements": [
             {
               "type": 0,
-              "definition": "attemptedAt"
+              "definition": "attempted"
             }
           ],
           "type": "btree",
@@ -175,7 +175,7 @@
           "dartType": "UuidValue?"
         },
         {
-          "name": "attemptedAt",
+          "name": "attempted",
           "columnType": 4,
           "isNullable": false,
           "dartType": "DateTime"
@@ -234,11 +234,11 @@
           "isPrimary": false
         },
         {
-          "indexName": "serverpod_auth_email_account_password_reset_attempt_at",
+          "indexName": "serverpod_auth_email_account_password_reset_attempted",
           "elements": [
             {
               "type": 0,
-              "definition": "attemptedAt"
+              "definition": "attempted"
             }
           ],
           "type": "btree",
@@ -338,7 +338,7 @@
           "dartType": "String"
         },
         {
-          "name": "attemptedAt",
+          "name": "attempted",
           "columnType": 4,
           "isNullable": false,
           "dartType": "DateTime"
@@ -389,11 +389,11 @@
           "isPrimary": false
         },
         {
-          "indexName": "serverpod_auth_email_account_pw_reset_request_attempt_at",
+          "indexName": "serverpod_auth_email_account_pw_reset_request_attempted",
           "elements": [
             {
               "type": 0,
-              "definition": "attemptedAt"
+              "definition": "attempted"
             }
           ],
           "type": "btree",
@@ -503,7 +503,7 @@
           "dartType": "UuidValue?"
         },
         {
-          "name": "attemptedAt",
+          "name": "attempted",
           "columnType": 4,
           "isNullable": false,
           "dartType": "DateTime"
@@ -562,11 +562,11 @@
           "isPrimary": false
         },
         {
-          "indexName": "serverpod_auth_email_account_request_completion_attempt_at",
+          "indexName": "serverpod_auth_email_account_request_completion_attempted",
           "elements": [
             {
               "type": 0,
-              "definition": "attemptedAt"
+              "definition": "attempted"
             }
           ],
           "type": "btree",
@@ -1766,7 +1766,7 @@
   "installedModules": [
     {
       "module": "serverpod_auth_email_account",
-      "version": "20250606090748154"
+      "version": "20250724100154487"
     },
     {
       "module": "serverpod",

--- a/modules/new_serverpod_auth/serverpod_auth_email_account/serverpod_auth_email_account_server/migrations/20250724100154487/definition.sql
+++ b/modules/new_serverpod_auth/serverpod_auth_email_account/serverpod_auth_email_account_server/migrations/20250724100154487/definition.sql
@@ -21,27 +21,27 @@ CREATE UNIQUE INDEX "serverpod_auth_email_account_email" ON "serverpod_auth_emai
 CREATE TABLE "serverpod_auth_email_account_failed_login_attempt" (
     "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
     "email" text NOT NULL,
-    "attemptedAt" timestamp without time zone NOT NULL,
+    "attempted" timestamp without time zone NOT NULL,
     "ipAddress" text NOT NULL
 );
 
 -- Indexes
 CREATE INDEX "serverpod_auth_email_account_failed_login_attempt_email" ON "serverpod_auth_email_account_failed_login_attempt" USING btree ("email");
-CREATE INDEX "serverpod_auth_email_account_failed_login_attempt_attempted_at" ON "serverpod_auth_email_account_failed_login_attempt" USING btree ("attemptedAt");
+CREATE INDEX "serverpod_auth_email_account_failed_login_attempt_attempted" ON "serverpod_auth_email_account_failed_login_attempt" USING btree ("attempted");
 
 --
 -- Class EmailAccountPasswordResetAttempt as table serverpod_auth_email_account_password_reset_attempt
 --
 CREATE TABLE "serverpod_auth_email_account_password_reset_attempt" (
     "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-    "attemptedAt" timestamp without time zone NOT NULL,
+    "attempted" timestamp without time zone NOT NULL,
     "ipAddress" text NOT NULL,
     "passwordResetRequestId" uuid NOT NULL
 );
 
 -- Indexes
 CREATE INDEX "serverpod_auth_email_account_password_reset_attempt_ip" ON "serverpod_auth_email_account_password_reset_attempt" USING btree ("ipAddress");
-CREATE INDEX "serverpod_auth_email_account_password_reset_attempt_at" ON "serverpod_auth_email_account_password_reset_attempt" USING btree ("attemptedAt");
+CREATE INDEX "serverpod_auth_email_account_password_reset_attempted" ON "serverpod_auth_email_account_password_reset_attempt" USING btree ("attempted");
 
 --
 -- Class EmailAccountPasswordResetRequest as table serverpod_auth_email_account_password_reset_request
@@ -60,14 +60,14 @@ CREATE TABLE "serverpod_auth_email_account_password_reset_request" (
 CREATE TABLE "serverpod_auth_email_account_pw_reset_request_attempt" (
     "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
     "email" text NOT NULL,
-    "attemptedAt" timestamp without time zone NOT NULL,
+    "attempted" timestamp without time zone NOT NULL,
     "ipAddress" text NOT NULL
 );
 
 -- Indexes
 CREATE INDEX "serverpod_auth_email_account_pw_reset_request_attempt_email" ON "serverpod_auth_email_account_pw_reset_request_attempt" USING btree ("email");
 CREATE INDEX "serverpod_auth_email_account_pw_reset_request_attempt_ip" ON "serverpod_auth_email_account_pw_reset_request_attempt" USING btree ("ipAddress");
-CREATE INDEX "serverpod_auth_email_account_pw_reset_request_attempt_at" ON "serverpod_auth_email_account_pw_reset_request_attempt" USING btree ("attemptedAt");
+CREATE INDEX "serverpod_auth_email_account_pw_reset_request_attempted" ON "serverpod_auth_email_account_pw_reset_request_attempt" USING btree ("attempted");
 
 --
 -- Class EmailAccountRequest as table serverpod_auth_email_account_request
@@ -91,14 +91,14 @@ CREATE UNIQUE INDEX "serverpod_auth_email_account_request_email" ON "serverpod_a
 --
 CREATE TABLE "serverpod_auth_email_account_request_completion_attempt" (
     "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-    "attemptedAt" timestamp without time zone NOT NULL,
+    "attempted" timestamp without time zone NOT NULL,
     "ipAddress" text NOT NULL,
     "emailAccountRequestId" uuid NOT NULL
 );
 
 -- Indexes
 CREATE INDEX "serverpod_auth_email_account_request_completion_attempt_ip" ON "serverpod_auth_email_account_request_completion_attempt" USING btree ("ipAddress");
-CREATE INDEX "serverpod_auth_email_account_request_completion_attempt_at" ON "serverpod_auth_email_account_request_completion_attempt" USING btree ("attemptedAt");
+CREATE INDEX "serverpod_auth_email_account_request_completion_attempted" ON "serverpod_auth_email_account_request_completion_attempt" USING btree ("attempted");
 
 --
 -- Class CloudStorageEntry as table serverpod_cloud_storage
@@ -391,9 +391,9 @@ ALTER TABLE ONLY "serverpod_query_log"
 -- MIGRATION VERSION FOR serverpod_auth_email_account
 --
 INSERT INTO "serverpod_migrations" ("module", "version", "timestamp")
-    VALUES ('serverpod_auth_email_account', '20250606090748154', now())
+    VALUES ('serverpod_auth_email_account', '20250724100154487', now())
     ON CONFLICT ("module")
-    DO UPDATE SET "version" = '20250606090748154', "timestamp" = now();
+    DO UPDATE SET "version" = '20250724100154487', "timestamp" = now();
 
 --
 -- MIGRATION VERSION FOR serverpod

--- a/modules/new_serverpod_auth/serverpod_auth_email_account/serverpod_auth_email_account_server/migrations/20250724100154487/definition_project.json
+++ b/modules/new_serverpod_auth/serverpod_auth_email_account/serverpod_auth_email_account_server/migrations/20250724100154487/definition_project.json
@@ -108,7 +108,7 @@
           "dartType": "String"
         },
         {
-          "name": "attemptedAt",
+          "name": "attempted",
           "columnType": 4,
           "isNullable": false,
           "dartType": "DateTime"
@@ -147,11 +147,11 @@
           "isPrimary": false
         },
         {
-          "indexName": "serverpod_auth_email_account_failed_login_attempt_attempted_at",
+          "indexName": "serverpod_auth_email_account_failed_login_attempt_attempted",
           "elements": [
             {
               "type": 0,
-              "definition": "attemptedAt"
+              "definition": "attempted"
             }
           ],
           "type": "btree",
@@ -175,7 +175,7 @@
           "dartType": "UuidValue?"
         },
         {
-          "name": "attemptedAt",
+          "name": "attempted",
           "columnType": 4,
           "isNullable": false,
           "dartType": "DateTime"
@@ -234,11 +234,11 @@
           "isPrimary": false
         },
         {
-          "indexName": "serverpod_auth_email_account_password_reset_attempt_at",
+          "indexName": "serverpod_auth_email_account_password_reset_attempted",
           "elements": [
             {
               "type": 0,
-              "definition": "attemptedAt"
+              "definition": "attempted"
             }
           ],
           "type": "btree",
@@ -338,7 +338,7 @@
           "dartType": "String"
         },
         {
-          "name": "attemptedAt",
+          "name": "attempted",
           "columnType": 4,
           "isNullable": false,
           "dartType": "DateTime"
@@ -389,11 +389,11 @@
           "isPrimary": false
         },
         {
-          "indexName": "serverpod_auth_email_account_pw_reset_request_attempt_at",
+          "indexName": "serverpod_auth_email_account_pw_reset_request_attempted",
           "elements": [
             {
               "type": 0,
-              "definition": "attemptedAt"
+              "definition": "attempted"
             }
           ],
           "type": "btree",
@@ -503,7 +503,7 @@
           "dartType": "UuidValue?"
         },
         {
-          "name": "attemptedAt",
+          "name": "attempted",
           "columnType": 4,
           "isNullable": false,
           "dartType": "DateTime"
@@ -562,11 +562,11 @@
           "isPrimary": false
         },
         {
-          "indexName": "serverpod_auth_email_account_request_completion_attempt_at",
+          "indexName": "serverpod_auth_email_account_request_completion_attempted",
           "elements": [
             {
               "type": 0,
-              "definition": "attemptedAt"
+              "definition": "attempted"
             }
           ],
           "type": "btree",

--- a/modules/new_serverpod_auth/serverpod_auth_email_account/serverpod_auth_email_account_server/migrations/20250724100154487/migration.json
+++ b/modules/new_serverpod_auth/serverpod_auth_email_account/serverpod_auth_email_account_server/migrations/20250724100154487/migration.json
@@ -112,7 +112,7 @@
             "dartType": "String"
           },
           {
-            "name": "attemptedAt",
+            "name": "attempted",
             "columnType": 4,
             "isNullable": false,
             "dartType": "DateTime"
@@ -151,11 +151,11 @@
             "isPrimary": false
           },
           {
-            "indexName": "serverpod_auth_email_account_failed_login_attempt_attempted_at",
+            "indexName": "serverpod_auth_email_account_failed_login_attempt_attempted",
             "elements": [
               {
                 "type": 0,
-                "definition": "attemptedAt"
+                "definition": "attempted"
               }
             ],
             "type": "btree",
@@ -182,7 +182,7 @@
             "dartType": "UuidValue?"
           },
           {
-            "name": "attemptedAt",
+            "name": "attempted",
             "columnType": 4,
             "isNullable": false,
             "dartType": "DateTime"
@@ -241,11 +241,11 @@
             "isPrimary": false
           },
           {
-            "indexName": "serverpod_auth_email_account_password_reset_attempt_at",
+            "indexName": "serverpod_auth_email_account_password_reset_attempted",
             "elements": [
               {
                 "type": 0,
-                "definition": "attemptedAt"
+                "definition": "attempted"
               }
             ],
             "type": "btree",
@@ -351,7 +351,7 @@
             "dartType": "String"
           },
           {
-            "name": "attemptedAt",
+            "name": "attempted",
             "columnType": 4,
             "isNullable": false,
             "dartType": "DateTime"
@@ -402,11 +402,11 @@
             "isPrimary": false
           },
           {
-            "indexName": "serverpod_auth_email_account_pw_reset_request_attempt_at",
+            "indexName": "serverpod_auth_email_account_pw_reset_request_attempted",
             "elements": [
               {
                 "type": 0,
-                "definition": "attemptedAt"
+                "definition": "attempted"
               }
             ],
             "type": "btree",
@@ -522,7 +522,7 @@
             "dartType": "UuidValue?"
           },
           {
-            "name": "attemptedAt",
+            "name": "attempted",
             "columnType": 4,
             "isNullable": false,
             "dartType": "DateTime"
@@ -581,11 +581,11 @@
             "isPrimary": false
           },
           {
-            "indexName": "serverpod_auth_email_account_request_completion_attempt_at",
+            "indexName": "serverpod_auth_email_account_request_completion_attempted",
             "elements": [
               {
                 "type": 0,
-                "definition": "attemptedAt"
+                "definition": "attempted"
               }
             ],
             "type": "btree",

--- a/modules/new_serverpod_auth/serverpod_auth_email_account/serverpod_auth_email_account_server/migrations/20250724100154487/migration.sql
+++ b/modules/new_serverpod_auth/serverpod_auth_email_account/serverpod_auth_email_account_server/migrations/20250724100154487/migration.sql
@@ -21,27 +21,27 @@ CREATE UNIQUE INDEX "serverpod_auth_email_account_email" ON "serverpod_auth_emai
 CREATE TABLE "serverpod_auth_email_account_failed_login_attempt" (
     "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
     "email" text NOT NULL,
-    "attemptedAt" timestamp without time zone NOT NULL,
+    "attempted" timestamp without time zone NOT NULL,
     "ipAddress" text NOT NULL
 );
 
 -- Indexes
 CREATE INDEX "serverpod_auth_email_account_failed_login_attempt_email" ON "serverpod_auth_email_account_failed_login_attempt" USING btree ("email");
-CREATE INDEX "serverpod_auth_email_account_failed_login_attempt_attempted_at" ON "serverpod_auth_email_account_failed_login_attempt" USING btree ("attemptedAt");
+CREATE INDEX "serverpod_auth_email_account_failed_login_attempt_attempted" ON "serverpod_auth_email_account_failed_login_attempt" USING btree ("attempted");
 
 --
 -- ACTION CREATE TABLE
 --
 CREATE TABLE "serverpod_auth_email_account_password_reset_attempt" (
     "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-    "attemptedAt" timestamp without time zone NOT NULL,
+    "attempted" timestamp without time zone NOT NULL,
     "ipAddress" text NOT NULL,
     "passwordResetRequestId" uuid NOT NULL
 );
 
 -- Indexes
 CREATE INDEX "serverpod_auth_email_account_password_reset_attempt_ip" ON "serverpod_auth_email_account_password_reset_attempt" USING btree ("ipAddress");
-CREATE INDEX "serverpod_auth_email_account_password_reset_attempt_at" ON "serverpod_auth_email_account_password_reset_attempt" USING btree ("attemptedAt");
+CREATE INDEX "serverpod_auth_email_account_password_reset_attempted" ON "serverpod_auth_email_account_password_reset_attempt" USING btree ("attempted");
 
 --
 -- ACTION CREATE TABLE
@@ -60,14 +60,14 @@ CREATE TABLE "serverpod_auth_email_account_password_reset_request" (
 CREATE TABLE "serverpod_auth_email_account_pw_reset_request_attempt" (
     "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
     "email" text NOT NULL,
-    "attemptedAt" timestamp without time zone NOT NULL,
+    "attempted" timestamp without time zone NOT NULL,
     "ipAddress" text NOT NULL
 );
 
 -- Indexes
 CREATE INDEX "serverpod_auth_email_account_pw_reset_request_attempt_email" ON "serverpod_auth_email_account_pw_reset_request_attempt" USING btree ("email");
 CREATE INDEX "serverpod_auth_email_account_pw_reset_request_attempt_ip" ON "serverpod_auth_email_account_pw_reset_request_attempt" USING btree ("ipAddress");
-CREATE INDEX "serverpod_auth_email_account_pw_reset_request_attempt_at" ON "serverpod_auth_email_account_pw_reset_request_attempt" USING btree ("attemptedAt");
+CREATE INDEX "serverpod_auth_email_account_pw_reset_request_attempted" ON "serverpod_auth_email_account_pw_reset_request_attempt" USING btree ("attempted");
 
 --
 -- ACTION CREATE TABLE
@@ -91,14 +91,14 @@ CREATE UNIQUE INDEX "serverpod_auth_email_account_request_email" ON "serverpod_a
 --
 CREATE TABLE "serverpod_auth_email_account_request_completion_attempt" (
     "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-    "attemptedAt" timestamp without time zone NOT NULL,
+    "attempted" timestamp without time zone NOT NULL,
     "ipAddress" text NOT NULL,
     "emailAccountRequestId" uuid NOT NULL
 );
 
 -- Indexes
 CREATE INDEX "serverpod_auth_email_account_request_completion_attempt_ip" ON "serverpod_auth_email_account_request_completion_attempt" USING btree ("ipAddress");
-CREATE INDEX "serverpod_auth_email_account_request_completion_attempt_at" ON "serverpod_auth_email_account_request_completion_attempt" USING btree ("attemptedAt");
+CREATE INDEX "serverpod_auth_email_account_request_completion_attempted" ON "serverpod_auth_email_account_request_completion_attempt" USING btree ("attempted");
 
 --
 -- ACTION CREATE TABLE
@@ -391,9 +391,9 @@ ALTER TABLE ONLY "serverpod_query_log"
 -- MIGRATION VERSION FOR serverpod_auth_email_account
 --
 INSERT INTO "serverpod_migrations" ("module", "version", "timestamp")
-    VALUES ('serverpod_auth_email_account', '20250606090748154', now())
+    VALUES ('serverpod_auth_email_account', '20250724100154487', now())
     ON CONFLICT ("module")
-    DO UPDATE SET "version" = '20250606090748154', "timestamp" = now();
+    DO UPDATE SET "version" = '20250724100154487', "timestamp" = now();
 
 --
 -- MIGRATION VERSION FOR serverpod

--- a/modules/new_serverpod_auth/serverpod_auth_email_account/serverpod_auth_email_account_server/migrations/migration_registry.txt
+++ b/modules/new_serverpod_auth/serverpod_auth_email_account/serverpod_auth_email_account_server/migrations/migration_registry.txt
@@ -4,4 +4,4 @@
 ### manually. If a collision is detected in this file when doing a code merge, resolve
 ### the conflict by removing and recreating the conflicting migration.
 
-20250606090748154
+20250724100154487

--- a/modules/new_serverpod_auth/serverpod_auth_migration/serverpod_auth_migration_server/migrations/20250724125819384/definition.json
+++ b/modules/new_serverpod_auth/serverpod_auth_migration/serverpod_auth_migration_server/migrations/20250724125819384/definition.json
@@ -1,6 +1,100 @@
 {
-  "moduleName": "serverpod_auth_email",
+  "moduleName": "serverpod_auth_migration",
   "tables": [
+    {
+      "name": "serverpod_auth_migration_migrated_user",
+      "dartName": "MigratedUser",
+      "module": "serverpod_auth_migration",
+      "schema": "public",
+      "columns": [
+        {
+          "name": "id",
+          "columnType": 6,
+          "isNullable": false,
+          "columnDefault": "nextval('serverpod_auth_migration_migrated_user_id_seq'::regclass)",
+          "dartType": "int?"
+        },
+        {
+          "name": "oldUserId",
+          "columnType": 6,
+          "isNullable": false,
+          "dartType": "int"
+        },
+        {
+          "name": "newAuthUserId",
+          "columnType": 7,
+          "isNullable": false,
+          "dartType": "UuidValue"
+        }
+      ],
+      "foreignKeys": [
+        {
+          "constraintName": "serverpod_auth_migration_migrated_user_fk_0",
+          "columns": [
+            "oldUserId"
+          ],
+          "referenceTable": "serverpod_user_info",
+          "referenceTableSchema": "public",
+          "referenceColumns": [
+            "id"
+          ],
+          "onUpdate": 3,
+          "onDelete": 4
+        },
+        {
+          "constraintName": "serverpod_auth_migration_migrated_user_fk_1",
+          "columns": [
+            "newAuthUserId"
+          ],
+          "referenceTable": "serverpod_auth_user",
+          "referenceTableSchema": "public",
+          "referenceColumns": [
+            "id"
+          ],
+          "onUpdate": 3,
+          "onDelete": 4
+        }
+      ],
+      "indexes": [
+        {
+          "indexName": "serverpod_auth_migration_migrated_user_pkey",
+          "elements": [
+            {
+              "type": 0,
+              "definition": "id"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": true
+        },
+        {
+          "indexName": "serverpod_auth_migration_migrated_user_old",
+          "elements": [
+            {
+              "type": 0,
+              "definition": "oldUserId"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": false
+        },
+        {
+          "indexName": "serverpod_auth_migration_migrated_user_new",
+          "elements": [
+            {
+              "type": 0,
+              "definition": "newAuthUserId"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": false
+        }
+      ],
+      "managed": true
+    },
     {
       "name": "serverpod_cloud_storage",
       "dartName": "CloudStorageEntry",
@@ -1139,6 +1233,213 @@
       "managed": true
     },
     {
+      "name": "serverpod_auth_backwards_compatibility_email_password",
+      "dartName": "LegacyEmailPassword",
+      "module": "serverpod_auth_backwards_compatibility",
+      "schema": "public",
+      "columns": [
+        {
+          "name": "id",
+          "columnType": 7,
+          "isNullable": false,
+          "columnDefault": "gen_random_uuid()",
+          "dartType": "UuidValue?"
+        },
+        {
+          "name": "emailAccountId",
+          "columnType": 7,
+          "isNullable": false,
+          "dartType": "UuidValue"
+        },
+        {
+          "name": "hash",
+          "columnType": 0,
+          "isNullable": false,
+          "dartType": "String"
+        }
+      ],
+      "foreignKeys": [
+        {
+          "constraintName": "serverpod_auth_backwards_compatibility_email_password_fk_0",
+          "columns": [
+            "emailAccountId"
+          ],
+          "referenceTable": "serverpod_auth_email_account",
+          "referenceTableSchema": "public",
+          "referenceColumns": [
+            "id"
+          ],
+          "onUpdate": 3,
+          "onDelete": 4
+        }
+      ],
+      "indexes": [
+        {
+          "indexName": "serverpod_auth_backwards_compatibility_email_password_pkey",
+          "elements": [
+            {
+              "type": 0,
+              "definition": "id"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": true
+        },
+        {
+          "indexName": "serverpod_auth_backwards_compatibility_email_password_account",
+          "elements": [
+            {
+              "type": 0,
+              "definition": "emailAccountId"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": false
+        }
+      ],
+      "managed": true
+    },
+    {
+      "name": "serverpod_auth_backwards_compatibility_external_user_id",
+      "dartName": "LegacyExternalUserIdentifier",
+      "module": "serverpod_auth_backwards_compatibility",
+      "schema": "public",
+      "columns": [
+        {
+          "name": "id",
+          "columnType": 7,
+          "isNullable": false,
+          "columnDefault": "gen_random_uuid()",
+          "dartType": "UuidValue?"
+        },
+        {
+          "name": "authUserId",
+          "columnType": 7,
+          "isNullable": false,
+          "dartType": "UuidValue"
+        },
+        {
+          "name": "userIdentifier",
+          "columnType": 0,
+          "isNullable": false,
+          "dartType": "String"
+        }
+      ],
+      "foreignKeys": [
+        {
+          "constraintName": "serverpod_auth_backwards_compatibility_external_user_id_fk_0",
+          "columns": [
+            "authUserId"
+          ],
+          "referenceTable": "serverpod_auth_user",
+          "referenceTableSchema": "public",
+          "referenceColumns": [
+            "id"
+          ],
+          "onUpdate": 3,
+          "onDelete": 4
+        }
+      ],
+      "indexes": [
+        {
+          "indexName": "serverpod_auth_backwards_compatibility_external_user_id_pkey",
+          "elements": [
+            {
+              "type": 0,
+              "definition": "id"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": true
+        },
+        {
+          "indexName": "serverpod_auth_backwards_compatibility_external_user_id_id",
+          "elements": [
+            {
+              "type": 0,
+              "definition": "userIdentifier"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": false
+        }
+      ],
+      "managed": true
+    },
+    {
+      "name": "serverpod_auth_backwards_compatibility_session",
+      "dartName": "LegacySession",
+      "module": "serverpod_auth_backwards_compatibility",
+      "schema": "public",
+      "columns": [
+        {
+          "name": "id",
+          "columnType": 6,
+          "isNullable": false,
+          "columnDefault": "nextval('serverpod_auth_backwards_compatibility_session_id_seq'::regclass)",
+          "dartType": "int?"
+        },
+        {
+          "name": "authUserId",
+          "columnType": 7,
+          "isNullable": false,
+          "dartType": "UuidValue"
+        },
+        {
+          "name": "scopeNames",
+          "columnType": 8,
+          "isNullable": false,
+          "dartType": "Set<String>"
+        },
+        {
+          "name": "hash",
+          "columnType": 0,
+          "isNullable": false,
+          "dartType": "String"
+        },
+        {
+          "name": "method",
+          "columnType": 0,
+          "isNullable": false,
+          "dartType": "String"
+        }
+      ],
+      "foreignKeys": [
+        {
+          "constraintName": "serverpod_auth_backwards_compatibility_session_fk_0",
+          "columns": [
+            "authUserId"
+          ],
+          "referenceTable": "serverpod_auth_user",
+          "referenceTableSchema": "public",
+          "referenceColumns": [
+            "id"
+          ],
+          "onUpdate": 3,
+          "onDelete": 4
+        }
+      ],
+      "indexes": [
+        {
+          "indexName": "serverpod_auth_backwards_compatibility_session_pkey",
+          "elements": [
+            {
+              "type": 0,
+              "definition": "id"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": true
+        }
+      ],
+      "managed": true
+    },
+    {
       "name": "serverpod_auth_email_account",
       "dartName": "EmailAccount",
       "module": "serverpod_auth_email_account",
@@ -1245,7 +1546,7 @@
           "dartType": "String"
         },
         {
-          "name": "attemptedAt",
+          "name": "attempted",
           "columnType": 4,
           "isNullable": false,
           "dartType": "DateTime"
@@ -1284,11 +1585,11 @@
           "isPrimary": false
         },
         {
-          "indexName": "serverpod_auth_email_account_failed_login_attempt_attempted_at",
+          "indexName": "serverpod_auth_email_account_failed_login_attempt_attempted",
           "elements": [
             {
               "type": 0,
-              "definition": "attemptedAt"
+              "definition": "attempted"
             }
           ],
           "type": "btree",
@@ -1312,7 +1613,7 @@
           "dartType": "UuidValue?"
         },
         {
-          "name": "attemptedAt",
+          "name": "attempted",
           "columnType": 4,
           "isNullable": false,
           "dartType": "DateTime"
@@ -1371,11 +1672,11 @@
           "isPrimary": false
         },
         {
-          "indexName": "serverpod_auth_email_account_password_reset_attempt_at",
+          "indexName": "serverpod_auth_email_account_password_reset_attempted",
           "elements": [
             {
               "type": 0,
-              "definition": "attemptedAt"
+              "definition": "attempted"
             }
           ],
           "type": "btree",
@@ -1475,7 +1776,7 @@
           "dartType": "String"
         },
         {
-          "name": "attemptedAt",
+          "name": "attempted",
           "columnType": 4,
           "isNullable": false,
           "dartType": "DateTime"
@@ -1526,11 +1827,11 @@
           "isPrimary": false
         },
         {
-          "indexName": "serverpod_auth_email_account_pw_reset_request_attempt_at",
+          "indexName": "serverpod_auth_email_account_pw_reset_request_attempted",
           "elements": [
             {
               "type": 0,
-              "definition": "attemptedAt"
+              "definition": "attempted"
             }
           ],
           "type": "btree",
@@ -1640,7 +1941,7 @@
           "dartType": "UuidValue?"
         },
         {
-          "name": "attemptedAt",
+          "name": "attempted",
           "columnType": 4,
           "isNullable": false,
           "dartType": "DateTime"
@@ -1699,11 +2000,11 @@
           "isPrimary": false
         },
         {
-          "indexName": "serverpod_auth_email_account_request_completion_attempt_at",
+          "indexName": "serverpod_auth_email_account_request_completion_attempted",
           "elements": [
             {
               "type": 0,
-              "definition": "attemptedAt"
+              "definition": "attempted"
             }
           ],
           "type": "btree",
@@ -1897,6 +2198,558 @@
       "managed": true
     },
     {
+      "name": "serverpod_auth_key",
+      "dartName": "AuthKey",
+      "module": "serverpod_auth",
+      "schema": "public",
+      "columns": [
+        {
+          "name": "id",
+          "columnType": 6,
+          "isNullable": false,
+          "columnDefault": "nextval('serverpod_auth_key_id_seq'::regclass)",
+          "dartType": "int?"
+        },
+        {
+          "name": "userId",
+          "columnType": 6,
+          "isNullable": false,
+          "dartType": "int"
+        },
+        {
+          "name": "hash",
+          "columnType": 0,
+          "isNullable": false,
+          "dartType": "String"
+        },
+        {
+          "name": "scopeNames",
+          "columnType": 8,
+          "isNullable": false,
+          "dartType": "List<String>"
+        },
+        {
+          "name": "method",
+          "columnType": 0,
+          "isNullable": false,
+          "dartType": "String"
+        }
+      ],
+      "foreignKeys": [],
+      "indexes": [
+        {
+          "indexName": "serverpod_auth_key_pkey",
+          "elements": [
+            {
+              "type": 0,
+              "definition": "id"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": true
+        },
+        {
+          "indexName": "serverpod_auth_key_userId_idx",
+          "elements": [
+            {
+              "type": 0,
+              "definition": "userId"
+            }
+          ],
+          "type": "btree",
+          "isUnique": false,
+          "isPrimary": false
+        }
+      ],
+      "managed": true
+    },
+    {
+      "name": "serverpod_email_auth",
+      "dartName": "EmailAuth",
+      "module": "serverpod_auth",
+      "schema": "public",
+      "columns": [
+        {
+          "name": "id",
+          "columnType": 6,
+          "isNullable": false,
+          "columnDefault": "nextval('serverpod_email_auth_id_seq'::regclass)",
+          "dartType": "int?"
+        },
+        {
+          "name": "userId",
+          "columnType": 6,
+          "isNullable": false,
+          "dartType": "int"
+        },
+        {
+          "name": "email",
+          "columnType": 0,
+          "isNullable": false,
+          "dartType": "String"
+        },
+        {
+          "name": "hash",
+          "columnType": 0,
+          "isNullable": false,
+          "dartType": "String"
+        }
+      ],
+      "foreignKeys": [],
+      "indexes": [
+        {
+          "indexName": "serverpod_email_auth_pkey",
+          "elements": [
+            {
+              "type": 0,
+              "definition": "id"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": true
+        },
+        {
+          "indexName": "serverpod_email_auth_email",
+          "elements": [
+            {
+              "type": 0,
+              "definition": "email"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": false
+        }
+      ],
+      "managed": true
+    },
+    {
+      "name": "serverpod_email_create_request",
+      "dartName": "EmailCreateAccountRequest",
+      "module": "serverpod_auth",
+      "schema": "public",
+      "columns": [
+        {
+          "name": "id",
+          "columnType": 6,
+          "isNullable": false,
+          "columnDefault": "nextval('serverpod_email_create_request_id_seq'::regclass)",
+          "dartType": "int?"
+        },
+        {
+          "name": "userName",
+          "columnType": 0,
+          "isNullable": false,
+          "dartType": "String"
+        },
+        {
+          "name": "email",
+          "columnType": 0,
+          "isNullable": false,
+          "dartType": "String"
+        },
+        {
+          "name": "hash",
+          "columnType": 0,
+          "isNullable": false,
+          "dartType": "String"
+        },
+        {
+          "name": "verificationCode",
+          "columnType": 0,
+          "isNullable": false,
+          "dartType": "String"
+        }
+      ],
+      "foreignKeys": [],
+      "indexes": [
+        {
+          "indexName": "serverpod_email_create_request_pkey",
+          "elements": [
+            {
+              "type": 0,
+              "definition": "id"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": true
+        },
+        {
+          "indexName": "serverpod_email_auth_create_account_request_idx",
+          "elements": [
+            {
+              "type": 0,
+              "definition": "email"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": false
+        }
+      ],
+      "managed": true
+    },
+    {
+      "name": "serverpod_email_failed_sign_in",
+      "dartName": "EmailFailedSignIn",
+      "module": "serverpod_auth",
+      "schema": "public",
+      "columns": [
+        {
+          "name": "id",
+          "columnType": 6,
+          "isNullable": false,
+          "columnDefault": "nextval('serverpod_email_failed_sign_in_id_seq'::regclass)",
+          "dartType": "int?"
+        },
+        {
+          "name": "email",
+          "columnType": 0,
+          "isNullable": false,
+          "dartType": "String"
+        },
+        {
+          "name": "time",
+          "columnType": 4,
+          "isNullable": false,
+          "dartType": "DateTime"
+        },
+        {
+          "name": "ipAddress",
+          "columnType": 0,
+          "isNullable": false,
+          "dartType": "String"
+        }
+      ],
+      "foreignKeys": [],
+      "indexes": [
+        {
+          "indexName": "serverpod_email_failed_sign_in_pkey",
+          "elements": [
+            {
+              "type": 0,
+              "definition": "id"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": true
+        },
+        {
+          "indexName": "serverpod_email_failed_sign_in_email_idx",
+          "elements": [
+            {
+              "type": 0,
+              "definition": "email"
+            }
+          ],
+          "type": "btree",
+          "isUnique": false,
+          "isPrimary": false
+        },
+        {
+          "indexName": "serverpod_email_failed_sign_in_time_idx",
+          "elements": [
+            {
+              "type": 0,
+              "definition": "time"
+            }
+          ],
+          "type": "btree",
+          "isUnique": false,
+          "isPrimary": false
+        }
+      ],
+      "managed": true
+    },
+    {
+      "name": "serverpod_email_reset",
+      "dartName": "EmailReset",
+      "module": "serverpod_auth",
+      "schema": "public",
+      "columns": [
+        {
+          "name": "id",
+          "columnType": 6,
+          "isNullable": false,
+          "columnDefault": "nextval('serverpod_email_reset_id_seq'::regclass)",
+          "dartType": "int?"
+        },
+        {
+          "name": "userId",
+          "columnType": 6,
+          "isNullable": false,
+          "dartType": "int"
+        },
+        {
+          "name": "verificationCode",
+          "columnType": 0,
+          "isNullable": false,
+          "dartType": "String"
+        },
+        {
+          "name": "expiration",
+          "columnType": 4,
+          "isNullable": false,
+          "dartType": "DateTime"
+        }
+      ],
+      "foreignKeys": [],
+      "indexes": [
+        {
+          "indexName": "serverpod_email_reset_pkey",
+          "elements": [
+            {
+              "type": 0,
+              "definition": "id"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": true
+        },
+        {
+          "indexName": "serverpod_email_reset_verification_idx",
+          "elements": [
+            {
+              "type": 0,
+              "definition": "verificationCode"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": false
+        }
+      ],
+      "managed": true
+    },
+    {
+      "name": "serverpod_google_refresh_token",
+      "dartName": "GoogleRefreshToken",
+      "module": "serverpod_auth",
+      "schema": "public",
+      "columns": [
+        {
+          "name": "id",
+          "columnType": 6,
+          "isNullable": false,
+          "columnDefault": "nextval('serverpod_google_refresh_token_id_seq'::regclass)",
+          "dartType": "int?"
+        },
+        {
+          "name": "userId",
+          "columnType": 6,
+          "isNullable": false,
+          "dartType": "int"
+        },
+        {
+          "name": "refreshToken",
+          "columnType": 0,
+          "isNullable": false,
+          "dartType": "String"
+        }
+      ],
+      "foreignKeys": [],
+      "indexes": [
+        {
+          "indexName": "serverpod_google_refresh_token_pkey",
+          "elements": [
+            {
+              "type": 0,
+              "definition": "id"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": true
+        },
+        {
+          "indexName": "serverpod_google_refresh_token_userId_idx",
+          "elements": [
+            {
+              "type": 0,
+              "definition": "userId"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": false
+        }
+      ],
+      "managed": true
+    },
+    {
+      "name": "serverpod_user_image",
+      "dartName": "UserImage",
+      "module": "serverpod_auth",
+      "schema": "public",
+      "columns": [
+        {
+          "name": "id",
+          "columnType": 6,
+          "isNullable": false,
+          "columnDefault": "nextval('serverpod_user_image_id_seq'::regclass)",
+          "dartType": "int?"
+        },
+        {
+          "name": "userId",
+          "columnType": 6,
+          "isNullable": false,
+          "dartType": "int"
+        },
+        {
+          "name": "version",
+          "columnType": 6,
+          "isNullable": false,
+          "dartType": "int"
+        },
+        {
+          "name": "url",
+          "columnType": 0,
+          "isNullable": false,
+          "dartType": "String"
+        }
+      ],
+      "foreignKeys": [],
+      "indexes": [
+        {
+          "indexName": "serverpod_user_image_pkey",
+          "elements": [
+            {
+              "type": 0,
+              "definition": "id"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": true
+        },
+        {
+          "indexName": "serverpod_user_image_user_id",
+          "elements": [
+            {
+              "type": 0,
+              "definition": "userId"
+            },
+            {
+              "type": 0,
+              "definition": "version"
+            }
+          ],
+          "type": "btree",
+          "isUnique": false,
+          "isPrimary": false
+        }
+      ],
+      "managed": true
+    },
+    {
+      "name": "serverpod_user_info",
+      "dartName": "UserInfo",
+      "module": "serverpod_auth",
+      "schema": "public",
+      "columns": [
+        {
+          "name": "id",
+          "columnType": 6,
+          "isNullable": false,
+          "columnDefault": "nextval('serverpod_user_info_id_seq'::regclass)",
+          "dartType": "int?"
+        },
+        {
+          "name": "userIdentifier",
+          "columnType": 0,
+          "isNullable": false,
+          "dartType": "String"
+        },
+        {
+          "name": "userName",
+          "columnType": 0,
+          "isNullable": true,
+          "dartType": "String?"
+        },
+        {
+          "name": "fullName",
+          "columnType": 0,
+          "isNullable": true,
+          "dartType": "String?"
+        },
+        {
+          "name": "email",
+          "columnType": 0,
+          "isNullable": true,
+          "dartType": "String?"
+        },
+        {
+          "name": "created",
+          "columnType": 4,
+          "isNullable": false,
+          "dartType": "DateTime"
+        },
+        {
+          "name": "imageUrl",
+          "columnType": 0,
+          "isNullable": true,
+          "dartType": "String?"
+        },
+        {
+          "name": "scopeNames",
+          "columnType": 8,
+          "isNullable": false,
+          "dartType": "List<String>"
+        },
+        {
+          "name": "blocked",
+          "columnType": 1,
+          "isNullable": false,
+          "dartType": "bool"
+        }
+      ],
+      "foreignKeys": [],
+      "indexes": [
+        {
+          "indexName": "serverpod_user_info_pkey",
+          "elements": [
+            {
+              "type": 0,
+              "definition": "id"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": true
+        },
+        {
+          "indexName": "serverpod_user_info_user_identifier",
+          "elements": [
+            {
+              "type": 0,
+              "definition": "userIdentifier"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": false
+        },
+        {
+          "indexName": "serverpod_user_info_email",
+          "elements": [
+            {
+              "type": 0,
+              "definition": "email"
+            }
+          ],
+          "type": "btree",
+          "isUnique": false,
+          "isPrimary": false
+        }
+      ],
+      "managed": true
+    },
+    {
       "name": "serverpod_auth_session",
       "dartName": "AuthSession",
       "module": "serverpod_auth_session",
@@ -1916,6 +2769,12 @@
           "dartType": "UuidValue"
         },
         {
+          "name": "scopeNames",
+          "columnType": 8,
+          "isNullable": false,
+          "dartType": "Set<String>"
+        },
+        {
           "name": "created",
           "columnType": 4,
           "isNullable": false,
@@ -1923,10 +2782,23 @@
           "dartType": "DateTime"
         },
         {
-          "name": "scopeNames",
-          "columnType": 8,
+          "name": "lastUsed",
+          "columnType": 4,
           "isNullable": false,
-          "dartType": "Set<String>"
+          "columnDefault": "CURRENT_TIMESTAMP",
+          "dartType": "DateTime"
+        },
+        {
+          "name": "expiresAt",
+          "columnType": 4,
+          "isNullable": true,
+          "dartType": "DateTime?"
+        },
+        {
+          "name": "expireAfterUnusedFor",
+          "columnType": 6,
+          "isNullable": true,
+          "dartType": "Duration?"
         },
         {
           "name": "sessionKeyHash",
@@ -2030,24 +2902,36 @@
   ],
   "installedModules": [
     {
-      "module": "serverpod_auth_email",
-      "version": "20250611073844715"
+      "module": "serverpod_auth_migration",
+      "version": "20250724125819384"
     },
     {
       "module": "serverpod",
       "version": "20240516151843329"
     },
     {
+      "module": "serverpod_auth_backwards_compatibility",
+      "version": "20250724125750464"
+    },
+    {
       "module": "serverpod_auth_email_account",
-      "version": "20250606090748154"
+      "version": "20250724100154487"
+    },
+    {
+      "module": "serverpod_auth_email",
+      "version": "20250724100231671"
     },
     {
       "module": "serverpod_auth_profile",
       "version": "20250519092101868"
     },
     {
+      "module": "serverpod_auth",
+      "version": "20240520102713718"
+    },
+    {
       "module": "serverpod_auth_session",
-      "version": "20250607101155018"
+      "version": "20250611085050241"
     },
     {
       "module": "serverpod_auth_user",

--- a/modules/new_serverpod_auth/serverpod_auth_migration/serverpod_auth_migration_server/migrations/20250724125819384/definition.sql
+++ b/modules/new_serverpod_auth/serverpod_auth_migration/serverpod_auth_migration_server/migrations/20250724125819384/definition.sql
@@ -1,39 +1,17 @@
 BEGIN;
 
 --
--- Class LegacyEmailPassword as table serverpod_auth_backwards_compatibility_email_password
+-- Class MigratedUser as table serverpod_auth_migration_migrated_user
 --
-CREATE TABLE "serverpod_auth_backwards_compatibility_email_password" (
-    "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-    "emailAccountId" uuid NOT NULL,
-    "hash" text NOT NULL
-);
-
--- Indexes
-CREATE UNIQUE INDEX "serverpod_auth_backwards_compatibility_email_password_account" ON "serverpod_auth_backwards_compatibility_email_password" USING btree ("emailAccountId");
-
---
--- Class LegacyExternalUserIdentifier as table serverpod_auth_backwards_compatibility_external_user_id
---
-CREATE TABLE "serverpod_auth_backwards_compatibility_external_user_id" (
-    "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-    "authUserId" uuid NOT NULL,
-    "userIdentifier" text NOT NULL
-);
-
--- Indexes
-CREATE UNIQUE INDEX "serverpod_auth_backwards_compatibility_external_user_id_id" ON "serverpod_auth_backwards_compatibility_external_user_id" USING btree ("userIdentifier");
-
---
--- Class LegacySession as table serverpod_auth_backwards_compatibility_session
---
-CREATE TABLE "serverpod_auth_backwards_compatibility_session" (
+CREATE TABLE "serverpod_auth_migration_migrated_user" (
     "id" bigserial PRIMARY KEY,
-    "authUserId" uuid NOT NULL,
-    "scopeNames" json NOT NULL,
-    "hash" text NOT NULL,
-    "method" text NOT NULL
+    "oldUserId" bigint NOT NULL,
+    "newAuthUserId" uuid NOT NULL
 );
+
+-- Indexes
+CREATE UNIQUE INDEX "serverpod_auth_migration_migrated_user_old" ON "serverpod_auth_migration_migrated_user" USING btree ("oldUserId");
+CREATE UNIQUE INDEX "serverpod_auth_migration_migrated_user_new" ON "serverpod_auth_migration_migrated_user" USING btree ("newAuthUserId");
 
 --
 -- Class CloudStorageEntry as table serverpod_cloud_storage
@@ -242,6 +220,41 @@ CREATE INDEX "serverpod_session_log_touched_idx" ON "serverpod_session_log" USIN
 CREATE INDEX "serverpod_session_log_isopen_idx" ON "serverpod_session_log" USING btree ("isOpen");
 
 --
+-- Class LegacyEmailPassword as table serverpod_auth_backwards_compatibility_email_password
+--
+CREATE TABLE "serverpod_auth_backwards_compatibility_email_password" (
+    "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    "emailAccountId" uuid NOT NULL,
+    "hash" text NOT NULL
+);
+
+-- Indexes
+CREATE UNIQUE INDEX "serverpod_auth_backwards_compatibility_email_password_account" ON "serverpod_auth_backwards_compatibility_email_password" USING btree ("emailAccountId");
+
+--
+-- Class LegacyExternalUserIdentifier as table serverpod_auth_backwards_compatibility_external_user_id
+--
+CREATE TABLE "serverpod_auth_backwards_compatibility_external_user_id" (
+    "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    "authUserId" uuid NOT NULL,
+    "userIdentifier" text NOT NULL
+);
+
+-- Indexes
+CREATE UNIQUE INDEX "serverpod_auth_backwards_compatibility_external_user_id_id" ON "serverpod_auth_backwards_compatibility_external_user_id" USING btree ("userIdentifier");
+
+--
+-- Class LegacySession as table serverpod_auth_backwards_compatibility_session
+--
+CREATE TABLE "serverpod_auth_backwards_compatibility_session" (
+    "id" bigserial PRIMARY KEY,
+    "authUserId" uuid NOT NULL,
+    "scopeNames" json NOT NULL,
+    "hash" text NOT NULL,
+    "method" text NOT NULL
+);
+
+--
 -- Class EmailAccount as table serverpod_auth_email_account
 --
 CREATE TABLE "serverpod_auth_email_account" (
@@ -262,27 +275,27 @@ CREATE UNIQUE INDEX "serverpod_auth_email_account_email" ON "serverpod_auth_emai
 CREATE TABLE "serverpod_auth_email_account_failed_login_attempt" (
     "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
     "email" text NOT NULL,
-    "attemptedAt" timestamp without time zone NOT NULL,
+    "attempted" timestamp without time zone NOT NULL,
     "ipAddress" text NOT NULL
 );
 
 -- Indexes
 CREATE INDEX "serverpod_auth_email_account_failed_login_attempt_email" ON "serverpod_auth_email_account_failed_login_attempt" USING btree ("email");
-CREATE INDEX "serverpod_auth_email_account_failed_login_attempt_attempted_at" ON "serverpod_auth_email_account_failed_login_attempt" USING btree ("attemptedAt");
+CREATE INDEX "serverpod_auth_email_account_failed_login_attempt_attempted" ON "serverpod_auth_email_account_failed_login_attempt" USING btree ("attempted");
 
 --
 -- Class EmailAccountPasswordResetAttempt as table serverpod_auth_email_account_password_reset_attempt
 --
 CREATE TABLE "serverpod_auth_email_account_password_reset_attempt" (
     "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-    "attemptedAt" timestamp without time zone NOT NULL,
+    "attempted" timestamp without time zone NOT NULL,
     "ipAddress" text NOT NULL,
     "passwordResetRequestId" uuid NOT NULL
 );
 
 -- Indexes
 CREATE INDEX "serverpod_auth_email_account_password_reset_attempt_ip" ON "serverpod_auth_email_account_password_reset_attempt" USING btree ("ipAddress");
-CREATE INDEX "serverpod_auth_email_account_password_reset_attempt_at" ON "serverpod_auth_email_account_password_reset_attempt" USING btree ("attemptedAt");
+CREATE INDEX "serverpod_auth_email_account_password_reset_attempted" ON "serverpod_auth_email_account_password_reset_attempt" USING btree ("attempted");
 
 --
 -- Class EmailAccountPasswordResetRequest as table serverpod_auth_email_account_password_reset_request
@@ -301,14 +314,14 @@ CREATE TABLE "serverpod_auth_email_account_password_reset_request" (
 CREATE TABLE "serverpod_auth_email_account_pw_reset_request_attempt" (
     "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
     "email" text NOT NULL,
-    "attemptedAt" timestamp without time zone NOT NULL,
+    "attempted" timestamp without time zone NOT NULL,
     "ipAddress" text NOT NULL
 );
 
 -- Indexes
 CREATE INDEX "serverpod_auth_email_account_pw_reset_request_attempt_email" ON "serverpod_auth_email_account_pw_reset_request_attempt" USING btree ("email");
 CREATE INDEX "serverpod_auth_email_account_pw_reset_request_attempt_ip" ON "serverpod_auth_email_account_pw_reset_request_attempt" USING btree ("ipAddress");
-CREATE INDEX "serverpod_auth_email_account_pw_reset_request_attempt_at" ON "serverpod_auth_email_account_pw_reset_request_attempt" USING btree ("attemptedAt");
+CREATE INDEX "serverpod_auth_email_account_pw_reset_request_attempted" ON "serverpod_auth_email_account_pw_reset_request_attempt" USING btree ("attempted");
 
 --
 -- Class EmailAccountRequest as table serverpod_auth_email_account_request
@@ -332,14 +345,154 @@ CREATE UNIQUE INDEX "serverpod_auth_email_account_request_email" ON "serverpod_a
 --
 CREATE TABLE "serverpod_auth_email_account_request_completion_attempt" (
     "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-    "attemptedAt" timestamp without time zone NOT NULL,
+    "attempted" timestamp without time zone NOT NULL,
     "ipAddress" text NOT NULL,
     "emailAccountRequestId" uuid NOT NULL
 );
 
 -- Indexes
 CREATE INDEX "serverpod_auth_email_account_request_completion_attempt_ip" ON "serverpod_auth_email_account_request_completion_attempt" USING btree ("ipAddress");
-CREATE INDEX "serverpod_auth_email_account_request_completion_attempt_at" ON "serverpod_auth_email_account_request_completion_attempt" USING btree ("attemptedAt");
+CREATE INDEX "serverpod_auth_email_account_request_completion_attempted" ON "serverpod_auth_email_account_request_completion_attempt" USING btree ("attempted");
+
+--
+-- Class UserProfile as table serverpod_auth_profile_user_profile
+--
+CREATE TABLE "serverpod_auth_profile_user_profile" (
+    "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    "authUserId" uuid NOT NULL,
+    "userName" text,
+    "fullName" text,
+    "email" text,
+    "created" timestamp without time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "imageId" uuid
+);
+
+-- Indexes
+CREATE UNIQUE INDEX "serverpod_auth_profile_user_profile_email_auth_user_id" ON "serverpod_auth_profile_user_profile" USING btree ("authUserId");
+
+--
+-- Class UserProfileImage as table serverpod_auth_profile_user_profile_image
+--
+CREATE TABLE "serverpod_auth_profile_user_profile_image" (
+    "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    "userProfileId" uuid NOT NULL,
+    "created" timestamp without time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "storageId" text NOT NULL,
+    "path" text NOT NULL,
+    "url" text NOT NULL
+);
+
+--
+-- Class AuthKey as table serverpod_auth_key
+--
+CREATE TABLE "serverpod_auth_key" (
+    "id" bigserial PRIMARY KEY,
+    "userId" bigint NOT NULL,
+    "hash" text NOT NULL,
+    "scopeNames" json NOT NULL,
+    "method" text NOT NULL
+);
+
+-- Indexes
+CREATE INDEX "serverpod_auth_key_userId_idx" ON "serverpod_auth_key" USING btree ("userId");
+
+--
+-- Class EmailAuth as table serverpod_email_auth
+--
+CREATE TABLE "serverpod_email_auth" (
+    "id" bigserial PRIMARY KEY,
+    "userId" bigint NOT NULL,
+    "email" text NOT NULL,
+    "hash" text NOT NULL
+);
+
+-- Indexes
+CREATE UNIQUE INDEX "serverpod_email_auth_email" ON "serverpod_email_auth" USING btree ("email");
+
+--
+-- Class EmailCreateAccountRequest as table serverpod_email_create_request
+--
+CREATE TABLE "serverpod_email_create_request" (
+    "id" bigserial PRIMARY KEY,
+    "userName" text NOT NULL,
+    "email" text NOT NULL,
+    "hash" text NOT NULL,
+    "verificationCode" text NOT NULL
+);
+
+-- Indexes
+CREATE UNIQUE INDEX "serverpod_email_auth_create_account_request_idx" ON "serverpod_email_create_request" USING btree ("email");
+
+--
+-- Class EmailFailedSignIn as table serverpod_email_failed_sign_in
+--
+CREATE TABLE "serverpod_email_failed_sign_in" (
+    "id" bigserial PRIMARY KEY,
+    "email" text NOT NULL,
+    "time" timestamp without time zone NOT NULL,
+    "ipAddress" text NOT NULL
+);
+
+-- Indexes
+CREATE INDEX "serverpod_email_failed_sign_in_email_idx" ON "serverpod_email_failed_sign_in" USING btree ("email");
+CREATE INDEX "serverpod_email_failed_sign_in_time_idx" ON "serverpod_email_failed_sign_in" USING btree ("time");
+
+--
+-- Class EmailReset as table serverpod_email_reset
+--
+CREATE TABLE "serverpod_email_reset" (
+    "id" bigserial PRIMARY KEY,
+    "userId" bigint NOT NULL,
+    "verificationCode" text NOT NULL,
+    "expiration" timestamp without time zone NOT NULL
+);
+
+-- Indexes
+CREATE UNIQUE INDEX "serverpod_email_reset_verification_idx" ON "serverpod_email_reset" USING btree ("verificationCode");
+
+--
+-- Class GoogleRefreshToken as table serverpod_google_refresh_token
+--
+CREATE TABLE "serverpod_google_refresh_token" (
+    "id" bigserial PRIMARY KEY,
+    "userId" bigint NOT NULL,
+    "refreshToken" text NOT NULL
+);
+
+-- Indexes
+CREATE UNIQUE INDEX "serverpod_google_refresh_token_userId_idx" ON "serverpod_google_refresh_token" USING btree ("userId");
+
+--
+-- Class UserImage as table serverpod_user_image
+--
+CREATE TABLE "serverpod_user_image" (
+    "id" bigserial PRIMARY KEY,
+    "userId" bigint NOT NULL,
+    "version" bigint NOT NULL,
+    "url" text NOT NULL
+);
+
+-- Indexes
+CREATE INDEX "serverpod_user_image_user_id" ON "serverpod_user_image" USING btree ("userId", "version");
+
+--
+-- Class UserInfo as table serverpod_user_info
+--
+CREATE TABLE "serverpod_user_info" (
+    "id" bigserial PRIMARY KEY,
+    "userIdentifier" text NOT NULL,
+    "userName" text,
+    "fullName" text,
+    "email" text,
+    "created" timestamp without time zone NOT NULL,
+    "imageUrl" text,
+    "scopeNames" json NOT NULL,
+    "blocked" boolean NOT NULL
+);
+
+-- Indexes
+CREATE UNIQUE INDEX "serverpod_user_info_user_identifier" ON "serverpod_user_info" USING btree ("userIdentifier");
+CREATE INDEX "serverpod_user_info_email" ON "serverpod_user_info" USING btree ("email");
 
 --
 -- Class AuthSession as table serverpod_auth_session
@@ -368,31 +521,17 @@ CREATE TABLE "serverpod_auth_user" (
 );
 
 --
--- Foreign relations for "serverpod_auth_backwards_compatibility_email_password" table
+-- Foreign relations for "serverpod_auth_migration_migrated_user" table
 --
-ALTER TABLE ONLY "serverpod_auth_backwards_compatibility_email_password"
-    ADD CONSTRAINT "serverpod_auth_backwards_compatibility_email_password_fk_0"
-    FOREIGN KEY("emailAccountId")
-    REFERENCES "serverpod_auth_email_account"("id")
+ALTER TABLE ONLY "serverpod_auth_migration_migrated_user"
+    ADD CONSTRAINT "serverpod_auth_migration_migrated_user_fk_0"
+    FOREIGN KEY("oldUserId")
+    REFERENCES "serverpod_user_info"("id")
     ON DELETE CASCADE
     ON UPDATE NO ACTION;
-
---
--- Foreign relations for "serverpod_auth_backwards_compatibility_external_user_id" table
---
-ALTER TABLE ONLY "serverpod_auth_backwards_compatibility_external_user_id"
-    ADD CONSTRAINT "serverpod_auth_backwards_compatibility_external_user_id_fk_0"
-    FOREIGN KEY("authUserId")
-    REFERENCES "serverpod_auth_user"("id")
-    ON DELETE CASCADE
-    ON UPDATE NO ACTION;
-
---
--- Foreign relations for "serverpod_auth_backwards_compatibility_session" table
---
-ALTER TABLE ONLY "serverpod_auth_backwards_compatibility_session"
-    ADD CONSTRAINT "serverpod_auth_backwards_compatibility_session_fk_0"
-    FOREIGN KEY("authUserId")
+ALTER TABLE ONLY "serverpod_auth_migration_migrated_user"
+    ADD CONSTRAINT "serverpod_auth_migration_migrated_user_fk_1"
+    FOREIGN KEY("newAuthUserId")
     REFERENCES "serverpod_auth_user"("id")
     ON DELETE CASCADE
     ON UPDATE NO ACTION;
@@ -424,6 +563,36 @@ ALTER TABLE ONLY "serverpod_query_log"
     ADD CONSTRAINT "serverpod_query_log_fk_0"
     FOREIGN KEY("sessionLogId")
     REFERENCES "serverpod_session_log"("id")
+    ON DELETE CASCADE
+    ON UPDATE NO ACTION;
+
+--
+-- Foreign relations for "serverpod_auth_backwards_compatibility_email_password" table
+--
+ALTER TABLE ONLY "serverpod_auth_backwards_compatibility_email_password"
+    ADD CONSTRAINT "serverpod_auth_backwards_compatibility_email_password_fk_0"
+    FOREIGN KEY("emailAccountId")
+    REFERENCES "serverpod_auth_email_account"("id")
+    ON DELETE CASCADE
+    ON UPDATE NO ACTION;
+
+--
+-- Foreign relations for "serverpod_auth_backwards_compatibility_external_user_id" table
+--
+ALTER TABLE ONLY "serverpod_auth_backwards_compatibility_external_user_id"
+    ADD CONSTRAINT "serverpod_auth_backwards_compatibility_external_user_id_fk_0"
+    FOREIGN KEY("authUserId")
+    REFERENCES "serverpod_auth_user"("id")
+    ON DELETE CASCADE
+    ON UPDATE NO ACTION;
+
+--
+-- Foreign relations for "serverpod_auth_backwards_compatibility_session" table
+--
+ALTER TABLE ONLY "serverpod_auth_backwards_compatibility_session"
+    ADD CONSTRAINT "serverpod_auth_backwards_compatibility_session_fk_0"
+    FOREIGN KEY("authUserId")
+    REFERENCES "serverpod_auth_user"("id")
     ON DELETE CASCADE
     ON UPDATE NO ACTION;
 
@@ -468,6 +637,32 @@ ALTER TABLE ONLY "serverpod_auth_email_account_request_completion_attempt"
     ON UPDATE NO ACTION;
 
 --
+-- Foreign relations for "serverpod_auth_profile_user_profile" table
+--
+ALTER TABLE ONLY "serverpod_auth_profile_user_profile"
+    ADD CONSTRAINT "serverpod_auth_profile_user_profile_fk_0"
+    FOREIGN KEY("authUserId")
+    REFERENCES "serverpod_auth_user"("id")
+    ON DELETE CASCADE
+    ON UPDATE NO ACTION;
+ALTER TABLE ONLY "serverpod_auth_profile_user_profile"
+    ADD CONSTRAINT "serverpod_auth_profile_user_profile_fk_1"
+    FOREIGN KEY("imageId")
+    REFERENCES "serverpod_auth_profile_user_profile_image"("id")
+    ON DELETE NO ACTION
+    ON UPDATE NO ACTION;
+
+--
+-- Foreign relations for "serverpod_auth_profile_user_profile_image" table
+--
+ALTER TABLE ONLY "serverpod_auth_profile_user_profile_image"
+    ADD CONSTRAINT "serverpod_auth_profile_user_profile_image_fk_0"
+    FOREIGN KEY("userProfileId")
+    REFERENCES "serverpod_auth_profile_user_profile"("id")
+    ON DELETE CASCADE
+    ON UPDATE NO ACTION;
+
+--
 -- Foreign relations for "serverpod_auth_session" table
 --
 ALTER TABLE ONLY "serverpod_auth_session"
@@ -479,12 +674,12 @@ ALTER TABLE ONLY "serverpod_auth_session"
 
 
 --
--- MIGRATION VERSION FOR serverpod_auth_backwards_compatibility
+-- MIGRATION VERSION FOR serverpod_auth_migration
 --
 INSERT INTO "serverpod_migrations" ("module", "version", "timestamp")
-    VALUES ('serverpod_auth_backwards_compatibility', '20250708110241098', now())
+    VALUES ('serverpod_auth_migration', '20250724125819384', now())
     ON CONFLICT ("module")
-    DO UPDATE SET "version" = '20250708110241098', "timestamp" = now();
+    DO UPDATE SET "version" = '20250724125819384', "timestamp" = now();
 
 --
 -- MIGRATION VERSION FOR serverpod
@@ -495,12 +690,44 @@ INSERT INTO "serverpod_migrations" ("module", "version", "timestamp")
     DO UPDATE SET "version" = '20240516151843329', "timestamp" = now();
 
 --
+-- MIGRATION VERSION FOR serverpod_auth_backwards_compatibility
+--
+INSERT INTO "serverpod_migrations" ("module", "version", "timestamp")
+    VALUES ('serverpod_auth_backwards_compatibility', '20250724125750464', now())
+    ON CONFLICT ("module")
+    DO UPDATE SET "version" = '20250724125750464', "timestamp" = now();
+
+--
 -- MIGRATION VERSION FOR serverpod_auth_email_account
 --
 INSERT INTO "serverpod_migrations" ("module", "version", "timestamp")
-    VALUES ('serverpod_auth_email_account', '20250606090748154', now())
+    VALUES ('serverpod_auth_email_account', '20250724100154487', now())
     ON CONFLICT ("module")
-    DO UPDATE SET "version" = '20250606090748154', "timestamp" = now();
+    DO UPDATE SET "version" = '20250724100154487', "timestamp" = now();
+
+--
+-- MIGRATION VERSION FOR serverpod_auth_email
+--
+INSERT INTO "serverpod_migrations" ("module", "version", "timestamp")
+    VALUES ('serverpod_auth_email', '20250724100231671', now())
+    ON CONFLICT ("module")
+    DO UPDATE SET "version" = '20250724100231671', "timestamp" = now();
+
+--
+-- MIGRATION VERSION FOR serverpod_auth_profile
+--
+INSERT INTO "serverpod_migrations" ("module", "version", "timestamp")
+    VALUES ('serverpod_auth_profile', '20250519092101868', now())
+    ON CONFLICT ("module")
+    DO UPDATE SET "version" = '20250519092101868', "timestamp" = now();
+
+--
+-- MIGRATION VERSION FOR serverpod_auth
+--
+INSERT INTO "serverpod_migrations" ("module", "version", "timestamp")
+    VALUES ('serverpod_auth', '20240520102713718', now())
+    ON CONFLICT ("module")
+    DO UPDATE SET "version" = '20240520102713718', "timestamp" = now();
 
 --
 -- MIGRATION VERSION FOR serverpod_auth_session

--- a/modules/new_serverpod_auth/serverpod_auth_migration/serverpod_auth_migration_server/migrations/20250724125819384/definition_project.json
+++ b/modules/new_serverpod_auth/serverpod_auth_migration/serverpod_auth_migration_server/migrations/20250724125819384/definition_project.json
@@ -103,15 +103,15 @@
     },
     {
       "module": "serverpod_auth_backwards_compatibility",
-      "version": "20250708110241098"
+      "version": "20250724125750464"
     },
     {
       "module": "serverpod_auth_email_account",
-      "version": "20250606090748154"
+      "version": "20250724100154487"
     },
     {
       "module": "serverpod_auth_email",
-      "version": "20250611073844715"
+      "version": "20250724100231671"
     },
     {
       "module": "serverpod_auth_profile",

--- a/modules/new_serverpod_auth/serverpod_auth_migration/serverpod_auth_migration_server/migrations/20250724125819384/migration.json
+++ b/modules/new_serverpod_auth/serverpod_auth_migration/serverpod_auth_migration_server/migrations/20250724125819384/migration.json
@@ -3,6 +3,103 @@
     {
       "type": "createTable",
       "createTable": {
+        "name": "serverpod_auth_migration_migrated_user",
+        "dartName": "MigratedUser",
+        "module": "serverpod_auth_migration",
+        "schema": "public",
+        "columns": [
+          {
+            "name": "id",
+            "columnType": 6,
+            "isNullable": false,
+            "columnDefault": "nextval('serverpod_auth_migration_migrated_user_id_seq'::regclass)",
+            "dartType": "int?"
+          },
+          {
+            "name": "oldUserId",
+            "columnType": 6,
+            "isNullable": false,
+            "dartType": "int"
+          },
+          {
+            "name": "newAuthUserId",
+            "columnType": 7,
+            "isNullable": false,
+            "dartType": "UuidValue"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "constraintName": "serverpod_auth_migration_migrated_user_fk_0",
+            "columns": [
+              "oldUserId"
+            ],
+            "referenceTable": "serverpod_user_info",
+            "referenceTableSchema": "public",
+            "referenceColumns": [
+              "id"
+            ],
+            "onUpdate": 3,
+            "onDelete": 4
+          },
+          {
+            "constraintName": "serverpod_auth_migration_migrated_user_fk_1",
+            "columns": [
+              "newAuthUserId"
+            ],
+            "referenceTable": "serverpod_auth_user",
+            "referenceTableSchema": "public",
+            "referenceColumns": [
+              "id"
+            ],
+            "onUpdate": 3,
+            "onDelete": 4
+          }
+        ],
+        "indexes": [
+          {
+            "indexName": "serverpod_auth_migration_migrated_user_pkey",
+            "elements": [
+              {
+                "type": 0,
+                "definition": "id"
+              }
+            ],
+            "type": "btree",
+            "isUnique": true,
+            "isPrimary": true
+          },
+          {
+            "indexName": "serverpod_auth_migration_migrated_user_old",
+            "elements": [
+              {
+                "type": 0,
+                "definition": "oldUserId"
+              }
+            ],
+            "type": "btree",
+            "isUnique": true,
+            "isPrimary": false
+          },
+          {
+            "indexName": "serverpod_auth_migration_migrated_user_new",
+            "elements": [
+              {
+                "type": 0,
+                "definition": "newAuthUserId"
+              }
+            ],
+            "type": "btree",
+            "isUnique": true,
+            "isPrimary": false
+          }
+        ],
+        "managed": true
+      }
+    },
+    {
+      "type": "createTable",
+      "createTable": {
         "name": "serverpod_cloud_storage",
         "dartName": "CloudStorageEntry",
         "module": "serverpod",
@@ -1179,6 +1276,222 @@
     {
       "type": "createTable",
       "createTable": {
+        "name": "serverpod_auth_backwards_compatibility_email_password",
+        "dartName": "LegacyEmailPassword",
+        "module": "serverpod_auth_backwards_compatibility",
+        "schema": "public",
+        "columns": [
+          {
+            "name": "id",
+            "columnType": 7,
+            "isNullable": false,
+            "columnDefault": "gen_random_uuid()",
+            "dartType": "UuidValue?"
+          },
+          {
+            "name": "emailAccountId",
+            "columnType": 7,
+            "isNullable": false,
+            "dartType": "UuidValue"
+          },
+          {
+            "name": "hash",
+            "columnType": 0,
+            "isNullable": false,
+            "dartType": "String"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "constraintName": "serverpod_auth_backwards_compatibility_email_password_fk_0",
+            "columns": [
+              "emailAccountId"
+            ],
+            "referenceTable": "serverpod_auth_email_account",
+            "referenceTableSchema": "public",
+            "referenceColumns": [
+              "id"
+            ],
+            "onUpdate": 3,
+            "onDelete": 4
+          }
+        ],
+        "indexes": [
+          {
+            "indexName": "serverpod_auth_backwards_compatibility_email_password_pkey",
+            "elements": [
+              {
+                "type": 0,
+                "definition": "id"
+              }
+            ],
+            "type": "btree",
+            "isUnique": true,
+            "isPrimary": true
+          },
+          {
+            "indexName": "serverpod_auth_backwards_compatibility_email_password_account",
+            "elements": [
+              {
+                "type": 0,
+                "definition": "emailAccountId"
+              }
+            ],
+            "type": "btree",
+            "isUnique": true,
+            "isPrimary": false
+          }
+        ],
+        "managed": true
+      }
+    },
+    {
+      "type": "createTable",
+      "createTable": {
+        "name": "serverpod_auth_backwards_compatibility_external_user_id",
+        "dartName": "LegacyExternalUserIdentifier",
+        "module": "serverpod_auth_backwards_compatibility",
+        "schema": "public",
+        "columns": [
+          {
+            "name": "id",
+            "columnType": 7,
+            "isNullable": false,
+            "columnDefault": "gen_random_uuid()",
+            "dartType": "UuidValue?"
+          },
+          {
+            "name": "authUserId",
+            "columnType": 7,
+            "isNullable": false,
+            "dartType": "UuidValue"
+          },
+          {
+            "name": "userIdentifier",
+            "columnType": 0,
+            "isNullable": false,
+            "dartType": "String"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "constraintName": "serverpod_auth_backwards_compatibility_external_user_id_fk_0",
+            "columns": [
+              "authUserId"
+            ],
+            "referenceTable": "serverpod_auth_user",
+            "referenceTableSchema": "public",
+            "referenceColumns": [
+              "id"
+            ],
+            "onUpdate": 3,
+            "onDelete": 4
+          }
+        ],
+        "indexes": [
+          {
+            "indexName": "serverpod_auth_backwards_compatibility_external_user_id_pkey",
+            "elements": [
+              {
+                "type": 0,
+                "definition": "id"
+              }
+            ],
+            "type": "btree",
+            "isUnique": true,
+            "isPrimary": true
+          },
+          {
+            "indexName": "serverpod_auth_backwards_compatibility_external_user_id_id",
+            "elements": [
+              {
+                "type": 0,
+                "definition": "userIdentifier"
+              }
+            ],
+            "type": "btree",
+            "isUnique": true,
+            "isPrimary": false
+          }
+        ],
+        "managed": true
+      }
+    },
+    {
+      "type": "createTable",
+      "createTable": {
+        "name": "serverpod_auth_backwards_compatibility_session",
+        "dartName": "LegacySession",
+        "module": "serverpod_auth_backwards_compatibility",
+        "schema": "public",
+        "columns": [
+          {
+            "name": "id",
+            "columnType": 6,
+            "isNullable": false,
+            "columnDefault": "nextval('serverpod_auth_backwards_compatibility_session_id_seq'::regclass)",
+            "dartType": "int?"
+          },
+          {
+            "name": "authUserId",
+            "columnType": 7,
+            "isNullable": false,
+            "dartType": "UuidValue"
+          },
+          {
+            "name": "scopeNames",
+            "columnType": 8,
+            "isNullable": false,
+            "dartType": "Set<String>"
+          },
+          {
+            "name": "hash",
+            "columnType": 0,
+            "isNullable": false,
+            "dartType": "String"
+          },
+          {
+            "name": "method",
+            "columnType": 0,
+            "isNullable": false,
+            "dartType": "String"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "constraintName": "serverpod_auth_backwards_compatibility_session_fk_0",
+            "columns": [
+              "authUserId"
+            ],
+            "referenceTable": "serverpod_auth_user",
+            "referenceTableSchema": "public",
+            "referenceColumns": [
+              "id"
+            ],
+            "onUpdate": 3,
+            "onDelete": 4
+          }
+        ],
+        "indexes": [
+          {
+            "indexName": "serverpod_auth_backwards_compatibility_session_pkey",
+            "elements": [
+              {
+                "type": 0,
+                "definition": "id"
+              }
+            ],
+            "type": "btree",
+            "isUnique": true,
+            "isPrimary": true
+          }
+        ],
+        "managed": true
+      }
+    },
+    {
+      "type": "createTable",
+      "createTable": {
         "name": "serverpod_auth_email_account",
         "dartName": "EmailAccount",
         "module": "serverpod_auth_email_account",
@@ -1288,7 +1601,7 @@
             "dartType": "String"
           },
           {
-            "name": "attemptedAt",
+            "name": "attempted",
             "columnType": 4,
             "isNullable": false,
             "dartType": "DateTime"
@@ -1327,11 +1640,11 @@
             "isPrimary": false
           },
           {
-            "indexName": "serverpod_auth_email_account_failed_login_attempt_attempted_at",
+            "indexName": "serverpod_auth_email_account_failed_login_attempt_attempted",
             "elements": [
               {
                 "type": 0,
-                "definition": "attemptedAt"
+                "definition": "attempted"
               }
             ],
             "type": "btree",
@@ -1358,7 +1671,7 @@
             "dartType": "UuidValue?"
           },
           {
-            "name": "attemptedAt",
+            "name": "attempted",
             "columnType": 4,
             "isNullable": false,
             "dartType": "DateTime"
@@ -1417,11 +1730,11 @@
             "isPrimary": false
           },
           {
-            "indexName": "serverpod_auth_email_account_password_reset_attempt_at",
+            "indexName": "serverpod_auth_email_account_password_reset_attempted",
             "elements": [
               {
                 "type": 0,
-                "definition": "attemptedAt"
+                "definition": "attempted"
               }
             ],
             "type": "btree",
@@ -1527,7 +1840,7 @@
             "dartType": "String"
           },
           {
-            "name": "attemptedAt",
+            "name": "attempted",
             "columnType": 4,
             "isNullable": false,
             "dartType": "DateTime"
@@ -1578,11 +1891,11 @@
             "isPrimary": false
           },
           {
-            "indexName": "serverpod_auth_email_account_pw_reset_request_attempt_at",
+            "indexName": "serverpod_auth_email_account_pw_reset_request_attempted",
             "elements": [
               {
                 "type": 0,
-                "definition": "attemptedAt"
+                "definition": "attempted"
               }
             ],
             "type": "btree",
@@ -1698,7 +2011,7 @@
             "dartType": "UuidValue?"
           },
           {
-            "name": "attemptedAt",
+            "name": "attempted",
             "columnType": 4,
             "isNullable": false,
             "dartType": "DateTime"
@@ -1757,11 +2070,11 @@
             "isPrimary": false
           },
           {
-            "indexName": "serverpod_auth_email_account_request_completion_attempt_at",
+            "indexName": "serverpod_auth_email_account_request_completion_attempted",
             "elements": [
               {
                 "type": 0,
-                "definition": "attemptedAt"
+                "definition": "attempted"
               }
             ],
             "type": "btree",
@@ -1964,6 +2277,582 @@
     {
       "type": "createTable",
       "createTable": {
+        "name": "serverpod_auth_key",
+        "dartName": "AuthKey",
+        "module": "serverpod_auth",
+        "schema": "public",
+        "columns": [
+          {
+            "name": "id",
+            "columnType": 6,
+            "isNullable": false,
+            "columnDefault": "nextval('serverpod_auth_key_id_seq'::regclass)",
+            "dartType": "int?"
+          },
+          {
+            "name": "userId",
+            "columnType": 6,
+            "isNullable": false,
+            "dartType": "int"
+          },
+          {
+            "name": "hash",
+            "columnType": 0,
+            "isNullable": false,
+            "dartType": "String"
+          },
+          {
+            "name": "scopeNames",
+            "columnType": 8,
+            "isNullable": false,
+            "dartType": "List<String>"
+          },
+          {
+            "name": "method",
+            "columnType": 0,
+            "isNullable": false,
+            "dartType": "String"
+          }
+        ],
+        "foreignKeys": [],
+        "indexes": [
+          {
+            "indexName": "serverpod_auth_key_pkey",
+            "elements": [
+              {
+                "type": 0,
+                "definition": "id"
+              }
+            ],
+            "type": "btree",
+            "isUnique": true,
+            "isPrimary": true
+          },
+          {
+            "indexName": "serverpod_auth_key_userId_idx",
+            "elements": [
+              {
+                "type": 0,
+                "definition": "userId"
+              }
+            ],
+            "type": "btree",
+            "isUnique": false,
+            "isPrimary": false
+          }
+        ],
+        "managed": true
+      }
+    },
+    {
+      "type": "createTable",
+      "createTable": {
+        "name": "serverpod_email_auth",
+        "dartName": "EmailAuth",
+        "module": "serverpod_auth",
+        "schema": "public",
+        "columns": [
+          {
+            "name": "id",
+            "columnType": 6,
+            "isNullable": false,
+            "columnDefault": "nextval('serverpod_email_auth_id_seq'::regclass)",
+            "dartType": "int?"
+          },
+          {
+            "name": "userId",
+            "columnType": 6,
+            "isNullable": false,
+            "dartType": "int"
+          },
+          {
+            "name": "email",
+            "columnType": 0,
+            "isNullable": false,
+            "dartType": "String"
+          },
+          {
+            "name": "hash",
+            "columnType": 0,
+            "isNullable": false,
+            "dartType": "String"
+          }
+        ],
+        "foreignKeys": [],
+        "indexes": [
+          {
+            "indexName": "serverpod_email_auth_pkey",
+            "elements": [
+              {
+                "type": 0,
+                "definition": "id"
+              }
+            ],
+            "type": "btree",
+            "isUnique": true,
+            "isPrimary": true
+          },
+          {
+            "indexName": "serverpod_email_auth_email",
+            "elements": [
+              {
+                "type": 0,
+                "definition": "email"
+              }
+            ],
+            "type": "btree",
+            "isUnique": true,
+            "isPrimary": false
+          }
+        ],
+        "managed": true
+      }
+    },
+    {
+      "type": "createTable",
+      "createTable": {
+        "name": "serverpod_email_create_request",
+        "dartName": "EmailCreateAccountRequest",
+        "module": "serverpod_auth",
+        "schema": "public",
+        "columns": [
+          {
+            "name": "id",
+            "columnType": 6,
+            "isNullable": false,
+            "columnDefault": "nextval('serverpod_email_create_request_id_seq'::regclass)",
+            "dartType": "int?"
+          },
+          {
+            "name": "userName",
+            "columnType": 0,
+            "isNullable": false,
+            "dartType": "String"
+          },
+          {
+            "name": "email",
+            "columnType": 0,
+            "isNullable": false,
+            "dartType": "String"
+          },
+          {
+            "name": "hash",
+            "columnType": 0,
+            "isNullable": false,
+            "dartType": "String"
+          },
+          {
+            "name": "verificationCode",
+            "columnType": 0,
+            "isNullable": false,
+            "dartType": "String"
+          }
+        ],
+        "foreignKeys": [],
+        "indexes": [
+          {
+            "indexName": "serverpod_email_create_request_pkey",
+            "elements": [
+              {
+                "type": 0,
+                "definition": "id"
+              }
+            ],
+            "type": "btree",
+            "isUnique": true,
+            "isPrimary": true
+          },
+          {
+            "indexName": "serverpod_email_auth_create_account_request_idx",
+            "elements": [
+              {
+                "type": 0,
+                "definition": "email"
+              }
+            ],
+            "type": "btree",
+            "isUnique": true,
+            "isPrimary": false
+          }
+        ],
+        "managed": true
+      }
+    },
+    {
+      "type": "createTable",
+      "createTable": {
+        "name": "serverpod_email_failed_sign_in",
+        "dartName": "EmailFailedSignIn",
+        "module": "serverpod_auth",
+        "schema": "public",
+        "columns": [
+          {
+            "name": "id",
+            "columnType": 6,
+            "isNullable": false,
+            "columnDefault": "nextval('serverpod_email_failed_sign_in_id_seq'::regclass)",
+            "dartType": "int?"
+          },
+          {
+            "name": "email",
+            "columnType": 0,
+            "isNullable": false,
+            "dartType": "String"
+          },
+          {
+            "name": "time",
+            "columnType": 4,
+            "isNullable": false,
+            "dartType": "DateTime"
+          },
+          {
+            "name": "ipAddress",
+            "columnType": 0,
+            "isNullable": false,
+            "dartType": "String"
+          }
+        ],
+        "foreignKeys": [],
+        "indexes": [
+          {
+            "indexName": "serverpod_email_failed_sign_in_pkey",
+            "elements": [
+              {
+                "type": 0,
+                "definition": "id"
+              }
+            ],
+            "type": "btree",
+            "isUnique": true,
+            "isPrimary": true
+          },
+          {
+            "indexName": "serverpod_email_failed_sign_in_email_idx",
+            "elements": [
+              {
+                "type": 0,
+                "definition": "email"
+              }
+            ],
+            "type": "btree",
+            "isUnique": false,
+            "isPrimary": false
+          },
+          {
+            "indexName": "serverpod_email_failed_sign_in_time_idx",
+            "elements": [
+              {
+                "type": 0,
+                "definition": "time"
+              }
+            ],
+            "type": "btree",
+            "isUnique": false,
+            "isPrimary": false
+          }
+        ],
+        "managed": true
+      }
+    },
+    {
+      "type": "createTable",
+      "createTable": {
+        "name": "serverpod_email_reset",
+        "dartName": "EmailReset",
+        "module": "serverpod_auth",
+        "schema": "public",
+        "columns": [
+          {
+            "name": "id",
+            "columnType": 6,
+            "isNullable": false,
+            "columnDefault": "nextval('serverpod_email_reset_id_seq'::regclass)",
+            "dartType": "int?"
+          },
+          {
+            "name": "userId",
+            "columnType": 6,
+            "isNullable": false,
+            "dartType": "int"
+          },
+          {
+            "name": "verificationCode",
+            "columnType": 0,
+            "isNullable": false,
+            "dartType": "String"
+          },
+          {
+            "name": "expiration",
+            "columnType": 4,
+            "isNullable": false,
+            "dartType": "DateTime"
+          }
+        ],
+        "foreignKeys": [],
+        "indexes": [
+          {
+            "indexName": "serverpod_email_reset_pkey",
+            "elements": [
+              {
+                "type": 0,
+                "definition": "id"
+              }
+            ],
+            "type": "btree",
+            "isUnique": true,
+            "isPrimary": true
+          },
+          {
+            "indexName": "serverpod_email_reset_verification_idx",
+            "elements": [
+              {
+                "type": 0,
+                "definition": "verificationCode"
+              }
+            ],
+            "type": "btree",
+            "isUnique": true,
+            "isPrimary": false
+          }
+        ],
+        "managed": true
+      }
+    },
+    {
+      "type": "createTable",
+      "createTable": {
+        "name": "serverpod_google_refresh_token",
+        "dartName": "GoogleRefreshToken",
+        "module": "serverpod_auth",
+        "schema": "public",
+        "columns": [
+          {
+            "name": "id",
+            "columnType": 6,
+            "isNullable": false,
+            "columnDefault": "nextval('serverpod_google_refresh_token_id_seq'::regclass)",
+            "dartType": "int?"
+          },
+          {
+            "name": "userId",
+            "columnType": 6,
+            "isNullable": false,
+            "dartType": "int"
+          },
+          {
+            "name": "refreshToken",
+            "columnType": 0,
+            "isNullable": false,
+            "dartType": "String"
+          }
+        ],
+        "foreignKeys": [],
+        "indexes": [
+          {
+            "indexName": "serverpod_google_refresh_token_pkey",
+            "elements": [
+              {
+                "type": 0,
+                "definition": "id"
+              }
+            ],
+            "type": "btree",
+            "isUnique": true,
+            "isPrimary": true
+          },
+          {
+            "indexName": "serverpod_google_refresh_token_userId_idx",
+            "elements": [
+              {
+                "type": 0,
+                "definition": "userId"
+              }
+            ],
+            "type": "btree",
+            "isUnique": true,
+            "isPrimary": false
+          }
+        ],
+        "managed": true
+      }
+    },
+    {
+      "type": "createTable",
+      "createTable": {
+        "name": "serverpod_user_image",
+        "dartName": "UserImage",
+        "module": "serverpod_auth",
+        "schema": "public",
+        "columns": [
+          {
+            "name": "id",
+            "columnType": 6,
+            "isNullable": false,
+            "columnDefault": "nextval('serverpod_user_image_id_seq'::regclass)",
+            "dartType": "int?"
+          },
+          {
+            "name": "userId",
+            "columnType": 6,
+            "isNullable": false,
+            "dartType": "int"
+          },
+          {
+            "name": "version",
+            "columnType": 6,
+            "isNullable": false,
+            "dartType": "int"
+          },
+          {
+            "name": "url",
+            "columnType": 0,
+            "isNullable": false,
+            "dartType": "String"
+          }
+        ],
+        "foreignKeys": [],
+        "indexes": [
+          {
+            "indexName": "serverpod_user_image_pkey",
+            "elements": [
+              {
+                "type": 0,
+                "definition": "id"
+              }
+            ],
+            "type": "btree",
+            "isUnique": true,
+            "isPrimary": true
+          },
+          {
+            "indexName": "serverpod_user_image_user_id",
+            "elements": [
+              {
+                "type": 0,
+                "definition": "userId"
+              },
+              {
+                "type": 0,
+                "definition": "version"
+              }
+            ],
+            "type": "btree",
+            "isUnique": false,
+            "isPrimary": false
+          }
+        ],
+        "managed": true
+      }
+    },
+    {
+      "type": "createTable",
+      "createTable": {
+        "name": "serverpod_user_info",
+        "dartName": "UserInfo",
+        "module": "serverpod_auth",
+        "schema": "public",
+        "columns": [
+          {
+            "name": "id",
+            "columnType": 6,
+            "isNullable": false,
+            "columnDefault": "nextval('serverpod_user_info_id_seq'::regclass)",
+            "dartType": "int?"
+          },
+          {
+            "name": "userIdentifier",
+            "columnType": 0,
+            "isNullable": false,
+            "dartType": "String"
+          },
+          {
+            "name": "userName",
+            "columnType": 0,
+            "isNullable": true,
+            "dartType": "String?"
+          },
+          {
+            "name": "fullName",
+            "columnType": 0,
+            "isNullable": true,
+            "dartType": "String?"
+          },
+          {
+            "name": "email",
+            "columnType": 0,
+            "isNullable": true,
+            "dartType": "String?"
+          },
+          {
+            "name": "created",
+            "columnType": 4,
+            "isNullable": false,
+            "dartType": "DateTime"
+          },
+          {
+            "name": "imageUrl",
+            "columnType": 0,
+            "isNullable": true,
+            "dartType": "String?"
+          },
+          {
+            "name": "scopeNames",
+            "columnType": 8,
+            "isNullable": false,
+            "dartType": "List<String>"
+          },
+          {
+            "name": "blocked",
+            "columnType": 1,
+            "isNullable": false,
+            "dartType": "bool"
+          }
+        ],
+        "foreignKeys": [],
+        "indexes": [
+          {
+            "indexName": "serverpod_user_info_pkey",
+            "elements": [
+              {
+                "type": 0,
+                "definition": "id"
+              }
+            ],
+            "type": "btree",
+            "isUnique": true,
+            "isPrimary": true
+          },
+          {
+            "indexName": "serverpod_user_info_user_identifier",
+            "elements": [
+              {
+                "type": 0,
+                "definition": "userIdentifier"
+              }
+            ],
+            "type": "btree",
+            "isUnique": true,
+            "isPrimary": false
+          },
+          {
+            "indexName": "serverpod_user_info_email",
+            "elements": [
+              {
+                "type": 0,
+                "definition": "email"
+              }
+            ],
+            "type": "btree",
+            "isUnique": false,
+            "isPrimary": false
+          }
+        ],
+        "managed": true
+      }
+    },
+    {
+      "type": "createTable",
+      "createTable": {
         "name": "serverpod_auth_session",
         "dartName": "AuthSession",
         "module": "serverpod_auth_session",
@@ -1983,6 +2872,12 @@
             "dartType": "UuidValue"
           },
           {
+            "name": "scopeNames",
+            "columnType": 8,
+            "isNullable": false,
+            "dartType": "Set<String>"
+          },
+          {
             "name": "created",
             "columnType": 4,
             "isNullable": false,
@@ -1990,10 +2885,23 @@
             "dartType": "DateTime"
           },
           {
-            "name": "scopeNames",
-            "columnType": 8,
+            "name": "lastUsed",
+            "columnType": 4,
             "isNullable": false,
-            "dartType": "Set<String>"
+            "columnDefault": "CURRENT_TIMESTAMP",
+            "dartType": "DateTime"
+          },
+          {
+            "name": "expiresAt",
+            "columnType": 4,
+            "isNullable": true,
+            "dartType": "DateTime?"
+          },
+          {
+            "name": "expireAfterUnusedFor",
+            "columnType": 6,
+            "isNullable": true,
+            "dartType": "Duration?"
           },
           {
             "name": "sessionKeyHash",

--- a/modules/new_serverpod_auth/serverpod_auth_migration/serverpod_auth_migration_server/migrations/20250724125819384/migration.sql
+++ b/modules/new_serverpod_auth/serverpod_auth_migration/serverpod_auth_migration_server/migrations/20250724125819384/migration.sql
@@ -3,6 +3,19 @@ BEGIN;
 --
 -- ACTION CREATE TABLE
 --
+CREATE TABLE "serverpod_auth_migration_migrated_user" (
+    "id" bigserial PRIMARY KEY,
+    "oldUserId" bigint NOT NULL,
+    "newAuthUserId" uuid NOT NULL
+);
+
+-- Indexes
+CREATE UNIQUE INDEX "serverpod_auth_migration_migrated_user_old" ON "serverpod_auth_migration_migrated_user" USING btree ("oldUserId");
+CREATE UNIQUE INDEX "serverpod_auth_migration_migrated_user_new" ON "serverpod_auth_migration_migrated_user" USING btree ("newAuthUserId");
+
+--
+-- ACTION CREATE TABLE
+--
 CREATE TABLE "serverpod_cloud_storage" (
     "id" bigserial PRIMARY KEY,
     "storageId" text NOT NULL,
@@ -209,6 +222,41 @@ CREATE INDEX "serverpod_session_log_isopen_idx" ON "serverpod_session_log" USING
 --
 -- ACTION CREATE TABLE
 --
+CREATE TABLE "serverpod_auth_backwards_compatibility_email_password" (
+    "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    "emailAccountId" uuid NOT NULL,
+    "hash" text NOT NULL
+);
+
+-- Indexes
+CREATE UNIQUE INDEX "serverpod_auth_backwards_compatibility_email_password_account" ON "serverpod_auth_backwards_compatibility_email_password" USING btree ("emailAccountId");
+
+--
+-- ACTION CREATE TABLE
+--
+CREATE TABLE "serverpod_auth_backwards_compatibility_external_user_id" (
+    "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    "authUserId" uuid NOT NULL,
+    "userIdentifier" text NOT NULL
+);
+
+-- Indexes
+CREATE UNIQUE INDEX "serverpod_auth_backwards_compatibility_external_user_id_id" ON "serverpod_auth_backwards_compatibility_external_user_id" USING btree ("userIdentifier");
+
+--
+-- ACTION CREATE TABLE
+--
+CREATE TABLE "serverpod_auth_backwards_compatibility_session" (
+    "id" bigserial PRIMARY KEY,
+    "authUserId" uuid NOT NULL,
+    "scopeNames" json NOT NULL,
+    "hash" text NOT NULL,
+    "method" text NOT NULL
+);
+
+--
+-- ACTION CREATE TABLE
+--
 CREATE TABLE "serverpod_auth_email_account" (
     "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
     "authUserId" uuid NOT NULL,
@@ -227,27 +275,27 @@ CREATE UNIQUE INDEX "serverpod_auth_email_account_email" ON "serverpod_auth_emai
 CREATE TABLE "serverpod_auth_email_account_failed_login_attempt" (
     "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
     "email" text NOT NULL,
-    "attemptedAt" timestamp without time zone NOT NULL,
+    "attempted" timestamp without time zone NOT NULL,
     "ipAddress" text NOT NULL
 );
 
 -- Indexes
 CREATE INDEX "serverpod_auth_email_account_failed_login_attempt_email" ON "serverpod_auth_email_account_failed_login_attempt" USING btree ("email");
-CREATE INDEX "serverpod_auth_email_account_failed_login_attempt_attempted_at" ON "serverpod_auth_email_account_failed_login_attempt" USING btree ("attemptedAt");
+CREATE INDEX "serverpod_auth_email_account_failed_login_attempt_attempted" ON "serverpod_auth_email_account_failed_login_attempt" USING btree ("attempted");
 
 --
 -- ACTION CREATE TABLE
 --
 CREATE TABLE "serverpod_auth_email_account_password_reset_attempt" (
     "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-    "attemptedAt" timestamp without time zone NOT NULL,
+    "attempted" timestamp without time zone NOT NULL,
     "ipAddress" text NOT NULL,
     "passwordResetRequestId" uuid NOT NULL
 );
 
 -- Indexes
 CREATE INDEX "serverpod_auth_email_account_password_reset_attempt_ip" ON "serverpod_auth_email_account_password_reset_attempt" USING btree ("ipAddress");
-CREATE INDEX "serverpod_auth_email_account_password_reset_attempt_at" ON "serverpod_auth_email_account_password_reset_attempt" USING btree ("attemptedAt");
+CREATE INDEX "serverpod_auth_email_account_password_reset_attempted" ON "serverpod_auth_email_account_password_reset_attempt" USING btree ("attempted");
 
 --
 -- ACTION CREATE TABLE
@@ -266,14 +314,14 @@ CREATE TABLE "serverpod_auth_email_account_password_reset_request" (
 CREATE TABLE "serverpod_auth_email_account_pw_reset_request_attempt" (
     "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
     "email" text NOT NULL,
-    "attemptedAt" timestamp without time zone NOT NULL,
+    "attempted" timestamp without time zone NOT NULL,
     "ipAddress" text NOT NULL
 );
 
 -- Indexes
 CREATE INDEX "serverpod_auth_email_account_pw_reset_request_attempt_email" ON "serverpod_auth_email_account_pw_reset_request_attempt" USING btree ("email");
 CREATE INDEX "serverpod_auth_email_account_pw_reset_request_attempt_ip" ON "serverpod_auth_email_account_pw_reset_request_attempt" USING btree ("ipAddress");
-CREATE INDEX "serverpod_auth_email_account_pw_reset_request_attempt_at" ON "serverpod_auth_email_account_pw_reset_request_attempt" USING btree ("attemptedAt");
+CREATE INDEX "serverpod_auth_email_account_pw_reset_request_attempted" ON "serverpod_auth_email_account_pw_reset_request_attempt" USING btree ("attempted");
 
 --
 -- ACTION CREATE TABLE
@@ -297,14 +345,14 @@ CREATE UNIQUE INDEX "serverpod_auth_email_account_request_email" ON "serverpod_a
 --
 CREATE TABLE "serverpod_auth_email_account_request_completion_attempt" (
     "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-    "attemptedAt" timestamp without time zone NOT NULL,
+    "attempted" timestamp without time zone NOT NULL,
     "ipAddress" text NOT NULL,
     "emailAccountRequestId" uuid NOT NULL
 );
 
 -- Indexes
 CREATE INDEX "serverpod_auth_email_account_request_completion_attempt_ip" ON "serverpod_auth_email_account_request_completion_attempt" USING btree ("ipAddress");
-CREATE INDEX "serverpod_auth_email_account_request_completion_attempt_at" ON "serverpod_auth_email_account_request_completion_attempt" USING btree ("attemptedAt");
+CREATE INDEX "serverpod_auth_email_account_request_completion_attempted" ON "serverpod_auth_email_account_request_completion_attempt" USING btree ("attempted");
 
 --
 -- ACTION CREATE TABLE
@@ -337,11 +385,126 @@ CREATE TABLE "serverpod_auth_profile_user_profile_image" (
 --
 -- ACTION CREATE TABLE
 --
+CREATE TABLE "serverpod_auth_key" (
+    "id" bigserial PRIMARY KEY,
+    "userId" bigint NOT NULL,
+    "hash" text NOT NULL,
+    "scopeNames" json NOT NULL,
+    "method" text NOT NULL
+);
+
+-- Indexes
+CREATE INDEX "serverpod_auth_key_userId_idx" ON "serverpod_auth_key" USING btree ("userId");
+
+--
+-- ACTION CREATE TABLE
+--
+CREATE TABLE "serverpod_email_auth" (
+    "id" bigserial PRIMARY KEY,
+    "userId" bigint NOT NULL,
+    "email" text NOT NULL,
+    "hash" text NOT NULL
+);
+
+-- Indexes
+CREATE UNIQUE INDEX "serverpod_email_auth_email" ON "serverpod_email_auth" USING btree ("email");
+
+--
+-- ACTION CREATE TABLE
+--
+CREATE TABLE "serverpod_email_create_request" (
+    "id" bigserial PRIMARY KEY,
+    "userName" text NOT NULL,
+    "email" text NOT NULL,
+    "hash" text NOT NULL,
+    "verificationCode" text NOT NULL
+);
+
+-- Indexes
+CREATE UNIQUE INDEX "serverpod_email_auth_create_account_request_idx" ON "serverpod_email_create_request" USING btree ("email");
+
+--
+-- ACTION CREATE TABLE
+--
+CREATE TABLE "serverpod_email_failed_sign_in" (
+    "id" bigserial PRIMARY KEY,
+    "email" text NOT NULL,
+    "time" timestamp without time zone NOT NULL,
+    "ipAddress" text NOT NULL
+);
+
+-- Indexes
+CREATE INDEX "serverpod_email_failed_sign_in_email_idx" ON "serverpod_email_failed_sign_in" USING btree ("email");
+CREATE INDEX "serverpod_email_failed_sign_in_time_idx" ON "serverpod_email_failed_sign_in" USING btree ("time");
+
+--
+-- ACTION CREATE TABLE
+--
+CREATE TABLE "serverpod_email_reset" (
+    "id" bigserial PRIMARY KEY,
+    "userId" bigint NOT NULL,
+    "verificationCode" text NOT NULL,
+    "expiration" timestamp without time zone NOT NULL
+);
+
+-- Indexes
+CREATE UNIQUE INDEX "serverpod_email_reset_verification_idx" ON "serverpod_email_reset" USING btree ("verificationCode");
+
+--
+-- ACTION CREATE TABLE
+--
+CREATE TABLE "serverpod_google_refresh_token" (
+    "id" bigserial PRIMARY KEY,
+    "userId" bigint NOT NULL,
+    "refreshToken" text NOT NULL
+);
+
+-- Indexes
+CREATE UNIQUE INDEX "serverpod_google_refresh_token_userId_idx" ON "serverpod_google_refresh_token" USING btree ("userId");
+
+--
+-- ACTION CREATE TABLE
+--
+CREATE TABLE "serverpod_user_image" (
+    "id" bigserial PRIMARY KEY,
+    "userId" bigint NOT NULL,
+    "version" bigint NOT NULL,
+    "url" text NOT NULL
+);
+
+-- Indexes
+CREATE INDEX "serverpod_user_image_user_id" ON "serverpod_user_image" USING btree ("userId", "version");
+
+--
+-- ACTION CREATE TABLE
+--
+CREATE TABLE "serverpod_user_info" (
+    "id" bigserial PRIMARY KEY,
+    "userIdentifier" text NOT NULL,
+    "userName" text,
+    "fullName" text,
+    "email" text,
+    "created" timestamp without time zone NOT NULL,
+    "imageUrl" text,
+    "scopeNames" json NOT NULL,
+    "blocked" boolean NOT NULL
+);
+
+-- Indexes
+CREATE UNIQUE INDEX "serverpod_user_info_user_identifier" ON "serverpod_user_info" USING btree ("userIdentifier");
+CREATE INDEX "serverpod_user_info_email" ON "serverpod_user_info" USING btree ("email");
+
+--
+-- ACTION CREATE TABLE
+--
 CREATE TABLE "serverpod_auth_session" (
     "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
     "authUserId" uuid NOT NULL,
-    "created" timestamp without time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "scopeNames" json NOT NULL,
+    "created" timestamp without time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "lastUsed" timestamp without time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "expiresAt" timestamp without time zone,
+    "expireAfterUnusedFor" bigint,
     "sessionKeyHash" bytea NOT NULL,
     "sessionKeySalt" bytea NOT NULL,
     "method" text NOT NULL
@@ -356,6 +519,22 @@ CREATE TABLE "serverpod_auth_user" (
     "scopeNames" json NOT NULL,
     "blocked" boolean NOT NULL
 );
+
+--
+-- ACTION CREATE FOREIGN KEY
+--
+ALTER TABLE ONLY "serverpod_auth_migration_migrated_user"
+    ADD CONSTRAINT "serverpod_auth_migration_migrated_user_fk_0"
+    FOREIGN KEY("oldUserId")
+    REFERENCES "serverpod_user_info"("id")
+    ON DELETE CASCADE
+    ON UPDATE NO ACTION;
+ALTER TABLE ONLY "serverpod_auth_migration_migrated_user"
+    ADD CONSTRAINT "serverpod_auth_migration_migrated_user_fk_1"
+    FOREIGN KEY("newAuthUserId")
+    REFERENCES "serverpod_auth_user"("id")
+    ON DELETE CASCADE
+    ON UPDATE NO ACTION;
 
 --
 -- ACTION CREATE FOREIGN KEY
@@ -384,6 +563,36 @@ ALTER TABLE ONLY "serverpod_query_log"
     ADD CONSTRAINT "serverpod_query_log_fk_0"
     FOREIGN KEY("sessionLogId")
     REFERENCES "serverpod_session_log"("id")
+    ON DELETE CASCADE
+    ON UPDATE NO ACTION;
+
+--
+-- ACTION CREATE FOREIGN KEY
+--
+ALTER TABLE ONLY "serverpod_auth_backwards_compatibility_email_password"
+    ADD CONSTRAINT "serverpod_auth_backwards_compatibility_email_password_fk_0"
+    FOREIGN KEY("emailAccountId")
+    REFERENCES "serverpod_auth_email_account"("id")
+    ON DELETE CASCADE
+    ON UPDATE NO ACTION;
+
+--
+-- ACTION CREATE FOREIGN KEY
+--
+ALTER TABLE ONLY "serverpod_auth_backwards_compatibility_external_user_id"
+    ADD CONSTRAINT "serverpod_auth_backwards_compatibility_external_user_id_fk_0"
+    FOREIGN KEY("authUserId")
+    REFERENCES "serverpod_auth_user"("id")
+    ON DELETE CASCADE
+    ON UPDATE NO ACTION;
+
+--
+-- ACTION CREATE FOREIGN KEY
+--
+ALTER TABLE ONLY "serverpod_auth_backwards_compatibility_session"
+    ADD CONSTRAINT "serverpod_auth_backwards_compatibility_session_fk_0"
+    FOREIGN KEY("authUserId")
+    REFERENCES "serverpod_auth_user"("id")
     ON DELETE CASCADE
     ON UPDATE NO ACTION;
 
@@ -465,12 +674,12 @@ ALTER TABLE ONLY "serverpod_auth_session"
 
 
 --
--- MIGRATION VERSION FOR serverpod_auth_email
+-- MIGRATION VERSION FOR serverpod_auth_migration
 --
 INSERT INTO "serverpod_migrations" ("module", "version", "timestamp")
-    VALUES ('serverpod_auth_email', '20250611073844715', now())
+    VALUES ('serverpod_auth_migration', '20250724125819384', now())
     ON CONFLICT ("module")
-    DO UPDATE SET "version" = '20250611073844715', "timestamp" = now();
+    DO UPDATE SET "version" = '20250724125819384', "timestamp" = now();
 
 --
 -- MIGRATION VERSION FOR serverpod
@@ -481,12 +690,28 @@ INSERT INTO "serverpod_migrations" ("module", "version", "timestamp")
     DO UPDATE SET "version" = '20240516151843329', "timestamp" = now();
 
 --
+-- MIGRATION VERSION FOR serverpod_auth_backwards_compatibility
+--
+INSERT INTO "serverpod_migrations" ("module", "version", "timestamp")
+    VALUES ('serverpod_auth_backwards_compatibility', '20250724125750464', now())
+    ON CONFLICT ("module")
+    DO UPDATE SET "version" = '20250724125750464', "timestamp" = now();
+
+--
 -- MIGRATION VERSION FOR serverpod_auth_email_account
 --
 INSERT INTO "serverpod_migrations" ("module", "version", "timestamp")
-    VALUES ('serverpod_auth_email_account', '20250606090748154', now())
+    VALUES ('serverpod_auth_email_account', '20250724100154487', now())
     ON CONFLICT ("module")
-    DO UPDATE SET "version" = '20250606090748154', "timestamp" = now();
+    DO UPDATE SET "version" = '20250724100154487', "timestamp" = now();
+
+--
+-- MIGRATION VERSION FOR serverpod_auth_email
+--
+INSERT INTO "serverpod_migrations" ("module", "version", "timestamp")
+    VALUES ('serverpod_auth_email', '20250724100231671', now())
+    ON CONFLICT ("module")
+    DO UPDATE SET "version" = '20250724100231671', "timestamp" = now();
 
 --
 -- MIGRATION VERSION FOR serverpod_auth_profile
@@ -497,12 +722,20 @@ INSERT INTO "serverpod_migrations" ("module", "version", "timestamp")
     DO UPDATE SET "version" = '20250519092101868', "timestamp" = now();
 
 --
+-- MIGRATION VERSION FOR serverpod_auth
+--
+INSERT INTO "serverpod_migrations" ("module", "version", "timestamp")
+    VALUES ('serverpod_auth', '20240520102713718', now())
+    ON CONFLICT ("module")
+    DO UPDATE SET "version" = '20240520102713718', "timestamp" = now();
+
+--
 -- MIGRATION VERSION FOR serverpod_auth_session
 --
 INSERT INTO "serverpod_migrations" ("module", "version", "timestamp")
-    VALUES ('serverpod_auth_session', '20250607101155018', now())
+    VALUES ('serverpod_auth_session', '20250611085050241', now())
     ON CONFLICT ("module")
-    DO UPDATE SET "version" = '20250607101155018', "timestamp" = now();
+    DO UPDATE SET "version" = '20250611085050241', "timestamp" = now();
 
 --
 -- MIGRATION VERSION FOR serverpod_auth_user

--- a/modules/new_serverpod_auth/serverpod_auth_migration/serverpod_auth_migration_server/migrations/migration_registry.txt
+++ b/modules/new_serverpod_auth/serverpod_auth_migration/serverpod_auth_migration_server/migrations/migration_registry.txt
@@ -4,4 +4,4 @@
 ### manually. If a collision is detected in this file when doing a code merge, resolve
 ### the conflict by removing and recreating the conflicting migration.
 
-20250711114550334
+20250724125819384

--- a/tests/serverpod_new_auth_test/serverpod_new_auth_test_server/migrations/20250724100312502/definition.json
+++ b/tests/serverpod_new_auth_test/serverpod_new_auth_test_server/migrations/20250724100312502/definition.json
@@ -1,213 +1,6 @@
 {
-  "moduleName": "serverpod_auth_backwards_compatibility",
+  "moduleName": "serverpod_new_auth_test",
   "tables": [
-    {
-      "name": "serverpod_auth_backwards_compatibility_email_password",
-      "dartName": "LegacyEmailPassword",
-      "module": "serverpod_auth_backwards_compatibility",
-      "schema": "public",
-      "columns": [
-        {
-          "name": "id",
-          "columnType": 7,
-          "isNullable": false,
-          "columnDefault": "gen_random_uuid()",
-          "dartType": "UuidValue?"
-        },
-        {
-          "name": "emailAccountId",
-          "columnType": 7,
-          "isNullable": false,
-          "dartType": "UuidValue"
-        },
-        {
-          "name": "hash",
-          "columnType": 0,
-          "isNullable": false,
-          "dartType": "String"
-        }
-      ],
-      "foreignKeys": [
-        {
-          "constraintName": "serverpod_auth_backwards_compatibility_email_password_fk_0",
-          "columns": [
-            "emailAccountId"
-          ],
-          "referenceTable": "serverpod_auth_email_account",
-          "referenceTableSchema": "public",
-          "referenceColumns": [
-            "id"
-          ],
-          "onUpdate": 3,
-          "onDelete": 4
-        }
-      ],
-      "indexes": [
-        {
-          "indexName": "serverpod_auth_backwards_compatibility_email_password_pkey",
-          "elements": [
-            {
-              "type": 0,
-              "definition": "id"
-            }
-          ],
-          "type": "btree",
-          "isUnique": true,
-          "isPrimary": true
-        },
-        {
-          "indexName": "serverpod_auth_backwards_compatibility_email_password_account",
-          "elements": [
-            {
-              "type": 0,
-              "definition": "emailAccountId"
-            }
-          ],
-          "type": "btree",
-          "isUnique": true,
-          "isPrimary": false
-        }
-      ],
-      "managed": true
-    },
-    {
-      "name": "serverpod_auth_backwards_compatibility_external_user_id",
-      "dartName": "LegacyExternalUserIdentifier",
-      "module": "serverpod_auth_backwards_compatibility",
-      "schema": "public",
-      "columns": [
-        {
-          "name": "id",
-          "columnType": 7,
-          "isNullable": false,
-          "columnDefault": "gen_random_uuid()",
-          "dartType": "UuidValue?"
-        },
-        {
-          "name": "authUserId",
-          "columnType": 7,
-          "isNullable": false,
-          "dartType": "UuidValue"
-        },
-        {
-          "name": "userIdentifier",
-          "columnType": 0,
-          "isNullable": false,
-          "dartType": "String"
-        }
-      ],
-      "foreignKeys": [
-        {
-          "constraintName": "serverpod_auth_backwards_compatibility_external_user_id_fk_0",
-          "columns": [
-            "authUserId"
-          ],
-          "referenceTable": "serverpod_auth_user",
-          "referenceTableSchema": "public",
-          "referenceColumns": [
-            "id"
-          ],
-          "onUpdate": 3,
-          "onDelete": 4
-        }
-      ],
-      "indexes": [
-        {
-          "indexName": "serverpod_auth_backwards_compatibility_external_user_id_pkey",
-          "elements": [
-            {
-              "type": 0,
-              "definition": "id"
-            }
-          ],
-          "type": "btree",
-          "isUnique": true,
-          "isPrimary": true
-        },
-        {
-          "indexName": "serverpod_auth_backwards_compatibility_external_user_id_id",
-          "elements": [
-            {
-              "type": 0,
-              "definition": "userIdentifier"
-            }
-          ],
-          "type": "btree",
-          "isUnique": true,
-          "isPrimary": false
-        }
-      ],
-      "managed": true
-    },
-    {
-      "name": "serverpod_auth_backwards_compatibility_session",
-      "dartName": "LegacySession",
-      "module": "serverpod_auth_backwards_compatibility",
-      "schema": "public",
-      "columns": [
-        {
-          "name": "id",
-          "columnType": 6,
-          "isNullable": false,
-          "columnDefault": "nextval('serverpod_auth_backwards_compatibility_session_id_seq'::regclass)",
-          "dartType": "int?"
-        },
-        {
-          "name": "authUserId",
-          "columnType": 7,
-          "isNullable": false,
-          "dartType": "UuidValue"
-        },
-        {
-          "name": "scopeNames",
-          "columnType": 8,
-          "isNullable": false,
-          "dartType": "Set<String>"
-        },
-        {
-          "name": "hash",
-          "columnType": 0,
-          "isNullable": false,
-          "dartType": "String"
-        },
-        {
-          "name": "method",
-          "columnType": 0,
-          "isNullable": false,
-          "dartType": "String"
-        }
-      ],
-      "foreignKeys": [
-        {
-          "constraintName": "serverpod_auth_backwards_compatibility_session_fk_0",
-          "columns": [
-            "authUserId"
-          ],
-          "referenceTable": "serverpod_auth_user",
-          "referenceTableSchema": "public",
-          "referenceColumns": [
-            "id"
-          ],
-          "onUpdate": 3,
-          "onDelete": 4
-        }
-      ],
-      "indexes": [
-        {
-          "indexName": "serverpod_auth_backwards_compatibility_session_pkey",
-          "elements": [
-            {
-              "type": 0,
-              "definition": "id"
-            }
-          ],
-          "type": "btree",
-          "isUnique": true,
-          "isPrimary": true
-        }
-      ],
-      "managed": true
-    },
     {
       "name": "serverpod_cloud_storage",
       "dartName": "CloudStorageEntry",
@@ -1346,6 +1139,1042 @@
       "managed": true
     },
     {
+      "name": "serverpod_auth_backwards_compatibility_email_password",
+      "dartName": "LegacyEmailPassword",
+      "module": "serverpod_auth_backwards_compatibility",
+      "schema": "public",
+      "columns": [
+        {
+          "name": "id",
+          "columnType": 7,
+          "isNullable": false,
+          "columnDefault": "gen_random_uuid()",
+          "dartType": "UuidValue?"
+        },
+        {
+          "name": "emailAccountId",
+          "columnType": 7,
+          "isNullable": false,
+          "dartType": "UuidValue"
+        },
+        {
+          "name": "hash",
+          "columnType": 0,
+          "isNullable": false,
+          "dartType": "String"
+        }
+      ],
+      "foreignKeys": [
+        {
+          "constraintName": "serverpod_auth_backwards_compatibility_email_password_fk_0",
+          "columns": [
+            "emailAccountId"
+          ],
+          "referenceTable": "serverpod_auth_email_account",
+          "referenceTableSchema": "public",
+          "referenceColumns": [
+            "id"
+          ],
+          "onUpdate": 3,
+          "onDelete": 4
+        }
+      ],
+      "indexes": [
+        {
+          "indexName": "serverpod_auth_backwards_compatibility_email_password_pkey",
+          "elements": [
+            {
+              "type": 0,
+              "definition": "id"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": true
+        },
+        {
+          "indexName": "serverpod_auth_backwards_compatibility_email_password_account",
+          "elements": [
+            {
+              "type": 0,
+              "definition": "emailAccountId"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": false
+        }
+      ],
+      "managed": true
+    },
+    {
+      "name": "serverpod_auth_backwards_compatibility_external_user_id",
+      "dartName": "LegacyExternalUserIdentifier",
+      "module": "serverpod_auth_backwards_compatibility",
+      "schema": "public",
+      "columns": [
+        {
+          "name": "id",
+          "columnType": 7,
+          "isNullable": false,
+          "columnDefault": "gen_random_uuid()",
+          "dartType": "UuidValue?"
+        },
+        {
+          "name": "authUserId",
+          "columnType": 7,
+          "isNullable": false,
+          "dartType": "UuidValue"
+        },
+        {
+          "name": "userIdentifier",
+          "columnType": 0,
+          "isNullable": false,
+          "dartType": "String"
+        }
+      ],
+      "foreignKeys": [
+        {
+          "constraintName": "serverpod_auth_backwards_compatibility_external_user_id_fk_0",
+          "columns": [
+            "authUserId"
+          ],
+          "referenceTable": "serverpod_auth_user",
+          "referenceTableSchema": "public",
+          "referenceColumns": [
+            "id"
+          ],
+          "onUpdate": 3,
+          "onDelete": 4
+        }
+      ],
+      "indexes": [
+        {
+          "indexName": "serverpod_auth_backwards_compatibility_external_user_id_pkey",
+          "elements": [
+            {
+              "type": 0,
+              "definition": "id"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": true
+        },
+        {
+          "indexName": "serverpod_auth_backwards_compatibility_external_user_id_id",
+          "elements": [
+            {
+              "type": 0,
+              "definition": "userIdentifier"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": false
+        }
+      ],
+      "managed": true
+    },
+    {
+      "name": "serverpod_auth_backwards_compatibility_session",
+      "dartName": "LegacySession",
+      "module": "serverpod_auth_backwards_compatibility",
+      "schema": "public",
+      "columns": [
+        {
+          "name": "id",
+          "columnType": 6,
+          "isNullable": false,
+          "columnDefault": "nextval('serverpod_auth_backwards_compatibility_session_id_seq'::regclass)",
+          "dartType": "int?"
+        },
+        {
+          "name": "authUserId",
+          "columnType": 7,
+          "isNullable": false,
+          "dartType": "UuidValue"
+        },
+        {
+          "name": "scopeNames",
+          "columnType": 8,
+          "isNullable": false,
+          "dartType": "Set<String>"
+        },
+        {
+          "name": "hash",
+          "columnType": 0,
+          "isNullable": false,
+          "dartType": "String"
+        },
+        {
+          "name": "method",
+          "columnType": 0,
+          "isNullable": false,
+          "dartType": "String"
+        }
+      ],
+      "foreignKeys": [
+        {
+          "constraintName": "serverpod_auth_backwards_compatibility_session_fk_0",
+          "columns": [
+            "authUserId"
+          ],
+          "referenceTable": "serverpod_auth_user",
+          "referenceTableSchema": "public",
+          "referenceColumns": [
+            "id"
+          ],
+          "onUpdate": 3,
+          "onDelete": 4
+        }
+      ],
+      "indexes": [
+        {
+          "indexName": "serverpod_auth_backwards_compatibility_session_pkey",
+          "elements": [
+            {
+              "type": 0,
+              "definition": "id"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": true
+        }
+      ],
+      "managed": true
+    },
+    {
+      "name": "serverpod_auth_migration_migrated_user",
+      "dartName": "MigratedUser",
+      "module": "serverpod_auth_migration",
+      "schema": "public",
+      "columns": [
+        {
+          "name": "id",
+          "columnType": 6,
+          "isNullable": false,
+          "columnDefault": "nextval('serverpod_auth_migration_migrated_user_id_seq'::regclass)",
+          "dartType": "int?"
+        },
+        {
+          "name": "oldUserId",
+          "columnType": 6,
+          "isNullable": false,
+          "dartType": "int"
+        },
+        {
+          "name": "newAuthUserId",
+          "columnType": 7,
+          "isNullable": false,
+          "dartType": "UuidValue"
+        }
+      ],
+      "foreignKeys": [
+        {
+          "constraintName": "serverpod_auth_migration_migrated_user_fk_0",
+          "columns": [
+            "oldUserId"
+          ],
+          "referenceTable": "serverpod_user_info",
+          "referenceTableSchema": "public",
+          "referenceColumns": [
+            "id"
+          ],
+          "onUpdate": 3,
+          "onDelete": 4
+        },
+        {
+          "constraintName": "serverpod_auth_migration_migrated_user_fk_1",
+          "columns": [
+            "newAuthUserId"
+          ],
+          "referenceTable": "serverpod_auth_user",
+          "referenceTableSchema": "public",
+          "referenceColumns": [
+            "id"
+          ],
+          "onUpdate": 3,
+          "onDelete": 4
+        }
+      ],
+      "indexes": [
+        {
+          "indexName": "serverpod_auth_migration_migrated_user_pkey",
+          "elements": [
+            {
+              "type": 0,
+              "definition": "id"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": true
+        },
+        {
+          "indexName": "serverpod_auth_migration_migrated_user_old",
+          "elements": [
+            {
+              "type": 0,
+              "definition": "oldUserId"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": false
+        },
+        {
+          "indexName": "serverpod_auth_migration_migrated_user_new",
+          "elements": [
+            {
+              "type": 0,
+              "definition": "newAuthUserId"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": false
+        }
+      ],
+      "managed": true
+    },
+    {
+      "name": "serverpod_auth_profile_user_profile",
+      "dartName": "UserProfile",
+      "module": "serverpod_auth_profile",
+      "schema": "public",
+      "columns": [
+        {
+          "name": "id",
+          "columnType": 7,
+          "isNullable": false,
+          "columnDefault": "gen_random_uuid()",
+          "dartType": "UuidValue?"
+        },
+        {
+          "name": "authUserId",
+          "columnType": 7,
+          "isNullable": false,
+          "dartType": "UuidValue"
+        },
+        {
+          "name": "userName",
+          "columnType": 0,
+          "isNullable": true,
+          "dartType": "String?"
+        },
+        {
+          "name": "fullName",
+          "columnType": 0,
+          "isNullable": true,
+          "dartType": "String?"
+        },
+        {
+          "name": "email",
+          "columnType": 0,
+          "isNullable": true,
+          "dartType": "String?"
+        },
+        {
+          "name": "created",
+          "columnType": 4,
+          "isNullable": false,
+          "columnDefault": "CURRENT_TIMESTAMP",
+          "dartType": "DateTime"
+        },
+        {
+          "name": "imageId",
+          "columnType": 7,
+          "isNullable": true,
+          "dartType": "UuidValue?"
+        }
+      ],
+      "foreignKeys": [
+        {
+          "constraintName": "serverpod_auth_profile_user_profile_fk_0",
+          "columns": [
+            "authUserId"
+          ],
+          "referenceTable": "serverpod_auth_user",
+          "referenceTableSchema": "public",
+          "referenceColumns": [
+            "id"
+          ],
+          "onUpdate": 3,
+          "onDelete": 4
+        },
+        {
+          "constraintName": "serverpod_auth_profile_user_profile_fk_1",
+          "columns": [
+            "imageId"
+          ],
+          "referenceTable": "serverpod_auth_profile_user_profile_image",
+          "referenceTableSchema": "public",
+          "referenceColumns": [
+            "id"
+          ],
+          "onUpdate": 3,
+          "onDelete": 3
+        }
+      ],
+      "indexes": [
+        {
+          "indexName": "serverpod_auth_profile_user_profile_pkey",
+          "elements": [
+            {
+              "type": 0,
+              "definition": "id"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": true
+        },
+        {
+          "indexName": "serverpod_auth_profile_user_profile_email_auth_user_id",
+          "elements": [
+            {
+              "type": 0,
+              "definition": "authUserId"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": false
+        }
+      ],
+      "managed": true
+    },
+    {
+      "name": "serverpod_auth_profile_user_profile_image",
+      "dartName": "UserProfileImage",
+      "module": "serverpod_auth_profile",
+      "schema": "public",
+      "columns": [
+        {
+          "name": "id",
+          "columnType": 7,
+          "isNullable": false,
+          "columnDefault": "gen_random_uuid()",
+          "dartType": "UuidValue?"
+        },
+        {
+          "name": "userProfileId",
+          "columnType": 7,
+          "isNullable": false,
+          "dartType": "UuidValue"
+        },
+        {
+          "name": "created",
+          "columnType": 4,
+          "isNullable": false,
+          "columnDefault": "CURRENT_TIMESTAMP",
+          "dartType": "DateTime"
+        },
+        {
+          "name": "storageId",
+          "columnType": 0,
+          "isNullable": false,
+          "dartType": "String"
+        },
+        {
+          "name": "path",
+          "columnType": 0,
+          "isNullable": false,
+          "dartType": "String"
+        },
+        {
+          "name": "url",
+          "columnType": 0,
+          "isNullable": false,
+          "dartType": "Uri"
+        }
+      ],
+      "foreignKeys": [
+        {
+          "constraintName": "serverpod_auth_profile_user_profile_image_fk_0",
+          "columns": [
+            "userProfileId"
+          ],
+          "referenceTable": "serverpod_auth_profile_user_profile",
+          "referenceTableSchema": "public",
+          "referenceColumns": [
+            "id"
+          ],
+          "onUpdate": 3,
+          "onDelete": 4
+        }
+      ],
+      "indexes": [
+        {
+          "indexName": "serverpod_auth_profile_user_profile_image_pkey",
+          "elements": [
+            {
+              "type": 0,
+              "definition": "id"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": true
+        }
+      ],
+      "managed": true
+    },
+    {
+      "name": "serverpod_auth_key",
+      "dartName": "AuthKey",
+      "module": "serverpod_auth",
+      "schema": "public",
+      "columns": [
+        {
+          "name": "id",
+          "columnType": 6,
+          "isNullable": false,
+          "columnDefault": "nextval('serverpod_auth_key_id_seq'::regclass)",
+          "dartType": "int?"
+        },
+        {
+          "name": "userId",
+          "columnType": 6,
+          "isNullable": false,
+          "dartType": "int"
+        },
+        {
+          "name": "hash",
+          "columnType": 0,
+          "isNullable": false,
+          "dartType": "String"
+        },
+        {
+          "name": "scopeNames",
+          "columnType": 8,
+          "isNullable": false,
+          "dartType": "List<String>"
+        },
+        {
+          "name": "method",
+          "columnType": 0,
+          "isNullable": false,
+          "dartType": "String"
+        }
+      ],
+      "foreignKeys": [],
+      "indexes": [
+        {
+          "indexName": "serverpod_auth_key_pkey",
+          "elements": [
+            {
+              "type": 0,
+              "definition": "id"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": true
+        },
+        {
+          "indexName": "serverpod_auth_key_userId_idx",
+          "elements": [
+            {
+              "type": 0,
+              "definition": "userId"
+            }
+          ],
+          "type": "btree",
+          "isUnique": false,
+          "isPrimary": false
+        }
+      ],
+      "managed": true
+    },
+    {
+      "name": "serverpod_email_auth",
+      "dartName": "EmailAuth",
+      "module": "serverpod_auth",
+      "schema": "public",
+      "columns": [
+        {
+          "name": "id",
+          "columnType": 6,
+          "isNullable": false,
+          "columnDefault": "nextval('serverpod_email_auth_id_seq'::regclass)",
+          "dartType": "int?"
+        },
+        {
+          "name": "userId",
+          "columnType": 6,
+          "isNullable": false,
+          "dartType": "int"
+        },
+        {
+          "name": "email",
+          "columnType": 0,
+          "isNullable": false,
+          "dartType": "String"
+        },
+        {
+          "name": "hash",
+          "columnType": 0,
+          "isNullable": false,
+          "dartType": "String"
+        }
+      ],
+      "foreignKeys": [],
+      "indexes": [
+        {
+          "indexName": "serverpod_email_auth_pkey",
+          "elements": [
+            {
+              "type": 0,
+              "definition": "id"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": true
+        },
+        {
+          "indexName": "serverpod_email_auth_email",
+          "elements": [
+            {
+              "type": 0,
+              "definition": "email"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": false
+        }
+      ],
+      "managed": true
+    },
+    {
+      "name": "serverpod_email_create_request",
+      "dartName": "EmailCreateAccountRequest",
+      "module": "serverpod_auth",
+      "schema": "public",
+      "columns": [
+        {
+          "name": "id",
+          "columnType": 6,
+          "isNullable": false,
+          "columnDefault": "nextval('serverpod_email_create_request_id_seq'::regclass)",
+          "dartType": "int?"
+        },
+        {
+          "name": "userName",
+          "columnType": 0,
+          "isNullable": false,
+          "dartType": "String"
+        },
+        {
+          "name": "email",
+          "columnType": 0,
+          "isNullable": false,
+          "dartType": "String"
+        },
+        {
+          "name": "hash",
+          "columnType": 0,
+          "isNullable": false,
+          "dartType": "String"
+        },
+        {
+          "name": "verificationCode",
+          "columnType": 0,
+          "isNullable": false,
+          "dartType": "String"
+        }
+      ],
+      "foreignKeys": [],
+      "indexes": [
+        {
+          "indexName": "serverpod_email_create_request_pkey",
+          "elements": [
+            {
+              "type": 0,
+              "definition": "id"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": true
+        },
+        {
+          "indexName": "serverpod_email_auth_create_account_request_idx",
+          "elements": [
+            {
+              "type": 0,
+              "definition": "email"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": false
+        }
+      ],
+      "managed": true
+    },
+    {
+      "name": "serverpod_email_failed_sign_in",
+      "dartName": "EmailFailedSignIn",
+      "module": "serverpod_auth",
+      "schema": "public",
+      "columns": [
+        {
+          "name": "id",
+          "columnType": 6,
+          "isNullable": false,
+          "columnDefault": "nextval('serverpod_email_failed_sign_in_id_seq'::regclass)",
+          "dartType": "int?"
+        },
+        {
+          "name": "email",
+          "columnType": 0,
+          "isNullable": false,
+          "dartType": "String"
+        },
+        {
+          "name": "time",
+          "columnType": 4,
+          "isNullable": false,
+          "dartType": "DateTime"
+        },
+        {
+          "name": "ipAddress",
+          "columnType": 0,
+          "isNullable": false,
+          "dartType": "String"
+        }
+      ],
+      "foreignKeys": [],
+      "indexes": [
+        {
+          "indexName": "serverpod_email_failed_sign_in_pkey",
+          "elements": [
+            {
+              "type": 0,
+              "definition": "id"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": true
+        },
+        {
+          "indexName": "serverpod_email_failed_sign_in_email_idx",
+          "elements": [
+            {
+              "type": 0,
+              "definition": "email"
+            }
+          ],
+          "type": "btree",
+          "isUnique": false,
+          "isPrimary": false
+        },
+        {
+          "indexName": "serverpod_email_failed_sign_in_time_idx",
+          "elements": [
+            {
+              "type": 0,
+              "definition": "time"
+            }
+          ],
+          "type": "btree",
+          "isUnique": false,
+          "isPrimary": false
+        }
+      ],
+      "managed": true
+    },
+    {
+      "name": "serverpod_email_reset",
+      "dartName": "EmailReset",
+      "module": "serverpod_auth",
+      "schema": "public",
+      "columns": [
+        {
+          "name": "id",
+          "columnType": 6,
+          "isNullable": false,
+          "columnDefault": "nextval('serverpod_email_reset_id_seq'::regclass)",
+          "dartType": "int?"
+        },
+        {
+          "name": "userId",
+          "columnType": 6,
+          "isNullable": false,
+          "dartType": "int"
+        },
+        {
+          "name": "verificationCode",
+          "columnType": 0,
+          "isNullable": false,
+          "dartType": "String"
+        },
+        {
+          "name": "expiration",
+          "columnType": 4,
+          "isNullable": false,
+          "dartType": "DateTime"
+        }
+      ],
+      "foreignKeys": [],
+      "indexes": [
+        {
+          "indexName": "serverpod_email_reset_pkey",
+          "elements": [
+            {
+              "type": 0,
+              "definition": "id"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": true
+        },
+        {
+          "indexName": "serverpod_email_reset_verification_idx",
+          "elements": [
+            {
+              "type": 0,
+              "definition": "verificationCode"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": false
+        }
+      ],
+      "managed": true
+    },
+    {
+      "name": "serverpod_google_refresh_token",
+      "dartName": "GoogleRefreshToken",
+      "module": "serverpod_auth",
+      "schema": "public",
+      "columns": [
+        {
+          "name": "id",
+          "columnType": 6,
+          "isNullable": false,
+          "columnDefault": "nextval('serverpod_google_refresh_token_id_seq'::regclass)",
+          "dartType": "int?"
+        },
+        {
+          "name": "userId",
+          "columnType": 6,
+          "isNullable": false,
+          "dartType": "int"
+        },
+        {
+          "name": "refreshToken",
+          "columnType": 0,
+          "isNullable": false,
+          "dartType": "String"
+        }
+      ],
+      "foreignKeys": [],
+      "indexes": [
+        {
+          "indexName": "serverpod_google_refresh_token_pkey",
+          "elements": [
+            {
+              "type": 0,
+              "definition": "id"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": true
+        },
+        {
+          "indexName": "serverpod_google_refresh_token_userId_idx",
+          "elements": [
+            {
+              "type": 0,
+              "definition": "userId"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": false
+        }
+      ],
+      "managed": true
+    },
+    {
+      "name": "serverpod_user_image",
+      "dartName": "UserImage",
+      "module": "serverpod_auth",
+      "schema": "public",
+      "columns": [
+        {
+          "name": "id",
+          "columnType": 6,
+          "isNullable": false,
+          "columnDefault": "nextval('serverpod_user_image_id_seq'::regclass)",
+          "dartType": "int?"
+        },
+        {
+          "name": "userId",
+          "columnType": 6,
+          "isNullable": false,
+          "dartType": "int"
+        },
+        {
+          "name": "version",
+          "columnType": 6,
+          "isNullable": false,
+          "dartType": "int"
+        },
+        {
+          "name": "url",
+          "columnType": 0,
+          "isNullable": false,
+          "dartType": "String"
+        }
+      ],
+      "foreignKeys": [],
+      "indexes": [
+        {
+          "indexName": "serverpod_user_image_pkey",
+          "elements": [
+            {
+              "type": 0,
+              "definition": "id"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": true
+        },
+        {
+          "indexName": "serverpod_user_image_user_id",
+          "elements": [
+            {
+              "type": 0,
+              "definition": "userId"
+            },
+            {
+              "type": 0,
+              "definition": "version"
+            }
+          ],
+          "type": "btree",
+          "isUnique": false,
+          "isPrimary": false
+        }
+      ],
+      "managed": true
+    },
+    {
+      "name": "serverpod_user_info",
+      "dartName": "UserInfo",
+      "module": "serverpod_auth",
+      "schema": "public",
+      "columns": [
+        {
+          "name": "id",
+          "columnType": 6,
+          "isNullable": false,
+          "columnDefault": "nextval('serverpod_user_info_id_seq'::regclass)",
+          "dartType": "int?"
+        },
+        {
+          "name": "userIdentifier",
+          "columnType": 0,
+          "isNullable": false,
+          "dartType": "String"
+        },
+        {
+          "name": "userName",
+          "columnType": 0,
+          "isNullable": true,
+          "dartType": "String?"
+        },
+        {
+          "name": "fullName",
+          "columnType": 0,
+          "isNullable": true,
+          "dartType": "String?"
+        },
+        {
+          "name": "email",
+          "columnType": 0,
+          "isNullable": true,
+          "dartType": "String?"
+        },
+        {
+          "name": "created",
+          "columnType": 4,
+          "isNullable": false,
+          "dartType": "DateTime"
+        },
+        {
+          "name": "imageUrl",
+          "columnType": 0,
+          "isNullable": true,
+          "dartType": "String?"
+        },
+        {
+          "name": "scopeNames",
+          "columnType": 8,
+          "isNullable": false,
+          "dartType": "List<String>"
+        },
+        {
+          "name": "blocked",
+          "columnType": 1,
+          "isNullable": false,
+          "dartType": "bool"
+        }
+      ],
+      "foreignKeys": [],
+      "indexes": [
+        {
+          "indexName": "serverpod_user_info_pkey",
+          "elements": [
+            {
+              "type": 0,
+              "definition": "id"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": true
+        },
+        {
+          "indexName": "serverpod_user_info_user_identifier",
+          "elements": [
+            {
+              "type": 0,
+              "definition": "userIdentifier"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": false
+        },
+        {
+          "indexName": "serverpod_user_info_email",
+          "elements": [
+            {
+              "type": 0,
+              "definition": "email"
+            }
+          ],
+          "type": "btree",
+          "isUnique": false,
+          "isPrimary": false
+        }
+      ],
+      "managed": true
+    },
+    {
       "name": "serverpod_auth_email_account",
       "dartName": "EmailAccount",
       "module": "serverpod_auth_email_account",
@@ -1452,7 +2281,7 @@
           "dartType": "String"
         },
         {
-          "name": "attemptedAt",
+          "name": "attempted",
           "columnType": 4,
           "isNullable": false,
           "dartType": "DateTime"
@@ -1491,11 +2320,11 @@
           "isPrimary": false
         },
         {
-          "indexName": "serverpod_auth_email_account_failed_login_attempt_attempted_at",
+          "indexName": "serverpod_auth_email_account_failed_login_attempt_attempted",
           "elements": [
             {
               "type": 0,
-              "definition": "attemptedAt"
+              "definition": "attempted"
             }
           ],
           "type": "btree",
@@ -1519,7 +2348,7 @@
           "dartType": "UuidValue?"
         },
         {
-          "name": "attemptedAt",
+          "name": "attempted",
           "columnType": 4,
           "isNullable": false,
           "dartType": "DateTime"
@@ -1578,11 +2407,11 @@
           "isPrimary": false
         },
         {
-          "indexName": "serverpod_auth_email_account_password_reset_attempt_at",
+          "indexName": "serverpod_auth_email_account_password_reset_attempted",
           "elements": [
             {
               "type": 0,
-              "definition": "attemptedAt"
+              "definition": "attempted"
             }
           ],
           "type": "btree",
@@ -1682,7 +2511,7 @@
           "dartType": "String"
         },
         {
-          "name": "attemptedAt",
+          "name": "attempted",
           "columnType": 4,
           "isNullable": false,
           "dartType": "DateTime"
@@ -1733,11 +2562,11 @@
           "isPrimary": false
         },
         {
-          "indexName": "serverpod_auth_email_account_pw_reset_request_attempt_at",
+          "indexName": "serverpod_auth_email_account_pw_reset_request_attempted",
           "elements": [
             {
               "type": 0,
-              "definition": "attemptedAt"
+              "definition": "attempted"
             }
           ],
           "type": "btree",
@@ -1847,7 +2676,7 @@
           "dartType": "UuidValue?"
         },
         {
-          "name": "attemptedAt",
+          "name": "attempted",
           "columnType": 4,
           "isNullable": false,
           "dartType": "DateTime"
@@ -1906,11 +2735,11 @@
           "isPrimary": false
         },
         {
-          "indexName": "serverpod_auth_email_account_request_completion_attempt_at",
+          "indexName": "serverpod_auth_email_account_request_completion_attempted",
           "elements": [
             {
               "type": 0,
-              "definition": "attemptedAt"
+              "definition": "attempted"
             }
           ],
           "type": "btree",
@@ -2073,16 +2902,36 @@
   ],
   "installedModules": [
     {
-      "module": "serverpod_auth_backwards_compatibility",
-      "version": "20250708110241098"
+      "module": "serverpod_new_auth_test",
+      "version": "20250724100312502"
     },
     {
       "module": "serverpod",
       "version": "20240516151843329"
     },
     {
+      "module": "serverpod_auth_backwards_compatibility",
+      "version": "20250708110241098"
+    },
+    {
+      "module": "serverpod_auth_email",
+      "version": "20250724100231671"
+    },
+    {
+      "module": "serverpod_auth_migration",
+      "version": "20250711114550334"
+    },
+    {
+      "module": "serverpod_auth_profile",
+      "version": "20250519092101868"
+    },
+    {
+      "module": "serverpod_auth",
+      "version": "20240520102713718"
+    },
+    {
       "module": "serverpod_auth_email_account",
-      "version": "20250606090748154"
+      "version": "20250724100154487"
     },
     {
       "module": "serverpod_auth_session",

--- a/tests/serverpod_new_auth_test/serverpod_new_auth_test_server/migrations/20250724100312502/definition.sql
+++ b/tests/serverpod_new_auth_test/serverpod_new_auth_test_server/migrations/20250724100312502/definition.sql
@@ -1,20 +1,7 @@
 BEGIN;
 
 --
--- ACTION CREATE TABLE
---
-CREATE TABLE "serverpod_auth_migration_migrated_user" (
-    "id" bigserial PRIMARY KEY,
-    "oldUserId" bigint NOT NULL,
-    "newAuthUserId" uuid NOT NULL
-);
-
--- Indexes
-CREATE UNIQUE INDEX "serverpod_auth_migration_migrated_user_old" ON "serverpod_auth_migration_migrated_user" USING btree ("oldUserId");
-CREATE UNIQUE INDEX "serverpod_auth_migration_migrated_user_new" ON "serverpod_auth_migration_migrated_user" USING btree ("newAuthUserId");
-
---
--- ACTION CREATE TABLE
+-- Class CloudStorageEntry as table serverpod_cloud_storage
 --
 CREATE TABLE "serverpod_cloud_storage" (
     "id" bigserial PRIMARY KEY,
@@ -31,7 +18,7 @@ CREATE UNIQUE INDEX "serverpod_cloud_storage_path_idx" ON "serverpod_cloud_stora
 CREATE INDEX "serverpod_cloud_storage_expiration" ON "serverpod_cloud_storage" USING btree ("expiration");
 
 --
--- ACTION CREATE TABLE
+-- Class CloudStorageDirectUploadEntry as table serverpod_cloud_storage_direct_upload
 --
 CREATE TABLE "serverpod_cloud_storage_direct_upload" (
     "id" bigserial PRIMARY KEY,
@@ -45,7 +32,7 @@ CREATE TABLE "serverpod_cloud_storage_direct_upload" (
 CREATE UNIQUE INDEX "serverpod_cloud_storage_direct_upload_storage_path" ON "serverpod_cloud_storage_direct_upload" USING btree ("storageId", "path");
 
 --
--- ACTION CREATE TABLE
+-- Class FutureCallEntry as table serverpod_future_call
 --
 CREATE TABLE "serverpod_future_call" (
     "id" bigserial PRIMARY KEY,
@@ -62,7 +49,7 @@ CREATE INDEX "serverpod_future_call_serverId_idx" ON "serverpod_future_call" USI
 CREATE INDEX "serverpod_future_call_identifier_idx" ON "serverpod_future_call" USING btree ("identifier");
 
 --
--- ACTION CREATE TABLE
+-- Class ServerHealthConnectionInfo as table serverpod_health_connection_info
 --
 CREATE TABLE "serverpod_health_connection_info" (
     "id" bigserial PRIMARY KEY,
@@ -78,7 +65,7 @@ CREATE TABLE "serverpod_health_connection_info" (
 CREATE UNIQUE INDEX "serverpod_health_connection_info_timestamp_idx" ON "serverpod_health_connection_info" USING btree ("timestamp", "serverId", "granularity");
 
 --
--- ACTION CREATE TABLE
+-- Class ServerHealthMetric as table serverpod_health_metric
 --
 CREATE TABLE "serverpod_health_metric" (
     "id" bigserial PRIMARY KEY,
@@ -94,7 +81,7 @@ CREATE TABLE "serverpod_health_metric" (
 CREATE UNIQUE INDEX "serverpod_health_metric_timestamp_idx" ON "serverpod_health_metric" USING btree ("timestamp", "serverId", "name", "granularity");
 
 --
--- ACTION CREATE TABLE
+-- Class LogEntry as table serverpod_log
 --
 CREATE TABLE "serverpod_log" (
     "id" bigserial PRIMARY KEY,
@@ -114,7 +101,7 @@ CREATE TABLE "serverpod_log" (
 CREATE INDEX "serverpod_log_sessionLogId_idx" ON "serverpod_log" USING btree ("sessionLogId");
 
 --
--- ACTION CREATE TABLE
+-- Class MessageLogEntry as table serverpod_message_log
 --
 CREATE TABLE "serverpod_message_log" (
     "id" bigserial PRIMARY KEY,
@@ -131,7 +118,7 @@ CREATE TABLE "serverpod_message_log" (
 );
 
 --
--- ACTION CREATE TABLE
+-- Class MethodInfo as table serverpod_method
 --
 CREATE TABLE "serverpod_method" (
     "id" bigserial PRIMARY KEY,
@@ -143,7 +130,7 @@ CREATE TABLE "serverpod_method" (
 CREATE UNIQUE INDEX "serverpod_method_endpoint_method_idx" ON "serverpod_method" USING btree ("endpoint", "method");
 
 --
--- ACTION CREATE TABLE
+-- Class DatabaseMigrationVersion as table serverpod_migrations
 --
 CREATE TABLE "serverpod_migrations" (
     "id" bigserial PRIMARY KEY,
@@ -156,7 +143,7 @@ CREATE TABLE "serverpod_migrations" (
 CREATE UNIQUE INDEX "serverpod_migrations_ids" ON "serverpod_migrations" USING btree ("module");
 
 --
--- ACTION CREATE TABLE
+-- Class QueryLogEntry as table serverpod_query_log
 --
 CREATE TABLE "serverpod_query_log" (
     "id" bigserial PRIMARY KEY,
@@ -176,7 +163,7 @@ CREATE TABLE "serverpod_query_log" (
 CREATE INDEX "serverpod_query_log_sessionLogId_idx" ON "serverpod_query_log" USING btree ("sessionLogId");
 
 --
--- ACTION CREATE TABLE
+-- Class ReadWriteTestEntry as table serverpod_readwrite_test
 --
 CREATE TABLE "serverpod_readwrite_test" (
     "id" bigserial PRIMARY KEY,
@@ -184,7 +171,7 @@ CREATE TABLE "serverpod_readwrite_test" (
 );
 
 --
--- ACTION CREATE TABLE
+-- Class RuntimeSettings as table serverpod_runtime_settings
 --
 CREATE TABLE "serverpod_runtime_settings" (
     "id" bigserial PRIMARY KEY,
@@ -195,7 +182,7 @@ CREATE TABLE "serverpod_runtime_settings" (
 );
 
 --
--- ACTION CREATE TABLE
+-- Class SessionLogEntry as table serverpod_session_log
 --
 CREATE TABLE "serverpod_session_log" (
     "id" bigserial PRIMARY KEY,
@@ -220,7 +207,7 @@ CREATE INDEX "serverpod_session_log_touched_idx" ON "serverpod_session_log" USIN
 CREATE INDEX "serverpod_session_log_isopen_idx" ON "serverpod_session_log" USING btree ("isOpen");
 
 --
--- ACTION CREATE TABLE
+-- Class LegacyEmailPassword as table serverpod_auth_backwards_compatibility_email_password
 --
 CREATE TABLE "serverpod_auth_backwards_compatibility_email_password" (
     "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -232,7 +219,7 @@ CREATE TABLE "serverpod_auth_backwards_compatibility_email_password" (
 CREATE UNIQUE INDEX "serverpod_auth_backwards_compatibility_email_password_account" ON "serverpod_auth_backwards_compatibility_email_password" USING btree ("emailAccountId");
 
 --
--- ACTION CREATE TABLE
+-- Class LegacyExternalUserIdentifier as table serverpod_auth_backwards_compatibility_external_user_id
 --
 CREATE TABLE "serverpod_auth_backwards_compatibility_external_user_id" (
     "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -244,7 +231,7 @@ CREATE TABLE "serverpod_auth_backwards_compatibility_external_user_id" (
 CREATE UNIQUE INDEX "serverpod_auth_backwards_compatibility_external_user_id_id" ON "serverpod_auth_backwards_compatibility_external_user_id" USING btree ("userIdentifier");
 
 --
--- ACTION CREATE TABLE
+-- Class LegacySession as table serverpod_auth_backwards_compatibility_session
 --
 CREATE TABLE "serverpod_auth_backwards_compatibility_session" (
     "id" bigserial PRIMARY KEY,
@@ -255,107 +242,20 @@ CREATE TABLE "serverpod_auth_backwards_compatibility_session" (
 );
 
 --
--- ACTION CREATE TABLE
+-- Class MigratedUser as table serverpod_auth_migration_migrated_user
 --
-CREATE TABLE "serverpod_auth_email_account" (
-    "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-    "authUserId" uuid NOT NULL,
-    "created" timestamp without time zone NOT NULL,
-    "email" text NOT NULL,
-    "passwordHash" bytea NOT NULL,
-    "passwordSalt" bytea NOT NULL
+CREATE TABLE "serverpod_auth_migration_migrated_user" (
+    "id" bigserial PRIMARY KEY,
+    "oldUserId" bigint NOT NULL,
+    "newAuthUserId" uuid NOT NULL
 );
 
 -- Indexes
-CREATE UNIQUE INDEX "serverpod_auth_email_account_email" ON "serverpod_auth_email_account" USING btree ("email");
+CREATE UNIQUE INDEX "serverpod_auth_migration_migrated_user_old" ON "serverpod_auth_migration_migrated_user" USING btree ("oldUserId");
+CREATE UNIQUE INDEX "serverpod_auth_migration_migrated_user_new" ON "serverpod_auth_migration_migrated_user" USING btree ("newAuthUserId");
 
 --
--- ACTION CREATE TABLE
---
-CREATE TABLE "serverpod_auth_email_account_failed_login_attempt" (
-    "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-    "email" text NOT NULL,
-    "attemptedAt" timestamp without time zone NOT NULL,
-    "ipAddress" text NOT NULL
-);
-
--- Indexes
-CREATE INDEX "serverpod_auth_email_account_failed_login_attempt_email" ON "serverpod_auth_email_account_failed_login_attempt" USING btree ("email");
-CREATE INDEX "serverpod_auth_email_account_failed_login_attempt_attempted_at" ON "serverpod_auth_email_account_failed_login_attempt" USING btree ("attemptedAt");
-
---
--- ACTION CREATE TABLE
---
-CREATE TABLE "serverpod_auth_email_account_password_reset_attempt" (
-    "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-    "attemptedAt" timestamp without time zone NOT NULL,
-    "ipAddress" text NOT NULL,
-    "passwordResetRequestId" uuid NOT NULL
-);
-
--- Indexes
-CREATE INDEX "serverpod_auth_email_account_password_reset_attempt_ip" ON "serverpod_auth_email_account_password_reset_attempt" USING btree ("ipAddress");
-CREATE INDEX "serverpod_auth_email_account_password_reset_attempt_at" ON "serverpod_auth_email_account_password_reset_attempt" USING btree ("attemptedAt");
-
---
--- ACTION CREATE TABLE
---
-CREATE TABLE "serverpod_auth_email_account_password_reset_request" (
-    "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-    "emailAccountId" uuid NOT NULL,
-    "created" timestamp without time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    "verificationCodeHash" bytea NOT NULL,
-    "verificationCodeSalt" bytea NOT NULL
-);
-
---
--- ACTION CREATE TABLE
---
-CREATE TABLE "serverpod_auth_email_account_pw_reset_request_attempt" (
-    "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-    "email" text NOT NULL,
-    "attemptedAt" timestamp without time zone NOT NULL,
-    "ipAddress" text NOT NULL
-);
-
--- Indexes
-CREATE INDEX "serverpod_auth_email_account_pw_reset_request_attempt_email" ON "serverpod_auth_email_account_pw_reset_request_attempt" USING btree ("email");
-CREATE INDEX "serverpod_auth_email_account_pw_reset_request_attempt_ip" ON "serverpod_auth_email_account_pw_reset_request_attempt" USING btree ("ipAddress");
-CREATE INDEX "serverpod_auth_email_account_pw_reset_request_attempt_at" ON "serverpod_auth_email_account_pw_reset_request_attempt" USING btree ("attemptedAt");
-
---
--- ACTION CREATE TABLE
---
-CREATE TABLE "serverpod_auth_email_account_request" (
-    "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-    "created" timestamp without time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    "email" text NOT NULL,
-    "passwordHash" bytea NOT NULL,
-    "passwordSalt" bytea NOT NULL,
-    "verificationCodeHash" bytea NOT NULL,
-    "verificationCodeSalt" bytea NOT NULL,
-    "verifiedAt" timestamp without time zone
-);
-
--- Indexes
-CREATE UNIQUE INDEX "serverpod_auth_email_account_request_email" ON "serverpod_auth_email_account_request" USING btree ("email");
-
---
--- ACTION CREATE TABLE
---
-CREATE TABLE "serverpod_auth_email_account_request_completion_attempt" (
-    "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-    "attemptedAt" timestamp without time zone NOT NULL,
-    "ipAddress" text NOT NULL,
-    "emailAccountRequestId" uuid NOT NULL
-);
-
--- Indexes
-CREATE INDEX "serverpod_auth_email_account_request_completion_attempt_ip" ON "serverpod_auth_email_account_request_completion_attempt" USING btree ("ipAddress");
-CREATE INDEX "serverpod_auth_email_account_request_completion_attempt_at" ON "serverpod_auth_email_account_request_completion_attempt" USING btree ("attemptedAt");
-
---
--- ACTION CREATE TABLE
+-- Class UserProfile as table serverpod_auth_profile_user_profile
 --
 CREATE TABLE "serverpod_auth_profile_user_profile" (
     "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -371,7 +271,7 @@ CREATE TABLE "serverpod_auth_profile_user_profile" (
 CREATE UNIQUE INDEX "serverpod_auth_profile_user_profile_email_auth_user_id" ON "serverpod_auth_profile_user_profile" USING btree ("authUserId");
 
 --
--- ACTION CREATE TABLE
+-- Class UserProfileImage as table serverpod_auth_profile_user_profile_image
 --
 CREATE TABLE "serverpod_auth_profile_user_profile_image" (
     "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -383,7 +283,7 @@ CREATE TABLE "serverpod_auth_profile_user_profile_image" (
 );
 
 --
--- ACTION CREATE TABLE
+-- Class AuthKey as table serverpod_auth_key
 --
 CREATE TABLE "serverpod_auth_key" (
     "id" bigserial PRIMARY KEY,
@@ -397,7 +297,7 @@ CREATE TABLE "serverpod_auth_key" (
 CREATE INDEX "serverpod_auth_key_userId_idx" ON "serverpod_auth_key" USING btree ("userId");
 
 --
--- ACTION CREATE TABLE
+-- Class EmailAuth as table serverpod_email_auth
 --
 CREATE TABLE "serverpod_email_auth" (
     "id" bigserial PRIMARY KEY,
@@ -410,7 +310,7 @@ CREATE TABLE "serverpod_email_auth" (
 CREATE UNIQUE INDEX "serverpod_email_auth_email" ON "serverpod_email_auth" USING btree ("email");
 
 --
--- ACTION CREATE TABLE
+-- Class EmailCreateAccountRequest as table serverpod_email_create_request
 --
 CREATE TABLE "serverpod_email_create_request" (
     "id" bigserial PRIMARY KEY,
@@ -424,7 +324,7 @@ CREATE TABLE "serverpod_email_create_request" (
 CREATE UNIQUE INDEX "serverpod_email_auth_create_account_request_idx" ON "serverpod_email_create_request" USING btree ("email");
 
 --
--- ACTION CREATE TABLE
+-- Class EmailFailedSignIn as table serverpod_email_failed_sign_in
 --
 CREATE TABLE "serverpod_email_failed_sign_in" (
     "id" bigserial PRIMARY KEY,
@@ -438,7 +338,7 @@ CREATE INDEX "serverpod_email_failed_sign_in_email_idx" ON "serverpod_email_fail
 CREATE INDEX "serverpod_email_failed_sign_in_time_idx" ON "serverpod_email_failed_sign_in" USING btree ("time");
 
 --
--- ACTION CREATE TABLE
+-- Class EmailReset as table serverpod_email_reset
 --
 CREATE TABLE "serverpod_email_reset" (
     "id" bigserial PRIMARY KEY,
@@ -451,7 +351,7 @@ CREATE TABLE "serverpod_email_reset" (
 CREATE UNIQUE INDEX "serverpod_email_reset_verification_idx" ON "serverpod_email_reset" USING btree ("verificationCode");
 
 --
--- ACTION CREATE TABLE
+-- Class GoogleRefreshToken as table serverpod_google_refresh_token
 --
 CREATE TABLE "serverpod_google_refresh_token" (
     "id" bigserial PRIMARY KEY,
@@ -463,7 +363,7 @@ CREATE TABLE "serverpod_google_refresh_token" (
 CREATE UNIQUE INDEX "serverpod_google_refresh_token_userId_idx" ON "serverpod_google_refresh_token" USING btree ("userId");
 
 --
--- ACTION CREATE TABLE
+-- Class UserImage as table serverpod_user_image
 --
 CREATE TABLE "serverpod_user_image" (
     "id" bigserial PRIMARY KEY,
@@ -476,7 +376,7 @@ CREATE TABLE "serverpod_user_image" (
 CREATE INDEX "serverpod_user_image_user_id" ON "serverpod_user_image" USING btree ("userId", "version");
 
 --
--- ACTION CREATE TABLE
+-- Class UserInfo as table serverpod_user_info
 --
 CREATE TABLE "serverpod_user_info" (
     "id" bigserial PRIMARY KEY,
@@ -495,7 +395,107 @@ CREATE UNIQUE INDEX "serverpod_user_info_user_identifier" ON "serverpod_user_inf
 CREATE INDEX "serverpod_user_info_email" ON "serverpod_user_info" USING btree ("email");
 
 --
--- ACTION CREATE TABLE
+-- Class EmailAccount as table serverpod_auth_email_account
+--
+CREATE TABLE "serverpod_auth_email_account" (
+    "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    "authUserId" uuid NOT NULL,
+    "created" timestamp without time zone NOT NULL,
+    "email" text NOT NULL,
+    "passwordHash" bytea NOT NULL,
+    "passwordSalt" bytea NOT NULL
+);
+
+-- Indexes
+CREATE UNIQUE INDEX "serverpod_auth_email_account_email" ON "serverpod_auth_email_account" USING btree ("email");
+
+--
+-- Class EmailAccountFailedLoginAttempt as table serverpod_auth_email_account_failed_login_attempt
+--
+CREATE TABLE "serverpod_auth_email_account_failed_login_attempt" (
+    "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    "email" text NOT NULL,
+    "attempted" timestamp without time zone NOT NULL,
+    "ipAddress" text NOT NULL
+);
+
+-- Indexes
+CREATE INDEX "serverpod_auth_email_account_failed_login_attempt_email" ON "serverpod_auth_email_account_failed_login_attempt" USING btree ("email");
+CREATE INDEX "serverpod_auth_email_account_failed_login_attempt_attempted" ON "serverpod_auth_email_account_failed_login_attempt" USING btree ("attempted");
+
+--
+-- Class EmailAccountPasswordResetAttempt as table serverpod_auth_email_account_password_reset_attempt
+--
+CREATE TABLE "serverpod_auth_email_account_password_reset_attempt" (
+    "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    "attempted" timestamp without time zone NOT NULL,
+    "ipAddress" text NOT NULL,
+    "passwordResetRequestId" uuid NOT NULL
+);
+
+-- Indexes
+CREATE INDEX "serverpod_auth_email_account_password_reset_attempt_ip" ON "serverpod_auth_email_account_password_reset_attempt" USING btree ("ipAddress");
+CREATE INDEX "serverpod_auth_email_account_password_reset_attempted" ON "serverpod_auth_email_account_password_reset_attempt" USING btree ("attempted");
+
+--
+-- Class EmailAccountPasswordResetRequest as table serverpod_auth_email_account_password_reset_request
+--
+CREATE TABLE "serverpod_auth_email_account_password_reset_request" (
+    "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    "emailAccountId" uuid NOT NULL,
+    "created" timestamp without time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "verificationCodeHash" bytea NOT NULL,
+    "verificationCodeSalt" bytea NOT NULL
+);
+
+--
+-- Class EmailAccountPasswordResetRequestAttempt as table serverpod_auth_email_account_pw_reset_request_attempt
+--
+CREATE TABLE "serverpod_auth_email_account_pw_reset_request_attempt" (
+    "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    "email" text NOT NULL,
+    "attempted" timestamp without time zone NOT NULL,
+    "ipAddress" text NOT NULL
+);
+
+-- Indexes
+CREATE INDEX "serverpod_auth_email_account_pw_reset_request_attempt_email" ON "serverpod_auth_email_account_pw_reset_request_attempt" USING btree ("email");
+CREATE INDEX "serverpod_auth_email_account_pw_reset_request_attempt_ip" ON "serverpod_auth_email_account_pw_reset_request_attempt" USING btree ("ipAddress");
+CREATE INDEX "serverpod_auth_email_account_pw_reset_request_attempted" ON "serverpod_auth_email_account_pw_reset_request_attempt" USING btree ("attempted");
+
+--
+-- Class EmailAccountRequest as table serverpod_auth_email_account_request
+--
+CREATE TABLE "serverpod_auth_email_account_request" (
+    "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    "created" timestamp without time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "email" text NOT NULL,
+    "passwordHash" bytea NOT NULL,
+    "passwordSalt" bytea NOT NULL,
+    "verificationCodeHash" bytea NOT NULL,
+    "verificationCodeSalt" bytea NOT NULL,
+    "verifiedAt" timestamp without time zone
+);
+
+-- Indexes
+CREATE UNIQUE INDEX "serverpod_auth_email_account_request_email" ON "serverpod_auth_email_account_request" USING btree ("email");
+
+--
+-- Class EmailAccountRequestCompletionAttempt as table serverpod_auth_email_account_request_completion_attempt
+--
+CREATE TABLE "serverpod_auth_email_account_request_completion_attempt" (
+    "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    "attempted" timestamp without time zone NOT NULL,
+    "ipAddress" text NOT NULL,
+    "emailAccountRequestId" uuid NOT NULL
+);
+
+-- Indexes
+CREATE INDEX "serverpod_auth_email_account_request_completion_attempt_ip" ON "serverpod_auth_email_account_request_completion_attempt" USING btree ("ipAddress");
+CREATE INDEX "serverpod_auth_email_account_request_completion_attempted" ON "serverpod_auth_email_account_request_completion_attempt" USING btree ("attempted");
+
+--
+-- Class AuthSession as table serverpod_auth_session
 --
 CREATE TABLE "serverpod_auth_session" (
     "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -511,7 +511,7 @@ CREATE TABLE "serverpod_auth_session" (
 );
 
 --
--- ACTION CREATE TABLE
+-- Class AuthUser as table serverpod_auth_user
 --
 CREATE TABLE "serverpod_auth_user" (
     "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -521,7 +521,67 @@ CREATE TABLE "serverpod_auth_user" (
 );
 
 --
--- ACTION CREATE FOREIGN KEY
+-- Foreign relations for "serverpod_log" table
+--
+ALTER TABLE ONLY "serverpod_log"
+    ADD CONSTRAINT "serverpod_log_fk_0"
+    FOREIGN KEY("sessionLogId")
+    REFERENCES "serverpod_session_log"("id")
+    ON DELETE CASCADE
+    ON UPDATE NO ACTION;
+
+--
+-- Foreign relations for "serverpod_message_log" table
+--
+ALTER TABLE ONLY "serverpod_message_log"
+    ADD CONSTRAINT "serverpod_message_log_fk_0"
+    FOREIGN KEY("sessionLogId")
+    REFERENCES "serverpod_session_log"("id")
+    ON DELETE CASCADE
+    ON UPDATE NO ACTION;
+
+--
+-- Foreign relations for "serverpod_query_log" table
+--
+ALTER TABLE ONLY "serverpod_query_log"
+    ADD CONSTRAINT "serverpod_query_log_fk_0"
+    FOREIGN KEY("sessionLogId")
+    REFERENCES "serverpod_session_log"("id")
+    ON DELETE CASCADE
+    ON UPDATE NO ACTION;
+
+--
+-- Foreign relations for "serverpod_auth_backwards_compatibility_email_password" table
+--
+ALTER TABLE ONLY "serverpod_auth_backwards_compatibility_email_password"
+    ADD CONSTRAINT "serverpod_auth_backwards_compatibility_email_password_fk_0"
+    FOREIGN KEY("emailAccountId")
+    REFERENCES "serverpod_auth_email_account"("id")
+    ON DELETE CASCADE
+    ON UPDATE NO ACTION;
+
+--
+-- Foreign relations for "serverpod_auth_backwards_compatibility_external_user_id" table
+--
+ALTER TABLE ONLY "serverpod_auth_backwards_compatibility_external_user_id"
+    ADD CONSTRAINT "serverpod_auth_backwards_compatibility_external_user_id_fk_0"
+    FOREIGN KEY("authUserId")
+    REFERENCES "serverpod_auth_user"("id")
+    ON DELETE CASCADE
+    ON UPDATE NO ACTION;
+
+--
+-- Foreign relations for "serverpod_auth_backwards_compatibility_session" table
+--
+ALTER TABLE ONLY "serverpod_auth_backwards_compatibility_session"
+    ADD CONSTRAINT "serverpod_auth_backwards_compatibility_session_fk_0"
+    FOREIGN KEY("authUserId")
+    REFERENCES "serverpod_auth_user"("id")
+    ON DELETE CASCADE
+    ON UPDATE NO ACTION;
+
+--
+-- Foreign relations for "serverpod_auth_migration_migrated_user" table
 --
 ALTER TABLE ONLY "serverpod_auth_migration_migrated_user"
     ADD CONSTRAINT "serverpod_auth_migration_migrated_user_fk_0"
@@ -537,107 +597,7 @@ ALTER TABLE ONLY "serverpod_auth_migration_migrated_user"
     ON UPDATE NO ACTION;
 
 --
--- ACTION CREATE FOREIGN KEY
---
-ALTER TABLE ONLY "serverpod_log"
-    ADD CONSTRAINT "serverpod_log_fk_0"
-    FOREIGN KEY("sessionLogId")
-    REFERENCES "serverpod_session_log"("id")
-    ON DELETE CASCADE
-    ON UPDATE NO ACTION;
-
---
--- ACTION CREATE FOREIGN KEY
---
-ALTER TABLE ONLY "serverpod_message_log"
-    ADD CONSTRAINT "serverpod_message_log_fk_0"
-    FOREIGN KEY("sessionLogId")
-    REFERENCES "serverpod_session_log"("id")
-    ON DELETE CASCADE
-    ON UPDATE NO ACTION;
-
---
--- ACTION CREATE FOREIGN KEY
---
-ALTER TABLE ONLY "serverpod_query_log"
-    ADD CONSTRAINT "serverpod_query_log_fk_0"
-    FOREIGN KEY("sessionLogId")
-    REFERENCES "serverpod_session_log"("id")
-    ON DELETE CASCADE
-    ON UPDATE NO ACTION;
-
---
--- ACTION CREATE FOREIGN KEY
---
-ALTER TABLE ONLY "serverpod_auth_backwards_compatibility_email_password"
-    ADD CONSTRAINT "serverpod_auth_backwards_compatibility_email_password_fk_0"
-    FOREIGN KEY("emailAccountId")
-    REFERENCES "serverpod_auth_email_account"("id")
-    ON DELETE CASCADE
-    ON UPDATE NO ACTION;
-
---
--- ACTION CREATE FOREIGN KEY
---
-ALTER TABLE ONLY "serverpod_auth_backwards_compatibility_external_user_id"
-    ADD CONSTRAINT "serverpod_auth_backwards_compatibility_external_user_id_fk_0"
-    FOREIGN KEY("authUserId")
-    REFERENCES "serverpod_auth_user"("id")
-    ON DELETE CASCADE
-    ON UPDATE NO ACTION;
-
---
--- ACTION CREATE FOREIGN KEY
---
-ALTER TABLE ONLY "serverpod_auth_backwards_compatibility_session"
-    ADD CONSTRAINT "serverpod_auth_backwards_compatibility_session_fk_0"
-    FOREIGN KEY("authUserId")
-    REFERENCES "serverpod_auth_user"("id")
-    ON DELETE CASCADE
-    ON UPDATE NO ACTION;
-
---
--- ACTION CREATE FOREIGN KEY
---
-ALTER TABLE ONLY "serverpod_auth_email_account"
-    ADD CONSTRAINT "serverpod_auth_email_account_fk_0"
-    FOREIGN KEY("authUserId")
-    REFERENCES "serverpod_auth_user"("id")
-    ON DELETE CASCADE
-    ON UPDATE NO ACTION;
-
---
--- ACTION CREATE FOREIGN KEY
---
-ALTER TABLE ONLY "serverpod_auth_email_account_password_reset_attempt"
-    ADD CONSTRAINT "serverpod_auth_email_account_password_reset_attempt_fk_0"
-    FOREIGN KEY("passwordResetRequestId")
-    REFERENCES "serverpod_auth_email_account_password_reset_request"("id")
-    ON DELETE CASCADE
-    ON UPDATE NO ACTION;
-
---
--- ACTION CREATE FOREIGN KEY
---
-ALTER TABLE ONLY "serverpod_auth_email_account_password_reset_request"
-    ADD CONSTRAINT "serverpod_auth_email_account_password_reset_request_fk_0"
-    FOREIGN KEY("emailAccountId")
-    REFERENCES "serverpod_auth_email_account"("id")
-    ON DELETE CASCADE
-    ON UPDATE NO ACTION;
-
---
--- ACTION CREATE FOREIGN KEY
---
-ALTER TABLE ONLY "serverpod_auth_email_account_request_completion_attempt"
-    ADD CONSTRAINT "serverpod_auth_email_account_request_completion_attempt_fk_0"
-    FOREIGN KEY("emailAccountRequestId")
-    REFERENCES "serverpod_auth_email_account_request"("id")
-    ON DELETE CASCADE
-    ON UPDATE NO ACTION;
-
---
--- ACTION CREATE FOREIGN KEY
+-- Foreign relations for "serverpod_auth_profile_user_profile" table
 --
 ALTER TABLE ONLY "serverpod_auth_profile_user_profile"
     ADD CONSTRAINT "serverpod_auth_profile_user_profile_fk_0"
@@ -653,7 +613,7 @@ ALTER TABLE ONLY "serverpod_auth_profile_user_profile"
     ON UPDATE NO ACTION;
 
 --
--- ACTION CREATE FOREIGN KEY
+-- Foreign relations for "serverpod_auth_profile_user_profile_image" table
 --
 ALTER TABLE ONLY "serverpod_auth_profile_user_profile_image"
     ADD CONSTRAINT "serverpod_auth_profile_user_profile_image_fk_0"
@@ -663,7 +623,47 @@ ALTER TABLE ONLY "serverpod_auth_profile_user_profile_image"
     ON UPDATE NO ACTION;
 
 --
--- ACTION CREATE FOREIGN KEY
+-- Foreign relations for "serverpod_auth_email_account" table
+--
+ALTER TABLE ONLY "serverpod_auth_email_account"
+    ADD CONSTRAINT "serverpod_auth_email_account_fk_0"
+    FOREIGN KEY("authUserId")
+    REFERENCES "serverpod_auth_user"("id")
+    ON DELETE CASCADE
+    ON UPDATE NO ACTION;
+
+--
+-- Foreign relations for "serverpod_auth_email_account_password_reset_attempt" table
+--
+ALTER TABLE ONLY "serverpod_auth_email_account_password_reset_attempt"
+    ADD CONSTRAINT "serverpod_auth_email_account_password_reset_attempt_fk_0"
+    FOREIGN KEY("passwordResetRequestId")
+    REFERENCES "serverpod_auth_email_account_password_reset_request"("id")
+    ON DELETE CASCADE
+    ON UPDATE NO ACTION;
+
+--
+-- Foreign relations for "serverpod_auth_email_account_password_reset_request" table
+--
+ALTER TABLE ONLY "serverpod_auth_email_account_password_reset_request"
+    ADD CONSTRAINT "serverpod_auth_email_account_password_reset_request_fk_0"
+    FOREIGN KEY("emailAccountId")
+    REFERENCES "serverpod_auth_email_account"("id")
+    ON DELETE CASCADE
+    ON UPDATE NO ACTION;
+
+--
+-- Foreign relations for "serverpod_auth_email_account_request_completion_attempt" table
+--
+ALTER TABLE ONLY "serverpod_auth_email_account_request_completion_attempt"
+    ADD CONSTRAINT "serverpod_auth_email_account_request_completion_attempt_fk_0"
+    FOREIGN KEY("emailAccountRequestId")
+    REFERENCES "serverpod_auth_email_account_request"("id")
+    ON DELETE CASCADE
+    ON UPDATE NO ACTION;
+
+--
+-- Foreign relations for "serverpod_auth_session" table
 --
 ALTER TABLE ONLY "serverpod_auth_session"
     ADD CONSTRAINT "serverpod_auth_session_fk_0"
@@ -674,12 +674,12 @@ ALTER TABLE ONLY "serverpod_auth_session"
 
 
 --
--- MIGRATION VERSION FOR serverpod_auth_migration
+-- MIGRATION VERSION FOR serverpod_new_auth_test
 --
 INSERT INTO "serverpod_migrations" ("module", "version", "timestamp")
-    VALUES ('serverpod_auth_migration', '20250711114550334', now())
+    VALUES ('serverpod_new_auth_test', '20250724100312502', now())
     ON CONFLICT ("module")
-    DO UPDATE SET "version" = '20250711114550334', "timestamp" = now();
+    DO UPDATE SET "version" = '20250724100312502', "timestamp" = now();
 
 --
 -- MIGRATION VERSION FOR serverpod
@@ -698,20 +698,20 @@ INSERT INTO "serverpod_migrations" ("module", "version", "timestamp")
     DO UPDATE SET "version" = '20250708110241098', "timestamp" = now();
 
 --
--- MIGRATION VERSION FOR serverpod_auth_email_account
---
-INSERT INTO "serverpod_migrations" ("module", "version", "timestamp")
-    VALUES ('serverpod_auth_email_account', '20250606090748154', now())
-    ON CONFLICT ("module")
-    DO UPDATE SET "version" = '20250606090748154', "timestamp" = now();
-
---
 -- MIGRATION VERSION FOR serverpod_auth_email
 --
 INSERT INTO "serverpod_migrations" ("module", "version", "timestamp")
-    VALUES ('serverpod_auth_email', '20250611073844715', now())
+    VALUES ('serverpod_auth_email', '20250724100231671', now())
     ON CONFLICT ("module")
-    DO UPDATE SET "version" = '20250611073844715', "timestamp" = now();
+    DO UPDATE SET "version" = '20250724100231671', "timestamp" = now();
+
+--
+-- MIGRATION VERSION FOR serverpod_auth_migration
+--
+INSERT INTO "serverpod_migrations" ("module", "version", "timestamp")
+    VALUES ('serverpod_auth_migration', '20250711114550334', now())
+    ON CONFLICT ("module")
+    DO UPDATE SET "version" = '20250711114550334', "timestamp" = now();
 
 --
 -- MIGRATION VERSION FOR serverpod_auth_profile
@@ -728,6 +728,14 @@ INSERT INTO "serverpod_migrations" ("module", "version", "timestamp")
     VALUES ('serverpod_auth', '20240520102713718', now())
     ON CONFLICT ("module")
     DO UPDATE SET "version" = '20240520102713718', "timestamp" = now();
+
+--
+-- MIGRATION VERSION FOR serverpod_auth_email_account
+--
+INSERT INTO "serverpod_migrations" ("module", "version", "timestamp")
+    VALUES ('serverpod_auth_email_account', '20250724100154487', now())
+    ON CONFLICT ("module")
+    DO UPDATE SET "version" = '20250724100154487', "timestamp" = now();
 
 --
 -- MIGRATION VERSION FOR serverpod_auth_session

--- a/tests/serverpod_new_auth_test/serverpod_new_auth_test_server/migrations/20250724100312502/definition_project.json
+++ b/tests/serverpod_new_auth_test/serverpod_new_auth_test_server/migrations/20250724100312502/definition_project.json
@@ -12,11 +12,11 @@
     },
     {
       "module": "serverpod_auth_email",
-      "version": "20250611073844715"
+      "version": "20250724100231671"
     },
     {
       "module": "serverpod_auth_migration",
-      "version": "20250705132233496"
+      "version": "20250711114550334"
     },
     {
       "module": "serverpod_auth_profile",
@@ -28,7 +28,7 @@
     },
     {
       "module": "serverpod_auth_email_account",
-      "version": "20250606090748154"
+      "version": "20250724100154487"
     },
     {
       "module": "serverpod_auth_session",

--- a/tests/serverpod_new_auth_test/serverpod_new_auth_test_server/migrations/20250724100312502/migration.json
+++ b/tests/serverpod_new_auth_test/serverpod_new_auth_test_server/migrations/20250724100312502/migration.json
@@ -2366,7 +2366,7 @@
             "dartType": "String"
           },
           {
-            "name": "attemptedAt",
+            "name": "attempted",
             "columnType": 4,
             "isNullable": false,
             "dartType": "DateTime"
@@ -2405,11 +2405,11 @@
             "isPrimary": false
           },
           {
-            "indexName": "serverpod_auth_email_account_failed_login_attempt_attempted_at",
+            "indexName": "serverpod_auth_email_account_failed_login_attempt_attempted",
             "elements": [
               {
                 "type": 0,
-                "definition": "attemptedAt"
+                "definition": "attempted"
               }
             ],
             "type": "btree",
@@ -2436,7 +2436,7 @@
             "dartType": "UuidValue?"
           },
           {
-            "name": "attemptedAt",
+            "name": "attempted",
             "columnType": 4,
             "isNullable": false,
             "dartType": "DateTime"
@@ -2495,11 +2495,11 @@
             "isPrimary": false
           },
           {
-            "indexName": "serverpod_auth_email_account_password_reset_attempt_at",
+            "indexName": "serverpod_auth_email_account_password_reset_attempted",
             "elements": [
               {
                 "type": 0,
-                "definition": "attemptedAt"
+                "definition": "attempted"
               }
             ],
             "type": "btree",
@@ -2605,7 +2605,7 @@
             "dartType": "String"
           },
           {
-            "name": "attemptedAt",
+            "name": "attempted",
             "columnType": 4,
             "isNullable": false,
             "dartType": "DateTime"
@@ -2656,11 +2656,11 @@
             "isPrimary": false
           },
           {
-            "indexName": "serverpod_auth_email_account_pw_reset_request_attempt_at",
+            "indexName": "serverpod_auth_email_account_pw_reset_request_attempted",
             "elements": [
               {
                 "type": 0,
-                "definition": "attemptedAt"
+                "definition": "attempted"
               }
             ],
             "type": "btree",
@@ -2776,7 +2776,7 @@
             "dartType": "UuidValue?"
           },
           {
-            "name": "attemptedAt",
+            "name": "attempted",
             "columnType": 4,
             "isNullable": false,
             "dartType": "DateTime"
@@ -2835,11 +2835,11 @@
             "isPrimary": false
           },
           {
-            "indexName": "serverpod_auth_email_account_request_completion_attempt_at",
+            "indexName": "serverpod_auth_email_account_request_completion_attempted",
             "elements": [
               {
                 "type": 0,
-                "definition": "attemptedAt"
+                "definition": "attempted"
               }
             ],
             "type": "btree",

--- a/tests/serverpod_new_auth_test/serverpod_new_auth_test_server/migrations/20250724100312502/migration.sql
+++ b/tests/serverpod_new_auth_test/serverpod_new_auth_test_server/migrations/20250724100312502/migration.sql
@@ -415,27 +415,27 @@ CREATE UNIQUE INDEX "serverpod_auth_email_account_email" ON "serverpod_auth_emai
 CREATE TABLE "serverpod_auth_email_account_failed_login_attempt" (
     "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
     "email" text NOT NULL,
-    "attemptedAt" timestamp without time zone NOT NULL,
+    "attempted" timestamp without time zone NOT NULL,
     "ipAddress" text NOT NULL
 );
 
 -- Indexes
 CREATE INDEX "serverpod_auth_email_account_failed_login_attempt_email" ON "serverpod_auth_email_account_failed_login_attempt" USING btree ("email");
-CREATE INDEX "serverpod_auth_email_account_failed_login_attempt_attempted_at" ON "serverpod_auth_email_account_failed_login_attempt" USING btree ("attemptedAt");
+CREATE INDEX "serverpod_auth_email_account_failed_login_attempt_attempted" ON "serverpod_auth_email_account_failed_login_attempt" USING btree ("attempted");
 
 --
 -- ACTION CREATE TABLE
 --
 CREATE TABLE "serverpod_auth_email_account_password_reset_attempt" (
     "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-    "attemptedAt" timestamp without time zone NOT NULL,
+    "attempted" timestamp without time zone NOT NULL,
     "ipAddress" text NOT NULL,
     "passwordResetRequestId" uuid NOT NULL
 );
 
 -- Indexes
 CREATE INDEX "serverpod_auth_email_account_password_reset_attempt_ip" ON "serverpod_auth_email_account_password_reset_attempt" USING btree ("ipAddress");
-CREATE INDEX "serverpod_auth_email_account_password_reset_attempt_at" ON "serverpod_auth_email_account_password_reset_attempt" USING btree ("attemptedAt");
+CREATE INDEX "serverpod_auth_email_account_password_reset_attempted" ON "serverpod_auth_email_account_password_reset_attempt" USING btree ("attempted");
 
 --
 -- ACTION CREATE TABLE
@@ -454,14 +454,14 @@ CREATE TABLE "serverpod_auth_email_account_password_reset_request" (
 CREATE TABLE "serverpod_auth_email_account_pw_reset_request_attempt" (
     "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
     "email" text NOT NULL,
-    "attemptedAt" timestamp without time zone NOT NULL,
+    "attempted" timestamp without time zone NOT NULL,
     "ipAddress" text NOT NULL
 );
 
 -- Indexes
 CREATE INDEX "serverpod_auth_email_account_pw_reset_request_attempt_email" ON "serverpod_auth_email_account_pw_reset_request_attempt" USING btree ("email");
 CREATE INDEX "serverpod_auth_email_account_pw_reset_request_attempt_ip" ON "serverpod_auth_email_account_pw_reset_request_attempt" USING btree ("ipAddress");
-CREATE INDEX "serverpod_auth_email_account_pw_reset_request_attempt_at" ON "serverpod_auth_email_account_pw_reset_request_attempt" USING btree ("attemptedAt");
+CREATE INDEX "serverpod_auth_email_account_pw_reset_request_attempted" ON "serverpod_auth_email_account_pw_reset_request_attempt" USING btree ("attempted");
 
 --
 -- ACTION CREATE TABLE
@@ -485,14 +485,14 @@ CREATE UNIQUE INDEX "serverpod_auth_email_account_request_email" ON "serverpod_a
 --
 CREATE TABLE "serverpod_auth_email_account_request_completion_attempt" (
     "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-    "attemptedAt" timestamp without time zone NOT NULL,
+    "attempted" timestamp without time zone NOT NULL,
     "ipAddress" text NOT NULL,
     "emailAccountRequestId" uuid NOT NULL
 );
 
 -- Indexes
 CREATE INDEX "serverpod_auth_email_account_request_completion_attempt_ip" ON "serverpod_auth_email_account_request_completion_attempt" USING btree ("ipAddress");
-CREATE INDEX "serverpod_auth_email_account_request_completion_attempt_at" ON "serverpod_auth_email_account_request_completion_attempt" USING btree ("attemptedAt");
+CREATE INDEX "serverpod_auth_email_account_request_completion_attempted" ON "serverpod_auth_email_account_request_completion_attempt" USING btree ("attempted");
 
 --
 -- ACTION CREATE TABLE
@@ -677,9 +677,9 @@ ALTER TABLE ONLY "serverpod_auth_session"
 -- MIGRATION VERSION FOR serverpod_new_auth_test
 --
 INSERT INTO "serverpod_migrations" ("module", "version", "timestamp")
-    VALUES ('serverpod_new_auth_test', '20250708110506342', now())
+    VALUES ('serverpod_new_auth_test', '20250724100312502', now())
     ON CONFLICT ("module")
-    DO UPDATE SET "version" = '20250708110506342', "timestamp" = now();
+    DO UPDATE SET "version" = '20250724100312502', "timestamp" = now();
 
 --
 -- MIGRATION VERSION FOR serverpod
@@ -701,17 +701,17 @@ INSERT INTO "serverpod_migrations" ("module", "version", "timestamp")
 -- MIGRATION VERSION FOR serverpod_auth_email
 --
 INSERT INTO "serverpod_migrations" ("module", "version", "timestamp")
-    VALUES ('serverpod_auth_email', '20250611073844715', now())
+    VALUES ('serverpod_auth_email', '20250724100231671', now())
     ON CONFLICT ("module")
-    DO UPDATE SET "version" = '20250611073844715', "timestamp" = now();
+    DO UPDATE SET "version" = '20250724100231671', "timestamp" = now();
 
 --
 -- MIGRATION VERSION FOR serverpod_auth_migration
 --
 INSERT INTO "serverpod_migrations" ("module", "version", "timestamp")
-    VALUES ('serverpod_auth_migration', '20250705132233496', now())
+    VALUES ('serverpod_auth_migration', '20250711114550334', now())
     ON CONFLICT ("module")
-    DO UPDATE SET "version" = '20250705132233496', "timestamp" = now();
+    DO UPDATE SET "version" = '20250711114550334', "timestamp" = now();
 
 --
 -- MIGRATION VERSION FOR serverpod_auth_profile
@@ -733,9 +733,9 @@ INSERT INTO "serverpod_migrations" ("module", "version", "timestamp")
 -- MIGRATION VERSION FOR serverpod_auth_email_account
 --
 INSERT INTO "serverpod_migrations" ("module", "version", "timestamp")
-    VALUES ('serverpod_auth_email_account', '20250606090748154', now())
+    VALUES ('serverpod_auth_email_account', '20250724100154487', now())
     ON CONFLICT ("module")
-    DO UPDATE SET "version" = '20250606090748154', "timestamp" = now();
+    DO UPDATE SET "version" = '20250724100154487', "timestamp" = now();
 
 --
 -- MIGRATION VERSION FOR serverpod_auth_session

--- a/tests/serverpod_new_auth_test/serverpod_new_auth_test_server/migrations/migration_registry.txt
+++ b/tests/serverpod_new_auth_test/serverpod_new_auth_test_server/migrations/migration_registry.txt
@@ -4,4 +4,4 @@
 ### manually. If a collision is detected in this file when doing a code merge, resolve
 ### the conflict by removing and recreating the conflicting migration.
 
-20250708110506342
+20250724100312502


### PR DESCRIPTION
like `created`, `lastUsed`, …


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the naming of timestamp fields from `attemptedAt` to `attempted` across several authentication-related models and queries for consistency.
  * Renamed associated database indexes to match the updated field names.
  * Adjusted filtering and deletion logic to use the new field names in rate limiting and record cleanup processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->