### PR TITLE
feat(auth)!: Remove `userId` getter from `AuthenticationInfo` and instead provide extension with getter in `serverpod_auth` package

### DIFF
--- a/modules/new_serverpod_auth/serverpod_auth_session/serverpod_auth_session_flutter/test/serverpod_auth_session_flutter_test.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_session/serverpod_auth_session_flutter/test/serverpod_auth_session_flutter_test.dart
@@ -1,5 +1,4 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:serverpod_auth_session_client/serverpod_auth_session_client.dart';
 import 'package:serverpod_auth_session_flutter/serverpod_auth_session_flutter.dart';
 import 'package:serverpod_auth_session_flutter/src/session_manager.dart';
 

--- a/modules/serverpod_auth/serverpod_auth_server/lib/serverpod_auth_server.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/serverpod_auth_server.dart
@@ -7,5 +7,6 @@ export 'src/business/users.dart';
 export 'src/generated/endpoints.dart';
 export 'src/generated/protocol.dart';
 export 'src/util/random_string.dart';
+export 'src/extensions/authentication_info_extension.dart';
 export 'src/extensions/user_info_extension.dart';
 export 'src/web/routes/route_google_sign_in.dart';

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/extensions/authentication_info_extension.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/extensions/authentication_info_extension.dart
@@ -1,0 +1,18 @@
+import 'package:serverpod/serverpod.dart';
+
+/// User ID extension for `AuthenticationInfo`.
+extension AuthenticationInfoUserId on AuthenticationInfo {
+  /// Returns the `int` user ID of the authenticated user.
+  ///
+  /// Assumes that the system uses `int` user IDs, otherwise throws.
+  int get userId {
+    final userId = int.tryParse(userIdentifier, radix: 10);
+    if (userId == null) {
+      throw FormatException(
+        'Expected `AuthenticationInfo.userIdentifier` to represent an int, got: "$userIdentifier"',
+      );
+    }
+
+    return userId;
+  }
+}

--- a/modules/serverpod_auth/serverpod_auth_server/test/extensions/authentication_info_extension_test.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/test/extensions/authentication_info_extension_test.dart
@@ -1,0 +1,25 @@
+import 'package:serverpod/serverpod.dart';
+import 'package:serverpod_auth_server/serverpod_auth_server.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Given an `AuthenticationInfo` with an integer `userIdentifier`', () {
+    final authInfo = AuthenticationInfo(123, {});
+
+    test('when calling the `userId` helper, then `int` value is returned.', () {
+      expect(authInfo.userId, 123);
+    });
+  });
+
+  group('Given an `AuthenticationInfo` with a non-integer `userIdentifier`',
+      () {
+    final authInfo = AuthenticationInfo('abc-123', {});
+
+    test('when calling the `userId` helper, then it throws.', () {
+      expect(
+        () => authInfo.userId,
+        throwsFormatException,
+      );
+    });
+  });
+}

--- a/packages/serverpod/lib/src/authentication/authentication_info.dart
+++ b/packages/serverpod/lib/src/authentication/authentication_info.dart
@@ -11,13 +11,6 @@ typedef AuthenticationHandler = Future<AuthenticationInfo?> Function(
 /// Holds the id for an authenticated user and which [scopes] it can access.
 /// Allowed scopes are defined for each [Endpoint].
 class AuthenticationInfo {
-  /// Returns the `int` user ID of the authenticated user.
-  ///
-  /// Assumes that the system uses `int` user IDs, otherwise throws.
-  int get userId {
-    return int.parse(userIdentifier, radix: 10);
-  }
-
   /// Identifier of the user, as set by the [AuthenticationHandler].
   final String userIdentifier;
 

--- a/tests/serverpod_test_server/test_integration/test_tools/session_copy_with_test.dart
+++ b/tests/serverpod_test_server/test_integration/test_tools/session_copy_with_test.dart
@@ -1,4 +1,5 @@
 import 'package:serverpod/serverpod.dart';
+import 'package:serverpod_auth_server/serverpod_auth_server.dart';
 import 'package:test/test.dart';
 
 import 'serverpod_test_tools.dart';

--- a/tests/serverpod_test_server/test_integration/test_tools/test_session_builder_test.dart
+++ b/tests/serverpod_test_server/test_integration/test_tools/test_session_builder_test.dart
@@ -1,4 +1,5 @@
 import 'package:serverpod/serverpod.dart';
+import 'package:serverpod_auth_server/serverpod_auth_server.dart';
 import 'package:test/test.dart';
 
 import 'serverpod_test_tools.dart';


### PR DESCRIPTION

Closes #3476


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new extension to provide a user ID property for authentication information.

* **Refactor**
  * Moved the user ID getter from the authentication information class to an extension, improving modularity.

* **Chores**
  * Updated test files to import the authentication server package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->