### PR TITLE
feat(auth2): Use url-safe base64 encoding for session key

### DIFF
--- a/modules/new_serverpod_auth/serverpod_auth_session/serverpod_auth_session_server/lib/src/business/session_key.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_session/serverpod_auth_session_server/lib/src/business/session_key.dart
@@ -1,0 +1,79 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:meta/meta.dart';
+import 'package:serverpod/serverpod.dart';
+
+/// Prefix for sessions keys
+/// "sas" being abbreviated of "serverpod_auth_session"
+const _sessionKeyPrefix = 'sas';
+
+/// Creates the String representation to map to an `AuthSession`.
+@internal
+String buildSessionKey({
+  required final UuidValue authSessionId,
+  required final Uint8List secret,
+}) {
+  // Since the session key is sent as a `Basic` HTTP `Authorization` header by the Serverpod client,
+  // it's important that it contains at least one `:` so the `user:pass` schema is obeyed.
+  return '$_sessionKeyPrefix:${base64Url.encode(authSessionId.toBytes())}:${base64Url.encode(secret)}';
+}
+
+/// Tries parsing a session key String created by [buildSessionKey] into its
+/// parts.
+///
+/// Returns `null` if it does not match the spec or parsing fails for any reason.
+@internal
+SessionKeyData? tryParseSessionKey(
+  final Session session,
+  final String key,
+) {
+  if (!key.startsWith('$_sessionKeyPrefix:')) {
+    return null;
+  }
+
+  final parts = key.split(':');
+  if (parts.length != 3) {
+    session.log(
+      'Unexpected key format',
+      level: LogLevel.debug,
+    );
+
+    return null;
+  }
+
+  final UuidValue authSessionId;
+  try {
+    authSessionId = UuidValue.fromByteList(base64Url.decode(parts[1]))
+      ..validate();
+  } catch (e, stackTrace) {
+    session.log(
+      'Failed to parse auth session ID',
+      level: LogLevel.debug,
+      exception: e,
+      stackTrace: stackTrace,
+    );
+
+    return null;
+  }
+
+  final Uint8List secret;
+  try {
+    secret = base64Url.decode(parts[2]);
+  } catch (e, stackTrace) {
+    session.log(
+      'Failed to parse secret ID',
+      level: LogLevel.debug,
+      exception: e,
+      stackTrace: stackTrace,
+    );
+
+    return null;
+  }
+
+  return (authSessionId: authSessionId, secret: secret);
+}
+
+/// The data retrieved from a session key string.
+@internal
+typedef SessionKeyData = ({UuidValue authSessionId, Uint8List secret});

--- a/modules/new_serverpod_auth/serverpod_auth_session/serverpod_auth_session_server/test/session_key_test.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_session/serverpod_auth_session_server/test/session_key_test.dart
@@ -1,0 +1,62 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:serverpod/serverpod.dart';
+import 'package:serverpod_auth_session_server/src/business/session_key.dart';
+import 'package:test/test.dart';
+
+import 'integration/test_tools/serverpod_test_tools.dart';
+
+void main() {
+  withServerpod(
+    'Given a session key based on a session secret which would result in `+` when base64 encoded,',
+    (final sessionBuilder, final endpoints) {
+      late Session session;
+      final secret = Uint8List.fromList([250]);
+      final authSessionId = const Uuid().v4obj();
+      late String sessionKey;
+
+      setUp(() {
+        session = sessionBuilder.build();
+
+        assert(base64Encode(secret) == '+g==');
+
+        sessionKey = buildSessionKey(
+          authSessionId: authSessionId,
+          secret: secret,
+        );
+      });
+
+      test(
+        'when inspecting the key, then it does not contain a "+" because the encoding is URL safe.',
+        () {
+          expect(sessionKey, isNot(contains('+')));
+        },
+      );
+
+      test(
+        'when inspecting the key, then it does at least one ":" to be usable as a Basic auth header.',
+        () {
+          expect(sessionKey, contains(':'));
+        },
+      );
+
+      test(
+        'when inspecting the key, then contains the secret in the expected format.',
+        () {
+          expect(sessionKey, endsWith(':-g=='));
+        },
+      );
+
+      test(
+        'when parsing the key, then it can be read again.',
+        () {
+          final keyParts = tryParseSessionKey(session, sessionKey);
+
+          expect(keyParts?.authSessionId, authSessionId);
+          expect(keyParts?.secret, secret);
+        },
+      );
+    },
+  );
+}


### PR DESCRIPTION
I attempted to simplify the format further by encoding the entire dataset in one URL-safe base64 encoded String, but since the Serverpod `Client` takes the raw "session key" and sends it as a `Basic` authorization header, that failed (rightfully) in the Relic webserver, as the string did not contain a `:` anymore and thus did not match the `user:pass` schema.

Thus we have to stick with this format for now, unless we change the client/server (while keeping backwards compatibility). For this token as well as JWT it might be prudent to support the `Bearer` token pattern, and not further modify the values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal handling of session keys for authentication sessions, delegating parsing and building logic to dedicated utilities.

* **Tests**
  * Added tests to ensure session keys are URL-safe, correctly formatted for authentication headers, and can be reliably encoded and decoded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->