### PR TITLE
fix: Shutdown server in dev mode only on db integrity failure

### DIFF
--- a/packages/serverpod/lib/src/server/serverpod.dart
+++ b/packages/serverpod/lib/src/server/serverpod.dart
@@ -792,7 +792,9 @@ class Serverpod {
 
     if (!verified) {
       logVerbose('Database integrity verification failed.');
-      throw ExitException(1);
+      if (config.runMode != ServerpodRunMode.production) {
+        throw ExitException(1);
+      }
     }
   }
 


### PR DESCRIPTION
https://github.com/serverpod/serverpod/pull/3740 introduced an issue where the server would be shut down when the database integrity check failed. This should only happen in dev mode which is what this PR addresses

## Pre-launch Checklist

- [X] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [X] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [X] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [X] I added new tests to check the change I am making.
- [X] All existing and new tests are passing.
- [X] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

