### PR TITLE
feat!: Require `String` for `userIdentifier` in `AuthenticationInfo` constructor

### DIFF
--- a/modules/new_serverpod_auth/serverpod_auth_jwt/serverpod_auth_jwt_server/lib/src/business/authentication_info_from_jwt.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_jwt/serverpod_auth_jwt_server/lib/src/business/authentication_info_from_jwt.dart
@@ -13,7 +13,7 @@ extension AuthenticationInfoFromJwt on AuthenticationInfo {
     final VerifiedJwtData result,
   ) {
     final authInfo = AuthenticationInfo(
-      result.authUserId,
+      result.authUserId.uuid,
       result.scopes,
       authId: result.refreshTokenId.toString(),
     );

--- a/modules/new_serverpod_auth/serverpod_auth_jwt/serverpod_auth_jwt_server/lib/src/business/authentication_tokens.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_jwt/serverpod_auth_jwt_server/lib/src/business/authentication_tokens.dart
@@ -203,7 +203,7 @@ abstract final class AuthenticationTokens {
     if (auths.isEmpty) return;
 
     await session.messages.authenticationRevoked(
-      authUserId,
+      authUserId.uuid,
       RevokedAuthenticationUser(),
     );
   }
@@ -233,7 +233,7 @@ abstract final class AuthenticationTokens {
     // Notify the client about the revoked authentication for the specific
     // refresh token.
     await session.messages.authenticationRevoked(
-      refreshToken.authUserId,
+      refreshToken.authUserId.uuid,
       RevokedAuthenticationAuthId(authId: refreshTokenId.toString()),
     );
   }

--- a/modules/new_serverpod_auth/serverpod_auth_session/serverpod_auth_session_server/lib/src/business/auth_sessions.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_session/serverpod_auth_session_server/lib/src/business/auth_sessions.dart
@@ -100,7 +100,7 @@ abstract final class AuthSessions {
     }
 
     return AuthenticationInfo(
-      authSession.authUserId,
+      authSession.authUserId.uuid,
       authSession.scopeNames.map(Scope.new).toSet(),
       authId: authSessionId.toString(),
     );
@@ -227,7 +227,7 @@ abstract final class AuthSessions {
     if (auths.isEmpty) return;
 
     await session.messages.authenticationRevoked(
-      authUserId,
+      authUserId.uuid,
       RevokedAuthenticationUser(),
     );
   }
@@ -258,7 +258,7 @@ abstract final class AuthSessions {
     // Notify the client about the revoked authentication for the specific
     // user session
     await session.messages.authenticationRevoked(
-      authSession.authUserId,
+      authSession.authUserId.uuid,
       RevokedAuthenticationAuthId(authId: authSessionId.toString()),
     );
   }

--- a/modules/new_serverpod_auth/serverpod_auth_session/serverpod_auth_session_server/test/authentication_info_extension_test.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_session/serverpod_auth_session_server/test/authentication_info_extension_test.dart
@@ -9,7 +9,7 @@ void main() {
     final authId = const Uuid().v4obj();
 
     final authenticationInfo = AuthenticationInfo(
-      authUserId,
+      authUserId.uuid,
       {},
       authId: authId.uuid,
     );
@@ -22,7 +22,7 @@ void main() {
 
   group('Given an `AuthenticationInfo` with a `null` `authId`', () {
     final authenticationInfo = AuthenticationInfo(
-      authUserId,
+      authUserId.uuid,
       {},
       authId: null,
     );
@@ -37,7 +37,7 @@ void main() {
 
   group('Given an `AuthenticationInfo` with a non-UUID `authId`', () {
     final authenticationInfo = AuthenticationInfo(
-      123,
+      '123',
       {},
       authId: 'foo-bar',
     );

--- a/modules/new_serverpod_auth/serverpod_auth_session/serverpod_auth_session_server/test/integration/auth_sessions_destroy_test.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_session/serverpod_auth_session_server/test/integration/auth_sessions_destroy_test.dart
@@ -74,7 +74,7 @@ void main() {
       () async {
         final channelName =
             MessageCentralServerpodChannels.revokedAuthentication(
-          authUserId,
+          authUserId.uuid,
         );
 
         final revocationMessages = <SerializableModel>[];

--- a/modules/new_serverpod_auth/serverpod_auth_user/serverpod_auth_user_server/test/authentication_info_extension_test.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_user/serverpod_auth_user_server/test/authentication_info_extension_test.dart
@@ -6,7 +6,7 @@ void main() {
   group('Given an `AuthenticationInfo` with a UUID `userIdentifier`', () {
     final authUserId = const Uuid().v4obj();
 
-    final authenticationInfo = AuthenticationInfo(authUserId, {});
+    final authenticationInfo = AuthenticationInfo(authUserId.uuid, {});
 
     test('when reading the `userUuid` field, then the UUID is returned.', () {
       expect(authenticationInfo.authUserId, authUserId);
@@ -14,7 +14,7 @@ void main() {
   });
 
   group('Given an `AuthenticationInfo` with a non-UUID `userIdentifier`', () {
-    final authenticationInfo = AuthenticationInfo(123, {});
+    final authenticationInfo = AuthenticationInfo('123', {});
 
     test('when reading the `userUuid` field, then it throws.', () {
       expect(

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/business/authentication_handler.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/business/authentication_handler.dart
@@ -42,7 +42,7 @@ Future<AuthenticationInfo?> authenticationHandler(
       scopes.add(Scope(scopeName));
     }
     return AuthenticationInfo(
-      authKey.userId,
+      authKey.userId.toString(),
       scopes,
       authId: keyIdStr,
     );

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/business/user_authentication.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/business/user_authentication.dart
@@ -42,7 +42,7 @@ class UserAuthentication {
     if (updateSession) {
       session.updateAuthenticated(
         AuthenticationInfo(
-          userId,
+          userId.toString(),
           scopes,
           authId: '${result.id}',
         ),
@@ -74,7 +74,7 @@ class UserAuthentication {
     if (auths.isEmpty) return;
 
     await session.messages.authenticationRevoked(
-      userId,
+      userId.toString(),
       RevokedAuthenticationUser(),
     );
 
@@ -112,7 +112,7 @@ class UserAuthentication {
     // Notify the client about the revoked authentication for the specific
     // auth key
     await session.messages.authenticationRevoked(
-      auth.userId,
+      auth.userId.toString(),
       RevokedAuthenticationAuthId(authId: authKeyId),
     );
 

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/business/users.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/business/users.dart
@@ -156,7 +156,7 @@ class Users {
       var removedScopesList =
           removedScopes.map((s) => s.name).whereType<String>().toList();
       await session.messages.authenticationRevoked(
-        userId,
+        userId.toString(),
         RevokedAuthenticationScope(
           scopes: removedScopesList,
         ),

--- a/modules/serverpod_auth/serverpod_auth_server/test/extensions/authentication_info_extension_test.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/test/extensions/authentication_info_extension_test.dart
@@ -4,7 +4,7 @@ import 'package:test/test.dart';
 
 void main() {
   group('Given an `AuthenticationInfo` with an integer `userIdentifier`', () {
-    final authInfo = AuthenticationInfo(123, {});
+    final authInfo = AuthenticationInfo('123', {});
 
     test('when calling the `userId` helper, then `int` value is returned.', () {
       expect(authInfo.userId, 123);

--- a/modules/serverpod_auth/serverpod_auth_server/test/signout_legacy_option_test.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/test/signout_legacy_option_test.dart
@@ -1,6 +1,7 @@
 import 'package:serverpod/serverpod.dart';
 import 'package:serverpod_auth_server/serverpod_auth_server.dart';
 import 'package:test/test.dart';
+
 import 'integration/test_tools/serverpod_test_tools.dart';
 
 void main() {
@@ -21,7 +22,7 @@ void main() {
         () async {
           sessionBuilder = sessionBuilder.copyWith(
             authentication: AuthenticationOverride.authenticationInfo(
-              authKeys.first.userId,
+              authKeys.first.userId.toString(),
               {},
               authId: '${authKeys.first.id}',
             ),
@@ -60,7 +61,7 @@ void main() {
         () async {
           sessionBuilder = sessionBuilder.copyWith(
             authentication: AuthenticationOverride.authenticationInfo(
-              authKeys.first.userId,
+              authKeys.first.userId.toString(),
               {},
               authId: '${authKeys.first.id}',
             ),
@@ -98,7 +99,7 @@ void main() {
         () async {
           sessionBuilder = sessionBuilder.copyWith(
             authentication: AuthenticationOverride.authenticationInfo(
-              authKeys.first.userId,
+              authKeys.first.userId.toString(),
               {},
               authId: '${authKeys.first.id}',
             ),

--- a/packages/serverpod/lib/src/authentication/authentication_info.dart
+++ b/packages/serverpod/lib/src/authentication/authentication_info.dart
@@ -28,8 +28,15 @@ class AuthenticationInfo {
 
   /// Creates a new [AuthenticationInfo].
   AuthenticationInfo(
-    Object userIdentifier,
+    this.userIdentifier,
     this.scopes, {
     this.authId,
-  }) : userIdentifier = userIdentifier.toString();
+  }) {
+    if (userIdentifier.isEmpty) {
+      throw ArgumentError(
+        'The user identifier must not be empty.',
+        'userIdentifier',
+      );
+    }
+  }
 }

--- a/packages/serverpod/lib/src/authentication/service_authentication.dart
+++ b/packages/serverpod/lib/src/authentication/service_authentication.dart
@@ -1,6 +1,6 @@
+import '../server/session.dart';
 import 'authentication_info.dart';
 import 'scope.dart';
-import '../server/session.dart';
 
 /// The [AuthenticationHandler] for the servers service connection.
 Future<AuthenticationInfo?> serviceAuthenticationHandler(
@@ -15,7 +15,7 @@ Future<AuthenticationInfo?> serviceAuthenticationHandler(
     }
 
     if (secret == session.server.serverpod.config.serviceSecret) {
-      return AuthenticationInfo(0, <Scope>{Scope.none});
+      return AuthenticationInfo('0', <Scope>{Scope.none});
     }
   } catch (e) {
     return null;

--- a/packages/serverpod/lib/src/server/message_central.dart
+++ b/packages/serverpod/lib/src/server/message_central.dart
@@ -9,7 +9,7 @@ abstract class MessageCentralServerpodChannels {
   /// [RevokedAuthenticationAuthId] or [RevokedAuthenticationScope].
   /// The [userIdentifier] should be the [AuthenticationInfo.userIdentifier] for the concerned
   /// user.
-  static String revokedAuthentication(Object userIdentifier) =>
+  static String revokedAuthentication(String userIdentifier) =>
       '_serverpod_revoked_authentication_$userIdentifier';
 }
 

--- a/packages/serverpod/lib/src/server/session.dart
+++ b/packages/serverpod/lib/src/server/session.dart
@@ -651,8 +651,7 @@ class MessageCentralAccess {
   /// [RevokedAuthenticationScope] is used to communicate that a specific
   /// scope or scopes have been revoked for the user.
   Future<bool> authenticationRevoked(
-    // Uses `Object` to avoid breaking change, but should switch to `String` (mirroring `AuthenticationInfo.userIdentifier`) in the future
-    Object userIdentifier,
+    String userIdentifier,
     SerializableModel message,
   ) async {
     if (message is! RevokedAuthenticationUser &&
@@ -666,8 +665,7 @@ class MessageCentralAccess {
 
     try {
       return await _session.server.messageCentral.postMessage(
-        MessageCentralServerpodChannels.revokedAuthentication(
-            userIdentifier.toString()),
+        MessageCentralServerpodChannels.revokedAuthentication(userIdentifier),
         message,
         global: true,
       );
@@ -677,8 +675,7 @@ class MessageCentralAccess {
 
     // If Redis is not enabled, send the message locally.
     return _session.server.messageCentral.postMessage(
-      MessageCentralServerpodChannels.revokedAuthentication(
-          userIdentifier.toString()),
+      MessageCentralServerpodChannels.revokedAuthentication(userIdentifier),
       message,
       global: false,
     );

--- a/packages/serverpod/test/endpoint/authentication_test.dart
+++ b/packages/serverpod/test/endpoint/authentication_test.dart
@@ -79,7 +79,7 @@ void main() {
   group('Given authenticated user with no scopes', () {
     Future<AuthenticationInfo?> authenticatedUserWithNoScopesProvider() async =>
         AuthenticationInfo(
-          1,
+          '1',
           {},
         );
 
@@ -151,7 +151,7 @@ void main() {
   group('Given authenticated user with "admin" scope', () {
     Future<AuthenticationInfo?> authenticatedUserWithNoScopesProvider() async =>
         AuthenticationInfo(
-          1,
+          '1',
           {Scope.admin},
         );
 

--- a/packages/serverpod_test/lib/src/test_session_builder.dart
+++ b/packages/serverpod_test/lib/src/test_session_builder.dart
@@ -6,7 +6,7 @@ import 'test_serverpod.dart';
 abstract class AuthenticationOverride {
   /// Sets the session to be authenticated with the provided [userIdentifier] and [scopes].
   static AuthenticationOverride authenticationInfo(
-    Object userIdentifier,
+    String userIdentifier,
     Set<Scope> scopes, {
     String? authId,
   }) =>
@@ -109,7 +109,7 @@ class _AuthenticationInfoOverride extends AuthenticationOverride {
 
   /// Creates a new AuthenticationInfoOverride with the provided authentication info.
   _AuthenticationInfoOverride(
-    Object userIdentifier,
+    String userIdentifier,
     Set<Scope> scopes, {
     String? authId,
   }) : _authenticationInfo = AuthenticationInfo(

--- a/tests/serverpod_new_auth_test/serverpod_new_auth_test_server/test/integration/user_profile_endpoint_test.dart
+++ b/tests/serverpod_new_auth_test/serverpod_new_auth_test_server/test/integration/user_profile_endpoint_test.dart
@@ -21,7 +21,7 @@ void main() {
         () async {
       final session = sessionBuilder.copyWith(
         authentication: AuthenticationOverride.authenticationInfo(
-          const Uuid().v4obj(),
+          const Uuid().v4obj().uuid,
           {},
         ),
       );
@@ -44,7 +44,7 @@ void main() {
 
         session = sessionBuilder.copyWith(
           authentication: AuthenticationOverride.authenticationInfo(
-            authUserId,
+            authUserId.uuid,
             {},
           ),
         );
@@ -82,7 +82,7 @@ void main() {
 
         session = sessionBuilder.copyWith(
           authentication: AuthenticationOverride.authenticationInfo(
-            authUserId,
+            authUserId.uuid,
             {},
           ),
         );

--- a/tests/serverpod_test_server/test_integration/auth_core/auth_header_test.dart
+++ b/tests/serverpod_test_server/test_integration/auth_core/auth_header_test.dart
@@ -13,7 +13,7 @@ void main() async {
     String token,
   ) {
     tokenInspectionCompleter.complete(token);
-    return Future.value(AuthenticationInfo(1, {}));
+    return Future.value(AuthenticationInfo('1', {}));
   }
 
   group('Given auth key in valid HTTP header format', () {

--- a/tests/serverpod_test_server/test_integration/session/revoked_authentication_test.dart
+++ b/tests/serverpod_test_server/test_integration/session/revoked_authentication_test.dart
@@ -25,7 +25,7 @@ void main() async {
         'and a non valid message type when broadcasting revoked authentication event then exception is thrown',
         () {
       expect(
-        () => session.messages.authenticationRevoked(1, EmptyModel()),
+        () => session.messages.authenticationRevoked('1', EmptyModel()),
         throwsA(isA<ArgumentError>()),
       );
     });
@@ -36,13 +36,13 @@ void main() async {
       var eventCompleter = Completer<RevokedAuthenticationUser>();
       session.messages
           .createStream(
-              MessageCentralServerpodChannels.revokedAuthentication(1))
+              MessageCentralServerpodChannels.revokedAuthentication('1'))
           .listen(
             (event) => eventCompleter.complete(event),
           );
 
       var message = RevokedAuthenticationUser();
-      var event = await session.messages.authenticationRevoked(1, message);
+      var event = await session.messages.authenticationRevoked('1', message);
 
       expect(event, isTrue);
       await expectLater(
@@ -80,13 +80,13 @@ void main() async {
       var eventCompleter = Completer<RevokedAuthenticationUser>();
       session.messages
           .createStream(
-              MessageCentralServerpodChannels.revokedAuthentication(1))
+              MessageCentralServerpodChannels.revokedAuthentication('1'))
           .listen(
             (event) => eventCompleter.complete(event),
           );
 
       var message = RevokedAuthenticationUser();
-      var event = await session.messages.authenticationRevoked(1, message);
+      var event = await session.messages.authenticationRevoked('1', message);
 
       expect(event, isTrue);
       await expectLater(

--- a/tests/serverpod_test_server/test_integration/test_tools/authentication_validation_test.dart
+++ b/tests/serverpod_test_server/test_integration/test_tools/authentication_validation_test.dart
@@ -27,7 +27,7 @@ void main() {
           'when not having sufficient access scopes and calling returnsString then throws ServerpodInsufficientAccessException',
           () async {
         sessionBuilder = sessionBuilder.copyWith(
-          authentication: AuthenticationOverride.authenticationInfo(1234, {}),
+          authentication: AuthenticationOverride.authenticationInfo('1234', {}),
         );
 
         final result = endpoints.authenticatedTestTools
@@ -40,7 +40,7 @@ void main() {
           () async {
         sessionBuilder = sessionBuilder.copyWith(
           authentication: AuthenticationOverride.authenticationInfo(
-            1234,
+            '1234',
             {Scope('user')},
           ),
         );
@@ -68,7 +68,7 @@ void main() {
           () async {
         sessionBuilder = sessionBuilder.copyWith(
             authentication: AuthenticationOverride.authenticationInfo(
-          1234,
+          '1234',
           {},
         ));
 
@@ -83,7 +83,7 @@ void main() {
           () async {
         sessionBuilder = sessionBuilder.copyWith(
           authentication: AuthenticationOverride.authenticationInfo(
-            1234,
+            '1234',
             {Scope('user')},
           ),
         );
@@ -99,7 +99,7 @@ void main() {
         late Completer<int> valueReceivedCompleter;
         late StreamController<int> inStream;
 
-        var authenticatedUserId = 1;
+        var authenticatedUserId = '1';
         var authenticatedSessionBuilder = sessionBuilder.copyWith(
           authentication: AuthenticationOverride.authenticationInfo(
               authenticatedUserId, {Scope('user')}),
@@ -190,7 +190,7 @@ void main() {
         late Completer<int> valueReceivedCompleter2;
         late StreamController<int> inStream2;
 
-        var authenticatedUserId = 1;
+        var authenticatedUserId = '1';
         var authenticatedSessionBuilder = sessionBuilder.copyWith(
           authentication: AuthenticationOverride.authenticationInfo(
               authenticatedUserId, {Scope('user')}),

--- a/tests/serverpod_test_server/test_integration/test_tools/database_operations_test.dart
+++ b/tests/serverpod_test_server/test_integration/test_tools/database_operations_test.dart
@@ -29,13 +29,13 @@ void main() {
         setUp(() async {
           firstSessionBuilder = sessionBuilder.copyWith(
             authentication: AuthenticationOverride.authenticationInfo(
-              111,
+              '111',
               {},
             ),
           );
           secondSessionBuilder = sessionBuilder.copyWith(
             authentication: AuthenticationOverride.authenticationInfo(
-              222,
+              '222',
               {},
             ),
           );

--- a/tests/serverpod_test_server/test_integration/test_tools/return_and_input_types_test.dart
+++ b/tests/serverpod_test_server/test_integration/test_tools/return_and_input_types_test.dart
@@ -71,13 +71,13 @@ void main() {
           () async {
         var userSession1 = sessionBuilder.copyWith(
           authentication: AuthenticationOverride.authenticationInfo(
-            1,
+            '1',
             {},
           ),
         );
         var userSession2 = sessionBuilder.copyWith(
           authentication: AuthenticationOverride.authenticationInfo(
-            2,
+            '2',
             {},
           ),
         );

--- a/tests/serverpod_test_server/test_integration/test_tools/session_copy_with_test.dart
+++ b/tests/serverpod_test_server/test_integration/test_tools/session_copy_with_test.dart
@@ -11,7 +11,7 @@ void main() {
       group('when setting a new shared session builder on the group level', () {
         TestSessionBuilder modifiedSessionBuilder = sessionBuilder.copyWith(
           authentication: AuthenticationOverride.authenticationInfo(
-            123,
+            '123',
             {},
           ),
         );
@@ -52,7 +52,7 @@ void main() {
         test('then the first test can change it', () async {
           modifiedSessionBuilder = sessionBuilder.copyWith(
             authentication: AuthenticationOverride.authenticationInfo(
-              123,
+              '123',
               {},
             ),
           );

--- a/tests/serverpod_test_server/test_integration/test_tools/test_session_builder_test.dart
+++ b/tests/serverpod_test_server/test_integration/test_tools/test_session_builder_test.dart
@@ -14,7 +14,7 @@ void main() {
         final session = sessionBuilder
             .copyWith(
               authentication: AuthenticationOverride.authenticationInfo(
-                123,
+                '123',
                 {},
               ),
             )
@@ -46,12 +46,10 @@ void main() {
       late AuthenticationInfo? authenticationInfo;
 
       setUp(() async {
-        final uuid = UuidValue.fromString(uuidString);
-
         final session = sessionBuilder
             .copyWith(
               authentication: AuthenticationOverride.authenticationInfo(
-                uuid,
+                uuidString,
                 {},
               ),
             )

--- a/tests/serverpod_test_server/test_integration/websockets/method_websockets/method_streams/revoked_authentication_stream_test.dart
+++ b/tests/serverpod_test_server/test_integration/websockets/method_websockets/method_streams/revoked_authentication_stream_test.dart
@@ -14,7 +14,7 @@ void main() {
   late Session session;
   late c.Client client;
   late TestAuthKeyManager authKeyManager;
-  var authenticatedUserId = 1;
+  var authenticatedUserId = '1';
   var tokenCounter = 0;
 
   setUp(() async {


### PR DESCRIPTION
Instead of internally converting `Object` to `String`

Also changes the related usages of `Object userIdentifier`, which mirror/are triggered by the `AuthenticationInfo` field.

Closes #3477

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized user identifier types across the authentication system to consistently use string values instead of integers or objects.

* **Tests**
  * Updated all related test cases to use string-based user identifiers, ensuring compatibility with the new identifier format.

* **Bug Fixes**
  * Improved reliability and consistency in authentication and session management by unifying the user identifier type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->