### PR TITLE
feat(auth2): Require callback parameter on `AppleAccountsAdmin.checkAccountStatus` instead of having it configured via the config

### DIFF
--- a/modules/new_serverpod_auth/serverpod_auth_apple_account/serverpod_auth_apple_account_server/lib/src/business/apple_accounts.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_apple_account/serverpod_auth_apple_account_server/lib/src/business/apple_accounts.dart
@@ -28,7 +28,7 @@ abstract final class AppleAccounts {
       ),
     );
 
-    admin = AppleAccountsAdmin(_config, _siwa);
+    admin = AppleAccountsAdmin(_siwa);
   }
 
   /// Returns the current configuration.

--- a/modules/new_serverpod_auth/serverpod_auth_apple_account/serverpod_auth_apple_account_server/lib/src/business/config.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_apple_account/serverpod_auth_apple_account_server/lib/src/business/config.dart
@@ -1,5 +1,3 @@
-import 'package:serverpod/serverpod.dart';
-
 /// Configuration for the Apple account module.
 class AppleAccountConfig {
   /// The service identifier for the Sign in with Apple project.
@@ -20,12 +18,6 @@ class AppleAccountConfig {
   /// The secret contents of the private key file received once from Apple.
   final String key;
 
-  /// Callback to be invoked when an Apple authentication has been revoked.
-  ///
-  /// In this case all sessions associated with this sign-in method should be
-  /// removed.
-  final void Function(UuidValue authUserId)? expiredUserAuthenticationCallback;
-
   /// Creates a new Sign in with Apple configuration.
   AppleAccountConfig({
     required this.serviceIdentifier,
@@ -34,6 +26,5 @@ class AppleAccountConfig {
     required this.teamId,
     required this.keyId,
     required this.key,
-    this.expiredUserAuthenticationCallback,
   });
 }

--- a/modules/new_serverpod_auth/serverpod_auth_apple_account/serverpod_auth_apple_account_server/test/integration/apple_account_admin_test.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_apple_account/serverpod_auth_apple_account_server/test/integration/apple_account_admin_test.dart
@@ -1,0 +1,113 @@
+import 'package:serverpod/serverpod.dart';
+import 'package:serverpod_auth_apple_account_server/serverpod_auth_apple_account_server.dart';
+import 'package:serverpod_auth_user_server/serverpod_auth_user_server.dart';
+import 'package:sign_in_with_apple_server/sign_in_with_apple_server.dart';
+import 'package:test/fake.dart';
+import 'package:test/test.dart';
+
+import './test_tools/serverpod_test_tools.dart';
+
+void main() {
+  withServerpod(
+    'Given 1 active and 1 expired Apple-backed auth user,',
+    (final sessionBuilder, final endpionts) {
+      late Session session;
+      late UuidValue activeUser;
+      late UuidValue inactiveUser;
+      late AppleAccountsAdmin admin;
+
+      setUp(() async {
+        session = sessionBuilder.build();
+
+        activeUser = await _createAppleBackedUser(session);
+        inactiveUser = await _createAppleBackedUser(session);
+
+        final siwa = _SignInWithAppleFake(knownRefreshTokens: {
+          activeUser.uuid,
+        });
+        admin = AppleAccountsAdmin(siwa);
+      });
+
+      test(
+          'when calling `AppleAccountsAdmin.checkAccountStatus`, then the callback is invoked for the expired one.',
+          () async {
+        final expiredUsers = <UuidValue>{};
+
+        await admin.checkAccountStatus(
+          session,
+          onExpiredUserAuthentication: expiredUsers.add,
+        );
+
+        expect(expiredUsers, equals({inactiveUser}));
+      });
+
+      test(
+          'when calling `AppleAccountsAdmin.checkAccountStatus`, then all `lastRefreshedAt` timestamps are updated.',
+          () async {
+        final timeBeforeUpdate = DateTime.now();
+
+        await admin.checkAccountStatus(
+          session,
+          onExpiredUserAuthentication: (final _) {},
+        );
+
+        for (final appleAccount in await AppleAccount.db.find(session)) {
+          expect(
+            appleAccount.lastRefreshedAt.isAfter(timeBeforeUpdate),
+            isTrue,
+          );
+        }
+      });
+    },
+  );
+}
+
+/// Creates an `AuthUser` with Apple authentication with a refresh token equal to the user id.
+///
+/// The account's refresh token is marked as not having been checked in the last 24 hours,
+/// so that it will get picked up by the next `checkAccountStatus` run.
+Future<UuidValue> _createAppleBackedUser(final Session session) async {
+  final authUser = await AuthUsers.create(session);
+
+  await AppleAccount.db.insertRow(
+    session,
+    AppleAccount(
+      userIdentifier: authUser.id.toString(),
+      refreshToken: authUser.id.toString(),
+      refreshTokenRequestedWithBundleIdentifier: false,
+      email: '${authUser.id}@serverpod.dev',
+      isEmailVerified: true,
+      isPrivateEmail: false,
+      authUserId: authUser.id,
+      firstName: 'firstName',
+      lastName: 'lastName',
+      lastRefreshedAt: DateTime.now().subtract(const Duration(days: 2)),
+    ),
+  );
+
+  return authUser.id;
+}
+
+class _SignInWithAppleFake extends Fake implements SignInWithApple {
+  final Set<String> knownRefreshTokens;
+
+  _SignInWithAppleFake({
+    required this.knownRefreshTokens,
+  });
+
+  @override
+  Future<RefreshTokenValidationResponse> validateRefreshToken(
+    final String refreshToken, {
+    required final bool useBundleIdentifier,
+  }) async {
+    if (knownRefreshTokens.contains(refreshToken)) {
+      return RefreshTokenValidationResponse(
+        accessToken: '',
+        accessTokenExpiresIn: 0,
+        idToken: '',
+      );
+    } else {
+      throw RevokedTokenException();
+    }
+  }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The batch size limit for database queries when checking Apple account status is now configurable.

* **Bug Fixes**
  * Improved handling of revoked Apple authentication tokens by requiring an explicit callback for expired user authentication.

* **Refactor**
  * Streamlined internal configuration for Apple account administration, removing unnecessary dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->