### PR TITLE
feat(auth2): Provide abstract email endpoint for both database and JWT backed sessions

### DIFF
--- a/modules/new_serverpod_auth/serverpod_auth_email/serverpod_auth_email_server/lib/serverpod_auth_email_server.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_email/serverpod_auth_email_server/lib/serverpod_auth_email_server.dart
@@ -8,6 +8,7 @@ export 'package:serverpod_auth_user_server/serverpod_auth_user_server.dart'
     hide Endpoints, Protocol;
 
 export 'src/business/auth_email.dart' show AuthEmail;
-export 'src/endpoints/auth_email_base_endpoint.dart' show AuthEmailBaseEndpoint;
+export 'src/endpoints/auth_email_base_endpoint.dart'
+    show AuthEmailBaseEndpoint, AuthEmailDatabaseSessionBaseEndpoint;
 export 'src/generated/endpoints.dart';
 export 'src/generated/protocol.dart';

--- a/modules/new_serverpod_auth/serverpod_auth_email/serverpod_auth_email_server/lib/src/business/auth_email.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_email/serverpod_auth_email_server/lib/src/business/auth_email.dart
@@ -1,3 +1,4 @@
+import 'package:meta/meta.dart';
 import 'package:serverpod/serverpod.dart';
 import 'package:serverpod_auth_email_account_server/serverpod_auth_email_account_server.dart';
 import 'package:serverpod_auth_profile_server/serverpod_auth_profile_server.dart';
@@ -12,12 +13,12 @@ part 'auth_email_admin.dart';
 ///
 /// Uses `serverpod_auth_session` for session management and
 /// `serverpod_auth_profile` for user profiles.
-abstract class AuthEmail {
+abstract class AuthEmail<SessionType extends SerializableModel> {
   /// Collection of admin-related functions.
-  static final AuthEmailAdmin admin = AuthEmailAdmin._();
+  AuthEmailAdmin<SessionType> get admin;
 
   /// {@macro email_account_base_endpoint.login}
-  static Future<AuthSuccess> login(
+  Future<SessionType> login(
     final Session session, {
     required final String email,
     required final String password,
@@ -44,7 +45,7 @@ abstract class AuthEmail {
   }
 
   /// {@macro email_account_base_endpoint.start_registration}
-  static Future<void> startRegistration(
+  Future<void> startRegistration(
     final Session session, {
     required final String email,
     required final String password,
@@ -69,7 +70,7 @@ abstract class AuthEmail {
   }
 
   /// {@macro email_account_base_endpoint.finish_registration}
-  static Future<AuthSuccess> finishRegistration(
+  Future<SessionType> finishRegistration(
     final Session session, {
     required final UuidValue accountRequestId,
     required final String verificationCode,
@@ -118,7 +119,7 @@ abstract class AuthEmail {
   }
 
   /// {@macro email_account_base_endpoint.start_password_reset}
-  static Future<void> startPasswordReset(
+  Future<void> startPasswordReset(
     final Session session, {
     required final String email,
     final Transaction? transaction,
@@ -140,7 +141,7 @@ abstract class AuthEmail {
   }
 
   /// {@macro email_account_base_endpoint.finish_password_reset}
-  static Future<AuthSuccess> finishPasswordReset(
+  Future<SessionType> finishPasswordReset(
     final Session session, {
     required final UuidValue passwordResetRequestId,
     required final String verificationCode,
@@ -173,4 +174,10 @@ abstract class AuthEmail {
       },
     );
   }
+}
+
+///
+class AuthEmailDatabaseSession extends AuthEmail<AuthSuccess> {
+  @override
+  AuthEmailAdmin<AuthSuccess> get admin => AuthEmailAdminDatabaseSession._();
 }

--- a/modules/new_serverpod_auth/serverpod_auth_email/serverpod_auth_email_server/lib/src/business/auth_email_admin.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_email/serverpod_auth_email_server/lib/src/business/auth_email_admin.dart
@@ -3,10 +3,12 @@ part of 'auth_email.dart';
 /// Admin operations complementing the end-user [AuthEmail] functionality.
 ///
 /// An instance of this class is available at [AuthEmail.admin].
-final class AuthEmailAdmin {
+abstract class AuthEmailAdmin<SessionType extends SerializableModel> {
   AuthEmailAdmin._();
 
-  static const String _method = 'email';
+  ///
+  @protected
+  final String method = 'email';
 
   /// Creates a user with an email-based authentication and the associated
   /// profile.
@@ -57,6 +59,21 @@ final class AuthEmailAdmin {
   /// Create a session for the given auth user.
   ///
   /// The session is marked as originating from the `email` provider.
+  Future<SessionType> createSession(
+    final Session session,
+    final UuidValue authUserId, {
+    required final Transaction? transaction,
+  });
+}
+
+///
+class AuthEmailAdminDatabaseSession extends AuthEmailAdmin<AuthSuccess> {
+  AuthEmailAdminDatabaseSession._() : super._();
+
+  /// Create a session for the given auth user.
+  ///
+  /// The session is marked as originating from the `email` provider.
+  @override
   Future<AuthSuccess> createSession(
     final Session session,
     final UuidValue authUserId, {
@@ -65,7 +82,7 @@ final class AuthEmailAdmin {
     return AuthSessions.createSession(
       session,
       authUserId: authUserId,
-      method: _method,
+      method: method,
       transaction: transaction,
     );
   }

--- a/modules/new_serverpod_auth/serverpod_auth_email/serverpod_auth_email_server/lib/src/endpoints/auth_email_base_endpoint.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_email/serverpod_auth_email_server/lib/src/endpoints/auth_email_base_endpoint.dart
@@ -1,5 +1,6 @@
 import 'package:serverpod/serverpod.dart';
 import 'package:serverpod_auth_email_server/serverpod_auth_email_server.dart';
+import 'package:serverpod_auth_email_server/src/business/auth_email.dart';
 
 /// Base endpoint for email-based accounts.
 ///
@@ -12,19 +13,23 @@ import 'package:serverpod_auth_email_server/serverpod_auth_email_server.dart';
 /// For further details see https://docs.serverpod.dev/concepts/working-with-endpoints#inheriting-from-an-endpoint-class-marked-abstract
 /// Alternatively you can build up your own endpoint on top of the same business
 /// logic by using [AuthEmail].
-abstract class AuthEmailBaseEndpoint extends Endpoint {
+abstract class AuthEmailBaseEndpoint<SessionType extends SerializableModel>
+    extends Endpoint {
+  ///
+  AuthEmail<SessionType> get authEmail;
+
   /// {@template email_account_base_endpoint.login}
   /// Logs in the user and returns a new session.
   ///
   /// In case an expected error occurs, this throws a
   /// [EmailAccountLoginException].
   /// {@endtemplate}
-  Future<AuthSuccess> login(
+  Future<SessionType> login(
     final Session session, {
     required final String email,
     required final String password,
   }) async {
-    return AuthEmail.login(
+    return authEmail.login(
       session,
       email: email,
       password: password,
@@ -44,7 +49,7 @@ abstract class AuthEmailBaseEndpoint extends Endpoint {
     required final String email,
     required final String password,
   }) async {
-    return AuthEmail.startRegistration(
+    return authEmail.startRegistration(
       session,
       email: email,
       password: password,
@@ -66,12 +71,12 @@ abstract class AuthEmailBaseEndpoint extends Endpoint {
   ///
   /// Returns a session for the newly created user.
   /// {@endtemplate}
-  Future<AuthSuccess> finishRegistration(
+  Future<SessionType> finishRegistration(
     final Session session, {
     required final UuidValue accountRequestId,
     required final String verificationCode,
   }) async {
-    return AuthEmail.finishRegistration(
+    return authEmail.finishRegistration(
       session,
       accountRequestId: accountRequestId,
       verificationCode: verificationCode,
@@ -91,7 +96,7 @@ abstract class AuthEmailBaseEndpoint extends Endpoint {
     final Session session, {
     required final String email,
   }) async {
-    return AuthEmail.startPasswordReset(session, email: email);
+    return authEmail.startPasswordReset(session, email: email);
   }
 
   /// {@template email_account_base_endpoint.finish_password_reset}
@@ -109,13 +114,13 @@ abstract class AuthEmailBaseEndpoint extends Endpoint {
   /// If the reset was successful, a new session is returned and
   /// all previous sessions of the user are destroyed.
   /// {@endtemplate}
-  Future<AuthSuccess> finishPasswordReset(
+  Future<SessionType> finishPasswordReset(
     final Session session, {
     required final UuidValue passwordResetRequestId,
     required final String verificationCode,
     required final String newPassword,
   }) async {
-    return AuthEmail.finishPasswordReset(
+    return authEmail.finishPasswordReset(
       session,
       passwordResetRequestId: passwordResetRequestId,
       verificationCode: verificationCode,
@@ -123,3 +128,13 @@ abstract class AuthEmailBaseEndpoint extends Endpoint {
     );
   }
 }
+
+///
+abstract class AuthEmailDatabaseSessionBaseEndpoint
+    extends AuthEmailBaseEndpoint<AuthSuccess> {
+  ///
+  @override
+  AuthEmail<AuthSuccess> get authEmail => AuthEmailDatabaseSession();
+}
+
+// class ProjectEmailEndpoint extends AuthEmailDatabaseSessionBaseEndpoint {}

--- a/tests/serverpod_new_auth_test/serverpod_new_auth_test_server/lib/src/endpoints/email_account_endpoint.dart
+++ b/tests/serverpod_new_auth_test/serverpod_new_auth_test_server/lib/src/endpoints/email_account_endpoint.dart
@@ -1,4 +1,4 @@
 import 'package:serverpod_auth_email_server/serverpod_auth_email_server.dart';
 
 /// Endpoint for email-based authentication.
-class EmailAccountEndpoint extends AuthEmailBaseEndpoint {}
+class EmailAccountEndpoint extends AuthEmailDatabaseSessionBaseEndpoint {}

--- a/tests/serverpod_new_auth_test/serverpod_new_auth_test_server/lib/src/endpoints/password_importing_email_account_endpoint.dart
+++ b/tests/serverpod_new_auth_test/serverpod_new_auth_test_server/lib/src/endpoints/password_importing_email_account_endpoint.dart
@@ -3,7 +3,8 @@ import 'package:serverpod_auth_backwards_compatibility_server/serverpod_auth_bac
 import 'package:serverpod_auth_email_server/serverpod_auth_email_server.dart';
 
 /// Endpoint for email-based authentication which imports the legacy passwords.
-class PasswordImportingEmailAccountEndpoint extends AuthEmailBaseEndpoint {
+class PasswordImportingEmailAccountEndpoint
+    extends AuthEmailDatabaseSessionBaseEndpoint {
   /// Logs in the user and returns a new session.
   ///
   /// In case an expected error occurs, this throws a `EmailAccountLoginException`.


### PR DESCRIPTION
@SandPod for your consideration, I have built out the class hierarchy as discussed yesterday to showcase how we could have a "session-type agnostic" email endpoint, and implemented the one for `serverpod_auth_session`.

Similarly, we would have to create JWT variants for each of the touched classes.
