### PR TITLE
feat(auth2): Use `UuidValue.withValidation` instead of `fromString`

### DIFF
--- a/modules/new_serverpod_auth/serverpod_auth_jwt/serverpod_auth_jwt_server/lib/src/business/jwt_util.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_jwt/serverpod_auth_jwt_server/lib/src/business/jwt_util.dart
@@ -79,7 +79,7 @@ class JwtUtil {
 
     final UuidValue refreshTokenId;
     try {
-      refreshTokenId = UuidValue.fromString(jwt.jwtId!);
+      refreshTokenId = UuidValue.withValidation(jwt.jwtId!);
     } catch (e) {
       throw ArgumentError(
         'The refresh token ID could not be read from the JWT\'s `id` claim: "${jwt.jwtId}"',
@@ -89,7 +89,7 @@ class JwtUtil {
 
     final UuidValue authUserId;
     try {
-      authUserId = UuidValue.fromString(jwt.subject!);
+      authUserId = UuidValue.withValidation(jwt.subject!);
     } catch (e) {
       throw ArgumentError(
         'The auth user ID could not be read from the JWT\'s `subject` claim: "${jwt.subject}"',


### PR DESCRIPTION
Ensuring that the string indeed represented a valid UUID
