### PR TITLE
fix: Unnessary optional null check on generated class with custom class

### DIFF
--- a/tests/serverpod_test_client/lib/src/protocol/object_with_nullable_custom_class.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/object_with_nullable_custom_class.dart
@@ -1,0 +1,163 @@
+/* AUTOMATICALLY GENERATED CODE DO NOT MODIFY */
+/*   To generate run: "serverpod generate"    */
+
+// ignore_for_file: implementation_imports
+// ignore_for_file: library_private_types_in_public_api
+// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: public_member_api_docs
+// ignore_for_file: type_literal_in_constant_pattern
+// ignore_for_file: use_super_parameters
+// ignore_for_file: invalid_use_of_internal_member
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:serverpod_test_shared/serverpod_test_shared.dart' as _i2;
+
+abstract class ObjectWithNullableCustomClass implements _i1.SerializableModel {
+  ObjectWithNullableCustomClass._({
+    this.nullableCustomClassWithoutProtocolSerialization,
+    this.nullableCustomClassWithProtocolSerialization,
+    this.nullableCustomClassWithProtocolSerializationMethod,
+    required this.nonNullableCustomClass,
+  });
+
+  factory ObjectWithNullableCustomClass({
+    _i2.CustomClassWithoutProtocolSerialization?
+        nullableCustomClassWithoutProtocolSerialization,
+    _i2.CustomClassWithProtocolSerialization?
+        nullableCustomClassWithProtocolSerialization,
+    _i2.CustomClassWithProtocolSerializationMethod?
+        nullableCustomClassWithProtocolSerializationMethod,
+    required _i2.CustomClassWithProtocolSerialization nonNullableCustomClass,
+  }) = _ObjectWithNullableCustomClassImpl;
+
+  factory ObjectWithNullableCustomClass.fromJson(
+      Map<String, dynamic> jsonSerialization) {
+    return ObjectWithNullableCustomClass(
+      nullableCustomClassWithoutProtocolSerialization: jsonSerialization[
+                  'nullableCustomClassWithoutProtocolSerialization'] ==
+              null
+          ? null
+          : _i2.CustomClassWithoutProtocolSerialization.fromJson(
+              jsonSerialization[
+                  'nullableCustomClassWithoutProtocolSerialization']),
+      nullableCustomClassWithProtocolSerialization:
+          jsonSerialization['nullableCustomClassWithProtocolSerialization'] ==
+                  null
+              ? null
+              : _i2.CustomClassWithProtocolSerialization.fromJson(
+                  jsonSerialization[
+                      'nullableCustomClassWithProtocolSerialization']),
+      nullableCustomClassWithProtocolSerializationMethod: jsonSerialization[
+                  'nullableCustomClassWithProtocolSerializationMethod'] ==
+              null
+          ? null
+          : _i2.CustomClassWithProtocolSerializationMethod.fromJson(
+              jsonSerialization[
+                  'nullableCustomClassWithProtocolSerializationMethod']),
+      nonNullableCustomClass: _i2.CustomClassWithProtocolSerialization.fromJson(
+          jsonSerialization['nonNullableCustomClass']),
+    );
+  }
+
+  _i2.CustomClassWithoutProtocolSerialization?
+      nullableCustomClassWithoutProtocolSerialization;
+
+  _i2.CustomClassWithProtocolSerialization?
+      nullableCustomClassWithProtocolSerialization;
+
+  _i2.CustomClassWithProtocolSerializationMethod?
+      nullableCustomClassWithProtocolSerializationMethod;
+
+  _i2.CustomClassWithProtocolSerialization nonNullableCustomClass;
+
+  /// Returns a shallow copy of this [ObjectWithNullableCustomClass]
+  /// with some or all fields replaced by the given arguments.
+  @_i1.useResult
+  ObjectWithNullableCustomClass copyWith({
+    _i2.CustomClassWithoutProtocolSerialization?
+        nullableCustomClassWithoutProtocolSerialization,
+    _i2.CustomClassWithProtocolSerialization?
+        nullableCustomClassWithProtocolSerialization,
+    _i2.CustomClassWithProtocolSerializationMethod?
+        nullableCustomClassWithProtocolSerializationMethod,
+    _i2.CustomClassWithProtocolSerialization? nonNullableCustomClass,
+  });
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      if (nullableCustomClassWithoutProtocolSerialization != null)
+        'nullableCustomClassWithoutProtocolSerialization':
+            nullableCustomClassWithoutProtocolSerialization?.toJson(),
+      if (nullableCustomClassWithProtocolSerialization != null)
+        'nullableCustomClassWithProtocolSerialization':
+            nullableCustomClassWithProtocolSerialization?.toJson(),
+      if (nullableCustomClassWithProtocolSerializationMethod != null)
+        'nullableCustomClassWithProtocolSerializationMethod':
+            nullableCustomClassWithProtocolSerializationMethod?.toJson(),
+      'nonNullableCustomClass': nonNullableCustomClass.toJson(),
+    };
+  }
+
+  @override
+  String toString() {
+    return _i1.SerializationManager.encode(this);
+  }
+}
+
+class _Undefined {}
+
+class _ObjectWithNullableCustomClassImpl extends ObjectWithNullableCustomClass {
+  _ObjectWithNullableCustomClassImpl({
+    _i2.CustomClassWithoutProtocolSerialization?
+        nullableCustomClassWithoutProtocolSerialization,
+    _i2.CustomClassWithProtocolSerialization?
+        nullableCustomClassWithProtocolSerialization,
+    _i2.CustomClassWithProtocolSerializationMethod?
+        nullableCustomClassWithProtocolSerializationMethod,
+    required _i2.CustomClassWithProtocolSerialization nonNullableCustomClass,
+  }) : super._(
+          nullableCustomClassWithoutProtocolSerialization:
+              nullableCustomClassWithoutProtocolSerialization,
+          nullableCustomClassWithProtocolSerialization:
+              nullableCustomClassWithProtocolSerialization,
+          nullableCustomClassWithProtocolSerializationMethod:
+              nullableCustomClassWithProtocolSerializationMethod,
+          nonNullableCustomClass: nonNullableCustomClass,
+        );
+
+  /// Returns a shallow copy of this [ObjectWithNullableCustomClass]
+  /// with some or all fields replaced by the given arguments.
+  @_i1.useResult
+  @override
+  ObjectWithNullableCustomClass copyWith({
+    Object? nullableCustomClassWithoutProtocolSerialization = _Undefined,
+    Object? nullableCustomClassWithProtocolSerialization = _Undefined,
+    Object? nullableCustomClassWithProtocolSerializationMethod = _Undefined,
+    _i2.CustomClassWithProtocolSerialization? nonNullableCustomClass,
+  }) {
+    return ObjectWithNullableCustomClass(
+      nullableCustomClassWithoutProtocolSerialization:
+          nullableCustomClassWithoutProtocolSerialization
+                  is _i2.CustomClassWithoutProtocolSerialization?
+              ? nullableCustomClassWithoutProtocolSerialization
+              : this
+                  .nullableCustomClassWithoutProtocolSerialization
+                  ?.copyWith(),
+      nullableCustomClassWithProtocolSerialization:
+          nullableCustomClassWithProtocolSerialization
+                  is _i2.CustomClassWithProtocolSerialization?
+              ? nullableCustomClassWithProtocolSerialization
+              : this.nullableCustomClassWithProtocolSerialization?.copyWith(),
+      nullableCustomClassWithProtocolSerializationMethod:
+          nullableCustomClassWithProtocolSerializationMethod
+                  is _i2.CustomClassWithProtocolSerializationMethod?
+              ? nullableCustomClassWithProtocolSerializationMethod
+              : this
+                  .nullableCustomClassWithProtocolSerializationMethod
+                  ?.copyWith(),
+      nonNullableCustomClass:
+          nonNullableCustomClass ?? this.nonNullableCustomClass.copyWith(),
+    );
+  }
+}

--- a/tests/serverpod_test_client/lib/src/protocol/protocol.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/protocol.dart
@@ -16,7 +16,7 @@ import 'inheritance/child_class.dart' as _i3;
 import 'inheritance/child_with_default.dart' as _i4;
 import 'inheritance/parent_class.dart' as _i5;
 import 'inheritance/sealed_parent.dart' as _i6;
-import 'defaults/string/string_default_persist.dart' as _i7;
+import 'defaults/uri/uri_default.dart' as _i7;
 import 'changed_id_type/one_to_many/comment.dart' as _i8;
 import 'changed_id_type/one_to_many/customer.dart' as _i9;
 import 'changed_id_type/one_to_many/order.dart' as _i10;
@@ -60,8 +60,8 @@ import 'defaults/integer/int_default_persist.dart' as _i47;
 import 'defaults/string/string_default.dart' as _i48;
 import 'defaults/string/string_default_mix.dart' as _i49;
 import 'defaults/string/string_default_model.dart' as _i50;
-import 'by_index_enum_with_name_value.dart' as _i51;
-import 'defaults/uri/uri_default.dart' as _i52;
+import 'defaults/string/string_default_persist.dart' as _i51;
+import 'by_index_enum_with_name_value.dart' as _i52;
 import 'defaults/uri/uri_default_mix.dart' as _i53;
 import 'defaults/uri/uri_default_model.dart' as _i54;
 import 'defaults/uri/uri_default_persist.dart' as _i55;
@@ -118,8 +118,8 @@ import 'models_with_relations/one_to_many/customer.dart' as _i97;
 import 'models_with_relations/one_to_many/implicit/book.dart' as _i98;
 import 'models_with_relations/one_to_many/implicit/chapter.dart' as _i99;
 import 'models_with_relations/one_to_many/order.dart' as _i100;
-import 'my_feature/models/my_feature_model.dart' as _i101;
-import 'models_with_relations/one_to_one/citizen.dart' as _i102;
+import 'models_with_relations/one_to_one/address.dart' as _i101;
+import 'my_feature/models/my_feature_model.dart' as _i102;
 import 'models_with_relations/one_to_one/company.dart' as _i103;
 import 'models_with_relations/one_to_one/town.dart' as _i104;
 import 'models_with_relations/self_relation/many_to_many/blocking.dart'
@@ -139,47 +139,48 @@ import 'object_with_enum.dart' as _i117;
 import 'object_with_half_vector.dart' as _i118;
 import 'object_with_index.dart' as _i119;
 import 'object_with_maps.dart' as _i120;
-import 'object_with_object.dart' as _i121;
-import 'object_with_parent.dart' as _i122;
-import 'object_with_self_parent.dart' as _i123;
-import 'object_with_sparse_vector.dart' as _i124;
-import 'object_with_uuid.dart' as _i125;
-import 'object_with_vector.dart' as _i126;
-import 'record.dart' as _i127;
-import 'related_unique_data.dart' as _i128;
-import 'scopes/scope_none_fields.dart' as _i129;
-import 'scopes/scope_server_only_field.dart' as _i130;
-import 'changed_id_type/nested_one_to_many/team.dart' as _i131;
-import 'scopes/serverOnly/default_server_only_class.dart' as _i132;
-import 'scopes/serverOnly/default_server_only_enum.dart' as _i133;
-import 'scopes/serverOnly/not_server_only_class.dart' as _i134;
-import 'scopes/serverOnly/not_server_only_enum.dart' as _i135;
-import 'scopes/server_only_class_field.dart' as _i136;
-import 'server_only_default.dart' as _i137;
-import 'simple_data.dart' as _i138;
-import 'simple_data_list.dart' as _i139;
-import 'simple_data_map.dart' as _i140;
-import 'simple_data_object.dart' as _i141;
-import 'simple_date_time.dart' as _i142;
-import 'subfolder/model_in_subfolder.dart' as _i143;
-import 'test_enum.dart' as _i144;
-import 'test_enum_stringified.dart' as _i145;
-import 'types.dart' as _i146;
-import 'types_list.dart' as _i147;
-import 'types_map.dart' as _i148;
-import 'types_record.dart' as _i149;
-import 'types_set.dart' as _i150;
-import 'types_set_required.dart' as _i151;
-import 'unique_data.dart' as _i152;
-import 'models_with_relations/one_to_one/address.dart' as _i153;
+import 'object_with_nullable_custom_class.dart' as _i121;
+import 'object_with_object.dart' as _i122;
+import 'object_with_parent.dart' as _i123;
+import 'object_with_self_parent.dart' as _i124;
+import 'object_with_sparse_vector.dart' as _i125;
+import 'object_with_uuid.dart' as _i126;
+import 'object_with_vector.dart' as _i127;
+import 'record.dart' as _i128;
+import 'related_unique_data.dart' as _i129;
+import 'scopes/scope_none_fields.dart' as _i130;
+import 'scopes/scope_server_only_field.dart' as _i131;
+import 'changed_id_type/nested_one_to_many/team.dart' as _i132;
+import 'scopes/serverOnly/default_server_only_class.dart' as _i133;
+import 'scopes/serverOnly/default_server_only_enum.dart' as _i134;
+import 'scopes/serverOnly/not_server_only_class.dart' as _i135;
+import 'scopes/serverOnly/not_server_only_enum.dart' as _i136;
+import 'scopes/server_only_class_field.dart' as _i137;
+import 'server_only_default.dart' as _i138;
+import 'simple_data.dart' as _i139;
+import 'simple_data_list.dart' as _i140;
+import 'simple_data_map.dart' as _i141;
+import 'simple_data_object.dart' as _i142;
+import 'simple_date_time.dart' as _i143;
+import 'subfolder/model_in_subfolder.dart' as _i144;
+import 'test_enum.dart' as _i145;
+import 'test_enum_stringified.dart' as _i146;
+import 'types.dart' as _i147;
+import 'types_list.dart' as _i148;
+import 'types_map.dart' as _i149;
+import 'types_record.dart' as _i150;
+import 'types_set.dart' as _i151;
+import 'types_set_required.dart' as _i152;
+import 'unique_data.dart' as _i153;
+import 'models_with_relations/one_to_one/citizen.dart' as _i154;
 import 'package:serverpod_test_module_client/serverpod_test_module_client.dart'
-    as _i154;
-import 'dart:typed_data' as _i155;
-import 'package:serverpod_test_shared/serverpod_test_shared.dart' as _i156;
-import 'package:serverpod_test_client/src/protocol/simple_data.dart' as _i157;
-import 'package:serverpod_test_client/src/protocol/test_enum.dart' as _i158;
-import 'package:serverpod_auth_client/serverpod_auth_client.dart' as _i159;
-import 'package:serverpod_test_client/src/protocol/types.dart' as _i160;
+    as _i155;
+import 'dart:typed_data' as _i156;
+import 'package:serverpod_test_shared/serverpod_test_shared.dart' as _i157;
+import 'package:serverpod_test_client/src/protocol/simple_data.dart' as _i158;
+import 'package:serverpod_test_client/src/protocol/test_enum.dart' as _i159;
+import 'package:serverpod_auth_client/serverpod_auth_client.dart' as _i160;
+import 'package:serverpod_test_client/src/protocol/types.dart' as _i161;
 export 'by_index_enum_with_name_value.dart';
 export 'by_name_enum_with_name_value.dart';
 export 'changed_id_type/many_to_many/course.dart';
@@ -300,6 +301,7 @@ export 'object_with_enum.dart';
 export 'object_with_half_vector.dart';
 export 'object_with_index.dart';
 export 'object_with_maps.dart';
+export 'object_with_nullable_custom_class.dart';
 export 'object_with_object.dart';
 export 'object_with_parent.dart';
 export 'object_with_self_parent.dart';
@@ -369,8 +371,8 @@ class Protocol extends _i1.SerializationManager {
     if (t == _i6.SealedOtherChild) {
       return _i6.SealedOtherChild.fromJson(data) as T;
     }
-    if (t == _i7.StringDefaultPersist) {
-      return _i7.StringDefaultPersist.fromJson(data) as T;
+    if (t == _i7.UriDefault) {
+      return _i7.UriDefault.fromJson(data) as T;
     }
     if (t == _i8.CommentInt) {
       return _i8.CommentInt.fromJson(data) as T;
@@ -501,11 +503,11 @@ class Protocol extends _i1.SerializationManager {
     if (t == _i50.StringDefaultModel) {
       return _i50.StringDefaultModel.fromJson(data) as T;
     }
-    if (t == _i51.ByIndexEnumWithNameValue) {
-      return _i51.ByIndexEnumWithNameValue.fromJson(data) as T;
+    if (t == _i51.StringDefaultPersist) {
+      return _i51.StringDefaultPersist.fromJson(data) as T;
     }
-    if (t == _i52.UriDefault) {
-      return _i52.UriDefault.fromJson(data) as T;
+    if (t == _i52.ByIndexEnumWithNameValue) {
+      return _i52.ByIndexEnumWithNameValue.fromJson(data) as T;
     }
     if (t == _i53.UriDefaultMix) {
       return _i53.UriDefaultMix.fromJson(data) as T;
@@ -651,11 +653,11 @@ class Protocol extends _i1.SerializationManager {
     if (t == _i100.Order) {
       return _i100.Order.fromJson(data) as T;
     }
-    if (t == _i101.MyFeatureModel) {
-      return _i101.MyFeatureModel.fromJson(data) as T;
+    if (t == _i101.Address) {
+      return _i101.Address.fromJson(data) as T;
     }
-    if (t == _i102.Citizen) {
-      return _i102.Citizen.fromJson(data) as T;
+    if (t == _i102.MyFeatureModel) {
+      return _i102.MyFeatureModel.fromJson(data) as T;
     }
     if (t == _i103.Company) {
       return _i103.Company.fromJson(data) as T;
@@ -711,104 +713,107 @@ class Protocol extends _i1.SerializationManager {
     if (t == _i120.ObjectWithMaps) {
       return _i120.ObjectWithMaps.fromJson(data) as T;
     }
-    if (t == _i121.ObjectWithObject) {
-      return _i121.ObjectWithObject.fromJson(data) as T;
+    if (t == _i121.ObjectWithNullableCustomClass) {
+      return _i121.ObjectWithNullableCustomClass.fromJson(data) as T;
     }
-    if (t == _i122.ObjectWithParent) {
-      return _i122.ObjectWithParent.fromJson(data) as T;
+    if (t == _i122.ObjectWithObject) {
+      return _i122.ObjectWithObject.fromJson(data) as T;
     }
-    if (t == _i123.ObjectWithSelfParent) {
-      return _i123.ObjectWithSelfParent.fromJson(data) as T;
+    if (t == _i123.ObjectWithParent) {
+      return _i123.ObjectWithParent.fromJson(data) as T;
     }
-    if (t == _i124.ObjectWithSparseVector) {
-      return _i124.ObjectWithSparseVector.fromJson(data) as T;
+    if (t == _i124.ObjectWithSelfParent) {
+      return _i124.ObjectWithSelfParent.fromJson(data) as T;
     }
-    if (t == _i125.ObjectWithUuid) {
-      return _i125.ObjectWithUuid.fromJson(data) as T;
+    if (t == _i125.ObjectWithSparseVector) {
+      return _i125.ObjectWithSparseVector.fromJson(data) as T;
     }
-    if (t == _i126.ObjectWithVector) {
-      return _i126.ObjectWithVector.fromJson(data) as T;
+    if (t == _i126.ObjectWithUuid) {
+      return _i126.ObjectWithUuid.fromJson(data) as T;
     }
-    if (t == _i127.Record) {
-      return _i127.Record.fromJson(data) as T;
+    if (t == _i127.ObjectWithVector) {
+      return _i127.ObjectWithVector.fromJson(data) as T;
     }
-    if (t == _i128.RelatedUniqueData) {
-      return _i128.RelatedUniqueData.fromJson(data) as T;
+    if (t == _i128.Record) {
+      return _i128.Record.fromJson(data) as T;
     }
-    if (t == _i129.ScopeNoneFields) {
-      return _i129.ScopeNoneFields.fromJson(data) as T;
+    if (t == _i129.RelatedUniqueData) {
+      return _i129.RelatedUniqueData.fromJson(data) as T;
     }
-    if (t == _i130.ScopeServerOnlyField) {
-      return _i130.ScopeServerOnlyField.fromJson(data) as T;
+    if (t == _i130.ScopeNoneFields) {
+      return _i130.ScopeNoneFields.fromJson(data) as T;
     }
-    if (t == _i131.TeamInt) {
-      return _i131.TeamInt.fromJson(data) as T;
+    if (t == _i131.ScopeServerOnlyField) {
+      return _i131.ScopeServerOnlyField.fromJson(data) as T;
     }
-    if (t == _i132.DefaultServerOnlyClass) {
-      return _i132.DefaultServerOnlyClass.fromJson(data) as T;
+    if (t == _i132.TeamInt) {
+      return _i132.TeamInt.fromJson(data) as T;
     }
-    if (t == _i133.DefaultServerOnlyEnum) {
-      return _i133.DefaultServerOnlyEnum.fromJson(data) as T;
+    if (t == _i133.DefaultServerOnlyClass) {
+      return _i133.DefaultServerOnlyClass.fromJson(data) as T;
     }
-    if (t == _i134.NotServerOnlyClass) {
-      return _i134.NotServerOnlyClass.fromJson(data) as T;
+    if (t == _i134.DefaultServerOnlyEnum) {
+      return _i134.DefaultServerOnlyEnum.fromJson(data) as T;
     }
-    if (t == _i135.NotServerOnlyEnum) {
-      return _i135.NotServerOnlyEnum.fromJson(data) as T;
+    if (t == _i135.NotServerOnlyClass) {
+      return _i135.NotServerOnlyClass.fromJson(data) as T;
     }
-    if (t == _i136.ServerOnlyClassField) {
-      return _i136.ServerOnlyClassField.fromJson(data) as T;
+    if (t == _i136.NotServerOnlyEnum) {
+      return _i136.NotServerOnlyEnum.fromJson(data) as T;
     }
-    if (t == _i137.ServerOnlyDefault) {
-      return _i137.ServerOnlyDefault.fromJson(data) as T;
+    if (t == _i137.ServerOnlyClassField) {
+      return _i137.ServerOnlyClassField.fromJson(data) as T;
     }
-    if (t == _i138.SimpleData) {
-      return _i138.SimpleData.fromJson(data) as T;
+    if (t == _i138.ServerOnlyDefault) {
+      return _i138.ServerOnlyDefault.fromJson(data) as T;
     }
-    if (t == _i139.SimpleDataList) {
-      return _i139.SimpleDataList.fromJson(data) as T;
+    if (t == _i139.SimpleData) {
+      return _i139.SimpleData.fromJson(data) as T;
     }
-    if (t == _i140.SimpleDataMap) {
-      return _i140.SimpleDataMap.fromJson(data) as T;
+    if (t == _i140.SimpleDataList) {
+      return _i140.SimpleDataList.fromJson(data) as T;
     }
-    if (t == _i141.SimpleDataObject) {
-      return _i141.SimpleDataObject.fromJson(data) as T;
+    if (t == _i141.SimpleDataMap) {
+      return _i141.SimpleDataMap.fromJson(data) as T;
     }
-    if (t == _i142.SimpleDateTime) {
-      return _i142.SimpleDateTime.fromJson(data) as T;
+    if (t == _i142.SimpleDataObject) {
+      return _i142.SimpleDataObject.fromJson(data) as T;
     }
-    if (t == _i143.ModelInSubfolder) {
-      return _i143.ModelInSubfolder.fromJson(data) as T;
+    if (t == _i143.SimpleDateTime) {
+      return _i143.SimpleDateTime.fromJson(data) as T;
     }
-    if (t == _i144.TestEnum) {
-      return _i144.TestEnum.fromJson(data) as T;
+    if (t == _i144.ModelInSubfolder) {
+      return _i144.ModelInSubfolder.fromJson(data) as T;
     }
-    if (t == _i145.TestEnumStringified) {
-      return _i145.TestEnumStringified.fromJson(data) as T;
+    if (t == _i145.TestEnum) {
+      return _i145.TestEnum.fromJson(data) as T;
     }
-    if (t == _i146.Types) {
-      return _i146.Types.fromJson(data) as T;
+    if (t == _i146.TestEnumStringified) {
+      return _i146.TestEnumStringified.fromJson(data) as T;
     }
-    if (t == _i147.TypesList) {
-      return _i147.TypesList.fromJson(data) as T;
+    if (t == _i147.Types) {
+      return _i147.Types.fromJson(data) as T;
     }
-    if (t == _i148.TypesMap) {
-      return _i148.TypesMap.fromJson(data) as T;
+    if (t == _i148.TypesList) {
+      return _i148.TypesList.fromJson(data) as T;
     }
-    if (t == _i149.TypesRecord) {
-      return _i149.TypesRecord.fromJson(data) as T;
+    if (t == _i149.TypesMap) {
+      return _i149.TypesMap.fromJson(data) as T;
     }
-    if (t == _i150.TypesSet) {
-      return _i150.TypesSet.fromJson(data) as T;
+    if (t == _i150.TypesRecord) {
+      return _i150.TypesRecord.fromJson(data) as T;
     }
-    if (t == _i151.TypesSetRequired) {
-      return _i151.TypesSetRequired.fromJson(data) as T;
+    if (t == _i151.TypesSet) {
+      return _i151.TypesSet.fromJson(data) as T;
     }
-    if (t == _i152.UniqueData) {
-      return _i152.UniqueData.fromJson(data) as T;
+    if (t == _i152.TypesSetRequired) {
+      return _i152.TypesSetRequired.fromJson(data) as T;
     }
-    if (t == _i153.Address) {
-      return _i153.Address.fromJson(data) as T;
+    if (t == _i153.UniqueData) {
+      return _i153.UniqueData.fromJson(data) as T;
+    }
+    if (t == _i154.Citizen) {
+      return _i154.Citizen.fromJson(data) as T;
     }
     if (t == _i1.getType<_i2.ScopeServerOnlyFieldChild?>()) {
       return (data != null
@@ -833,9 +838,8 @@ class Protocol extends _i1.SerializationManager {
     if (t == _i1.getType<_i6.SealedOtherChild?>()) {
       return (data != null ? _i6.SealedOtherChild.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i7.StringDefaultPersist?>()) {
-      return (data != null ? _i7.StringDefaultPersist.fromJson(data) : null)
-          as T;
+    if (t == _i1.getType<_i7.UriDefault?>()) {
+      return (data != null ? _i7.UriDefault.fromJson(data) : null) as T;
     }
     if (t == _i1.getType<_i8.CommentInt?>()) {
       return (data != null ? _i8.CommentInt.fromJson(data) : null) as T;
@@ -979,13 +983,14 @@ class Protocol extends _i1.SerializationManager {
       return (data != null ? _i50.StringDefaultModel.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i51.ByIndexEnumWithNameValue?>()) {
-      return (data != null
-          ? _i51.ByIndexEnumWithNameValue.fromJson(data)
-          : null) as T;
+    if (t == _i1.getType<_i51.StringDefaultPersist?>()) {
+      return (data != null ? _i51.StringDefaultPersist.fromJson(data) : null)
+          as T;
     }
-    if (t == _i1.getType<_i52.UriDefault?>()) {
-      return (data != null ? _i52.UriDefault.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i52.ByIndexEnumWithNameValue?>()) {
+      return (data != null
+          ? _i52.ByIndexEnumWithNameValue.fromJson(data)
+          : null) as T;
     }
     if (t == _i1.getType<_i53.UriDefaultMix?>()) {
       return (data != null ? _i53.UriDefaultMix.fromJson(data) : null) as T;
@@ -1150,11 +1155,11 @@ class Protocol extends _i1.SerializationManager {
     if (t == _i1.getType<_i100.Order?>()) {
       return (data != null ? _i100.Order.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i101.MyFeatureModel?>()) {
-      return (data != null ? _i101.MyFeatureModel.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i101.Address?>()) {
+      return (data != null ? _i101.Address.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i102.Citizen?>()) {
-      return (data != null ? _i102.Citizen.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i102.MyFeatureModel?>()) {
+      return (data != null ? _i102.MyFeatureModel.fromJson(data) : null) as T;
     }
     if (t == _i1.getType<_i103.Company?>()) {
       return (data != null ? _i103.Company.fromJson(data) : null) as T;
@@ -1216,115 +1221,120 @@ class Protocol extends _i1.SerializationManager {
     if (t == _i1.getType<_i120.ObjectWithMaps?>()) {
       return (data != null ? _i120.ObjectWithMaps.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i121.ObjectWithObject?>()) {
-      return (data != null ? _i121.ObjectWithObject.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i121.ObjectWithNullableCustomClass?>()) {
+      return (data != null
+          ? _i121.ObjectWithNullableCustomClass.fromJson(data)
+          : null) as T;
     }
-    if (t == _i1.getType<_i122.ObjectWithParent?>()) {
-      return (data != null ? _i122.ObjectWithParent.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i122.ObjectWithObject?>()) {
+      return (data != null ? _i122.ObjectWithObject.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i123.ObjectWithSelfParent?>()) {
-      return (data != null ? _i123.ObjectWithSelfParent.fromJson(data) : null)
+    if (t == _i1.getType<_i123.ObjectWithParent?>()) {
+      return (data != null ? _i123.ObjectWithParent.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i124.ObjectWithSelfParent?>()) {
+      return (data != null ? _i124.ObjectWithSelfParent.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i124.ObjectWithSparseVector?>()) {
-      return (data != null ? _i124.ObjectWithSparseVector.fromJson(data) : null)
+    if (t == _i1.getType<_i125.ObjectWithSparseVector?>()) {
+      return (data != null ? _i125.ObjectWithSparseVector.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i125.ObjectWithUuid?>()) {
-      return (data != null ? _i125.ObjectWithUuid.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i126.ObjectWithUuid?>()) {
+      return (data != null ? _i126.ObjectWithUuid.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i126.ObjectWithVector?>()) {
-      return (data != null ? _i126.ObjectWithVector.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i127.ObjectWithVector?>()) {
+      return (data != null ? _i127.ObjectWithVector.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i127.Record?>()) {
-      return (data != null ? _i127.Record.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i128.Record?>()) {
+      return (data != null ? _i128.Record.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i128.RelatedUniqueData?>()) {
-      return (data != null ? _i128.RelatedUniqueData.fromJson(data) : null)
+    if (t == _i1.getType<_i129.RelatedUniqueData?>()) {
+      return (data != null ? _i129.RelatedUniqueData.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i129.ScopeNoneFields?>()) {
-      return (data != null ? _i129.ScopeNoneFields.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i130.ScopeNoneFields?>()) {
+      return (data != null ? _i130.ScopeNoneFields.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i130.ScopeServerOnlyField?>()) {
-      return (data != null ? _i130.ScopeServerOnlyField.fromJson(data) : null)
+    if (t == _i1.getType<_i131.ScopeServerOnlyField?>()) {
+      return (data != null ? _i131.ScopeServerOnlyField.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i131.TeamInt?>()) {
-      return (data != null ? _i131.TeamInt.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i132.TeamInt?>()) {
+      return (data != null ? _i132.TeamInt.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i132.DefaultServerOnlyClass?>()) {
-      return (data != null ? _i132.DefaultServerOnlyClass.fromJson(data) : null)
+    if (t == _i1.getType<_i133.DefaultServerOnlyClass?>()) {
+      return (data != null ? _i133.DefaultServerOnlyClass.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i133.DefaultServerOnlyEnum?>()) {
-      return (data != null ? _i133.DefaultServerOnlyEnum.fromJson(data) : null)
+    if (t == _i1.getType<_i134.DefaultServerOnlyEnum?>()) {
+      return (data != null ? _i134.DefaultServerOnlyEnum.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i134.NotServerOnlyClass?>()) {
-      return (data != null ? _i134.NotServerOnlyClass.fromJson(data) : null)
+    if (t == _i1.getType<_i135.NotServerOnlyClass?>()) {
+      return (data != null ? _i135.NotServerOnlyClass.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i135.NotServerOnlyEnum?>()) {
-      return (data != null ? _i135.NotServerOnlyEnum.fromJson(data) : null)
+    if (t == _i1.getType<_i136.NotServerOnlyEnum?>()) {
+      return (data != null ? _i136.NotServerOnlyEnum.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i136.ServerOnlyClassField?>()) {
-      return (data != null ? _i136.ServerOnlyClassField.fromJson(data) : null)
+    if (t == _i1.getType<_i137.ServerOnlyClassField?>()) {
+      return (data != null ? _i137.ServerOnlyClassField.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i137.ServerOnlyDefault?>()) {
-      return (data != null ? _i137.ServerOnlyDefault.fromJson(data) : null)
+    if (t == _i1.getType<_i138.ServerOnlyDefault?>()) {
+      return (data != null ? _i138.ServerOnlyDefault.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i138.SimpleData?>()) {
-      return (data != null ? _i138.SimpleData.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i139.SimpleData?>()) {
+      return (data != null ? _i139.SimpleData.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i139.SimpleDataList?>()) {
-      return (data != null ? _i139.SimpleDataList.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i140.SimpleDataList?>()) {
+      return (data != null ? _i140.SimpleDataList.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i140.SimpleDataMap?>()) {
-      return (data != null ? _i140.SimpleDataMap.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i141.SimpleDataMap?>()) {
+      return (data != null ? _i141.SimpleDataMap.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i141.SimpleDataObject?>()) {
-      return (data != null ? _i141.SimpleDataObject.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i142.SimpleDataObject?>()) {
+      return (data != null ? _i142.SimpleDataObject.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i142.SimpleDateTime?>()) {
-      return (data != null ? _i142.SimpleDateTime.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i143.SimpleDateTime?>()) {
+      return (data != null ? _i143.SimpleDateTime.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i143.ModelInSubfolder?>()) {
-      return (data != null ? _i143.ModelInSubfolder.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i144.ModelInSubfolder?>()) {
+      return (data != null ? _i144.ModelInSubfolder.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i144.TestEnum?>()) {
-      return (data != null ? _i144.TestEnum.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i145.TestEnum?>()) {
+      return (data != null ? _i145.TestEnum.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i145.TestEnumStringified?>()) {
-      return (data != null ? _i145.TestEnumStringified.fromJson(data) : null)
+    if (t == _i1.getType<_i146.TestEnumStringified?>()) {
+      return (data != null ? _i146.TestEnumStringified.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i146.Types?>()) {
-      return (data != null ? _i146.Types.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i147.Types?>()) {
+      return (data != null ? _i147.Types.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i147.TypesList?>()) {
-      return (data != null ? _i147.TypesList.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i148.TypesList?>()) {
+      return (data != null ? _i148.TypesList.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i148.TypesMap?>()) {
-      return (data != null ? _i148.TypesMap.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i149.TypesMap?>()) {
+      return (data != null ? _i149.TypesMap.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i149.TypesRecord?>()) {
-      return (data != null ? _i149.TypesRecord.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i150.TypesRecord?>()) {
+      return (data != null ? _i150.TypesRecord.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i150.TypesSet?>()) {
-      return (data != null ? _i150.TypesSet.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i151.TypesSet?>()) {
+      return (data != null ? _i151.TypesSet.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i151.TypesSetRequired?>()) {
-      return (data != null ? _i151.TypesSetRequired.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i152.TypesSetRequired?>()) {
+      return (data != null ? _i152.TypesSetRequired.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i152.UniqueData?>()) {
-      return (data != null ? _i152.UniqueData.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i153.UniqueData?>()) {
+      return (data != null ? _i153.UniqueData.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i153.Address?>()) {
-      return (data != null ? _i153.Address.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i154.Citizen?>()) {
+      return (data != null ? _i154.Citizen.fromJson(data) : null) as T;
     }
     if (t == _i1.getType<List<_i10.OrderUuid>?>()) {
       return (data != null
@@ -1476,19 +1486,19 @@ class Protocol extends _i1.SerializationManager {
           ? (data as List).map((e) => deserialize<_i107.Cat>(e)).toList()
           : null) as T;
     }
-    if (t == List<_i154.ModuleClass>) {
+    if (t == List<_i155.ModuleClass>) {
       return (data as List)
-          .map((e) => deserialize<_i154.ModuleClass>(e))
+          .map((e) => deserialize<_i155.ModuleClass>(e))
           .toList() as T;
     }
-    if (t == Map<String, _i154.ModuleClass>) {
+    if (t == Map<String, _i155.ModuleClass>) {
       return (data as Map).map((k, v) => MapEntry(
-          deserialize<String>(k), deserialize<_i154.ModuleClass>(v))) as T;
+          deserialize<String>(k), deserialize<_i155.ModuleClass>(v))) as T;
     }
-    if (t == _i1.getType<(_i154.ModuleClass,)?>()) {
+    if (t == _i1.getType<(_i155.ModuleClass,)?>()) {
       return (data == null)
           ? null as T
-          : (deserialize<_i154.ModuleClass>(((data as Map)['p'] as List)[0]),)
+          : (deserialize<_i155.ModuleClass>(((data as Map)['p'] as List)[0]),)
               as T;
     }
     if (t == List<int>) {
@@ -1507,25 +1517,25 @@ class Protocol extends _i1.SerializationManager {
           ? (data as List).map((e) => deserialize<int?>(e)).toList()
           : null) as T;
     }
-    if (t == List<_i138.SimpleData>) {
+    if (t == List<_i139.SimpleData>) {
       return (data as List)
-          .map((e) => deserialize<_i138.SimpleData>(e))
+          .map((e) => deserialize<_i139.SimpleData>(e))
           .toList() as T;
     }
-    if (t == _i1.getType<List<_i138.SimpleData>?>()) {
+    if (t == _i1.getType<List<_i139.SimpleData>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i138.SimpleData>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i139.SimpleData>(e)).toList()
           : null) as T;
     }
-    if (t == List<_i138.SimpleData?>) {
+    if (t == List<_i139.SimpleData?>) {
       return (data as List)
-          .map((e) => deserialize<_i138.SimpleData?>(e))
+          .map((e) => deserialize<_i139.SimpleData?>(e))
           .toList() as T;
     }
-    if (t == _i1.getType<List<_i138.SimpleData?>?>()) {
+    if (t == _i1.getType<List<_i139.SimpleData?>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i138.SimpleData?>(e))
+              .map((e) => deserialize<_i139.SimpleData?>(e))
               .toList()
           : null) as T;
     }
@@ -1545,22 +1555,22 @@ class Protocol extends _i1.SerializationManager {
           ? (data as List).map((e) => deserialize<DateTime?>(e)).toList()
           : null) as T;
     }
-    if (t == List<_i155.ByteData>) {
-      return (data as List).map((e) => deserialize<_i155.ByteData>(e)).toList()
+    if (t == List<_i156.ByteData>) {
+      return (data as List).map((e) => deserialize<_i156.ByteData>(e)).toList()
           as T;
     }
-    if (t == _i1.getType<List<_i155.ByteData>?>()) {
+    if (t == _i1.getType<List<_i156.ByteData>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i155.ByteData>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i156.ByteData>(e)).toList()
           : null) as T;
     }
-    if (t == List<_i155.ByteData?>) {
-      return (data as List).map((e) => deserialize<_i155.ByteData?>(e)).toList()
+    if (t == List<_i156.ByteData?>) {
+      return (data as List).map((e) => deserialize<_i156.ByteData?>(e)).toList()
           as T;
     }
-    if (t == _i1.getType<List<_i155.ByteData?>?>()) {
+    if (t == _i1.getType<List<_i156.ByteData?>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i155.ByteData?>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i156.ByteData?>(e)).toList()
           : null) as T;
     }
     if (t == List<Duration>) {
@@ -1618,32 +1628,32 @@ class Protocol extends _i1.SerializationManager {
               (k, v) => MapEntry(deserialize<String>(k), deserialize<int?>(v)))
           : null) as T;
     }
-    if (t == _i156.CustomClassWithoutProtocolSerialization) {
-      return _i156.CustomClassWithoutProtocolSerialization.fromJson(data) as T;
+    if (t == _i157.CustomClassWithoutProtocolSerialization) {
+      return _i157.CustomClassWithoutProtocolSerialization.fromJson(data) as T;
     }
-    if (t == _i156.CustomClassWithProtocolSerialization) {
-      return _i156.CustomClassWithProtocolSerialization.fromJson(data) as T;
+    if (t == _i157.CustomClassWithProtocolSerialization) {
+      return _i157.CustomClassWithProtocolSerialization.fromJson(data) as T;
     }
-    if (t == _i156.CustomClassWithProtocolSerializationMethod) {
-      return _i156.CustomClassWithProtocolSerializationMethod.fromJson(data)
+    if (t == _i157.CustomClassWithProtocolSerializationMethod) {
+      return _i157.CustomClassWithProtocolSerializationMethod.fromJson(data)
           as T;
     }
-    if (t == List<_i144.TestEnum>) {
-      return (data as List).map((e) => deserialize<_i144.TestEnum>(e)).toList()
+    if (t == List<_i145.TestEnum>) {
+      return (data as List).map((e) => deserialize<_i145.TestEnum>(e)).toList()
           as T;
     }
-    if (t == List<_i144.TestEnum?>) {
-      return (data as List).map((e) => deserialize<_i144.TestEnum?>(e)).toList()
+    if (t == List<_i145.TestEnum?>) {
+      return (data as List).map((e) => deserialize<_i145.TestEnum?>(e)).toList()
           as T;
     }
-    if (t == List<List<_i144.TestEnum>>) {
+    if (t == List<List<_i145.TestEnum>>) {
       return (data as List)
-          .map((e) => deserialize<List<_i144.TestEnum>>(e))
+          .map((e) => deserialize<List<_i145.TestEnum>>(e))
           .toList() as T;
     }
-    if (t == Map<String, _i138.SimpleData>) {
+    if (t == Map<String, _i139.SimpleData>) {
       return (data as Map).map((k, v) => MapEntry(
-          deserialize<String>(k), deserialize<_i138.SimpleData>(v))) as T;
+          deserialize<String>(k), deserialize<_i139.SimpleData>(v))) as T;
     }
     if (t == Map<String, String>) {
       return (data as Map).map((k, v) =>
@@ -1653,9 +1663,9 @@ class Protocol extends _i1.SerializationManager {
       return (data as Map).map((k, v) =>
           MapEntry(deserialize<String>(k), deserialize<DateTime>(v))) as T;
     }
-    if (t == Map<String, _i155.ByteData>) {
+    if (t == Map<String, _i156.ByteData>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i155.ByteData>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i156.ByteData>(v)))
           as T;
     }
     if (t == Map<String, Duration>) {
@@ -1666,9 +1676,9 @@ class Protocol extends _i1.SerializationManager {
       return (data as Map).map((k, v) =>
           MapEntry(deserialize<String>(k), deserialize<_i1.UuidValue>(v))) as T;
     }
-    if (t == Map<String, _i138.SimpleData?>) {
+    if (t == Map<String, _i139.SimpleData?>) {
       return (data as Map).map((k, v) => MapEntry(
-          deserialize<String>(k), deserialize<_i138.SimpleData?>(v))) as T;
+          deserialize<String>(k), deserialize<_i139.SimpleData?>(v))) as T;
     }
     if (t == Map<String, String?>) {
       return (data as Map).map((k, v) =>
@@ -1678,9 +1688,9 @@ class Protocol extends _i1.SerializationManager {
       return (data as Map).map((k, v) =>
           MapEntry(deserialize<String>(k), deserialize<DateTime?>(v))) as T;
     }
-    if (t == Map<String, _i155.ByteData?>) {
+    if (t == Map<String, _i156.ByteData?>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i155.ByteData?>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i156.ByteData?>(v)))
           as T;
     }
     if (t == Map<String, Duration?>) {
@@ -1696,53 +1706,68 @@ class Protocol extends _i1.SerializationManager {
       return Map.fromEntries((data as List).map((e) =>
           MapEntry(deserialize<int>(e['k']), deserialize<int>(e['v'])))) as T;
     }
-    if (t == _i1.getType<List<_i138.SimpleData>?>()) {
+    if (t == _i1.getType<_i157.CustomClassWithoutProtocolSerialization?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i138.SimpleData>(e)).toList()
+          ? _i157.CustomClassWithoutProtocolSerialization.fromJson(data)
           : null) as T;
     }
-    if (t == _i1.getType<List<_i138.SimpleData?>?>()) {
+    if (t == _i1.getType<_i157.CustomClassWithProtocolSerialization?>()) {
+      return (data != null
+          ? _i157.CustomClassWithProtocolSerialization.fromJson(data)
+          : null) as T;
+    }
+    if (t == _i1.getType<_i157.CustomClassWithProtocolSerializationMethod?>()) {
+      return (data != null
+          ? _i157.CustomClassWithProtocolSerializationMethod.fromJson(data)
+          : null) as T;
+    }
+    if (t == _i1.getType<List<_i139.SimpleData>?>()) {
+      return (data != null
+          ? (data as List).map((e) => deserialize<_i139.SimpleData>(e)).toList()
+          : null) as T;
+    }
+    if (t == _i1.getType<List<_i139.SimpleData?>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i138.SimpleData?>(e))
+              .map((e) => deserialize<_i139.SimpleData?>(e))
               .toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<List<_i138.SimpleData>>?>()) {
+    if (t == _i1.getType<List<List<_i139.SimpleData>>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<List<_i138.SimpleData>>(e))
+              .map((e) => deserialize<List<_i139.SimpleData>>(e))
               .toList()
           : null) as T;
     }
     if (t ==
-        _i1.getType<Map<String, List<List<Map<int, _i138.SimpleData>>?>>?>()) {
+        _i1.getType<Map<String, List<List<Map<int, _i139.SimpleData>>?>>?>()) {
       return (data != null
           ? (data as Map).map((k, v) => MapEntry(deserialize<String>(k),
-              deserialize<List<List<Map<int, _i138.SimpleData>>?>>(v)))
+              deserialize<List<List<Map<int, _i139.SimpleData>>?>>(v)))
           : null) as T;
     }
-    if (t == List<List<Map<int, _i138.SimpleData>>?>) {
+    if (t == List<List<Map<int, _i139.SimpleData>>?>) {
       return (data as List)
-          .map((e) => deserialize<List<Map<int, _i138.SimpleData>>?>(e))
+          .map((e) => deserialize<List<Map<int, _i139.SimpleData>>?>(e))
           .toList() as T;
     }
-    if (t == _i1.getType<List<Map<int, _i138.SimpleData>>?>()) {
+    if (t == _i1.getType<List<Map<int, _i139.SimpleData>>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<Map<int, _i138.SimpleData>>(e))
+              .map((e) => deserialize<Map<int, _i139.SimpleData>>(e))
               .toList()
           : null) as T;
     }
-    if (t == Map<int, _i138.SimpleData>) {
+    if (t == Map<int, _i139.SimpleData>) {
       return Map.fromEntries((data as List).map((e) => MapEntry(
-              deserialize<int>(e['k']), deserialize<_i138.SimpleData>(e['v']))))
+              deserialize<int>(e['k']), deserialize<_i139.SimpleData>(e['v']))))
           as T;
     }
-    if (t == _i1.getType<Map<String, Map<int, _i138.SimpleData>>?>()) {
+    if (t == _i1.getType<Map<String, Map<int, _i139.SimpleData>>?>()) {
       return (data != null
           ? (data as Map).map((k, v) => MapEntry(deserialize<String>(k),
-              deserialize<Map<int, _i138.SimpleData>>(v)))
+              deserialize<Map<int, _i139.SimpleData>>(v)))
           : null) as T;
     }
     if (t == _i1.getType<(bool,)?>()) {
@@ -1755,37 +1780,37 @@ class Protocol extends _i1.SerializationManager {
           ? (data as List).map((e) => deserialize<_i72.PlayerUuid>(e)).toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i145.TestEnumStringified>?>()) {
+    if (t == _i1.getType<List<_i146.TestEnumStringified>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i145.TestEnumStringified>(e))
+              .map((e) => deserialize<_i146.TestEnumStringified>(e))
               .toList()
           : null) as T;
     }
-    if (t == _i1.getType<(_i145.TestEnumStringified,)?>()) {
+    if (t == _i1.getType<(_i146.TestEnumStringified,)?>()) {
       return (data == null)
           ? null as T
           : (
-              deserialize<_i145.TestEnumStringified>(
+              deserialize<_i146.TestEnumStringified>(
                   ((data as Map)['p'] as List)[0]),
             ) as T;
     }
-    if (t == _i1.getType<List<(_i145.TestEnumStringified,)>?>()) {
+    if (t == _i1.getType<List<(_i146.TestEnumStringified,)>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<(_i145.TestEnumStringified,)>(e))
+              .map((e) => deserialize<(_i146.TestEnumStringified,)>(e))
               .toList()
           : null) as T;
     }
-    if (t == _i1.getType<(_i145.TestEnumStringified,)>()) {
+    if (t == _i1.getType<(_i146.TestEnumStringified,)>()) {
       return (
-        deserialize<_i145.TestEnumStringified>(((data as Map)['p'] as List)[0]),
+        deserialize<_i146.TestEnumStringified>(((data as Map)['p'] as List)[0]),
       ) as T;
     }
-    if (t == _i1.getType<(_i154.ModuleClass,)?>()) {
+    if (t == _i1.getType<(_i155.ModuleClass,)?>()) {
       return (data == null)
           ? null as T
-          : (deserialize<_i154.ModuleClass>(((data as Map)['p'] as List)[0]),)
+          : (deserialize<_i155.ModuleClass>(((data as Map)['p'] as List)[0]),)
               as T;
     }
     if (t == _i1.getType<(_i110.Nullability,)?>()) {
@@ -1794,32 +1819,32 @@ class Protocol extends _i1.SerializationManager {
           : (deserialize<_i110.Nullability>(((data as Map)['p'] as List)[0]),)
               as T;
     }
-    if (t == _i1.getType<({_i145.TestEnumStringified value})?>()) {
+    if (t == _i1.getType<({_i146.TestEnumStringified value})?>()) {
       return (data == null)
           ? null as T
           : (
-              value: deserialize<_i145.TestEnumStringified>(
+              value: deserialize<_i146.TestEnumStringified>(
                   ((data as Map)['n'] as Map)['value']),
             ) as T;
     }
-    if (t == _i1.getType<List<({_i145.TestEnumStringified value})>?>()) {
+    if (t == _i1.getType<List<({_i146.TestEnumStringified value})>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<({_i145.TestEnumStringified value})>(e))
+              .map((e) => deserialize<({_i146.TestEnumStringified value})>(e))
               .toList()
           : null) as T;
     }
-    if (t == _i1.getType<({_i145.TestEnumStringified value})>()) {
+    if (t == _i1.getType<({_i146.TestEnumStringified value})>()) {
       return (
-        value: deserialize<_i145.TestEnumStringified>(
+        value: deserialize<_i146.TestEnumStringified>(
             ((data as Map)['n'] as Map)['value']),
       ) as T;
     }
-    if (t == _i1.getType<({_i154.ModuleClass value})?>()) {
+    if (t == _i1.getType<({_i155.ModuleClass value})?>()) {
       return (data == null)
           ? null as T
           : (
-              value: deserialize<_i154.ModuleClass>(
+              value: deserialize<_i155.ModuleClass>(
                   ((data as Map)['n'] as Map)['value']),
             ) as T;
     }
@@ -1882,9 +1907,9 @@ class Protocol extends _i1.SerializationManager {
           ? (data as List).map((e) => deserialize<String>(e)).toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i155.ByteData>?>()) {
+    if (t == _i1.getType<List<_i156.ByteData>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i155.ByteData>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i156.ByteData>(e)).toList()
           : null) as T;
     }
     if (t == _i1.getType<List<Duration>?>()) {
@@ -1907,43 +1932,43 @@ class Protocol extends _i1.SerializationManager {
           ? (data as List).map((e) => deserialize<BigInt>(e)).toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i144.TestEnum>?>()) {
+    if (t == _i1.getType<List<_i145.TestEnum>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i144.TestEnum>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i145.TestEnum>(e)).toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i145.TestEnumStringified>?>()) {
+    if (t == _i1.getType<List<_i146.TestEnumStringified>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i145.TestEnumStringified>(e))
+              .map((e) => deserialize<_i146.TestEnumStringified>(e))
               .toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i146.Types>?>()) {
+    if (t == _i1.getType<List<_i147.Types>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i146.Types>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i147.Types>(e)).toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<Map<String, _i146.Types>>?>()) {
+    if (t == _i1.getType<List<Map<String, _i147.Types>>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<Map<String, _i146.Types>>(e))
+              .map((e) => deserialize<Map<String, _i147.Types>>(e))
               .toList()
           : null) as T;
     }
-    if (t == Map<String, _i146.Types>) {
+    if (t == Map<String, _i147.Types>) {
       return (data as Map).map((k, v) =>
-          MapEntry(deserialize<String>(k), deserialize<_i146.Types>(v))) as T;
+          MapEntry(deserialize<String>(k), deserialize<_i147.Types>(v))) as T;
     }
-    if (t == _i1.getType<List<List<_i146.Types>>?>()) {
+    if (t == _i1.getType<List<List<_i147.Types>>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<List<_i146.Types>>(e))
+              .map((e) => deserialize<List<_i147.Types>>(e))
               .toList()
           : null) as T;
     }
-    if (t == List<_i146.Types>) {
-      return (data as List).map((e) => deserialize<_i146.Types>(e)).toList()
+    if (t == List<_i147.Types>) {
+      return (data as List).map((e) => deserialize<_i147.Types>(e)).toList()
           as T;
     }
     if (t == _i1.getType<List<(int,)>?>()) {
@@ -1964,27 +1989,27 @@ class Protocol extends _i1.SerializationManager {
           ? null as T
           : (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
     }
-    if (t == _i1.getType<List<(_i144.TestEnum,)>?>()) {
+    if (t == _i1.getType<List<(_i145.TestEnum,)>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<(_i144.TestEnum,)>(e))
+              .map((e) => deserialize<(_i145.TestEnum,)>(e))
               .toList()
           : null) as T;
     }
-    if (t == _i1.getType<(_i144.TestEnum,)>()) {
-      return (deserialize<_i144.TestEnum>(((data as Map)['p'] as List)[0]),)
+    if (t == _i1.getType<(_i145.TestEnum,)>()) {
+      return (deserialize<_i145.TestEnum>(((data as Map)['p'] as List)[0]),)
           as T;
     }
-    if (t == _i1.getType<List<(_i145.TestEnumStringified,)>?>()) {
+    if (t == _i1.getType<List<(_i146.TestEnumStringified,)>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<(_i145.TestEnumStringified,)>(e))
+              .map((e) => deserialize<(_i146.TestEnumStringified,)>(e))
               .toList()
           : null) as T;
     }
-    if (t == _i1.getType<(_i145.TestEnumStringified,)>()) {
+    if (t == _i1.getType<(_i146.TestEnumStringified,)>()) {
       return (
-        deserialize<_i145.TestEnumStringified>(((data as Map)['p'] as List)[0]),
+        deserialize<_i146.TestEnumStringified>(((data as Map)['p'] as List)[0]),
       ) as T;
     }
     if (t == _i1.getType<Map<int, String>?>()) {
@@ -2017,10 +2042,10 @@ class Protocol extends _i1.SerializationManager {
               MapEntry(deserialize<String>(k), deserialize<String>(v)))
           : null) as T;
     }
-    if (t == _i1.getType<Map<_i155.ByteData, String>?>()) {
+    if (t == _i1.getType<Map<_i156.ByteData, String>?>()) {
       return (data != null
           ? Map.fromEntries((data as List).map((e) => MapEntry(
-              deserialize<_i155.ByteData>(e['k']),
+              deserialize<_i156.ByteData>(e['k']),
               deserialize<String>(e['v']))))
           : null) as T;
     }
@@ -2048,41 +2073,41 @@ class Protocol extends _i1.SerializationManager {
               deserialize<BigInt>(e['k']), deserialize<String>(e['v']))))
           : null) as T;
     }
-    if (t == _i1.getType<Map<_i144.TestEnum, String>?>()) {
+    if (t == _i1.getType<Map<_i145.TestEnum, String>?>()) {
       return (data != null
           ? Map.fromEntries((data as List).map((e) => MapEntry(
-              deserialize<_i144.TestEnum>(e['k']),
+              deserialize<_i145.TestEnum>(e['k']),
               deserialize<String>(e['v']))))
           : null) as T;
     }
-    if (t == _i1.getType<Map<_i145.TestEnumStringified, String>?>()) {
+    if (t == _i1.getType<Map<_i146.TestEnumStringified, String>?>()) {
       return (data != null
           ? Map.fromEntries((data as List).map((e) => MapEntry(
-              deserialize<_i145.TestEnumStringified>(e['k']),
+              deserialize<_i146.TestEnumStringified>(e['k']),
               deserialize<String>(e['v']))))
           : null) as T;
     }
-    if (t == _i1.getType<Map<_i146.Types, String>?>()) {
+    if (t == _i1.getType<Map<_i147.Types, String>?>()) {
       return (data != null
           ? Map.fromEntries((data as List).map((e) => MapEntry(
-              deserialize<_i146.Types>(e['k']), deserialize<String>(e['v']))))
+              deserialize<_i147.Types>(e['k']), deserialize<String>(e['v']))))
           : null) as T;
     }
-    if (t == _i1.getType<Map<Map<_i146.Types, String>, String>?>()) {
+    if (t == _i1.getType<Map<Map<_i147.Types, String>, String>?>()) {
       return (data != null
           ? Map.fromEntries((data as List).map((e) => MapEntry(
-              deserialize<Map<_i146.Types, String>>(e['k']),
+              deserialize<Map<_i147.Types, String>>(e['k']),
               deserialize<String>(e['v']))))
           : null) as T;
     }
-    if (t == Map<_i146.Types, String>) {
+    if (t == Map<_i147.Types, String>) {
       return Map.fromEntries((data as List).map((e) => MapEntry(
-          deserialize<_i146.Types>(e['k']), deserialize<String>(e['v'])))) as T;
+          deserialize<_i147.Types>(e['k']), deserialize<String>(e['v'])))) as T;
     }
-    if (t == _i1.getType<Map<List<_i146.Types>, String>?>()) {
+    if (t == _i1.getType<Map<List<_i147.Types>, String>?>()) {
       return (data != null
           ? Map.fromEntries((data as List).map((e) => MapEntry(
-              deserialize<List<_i146.Types>>(e['k']),
+              deserialize<List<_i147.Types>>(e['k']),
               deserialize<String>(e['v']))))
           : null) as T;
     }
@@ -2125,10 +2150,10 @@ class Protocol extends _i1.SerializationManager {
               MapEntry(deserialize<String>(k), deserialize<String>(v)))
           : null) as T;
     }
-    if (t == _i1.getType<Map<String, _i155.ByteData>?>()) {
+    if (t == _i1.getType<Map<String, _i156.ByteData>?>()) {
       return (data != null
           ? (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i155.ByteData>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i156.ByteData>(v)))
           : null) as T;
     }
     if (t == _i1.getType<Map<String, Duration>?>()) {
@@ -2155,34 +2180,34 @@ class Protocol extends _i1.SerializationManager {
               MapEntry(deserialize<String>(k), deserialize<BigInt>(v)))
           : null) as T;
     }
-    if (t == _i1.getType<Map<String, _i144.TestEnum>?>()) {
+    if (t == _i1.getType<Map<String, _i145.TestEnum>?>()) {
       return (data != null
           ? (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i144.TestEnum>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i145.TestEnum>(v)))
           : null) as T;
     }
-    if (t == _i1.getType<Map<String, _i145.TestEnumStringified>?>()) {
+    if (t == _i1.getType<Map<String, _i146.TestEnumStringified>?>()) {
       return (data != null
           ? (data as Map).map((k, v) => MapEntry(deserialize<String>(k),
-              deserialize<_i145.TestEnumStringified>(v)))
+              deserialize<_i146.TestEnumStringified>(v)))
           : null) as T;
     }
-    if (t == _i1.getType<Map<String, _i146.Types>?>()) {
+    if (t == _i1.getType<Map<String, _i147.Types>?>()) {
       return (data != null
           ? (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i146.Types>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i147.Types>(v)))
           : null) as T;
     }
-    if (t == _i1.getType<Map<String, Map<String, _i146.Types>>?>()) {
+    if (t == _i1.getType<Map<String, Map<String, _i147.Types>>?>()) {
       return (data != null
           ? (data as Map).map((k, v) => MapEntry(
-              deserialize<String>(k), deserialize<Map<String, _i146.Types>>(v)))
+              deserialize<String>(k), deserialize<Map<String, _i147.Types>>(v)))
           : null) as T;
     }
-    if (t == _i1.getType<Map<String, List<_i146.Types>>?>()) {
+    if (t == _i1.getType<Map<String, List<_i147.Types>>?>()) {
       return (data != null
           ? (data as Map).map((k, v) => MapEntry(
-              deserialize<String>(k), deserialize<List<_i146.Types>>(v)))
+              deserialize<String>(k), deserialize<List<_i147.Types>>(v)))
           : null) as T;
     }
     if (t == _i1.getType<Map<String, (String,)>?>()) {
@@ -2241,10 +2266,10 @@ class Protocol extends _i1.SerializationManager {
           ? null as T
           : (deserialize<String>(((data as Map)['p'] as List)[0]),) as T;
     }
-    if (t == _i1.getType<(_i155.ByteData,)?>()) {
+    if (t == _i1.getType<(_i156.ByteData,)?>()) {
       return (data == null)
           ? null as T
-          : (deserialize<_i155.ByteData>(((data as Map)['p'] as List)[0]),)
+          : (deserialize<_i156.ByteData>(((data as Map)['p'] as List)[0]),)
               as T;
     }
     if (t == _i1.getType<(Duration,)?>()) {
@@ -2267,17 +2292,17 @@ class Protocol extends _i1.SerializationManager {
           ? null as T
           : (deserialize<BigInt>(((data as Map)['p'] as List)[0]),) as T;
     }
-    if (t == _i1.getType<(_i144.TestEnum,)?>()) {
+    if (t == _i1.getType<(_i145.TestEnum,)?>()) {
       return (data == null)
           ? null as T
-          : (deserialize<_i144.TestEnum>(((data as Map)['p'] as List)[0]),)
+          : (deserialize<_i145.TestEnum>(((data as Map)['p'] as List)[0]),)
               as T;
     }
-    if (t == _i1.getType<(_i145.TestEnumStringified,)?>()) {
+    if (t == _i1.getType<(_i146.TestEnumStringified,)?>()) {
       return (data == null)
           ? null as T
           : (
-              deserialize<_i145.TestEnumStringified>(
+              deserialize<_i146.TestEnumStringified>(
                   ((data as Map)['p'] as List)[0]),
             ) as T;
     }
@@ -2296,28 +2321,28 @@ class Protocol extends _i1.SerializationManager {
           ? null as T
           : (deserialize<Set<int>>(((data as Map)['p'] as List)[0]),) as T;
     }
-    if (t == _i1.getType<(_i138.SimpleData,)?>()) {
+    if (t == _i1.getType<(_i139.SimpleData,)?>()) {
       return (data == null)
           ? null as T
-          : (deserialize<_i138.SimpleData>(((data as Map)['p'] as List)[0]),)
+          : (deserialize<_i139.SimpleData>(((data as Map)['p'] as List)[0]),)
               as T;
     }
-    if (t == _i1.getType<({_i138.SimpleData namedModel})?>()) {
+    if (t == _i1.getType<({_i139.SimpleData namedModel})?>()) {
       return (data == null)
           ? null as T
           : (
-              namedModel: deserialize<_i138.SimpleData>(
+              namedModel: deserialize<_i139.SimpleData>(
                   ((data as Map)['n'] as Map)['namedModel']),
             ) as T;
     }
     if (t ==
-        _i1.getType<(_i138.SimpleData, {_i138.SimpleData namedModel})?>()) {
+        _i1.getType<(_i139.SimpleData, {_i139.SimpleData namedModel})?>()) {
       return (data == null)
           ? null as T
           : (
-              deserialize<_i138.SimpleData>(((data as Map)['p'] as List)[0]),
+              deserialize<_i139.SimpleData>(((data as Map)['p'] as List)[0]),
               namedModel:
-                  deserialize<_i138.SimpleData>(data['n']['namedModel']),
+                  deserialize<_i139.SimpleData>(data['n']['namedModel']),
             ) as T;
     }
     if (t ==
@@ -2333,21 +2358,21 @@ class Protocol extends _i1.SerializationManager {
     if (t ==
         _i1.getType<
             (
-              (List<(_i138.SimpleData,)>,), {
+              (List<(_i139.SimpleData,)>,), {
               (
-                _i138.SimpleData,
-                Map<String, _i138.SimpleData>
+                _i139.SimpleData,
+                Map<String, _i139.SimpleData>
               ) namedNestedRecord
             })?>()) {
       return (data == null)
           ? null as T
           : (
-              deserialize<(List<(_i138.SimpleData,)>,)>(
+              deserialize<(List<(_i139.SimpleData,)>,)>(
                   ((data as Map)['p'] as List)[0]),
               namedNestedRecord: deserialize<
                   (
-                    _i138.SimpleData,
-                    Map<String, _i138.SimpleData>
+                    _i139.SimpleData,
+                    Map<String, _i139.SimpleData>
                   )>(data['n']['namedNestedRecord']),
             ) as T;
     }
@@ -2376,9 +2401,9 @@ class Protocol extends _i1.SerializationManager {
           ? (data as List).map((e) => deserialize<String>(e)).toSet()
           : null) as T;
     }
-    if (t == _i1.getType<Set<_i155.ByteData>?>()) {
+    if (t == _i1.getType<Set<_i156.ByteData>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i155.ByteData>(e)).toSet()
+          ? (data as List).map((e) => deserialize<_i156.ByteData>(e)).toSet()
           : null) as T;
     }
     if (t == _i1.getType<Set<Duration>?>()) {
@@ -2396,33 +2421,33 @@ class Protocol extends _i1.SerializationManager {
           ? (data as List).map((e) => deserialize<BigInt>(e)).toSet()
           : null) as T;
     }
-    if (t == _i1.getType<Set<_i144.TestEnum>?>()) {
+    if (t == _i1.getType<Set<_i145.TestEnum>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i144.TestEnum>(e)).toSet()
+          ? (data as List).map((e) => deserialize<_i145.TestEnum>(e)).toSet()
           : null) as T;
     }
-    if (t == _i1.getType<Set<_i145.TestEnumStringified>?>()) {
+    if (t == _i1.getType<Set<_i146.TestEnumStringified>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i145.TestEnumStringified>(e))
+              .map((e) => deserialize<_i146.TestEnumStringified>(e))
               .toSet()
           : null) as T;
     }
-    if (t == _i1.getType<Set<_i146.Types>?>()) {
+    if (t == _i1.getType<Set<_i147.Types>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i146.Types>(e)).toSet()
+          ? (data as List).map((e) => deserialize<_i147.Types>(e)).toSet()
           : null) as T;
     }
-    if (t == _i1.getType<Set<Map<String, _i146.Types>>?>()) {
+    if (t == _i1.getType<Set<Map<String, _i147.Types>>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<Map<String, _i146.Types>>(e))
+              .map((e) => deserialize<Map<String, _i147.Types>>(e))
               .toSet()
           : null) as T;
     }
-    if (t == _i1.getType<Set<List<_i146.Types>>?>()) {
+    if (t == _i1.getType<Set<List<_i147.Types>>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<List<_i146.Types>>(e)).toSet()
+          ? (data as List).map((e) => deserialize<List<_i147.Types>>(e)).toSet()
           : null) as T;
     }
     if (t == _i1.getType<Set<(int,)>?>()) {
@@ -2454,9 +2479,9 @@ class Protocol extends _i1.SerializationManager {
     if (t == List<String>) {
       return (data as List).map((e) => deserialize<String>(e)).toList() as T;
     }
-    if (t == List<_i157.SimpleData>) {
+    if (t == List<_i158.SimpleData>) {
       return (data as List)
-          .map((e) => deserialize<_i157.SimpleData>(e))
+          .map((e) => deserialize<_i158.SimpleData>(e))
           .toList() as T;
     }
     if (t == List<int>) {
@@ -2513,28 +2538,28 @@ class Protocol extends _i1.SerializationManager {
     if (t == List<DateTime?>) {
       return (data as List).map((e) => deserialize<DateTime?>(e)).toList() as T;
     }
-    if (t == List<_i155.ByteData>) {
-      return (data as List).map((e) => deserialize<_i155.ByteData>(e)).toList()
+    if (t == List<_i156.ByteData>) {
+      return (data as List).map((e) => deserialize<_i156.ByteData>(e)).toList()
           as T;
     }
-    if (t == List<_i155.ByteData?>) {
-      return (data as List).map((e) => deserialize<_i155.ByteData?>(e)).toList()
+    if (t == List<_i156.ByteData?>) {
+      return (data as List).map((e) => deserialize<_i156.ByteData?>(e)).toList()
           as T;
     }
-    if (t == List<_i157.SimpleData?>) {
+    if (t == List<_i158.SimpleData?>) {
       return (data as List)
-          .map((e) => deserialize<_i157.SimpleData?>(e))
+          .map((e) => deserialize<_i158.SimpleData?>(e))
           .toList() as T;
     }
-    if (t == _i1.getType<List<_i157.SimpleData>?>()) {
+    if (t == _i1.getType<List<_i158.SimpleData>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i157.SimpleData>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i158.SimpleData>(e)).toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i157.SimpleData?>?>()) {
+    if (t == _i1.getType<List<_i158.SimpleData?>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i157.SimpleData?>(e))
+              .map((e) => deserialize<_i158.SimpleData?>(e))
               .toList()
           : null) as T;
     }
@@ -2577,13 +2602,13 @@ class Protocol extends _i1.SerializationManager {
       return (data as Map).map((k, v) =>
           MapEntry(deserialize<String>(k), deserialize<Map<int, int>>(v))) as T;
     }
-    if (t == Map<_i158.TestEnum, int>) {
+    if (t == Map<_i159.TestEnum, int>) {
       return Map.fromEntries((data as List).map((e) => MapEntry(
-          deserialize<_i158.TestEnum>(e['k']), deserialize<int>(e['v'])))) as T;
+          deserialize<_i159.TestEnum>(e['k']), deserialize<int>(e['v'])))) as T;
     }
-    if (t == Map<String, _i158.TestEnum>) {
+    if (t == Map<String, _i159.TestEnum>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i158.TestEnum>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i159.TestEnum>(v)))
           as T;
     }
     if (t == Map<String, double>) {
@@ -2620,34 +2645,34 @@ class Protocol extends _i1.SerializationManager {
       return (data as Map).map((k, v) =>
           MapEntry(deserialize<String>(k), deserialize<DateTime?>(v))) as T;
     }
-    if (t == Map<String, _i155.ByteData>) {
+    if (t == Map<String, _i156.ByteData>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i155.ByteData>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i156.ByteData>(v)))
           as T;
     }
-    if (t == Map<String, _i155.ByteData?>) {
+    if (t == Map<String, _i156.ByteData?>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i155.ByteData?>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i156.ByteData?>(v)))
           as T;
     }
-    if (t == Map<String, _i157.SimpleData>) {
+    if (t == Map<String, _i158.SimpleData>) {
       return (data as Map).map((k, v) => MapEntry(
-          deserialize<String>(k), deserialize<_i157.SimpleData>(v))) as T;
+          deserialize<String>(k), deserialize<_i158.SimpleData>(v))) as T;
     }
-    if (t == Map<String, _i157.SimpleData?>) {
+    if (t == Map<String, _i158.SimpleData?>) {
       return (data as Map).map((k, v) => MapEntry(
-          deserialize<String>(k), deserialize<_i157.SimpleData?>(v))) as T;
+          deserialize<String>(k), deserialize<_i158.SimpleData?>(v))) as T;
     }
-    if (t == _i1.getType<Map<String, _i157.SimpleData>?>()) {
+    if (t == _i1.getType<Map<String, _i158.SimpleData>?>()) {
       return (data != null
           ? (data as Map).map((k, v) => MapEntry(
-              deserialize<String>(k), deserialize<_i157.SimpleData>(v)))
+              deserialize<String>(k), deserialize<_i158.SimpleData>(v)))
           : null) as T;
     }
-    if (t == _i1.getType<Map<String, _i157.SimpleData?>?>()) {
+    if (t == _i1.getType<Map<String, _i158.SimpleData?>?>()) {
       return (data != null
           ? (data as Map).map((k, v) => MapEntry(
-              deserialize<String>(k), deserialize<_i157.SimpleData?>(v)))
+              deserialize<String>(k), deserialize<_i158.SimpleData?>(v)))
           : null) as T;
     }
     if (t == Map<String, Duration>) {
@@ -2692,20 +2717,20 @@ class Protocol extends _i1.SerializationManager {
       return (deserialize<Map<int, int>>(((data as Map)['p'] as List)[0]),)
           as T;
     }
-    if (t == List<_i159.UserInfo>) {
-      return (data as List).map((e) => deserialize<_i159.UserInfo>(e)).toList()
+    if (t == List<_i160.UserInfo>) {
+      return (data as List).map((e) => deserialize<_i160.UserInfo>(e)).toList()
           as T;
     }
     if (t == Set<int>) {
       return (data as List).map((e) => deserialize<int>(e)).toSet() as T;
     }
-    if (t == Set<_i157.SimpleData>) {
-      return (data as List).map((e) => deserialize<_i157.SimpleData>(e)).toSet()
+    if (t == Set<_i158.SimpleData>) {
+      return (data as List).map((e) => deserialize<_i158.SimpleData>(e)).toSet()
           as T;
     }
-    if (t == List<Set<_i157.SimpleData>>) {
+    if (t == List<Set<_i158.SimpleData>>) {
       return (data as List)
-          .map((e) => deserialize<Set<_i157.SimpleData>>(e))
+          .map((e) => deserialize<Set<_i158.SimpleData>>(e))
           .toList() as T;
     }
     if (t == _i1.getType<(int, BigInt)>()) {
@@ -2752,18 +2777,18 @@ class Protocol extends _i1.SerializationManager {
               deserialize<String>(data['p'][1]),
             ) as T;
     }
-    if (t == _i1.getType<(int, _i157.SimpleData)>()) {
+    if (t == _i1.getType<(int, _i158.SimpleData)>()) {
       return (
         deserialize<int>(((data as Map)['p'] as List)[0]),
-        deserialize<_i157.SimpleData>(data['p'][1]),
+        deserialize<_i158.SimpleData>(data['p'][1]),
       ) as T;
     }
-    if (t == _i1.getType<(int, _i157.SimpleData)?>()) {
+    if (t == _i1.getType<(int, _i158.SimpleData)?>()) {
       return (data == null)
           ? null as T
           : (
               deserialize<int>(((data as Map)['p'] as List)[0]),
-              deserialize<_i157.SimpleData>(data['p'][1]),
+              deserialize<_i158.SimpleData>(data['p'][1]),
             ) as T;
     }
     if (t == _i1.getType<(Map<String, int>,)>()) {
@@ -2793,27 +2818,27 @@ class Protocol extends _i1.SerializationManager {
               text: deserialize<String>(data['n']['text']),
             ) as T;
     }
-    if (t == _i1.getType<({_i157.SimpleData data, int number})>()) {
+    if (t == _i1.getType<({_i158.SimpleData data, int number})>()) {
       return (
         data:
-            deserialize<_i157.SimpleData>(((data as Map)['n'] as Map)['data']),
+            deserialize<_i158.SimpleData>(((data as Map)['n'] as Map)['data']),
         number: deserialize<int>(data['n']['number']),
       ) as T;
     }
-    if (t == _i1.getType<({_i157.SimpleData data, int number})?>()) {
+    if (t == _i1.getType<({_i158.SimpleData data, int number})?>()) {
       return (data == null)
           ? null as T
           : (
-              data: deserialize<_i157.SimpleData>(
+              data: deserialize<_i158.SimpleData>(
                   ((data as Map)['n'] as Map)['data']),
               number: deserialize<int>(data['n']['number']),
             ) as T;
     }
-    if (t == _i1.getType<({_i157.SimpleData? data, int? number})>()) {
+    if (t == _i1.getType<({_i158.SimpleData? data, int? number})>()) {
       return (
         data: ((data as Map)['n'] as Map)['data'] == null
             ? null
-            : deserialize<_i157.SimpleData>(data['n']['data']),
+            : deserialize<_i158.SimpleData>(data['n']['data']),
         number: ((data)['n'] as Map)['number'] == null
             ? null
             : deserialize<int>(data['n']['number']),
@@ -2846,109 +2871,109 @@ class Protocol extends _i1.SerializationManager {
             ((data as Map)['p'] as List)[0]),
       ) as T;
     }
-    if (t == _i1.getType<(int, {_i157.SimpleData data})>()) {
+    if (t == _i1.getType<(int, {_i158.SimpleData data})>()) {
       return (
         deserialize<int>(((data as Map)['p'] as List)[0]),
-        data: deserialize<_i157.SimpleData>(data['n']['data']),
+        data: deserialize<_i158.SimpleData>(data['n']['data']),
       ) as T;
     }
-    if (t == _i1.getType<(int, {_i157.SimpleData data})?>()) {
+    if (t == _i1.getType<(int, {_i158.SimpleData data})?>()) {
       return (data == null)
           ? null as T
           : (
               deserialize<int>(((data as Map)['p'] as List)[0]),
-              data: deserialize<_i157.SimpleData>(data['n']['data']),
+              data: deserialize<_i158.SimpleData>(data['n']['data']),
             ) as T;
     }
-    if (t == List<(int, _i157.SimpleData)>) {
+    if (t == List<(int, _i158.SimpleData)>) {
       return (data as List)
-          .map((e) => deserialize<(int, _i157.SimpleData)>(e))
+          .map((e) => deserialize<(int, _i158.SimpleData)>(e))
           .toList() as T;
     }
-    if (t == _i1.getType<(int, _i157.SimpleData)>()) {
+    if (t == _i1.getType<(int, _i158.SimpleData)>()) {
       return (
         deserialize<int>(((data as Map)['p'] as List)[0]),
-        deserialize<_i157.SimpleData>(data['p'][1]),
+        deserialize<_i158.SimpleData>(data['p'][1]),
       ) as T;
     }
-    if (t == List<(int, _i157.SimpleData)?>) {
+    if (t == List<(int, _i158.SimpleData)?>) {
       return (data as List)
-          .map((e) => deserialize<(int, _i157.SimpleData)?>(e))
+          .map((e) => deserialize<(int, _i158.SimpleData)?>(e))
           .toList() as T;
     }
-    if (t == _i1.getType<(int, _i157.SimpleData)?>()) {
+    if (t == _i1.getType<(int, _i158.SimpleData)?>()) {
       return (data == null)
           ? null as T
           : (
               deserialize<int>(((data as Map)['p'] as List)[0]),
-              deserialize<_i157.SimpleData>(data['p'][1]),
+              deserialize<_i158.SimpleData>(data['p'][1]),
             ) as T;
     }
-    if (t == Set<(int, _i157.SimpleData)>) {
+    if (t == Set<(int, _i158.SimpleData)>) {
       return (data as List)
-          .map((e) => deserialize<(int, _i157.SimpleData)>(e))
+          .map((e) => deserialize<(int, _i158.SimpleData)>(e))
           .toSet() as T;
     }
-    if (t == _i1.getType<(int, _i157.SimpleData)>()) {
+    if (t == _i1.getType<(int, _i158.SimpleData)>()) {
       return (
         deserialize<int>(((data as Map)['p'] as List)[0]),
-        deserialize<_i157.SimpleData>(data['p'][1]),
+        deserialize<_i158.SimpleData>(data['p'][1]),
       ) as T;
     }
-    if (t == Set<(int, _i157.SimpleData)?>) {
+    if (t == Set<(int, _i158.SimpleData)?>) {
       return (data as List)
-          .map((e) => deserialize<(int, _i157.SimpleData)?>(e))
+          .map((e) => deserialize<(int, _i158.SimpleData)?>(e))
           .toSet() as T;
     }
-    if (t == _i1.getType<(int, _i157.SimpleData)?>()) {
+    if (t == _i1.getType<(int, _i158.SimpleData)?>()) {
       return (data == null)
           ? null as T
           : (
               deserialize<int>(((data as Map)['p'] as List)[0]),
-              deserialize<_i157.SimpleData>(data['p'][1]),
+              deserialize<_i158.SimpleData>(data['p'][1]),
             ) as T;
     }
-    if (t == _i1.getType<Set<(int, _i157.SimpleData)>?>()) {
+    if (t == _i1.getType<Set<(int, _i158.SimpleData)>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<(int, _i157.SimpleData)>(e))
+              .map((e) => deserialize<(int, _i158.SimpleData)>(e))
               .toSet()
           : null) as T;
     }
-    if (t == _i1.getType<(int, _i157.SimpleData)>()) {
+    if (t == _i1.getType<(int, _i158.SimpleData)>()) {
       return (
         deserialize<int>(((data as Map)['p'] as List)[0]),
-        deserialize<_i157.SimpleData>(data['p'][1]),
+        deserialize<_i158.SimpleData>(data['p'][1]),
       ) as T;
     }
-    if (t == Map<String, (int, _i157.SimpleData)>) {
+    if (t == Map<String, (int, _i158.SimpleData)>) {
       return (data as Map).map((k, v) => MapEntry(
-              deserialize<String>(k), deserialize<(int, _i157.SimpleData)>(v)))
+              deserialize<String>(k), deserialize<(int, _i158.SimpleData)>(v)))
           as T;
     }
-    if (t == _i1.getType<(int, _i157.SimpleData)>()) {
+    if (t == _i1.getType<(int, _i158.SimpleData)>()) {
       return (
         deserialize<int>(((data as Map)['p'] as List)[0]),
-        deserialize<_i157.SimpleData>(data['p'][1]),
+        deserialize<_i158.SimpleData>(data['p'][1]),
       ) as T;
     }
-    if (t == Map<String, (int, _i157.SimpleData)?>) {
+    if (t == Map<String, (int, _i158.SimpleData)?>) {
       return (data as Map).map((k, v) => MapEntry(
-              deserialize<String>(k), deserialize<(int, _i157.SimpleData)?>(v)))
+              deserialize<String>(k), deserialize<(int, _i158.SimpleData)?>(v)))
           as T;
     }
-    if (t == _i1.getType<(int, _i157.SimpleData)?>()) {
+    if (t == _i1.getType<(int, _i158.SimpleData)?>()) {
       return (data == null)
           ? null as T
           : (
               deserialize<int>(((data as Map)['p'] as List)[0]),
-              deserialize<_i157.SimpleData>(data['p'][1]),
+              deserialize<_i158.SimpleData>(data['p'][1]),
             ) as T;
     }
-    if (t == Map<(String, int), (int, _i157.SimpleData)>) {
+    if (t == Map<(String, int), (int, _i158.SimpleData)>) {
       return Map.fromEntries((data as List).map((e) => MapEntry(
           deserialize<(String, int)>(e['k']),
-          deserialize<(int, _i157.SimpleData)>(e['v'])))) as T;
+          deserialize<(int, _i158.SimpleData)>(e['v'])))) as T;
     }
     if (t == _i1.getType<(String, int)>()) {
       return (
@@ -2956,10 +2981,10 @@ class Protocol extends _i1.SerializationManager {
         deserialize<int>(data['p'][1]),
       ) as T;
     }
-    if (t == _i1.getType<(int, _i157.SimpleData)>()) {
+    if (t == _i1.getType<(int, _i158.SimpleData)>()) {
       return (
         deserialize<int>(((data as Map)['p'] as List)[0]),
-        deserialize<_i157.SimpleData>(data['p'][1]),
+        deserialize<_i158.SimpleData>(data['p'][1]),
       ) as T;
     }
     if (t == _i1.getType<(String, int)>()) {
@@ -3005,56 +3030,56 @@ class Protocol extends _i1.SerializationManager {
     if (t == _i1.getType<(int,)>()) {
       return (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
     }
-    if (t == _i1.getType<({(_i157.SimpleData, double) namedSubRecord})>()) {
+    if (t == _i1.getType<({(_i158.SimpleData, double) namedSubRecord})>()) {
       return (
-        namedSubRecord: deserialize<(_i157.SimpleData, double)>(
+        namedSubRecord: deserialize<(_i158.SimpleData, double)>(
             ((data as Map)['n'] as Map)['namedSubRecord']),
       ) as T;
     }
-    if (t == _i1.getType<(_i157.SimpleData, double)>()) {
+    if (t == _i1.getType<(_i158.SimpleData, double)>()) {
       return (
-        deserialize<_i157.SimpleData>(((data as Map)['p'] as List)[0]),
+        deserialize<_i158.SimpleData>(((data as Map)['p'] as List)[0]),
         deserialize<double>(data['p'][1]),
       ) as T;
     }
-    if (t == _i1.getType<({(_i157.SimpleData, double)? namedSubRecord})>()) {
+    if (t == _i1.getType<({(_i158.SimpleData, double)? namedSubRecord})>()) {
       return (
         namedSubRecord: ((data as Map)['n'] as Map)['namedSubRecord'] == null
             ? null
-            : deserialize<(_i157.SimpleData, double)>(
+            : deserialize<(_i158.SimpleData, double)>(
                 data['n']['namedSubRecord']),
       ) as T;
     }
-    if (t == _i1.getType<(_i157.SimpleData, double)?>()) {
+    if (t == _i1.getType<(_i158.SimpleData, double)?>()) {
       return (data == null)
           ? null as T
           : (
-              deserialize<_i157.SimpleData>(((data as Map)['p'] as List)[0]),
+              deserialize<_i158.SimpleData>(((data as Map)['p'] as List)[0]),
               deserialize<double>(data['p'][1]),
             ) as T;
     }
     if (t ==
         _i1.getType<
-            ((int, String), {(_i157.SimpleData, double) namedSubRecord})>()) {
+            ((int, String), {(_i158.SimpleData, double) namedSubRecord})>()) {
       return (
         deserialize<(int, String)>(((data as Map)['p'] as List)[0]),
-        namedSubRecord: deserialize<(_i157.SimpleData, double)>(
+        namedSubRecord: deserialize<(_i158.SimpleData, double)>(
             data['n']['namedSubRecord']),
       ) as T;
     }
     if (t ==
-        List<((int, String), {(_i157.SimpleData, double) namedSubRecord})>) {
+        List<((int, String), {(_i158.SimpleData, double) namedSubRecord})>) {
       return (data as List)
           .map((e) => deserialize<
-              ((int, String), {(_i157.SimpleData, double) namedSubRecord})>(e))
+              ((int, String), {(_i158.SimpleData, double) namedSubRecord})>(e))
           .toList() as T;
     }
     if (t ==
         _i1.getType<
-            ((int, String), {(_i157.SimpleData, double) namedSubRecord})>()) {
+            ((int, String), {(_i158.SimpleData, double) namedSubRecord})>()) {
       return (
         deserialize<(int, String)>(((data as Map)['p'] as List)[0]),
-        namedSubRecord: deserialize<(_i157.SimpleData, double)>(
+        namedSubRecord: deserialize<(_i158.SimpleData, double)>(
             data['n']['namedSubRecord']),
       ) as T;
     }
@@ -3063,37 +3088,37 @@ class Protocol extends _i1.SerializationManager {
             List<
                 (
                   (int, String), {
-                  (_i157.SimpleData, double) namedSubRecord
+                  (_i158.SimpleData, double) namedSubRecord
                 })?>?>()) {
       return (data != null
           ? (data as List)
               .map((e) => deserialize<
                   (
                     (int, String), {
-                    (_i157.SimpleData, double) namedSubRecord
+                    (_i158.SimpleData, double) namedSubRecord
                   })?>(e))
               .toList()
           : null) as T;
     }
     if (t ==
         _i1.getType<
-            ((int, String), {(_i157.SimpleData, double) namedSubRecord})?>()) {
+            ((int, String), {(_i158.SimpleData, double) namedSubRecord})?>()) {
       return (data == null)
           ? null as T
           : (
               deserialize<(int, String)>(((data as Map)['p'] as List)[0]),
-              namedSubRecord: deserialize<(_i157.SimpleData, double)>(
+              namedSubRecord: deserialize<(_i158.SimpleData, double)>(
                   data['n']['namedSubRecord']),
             ) as T;
     }
     if (t ==
         _i1.getType<
-            ((int, String), {(_i157.SimpleData, double) namedSubRecord})?>()) {
+            ((int, String), {(_i158.SimpleData, double) namedSubRecord})?>()) {
       return (data == null)
           ? null as T
           : (
               deserialize<(int, String)>(((data as Map)['p'] as List)[0]),
-              namedSubRecord: deserialize<(_i157.SimpleData, double)>(
+              namedSubRecord: deserialize<(_i158.SimpleData, double)>(
                   data['n']['namedSubRecord']),
             ) as T;
     }
@@ -3153,17 +3178,17 @@ class Protocol extends _i1.SerializationManager {
     if (t == Set<DateTime?>) {
       return (data as List).map((e) => deserialize<DateTime?>(e)).toSet() as T;
     }
-    if (t == Set<_i155.ByteData>) {
-      return (data as List).map((e) => deserialize<_i155.ByteData>(e)).toSet()
+    if (t == Set<_i156.ByteData>) {
+      return (data as List).map((e) => deserialize<_i156.ByteData>(e)).toSet()
           as T;
     }
-    if (t == Set<_i155.ByteData?>) {
-      return (data as List).map((e) => deserialize<_i155.ByteData?>(e)).toSet()
+    if (t == Set<_i156.ByteData?>) {
+      return (data as List).map((e) => deserialize<_i156.ByteData?>(e)).toSet()
           as T;
     }
-    if (t == Set<_i157.SimpleData?>) {
+    if (t == Set<_i158.SimpleData?>) {
       return (data as List)
-          .map((e) => deserialize<_i157.SimpleData?>(e))
+          .map((e) => deserialize<_i158.SimpleData?>(e))
           .toSet() as T;
     }
     if (t == Set<Duration>) {
@@ -3172,8 +3197,8 @@ class Protocol extends _i1.SerializationManager {
     if (t == Set<Duration?>) {
       return (data as List).map((e) => deserialize<Duration?>(e)).toSet() as T;
     }
-    if (t == List<_i160.Types>) {
-      return (data as List).map((e) => deserialize<_i160.Types>(e)).toList()
+    if (t == List<_i161.Types>) {
+      return (data as List).map((e) => deserialize<_i161.Types>(e)).toList()
           as T;
     }
     if (t == _i1.getType<(String, (int, bool))>()) {
@@ -3203,7 +3228,7 @@ class Protocol extends _i1.SerializationManager {
         _i1.getType<
             (
               String,
-              (Map<String, int>, {bool flag, _i157.SimpleData simpleData})
+              (Map<String, int>, {bool flag, _i158.SimpleData simpleData})
             )>()) {
       return (
         deserialize<String>(((data as Map)['p'] as List)[0]),
@@ -3211,17 +3236,17 @@ class Protocol extends _i1.SerializationManager {
             (
               Map<String, int>, {
               bool flag,
-              _i157.SimpleData simpleData
+              _i158.SimpleData simpleData
             })>(data['p'][1]),
       ) as T;
     }
     if (t ==
         _i1.getType<
-            (Map<String, int>, {bool flag, _i157.SimpleData simpleData})>()) {
+            (Map<String, int>, {bool flag, _i158.SimpleData simpleData})>()) {
       return (
         deserialize<Map<String, int>>(((data as Map)['p'] as List)[0]),
         flag: deserialize<bool>(data['n']['flag']),
-        simpleData: deserialize<_i157.SimpleData>(data['n']['simpleData']),
+        simpleData: deserialize<_i158.SimpleData>(data['n']['simpleData']),
       ) as T;
     }
     if (t == List<(String, int)>) {
@@ -3238,7 +3263,7 @@ class Protocol extends _i1.SerializationManager {
         _i1.getType<
             (
               String,
-              (Map<String, int>, {bool flag, _i157.SimpleData simpleData})
+              (Map<String, int>, {bool flag, _i158.SimpleData simpleData})
             )?>()) {
       return (data == null)
           ? null as T
@@ -3248,7 +3273,7 @@ class Protocol extends _i1.SerializationManager {
                   (
                     Map<String, int>, {
                     bool flag,
-                    _i157.SimpleData simpleData
+                    _i158.SimpleData simpleData
                   })>(data['p'][1]),
             ) as T;
     }
@@ -3263,10 +3288,10 @@ class Protocol extends _i1.SerializationManager {
         deserialize<int>(data['p'][1]),
       ) as T;
     }
-    if (t == _i1.getType<(_i154.ModuleClass,)?>()) {
+    if (t == _i1.getType<(_i155.ModuleClass,)?>()) {
       return (data == null)
           ? null as T
-          : (deserialize<_i154.ModuleClass>(((data as Map)['p'] as List)[0]),)
+          : (deserialize<_i155.ModuleClass>(((data as Map)['p'] as List)[0]),)
               as T;
     }
     if (t == _i1.getType<(bool,)?>()) {
@@ -3274,29 +3299,29 @@ class Protocol extends _i1.SerializationManager {
           ? null as T
           : (deserialize<bool>(((data as Map)['p'] as List)[0]),) as T;
     }
-    if (t == _i1.getType<(_i145.TestEnumStringified,)?>()) {
+    if (t == _i1.getType<(_i146.TestEnumStringified,)?>()) {
       return (data == null)
           ? null as T
           : (
-              deserialize<_i145.TestEnumStringified>(
+              deserialize<_i146.TestEnumStringified>(
                   ((data as Map)['p'] as List)[0]),
             ) as T;
     }
-    if (t == _i1.getType<List<(_i145.TestEnumStringified,)>?>()) {
+    if (t == _i1.getType<List<(_i146.TestEnumStringified,)>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<(_i145.TestEnumStringified,)>(e))
+              .map((e) => deserialize<(_i146.TestEnumStringified,)>(e))
               .toList()
           : null) as T;
     }
-    if (t == _i1.getType<(_i145.TestEnumStringified,)>()) {
+    if (t == _i1.getType<(_i146.TestEnumStringified,)>()) {
       return (
-        deserialize<_i145.TestEnumStringified>(((data as Map)['p'] as List)[0]),
+        deserialize<_i146.TestEnumStringified>(((data as Map)['p'] as List)[0]),
       ) as T;
     }
-    if (t == _i1.getType<(_i145.TestEnumStringified,)>()) {
+    if (t == _i1.getType<(_i146.TestEnumStringified,)>()) {
       return (
-        deserialize<_i145.TestEnumStringified>(((data as Map)['p'] as List)[0]),
+        deserialize<_i146.TestEnumStringified>(((data as Map)['p'] as List)[0]),
       ) as T;
     }
     if (t == _i1.getType<(_i110.Nullability,)?>()) {
@@ -3305,38 +3330,38 @@ class Protocol extends _i1.SerializationManager {
           : (deserialize<_i110.Nullability>(((data as Map)['p'] as List)[0]),)
               as T;
     }
-    if (t == _i1.getType<({_i145.TestEnumStringified value})?>()) {
+    if (t == _i1.getType<({_i146.TestEnumStringified value})?>()) {
       return (data == null)
           ? null as T
           : (
-              value: deserialize<_i145.TestEnumStringified>(
+              value: deserialize<_i146.TestEnumStringified>(
                   ((data as Map)['n'] as Map)['value']),
             ) as T;
     }
-    if (t == _i1.getType<List<({_i145.TestEnumStringified value})>?>()) {
+    if (t == _i1.getType<List<({_i146.TestEnumStringified value})>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<({_i145.TestEnumStringified value})>(e))
+              .map((e) => deserialize<({_i146.TestEnumStringified value})>(e))
               .toList()
           : null) as T;
     }
-    if (t == _i1.getType<({_i145.TestEnumStringified value})>()) {
+    if (t == _i1.getType<({_i146.TestEnumStringified value})>()) {
       return (
-        value: deserialize<_i145.TestEnumStringified>(
+        value: deserialize<_i146.TestEnumStringified>(
             ((data as Map)['n'] as Map)['value']),
       ) as T;
     }
-    if (t == _i1.getType<({_i145.TestEnumStringified value})>()) {
+    if (t == _i1.getType<({_i146.TestEnumStringified value})>()) {
       return (
-        value: deserialize<_i145.TestEnumStringified>(
+        value: deserialize<_i146.TestEnumStringified>(
             ((data as Map)['n'] as Map)['value']),
       ) as T;
     }
-    if (t == _i1.getType<({_i154.ModuleClass value})?>()) {
+    if (t == _i1.getType<({_i155.ModuleClass value})?>()) {
       return (data == null)
           ? null as T
           : (
-              value: deserialize<_i154.ModuleClass>(
+              value: deserialize<_i155.ModuleClass>(
                   ((data as Map)['n'] as Map)['value']),
             ) as T;
     }
@@ -3376,19 +3401,19 @@ class Protocol extends _i1.SerializationManager {
           ? null as T
           : (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
     }
-    if (t == _i1.getType<List<(_i144.TestEnum,)>?>()) {
+    if (t == _i1.getType<List<(_i145.TestEnum,)>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<(_i144.TestEnum,)>(e))
+              .map((e) => deserialize<(_i145.TestEnum,)>(e))
               .toList()
           : null) as T;
     }
-    if (t == _i1.getType<(_i144.TestEnum,)>()) {
-      return (deserialize<_i144.TestEnum>(((data as Map)['p'] as List)[0]),)
+    if (t == _i1.getType<(_i145.TestEnum,)>()) {
+      return (deserialize<_i145.TestEnum>(((data as Map)['p'] as List)[0]),)
           as T;
     }
-    if (t == _i1.getType<(_i144.TestEnum,)>()) {
-      return (deserialize<_i144.TestEnum>(((data as Map)['p'] as List)[0]),)
+    if (t == _i1.getType<(_i145.TestEnum,)>()) {
+      return (deserialize<_i145.TestEnum>(((data as Map)['p'] as List)[0]),)
           as T;
     }
     if (t == _i1.getType<Map<(String,), String>?>()) {
@@ -3449,10 +3474,10 @@ class Protocol extends _i1.SerializationManager {
           ? null as T
           : (deserialize<DateTime>(((data as Map)['p'] as List)[0]),) as T;
     }
-    if (t == _i1.getType<(_i155.ByteData,)?>()) {
+    if (t == _i1.getType<(_i156.ByteData,)?>()) {
       return (data == null)
           ? null as T
-          : (deserialize<_i155.ByteData>(((data as Map)['p'] as List)[0]),)
+          : (deserialize<_i156.ByteData>(((data as Map)['p'] as List)[0]),)
               as T;
     }
     if (t == _i1.getType<(Duration,)?>()) {
@@ -3475,10 +3500,10 @@ class Protocol extends _i1.SerializationManager {
           ? null as T
           : (deserialize<BigInt>(((data as Map)['p'] as List)[0]),) as T;
     }
-    if (t == _i1.getType<(_i144.TestEnum,)?>()) {
+    if (t == _i1.getType<(_i145.TestEnum,)?>()) {
       return (data == null)
           ? null as T
-          : (deserialize<_i144.TestEnum>(((data as Map)['p'] as List)[0]),)
+          : (deserialize<_i145.TestEnum>(((data as Map)['p'] as List)[0]),)
               as T;
     }
     if (t == _i1.getType<(List<int>,)?>()) {
@@ -3496,28 +3521,28 @@ class Protocol extends _i1.SerializationManager {
           ? null as T
           : (deserialize<Set<int>>(((data as Map)['p'] as List)[0]),) as T;
     }
-    if (t == _i1.getType<(_i138.SimpleData,)?>()) {
+    if (t == _i1.getType<(_i139.SimpleData,)?>()) {
       return (data == null)
           ? null as T
-          : (deserialize<_i138.SimpleData>(((data as Map)['p'] as List)[0]),)
+          : (deserialize<_i139.SimpleData>(((data as Map)['p'] as List)[0]),)
               as T;
     }
-    if (t == _i1.getType<({_i138.SimpleData namedModel})?>()) {
+    if (t == _i1.getType<({_i139.SimpleData namedModel})?>()) {
       return (data == null)
           ? null as T
           : (
-              namedModel: deserialize<_i138.SimpleData>(
+              namedModel: deserialize<_i139.SimpleData>(
                   ((data as Map)['n'] as Map)['namedModel']),
             ) as T;
     }
     if (t ==
-        _i1.getType<(_i138.SimpleData, {_i138.SimpleData namedModel})?>()) {
+        _i1.getType<(_i139.SimpleData, {_i139.SimpleData namedModel})?>()) {
       return (data == null)
           ? null as T
           : (
-              deserialize<_i138.SimpleData>(((data as Map)['p'] as List)[0]),
+              deserialize<_i139.SimpleData>(((data as Map)['p'] as List)[0]),
               namedModel:
-                  deserialize<_i138.SimpleData>(data['n']['namedModel']),
+                  deserialize<_i139.SimpleData>(data['n']['namedModel']),
             ) as T;
     }
     if (t ==
@@ -3539,46 +3564,46 @@ class Protocol extends _i1.SerializationManager {
     if (t ==
         _i1.getType<
             (
-              (List<(_i138.SimpleData,)>,), {
+              (List<(_i139.SimpleData,)>,), {
               (
-                _i138.SimpleData,
-                Map<String, _i138.SimpleData>
+                _i139.SimpleData,
+                Map<String, _i139.SimpleData>
               ) namedNestedRecord
             })?>()) {
       return (data == null)
           ? null as T
           : (
-              deserialize<(List<(_i138.SimpleData,)>,)>(
+              deserialize<(List<(_i139.SimpleData,)>,)>(
                   ((data as Map)['p'] as List)[0]),
               namedNestedRecord: deserialize<
                   (
-                    _i138.SimpleData,
-                    Map<String, _i138.SimpleData>
+                    _i139.SimpleData,
+                    Map<String, _i139.SimpleData>
                   )>(data['n']['namedNestedRecord']),
             ) as T;
     }
-    if (t == _i1.getType<(List<(_i138.SimpleData,)>,)>()) {
+    if (t == _i1.getType<(List<(_i139.SimpleData,)>,)>()) {
       return (
-        deserialize<List<(_i138.SimpleData,)>>(((data as Map)['p'] as List)[0]),
+        deserialize<List<(_i139.SimpleData,)>>(((data as Map)['p'] as List)[0]),
       ) as T;
     }
-    if (t == List<(_i138.SimpleData,)>) {
+    if (t == List<(_i139.SimpleData,)>) {
       return (data as List)
-          .map((e) => deserialize<(_i138.SimpleData,)>(e))
+          .map((e) => deserialize<(_i139.SimpleData,)>(e))
           .toList() as T;
     }
-    if (t == _i1.getType<(_i138.SimpleData,)>()) {
-      return (deserialize<_i138.SimpleData>(((data as Map)['p'] as List)[0]),)
+    if (t == _i1.getType<(_i139.SimpleData,)>()) {
+      return (deserialize<_i139.SimpleData>(((data as Map)['p'] as List)[0]),)
           as T;
     }
-    if (t == _i1.getType<(_i138.SimpleData,)>()) {
-      return (deserialize<_i138.SimpleData>(((data as Map)['p'] as List)[0]),)
+    if (t == _i1.getType<(_i139.SimpleData,)>()) {
+      return (deserialize<_i139.SimpleData>(((data as Map)['p'] as List)[0]),)
           as T;
     }
-    if (t == _i1.getType<(_i138.SimpleData, Map<String, _i138.SimpleData>)>()) {
+    if (t == _i1.getType<(_i139.SimpleData, Map<String, _i139.SimpleData>)>()) {
       return (
-        deserialize<_i138.SimpleData>(((data as Map)['p'] as List)[0]),
-        deserialize<Map<String, _i138.SimpleData>>(data['p'][1]),
+        deserialize<_i139.SimpleData>(((data as Map)['p'] as List)[0]),
+        deserialize<Map<String, _i139.SimpleData>>(data['p'][1]),
       ) as T;
     }
     if (t == _i1.getType<Set<(int,)>?>()) {
@@ -3599,57 +3624,57 @@ class Protocol extends _i1.SerializationManager {
           ? null as T
           : (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
     }
-    if (t == _i156.CustomClass) {
-      return _i156.CustomClass.fromJson(data) as T;
+    if (t == _i157.CustomClass) {
+      return _i157.CustomClass.fromJson(data) as T;
     }
-    if (t == _i156.CustomClass2) {
-      return _i156.CustomClass2.fromJson(data) as T;
+    if (t == _i157.CustomClass2) {
+      return _i157.CustomClass2.fromJson(data) as T;
     }
-    if (t == _i156.ProtocolCustomClass) {
-      return _i156.ProtocolCustomClass.fromJson(data) as T;
+    if (t == _i157.ProtocolCustomClass) {
+      return _i157.ProtocolCustomClass.fromJson(data) as T;
     }
-    if (t == _i156.ExternalCustomClass) {
-      return _i156.ExternalCustomClass.fromJson(data) as T;
+    if (t == _i157.ExternalCustomClass) {
+      return _i157.ExternalCustomClass.fromJson(data) as T;
     }
-    if (t == _i156.FreezedCustomClass) {
-      return _i156.FreezedCustomClass.fromJson(data) as T;
+    if (t == _i157.FreezedCustomClass) {
+      return _i157.FreezedCustomClass.fromJson(data) as T;
     }
-    if (t == _i1.getType<_i156.CustomClass?>()) {
-      return (data != null ? _i156.CustomClass.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i157.CustomClass?>()) {
+      return (data != null ? _i157.CustomClass.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i156.CustomClass2?>()) {
-      return (data != null ? _i156.CustomClass2.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i157.CustomClass2?>()) {
+      return (data != null ? _i157.CustomClass2.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i156.CustomClassWithoutProtocolSerialization?>()) {
+    if (t == _i1.getType<_i157.CustomClassWithoutProtocolSerialization?>()) {
       return (data != null
-          ? _i156.CustomClassWithoutProtocolSerialization.fromJson(data)
+          ? _i157.CustomClassWithoutProtocolSerialization.fromJson(data)
           : null) as T;
     }
-    if (t == _i1.getType<_i156.CustomClassWithProtocolSerialization?>()) {
+    if (t == _i1.getType<_i157.CustomClassWithProtocolSerialization?>()) {
       return (data != null
-          ? _i156.CustomClassWithProtocolSerialization.fromJson(data)
+          ? _i157.CustomClassWithProtocolSerialization.fromJson(data)
           : null) as T;
     }
-    if (t == _i1.getType<_i156.CustomClassWithProtocolSerializationMethod?>()) {
+    if (t == _i1.getType<_i157.CustomClassWithProtocolSerializationMethod?>()) {
       return (data != null
-          ? _i156.CustomClassWithProtocolSerializationMethod.fromJson(data)
+          ? _i157.CustomClassWithProtocolSerializationMethod.fromJson(data)
           : null) as T;
     }
-    if (t == _i1.getType<_i156.ProtocolCustomClass?>()) {
-      return (data != null ? _i156.ProtocolCustomClass.fromJson(data) : null)
+    if (t == _i1.getType<_i157.ProtocolCustomClass?>()) {
+      return (data != null ? _i157.ProtocolCustomClass.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i156.ExternalCustomClass?>()) {
-      return (data != null ? _i156.ExternalCustomClass.fromJson(data) : null)
+    if (t == _i1.getType<_i157.ExternalCustomClass?>()) {
+      return (data != null ? _i157.ExternalCustomClass.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i156.FreezedCustomClass?>()) {
-      return (data != null ? _i156.FreezedCustomClass.fromJson(data) : null)
+    if (t == _i1.getType<_i157.FreezedCustomClass?>()) {
+      return (data != null ? _i157.FreezedCustomClass.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<List<_i157.SimpleData>?>()) {
+    if (t == _i1.getType<List<_i158.SimpleData>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i157.SimpleData>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i158.SimpleData>(e)).toList()
           : null) as T;
     }
     if (t == _i1.getType<(int?,)?>()) {
@@ -3666,26 +3691,26 @@ class Protocol extends _i1.SerializationManager {
             List<
                 (
                   (int, String), {
-                  (_i157.SimpleData, double) namedSubRecord
+                  (_i158.SimpleData, double) namedSubRecord
                 })?>?>()) {
       return (data != null
           ? (data as List)
               .map((e) => deserialize<
                   (
                     (int, String), {
-                    (_i157.SimpleData, double) namedSubRecord
+                    (_i158.SimpleData, double) namedSubRecord
                   })?>(e))
               .toList()
           : null) as T;
     }
     if (t ==
         _i1.getType<
-            ((int, String), {(_i157.SimpleData, double) namedSubRecord})?>()) {
+            ((int, String), {(_i158.SimpleData, double) namedSubRecord})?>()) {
       return (data == null)
           ? null as T
           : (
               deserialize<(int, String)>(((data as Map)['p'] as List)[0]),
-              namedSubRecord: deserialize<(_i157.SimpleData, double)>(
+              namedSubRecord: deserialize<(_i158.SimpleData, double)>(
                   data['n']['namedSubRecord']),
             ) as T;
     }
@@ -3693,7 +3718,7 @@ class Protocol extends _i1.SerializationManager {
         _i1.getType<
             (
               String,
-              (Map<String, int>, {bool flag, _i157.SimpleData simpleData})
+              (Map<String, int>, {bool flag, _i158.SimpleData simpleData})
             )>()) {
       return (
         deserialize<String>(((data as Map)['p'] as List)[0]),
@@ -3701,7 +3726,7 @@ class Protocol extends _i1.SerializationManager {
             (
               Map<String, int>, {
               bool flag,
-              _i157.SimpleData simpleData
+              _i158.SimpleData simpleData
             })>(data['p'][1]),
       ) as T;
     }
@@ -3715,7 +3740,7 @@ class Protocol extends _i1.SerializationManager {
         _i1.getType<
             (
               String,
-              (Map<String, int>, {bool flag, _i157.SimpleData simpleData})
+              (Map<String, int>, {bool flag, _i158.SimpleData simpleData})
             )?>()) {
       return (data == null)
           ? null as T
@@ -3725,7 +3750,7 @@ class Protocol extends _i1.SerializationManager {
                   (
                     Map<String, int>, {
                     bool flag,
-                    _i157.SimpleData simpleData
+                    _i158.SimpleData simpleData
                   })>(data['p'][1]),
             ) as T;
     }
@@ -3741,10 +3766,10 @@ class Protocol extends _i1.SerializationManager {
       ) as T;
     }
     try {
-      return _i159.Protocol().deserialize<T>(data, t);
+      return _i160.Protocol().deserialize<T>(data, t);
     } on _i1.DeserializationTypeNotFoundException catch (_) {}
     try {
-      return _i154.Protocol().deserialize<T>(data, t);
+      return _i155.Protocol().deserialize<T>(data, t);
     } on _i1.DeserializationTypeNotFoundException catch (_) {}
     return super.deserialize<T>(data, t);
   }
@@ -3754,21 +3779,21 @@ class Protocol extends _i1.SerializationManager {
     String? className = super.getClassNameForObject(data);
     if (className != null) return className;
     switch (data) {
-      case _i156.CustomClass():
+      case _i157.CustomClass():
         return 'CustomClass';
-      case _i156.CustomClass2():
+      case _i157.CustomClass2():
         return 'CustomClass2';
-      case _i156.CustomClassWithoutProtocolSerialization():
+      case _i157.CustomClassWithoutProtocolSerialization():
         return 'CustomClassWithoutProtocolSerialization';
-      case _i156.CustomClassWithProtocolSerialization():
+      case _i157.CustomClassWithProtocolSerialization():
         return 'CustomClassWithProtocolSerialization';
-      case _i156.CustomClassWithProtocolSerializationMethod():
+      case _i157.CustomClassWithProtocolSerializationMethod():
         return 'CustomClassWithProtocolSerializationMethod';
-      case _i156.ProtocolCustomClass():
+      case _i157.ProtocolCustomClass():
         return 'ProtocolCustomClass';
-      case _i156.ExternalCustomClass():
+      case _i157.ExternalCustomClass():
         return 'ExternalCustomClass';
-      case _i156.FreezedCustomClass():
+      case _i157.FreezedCustomClass():
         return 'FreezedCustomClass';
       case _i2.ScopeServerOnlyFieldChild():
         return 'ScopeServerOnlyFieldChild';
@@ -3784,8 +3809,8 @@ class Protocol extends _i1.SerializationManager {
         return 'SealedChild';
       case _i6.SealedOtherChild():
         return 'SealedOtherChild';
-      case _i7.StringDefaultPersist():
-        return 'StringDefaultPersist';
+      case _i7.UriDefault():
+        return 'UriDefault';
       case _i8.CommentInt():
         return 'CommentInt';
       case _i9.CustomerInt():
@@ -3872,10 +3897,10 @@ class Protocol extends _i1.SerializationManager {
         return 'StringDefaultMix';
       case _i50.StringDefaultModel():
         return 'StringDefaultModel';
-      case _i51.ByIndexEnumWithNameValue():
+      case _i51.StringDefaultPersist():
+        return 'StringDefaultPersist';
+      case _i52.ByIndexEnumWithNameValue():
         return 'ByIndexEnumWithNameValue';
-      case _i52.UriDefault():
-        return 'UriDefault';
       case _i53.UriDefaultMix():
         return 'UriDefaultMix';
       case _i54.UriDefaultModel():
@@ -3972,10 +3997,10 @@ class Protocol extends _i1.SerializationManager {
         return 'Chapter';
       case _i100.Order():
         return 'Order';
-      case _i101.MyFeatureModel():
+      case _i101.Address():
+        return 'Address';
+      case _i102.MyFeatureModel():
         return 'MyFeatureModel';
-      case _i102.Citizen():
-        return 'Citizen';
       case _i103.Company():
         return 'Company';
       case _i104.Town():
@@ -4012,115 +4037,117 @@ class Protocol extends _i1.SerializationManager {
         return 'ObjectWithIndex';
       case _i120.ObjectWithMaps():
         return 'ObjectWithMaps';
-      case _i121.ObjectWithObject():
+      case _i121.ObjectWithNullableCustomClass():
+        return 'ObjectWithNullableCustomClass';
+      case _i122.ObjectWithObject():
         return 'ObjectWithObject';
-      case _i122.ObjectWithParent():
+      case _i123.ObjectWithParent():
         return 'ObjectWithParent';
-      case _i123.ObjectWithSelfParent():
+      case _i124.ObjectWithSelfParent():
         return 'ObjectWithSelfParent';
-      case _i124.ObjectWithSparseVector():
+      case _i125.ObjectWithSparseVector():
         return 'ObjectWithSparseVector';
-      case _i125.ObjectWithUuid():
+      case _i126.ObjectWithUuid():
         return 'ObjectWithUuid';
-      case _i126.ObjectWithVector():
+      case _i127.ObjectWithVector():
         return 'ObjectWithVector';
-      case _i127.Record():
+      case _i128.Record():
         return 'Record';
-      case _i128.RelatedUniqueData():
+      case _i129.RelatedUniqueData():
         return 'RelatedUniqueData';
-      case _i129.ScopeNoneFields():
+      case _i130.ScopeNoneFields():
         return 'ScopeNoneFields';
-      case _i130.ScopeServerOnlyField():
+      case _i131.ScopeServerOnlyField():
         return 'ScopeServerOnlyField';
-      case _i131.TeamInt():
+      case _i132.TeamInt():
         return 'TeamInt';
-      case _i132.DefaultServerOnlyClass():
+      case _i133.DefaultServerOnlyClass():
         return 'DefaultServerOnlyClass';
-      case _i133.DefaultServerOnlyEnum():
+      case _i134.DefaultServerOnlyEnum():
         return 'DefaultServerOnlyEnum';
-      case _i134.NotServerOnlyClass():
+      case _i135.NotServerOnlyClass():
         return 'NotServerOnlyClass';
-      case _i135.NotServerOnlyEnum():
+      case _i136.NotServerOnlyEnum():
         return 'NotServerOnlyEnum';
-      case _i136.ServerOnlyClassField():
+      case _i137.ServerOnlyClassField():
         return 'ServerOnlyClassField';
-      case _i137.ServerOnlyDefault():
+      case _i138.ServerOnlyDefault():
         return 'ServerOnlyDefault';
-      case _i138.SimpleData():
+      case _i139.SimpleData():
         return 'SimpleData';
-      case _i139.SimpleDataList():
+      case _i140.SimpleDataList():
         return 'SimpleDataList';
-      case _i140.SimpleDataMap():
+      case _i141.SimpleDataMap():
         return 'SimpleDataMap';
-      case _i141.SimpleDataObject():
+      case _i142.SimpleDataObject():
         return 'SimpleDataObject';
-      case _i142.SimpleDateTime():
+      case _i143.SimpleDateTime():
         return 'SimpleDateTime';
-      case _i143.ModelInSubfolder():
+      case _i144.ModelInSubfolder():
         return 'ModelInSubfolder';
-      case _i144.TestEnum():
+      case _i145.TestEnum():
         return 'TestEnum';
-      case _i145.TestEnumStringified():
+      case _i146.TestEnumStringified():
         return 'TestEnumStringified';
-      case _i146.Types():
+      case _i147.Types():
         return 'Types';
-      case _i147.TypesList():
+      case _i148.TypesList():
         return 'TypesList';
-      case _i148.TypesMap():
+      case _i149.TypesMap():
         return 'TypesMap';
-      case _i149.TypesRecord():
+      case _i150.TypesRecord():
         return 'TypesRecord';
-      case _i150.TypesSet():
+      case _i151.TypesSet():
         return 'TypesSet';
-      case _i151.TypesSetRequired():
+      case _i152.TypesSetRequired():
         return 'TypesSetRequired';
-      case _i152.UniqueData():
+      case _i153.UniqueData():
         return 'UniqueData';
-      case _i153.Address():
-        return 'Address';
+      case _i154.Citizen():
+        return 'Citizen';
     }
-    className = _i159.Protocol().getClassNameForObject(data);
+    className = _i160.Protocol().getClassNameForObject(data);
     if (className != null) {
       return 'serverpod_auth.$className';
     }
-    className = _i154.Protocol().getClassNameForObject(data);
+    className = _i155.Protocol().getClassNameForObject(data);
     if (className != null) {
       return 'serverpod_test_module.$className';
     }
     if (data is List<int>) {
       return 'List<int>';
     }
-    if (data is List<_i157.SimpleData>) {
+    if (data is List<_i158.SimpleData>) {
       return 'List<SimpleData>';
     }
-    if (data is List<_i159.UserInfo>) {
+    if (data is List<_i160.UserInfo>) {
       return 'List<serverpod_auth.UserInfo>';
     }
-    if (data is List<_i157.SimpleData>?) {
+    if (data is List<_i158.SimpleData>?) {
       return 'List<SimpleData>?';
     }
-    if (data is List<_i157.SimpleData?>) {
+    if (data is List<_i158.SimpleData?>) {
       return 'List<SimpleData?>';
     }
     if (data is Set<int>) {
       return 'Set<int>';
     }
-    if (data is Set<_i157.SimpleData>) {
+    if (data is Set<_i158.SimpleData>) {
       return 'Set<SimpleData>';
     }
-    if (data is List<Set<_i157.SimpleData>>) {
+    if (data is List<Set<_i158.SimpleData>>) {
       return 'List<Set<SimpleData>>';
     }
     if (data is (int?,)?) {
       return '(int?,)?';
     }
     if (data is List<
-        ((int, String), {(_i157.SimpleData, double) namedSubRecord})?>?) {
+        ((int, String), {(_i158.SimpleData, double) namedSubRecord})?>?) {
       return 'List<((int,String),{(SimpleData,double) namedSubRecord})?>?';
     }
     if (data is (
       String,
-      (Map<String, int>, {bool flag, _i157.SimpleData simpleData})
+      (Map<String, int>, {bool flag, _i158.SimpleData simpleData})
     )) {
       return '(String,(Map<String,int>,{bool flag,SimpleData simpleData}))';
     }
@@ -4129,7 +4156,7 @@ class Protocol extends _i1.SerializationManager {
     }
     if (data is (
       String,
-      (Map<String, int>, {bool flag, _i157.SimpleData simpleData})
+      (Map<String, int>, {bool flag, _i158.SimpleData simpleData})
     )?) {
       return '(String,(Map<String,int>,{bool flag,SimpleData simpleData}))?';
     }
@@ -4146,31 +4173,31 @@ class Protocol extends _i1.SerializationManager {
       return super.deserializeByClassName(data);
     }
     if (dataClassName == 'CustomClass') {
-      return deserialize<_i156.CustomClass>(data['data']);
+      return deserialize<_i157.CustomClass>(data['data']);
     }
     if (dataClassName == 'CustomClass2') {
-      return deserialize<_i156.CustomClass2>(data['data']);
+      return deserialize<_i157.CustomClass2>(data['data']);
     }
     if (dataClassName == 'CustomClassWithoutProtocolSerialization') {
-      return deserialize<_i156.CustomClassWithoutProtocolSerialization>(
+      return deserialize<_i157.CustomClassWithoutProtocolSerialization>(
           data['data']);
     }
     if (dataClassName == 'CustomClassWithProtocolSerialization') {
-      return deserialize<_i156.CustomClassWithProtocolSerialization>(
+      return deserialize<_i157.CustomClassWithProtocolSerialization>(
           data['data']);
     }
     if (dataClassName == 'CustomClassWithProtocolSerializationMethod') {
-      return deserialize<_i156.CustomClassWithProtocolSerializationMethod>(
+      return deserialize<_i157.CustomClassWithProtocolSerializationMethod>(
           data['data']);
     }
     if (dataClassName == 'ProtocolCustomClass') {
-      return deserialize<_i156.ProtocolCustomClass>(data['data']);
+      return deserialize<_i157.ProtocolCustomClass>(data['data']);
     }
     if (dataClassName == 'ExternalCustomClass') {
-      return deserialize<_i156.ExternalCustomClass>(data['data']);
+      return deserialize<_i157.ExternalCustomClass>(data['data']);
     }
     if (dataClassName == 'FreezedCustomClass') {
-      return deserialize<_i156.FreezedCustomClass>(data['data']);
+      return deserialize<_i157.FreezedCustomClass>(data['data']);
     }
     if (dataClassName == 'ScopeServerOnlyFieldChild') {
       return deserialize<_i2.ScopeServerOnlyFieldChild>(data['data']);
@@ -4193,8 +4220,8 @@ class Protocol extends _i1.SerializationManager {
     if (dataClassName == 'SealedOtherChild') {
       return deserialize<_i6.SealedOtherChild>(data['data']);
     }
-    if (dataClassName == 'StringDefaultPersist') {
-      return deserialize<_i7.StringDefaultPersist>(data['data']);
+    if (dataClassName == 'UriDefault') {
+      return deserialize<_i7.UriDefault>(data['data']);
     }
     if (dataClassName == 'CommentInt') {
       return deserialize<_i8.CommentInt>(data['data']);
@@ -4325,11 +4352,11 @@ class Protocol extends _i1.SerializationManager {
     if (dataClassName == 'StringDefaultModel') {
       return deserialize<_i50.StringDefaultModel>(data['data']);
     }
-    if (dataClassName == 'ByIndexEnumWithNameValue') {
-      return deserialize<_i51.ByIndexEnumWithNameValue>(data['data']);
+    if (dataClassName == 'StringDefaultPersist') {
+      return deserialize<_i51.StringDefaultPersist>(data['data']);
     }
-    if (dataClassName == 'UriDefault') {
-      return deserialize<_i52.UriDefault>(data['data']);
+    if (dataClassName == 'ByIndexEnumWithNameValue') {
+      return deserialize<_i52.ByIndexEnumWithNameValue>(data['data']);
     }
     if (dataClassName == 'UriDefaultMix') {
       return deserialize<_i53.UriDefaultMix>(data['data']);
@@ -4475,11 +4502,11 @@ class Protocol extends _i1.SerializationManager {
     if (dataClassName == 'Order') {
       return deserialize<_i100.Order>(data['data']);
     }
-    if (dataClassName == 'MyFeatureModel') {
-      return deserialize<_i101.MyFeatureModel>(data['data']);
+    if (dataClassName == 'Address') {
+      return deserialize<_i101.Address>(data['data']);
     }
-    if (dataClassName == 'Citizen') {
-      return deserialize<_i102.Citizen>(data['data']);
+    if (dataClassName == 'MyFeatureModel') {
+      return deserialize<_i102.MyFeatureModel>(data['data']);
     }
     if (dataClassName == 'Company') {
       return deserialize<_i103.Company>(data['data']);
@@ -4535,136 +4562,139 @@ class Protocol extends _i1.SerializationManager {
     if (dataClassName == 'ObjectWithMaps') {
       return deserialize<_i120.ObjectWithMaps>(data['data']);
     }
+    if (dataClassName == 'ObjectWithNullableCustomClass') {
+      return deserialize<_i121.ObjectWithNullableCustomClass>(data['data']);
+    }
     if (dataClassName == 'ObjectWithObject') {
-      return deserialize<_i121.ObjectWithObject>(data['data']);
+      return deserialize<_i122.ObjectWithObject>(data['data']);
     }
     if (dataClassName == 'ObjectWithParent') {
-      return deserialize<_i122.ObjectWithParent>(data['data']);
+      return deserialize<_i123.ObjectWithParent>(data['data']);
     }
     if (dataClassName == 'ObjectWithSelfParent') {
-      return deserialize<_i123.ObjectWithSelfParent>(data['data']);
+      return deserialize<_i124.ObjectWithSelfParent>(data['data']);
     }
     if (dataClassName == 'ObjectWithSparseVector') {
-      return deserialize<_i124.ObjectWithSparseVector>(data['data']);
+      return deserialize<_i125.ObjectWithSparseVector>(data['data']);
     }
     if (dataClassName == 'ObjectWithUuid') {
-      return deserialize<_i125.ObjectWithUuid>(data['data']);
+      return deserialize<_i126.ObjectWithUuid>(data['data']);
     }
     if (dataClassName == 'ObjectWithVector') {
-      return deserialize<_i126.ObjectWithVector>(data['data']);
+      return deserialize<_i127.ObjectWithVector>(data['data']);
     }
     if (dataClassName == 'Record') {
-      return deserialize<_i127.Record>(data['data']);
+      return deserialize<_i128.Record>(data['data']);
     }
     if (dataClassName == 'RelatedUniqueData') {
-      return deserialize<_i128.RelatedUniqueData>(data['data']);
+      return deserialize<_i129.RelatedUniqueData>(data['data']);
     }
     if (dataClassName == 'ScopeNoneFields') {
-      return deserialize<_i129.ScopeNoneFields>(data['data']);
+      return deserialize<_i130.ScopeNoneFields>(data['data']);
     }
     if (dataClassName == 'ScopeServerOnlyField') {
-      return deserialize<_i130.ScopeServerOnlyField>(data['data']);
+      return deserialize<_i131.ScopeServerOnlyField>(data['data']);
     }
     if (dataClassName == 'TeamInt') {
-      return deserialize<_i131.TeamInt>(data['data']);
+      return deserialize<_i132.TeamInt>(data['data']);
     }
     if (dataClassName == 'DefaultServerOnlyClass') {
-      return deserialize<_i132.DefaultServerOnlyClass>(data['data']);
+      return deserialize<_i133.DefaultServerOnlyClass>(data['data']);
     }
     if (dataClassName == 'DefaultServerOnlyEnum') {
-      return deserialize<_i133.DefaultServerOnlyEnum>(data['data']);
+      return deserialize<_i134.DefaultServerOnlyEnum>(data['data']);
     }
     if (dataClassName == 'NotServerOnlyClass') {
-      return deserialize<_i134.NotServerOnlyClass>(data['data']);
+      return deserialize<_i135.NotServerOnlyClass>(data['data']);
     }
     if (dataClassName == 'NotServerOnlyEnum') {
-      return deserialize<_i135.NotServerOnlyEnum>(data['data']);
+      return deserialize<_i136.NotServerOnlyEnum>(data['data']);
     }
     if (dataClassName == 'ServerOnlyClassField') {
-      return deserialize<_i136.ServerOnlyClassField>(data['data']);
+      return deserialize<_i137.ServerOnlyClassField>(data['data']);
     }
     if (dataClassName == 'ServerOnlyDefault') {
-      return deserialize<_i137.ServerOnlyDefault>(data['data']);
+      return deserialize<_i138.ServerOnlyDefault>(data['data']);
     }
     if (dataClassName == 'SimpleData') {
-      return deserialize<_i138.SimpleData>(data['data']);
+      return deserialize<_i139.SimpleData>(data['data']);
     }
     if (dataClassName == 'SimpleDataList') {
-      return deserialize<_i139.SimpleDataList>(data['data']);
+      return deserialize<_i140.SimpleDataList>(data['data']);
     }
     if (dataClassName == 'SimpleDataMap') {
-      return deserialize<_i140.SimpleDataMap>(data['data']);
+      return deserialize<_i141.SimpleDataMap>(data['data']);
     }
     if (dataClassName == 'SimpleDataObject') {
-      return deserialize<_i141.SimpleDataObject>(data['data']);
+      return deserialize<_i142.SimpleDataObject>(data['data']);
     }
     if (dataClassName == 'SimpleDateTime') {
-      return deserialize<_i142.SimpleDateTime>(data['data']);
+      return deserialize<_i143.SimpleDateTime>(data['data']);
     }
     if (dataClassName == 'ModelInSubfolder') {
-      return deserialize<_i143.ModelInSubfolder>(data['data']);
+      return deserialize<_i144.ModelInSubfolder>(data['data']);
     }
     if (dataClassName == 'TestEnum') {
-      return deserialize<_i144.TestEnum>(data['data']);
+      return deserialize<_i145.TestEnum>(data['data']);
     }
     if (dataClassName == 'TestEnumStringified') {
-      return deserialize<_i145.TestEnumStringified>(data['data']);
+      return deserialize<_i146.TestEnumStringified>(data['data']);
     }
     if (dataClassName == 'Types') {
-      return deserialize<_i146.Types>(data['data']);
+      return deserialize<_i147.Types>(data['data']);
     }
     if (dataClassName == 'TypesList') {
-      return deserialize<_i147.TypesList>(data['data']);
+      return deserialize<_i148.TypesList>(data['data']);
     }
     if (dataClassName == 'TypesMap') {
-      return deserialize<_i148.TypesMap>(data['data']);
+      return deserialize<_i149.TypesMap>(data['data']);
     }
     if (dataClassName == 'TypesRecord') {
-      return deserialize<_i149.TypesRecord>(data['data']);
+      return deserialize<_i150.TypesRecord>(data['data']);
     }
     if (dataClassName == 'TypesSet') {
-      return deserialize<_i150.TypesSet>(data['data']);
+      return deserialize<_i151.TypesSet>(data['data']);
     }
     if (dataClassName == 'TypesSetRequired') {
-      return deserialize<_i151.TypesSetRequired>(data['data']);
+      return deserialize<_i152.TypesSetRequired>(data['data']);
     }
     if (dataClassName == 'UniqueData') {
-      return deserialize<_i152.UniqueData>(data['data']);
+      return deserialize<_i153.UniqueData>(data['data']);
     }
-    if (dataClassName == 'Address') {
-      return deserialize<_i153.Address>(data['data']);
+    if (dataClassName == 'Citizen') {
+      return deserialize<_i154.Citizen>(data['data']);
     }
     if (dataClassName.startsWith('serverpod_auth.')) {
       data['className'] = dataClassName.substring(15);
-      return _i159.Protocol().deserializeByClassName(data);
+      return _i160.Protocol().deserializeByClassName(data);
     }
     if (dataClassName.startsWith('serverpod_test_module.')) {
       data['className'] = dataClassName.substring(22);
-      return _i154.Protocol().deserializeByClassName(data);
+      return _i155.Protocol().deserializeByClassName(data);
     }
     if (dataClassName == 'List<int>') {
       return deserialize<List<int>>(data['data']);
     }
     if (dataClassName == 'List<SimpleData>') {
-      return deserialize<List<_i157.SimpleData>>(data['data']);
+      return deserialize<List<_i158.SimpleData>>(data['data']);
     }
     if (dataClassName == 'List<serverpod_auth.UserInfo>') {
-      return deserialize<List<_i159.UserInfo>>(data['data']);
+      return deserialize<List<_i160.UserInfo>>(data['data']);
     }
     if (dataClassName == 'List<SimpleData>?') {
-      return deserialize<List<_i157.SimpleData>?>(data['data']);
+      return deserialize<List<_i158.SimpleData>?>(data['data']);
     }
     if (dataClassName == 'List<SimpleData?>') {
-      return deserialize<List<_i157.SimpleData?>>(data['data']);
+      return deserialize<List<_i158.SimpleData?>>(data['data']);
     }
     if (dataClassName == 'Set<int>') {
       return deserialize<Set<int>>(data['data']);
     }
     if (dataClassName == 'Set<SimpleData>') {
-      return deserialize<Set<_i157.SimpleData>>(data['data']);
+      return deserialize<Set<_i158.SimpleData>>(data['data']);
     }
     if (dataClassName == 'List<Set<SimpleData>>') {
-      return deserialize<List<Set<_i157.SimpleData>>>(data['data']);
+      return deserialize<List<Set<_i158.SimpleData>>>(data['data']);
     }
     if (dataClassName == '(int?,)?') {
       return deserialize<(int?,)?>(data['data']);
@@ -4675,7 +4705,7 @@ class Protocol extends _i1.SerializationManager {
           List<
               (
                 (int, String), {
-                (_i157.SimpleData, double) namedSubRecord
+                (_i158.SimpleData, double) namedSubRecord
               })?>?>(data['data']);
     }
     if (dataClassName ==
@@ -4683,7 +4713,7 @@ class Protocol extends _i1.SerializationManager {
       return deserialize<
           (
             String,
-            (Map<String, int>, {bool flag, _i157.SimpleData simpleData})
+            (Map<String, int>, {bool flag, _i158.SimpleData simpleData})
           )>(data['data']);
     }
     if (dataClassName == 'List<(String,int)>') {
@@ -4694,7 +4724,7 @@ class Protocol extends _i1.SerializationManager {
       return deserialize<
           (
             String,
-            (Map<String, int>, {bool flag, _i157.SimpleData simpleData})
+            (Map<String, int>, {bool flag, _i158.SimpleData simpleData})
           )?>(data['data']);
     }
     if (dataClassName == 'List<(String,int)>?') {
@@ -4780,7 +4810,7 @@ Map<String, dynamic>? mapRecordToJson(Record? record) {
       ],
     };
   }
-  if (record is (int, _i157.SimpleData)) {
+  if (record is (int, _i158.SimpleData)) {
     return {
       "p": [
         record.$1,
@@ -4810,7 +4840,7 @@ Map<String, dynamic>? mapRecordToJson(Record? record) {
       },
     };
   }
-  if (record is ({_i157.SimpleData data, int number})) {
+  if (record is ({_i158.SimpleData data, int number})) {
     return {
       "n": {
         "data": record.data,
@@ -4818,7 +4848,7 @@ Map<String, dynamic>? mapRecordToJson(Record? record) {
       },
     };
   }
-  if (record is ({_i157.SimpleData? data, int? number})) {
+  if (record is ({_i158.SimpleData? data, int? number})) {
     return {
       "n": {
         "data": record.data,
@@ -4854,7 +4884,7 @@ Map<String, dynamic>? mapRecordToJson(Record? record) {
       ],
     };
   }
-  if (record is (int, {_i157.SimpleData data})) {
+  if (record is (int, {_i158.SimpleData data})) {
     return {
       "p": [
         record.$1,
@@ -4872,14 +4902,14 @@ Map<String, dynamic>? mapRecordToJson(Record? record) {
       ],
     };
   }
-  if (record is ({(_i157.SimpleData, double) namedSubRecord})) {
+  if (record is ({(_i158.SimpleData, double) namedSubRecord})) {
     return {
       "n": {
         "namedSubRecord": mapRecordToJson(record.namedSubRecord),
       },
     };
   }
-  if (record is (_i157.SimpleData, double)) {
+  if (record is (_i158.SimpleData, double)) {
     return {
       "p": [
         record.$1,
@@ -4887,14 +4917,14 @@ Map<String, dynamic>? mapRecordToJson(Record? record) {
       ],
     };
   }
-  if (record is ({(_i157.SimpleData, double)? namedSubRecord})) {
+  if (record is ({(_i158.SimpleData, double)? namedSubRecord})) {
     return {
       "n": {
         "namedSubRecord": mapRecordToJson(record.namedSubRecord),
       },
     };
   }
-  if (record is ((int, String), {(_i157.SimpleData, double) namedSubRecord})) {
+  if (record is ((int, String), {(_i158.SimpleData, double) namedSubRecord})) {
     return {
       "p": [
         mapRecordToJson(record.$1),
@@ -4922,7 +4952,7 @@ Map<String, dynamic>? mapRecordToJson(Record? record) {
   }
   if (record is (
     String,
-    (Map<String, int>, {bool flag, _i157.SimpleData simpleData})
+    (Map<String, int>, {bool flag, _i158.SimpleData simpleData})
   )) {
     return {
       "p": [
@@ -4931,7 +4961,7 @@ Map<String, dynamic>? mapRecordToJson(Record? record) {
       ],
     };
   }
-  if (record is (Map<String, int>, {bool flag, _i157.SimpleData simpleData})) {
+  if (record is (Map<String, int>, {bool flag, _i158.SimpleData simpleData})) {
     return {
       "p": [
         record.$1,
@@ -4942,7 +4972,7 @@ Map<String, dynamic>? mapRecordToJson(Record? record) {
       },
     };
   }
-  if (record is (_i154.ModuleClass,)) {
+  if (record is (_i155.ModuleClass,)) {
     return {
       "p": [
         record.$1,
@@ -4956,7 +4986,7 @@ Map<String, dynamic>? mapRecordToJson(Record? record) {
       ],
     };
   }
-  if (record is (_i145.TestEnumStringified,)) {
+  if (record is (_i146.TestEnumStringified,)) {
     return {
       "p": [
         record.$1,
@@ -4970,14 +5000,14 @@ Map<String, dynamic>? mapRecordToJson(Record? record) {
       ],
     };
   }
-  if (record is ({_i145.TestEnumStringified value})) {
+  if (record is ({_i146.TestEnumStringified value})) {
     return {
       "n": {
         "value": record.value,
       },
     };
   }
-  if (record is ({_i154.ModuleClass value})) {
+  if (record is ({_i155.ModuleClass value})) {
     return {
       "n": {
         "value": record.value,
@@ -5001,7 +5031,7 @@ Map<String, dynamic>? mapRecordToJson(Record? record) {
       },
     };
   }
-  if (record is (_i144.TestEnum,)) {
+  if (record is (_i145.TestEnum,)) {
     return {
       "p": [
         record.$1,
@@ -5029,7 +5059,7 @@ Map<String, dynamic>? mapRecordToJson(Record? record) {
       ],
     };
   }
-  if (record is (_i155.ByteData,)) {
+  if (record is (_i156.ByteData,)) {
     return {
       "p": [
         record.$1,
@@ -5085,21 +5115,21 @@ Map<String, dynamic>? mapRecordToJson(Record? record) {
       ],
     };
   }
-  if (record is (_i138.SimpleData,)) {
+  if (record is (_i139.SimpleData,)) {
     return {
       "p": [
         record.$1,
       ],
     };
   }
-  if (record is ({_i138.SimpleData namedModel})) {
+  if (record is ({_i139.SimpleData namedModel})) {
     return {
       "n": {
         "namedModel": record.namedModel,
       },
     };
   }
-  if (record is (_i138.SimpleData, {_i138.SimpleData namedModel})) {
+  if (record is (_i139.SimpleData, {_i139.SimpleData namedModel})) {
     return {
       "p": [
         record.$1,
@@ -5128,8 +5158,8 @@ Map<String, dynamic>? mapRecordToJson(Record? record) {
     };
   }
   if (record is (
-    (List<(_i138.SimpleData,)>,), {
-    (_i138.SimpleData, Map<String, _i138.SimpleData>) namedNestedRecord
+    (List<(_i139.SimpleData,)>,), {
+    (_i139.SimpleData, Map<String, _i139.SimpleData>) namedNestedRecord
   })) {
     return {
       "p": [
@@ -5140,14 +5170,14 @@ Map<String, dynamic>? mapRecordToJson(Record? record) {
       },
     };
   }
-  if (record is (List<(_i138.SimpleData,)>,)) {
+  if (record is (List<(_i139.SimpleData,)>,)) {
     return {
       "p": [
         mapContainerToJson(record.$1),
       ],
     };
   }
-  if (record is (_i138.SimpleData, Map<String, _i138.SimpleData>)) {
+  if (record is (_i139.SimpleData, Map<String, _i139.SimpleData>)) {
     return {
       "p": [
         record.$1,

--- a/tests/serverpod_test_server/lib/src/generated/object_with_nullable_custom_class.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_nullable_custom_class.dart
@@ -1,0 +1,203 @@
+/* AUTOMATICALLY GENERATED CODE DO NOT MODIFY */
+/*   To generate run: "serverpod generate"    */
+
+// ignore_for_file: implementation_imports
+// ignore_for_file: library_private_types_in_public_api
+// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: public_member_api_docs
+// ignore_for_file: type_literal_in_constant_pattern
+// ignore_for_file: use_super_parameters
+// ignore_for_file: invalid_use_of_internal_member
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:serverpod_test_shared/serverpod_test_shared.dart' as _i2;
+
+abstract class ObjectWithNullableCustomClass
+    implements _i1.SerializableModel, _i1.ProtocolSerialization {
+  ObjectWithNullableCustomClass._({
+    this.nullableCustomClassWithoutProtocolSerialization,
+    this.nullableCustomClassWithProtocolSerialization,
+    this.nullableCustomClassWithProtocolSerializationMethod,
+    required this.nonNullableCustomClass,
+  });
+
+  factory ObjectWithNullableCustomClass({
+    _i2.CustomClassWithoutProtocolSerialization?
+        nullableCustomClassWithoutProtocolSerialization,
+    _i2.CustomClassWithProtocolSerialization?
+        nullableCustomClassWithProtocolSerialization,
+    _i2.CustomClassWithProtocolSerializationMethod?
+        nullableCustomClassWithProtocolSerializationMethod,
+    required _i2.CustomClassWithProtocolSerialization nonNullableCustomClass,
+  }) = _ObjectWithNullableCustomClassImpl;
+
+  factory ObjectWithNullableCustomClass.fromJson(
+      Map<String, dynamic> jsonSerialization) {
+    return ObjectWithNullableCustomClass(
+      nullableCustomClassWithoutProtocolSerialization: jsonSerialization[
+                  'nullableCustomClassWithoutProtocolSerialization'] ==
+              null
+          ? null
+          : _i2.CustomClassWithoutProtocolSerialization.fromJson(
+              jsonSerialization[
+                  'nullableCustomClassWithoutProtocolSerialization']),
+      nullableCustomClassWithProtocolSerialization:
+          jsonSerialization['nullableCustomClassWithProtocolSerialization'] ==
+                  null
+              ? null
+              : _i2.CustomClassWithProtocolSerialization.fromJson(
+                  jsonSerialization[
+                      'nullableCustomClassWithProtocolSerialization']),
+      nullableCustomClassWithProtocolSerializationMethod: jsonSerialization[
+                  'nullableCustomClassWithProtocolSerializationMethod'] ==
+              null
+          ? null
+          : _i2.CustomClassWithProtocolSerializationMethod.fromJson(
+              jsonSerialization[
+                  'nullableCustomClassWithProtocolSerializationMethod']),
+      nonNullableCustomClass: _i2.CustomClassWithProtocolSerialization.fromJson(
+          jsonSerialization['nonNullableCustomClass']),
+    );
+  }
+
+  _i2.CustomClassWithoutProtocolSerialization?
+      nullableCustomClassWithoutProtocolSerialization;
+
+  _i2.CustomClassWithProtocolSerialization?
+      nullableCustomClassWithProtocolSerialization;
+
+  _i2.CustomClassWithProtocolSerializationMethod?
+      nullableCustomClassWithProtocolSerializationMethod;
+
+  _i2.CustomClassWithProtocolSerialization nonNullableCustomClass;
+
+  /// Returns a shallow copy of this [ObjectWithNullableCustomClass]
+  /// with some or all fields replaced by the given arguments.
+  @_i1.useResult
+  ObjectWithNullableCustomClass copyWith({
+    _i2.CustomClassWithoutProtocolSerialization?
+        nullableCustomClassWithoutProtocolSerialization,
+    _i2.CustomClassWithProtocolSerialization?
+        nullableCustomClassWithProtocolSerialization,
+    _i2.CustomClassWithProtocolSerializationMethod?
+        nullableCustomClassWithProtocolSerializationMethod,
+    _i2.CustomClassWithProtocolSerialization? nonNullableCustomClass,
+  });
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      if (nullableCustomClassWithoutProtocolSerialization != null)
+        'nullableCustomClassWithoutProtocolSerialization':
+            nullableCustomClassWithoutProtocolSerialization?.toJson(),
+      if (nullableCustomClassWithProtocolSerialization != null)
+        'nullableCustomClassWithProtocolSerialization':
+            nullableCustomClassWithProtocolSerialization?.toJson(),
+      if (nullableCustomClassWithProtocolSerializationMethod != null)
+        'nullableCustomClassWithProtocolSerializationMethod':
+            nullableCustomClassWithProtocolSerializationMethod?.toJson(),
+      'nonNullableCustomClass': nonNullableCustomClass.toJson(),
+    };
+  }
+
+  @override
+  Map<String, dynamic> toJsonForProtocol() {
+    return {
+      if (nullableCustomClassWithoutProtocolSerialization != null)
+        'nullableCustomClassWithoutProtocolSerialization':
+// ignore: unnecessary_type_check
+            nullableCustomClassWithoutProtocolSerialization
+                    is _i1.ProtocolSerialization
+                ? (nullableCustomClassWithoutProtocolSerialization
+                        as _i1.ProtocolSerialization)
+                    .toJsonForProtocol()
+                : nullableCustomClassWithoutProtocolSerialization?.toJson(),
+      if (nullableCustomClassWithProtocolSerialization != null)
+        'nullableCustomClassWithProtocolSerialization':
+// ignore: unnecessary_type_check
+            nullableCustomClassWithProtocolSerialization
+                    is _i1.ProtocolSerialization
+                ? (nullableCustomClassWithProtocolSerialization
+                        as _i1.ProtocolSerialization)
+                    .toJsonForProtocol()
+                : nullableCustomClassWithProtocolSerialization?.toJson(),
+      if (nullableCustomClassWithProtocolSerializationMethod != null)
+        'nullableCustomClassWithProtocolSerializationMethod':
+// ignore: unnecessary_type_check
+            nullableCustomClassWithProtocolSerializationMethod
+                    is _i1.ProtocolSerialization
+                ? (nullableCustomClassWithProtocolSerializationMethod
+                        as _i1.ProtocolSerialization)
+                    .toJsonForProtocol()
+                : nullableCustomClassWithProtocolSerializationMethod?.toJson(),
+      'nonNullableCustomClass':
+// ignore: unnecessary_type_check
+          nonNullableCustomClass is _i1.ProtocolSerialization
+              ? (nonNullableCustomClass as _i1.ProtocolSerialization)
+                  .toJsonForProtocol()
+              : nonNullableCustomClass.toJson(),
+    };
+  }
+
+  @override
+  String toString() {
+    return _i1.SerializationManager.encode(this);
+  }
+}
+
+class _Undefined {}
+
+class _ObjectWithNullableCustomClassImpl extends ObjectWithNullableCustomClass {
+  _ObjectWithNullableCustomClassImpl({
+    _i2.CustomClassWithoutProtocolSerialization?
+        nullableCustomClassWithoutProtocolSerialization,
+    _i2.CustomClassWithProtocolSerialization?
+        nullableCustomClassWithProtocolSerialization,
+    _i2.CustomClassWithProtocolSerializationMethod?
+        nullableCustomClassWithProtocolSerializationMethod,
+    required _i2.CustomClassWithProtocolSerialization nonNullableCustomClass,
+  }) : super._(
+          nullableCustomClassWithoutProtocolSerialization:
+              nullableCustomClassWithoutProtocolSerialization,
+          nullableCustomClassWithProtocolSerialization:
+              nullableCustomClassWithProtocolSerialization,
+          nullableCustomClassWithProtocolSerializationMethod:
+              nullableCustomClassWithProtocolSerializationMethod,
+          nonNullableCustomClass: nonNullableCustomClass,
+        );
+
+  /// Returns a shallow copy of this [ObjectWithNullableCustomClass]
+  /// with some or all fields replaced by the given arguments.
+  @_i1.useResult
+  @override
+  ObjectWithNullableCustomClass copyWith({
+    Object? nullableCustomClassWithoutProtocolSerialization = _Undefined,
+    Object? nullableCustomClassWithProtocolSerialization = _Undefined,
+    Object? nullableCustomClassWithProtocolSerializationMethod = _Undefined,
+    _i2.CustomClassWithProtocolSerialization? nonNullableCustomClass,
+  }) {
+    return ObjectWithNullableCustomClass(
+      nullableCustomClassWithoutProtocolSerialization:
+          nullableCustomClassWithoutProtocolSerialization
+                  is _i2.CustomClassWithoutProtocolSerialization?
+              ? nullableCustomClassWithoutProtocolSerialization
+              : this
+                  .nullableCustomClassWithoutProtocolSerialization
+                  ?.copyWith(),
+      nullableCustomClassWithProtocolSerialization:
+          nullableCustomClassWithProtocolSerialization
+                  is _i2.CustomClassWithProtocolSerialization?
+              ? nullableCustomClassWithProtocolSerialization
+              : this.nullableCustomClassWithProtocolSerialization?.copyWith(),
+      nullableCustomClassWithProtocolSerializationMethod:
+          nullableCustomClassWithProtocolSerializationMethod
+                  is _i2.CustomClassWithProtocolSerializationMethod?
+              ? nullableCustomClassWithProtocolSerializationMethod
+              : this
+                  .nullableCustomClassWithProtocolSerializationMethod
+                  ?.copyWith(),
+      nonNullableCustomClass:
+          nonNullableCustomClass ?? this.nonNullableCustomClass.copyWith(),
+    );
+  }
+}

--- a/tests/serverpod_test_server/lib/src/generated/protocol.dart
+++ b/tests/serverpod_test_server/lib/src/generated/protocol.dart
@@ -20,7 +20,7 @@ import 'inheritance/child_class.dart' as _i6;
 import 'inheritance/child_with_default.dart' as _i7;
 import 'inheritance/parent_class.dart' as _i8;
 import 'inheritance/sealed_parent.dart' as _i9;
-import 'defaults/string/string_default_persist.dart' as _i10;
+import 'defaults/uri/uri_default.dart' as _i10;
 import 'changed_id_type/one_to_many/comment.dart' as _i11;
 import 'changed_id_type/one_to_many/customer.dart' as _i12;
 import 'changed_id_type/one_to_many/order.dart' as _i13;
@@ -64,8 +64,8 @@ import 'defaults/integer/int_default_persist.dart' as _i50;
 import 'defaults/string/string_default.dart' as _i51;
 import 'defaults/string/string_default_mix.dart' as _i52;
 import 'defaults/string/string_default_model.dart' as _i53;
-import 'by_index_enum_with_name_value.dart' as _i54;
-import 'defaults/uri/uri_default.dart' as _i55;
+import 'defaults/string/string_default_persist.dart' as _i54;
+import 'by_index_enum_with_name_value.dart' as _i55;
 import 'defaults/uri/uri_default_mix.dart' as _i56;
 import 'defaults/uri/uri_default_model.dart' as _i57;
 import 'defaults/uri/uri_default_persist.dart' as _i58;
@@ -124,8 +124,8 @@ import 'models_with_relations/one_to_many/implicit/chapter.dart' as _i102;
 import 'models_with_relations/one_to_many/order.dart' as _i103;
 import 'models_with_relations/one_to_one/address.dart' as _i104;
 import 'models_with_relations/one_to_one/citizen.dart' as _i105;
-import 'my_feature/models/my_feature_model.dart' as _i106;
-import 'models_with_relations/one_to_one/town.dart' as _i107;
+import 'models_with_relations/one_to_one/company.dart' as _i106;
+import 'my_feature/models/my_feature_model.dart' as _i107;
 import 'models_with_relations/self_relation/many_to_many/blocking.dart'
     as _i108;
 import 'models_with_relations/self_relation/many_to_many/member.dart' as _i109;
@@ -143,46 +143,47 @@ import 'object_with_enum.dart' as _i120;
 import 'object_with_half_vector.dart' as _i121;
 import 'object_with_index.dart' as _i122;
 import 'object_with_maps.dart' as _i123;
-import 'object_with_object.dart' as _i124;
-import 'object_with_parent.dart' as _i125;
-import 'object_with_self_parent.dart' as _i126;
-import 'object_with_sparse_vector.dart' as _i127;
-import 'object_with_uuid.dart' as _i128;
-import 'object_with_vector.dart' as _i129;
-import 'record.dart' as _i130;
-import 'related_unique_data.dart' as _i131;
-import 'scopes/scope_none_fields.dart' as _i132;
-import 'scopes/scope_server_only_field.dart' as _i133;
-import 'changed_id_type/nested_one_to_many/team.dart' as _i134;
-import 'scopes/serverOnly/default_server_only_class.dart' as _i135;
-import 'scopes/serverOnly/default_server_only_enum.dart' as _i136;
-import 'scopes/serverOnly/not_server_only_class.dart' as _i137;
-import 'scopes/serverOnly/not_server_only_enum.dart' as _i138;
-import 'scopes/serverOnly/server_only_class.dart' as _i139;
-import 'scopes/serverOnly/server_only_enum.dart' as _i140;
-import 'scopes/server_only_class_field.dart' as _i141;
-import 'server_only_default.dart' as _i142;
-import 'simple_data.dart' as _i143;
-import 'simple_data_list.dart' as _i144;
-import 'simple_data_map.dart' as _i145;
-import 'simple_data_object.dart' as _i146;
-import 'simple_date_time.dart' as _i147;
-import 'subfolder/model_in_subfolder.dart' as _i148;
-import 'test_enum.dart' as _i149;
-import 'test_enum_stringified.dart' as _i150;
-import 'types.dart' as _i151;
-import 'types_list.dart' as _i152;
-import 'types_map.dart' as _i153;
-import 'types_record.dart' as _i154;
-import 'types_set.dart' as _i155;
-import 'types_set_required.dart' as _i156;
-import 'unique_data.dart' as _i157;
-import 'models_with_relations/one_to_one/company.dart' as _i158;
-import 'dart:typed_data' as _i159;
-import 'package:serverpod_test_shared/serverpod_test_shared.dart' as _i160;
-import 'package:serverpod_test_server/src/generated/simple_data.dart' as _i161;
-import 'package:serverpod_test_server/src/generated/test_enum.dart' as _i162;
-import 'package:serverpod_test_server/src/generated/types.dart' as _i163;
+import 'object_with_nullable_custom_class.dart' as _i124;
+import 'object_with_object.dart' as _i125;
+import 'object_with_parent.dart' as _i126;
+import 'object_with_self_parent.dart' as _i127;
+import 'object_with_sparse_vector.dart' as _i128;
+import 'object_with_uuid.dart' as _i129;
+import 'object_with_vector.dart' as _i130;
+import 'record.dart' as _i131;
+import 'related_unique_data.dart' as _i132;
+import 'scopes/scope_none_fields.dart' as _i133;
+import 'scopes/scope_server_only_field.dart' as _i134;
+import 'changed_id_type/nested_one_to_many/team.dart' as _i135;
+import 'scopes/serverOnly/default_server_only_class.dart' as _i136;
+import 'scopes/serverOnly/default_server_only_enum.dart' as _i137;
+import 'scopes/serverOnly/not_server_only_class.dart' as _i138;
+import 'scopes/serverOnly/not_server_only_enum.dart' as _i139;
+import 'scopes/serverOnly/server_only_class.dart' as _i140;
+import 'scopes/serverOnly/server_only_enum.dart' as _i141;
+import 'scopes/server_only_class_field.dart' as _i142;
+import 'server_only_default.dart' as _i143;
+import 'simple_data.dart' as _i144;
+import 'simple_data_list.dart' as _i145;
+import 'simple_data_map.dart' as _i146;
+import 'simple_data_object.dart' as _i147;
+import 'simple_date_time.dart' as _i148;
+import 'subfolder/model_in_subfolder.dart' as _i149;
+import 'test_enum.dart' as _i150;
+import 'test_enum_stringified.dart' as _i151;
+import 'types.dart' as _i152;
+import 'types_list.dart' as _i153;
+import 'types_map.dart' as _i154;
+import 'types_record.dart' as _i155;
+import 'types_set.dart' as _i156;
+import 'types_set_required.dart' as _i157;
+import 'unique_data.dart' as _i158;
+import 'models_with_relations/one_to_one/town.dart' as _i159;
+import 'dart:typed_data' as _i160;
+import 'package:serverpod_test_shared/serverpod_test_shared.dart' as _i161;
+import 'package:serverpod_test_server/src/generated/simple_data.dart' as _i162;
+import 'package:serverpod_test_server/src/generated/test_enum.dart' as _i163;
+import 'package:serverpod_test_server/src/generated/types.dart' as _i164;
 export 'by_index_enum_with_name_value.dart';
 export 'by_name_enum_with_name_value.dart';
 export 'changed_id_type/many_to_many/course.dart';
@@ -303,6 +304,7 @@ export 'object_with_enum.dart';
 export 'object_with_half_vector.dart';
 export 'object_with_index.dart';
 export 'object_with_maps.dart';
+export 'object_with_nullable_custom_class.dart';
 export 'object_with_object.dart';
 export 'object_with_parent.dart';
 export 'object_with_self_parent.dart';
@@ -6752,8 +6754,8 @@ class Protocol extends _i1.SerializationManagerServer {
     if (t == _i9.SealedOtherChild) {
       return _i9.SealedOtherChild.fromJson(data) as T;
     }
-    if (t == _i10.StringDefaultPersist) {
-      return _i10.StringDefaultPersist.fromJson(data) as T;
+    if (t == _i10.UriDefault) {
+      return _i10.UriDefault.fromJson(data) as T;
     }
     if (t == _i11.CommentInt) {
       return _i11.CommentInt.fromJson(data) as T;
@@ -6884,11 +6886,11 @@ class Protocol extends _i1.SerializationManagerServer {
     if (t == _i53.StringDefaultModel) {
       return _i53.StringDefaultModel.fromJson(data) as T;
     }
-    if (t == _i54.ByIndexEnumWithNameValue) {
-      return _i54.ByIndexEnumWithNameValue.fromJson(data) as T;
+    if (t == _i54.StringDefaultPersist) {
+      return _i54.StringDefaultPersist.fromJson(data) as T;
     }
-    if (t == _i55.UriDefault) {
-      return _i55.UriDefault.fromJson(data) as T;
+    if (t == _i55.ByIndexEnumWithNameValue) {
+      return _i55.ByIndexEnumWithNameValue.fromJson(data) as T;
     }
     if (t == _i56.UriDefaultMix) {
       return _i56.UriDefaultMix.fromJson(data) as T;
@@ -7040,11 +7042,11 @@ class Protocol extends _i1.SerializationManagerServer {
     if (t == _i105.Citizen) {
       return _i105.Citizen.fromJson(data) as T;
     }
-    if (t == _i106.MyFeatureModel) {
-      return _i106.MyFeatureModel.fromJson(data) as T;
+    if (t == _i106.Company) {
+      return _i106.Company.fromJson(data) as T;
     }
-    if (t == _i107.Town) {
-      return _i107.Town.fromJson(data) as T;
+    if (t == _i107.MyFeatureModel) {
+      return _i107.MyFeatureModel.fromJson(data) as T;
     }
     if (t == _i108.Blocking) {
       return _i108.Blocking.fromJson(data) as T;
@@ -7094,110 +7096,113 @@ class Protocol extends _i1.SerializationManagerServer {
     if (t == _i123.ObjectWithMaps) {
       return _i123.ObjectWithMaps.fromJson(data) as T;
     }
-    if (t == _i124.ObjectWithObject) {
-      return _i124.ObjectWithObject.fromJson(data) as T;
+    if (t == _i124.ObjectWithNullableCustomClass) {
+      return _i124.ObjectWithNullableCustomClass.fromJson(data) as T;
     }
-    if (t == _i125.ObjectWithParent) {
-      return _i125.ObjectWithParent.fromJson(data) as T;
+    if (t == _i125.ObjectWithObject) {
+      return _i125.ObjectWithObject.fromJson(data) as T;
     }
-    if (t == _i126.ObjectWithSelfParent) {
-      return _i126.ObjectWithSelfParent.fromJson(data) as T;
+    if (t == _i126.ObjectWithParent) {
+      return _i126.ObjectWithParent.fromJson(data) as T;
     }
-    if (t == _i127.ObjectWithSparseVector) {
-      return _i127.ObjectWithSparseVector.fromJson(data) as T;
+    if (t == _i127.ObjectWithSelfParent) {
+      return _i127.ObjectWithSelfParent.fromJson(data) as T;
     }
-    if (t == _i128.ObjectWithUuid) {
-      return _i128.ObjectWithUuid.fromJson(data) as T;
+    if (t == _i128.ObjectWithSparseVector) {
+      return _i128.ObjectWithSparseVector.fromJson(data) as T;
     }
-    if (t == _i129.ObjectWithVector) {
-      return _i129.ObjectWithVector.fromJson(data) as T;
+    if (t == _i129.ObjectWithUuid) {
+      return _i129.ObjectWithUuid.fromJson(data) as T;
     }
-    if (t == _i130.Record) {
-      return _i130.Record.fromJson(data) as T;
+    if (t == _i130.ObjectWithVector) {
+      return _i130.ObjectWithVector.fromJson(data) as T;
     }
-    if (t == _i131.RelatedUniqueData) {
-      return _i131.RelatedUniqueData.fromJson(data) as T;
+    if (t == _i131.Record) {
+      return _i131.Record.fromJson(data) as T;
     }
-    if (t == _i132.ScopeNoneFields) {
-      return _i132.ScopeNoneFields.fromJson(data) as T;
+    if (t == _i132.RelatedUniqueData) {
+      return _i132.RelatedUniqueData.fromJson(data) as T;
     }
-    if (t == _i133.ScopeServerOnlyField) {
-      return _i133.ScopeServerOnlyField.fromJson(data) as T;
+    if (t == _i133.ScopeNoneFields) {
+      return _i133.ScopeNoneFields.fromJson(data) as T;
     }
-    if (t == _i134.TeamInt) {
-      return _i134.TeamInt.fromJson(data) as T;
+    if (t == _i134.ScopeServerOnlyField) {
+      return _i134.ScopeServerOnlyField.fromJson(data) as T;
     }
-    if (t == _i135.DefaultServerOnlyClass) {
-      return _i135.DefaultServerOnlyClass.fromJson(data) as T;
+    if (t == _i135.TeamInt) {
+      return _i135.TeamInt.fromJson(data) as T;
     }
-    if (t == _i136.DefaultServerOnlyEnum) {
-      return _i136.DefaultServerOnlyEnum.fromJson(data) as T;
+    if (t == _i136.DefaultServerOnlyClass) {
+      return _i136.DefaultServerOnlyClass.fromJson(data) as T;
     }
-    if (t == _i137.NotServerOnlyClass) {
-      return _i137.NotServerOnlyClass.fromJson(data) as T;
+    if (t == _i137.DefaultServerOnlyEnum) {
+      return _i137.DefaultServerOnlyEnum.fromJson(data) as T;
     }
-    if (t == _i138.NotServerOnlyEnum) {
-      return _i138.NotServerOnlyEnum.fromJson(data) as T;
+    if (t == _i138.NotServerOnlyClass) {
+      return _i138.NotServerOnlyClass.fromJson(data) as T;
     }
-    if (t == _i139.ServerOnlyClass) {
-      return _i139.ServerOnlyClass.fromJson(data) as T;
+    if (t == _i139.NotServerOnlyEnum) {
+      return _i139.NotServerOnlyEnum.fromJson(data) as T;
     }
-    if (t == _i140.ServerOnlyEnum) {
-      return _i140.ServerOnlyEnum.fromJson(data) as T;
+    if (t == _i140.ServerOnlyClass) {
+      return _i140.ServerOnlyClass.fromJson(data) as T;
     }
-    if (t == _i141.ServerOnlyClassField) {
-      return _i141.ServerOnlyClassField.fromJson(data) as T;
+    if (t == _i141.ServerOnlyEnum) {
+      return _i141.ServerOnlyEnum.fromJson(data) as T;
     }
-    if (t == _i142.ServerOnlyDefault) {
-      return _i142.ServerOnlyDefault.fromJson(data) as T;
+    if (t == _i142.ServerOnlyClassField) {
+      return _i142.ServerOnlyClassField.fromJson(data) as T;
     }
-    if (t == _i143.SimpleData) {
-      return _i143.SimpleData.fromJson(data) as T;
+    if (t == _i143.ServerOnlyDefault) {
+      return _i143.ServerOnlyDefault.fromJson(data) as T;
     }
-    if (t == _i144.SimpleDataList) {
-      return _i144.SimpleDataList.fromJson(data) as T;
+    if (t == _i144.SimpleData) {
+      return _i144.SimpleData.fromJson(data) as T;
     }
-    if (t == _i145.SimpleDataMap) {
-      return _i145.SimpleDataMap.fromJson(data) as T;
+    if (t == _i145.SimpleDataList) {
+      return _i145.SimpleDataList.fromJson(data) as T;
     }
-    if (t == _i146.SimpleDataObject) {
-      return _i146.SimpleDataObject.fromJson(data) as T;
+    if (t == _i146.SimpleDataMap) {
+      return _i146.SimpleDataMap.fromJson(data) as T;
     }
-    if (t == _i147.SimpleDateTime) {
-      return _i147.SimpleDateTime.fromJson(data) as T;
+    if (t == _i147.SimpleDataObject) {
+      return _i147.SimpleDataObject.fromJson(data) as T;
     }
-    if (t == _i148.ModelInSubfolder) {
-      return _i148.ModelInSubfolder.fromJson(data) as T;
+    if (t == _i148.SimpleDateTime) {
+      return _i148.SimpleDateTime.fromJson(data) as T;
     }
-    if (t == _i149.TestEnum) {
-      return _i149.TestEnum.fromJson(data) as T;
+    if (t == _i149.ModelInSubfolder) {
+      return _i149.ModelInSubfolder.fromJson(data) as T;
     }
-    if (t == _i150.TestEnumStringified) {
-      return _i150.TestEnumStringified.fromJson(data) as T;
+    if (t == _i150.TestEnum) {
+      return _i150.TestEnum.fromJson(data) as T;
     }
-    if (t == _i151.Types) {
-      return _i151.Types.fromJson(data) as T;
+    if (t == _i151.TestEnumStringified) {
+      return _i151.TestEnumStringified.fromJson(data) as T;
     }
-    if (t == _i152.TypesList) {
-      return _i152.TypesList.fromJson(data) as T;
+    if (t == _i152.Types) {
+      return _i152.Types.fromJson(data) as T;
     }
-    if (t == _i153.TypesMap) {
-      return _i153.TypesMap.fromJson(data) as T;
+    if (t == _i153.TypesList) {
+      return _i153.TypesList.fromJson(data) as T;
     }
-    if (t == _i154.TypesRecord) {
-      return _i154.TypesRecord.fromJson(data) as T;
+    if (t == _i154.TypesMap) {
+      return _i154.TypesMap.fromJson(data) as T;
     }
-    if (t == _i155.TypesSet) {
-      return _i155.TypesSet.fromJson(data) as T;
+    if (t == _i155.TypesRecord) {
+      return _i155.TypesRecord.fromJson(data) as T;
     }
-    if (t == _i156.TypesSetRequired) {
-      return _i156.TypesSetRequired.fromJson(data) as T;
+    if (t == _i156.TypesSet) {
+      return _i156.TypesSet.fromJson(data) as T;
     }
-    if (t == _i157.UniqueData) {
-      return _i157.UniqueData.fromJson(data) as T;
+    if (t == _i157.TypesSetRequired) {
+      return _i157.TypesSetRequired.fromJson(data) as T;
     }
-    if (t == _i158.Company) {
-      return _i158.Company.fromJson(data) as T;
+    if (t == _i158.UniqueData) {
+      return _i158.UniqueData.fromJson(data) as T;
+    }
+    if (t == _i159.Town) {
+      return _i159.Town.fromJson(data) as T;
     }
     if (t == _i1.getType<_i5.ScopeServerOnlyFieldChild?>()) {
       return (data != null
@@ -7222,9 +7227,8 @@ class Protocol extends _i1.SerializationManagerServer {
     if (t == _i1.getType<_i9.SealedOtherChild?>()) {
       return (data != null ? _i9.SealedOtherChild.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i10.StringDefaultPersist?>()) {
-      return (data != null ? _i10.StringDefaultPersist.fromJson(data) : null)
-          as T;
+    if (t == _i1.getType<_i10.UriDefault?>()) {
+      return (data != null ? _i10.UriDefault.fromJson(data) : null) as T;
     }
     if (t == _i1.getType<_i11.CommentInt?>()) {
       return (data != null ? _i11.CommentInt.fromJson(data) : null) as T;
@@ -7368,13 +7372,14 @@ class Protocol extends _i1.SerializationManagerServer {
       return (data != null ? _i53.StringDefaultModel.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i54.ByIndexEnumWithNameValue?>()) {
-      return (data != null
-          ? _i54.ByIndexEnumWithNameValue.fromJson(data)
-          : null) as T;
+    if (t == _i1.getType<_i54.StringDefaultPersist?>()) {
+      return (data != null ? _i54.StringDefaultPersist.fromJson(data) : null)
+          as T;
     }
-    if (t == _i1.getType<_i55.UriDefault?>()) {
-      return (data != null ? _i55.UriDefault.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i55.ByIndexEnumWithNameValue?>()) {
+      return (data != null
+          ? _i55.ByIndexEnumWithNameValue.fromJson(data)
+          : null) as T;
     }
     if (t == _i1.getType<_i56.UriDefaultMix?>()) {
       return (data != null ? _i56.UriDefaultMix.fromJson(data) : null) as T;
@@ -7545,11 +7550,11 @@ class Protocol extends _i1.SerializationManagerServer {
     if (t == _i1.getType<_i105.Citizen?>()) {
       return (data != null ? _i105.Citizen.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i106.MyFeatureModel?>()) {
-      return (data != null ? _i106.MyFeatureModel.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i106.Company?>()) {
+      return (data != null ? _i106.Company.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i107.Town?>()) {
-      return (data != null ? _i107.Town.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i107.MyFeatureModel?>()) {
+      return (data != null ? _i107.MyFeatureModel.fromJson(data) : null) as T;
     }
     if (t == _i1.getType<_i108.Blocking?>()) {
       return (data != null ? _i108.Blocking.fromJson(data) : null) as T;
@@ -7605,121 +7610,126 @@ class Protocol extends _i1.SerializationManagerServer {
     if (t == _i1.getType<_i123.ObjectWithMaps?>()) {
       return (data != null ? _i123.ObjectWithMaps.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i124.ObjectWithObject?>()) {
-      return (data != null ? _i124.ObjectWithObject.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i124.ObjectWithNullableCustomClass?>()) {
+      return (data != null
+          ? _i124.ObjectWithNullableCustomClass.fromJson(data)
+          : null) as T;
     }
-    if (t == _i1.getType<_i125.ObjectWithParent?>()) {
-      return (data != null ? _i125.ObjectWithParent.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i125.ObjectWithObject?>()) {
+      return (data != null ? _i125.ObjectWithObject.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i126.ObjectWithSelfParent?>()) {
-      return (data != null ? _i126.ObjectWithSelfParent.fromJson(data) : null)
+    if (t == _i1.getType<_i126.ObjectWithParent?>()) {
+      return (data != null ? _i126.ObjectWithParent.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i127.ObjectWithSelfParent?>()) {
+      return (data != null ? _i127.ObjectWithSelfParent.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i127.ObjectWithSparseVector?>()) {
-      return (data != null ? _i127.ObjectWithSparseVector.fromJson(data) : null)
+    if (t == _i1.getType<_i128.ObjectWithSparseVector?>()) {
+      return (data != null ? _i128.ObjectWithSparseVector.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i128.ObjectWithUuid?>()) {
-      return (data != null ? _i128.ObjectWithUuid.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i129.ObjectWithUuid?>()) {
+      return (data != null ? _i129.ObjectWithUuid.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i129.ObjectWithVector?>()) {
-      return (data != null ? _i129.ObjectWithVector.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i130.ObjectWithVector?>()) {
+      return (data != null ? _i130.ObjectWithVector.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i130.Record?>()) {
-      return (data != null ? _i130.Record.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i131.Record?>()) {
+      return (data != null ? _i131.Record.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i131.RelatedUniqueData?>()) {
-      return (data != null ? _i131.RelatedUniqueData.fromJson(data) : null)
+    if (t == _i1.getType<_i132.RelatedUniqueData?>()) {
+      return (data != null ? _i132.RelatedUniqueData.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i132.ScopeNoneFields?>()) {
-      return (data != null ? _i132.ScopeNoneFields.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i133.ScopeNoneFields?>()) {
+      return (data != null ? _i133.ScopeNoneFields.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i133.ScopeServerOnlyField?>()) {
-      return (data != null ? _i133.ScopeServerOnlyField.fromJson(data) : null)
+    if (t == _i1.getType<_i134.ScopeServerOnlyField?>()) {
+      return (data != null ? _i134.ScopeServerOnlyField.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i134.TeamInt?>()) {
-      return (data != null ? _i134.TeamInt.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i135.TeamInt?>()) {
+      return (data != null ? _i135.TeamInt.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i135.DefaultServerOnlyClass?>()) {
-      return (data != null ? _i135.DefaultServerOnlyClass.fromJson(data) : null)
+    if (t == _i1.getType<_i136.DefaultServerOnlyClass?>()) {
+      return (data != null ? _i136.DefaultServerOnlyClass.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i136.DefaultServerOnlyEnum?>()) {
-      return (data != null ? _i136.DefaultServerOnlyEnum.fromJson(data) : null)
+    if (t == _i1.getType<_i137.DefaultServerOnlyEnum?>()) {
+      return (data != null ? _i137.DefaultServerOnlyEnum.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i137.NotServerOnlyClass?>()) {
-      return (data != null ? _i137.NotServerOnlyClass.fromJson(data) : null)
+    if (t == _i1.getType<_i138.NotServerOnlyClass?>()) {
+      return (data != null ? _i138.NotServerOnlyClass.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i138.NotServerOnlyEnum?>()) {
-      return (data != null ? _i138.NotServerOnlyEnum.fromJson(data) : null)
+    if (t == _i1.getType<_i139.NotServerOnlyEnum?>()) {
+      return (data != null ? _i139.NotServerOnlyEnum.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i139.ServerOnlyClass?>()) {
-      return (data != null ? _i139.ServerOnlyClass.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i140.ServerOnlyClass?>()) {
+      return (data != null ? _i140.ServerOnlyClass.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i140.ServerOnlyEnum?>()) {
-      return (data != null ? _i140.ServerOnlyEnum.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i141.ServerOnlyEnum?>()) {
+      return (data != null ? _i141.ServerOnlyEnum.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i141.ServerOnlyClassField?>()) {
-      return (data != null ? _i141.ServerOnlyClassField.fromJson(data) : null)
+    if (t == _i1.getType<_i142.ServerOnlyClassField?>()) {
+      return (data != null ? _i142.ServerOnlyClassField.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i142.ServerOnlyDefault?>()) {
-      return (data != null ? _i142.ServerOnlyDefault.fromJson(data) : null)
+    if (t == _i1.getType<_i143.ServerOnlyDefault?>()) {
+      return (data != null ? _i143.ServerOnlyDefault.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i143.SimpleData?>()) {
-      return (data != null ? _i143.SimpleData.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i144.SimpleData?>()) {
+      return (data != null ? _i144.SimpleData.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i144.SimpleDataList?>()) {
-      return (data != null ? _i144.SimpleDataList.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i145.SimpleDataList?>()) {
+      return (data != null ? _i145.SimpleDataList.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i145.SimpleDataMap?>()) {
-      return (data != null ? _i145.SimpleDataMap.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i146.SimpleDataMap?>()) {
+      return (data != null ? _i146.SimpleDataMap.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i146.SimpleDataObject?>()) {
-      return (data != null ? _i146.SimpleDataObject.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i147.SimpleDataObject?>()) {
+      return (data != null ? _i147.SimpleDataObject.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i147.SimpleDateTime?>()) {
-      return (data != null ? _i147.SimpleDateTime.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i148.SimpleDateTime?>()) {
+      return (data != null ? _i148.SimpleDateTime.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i148.ModelInSubfolder?>()) {
-      return (data != null ? _i148.ModelInSubfolder.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i149.ModelInSubfolder?>()) {
+      return (data != null ? _i149.ModelInSubfolder.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i149.TestEnum?>()) {
-      return (data != null ? _i149.TestEnum.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i150.TestEnum?>()) {
+      return (data != null ? _i150.TestEnum.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i150.TestEnumStringified?>()) {
-      return (data != null ? _i150.TestEnumStringified.fromJson(data) : null)
+    if (t == _i1.getType<_i151.TestEnumStringified?>()) {
+      return (data != null ? _i151.TestEnumStringified.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i151.Types?>()) {
-      return (data != null ? _i151.Types.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i152.Types?>()) {
+      return (data != null ? _i152.Types.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i152.TypesList?>()) {
-      return (data != null ? _i152.TypesList.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i153.TypesList?>()) {
+      return (data != null ? _i153.TypesList.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i153.TypesMap?>()) {
-      return (data != null ? _i153.TypesMap.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i154.TypesMap?>()) {
+      return (data != null ? _i154.TypesMap.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i154.TypesRecord?>()) {
-      return (data != null ? _i154.TypesRecord.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i155.TypesRecord?>()) {
+      return (data != null ? _i155.TypesRecord.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i155.TypesSet?>()) {
-      return (data != null ? _i155.TypesSet.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i156.TypesSet?>()) {
+      return (data != null ? _i156.TypesSet.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i156.TypesSetRequired?>()) {
-      return (data != null ? _i156.TypesSetRequired.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i157.TypesSetRequired?>()) {
+      return (data != null ? _i157.TypesSetRequired.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i157.UniqueData?>()) {
-      return (data != null ? _i157.UniqueData.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i158.UniqueData?>()) {
+      return (data != null ? _i158.UniqueData.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i158.Company?>()) {
-      return (data != null ? _i158.Company.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i159.Town?>()) {
+      return (data != null ? _i159.Town.fromJson(data) : null) as T;
     }
     if (t == _i1.getType<List<_i13.OrderUuid>?>()) {
       return (data != null
@@ -7902,25 +7912,25 @@ class Protocol extends _i1.SerializationManagerServer {
           ? (data as List).map((e) => deserialize<int?>(e)).toList()
           : null) as T;
     }
-    if (t == List<_i143.SimpleData>) {
+    if (t == List<_i144.SimpleData>) {
       return (data as List)
-          .map((e) => deserialize<_i143.SimpleData>(e))
+          .map((e) => deserialize<_i144.SimpleData>(e))
           .toList() as T;
     }
-    if (t == _i1.getType<List<_i143.SimpleData>?>()) {
+    if (t == _i1.getType<List<_i144.SimpleData>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i143.SimpleData>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i144.SimpleData>(e)).toList()
           : null) as T;
     }
-    if (t == List<_i143.SimpleData?>) {
+    if (t == List<_i144.SimpleData?>) {
       return (data as List)
-          .map((e) => deserialize<_i143.SimpleData?>(e))
+          .map((e) => deserialize<_i144.SimpleData?>(e))
           .toList() as T;
     }
-    if (t == _i1.getType<List<_i143.SimpleData?>?>()) {
+    if (t == _i1.getType<List<_i144.SimpleData?>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i143.SimpleData?>(e))
+              .map((e) => deserialize<_i144.SimpleData?>(e))
               .toList()
           : null) as T;
     }
@@ -7940,22 +7950,22 @@ class Protocol extends _i1.SerializationManagerServer {
           ? (data as List).map((e) => deserialize<DateTime?>(e)).toList()
           : null) as T;
     }
-    if (t == List<_i159.ByteData>) {
-      return (data as List).map((e) => deserialize<_i159.ByteData>(e)).toList()
+    if (t == List<_i160.ByteData>) {
+      return (data as List).map((e) => deserialize<_i160.ByteData>(e)).toList()
           as T;
     }
-    if (t == _i1.getType<List<_i159.ByteData>?>()) {
+    if (t == _i1.getType<List<_i160.ByteData>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i159.ByteData>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i160.ByteData>(e)).toList()
           : null) as T;
     }
-    if (t == List<_i159.ByteData?>) {
-      return (data as List).map((e) => deserialize<_i159.ByteData?>(e)).toList()
+    if (t == List<_i160.ByteData?>) {
+      return (data as List).map((e) => deserialize<_i160.ByteData?>(e)).toList()
           as T;
     }
-    if (t == _i1.getType<List<_i159.ByteData?>?>()) {
+    if (t == _i1.getType<List<_i160.ByteData?>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i159.ByteData?>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i160.ByteData?>(e)).toList()
           : null) as T;
     }
     if (t == List<Duration>) {
@@ -8013,32 +8023,32 @@ class Protocol extends _i1.SerializationManagerServer {
               (k, v) => MapEntry(deserialize<String>(k), deserialize<int?>(v)))
           : null) as T;
     }
-    if (t == _i160.CustomClassWithoutProtocolSerialization) {
-      return _i160.CustomClassWithoutProtocolSerialization.fromJson(data) as T;
+    if (t == _i161.CustomClassWithoutProtocolSerialization) {
+      return _i161.CustomClassWithoutProtocolSerialization.fromJson(data) as T;
     }
-    if (t == _i160.CustomClassWithProtocolSerialization) {
-      return _i160.CustomClassWithProtocolSerialization.fromJson(data) as T;
+    if (t == _i161.CustomClassWithProtocolSerialization) {
+      return _i161.CustomClassWithProtocolSerialization.fromJson(data) as T;
     }
-    if (t == _i160.CustomClassWithProtocolSerializationMethod) {
-      return _i160.CustomClassWithProtocolSerializationMethod.fromJson(data)
+    if (t == _i161.CustomClassWithProtocolSerializationMethod) {
+      return _i161.CustomClassWithProtocolSerializationMethod.fromJson(data)
           as T;
     }
-    if (t == List<_i149.TestEnum>) {
-      return (data as List).map((e) => deserialize<_i149.TestEnum>(e)).toList()
+    if (t == List<_i150.TestEnum>) {
+      return (data as List).map((e) => deserialize<_i150.TestEnum>(e)).toList()
           as T;
     }
-    if (t == List<_i149.TestEnum?>) {
-      return (data as List).map((e) => deserialize<_i149.TestEnum?>(e)).toList()
+    if (t == List<_i150.TestEnum?>) {
+      return (data as List).map((e) => deserialize<_i150.TestEnum?>(e)).toList()
           as T;
     }
-    if (t == List<List<_i149.TestEnum>>) {
+    if (t == List<List<_i150.TestEnum>>) {
       return (data as List)
-          .map((e) => deserialize<List<_i149.TestEnum>>(e))
+          .map((e) => deserialize<List<_i150.TestEnum>>(e))
           .toList() as T;
     }
-    if (t == Map<String, _i143.SimpleData>) {
+    if (t == Map<String, _i144.SimpleData>) {
       return (data as Map).map((k, v) => MapEntry(
-          deserialize<String>(k), deserialize<_i143.SimpleData>(v))) as T;
+          deserialize<String>(k), deserialize<_i144.SimpleData>(v))) as T;
     }
     if (t == Map<String, String>) {
       return (data as Map).map((k, v) =>
@@ -8048,9 +8058,9 @@ class Protocol extends _i1.SerializationManagerServer {
       return (data as Map).map((k, v) =>
           MapEntry(deserialize<String>(k), deserialize<DateTime>(v))) as T;
     }
-    if (t == Map<String, _i159.ByteData>) {
+    if (t == Map<String, _i160.ByteData>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i159.ByteData>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i160.ByteData>(v)))
           as T;
     }
     if (t == Map<String, Duration>) {
@@ -8061,9 +8071,9 @@ class Protocol extends _i1.SerializationManagerServer {
       return (data as Map).map((k, v) =>
           MapEntry(deserialize<String>(k), deserialize<_i1.UuidValue>(v))) as T;
     }
-    if (t == Map<String, _i143.SimpleData?>) {
+    if (t == Map<String, _i144.SimpleData?>) {
       return (data as Map).map((k, v) => MapEntry(
-          deserialize<String>(k), deserialize<_i143.SimpleData?>(v))) as T;
+          deserialize<String>(k), deserialize<_i144.SimpleData?>(v))) as T;
     }
     if (t == Map<String, String?>) {
       return (data as Map).map((k, v) =>
@@ -8073,9 +8083,9 @@ class Protocol extends _i1.SerializationManagerServer {
       return (data as Map).map((k, v) =>
           MapEntry(deserialize<String>(k), deserialize<DateTime?>(v))) as T;
     }
-    if (t == Map<String, _i159.ByteData?>) {
+    if (t == Map<String, _i160.ByteData?>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i159.ByteData?>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i160.ByteData?>(v)))
           as T;
     }
     if (t == Map<String, Duration?>) {
@@ -8091,53 +8101,68 @@ class Protocol extends _i1.SerializationManagerServer {
       return Map.fromEntries((data as List).map((e) =>
           MapEntry(deserialize<int>(e['k']), deserialize<int>(e['v'])))) as T;
     }
-    if (t == _i1.getType<List<_i143.SimpleData>?>()) {
+    if (t == _i1.getType<_i161.CustomClassWithoutProtocolSerialization?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i143.SimpleData>(e)).toList()
+          ? _i161.CustomClassWithoutProtocolSerialization.fromJson(data)
           : null) as T;
     }
-    if (t == _i1.getType<List<_i143.SimpleData?>?>()) {
+    if (t == _i1.getType<_i161.CustomClassWithProtocolSerialization?>()) {
+      return (data != null
+          ? _i161.CustomClassWithProtocolSerialization.fromJson(data)
+          : null) as T;
+    }
+    if (t == _i1.getType<_i161.CustomClassWithProtocolSerializationMethod?>()) {
+      return (data != null
+          ? _i161.CustomClassWithProtocolSerializationMethod.fromJson(data)
+          : null) as T;
+    }
+    if (t == _i1.getType<List<_i144.SimpleData>?>()) {
+      return (data != null
+          ? (data as List).map((e) => deserialize<_i144.SimpleData>(e)).toList()
+          : null) as T;
+    }
+    if (t == _i1.getType<List<_i144.SimpleData?>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i143.SimpleData?>(e))
+              .map((e) => deserialize<_i144.SimpleData?>(e))
               .toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<List<_i143.SimpleData>>?>()) {
+    if (t == _i1.getType<List<List<_i144.SimpleData>>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<List<_i143.SimpleData>>(e))
+              .map((e) => deserialize<List<_i144.SimpleData>>(e))
               .toList()
           : null) as T;
     }
     if (t ==
-        _i1.getType<Map<String, List<List<Map<int, _i143.SimpleData>>?>>?>()) {
+        _i1.getType<Map<String, List<List<Map<int, _i144.SimpleData>>?>>?>()) {
       return (data != null
           ? (data as Map).map((k, v) => MapEntry(deserialize<String>(k),
-              deserialize<List<List<Map<int, _i143.SimpleData>>?>>(v)))
+              deserialize<List<List<Map<int, _i144.SimpleData>>?>>(v)))
           : null) as T;
     }
-    if (t == List<List<Map<int, _i143.SimpleData>>?>) {
+    if (t == List<List<Map<int, _i144.SimpleData>>?>) {
       return (data as List)
-          .map((e) => deserialize<List<Map<int, _i143.SimpleData>>?>(e))
+          .map((e) => deserialize<List<Map<int, _i144.SimpleData>>?>(e))
           .toList() as T;
     }
-    if (t == _i1.getType<List<Map<int, _i143.SimpleData>>?>()) {
+    if (t == _i1.getType<List<Map<int, _i144.SimpleData>>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<Map<int, _i143.SimpleData>>(e))
+              .map((e) => deserialize<Map<int, _i144.SimpleData>>(e))
               .toList()
           : null) as T;
     }
-    if (t == Map<int, _i143.SimpleData>) {
+    if (t == Map<int, _i144.SimpleData>) {
       return Map.fromEntries((data as List).map((e) => MapEntry(
-              deserialize<int>(e['k']), deserialize<_i143.SimpleData>(e['v']))))
+              deserialize<int>(e['k']), deserialize<_i144.SimpleData>(e['v']))))
           as T;
     }
-    if (t == _i1.getType<Map<String, Map<int, _i143.SimpleData>>?>()) {
+    if (t == _i1.getType<Map<String, Map<int, _i144.SimpleData>>?>()) {
       return (data != null
           ? (data as Map).map((k, v) => MapEntry(deserialize<String>(k),
-              deserialize<Map<int, _i143.SimpleData>>(v)))
+              deserialize<Map<int, _i144.SimpleData>>(v)))
           : null) as T;
     }
     if (t == _i1.getType<(bool,)?>()) {
@@ -8150,44 +8175,44 @@ class Protocol extends _i1.SerializationManagerServer {
           ? (data as List).map((e) => deserialize<_i75.PlayerUuid>(e)).toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i139.ServerOnlyClass>?>()) {
+    if (t == _i1.getType<List<_i140.ServerOnlyClass>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i139.ServerOnlyClass>(e))
+              .map((e) => deserialize<_i140.ServerOnlyClass>(e))
               .toList()
           : null) as T;
     }
-    if (t == _i1.getType<Map<String, _i139.ServerOnlyClass>?>()) {
+    if (t == _i1.getType<Map<String, _i140.ServerOnlyClass>?>()) {
       return (data != null
           ? (data as Map).map((k, v) => MapEntry(
-              deserialize<String>(k), deserialize<_i139.ServerOnlyClass>(v)))
+              deserialize<String>(k), deserialize<_i140.ServerOnlyClass>(v)))
           : null) as T;
     }
-    if (t == _i1.getType<List<_i150.TestEnumStringified>?>()) {
+    if (t == _i1.getType<List<_i151.TestEnumStringified>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i150.TestEnumStringified>(e))
+              .map((e) => deserialize<_i151.TestEnumStringified>(e))
               .toList()
           : null) as T;
     }
-    if (t == _i1.getType<(_i150.TestEnumStringified,)?>()) {
+    if (t == _i1.getType<(_i151.TestEnumStringified,)?>()) {
       return (data == null)
           ? null as T
           : (
-              deserialize<_i150.TestEnumStringified>(
+              deserialize<_i151.TestEnumStringified>(
                   ((data as Map)['p'] as List)[0]),
             ) as T;
     }
-    if (t == _i1.getType<List<(_i150.TestEnumStringified,)>?>()) {
+    if (t == _i1.getType<List<(_i151.TestEnumStringified,)>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<(_i150.TestEnumStringified,)>(e))
+              .map((e) => deserialize<(_i151.TestEnumStringified,)>(e))
               .toList()
           : null) as T;
     }
-    if (t == _i1.getType<(_i150.TestEnumStringified,)>()) {
+    if (t == _i1.getType<(_i151.TestEnumStringified,)>()) {
       return (
-        deserialize<_i150.TestEnumStringified>(((data as Map)['p'] as List)[0]),
+        deserialize<_i151.TestEnumStringified>(((data as Map)['p'] as List)[0]),
       ) as T;
     }
     if (t == _i1.getType<(_i4.ModuleClass,)?>()) {
@@ -8202,24 +8227,24 @@ class Protocol extends _i1.SerializationManagerServer {
           : (deserialize<_i113.Nullability>(((data as Map)['p'] as List)[0]),)
               as T;
     }
-    if (t == _i1.getType<({_i150.TestEnumStringified value})?>()) {
+    if (t == _i1.getType<({_i151.TestEnumStringified value})?>()) {
       return (data == null)
           ? null as T
           : (
-              value: deserialize<_i150.TestEnumStringified>(
+              value: deserialize<_i151.TestEnumStringified>(
                   ((data as Map)['n'] as Map)['value']),
             ) as T;
     }
-    if (t == _i1.getType<List<({_i150.TestEnumStringified value})>?>()) {
+    if (t == _i1.getType<List<({_i151.TestEnumStringified value})>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<({_i150.TestEnumStringified value})>(e))
+              .map((e) => deserialize<({_i151.TestEnumStringified value})>(e))
               .toList()
           : null) as T;
     }
-    if (t == _i1.getType<({_i150.TestEnumStringified value})>()) {
+    if (t == _i1.getType<({_i151.TestEnumStringified value})>()) {
       return (
-        value: deserialize<_i150.TestEnumStringified>(
+        value: deserialize<_i151.TestEnumStringified>(
             ((data as Map)['n'] as Map)['value']),
       ) as T;
     }
@@ -8290,9 +8315,9 @@ class Protocol extends _i1.SerializationManagerServer {
           ? (data as List).map((e) => deserialize<String>(e)).toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i159.ByteData>?>()) {
+    if (t == _i1.getType<List<_i160.ByteData>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i159.ByteData>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i160.ByteData>(e)).toList()
           : null) as T;
     }
     if (t == _i1.getType<List<Duration>?>()) {
@@ -8315,43 +8340,43 @@ class Protocol extends _i1.SerializationManagerServer {
           ? (data as List).map((e) => deserialize<BigInt>(e)).toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i149.TestEnum>?>()) {
+    if (t == _i1.getType<List<_i150.TestEnum>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i149.TestEnum>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i150.TestEnum>(e)).toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i150.TestEnumStringified>?>()) {
+    if (t == _i1.getType<List<_i151.TestEnumStringified>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i150.TestEnumStringified>(e))
+              .map((e) => deserialize<_i151.TestEnumStringified>(e))
               .toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i151.Types>?>()) {
+    if (t == _i1.getType<List<_i152.Types>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i151.Types>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i152.Types>(e)).toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<Map<String, _i151.Types>>?>()) {
+    if (t == _i1.getType<List<Map<String, _i152.Types>>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<Map<String, _i151.Types>>(e))
+              .map((e) => deserialize<Map<String, _i152.Types>>(e))
               .toList()
           : null) as T;
     }
-    if (t == Map<String, _i151.Types>) {
+    if (t == Map<String, _i152.Types>) {
       return (data as Map).map((k, v) =>
-          MapEntry(deserialize<String>(k), deserialize<_i151.Types>(v))) as T;
+          MapEntry(deserialize<String>(k), deserialize<_i152.Types>(v))) as T;
     }
-    if (t == _i1.getType<List<List<_i151.Types>>?>()) {
+    if (t == _i1.getType<List<List<_i152.Types>>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<List<_i151.Types>>(e))
+              .map((e) => deserialize<List<_i152.Types>>(e))
               .toList()
           : null) as T;
     }
-    if (t == List<_i151.Types>) {
-      return (data as List).map((e) => deserialize<_i151.Types>(e)).toList()
+    if (t == List<_i152.Types>) {
+      return (data as List).map((e) => deserialize<_i152.Types>(e)).toList()
           as T;
     }
     if (t == _i1.getType<List<(int,)>?>()) {
@@ -8372,27 +8397,27 @@ class Protocol extends _i1.SerializationManagerServer {
           ? null as T
           : (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
     }
-    if (t == _i1.getType<List<(_i149.TestEnum,)>?>()) {
+    if (t == _i1.getType<List<(_i150.TestEnum,)>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<(_i149.TestEnum,)>(e))
+              .map((e) => deserialize<(_i150.TestEnum,)>(e))
               .toList()
           : null) as T;
     }
-    if (t == _i1.getType<(_i149.TestEnum,)>()) {
-      return (deserialize<_i149.TestEnum>(((data as Map)['p'] as List)[0]),)
+    if (t == _i1.getType<(_i150.TestEnum,)>()) {
+      return (deserialize<_i150.TestEnum>(((data as Map)['p'] as List)[0]),)
           as T;
     }
-    if (t == _i1.getType<List<(_i150.TestEnumStringified,)>?>()) {
+    if (t == _i1.getType<List<(_i151.TestEnumStringified,)>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<(_i150.TestEnumStringified,)>(e))
+              .map((e) => deserialize<(_i151.TestEnumStringified,)>(e))
               .toList()
           : null) as T;
     }
-    if (t == _i1.getType<(_i150.TestEnumStringified,)>()) {
+    if (t == _i1.getType<(_i151.TestEnumStringified,)>()) {
       return (
-        deserialize<_i150.TestEnumStringified>(((data as Map)['p'] as List)[0]),
+        deserialize<_i151.TestEnumStringified>(((data as Map)['p'] as List)[0]),
       ) as T;
     }
     if (t == _i1.getType<Map<int, String>?>()) {
@@ -8425,10 +8450,10 @@ class Protocol extends _i1.SerializationManagerServer {
               MapEntry(deserialize<String>(k), deserialize<String>(v)))
           : null) as T;
     }
-    if (t == _i1.getType<Map<_i159.ByteData, String>?>()) {
+    if (t == _i1.getType<Map<_i160.ByteData, String>?>()) {
       return (data != null
           ? Map.fromEntries((data as List).map((e) => MapEntry(
-              deserialize<_i159.ByteData>(e['k']),
+              deserialize<_i160.ByteData>(e['k']),
               deserialize<String>(e['v']))))
           : null) as T;
     }
@@ -8456,41 +8481,41 @@ class Protocol extends _i1.SerializationManagerServer {
               deserialize<BigInt>(e['k']), deserialize<String>(e['v']))))
           : null) as T;
     }
-    if (t == _i1.getType<Map<_i149.TestEnum, String>?>()) {
+    if (t == _i1.getType<Map<_i150.TestEnum, String>?>()) {
       return (data != null
           ? Map.fromEntries((data as List).map((e) => MapEntry(
-              deserialize<_i149.TestEnum>(e['k']),
+              deserialize<_i150.TestEnum>(e['k']),
               deserialize<String>(e['v']))))
           : null) as T;
     }
-    if (t == _i1.getType<Map<_i150.TestEnumStringified, String>?>()) {
+    if (t == _i1.getType<Map<_i151.TestEnumStringified, String>?>()) {
       return (data != null
           ? Map.fromEntries((data as List).map((e) => MapEntry(
-              deserialize<_i150.TestEnumStringified>(e['k']),
+              deserialize<_i151.TestEnumStringified>(e['k']),
               deserialize<String>(e['v']))))
           : null) as T;
     }
-    if (t == _i1.getType<Map<_i151.Types, String>?>()) {
+    if (t == _i1.getType<Map<_i152.Types, String>?>()) {
       return (data != null
           ? Map.fromEntries((data as List).map((e) => MapEntry(
-              deserialize<_i151.Types>(e['k']), deserialize<String>(e['v']))))
+              deserialize<_i152.Types>(e['k']), deserialize<String>(e['v']))))
           : null) as T;
     }
-    if (t == _i1.getType<Map<Map<_i151.Types, String>, String>?>()) {
+    if (t == _i1.getType<Map<Map<_i152.Types, String>, String>?>()) {
       return (data != null
           ? Map.fromEntries((data as List).map((e) => MapEntry(
-              deserialize<Map<_i151.Types, String>>(e['k']),
+              deserialize<Map<_i152.Types, String>>(e['k']),
               deserialize<String>(e['v']))))
           : null) as T;
     }
-    if (t == Map<_i151.Types, String>) {
+    if (t == Map<_i152.Types, String>) {
       return Map.fromEntries((data as List).map((e) => MapEntry(
-          deserialize<_i151.Types>(e['k']), deserialize<String>(e['v'])))) as T;
+          deserialize<_i152.Types>(e['k']), deserialize<String>(e['v'])))) as T;
     }
-    if (t == _i1.getType<Map<List<_i151.Types>, String>?>()) {
+    if (t == _i1.getType<Map<List<_i152.Types>, String>?>()) {
       return (data != null
           ? Map.fromEntries((data as List).map((e) => MapEntry(
-              deserialize<List<_i151.Types>>(e['k']),
+              deserialize<List<_i152.Types>>(e['k']),
               deserialize<String>(e['v']))))
           : null) as T;
     }
@@ -8533,10 +8558,10 @@ class Protocol extends _i1.SerializationManagerServer {
               MapEntry(deserialize<String>(k), deserialize<String>(v)))
           : null) as T;
     }
-    if (t == _i1.getType<Map<String, _i159.ByteData>?>()) {
+    if (t == _i1.getType<Map<String, _i160.ByteData>?>()) {
       return (data != null
           ? (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i159.ByteData>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i160.ByteData>(v)))
           : null) as T;
     }
     if (t == _i1.getType<Map<String, Duration>?>()) {
@@ -8563,34 +8588,34 @@ class Protocol extends _i1.SerializationManagerServer {
               MapEntry(deserialize<String>(k), deserialize<BigInt>(v)))
           : null) as T;
     }
-    if (t == _i1.getType<Map<String, _i149.TestEnum>?>()) {
+    if (t == _i1.getType<Map<String, _i150.TestEnum>?>()) {
       return (data != null
           ? (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i149.TestEnum>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i150.TestEnum>(v)))
           : null) as T;
     }
-    if (t == _i1.getType<Map<String, _i150.TestEnumStringified>?>()) {
+    if (t == _i1.getType<Map<String, _i151.TestEnumStringified>?>()) {
       return (data != null
           ? (data as Map).map((k, v) => MapEntry(deserialize<String>(k),
-              deserialize<_i150.TestEnumStringified>(v)))
+              deserialize<_i151.TestEnumStringified>(v)))
           : null) as T;
     }
-    if (t == _i1.getType<Map<String, _i151.Types>?>()) {
+    if (t == _i1.getType<Map<String, _i152.Types>?>()) {
       return (data != null
           ? (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i151.Types>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i152.Types>(v)))
           : null) as T;
     }
-    if (t == _i1.getType<Map<String, Map<String, _i151.Types>>?>()) {
+    if (t == _i1.getType<Map<String, Map<String, _i152.Types>>?>()) {
       return (data != null
           ? (data as Map).map((k, v) => MapEntry(
-              deserialize<String>(k), deserialize<Map<String, _i151.Types>>(v)))
+              deserialize<String>(k), deserialize<Map<String, _i152.Types>>(v)))
           : null) as T;
     }
-    if (t == _i1.getType<Map<String, List<_i151.Types>>?>()) {
+    if (t == _i1.getType<Map<String, List<_i152.Types>>?>()) {
       return (data != null
           ? (data as Map).map((k, v) => MapEntry(
-              deserialize<String>(k), deserialize<List<_i151.Types>>(v)))
+              deserialize<String>(k), deserialize<List<_i152.Types>>(v)))
           : null) as T;
     }
     if (t == _i1.getType<Map<String, (String,)>?>()) {
@@ -8649,10 +8674,10 @@ class Protocol extends _i1.SerializationManagerServer {
           ? null as T
           : (deserialize<String>(((data as Map)['p'] as List)[0]),) as T;
     }
-    if (t == _i1.getType<(_i159.ByteData,)?>()) {
+    if (t == _i1.getType<(_i160.ByteData,)?>()) {
       return (data == null)
           ? null as T
-          : (deserialize<_i159.ByteData>(((data as Map)['p'] as List)[0]),)
+          : (deserialize<_i160.ByteData>(((data as Map)['p'] as List)[0]),)
               as T;
     }
     if (t == _i1.getType<(Duration,)?>()) {
@@ -8675,17 +8700,17 @@ class Protocol extends _i1.SerializationManagerServer {
           ? null as T
           : (deserialize<BigInt>(((data as Map)['p'] as List)[0]),) as T;
     }
-    if (t == _i1.getType<(_i149.TestEnum,)?>()) {
+    if (t == _i1.getType<(_i150.TestEnum,)?>()) {
       return (data == null)
           ? null as T
-          : (deserialize<_i149.TestEnum>(((data as Map)['p'] as List)[0]),)
+          : (deserialize<_i150.TestEnum>(((data as Map)['p'] as List)[0]),)
               as T;
     }
-    if (t == _i1.getType<(_i150.TestEnumStringified,)?>()) {
+    if (t == _i1.getType<(_i151.TestEnumStringified,)?>()) {
       return (data == null)
           ? null as T
           : (
-              deserialize<_i150.TestEnumStringified>(
+              deserialize<_i151.TestEnumStringified>(
                   ((data as Map)['p'] as List)[0]),
             ) as T;
     }
@@ -8704,28 +8729,28 @@ class Protocol extends _i1.SerializationManagerServer {
           ? null as T
           : (deserialize<Set<int>>(((data as Map)['p'] as List)[0]),) as T;
     }
-    if (t == _i1.getType<(_i143.SimpleData,)?>()) {
+    if (t == _i1.getType<(_i144.SimpleData,)?>()) {
       return (data == null)
           ? null as T
-          : (deserialize<_i143.SimpleData>(((data as Map)['p'] as List)[0]),)
+          : (deserialize<_i144.SimpleData>(((data as Map)['p'] as List)[0]),)
               as T;
     }
-    if (t == _i1.getType<({_i143.SimpleData namedModel})?>()) {
+    if (t == _i1.getType<({_i144.SimpleData namedModel})?>()) {
       return (data == null)
           ? null as T
           : (
-              namedModel: deserialize<_i143.SimpleData>(
+              namedModel: deserialize<_i144.SimpleData>(
                   ((data as Map)['n'] as Map)['namedModel']),
             ) as T;
     }
     if (t ==
-        _i1.getType<(_i143.SimpleData, {_i143.SimpleData namedModel})?>()) {
+        _i1.getType<(_i144.SimpleData, {_i144.SimpleData namedModel})?>()) {
       return (data == null)
           ? null as T
           : (
-              deserialize<_i143.SimpleData>(((data as Map)['p'] as List)[0]),
+              deserialize<_i144.SimpleData>(((data as Map)['p'] as List)[0]),
               namedModel:
-                  deserialize<_i143.SimpleData>(data['n']['namedModel']),
+                  deserialize<_i144.SimpleData>(data['n']['namedModel']),
             ) as T;
     }
     if (t ==
@@ -8741,21 +8766,21 @@ class Protocol extends _i1.SerializationManagerServer {
     if (t ==
         _i1.getType<
             (
-              (List<(_i143.SimpleData,)>,), {
+              (List<(_i144.SimpleData,)>,), {
               (
-                _i143.SimpleData,
-                Map<String, _i143.SimpleData>
+                _i144.SimpleData,
+                Map<String, _i144.SimpleData>
               ) namedNestedRecord
             })?>()) {
       return (data == null)
           ? null as T
           : (
-              deserialize<(List<(_i143.SimpleData,)>,)>(
+              deserialize<(List<(_i144.SimpleData,)>,)>(
                   ((data as Map)['p'] as List)[0]),
               namedNestedRecord: deserialize<
                   (
-                    _i143.SimpleData,
-                    Map<String, _i143.SimpleData>
+                    _i144.SimpleData,
+                    Map<String, _i144.SimpleData>
                   )>(data['n']['namedNestedRecord']),
             ) as T;
     }
@@ -8784,9 +8809,9 @@ class Protocol extends _i1.SerializationManagerServer {
           ? (data as List).map((e) => deserialize<String>(e)).toSet()
           : null) as T;
     }
-    if (t == _i1.getType<Set<_i159.ByteData>?>()) {
+    if (t == _i1.getType<Set<_i160.ByteData>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i159.ByteData>(e)).toSet()
+          ? (data as List).map((e) => deserialize<_i160.ByteData>(e)).toSet()
           : null) as T;
     }
     if (t == _i1.getType<Set<Duration>?>()) {
@@ -8804,33 +8829,33 @@ class Protocol extends _i1.SerializationManagerServer {
           ? (data as List).map((e) => deserialize<BigInt>(e)).toSet()
           : null) as T;
     }
-    if (t == _i1.getType<Set<_i149.TestEnum>?>()) {
+    if (t == _i1.getType<Set<_i150.TestEnum>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i149.TestEnum>(e)).toSet()
+          ? (data as List).map((e) => deserialize<_i150.TestEnum>(e)).toSet()
           : null) as T;
     }
-    if (t == _i1.getType<Set<_i150.TestEnumStringified>?>()) {
+    if (t == _i1.getType<Set<_i151.TestEnumStringified>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i150.TestEnumStringified>(e))
+              .map((e) => deserialize<_i151.TestEnumStringified>(e))
               .toSet()
           : null) as T;
     }
-    if (t == _i1.getType<Set<_i151.Types>?>()) {
+    if (t == _i1.getType<Set<_i152.Types>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i151.Types>(e)).toSet()
+          ? (data as List).map((e) => deserialize<_i152.Types>(e)).toSet()
           : null) as T;
     }
-    if (t == _i1.getType<Set<Map<String, _i151.Types>>?>()) {
+    if (t == _i1.getType<Set<Map<String, _i152.Types>>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<Map<String, _i151.Types>>(e))
+              .map((e) => deserialize<Map<String, _i152.Types>>(e))
               .toSet()
           : null) as T;
     }
-    if (t == _i1.getType<Set<List<_i151.Types>>?>()) {
+    if (t == _i1.getType<Set<List<_i152.Types>>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<List<_i151.Types>>(e)).toSet()
+          ? (data as List).map((e) => deserialize<List<_i152.Types>>(e)).toSet()
           : null) as T;
     }
     if (t == _i1.getType<Set<(int,)>?>()) {
@@ -8862,9 +8887,9 @@ class Protocol extends _i1.SerializationManagerServer {
     if (t == List<String>) {
       return (data as List).map((e) => deserialize<String>(e)).toList() as T;
     }
-    if (t == List<_i161.SimpleData>) {
+    if (t == List<_i162.SimpleData>) {
       return (data as List)
-          .map((e) => deserialize<_i161.SimpleData>(e))
+          .map((e) => deserialize<_i162.SimpleData>(e))
           .toList() as T;
     }
     if (t == List<int>) {
@@ -8921,28 +8946,28 @@ class Protocol extends _i1.SerializationManagerServer {
     if (t == List<DateTime?>) {
       return (data as List).map((e) => deserialize<DateTime?>(e)).toList() as T;
     }
-    if (t == List<_i159.ByteData>) {
-      return (data as List).map((e) => deserialize<_i159.ByteData>(e)).toList()
+    if (t == List<_i160.ByteData>) {
+      return (data as List).map((e) => deserialize<_i160.ByteData>(e)).toList()
           as T;
     }
-    if (t == List<_i159.ByteData?>) {
-      return (data as List).map((e) => deserialize<_i159.ByteData?>(e)).toList()
+    if (t == List<_i160.ByteData?>) {
+      return (data as List).map((e) => deserialize<_i160.ByteData?>(e)).toList()
           as T;
     }
-    if (t == List<_i161.SimpleData?>) {
+    if (t == List<_i162.SimpleData?>) {
       return (data as List)
-          .map((e) => deserialize<_i161.SimpleData?>(e))
+          .map((e) => deserialize<_i162.SimpleData?>(e))
           .toList() as T;
     }
-    if (t == _i1.getType<List<_i161.SimpleData>?>()) {
+    if (t == _i1.getType<List<_i162.SimpleData>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i161.SimpleData>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i162.SimpleData>(e)).toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i161.SimpleData?>?>()) {
+    if (t == _i1.getType<List<_i162.SimpleData?>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i161.SimpleData?>(e))
+              .map((e) => deserialize<_i162.SimpleData?>(e))
               .toList()
           : null) as T;
     }
@@ -8985,13 +9010,13 @@ class Protocol extends _i1.SerializationManagerServer {
       return (data as Map).map((k, v) =>
           MapEntry(deserialize<String>(k), deserialize<Map<int, int>>(v))) as T;
     }
-    if (t == Map<_i162.TestEnum, int>) {
+    if (t == Map<_i163.TestEnum, int>) {
       return Map.fromEntries((data as List).map((e) => MapEntry(
-          deserialize<_i162.TestEnum>(e['k']), deserialize<int>(e['v'])))) as T;
+          deserialize<_i163.TestEnum>(e['k']), deserialize<int>(e['v'])))) as T;
     }
-    if (t == Map<String, _i162.TestEnum>) {
+    if (t == Map<String, _i163.TestEnum>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i162.TestEnum>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i163.TestEnum>(v)))
           as T;
     }
     if (t == Map<String, double>) {
@@ -9028,34 +9053,34 @@ class Protocol extends _i1.SerializationManagerServer {
       return (data as Map).map((k, v) =>
           MapEntry(deserialize<String>(k), deserialize<DateTime?>(v))) as T;
     }
-    if (t == Map<String, _i159.ByteData>) {
+    if (t == Map<String, _i160.ByteData>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i159.ByteData>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i160.ByteData>(v)))
           as T;
     }
-    if (t == Map<String, _i159.ByteData?>) {
+    if (t == Map<String, _i160.ByteData?>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i159.ByteData?>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i160.ByteData?>(v)))
           as T;
     }
-    if (t == Map<String, _i161.SimpleData>) {
+    if (t == Map<String, _i162.SimpleData>) {
       return (data as Map).map((k, v) => MapEntry(
-          deserialize<String>(k), deserialize<_i161.SimpleData>(v))) as T;
+          deserialize<String>(k), deserialize<_i162.SimpleData>(v))) as T;
     }
-    if (t == Map<String, _i161.SimpleData?>) {
+    if (t == Map<String, _i162.SimpleData?>) {
       return (data as Map).map((k, v) => MapEntry(
-          deserialize<String>(k), deserialize<_i161.SimpleData?>(v))) as T;
+          deserialize<String>(k), deserialize<_i162.SimpleData?>(v))) as T;
     }
-    if (t == _i1.getType<Map<String, _i161.SimpleData>?>()) {
+    if (t == _i1.getType<Map<String, _i162.SimpleData>?>()) {
       return (data != null
           ? (data as Map).map((k, v) => MapEntry(
-              deserialize<String>(k), deserialize<_i161.SimpleData>(v)))
+              deserialize<String>(k), deserialize<_i162.SimpleData>(v)))
           : null) as T;
     }
-    if (t == _i1.getType<Map<String, _i161.SimpleData?>?>()) {
+    if (t == _i1.getType<Map<String, _i162.SimpleData?>?>()) {
       return (data != null
           ? (data as Map).map((k, v) => MapEntry(
-              deserialize<String>(k), deserialize<_i161.SimpleData?>(v)))
+              deserialize<String>(k), deserialize<_i162.SimpleData?>(v)))
           : null) as T;
     }
     if (t == Map<String, Duration>) {
@@ -9107,13 +9132,13 @@ class Protocol extends _i1.SerializationManagerServer {
     if (t == Set<int>) {
       return (data as List).map((e) => deserialize<int>(e)).toSet() as T;
     }
-    if (t == Set<_i161.SimpleData>) {
-      return (data as List).map((e) => deserialize<_i161.SimpleData>(e)).toSet()
+    if (t == Set<_i162.SimpleData>) {
+      return (data as List).map((e) => deserialize<_i162.SimpleData>(e)).toSet()
           as T;
     }
-    if (t == List<Set<_i161.SimpleData>>) {
+    if (t == List<Set<_i162.SimpleData>>) {
       return (data as List)
-          .map((e) => deserialize<Set<_i161.SimpleData>>(e))
+          .map((e) => deserialize<Set<_i162.SimpleData>>(e))
           .toList() as T;
     }
     if (t == _i1.getType<(int, BigInt)>()) {
@@ -9160,18 +9185,18 @@ class Protocol extends _i1.SerializationManagerServer {
               deserialize<String>(data['p'][1]),
             ) as T;
     }
-    if (t == _i1.getType<(int, _i161.SimpleData)>()) {
+    if (t == _i1.getType<(int, _i162.SimpleData)>()) {
       return (
         deserialize<int>(((data as Map)['p'] as List)[0]),
-        deserialize<_i161.SimpleData>(data['p'][1]),
+        deserialize<_i162.SimpleData>(data['p'][1]),
       ) as T;
     }
-    if (t == _i1.getType<(int, _i161.SimpleData)?>()) {
+    if (t == _i1.getType<(int, _i162.SimpleData)?>()) {
       return (data == null)
           ? null as T
           : (
               deserialize<int>(((data as Map)['p'] as List)[0]),
-              deserialize<_i161.SimpleData>(data['p'][1]),
+              deserialize<_i162.SimpleData>(data['p'][1]),
             ) as T;
     }
     if (t == _i1.getType<(Map<String, int>,)>()) {
@@ -9201,27 +9226,27 @@ class Protocol extends _i1.SerializationManagerServer {
               text: deserialize<String>(data['n']['text']),
             ) as T;
     }
-    if (t == _i1.getType<({_i161.SimpleData data, int number})>()) {
+    if (t == _i1.getType<({_i162.SimpleData data, int number})>()) {
       return (
         data:
-            deserialize<_i161.SimpleData>(((data as Map)['n'] as Map)['data']),
+            deserialize<_i162.SimpleData>(((data as Map)['n'] as Map)['data']),
         number: deserialize<int>(data['n']['number']),
       ) as T;
     }
-    if (t == _i1.getType<({_i161.SimpleData data, int number})?>()) {
+    if (t == _i1.getType<({_i162.SimpleData data, int number})?>()) {
       return (data == null)
           ? null as T
           : (
-              data: deserialize<_i161.SimpleData>(
+              data: deserialize<_i162.SimpleData>(
                   ((data as Map)['n'] as Map)['data']),
               number: deserialize<int>(data['n']['number']),
             ) as T;
     }
-    if (t == _i1.getType<({_i161.SimpleData? data, int? number})>()) {
+    if (t == _i1.getType<({_i162.SimpleData? data, int? number})>()) {
       return (
         data: ((data as Map)['n'] as Map)['data'] == null
             ? null
-            : deserialize<_i161.SimpleData>(data['n']['data']),
+            : deserialize<_i162.SimpleData>(data['n']['data']),
         number: ((data)['n'] as Map)['number'] == null
             ? null
             : deserialize<int>(data['n']['number']),
@@ -9254,109 +9279,109 @@ class Protocol extends _i1.SerializationManagerServer {
             ((data as Map)['p'] as List)[0]),
       ) as T;
     }
-    if (t == _i1.getType<(int, {_i161.SimpleData data})>()) {
+    if (t == _i1.getType<(int, {_i162.SimpleData data})>()) {
       return (
         deserialize<int>(((data as Map)['p'] as List)[0]),
-        data: deserialize<_i161.SimpleData>(data['n']['data']),
+        data: deserialize<_i162.SimpleData>(data['n']['data']),
       ) as T;
     }
-    if (t == _i1.getType<(int, {_i161.SimpleData data})?>()) {
+    if (t == _i1.getType<(int, {_i162.SimpleData data})?>()) {
       return (data == null)
           ? null as T
           : (
               deserialize<int>(((data as Map)['p'] as List)[0]),
-              data: deserialize<_i161.SimpleData>(data['n']['data']),
+              data: deserialize<_i162.SimpleData>(data['n']['data']),
             ) as T;
     }
-    if (t == List<(int, _i161.SimpleData)>) {
+    if (t == List<(int, _i162.SimpleData)>) {
       return (data as List)
-          .map((e) => deserialize<(int, _i161.SimpleData)>(e))
+          .map((e) => deserialize<(int, _i162.SimpleData)>(e))
           .toList() as T;
     }
-    if (t == _i1.getType<(int, _i161.SimpleData)>()) {
+    if (t == _i1.getType<(int, _i162.SimpleData)>()) {
       return (
         deserialize<int>(((data as Map)['p'] as List)[0]),
-        deserialize<_i161.SimpleData>(data['p'][1]),
+        deserialize<_i162.SimpleData>(data['p'][1]),
       ) as T;
     }
-    if (t == List<(int, _i161.SimpleData)?>) {
+    if (t == List<(int, _i162.SimpleData)?>) {
       return (data as List)
-          .map((e) => deserialize<(int, _i161.SimpleData)?>(e))
+          .map((e) => deserialize<(int, _i162.SimpleData)?>(e))
           .toList() as T;
     }
-    if (t == _i1.getType<(int, _i161.SimpleData)?>()) {
+    if (t == _i1.getType<(int, _i162.SimpleData)?>()) {
       return (data == null)
           ? null as T
           : (
               deserialize<int>(((data as Map)['p'] as List)[0]),
-              deserialize<_i161.SimpleData>(data['p'][1]),
+              deserialize<_i162.SimpleData>(data['p'][1]),
             ) as T;
     }
-    if (t == Set<(int, _i161.SimpleData)>) {
+    if (t == Set<(int, _i162.SimpleData)>) {
       return (data as List)
-          .map((e) => deserialize<(int, _i161.SimpleData)>(e))
+          .map((e) => deserialize<(int, _i162.SimpleData)>(e))
           .toSet() as T;
     }
-    if (t == _i1.getType<(int, _i161.SimpleData)>()) {
+    if (t == _i1.getType<(int, _i162.SimpleData)>()) {
       return (
         deserialize<int>(((data as Map)['p'] as List)[0]),
-        deserialize<_i161.SimpleData>(data['p'][1]),
+        deserialize<_i162.SimpleData>(data['p'][1]),
       ) as T;
     }
-    if (t == Set<(int, _i161.SimpleData)?>) {
+    if (t == Set<(int, _i162.SimpleData)?>) {
       return (data as List)
-          .map((e) => deserialize<(int, _i161.SimpleData)?>(e))
+          .map((e) => deserialize<(int, _i162.SimpleData)?>(e))
           .toSet() as T;
     }
-    if (t == _i1.getType<(int, _i161.SimpleData)?>()) {
+    if (t == _i1.getType<(int, _i162.SimpleData)?>()) {
       return (data == null)
           ? null as T
           : (
               deserialize<int>(((data as Map)['p'] as List)[0]),
-              deserialize<_i161.SimpleData>(data['p'][1]),
+              deserialize<_i162.SimpleData>(data['p'][1]),
             ) as T;
     }
-    if (t == _i1.getType<Set<(int, _i161.SimpleData)>?>()) {
+    if (t == _i1.getType<Set<(int, _i162.SimpleData)>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<(int, _i161.SimpleData)>(e))
+              .map((e) => deserialize<(int, _i162.SimpleData)>(e))
               .toSet()
           : null) as T;
     }
-    if (t == _i1.getType<(int, _i161.SimpleData)>()) {
+    if (t == _i1.getType<(int, _i162.SimpleData)>()) {
       return (
         deserialize<int>(((data as Map)['p'] as List)[0]),
-        deserialize<_i161.SimpleData>(data['p'][1]),
+        deserialize<_i162.SimpleData>(data['p'][1]),
       ) as T;
     }
-    if (t == Map<String, (int, _i161.SimpleData)>) {
+    if (t == Map<String, (int, _i162.SimpleData)>) {
       return (data as Map).map((k, v) => MapEntry(
-              deserialize<String>(k), deserialize<(int, _i161.SimpleData)>(v)))
+              deserialize<String>(k), deserialize<(int, _i162.SimpleData)>(v)))
           as T;
     }
-    if (t == _i1.getType<(int, _i161.SimpleData)>()) {
+    if (t == _i1.getType<(int, _i162.SimpleData)>()) {
       return (
         deserialize<int>(((data as Map)['p'] as List)[0]),
-        deserialize<_i161.SimpleData>(data['p'][1]),
+        deserialize<_i162.SimpleData>(data['p'][1]),
       ) as T;
     }
-    if (t == Map<String, (int, _i161.SimpleData)?>) {
+    if (t == Map<String, (int, _i162.SimpleData)?>) {
       return (data as Map).map((k, v) => MapEntry(
-              deserialize<String>(k), deserialize<(int, _i161.SimpleData)?>(v)))
+              deserialize<String>(k), deserialize<(int, _i162.SimpleData)?>(v)))
           as T;
     }
-    if (t == _i1.getType<(int, _i161.SimpleData)?>()) {
+    if (t == _i1.getType<(int, _i162.SimpleData)?>()) {
       return (data == null)
           ? null as T
           : (
               deserialize<int>(((data as Map)['p'] as List)[0]),
-              deserialize<_i161.SimpleData>(data['p'][1]),
+              deserialize<_i162.SimpleData>(data['p'][1]),
             ) as T;
     }
-    if (t == Map<(String, int), (int, _i161.SimpleData)>) {
+    if (t == Map<(String, int), (int, _i162.SimpleData)>) {
       return Map.fromEntries((data as List).map((e) => MapEntry(
           deserialize<(String, int)>(e['k']),
-          deserialize<(int, _i161.SimpleData)>(e['v'])))) as T;
+          deserialize<(int, _i162.SimpleData)>(e['v'])))) as T;
     }
     if (t == _i1.getType<(String, int)>()) {
       return (
@@ -9364,10 +9389,10 @@ class Protocol extends _i1.SerializationManagerServer {
         deserialize<int>(data['p'][1]),
       ) as T;
     }
-    if (t == _i1.getType<(int, _i161.SimpleData)>()) {
+    if (t == _i1.getType<(int, _i162.SimpleData)>()) {
       return (
         deserialize<int>(((data as Map)['p'] as List)[0]),
-        deserialize<_i161.SimpleData>(data['p'][1]),
+        deserialize<_i162.SimpleData>(data['p'][1]),
       ) as T;
     }
     if (t == _i1.getType<(String, int)>()) {
@@ -9413,56 +9438,56 @@ class Protocol extends _i1.SerializationManagerServer {
     if (t == _i1.getType<(int,)>()) {
       return (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
     }
-    if (t == _i1.getType<({(_i161.SimpleData, double) namedSubRecord})>()) {
+    if (t == _i1.getType<({(_i162.SimpleData, double) namedSubRecord})>()) {
       return (
-        namedSubRecord: deserialize<(_i161.SimpleData, double)>(
+        namedSubRecord: deserialize<(_i162.SimpleData, double)>(
             ((data as Map)['n'] as Map)['namedSubRecord']),
       ) as T;
     }
-    if (t == _i1.getType<(_i161.SimpleData, double)>()) {
+    if (t == _i1.getType<(_i162.SimpleData, double)>()) {
       return (
-        deserialize<_i161.SimpleData>(((data as Map)['p'] as List)[0]),
+        deserialize<_i162.SimpleData>(((data as Map)['p'] as List)[0]),
         deserialize<double>(data['p'][1]),
       ) as T;
     }
-    if (t == _i1.getType<({(_i161.SimpleData, double)? namedSubRecord})>()) {
+    if (t == _i1.getType<({(_i162.SimpleData, double)? namedSubRecord})>()) {
       return (
         namedSubRecord: ((data as Map)['n'] as Map)['namedSubRecord'] == null
             ? null
-            : deserialize<(_i161.SimpleData, double)>(
+            : deserialize<(_i162.SimpleData, double)>(
                 data['n']['namedSubRecord']),
       ) as T;
     }
-    if (t == _i1.getType<(_i161.SimpleData, double)?>()) {
+    if (t == _i1.getType<(_i162.SimpleData, double)?>()) {
       return (data == null)
           ? null as T
           : (
-              deserialize<_i161.SimpleData>(((data as Map)['p'] as List)[0]),
+              deserialize<_i162.SimpleData>(((data as Map)['p'] as List)[0]),
               deserialize<double>(data['p'][1]),
             ) as T;
     }
     if (t ==
         _i1.getType<
-            ((int, String), {(_i161.SimpleData, double) namedSubRecord})>()) {
+            ((int, String), {(_i162.SimpleData, double) namedSubRecord})>()) {
       return (
         deserialize<(int, String)>(((data as Map)['p'] as List)[0]),
-        namedSubRecord: deserialize<(_i161.SimpleData, double)>(
+        namedSubRecord: deserialize<(_i162.SimpleData, double)>(
             data['n']['namedSubRecord']),
       ) as T;
     }
     if (t ==
-        List<((int, String), {(_i161.SimpleData, double) namedSubRecord})>) {
+        List<((int, String), {(_i162.SimpleData, double) namedSubRecord})>) {
       return (data as List)
           .map((e) => deserialize<
-              ((int, String), {(_i161.SimpleData, double) namedSubRecord})>(e))
+              ((int, String), {(_i162.SimpleData, double) namedSubRecord})>(e))
           .toList() as T;
     }
     if (t ==
         _i1.getType<
-            ((int, String), {(_i161.SimpleData, double) namedSubRecord})>()) {
+            ((int, String), {(_i162.SimpleData, double) namedSubRecord})>()) {
       return (
         deserialize<(int, String)>(((data as Map)['p'] as List)[0]),
-        namedSubRecord: deserialize<(_i161.SimpleData, double)>(
+        namedSubRecord: deserialize<(_i162.SimpleData, double)>(
             data['n']['namedSubRecord']),
       ) as T;
     }
@@ -9471,37 +9496,37 @@ class Protocol extends _i1.SerializationManagerServer {
             List<
                 (
                   (int, String), {
-                  (_i161.SimpleData, double) namedSubRecord
+                  (_i162.SimpleData, double) namedSubRecord
                 })?>?>()) {
       return (data != null
           ? (data as List)
               .map((e) => deserialize<
                   (
                     (int, String), {
-                    (_i161.SimpleData, double) namedSubRecord
+                    (_i162.SimpleData, double) namedSubRecord
                   })?>(e))
               .toList()
           : null) as T;
     }
     if (t ==
         _i1.getType<
-            ((int, String), {(_i161.SimpleData, double) namedSubRecord})?>()) {
+            ((int, String), {(_i162.SimpleData, double) namedSubRecord})?>()) {
       return (data == null)
           ? null as T
           : (
               deserialize<(int, String)>(((data as Map)['p'] as List)[0]),
-              namedSubRecord: deserialize<(_i161.SimpleData, double)>(
+              namedSubRecord: deserialize<(_i162.SimpleData, double)>(
                   data['n']['namedSubRecord']),
             ) as T;
     }
     if (t ==
         _i1.getType<
-            ((int, String), {(_i161.SimpleData, double) namedSubRecord})?>()) {
+            ((int, String), {(_i162.SimpleData, double) namedSubRecord})?>()) {
       return (data == null)
           ? null as T
           : (
               deserialize<(int, String)>(((data as Map)['p'] as List)[0]),
-              namedSubRecord: deserialize<(_i161.SimpleData, double)>(
+              namedSubRecord: deserialize<(_i162.SimpleData, double)>(
                   data['n']['namedSubRecord']),
             ) as T;
     }
@@ -9561,17 +9586,17 @@ class Protocol extends _i1.SerializationManagerServer {
     if (t == Set<DateTime?>) {
       return (data as List).map((e) => deserialize<DateTime?>(e)).toSet() as T;
     }
-    if (t == Set<_i159.ByteData>) {
-      return (data as List).map((e) => deserialize<_i159.ByteData>(e)).toSet()
+    if (t == Set<_i160.ByteData>) {
+      return (data as List).map((e) => deserialize<_i160.ByteData>(e)).toSet()
           as T;
     }
-    if (t == Set<_i159.ByteData?>) {
-      return (data as List).map((e) => deserialize<_i159.ByteData?>(e)).toSet()
+    if (t == Set<_i160.ByteData?>) {
+      return (data as List).map((e) => deserialize<_i160.ByteData?>(e)).toSet()
           as T;
     }
-    if (t == Set<_i161.SimpleData?>) {
+    if (t == Set<_i162.SimpleData?>) {
       return (data as List)
-          .map((e) => deserialize<_i161.SimpleData?>(e))
+          .map((e) => deserialize<_i162.SimpleData?>(e))
           .toSet() as T;
     }
     if (t == Set<Duration>) {
@@ -9580,8 +9605,8 @@ class Protocol extends _i1.SerializationManagerServer {
     if (t == Set<Duration?>) {
       return (data as List).map((e) => deserialize<Duration?>(e)).toSet() as T;
     }
-    if (t == List<_i163.Types>) {
-      return (data as List).map((e) => deserialize<_i163.Types>(e)).toList()
+    if (t == List<_i164.Types>) {
+      return (data as List).map((e) => deserialize<_i164.Types>(e)).toList()
           as T;
     }
     if (t == _i1.getType<(String, (int, bool))>()) {
@@ -9611,7 +9636,7 @@ class Protocol extends _i1.SerializationManagerServer {
         _i1.getType<
             (
               String,
-              (Map<String, int>, {bool flag, _i161.SimpleData simpleData})
+              (Map<String, int>, {bool flag, _i162.SimpleData simpleData})
             )>()) {
       return (
         deserialize<String>(((data as Map)['p'] as List)[0]),
@@ -9619,17 +9644,17 @@ class Protocol extends _i1.SerializationManagerServer {
             (
               Map<String, int>, {
               bool flag,
-              _i161.SimpleData simpleData
+              _i162.SimpleData simpleData
             })>(data['p'][1]),
       ) as T;
     }
     if (t ==
         _i1.getType<
-            (Map<String, int>, {bool flag, _i161.SimpleData simpleData})>()) {
+            (Map<String, int>, {bool flag, _i162.SimpleData simpleData})>()) {
       return (
         deserialize<Map<String, int>>(((data as Map)['p'] as List)[0]),
         flag: deserialize<bool>(data['n']['flag']),
-        simpleData: deserialize<_i161.SimpleData>(data['n']['simpleData']),
+        simpleData: deserialize<_i162.SimpleData>(data['n']['simpleData']),
       ) as T;
     }
     if (t == List<(String, int)>) {
@@ -9646,7 +9671,7 @@ class Protocol extends _i1.SerializationManagerServer {
         _i1.getType<
             (
               String,
-              (Map<String, int>, {bool flag, _i161.SimpleData simpleData})
+              (Map<String, int>, {bool flag, _i162.SimpleData simpleData})
             )?>()) {
       return (data == null)
           ? null as T
@@ -9656,7 +9681,7 @@ class Protocol extends _i1.SerializationManagerServer {
                   (
                     Map<String, int>, {
                     bool flag,
-                    _i161.SimpleData simpleData
+                    _i162.SimpleData simpleData
                   })>(data['p'][1]),
             ) as T;
     }
@@ -9682,29 +9707,29 @@ class Protocol extends _i1.SerializationManagerServer {
           ? null as T
           : (deserialize<bool>(((data as Map)['p'] as List)[0]),) as T;
     }
-    if (t == _i1.getType<(_i150.TestEnumStringified,)?>()) {
+    if (t == _i1.getType<(_i151.TestEnumStringified,)?>()) {
       return (data == null)
           ? null as T
           : (
-              deserialize<_i150.TestEnumStringified>(
+              deserialize<_i151.TestEnumStringified>(
                   ((data as Map)['p'] as List)[0]),
             ) as T;
     }
-    if (t == _i1.getType<List<(_i150.TestEnumStringified,)>?>()) {
+    if (t == _i1.getType<List<(_i151.TestEnumStringified,)>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<(_i150.TestEnumStringified,)>(e))
+              .map((e) => deserialize<(_i151.TestEnumStringified,)>(e))
               .toList()
           : null) as T;
     }
-    if (t == _i1.getType<(_i150.TestEnumStringified,)>()) {
+    if (t == _i1.getType<(_i151.TestEnumStringified,)>()) {
       return (
-        deserialize<_i150.TestEnumStringified>(((data as Map)['p'] as List)[0]),
+        deserialize<_i151.TestEnumStringified>(((data as Map)['p'] as List)[0]),
       ) as T;
     }
-    if (t == _i1.getType<(_i150.TestEnumStringified,)>()) {
+    if (t == _i1.getType<(_i151.TestEnumStringified,)>()) {
       return (
-        deserialize<_i150.TestEnumStringified>(((data as Map)['p'] as List)[0]),
+        deserialize<_i151.TestEnumStringified>(((data as Map)['p'] as List)[0]),
       ) as T;
     }
     if (t == _i1.getType<(_i113.Nullability,)?>()) {
@@ -9713,30 +9738,30 @@ class Protocol extends _i1.SerializationManagerServer {
           : (deserialize<_i113.Nullability>(((data as Map)['p'] as List)[0]),)
               as T;
     }
-    if (t == _i1.getType<({_i150.TestEnumStringified value})?>()) {
+    if (t == _i1.getType<({_i151.TestEnumStringified value})?>()) {
       return (data == null)
           ? null as T
           : (
-              value: deserialize<_i150.TestEnumStringified>(
+              value: deserialize<_i151.TestEnumStringified>(
                   ((data as Map)['n'] as Map)['value']),
             ) as T;
     }
-    if (t == _i1.getType<List<({_i150.TestEnumStringified value})>?>()) {
+    if (t == _i1.getType<List<({_i151.TestEnumStringified value})>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<({_i150.TestEnumStringified value})>(e))
+              .map((e) => deserialize<({_i151.TestEnumStringified value})>(e))
               .toList()
           : null) as T;
     }
-    if (t == _i1.getType<({_i150.TestEnumStringified value})>()) {
+    if (t == _i1.getType<({_i151.TestEnumStringified value})>()) {
       return (
-        value: deserialize<_i150.TestEnumStringified>(
+        value: deserialize<_i151.TestEnumStringified>(
             ((data as Map)['n'] as Map)['value']),
       ) as T;
     }
-    if (t == _i1.getType<({_i150.TestEnumStringified value})>()) {
+    if (t == _i1.getType<({_i151.TestEnumStringified value})>()) {
       return (
-        value: deserialize<_i150.TestEnumStringified>(
+        value: deserialize<_i151.TestEnumStringified>(
             ((data as Map)['n'] as Map)['value']),
       ) as T;
     }
@@ -9784,19 +9809,19 @@ class Protocol extends _i1.SerializationManagerServer {
           ? null as T
           : (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
     }
-    if (t == _i1.getType<List<(_i149.TestEnum,)>?>()) {
+    if (t == _i1.getType<List<(_i150.TestEnum,)>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<(_i149.TestEnum,)>(e))
+              .map((e) => deserialize<(_i150.TestEnum,)>(e))
               .toList()
           : null) as T;
     }
-    if (t == _i1.getType<(_i149.TestEnum,)>()) {
-      return (deserialize<_i149.TestEnum>(((data as Map)['p'] as List)[0]),)
+    if (t == _i1.getType<(_i150.TestEnum,)>()) {
+      return (deserialize<_i150.TestEnum>(((data as Map)['p'] as List)[0]),)
           as T;
     }
-    if (t == _i1.getType<(_i149.TestEnum,)>()) {
-      return (deserialize<_i149.TestEnum>(((data as Map)['p'] as List)[0]),)
+    if (t == _i1.getType<(_i150.TestEnum,)>()) {
+      return (deserialize<_i150.TestEnum>(((data as Map)['p'] as List)[0]),)
           as T;
     }
     if (t == _i1.getType<Map<(String,), String>?>()) {
@@ -9857,10 +9882,10 @@ class Protocol extends _i1.SerializationManagerServer {
           ? null as T
           : (deserialize<DateTime>(((data as Map)['p'] as List)[0]),) as T;
     }
-    if (t == _i1.getType<(_i159.ByteData,)?>()) {
+    if (t == _i1.getType<(_i160.ByteData,)?>()) {
       return (data == null)
           ? null as T
-          : (deserialize<_i159.ByteData>(((data as Map)['p'] as List)[0]),)
+          : (deserialize<_i160.ByteData>(((data as Map)['p'] as List)[0]),)
               as T;
     }
     if (t == _i1.getType<(Duration,)?>()) {
@@ -9883,10 +9908,10 @@ class Protocol extends _i1.SerializationManagerServer {
           ? null as T
           : (deserialize<BigInt>(((data as Map)['p'] as List)[0]),) as T;
     }
-    if (t == _i1.getType<(_i149.TestEnum,)?>()) {
+    if (t == _i1.getType<(_i150.TestEnum,)?>()) {
       return (data == null)
           ? null as T
-          : (deserialize<_i149.TestEnum>(((data as Map)['p'] as List)[0]),)
+          : (deserialize<_i150.TestEnum>(((data as Map)['p'] as List)[0]),)
               as T;
     }
     if (t == _i1.getType<(List<int>,)?>()) {
@@ -9904,28 +9929,28 @@ class Protocol extends _i1.SerializationManagerServer {
           ? null as T
           : (deserialize<Set<int>>(((data as Map)['p'] as List)[0]),) as T;
     }
-    if (t == _i1.getType<(_i143.SimpleData,)?>()) {
+    if (t == _i1.getType<(_i144.SimpleData,)?>()) {
       return (data == null)
           ? null as T
-          : (deserialize<_i143.SimpleData>(((data as Map)['p'] as List)[0]),)
+          : (deserialize<_i144.SimpleData>(((data as Map)['p'] as List)[0]),)
               as T;
     }
-    if (t == _i1.getType<({_i143.SimpleData namedModel})?>()) {
+    if (t == _i1.getType<({_i144.SimpleData namedModel})?>()) {
       return (data == null)
           ? null as T
           : (
-              namedModel: deserialize<_i143.SimpleData>(
+              namedModel: deserialize<_i144.SimpleData>(
                   ((data as Map)['n'] as Map)['namedModel']),
             ) as T;
     }
     if (t ==
-        _i1.getType<(_i143.SimpleData, {_i143.SimpleData namedModel})?>()) {
+        _i1.getType<(_i144.SimpleData, {_i144.SimpleData namedModel})?>()) {
       return (data == null)
           ? null as T
           : (
-              deserialize<_i143.SimpleData>(((data as Map)['p'] as List)[0]),
+              deserialize<_i144.SimpleData>(((data as Map)['p'] as List)[0]),
               namedModel:
-                  deserialize<_i143.SimpleData>(data['n']['namedModel']),
+                  deserialize<_i144.SimpleData>(data['n']['namedModel']),
             ) as T;
     }
     if (t ==
@@ -9947,46 +9972,46 @@ class Protocol extends _i1.SerializationManagerServer {
     if (t ==
         _i1.getType<
             (
-              (List<(_i143.SimpleData,)>,), {
+              (List<(_i144.SimpleData,)>,), {
               (
-                _i143.SimpleData,
-                Map<String, _i143.SimpleData>
+                _i144.SimpleData,
+                Map<String, _i144.SimpleData>
               ) namedNestedRecord
             })?>()) {
       return (data == null)
           ? null as T
           : (
-              deserialize<(List<(_i143.SimpleData,)>,)>(
+              deserialize<(List<(_i144.SimpleData,)>,)>(
                   ((data as Map)['p'] as List)[0]),
               namedNestedRecord: deserialize<
                   (
-                    _i143.SimpleData,
-                    Map<String, _i143.SimpleData>
+                    _i144.SimpleData,
+                    Map<String, _i144.SimpleData>
                   )>(data['n']['namedNestedRecord']),
             ) as T;
     }
-    if (t == _i1.getType<(List<(_i143.SimpleData,)>,)>()) {
+    if (t == _i1.getType<(List<(_i144.SimpleData,)>,)>()) {
       return (
-        deserialize<List<(_i143.SimpleData,)>>(((data as Map)['p'] as List)[0]),
+        deserialize<List<(_i144.SimpleData,)>>(((data as Map)['p'] as List)[0]),
       ) as T;
     }
-    if (t == List<(_i143.SimpleData,)>) {
+    if (t == List<(_i144.SimpleData,)>) {
       return (data as List)
-          .map((e) => deserialize<(_i143.SimpleData,)>(e))
+          .map((e) => deserialize<(_i144.SimpleData,)>(e))
           .toList() as T;
     }
-    if (t == _i1.getType<(_i143.SimpleData,)>()) {
-      return (deserialize<_i143.SimpleData>(((data as Map)['p'] as List)[0]),)
+    if (t == _i1.getType<(_i144.SimpleData,)>()) {
+      return (deserialize<_i144.SimpleData>(((data as Map)['p'] as List)[0]),)
           as T;
     }
-    if (t == _i1.getType<(_i143.SimpleData,)>()) {
-      return (deserialize<_i143.SimpleData>(((data as Map)['p'] as List)[0]),)
+    if (t == _i1.getType<(_i144.SimpleData,)>()) {
+      return (deserialize<_i144.SimpleData>(((data as Map)['p'] as List)[0]),)
           as T;
     }
-    if (t == _i1.getType<(_i143.SimpleData, Map<String, _i143.SimpleData>)>()) {
+    if (t == _i1.getType<(_i144.SimpleData, Map<String, _i144.SimpleData>)>()) {
       return (
-        deserialize<_i143.SimpleData>(((data as Map)['p'] as List)[0]),
-        deserialize<Map<String, _i143.SimpleData>>(data['p'][1]),
+        deserialize<_i144.SimpleData>(((data as Map)['p'] as List)[0]),
+        deserialize<Map<String, _i144.SimpleData>>(data['p'][1]),
       ) as T;
     }
     if (t == _i1.getType<Set<(int,)>?>()) {
@@ -10007,57 +10032,57 @@ class Protocol extends _i1.SerializationManagerServer {
           ? null as T
           : (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
     }
-    if (t == _i160.CustomClass) {
-      return _i160.CustomClass.fromJson(data) as T;
+    if (t == _i161.CustomClass) {
+      return _i161.CustomClass.fromJson(data) as T;
     }
-    if (t == _i160.CustomClass2) {
-      return _i160.CustomClass2.fromJson(data) as T;
+    if (t == _i161.CustomClass2) {
+      return _i161.CustomClass2.fromJson(data) as T;
     }
-    if (t == _i160.ProtocolCustomClass) {
-      return _i160.ProtocolCustomClass.fromJson(data) as T;
+    if (t == _i161.ProtocolCustomClass) {
+      return _i161.ProtocolCustomClass.fromJson(data) as T;
     }
-    if (t == _i160.ExternalCustomClass) {
-      return _i160.ExternalCustomClass.fromJson(data) as T;
+    if (t == _i161.ExternalCustomClass) {
+      return _i161.ExternalCustomClass.fromJson(data) as T;
     }
-    if (t == _i160.FreezedCustomClass) {
-      return _i160.FreezedCustomClass.fromJson(data) as T;
+    if (t == _i161.FreezedCustomClass) {
+      return _i161.FreezedCustomClass.fromJson(data) as T;
     }
-    if (t == _i1.getType<_i160.CustomClass?>()) {
-      return (data != null ? _i160.CustomClass.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i161.CustomClass?>()) {
+      return (data != null ? _i161.CustomClass.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i160.CustomClass2?>()) {
-      return (data != null ? _i160.CustomClass2.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i161.CustomClass2?>()) {
+      return (data != null ? _i161.CustomClass2.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i160.CustomClassWithoutProtocolSerialization?>()) {
+    if (t == _i1.getType<_i161.CustomClassWithoutProtocolSerialization?>()) {
       return (data != null
-          ? _i160.CustomClassWithoutProtocolSerialization.fromJson(data)
+          ? _i161.CustomClassWithoutProtocolSerialization.fromJson(data)
           : null) as T;
     }
-    if (t == _i1.getType<_i160.CustomClassWithProtocolSerialization?>()) {
+    if (t == _i1.getType<_i161.CustomClassWithProtocolSerialization?>()) {
       return (data != null
-          ? _i160.CustomClassWithProtocolSerialization.fromJson(data)
+          ? _i161.CustomClassWithProtocolSerialization.fromJson(data)
           : null) as T;
     }
-    if (t == _i1.getType<_i160.CustomClassWithProtocolSerializationMethod?>()) {
+    if (t == _i1.getType<_i161.CustomClassWithProtocolSerializationMethod?>()) {
       return (data != null
-          ? _i160.CustomClassWithProtocolSerializationMethod.fromJson(data)
+          ? _i161.CustomClassWithProtocolSerializationMethod.fromJson(data)
           : null) as T;
     }
-    if (t == _i1.getType<_i160.ProtocolCustomClass?>()) {
-      return (data != null ? _i160.ProtocolCustomClass.fromJson(data) : null)
+    if (t == _i1.getType<_i161.ProtocolCustomClass?>()) {
+      return (data != null ? _i161.ProtocolCustomClass.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i160.ExternalCustomClass?>()) {
-      return (data != null ? _i160.ExternalCustomClass.fromJson(data) : null)
+    if (t == _i1.getType<_i161.ExternalCustomClass?>()) {
+      return (data != null ? _i161.ExternalCustomClass.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i160.FreezedCustomClass?>()) {
-      return (data != null ? _i160.FreezedCustomClass.fromJson(data) : null)
+    if (t == _i1.getType<_i161.FreezedCustomClass?>()) {
+      return (data != null ? _i161.FreezedCustomClass.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<List<_i161.SimpleData>?>()) {
+    if (t == _i1.getType<List<_i162.SimpleData>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i161.SimpleData>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i162.SimpleData>(e)).toList()
           : null) as T;
     }
     if (t == _i1.getType<(int?,)?>()) {
@@ -10074,26 +10099,26 @@ class Protocol extends _i1.SerializationManagerServer {
             List<
                 (
                   (int, String), {
-                  (_i161.SimpleData, double) namedSubRecord
+                  (_i162.SimpleData, double) namedSubRecord
                 })?>?>()) {
       return (data != null
           ? (data as List)
               .map((e) => deserialize<
                   (
                     (int, String), {
-                    (_i161.SimpleData, double) namedSubRecord
+                    (_i162.SimpleData, double) namedSubRecord
                   })?>(e))
               .toList()
           : null) as T;
     }
     if (t ==
         _i1.getType<
-            ((int, String), {(_i161.SimpleData, double) namedSubRecord})?>()) {
+            ((int, String), {(_i162.SimpleData, double) namedSubRecord})?>()) {
       return (data == null)
           ? null as T
           : (
               deserialize<(int, String)>(((data as Map)['p'] as List)[0]),
-              namedSubRecord: deserialize<(_i161.SimpleData, double)>(
+              namedSubRecord: deserialize<(_i162.SimpleData, double)>(
                   data['n']['namedSubRecord']),
             ) as T;
     }
@@ -10101,7 +10126,7 @@ class Protocol extends _i1.SerializationManagerServer {
         _i1.getType<
             (
               String,
-              (Map<String, int>, {bool flag, _i161.SimpleData simpleData})
+              (Map<String, int>, {bool flag, _i162.SimpleData simpleData})
             )>()) {
       return (
         deserialize<String>(((data as Map)['p'] as List)[0]),
@@ -10109,7 +10134,7 @@ class Protocol extends _i1.SerializationManagerServer {
             (
               Map<String, int>, {
               bool flag,
-              _i161.SimpleData simpleData
+              _i162.SimpleData simpleData
             })>(data['p'][1]),
       ) as T;
     }
@@ -10123,7 +10148,7 @@ class Protocol extends _i1.SerializationManagerServer {
         _i1.getType<
             (
               String,
-              (Map<String, int>, {bool flag, _i161.SimpleData simpleData})
+              (Map<String, int>, {bool flag, _i162.SimpleData simpleData})
             )?>()) {
       return (data == null)
           ? null as T
@@ -10133,7 +10158,7 @@ class Protocol extends _i1.SerializationManagerServer {
                   (
                     Map<String, int>, {
                     bool flag,
-                    _i161.SimpleData simpleData
+                    _i162.SimpleData simpleData
                   })>(data['p'][1]),
             ) as T;
     }
@@ -10165,21 +10190,21 @@ class Protocol extends _i1.SerializationManagerServer {
     String? className = super.getClassNameForObject(data);
     if (className != null) return className;
     switch (data) {
-      case _i160.CustomClass():
+      case _i161.CustomClass():
         return 'CustomClass';
-      case _i160.CustomClass2():
+      case _i161.CustomClass2():
         return 'CustomClass2';
-      case _i160.CustomClassWithoutProtocolSerialization():
+      case _i161.CustomClassWithoutProtocolSerialization():
         return 'CustomClassWithoutProtocolSerialization';
-      case _i160.CustomClassWithProtocolSerialization():
+      case _i161.CustomClassWithProtocolSerialization():
         return 'CustomClassWithProtocolSerialization';
-      case _i160.CustomClassWithProtocolSerializationMethod():
+      case _i161.CustomClassWithProtocolSerializationMethod():
         return 'CustomClassWithProtocolSerializationMethod';
-      case _i160.ProtocolCustomClass():
+      case _i161.ProtocolCustomClass():
         return 'ProtocolCustomClass';
-      case _i160.ExternalCustomClass():
+      case _i161.ExternalCustomClass():
         return 'ExternalCustomClass';
-      case _i160.FreezedCustomClass():
+      case _i161.FreezedCustomClass():
         return 'FreezedCustomClass';
       case _i5.ScopeServerOnlyFieldChild():
         return 'ScopeServerOnlyFieldChild';
@@ -10195,8 +10220,8 @@ class Protocol extends _i1.SerializationManagerServer {
         return 'SealedChild';
       case _i9.SealedOtherChild():
         return 'SealedOtherChild';
-      case _i10.StringDefaultPersist():
-        return 'StringDefaultPersist';
+      case _i10.UriDefault():
+        return 'UriDefault';
       case _i11.CommentInt():
         return 'CommentInt';
       case _i12.CustomerInt():
@@ -10283,10 +10308,10 @@ class Protocol extends _i1.SerializationManagerServer {
         return 'StringDefaultMix';
       case _i53.StringDefaultModel():
         return 'StringDefaultModel';
-      case _i54.ByIndexEnumWithNameValue():
+      case _i54.StringDefaultPersist():
+        return 'StringDefaultPersist';
+      case _i55.ByIndexEnumWithNameValue():
         return 'ByIndexEnumWithNameValue';
-      case _i55.UriDefault():
-        return 'UriDefault';
       case _i56.UriDefaultMix():
         return 'UriDefaultMix';
       case _i57.UriDefaultModel():
@@ -10387,10 +10412,10 @@ class Protocol extends _i1.SerializationManagerServer {
         return 'Address';
       case _i105.Citizen():
         return 'Citizen';
-      case _i106.MyFeatureModel():
+      case _i106.Company():
+        return 'Company';
+      case _i107.MyFeatureModel():
         return 'MyFeatureModel';
-      case _i107.Town():
-        return 'Town';
       case _i108.Blocking():
         return 'Blocking';
       case _i109.Member():
@@ -10423,76 +10448,78 @@ class Protocol extends _i1.SerializationManagerServer {
         return 'ObjectWithIndex';
       case _i123.ObjectWithMaps():
         return 'ObjectWithMaps';
-      case _i124.ObjectWithObject():
+      case _i124.ObjectWithNullableCustomClass():
+        return 'ObjectWithNullableCustomClass';
+      case _i125.ObjectWithObject():
         return 'ObjectWithObject';
-      case _i125.ObjectWithParent():
+      case _i126.ObjectWithParent():
         return 'ObjectWithParent';
-      case _i126.ObjectWithSelfParent():
+      case _i127.ObjectWithSelfParent():
         return 'ObjectWithSelfParent';
-      case _i127.ObjectWithSparseVector():
+      case _i128.ObjectWithSparseVector():
         return 'ObjectWithSparseVector';
-      case _i128.ObjectWithUuid():
+      case _i129.ObjectWithUuid():
         return 'ObjectWithUuid';
-      case _i129.ObjectWithVector():
+      case _i130.ObjectWithVector():
         return 'ObjectWithVector';
-      case _i130.Record():
+      case _i131.Record():
         return 'Record';
-      case _i131.RelatedUniqueData():
+      case _i132.RelatedUniqueData():
         return 'RelatedUniqueData';
-      case _i132.ScopeNoneFields():
+      case _i133.ScopeNoneFields():
         return 'ScopeNoneFields';
-      case _i133.ScopeServerOnlyField():
+      case _i134.ScopeServerOnlyField():
         return 'ScopeServerOnlyField';
-      case _i134.TeamInt():
+      case _i135.TeamInt():
         return 'TeamInt';
-      case _i135.DefaultServerOnlyClass():
+      case _i136.DefaultServerOnlyClass():
         return 'DefaultServerOnlyClass';
-      case _i136.DefaultServerOnlyEnum():
+      case _i137.DefaultServerOnlyEnum():
         return 'DefaultServerOnlyEnum';
-      case _i137.NotServerOnlyClass():
+      case _i138.NotServerOnlyClass():
         return 'NotServerOnlyClass';
-      case _i138.NotServerOnlyEnum():
+      case _i139.NotServerOnlyEnum():
         return 'NotServerOnlyEnum';
-      case _i139.ServerOnlyClass():
+      case _i140.ServerOnlyClass():
         return 'ServerOnlyClass';
-      case _i140.ServerOnlyEnum():
+      case _i141.ServerOnlyEnum():
         return 'ServerOnlyEnum';
-      case _i141.ServerOnlyClassField():
+      case _i142.ServerOnlyClassField():
         return 'ServerOnlyClassField';
-      case _i142.ServerOnlyDefault():
+      case _i143.ServerOnlyDefault():
         return 'ServerOnlyDefault';
-      case _i143.SimpleData():
+      case _i144.SimpleData():
         return 'SimpleData';
-      case _i144.SimpleDataList():
+      case _i145.SimpleDataList():
         return 'SimpleDataList';
-      case _i145.SimpleDataMap():
+      case _i146.SimpleDataMap():
         return 'SimpleDataMap';
-      case _i146.SimpleDataObject():
+      case _i147.SimpleDataObject():
         return 'SimpleDataObject';
-      case _i147.SimpleDateTime():
+      case _i148.SimpleDateTime():
         return 'SimpleDateTime';
-      case _i148.ModelInSubfolder():
+      case _i149.ModelInSubfolder():
         return 'ModelInSubfolder';
-      case _i149.TestEnum():
+      case _i150.TestEnum():
         return 'TestEnum';
-      case _i150.TestEnumStringified():
+      case _i151.TestEnumStringified():
         return 'TestEnumStringified';
-      case _i151.Types():
+      case _i152.Types():
         return 'Types';
-      case _i152.TypesList():
+      case _i153.TypesList():
         return 'TypesList';
-      case _i153.TypesMap():
+      case _i154.TypesMap():
         return 'TypesMap';
-      case _i154.TypesRecord():
+      case _i155.TypesRecord():
         return 'TypesRecord';
-      case _i155.TypesSet():
+      case _i156.TypesSet():
         return 'TypesSet';
-      case _i156.TypesSetRequired():
+      case _i157.TypesSetRequired():
         return 'TypesSetRequired';
-      case _i157.UniqueData():
+      case _i158.UniqueData():
         return 'UniqueData';
-      case _i158.Company():
-        return 'Company';
+      case _i159.Town():
+        return 'Town';
     }
     className = _i2.Protocol().getClassNameForObject(data);
     if (className != null) {
@@ -10509,37 +10536,37 @@ class Protocol extends _i1.SerializationManagerServer {
     if (data is List<int>) {
       return 'List<int>';
     }
-    if (data is List<_i161.SimpleData>) {
+    if (data is List<_i162.SimpleData>) {
       return 'List<SimpleData>';
     }
     if (data is List<_i3.UserInfo>) {
       return 'List<serverpod_auth.UserInfo>';
     }
-    if (data is List<_i161.SimpleData>?) {
+    if (data is List<_i162.SimpleData>?) {
       return 'List<SimpleData>?';
     }
-    if (data is List<_i161.SimpleData?>) {
+    if (data is List<_i162.SimpleData?>) {
       return 'List<SimpleData?>';
     }
     if (data is Set<int>) {
       return 'Set<int>';
     }
-    if (data is Set<_i161.SimpleData>) {
+    if (data is Set<_i162.SimpleData>) {
       return 'Set<SimpleData>';
     }
-    if (data is List<Set<_i161.SimpleData>>) {
+    if (data is List<Set<_i162.SimpleData>>) {
       return 'List<Set<SimpleData>>';
     }
     if (data is (int?,)?) {
       return '(int?,)?';
     }
     if (data is List<
-        ((int, String), {(_i161.SimpleData, double) namedSubRecord})?>?) {
+        ((int, String), {(_i162.SimpleData, double) namedSubRecord})?>?) {
       return 'List<((int,String),{(SimpleData,double) namedSubRecord})?>?';
     }
     if (data is (
       String,
-      (Map<String, int>, {bool flag, _i161.SimpleData simpleData})
+      (Map<String, int>, {bool flag, _i162.SimpleData simpleData})
     )) {
       return '(String,(Map<String,int>,{bool flag,SimpleData simpleData}))';
     }
@@ -10548,7 +10575,7 @@ class Protocol extends _i1.SerializationManagerServer {
     }
     if (data is (
       String,
-      (Map<String, int>, {bool flag, _i161.SimpleData simpleData})
+      (Map<String, int>, {bool flag, _i162.SimpleData simpleData})
     )?) {
       return '(String,(Map<String,int>,{bool flag,SimpleData simpleData}))?';
     }
@@ -10565,31 +10592,31 @@ class Protocol extends _i1.SerializationManagerServer {
       return super.deserializeByClassName(data);
     }
     if (dataClassName == 'CustomClass') {
-      return deserialize<_i160.CustomClass>(data['data']);
+      return deserialize<_i161.CustomClass>(data['data']);
     }
     if (dataClassName == 'CustomClass2') {
-      return deserialize<_i160.CustomClass2>(data['data']);
+      return deserialize<_i161.CustomClass2>(data['data']);
     }
     if (dataClassName == 'CustomClassWithoutProtocolSerialization') {
-      return deserialize<_i160.CustomClassWithoutProtocolSerialization>(
+      return deserialize<_i161.CustomClassWithoutProtocolSerialization>(
           data['data']);
     }
     if (dataClassName == 'CustomClassWithProtocolSerialization') {
-      return deserialize<_i160.CustomClassWithProtocolSerialization>(
+      return deserialize<_i161.CustomClassWithProtocolSerialization>(
           data['data']);
     }
     if (dataClassName == 'CustomClassWithProtocolSerializationMethod') {
-      return deserialize<_i160.CustomClassWithProtocolSerializationMethod>(
+      return deserialize<_i161.CustomClassWithProtocolSerializationMethod>(
           data['data']);
     }
     if (dataClassName == 'ProtocolCustomClass') {
-      return deserialize<_i160.ProtocolCustomClass>(data['data']);
+      return deserialize<_i161.ProtocolCustomClass>(data['data']);
     }
     if (dataClassName == 'ExternalCustomClass') {
-      return deserialize<_i160.ExternalCustomClass>(data['data']);
+      return deserialize<_i161.ExternalCustomClass>(data['data']);
     }
     if (dataClassName == 'FreezedCustomClass') {
-      return deserialize<_i160.FreezedCustomClass>(data['data']);
+      return deserialize<_i161.FreezedCustomClass>(data['data']);
     }
     if (dataClassName == 'ScopeServerOnlyFieldChild') {
       return deserialize<_i5.ScopeServerOnlyFieldChild>(data['data']);
@@ -10612,8 +10639,8 @@ class Protocol extends _i1.SerializationManagerServer {
     if (dataClassName == 'SealedOtherChild') {
       return deserialize<_i9.SealedOtherChild>(data['data']);
     }
-    if (dataClassName == 'StringDefaultPersist') {
-      return deserialize<_i10.StringDefaultPersist>(data['data']);
+    if (dataClassName == 'UriDefault') {
+      return deserialize<_i10.UriDefault>(data['data']);
     }
     if (dataClassName == 'CommentInt') {
       return deserialize<_i11.CommentInt>(data['data']);
@@ -10744,11 +10771,11 @@ class Protocol extends _i1.SerializationManagerServer {
     if (dataClassName == 'StringDefaultModel') {
       return deserialize<_i53.StringDefaultModel>(data['data']);
     }
-    if (dataClassName == 'ByIndexEnumWithNameValue') {
-      return deserialize<_i54.ByIndexEnumWithNameValue>(data['data']);
+    if (dataClassName == 'StringDefaultPersist') {
+      return deserialize<_i54.StringDefaultPersist>(data['data']);
     }
-    if (dataClassName == 'UriDefault') {
-      return deserialize<_i55.UriDefault>(data['data']);
+    if (dataClassName == 'ByIndexEnumWithNameValue') {
+      return deserialize<_i55.ByIndexEnumWithNameValue>(data['data']);
     }
     if (dataClassName == 'UriDefaultMix') {
       return deserialize<_i56.UriDefaultMix>(data['data']);
@@ -10900,11 +10927,11 @@ class Protocol extends _i1.SerializationManagerServer {
     if (dataClassName == 'Citizen') {
       return deserialize<_i105.Citizen>(data['data']);
     }
-    if (dataClassName == 'MyFeatureModel') {
-      return deserialize<_i106.MyFeatureModel>(data['data']);
+    if (dataClassName == 'Company') {
+      return deserialize<_i106.Company>(data['data']);
     }
-    if (dataClassName == 'Town') {
-      return deserialize<_i107.Town>(data['data']);
+    if (dataClassName == 'MyFeatureModel') {
+      return deserialize<_i107.MyFeatureModel>(data['data']);
     }
     if (dataClassName == 'Blocking') {
       return deserialize<_i108.Blocking>(data['data']);
@@ -10954,110 +10981,113 @@ class Protocol extends _i1.SerializationManagerServer {
     if (dataClassName == 'ObjectWithMaps') {
       return deserialize<_i123.ObjectWithMaps>(data['data']);
     }
+    if (dataClassName == 'ObjectWithNullableCustomClass') {
+      return deserialize<_i124.ObjectWithNullableCustomClass>(data['data']);
+    }
     if (dataClassName == 'ObjectWithObject') {
-      return deserialize<_i124.ObjectWithObject>(data['data']);
+      return deserialize<_i125.ObjectWithObject>(data['data']);
     }
     if (dataClassName == 'ObjectWithParent') {
-      return deserialize<_i125.ObjectWithParent>(data['data']);
+      return deserialize<_i126.ObjectWithParent>(data['data']);
     }
     if (dataClassName == 'ObjectWithSelfParent') {
-      return deserialize<_i126.ObjectWithSelfParent>(data['data']);
+      return deserialize<_i127.ObjectWithSelfParent>(data['data']);
     }
     if (dataClassName == 'ObjectWithSparseVector') {
-      return deserialize<_i127.ObjectWithSparseVector>(data['data']);
+      return deserialize<_i128.ObjectWithSparseVector>(data['data']);
     }
     if (dataClassName == 'ObjectWithUuid') {
-      return deserialize<_i128.ObjectWithUuid>(data['data']);
+      return deserialize<_i129.ObjectWithUuid>(data['data']);
     }
     if (dataClassName == 'ObjectWithVector') {
-      return deserialize<_i129.ObjectWithVector>(data['data']);
+      return deserialize<_i130.ObjectWithVector>(data['data']);
     }
     if (dataClassName == 'Record') {
-      return deserialize<_i130.Record>(data['data']);
+      return deserialize<_i131.Record>(data['data']);
     }
     if (dataClassName == 'RelatedUniqueData') {
-      return deserialize<_i131.RelatedUniqueData>(data['data']);
+      return deserialize<_i132.RelatedUniqueData>(data['data']);
     }
     if (dataClassName == 'ScopeNoneFields') {
-      return deserialize<_i132.ScopeNoneFields>(data['data']);
+      return deserialize<_i133.ScopeNoneFields>(data['data']);
     }
     if (dataClassName == 'ScopeServerOnlyField') {
-      return deserialize<_i133.ScopeServerOnlyField>(data['data']);
+      return deserialize<_i134.ScopeServerOnlyField>(data['data']);
     }
     if (dataClassName == 'TeamInt') {
-      return deserialize<_i134.TeamInt>(data['data']);
+      return deserialize<_i135.TeamInt>(data['data']);
     }
     if (dataClassName == 'DefaultServerOnlyClass') {
-      return deserialize<_i135.DefaultServerOnlyClass>(data['data']);
+      return deserialize<_i136.DefaultServerOnlyClass>(data['data']);
     }
     if (dataClassName == 'DefaultServerOnlyEnum') {
-      return deserialize<_i136.DefaultServerOnlyEnum>(data['data']);
+      return deserialize<_i137.DefaultServerOnlyEnum>(data['data']);
     }
     if (dataClassName == 'NotServerOnlyClass') {
-      return deserialize<_i137.NotServerOnlyClass>(data['data']);
+      return deserialize<_i138.NotServerOnlyClass>(data['data']);
     }
     if (dataClassName == 'NotServerOnlyEnum') {
-      return deserialize<_i138.NotServerOnlyEnum>(data['data']);
+      return deserialize<_i139.NotServerOnlyEnum>(data['data']);
     }
     if (dataClassName == 'ServerOnlyClass') {
-      return deserialize<_i139.ServerOnlyClass>(data['data']);
+      return deserialize<_i140.ServerOnlyClass>(data['data']);
     }
     if (dataClassName == 'ServerOnlyEnum') {
-      return deserialize<_i140.ServerOnlyEnum>(data['data']);
+      return deserialize<_i141.ServerOnlyEnum>(data['data']);
     }
     if (dataClassName == 'ServerOnlyClassField') {
-      return deserialize<_i141.ServerOnlyClassField>(data['data']);
+      return deserialize<_i142.ServerOnlyClassField>(data['data']);
     }
     if (dataClassName == 'ServerOnlyDefault') {
-      return deserialize<_i142.ServerOnlyDefault>(data['data']);
+      return deserialize<_i143.ServerOnlyDefault>(data['data']);
     }
     if (dataClassName == 'SimpleData') {
-      return deserialize<_i143.SimpleData>(data['data']);
+      return deserialize<_i144.SimpleData>(data['data']);
     }
     if (dataClassName == 'SimpleDataList') {
-      return deserialize<_i144.SimpleDataList>(data['data']);
+      return deserialize<_i145.SimpleDataList>(data['data']);
     }
     if (dataClassName == 'SimpleDataMap') {
-      return deserialize<_i145.SimpleDataMap>(data['data']);
+      return deserialize<_i146.SimpleDataMap>(data['data']);
     }
     if (dataClassName == 'SimpleDataObject') {
-      return deserialize<_i146.SimpleDataObject>(data['data']);
+      return deserialize<_i147.SimpleDataObject>(data['data']);
     }
     if (dataClassName == 'SimpleDateTime') {
-      return deserialize<_i147.SimpleDateTime>(data['data']);
+      return deserialize<_i148.SimpleDateTime>(data['data']);
     }
     if (dataClassName == 'ModelInSubfolder') {
-      return deserialize<_i148.ModelInSubfolder>(data['data']);
+      return deserialize<_i149.ModelInSubfolder>(data['data']);
     }
     if (dataClassName == 'TestEnum') {
-      return deserialize<_i149.TestEnum>(data['data']);
+      return deserialize<_i150.TestEnum>(data['data']);
     }
     if (dataClassName == 'TestEnumStringified') {
-      return deserialize<_i150.TestEnumStringified>(data['data']);
+      return deserialize<_i151.TestEnumStringified>(data['data']);
     }
     if (dataClassName == 'Types') {
-      return deserialize<_i151.Types>(data['data']);
+      return deserialize<_i152.Types>(data['data']);
     }
     if (dataClassName == 'TypesList') {
-      return deserialize<_i152.TypesList>(data['data']);
+      return deserialize<_i153.TypesList>(data['data']);
     }
     if (dataClassName == 'TypesMap') {
-      return deserialize<_i153.TypesMap>(data['data']);
+      return deserialize<_i154.TypesMap>(data['data']);
     }
     if (dataClassName == 'TypesRecord') {
-      return deserialize<_i154.TypesRecord>(data['data']);
+      return deserialize<_i155.TypesRecord>(data['data']);
     }
     if (dataClassName == 'TypesSet') {
-      return deserialize<_i155.TypesSet>(data['data']);
+      return deserialize<_i156.TypesSet>(data['data']);
     }
     if (dataClassName == 'TypesSetRequired') {
-      return deserialize<_i156.TypesSetRequired>(data['data']);
+      return deserialize<_i157.TypesSetRequired>(data['data']);
     }
     if (dataClassName == 'UniqueData') {
-      return deserialize<_i157.UniqueData>(data['data']);
+      return deserialize<_i158.UniqueData>(data['data']);
     }
-    if (dataClassName == 'Company') {
-      return deserialize<_i158.Company>(data['data']);
+    if (dataClassName == 'Town') {
+      return deserialize<_i159.Town>(data['data']);
     }
     if (dataClassName.startsWith('serverpod.')) {
       data['className'] = dataClassName.substring(10);
@@ -11075,25 +11105,25 @@ class Protocol extends _i1.SerializationManagerServer {
       return deserialize<List<int>>(data['data']);
     }
     if (dataClassName == 'List<SimpleData>') {
-      return deserialize<List<_i161.SimpleData>>(data['data']);
+      return deserialize<List<_i162.SimpleData>>(data['data']);
     }
     if (dataClassName == 'List<serverpod_auth.UserInfo>') {
       return deserialize<List<_i3.UserInfo>>(data['data']);
     }
     if (dataClassName == 'List<SimpleData>?') {
-      return deserialize<List<_i161.SimpleData>?>(data['data']);
+      return deserialize<List<_i162.SimpleData>?>(data['data']);
     }
     if (dataClassName == 'List<SimpleData?>') {
-      return deserialize<List<_i161.SimpleData?>>(data['data']);
+      return deserialize<List<_i162.SimpleData?>>(data['data']);
     }
     if (dataClassName == 'Set<int>') {
       return deserialize<Set<int>>(data['data']);
     }
     if (dataClassName == 'Set<SimpleData>') {
-      return deserialize<Set<_i161.SimpleData>>(data['data']);
+      return deserialize<Set<_i162.SimpleData>>(data['data']);
     }
     if (dataClassName == 'List<Set<SimpleData>>') {
-      return deserialize<List<Set<_i161.SimpleData>>>(data['data']);
+      return deserialize<List<Set<_i162.SimpleData>>>(data['data']);
     }
     if (dataClassName == '(int?,)?') {
       return deserialize<(int?,)?>(data['data']);
@@ -11104,7 +11134,7 @@ class Protocol extends _i1.SerializationManagerServer {
           List<
               (
                 (int, String), {
-                (_i161.SimpleData, double) namedSubRecord
+                (_i162.SimpleData, double) namedSubRecord
               })?>?>(data['data']);
     }
     if (dataClassName ==
@@ -11112,7 +11142,7 @@ class Protocol extends _i1.SerializationManagerServer {
       return deserialize<
           (
             String,
-            (Map<String, int>, {bool flag, _i161.SimpleData simpleData})
+            (Map<String, int>, {bool flag, _i162.SimpleData simpleData})
           )>(data['data']);
     }
     if (dataClassName == 'List<(String,int)>') {
@@ -11123,7 +11153,7 @@ class Protocol extends _i1.SerializationManagerServer {
       return deserialize<
           (
             String,
-            (Map<String, int>, {bool flag, _i161.SimpleData simpleData})
+            (Map<String, int>, {bool flag, _i162.SimpleData simpleData})
           )?>(data['data']);
     }
     if (dataClassName == 'List<(String,int)>?') {
@@ -11163,8 +11193,8 @@ class Protocol extends _i1.SerializationManagerServer {
         return _i74.ArenaUuid.t;
       case _i75.PlayerUuid:
         return _i75.PlayerUuid.t;
-      case _i134.TeamInt:
-        return _i134.TeamInt.t;
+      case _i135.TeamInt:
+        return _i135.TeamInt.t;
       case _i11.CommentInt:
         return _i11.CommentInt.t;
       case _i12.CustomerInt:
@@ -11243,10 +11273,10 @@ class Protocol extends _i1.SerializationManagerServer {
         return _i52.StringDefaultMix.t;
       case _i53.StringDefaultModel:
         return _i53.StringDefaultModel.t;
-      case _i10.StringDefaultPersist:
-        return _i10.StringDefaultPersist.t;
-      case _i55.UriDefault:
-        return _i55.UriDefault.t;
+      case _i54.StringDefaultPersist:
+        return _i54.StringDefaultPersist.t;
+      case _i10.UriDefault:
+        return _i10.UriDefault.t;
       case _i56.UriDefaultMix:
         return _i56.UriDefaultMix.t;
       case _i57.UriDefaultModel:
@@ -11329,10 +11359,10 @@ class Protocol extends _i1.SerializationManagerServer {
         return _i104.Address.t;
       case _i105.Citizen:
         return _i105.Citizen.t;
-      case _i158.Company:
-        return _i158.Company.t;
-      case _i107.Town:
-        return _i107.Town.t;
+      case _i106.Company:
+        return _i106.Company.t;
+      case _i159.Town:
+        return _i159.Town.t;
       case _i108.Blocking:
         return _i108.Blocking.t;
       case _i109.Member:
@@ -11357,30 +11387,30 @@ class Protocol extends _i1.SerializationManagerServer {
         return _i121.ObjectWithHalfVector.t;
       case _i122.ObjectWithIndex:
         return _i122.ObjectWithIndex.t;
-      case _i124.ObjectWithObject:
-        return _i124.ObjectWithObject.t;
-      case _i125.ObjectWithParent:
-        return _i125.ObjectWithParent.t;
-      case _i126.ObjectWithSelfParent:
-        return _i126.ObjectWithSelfParent.t;
-      case _i127.ObjectWithSparseVector:
-        return _i127.ObjectWithSparseVector.t;
-      case _i128.ObjectWithUuid:
-        return _i128.ObjectWithUuid.t;
-      case _i129.ObjectWithVector:
-        return _i129.ObjectWithVector.t;
-      case _i131.RelatedUniqueData:
-        return _i131.RelatedUniqueData.t;
-      case _i132.ScopeNoneFields:
-        return _i132.ScopeNoneFields.t;
-      case _i143.SimpleData:
-        return _i143.SimpleData.t;
-      case _i147.SimpleDateTime:
-        return _i147.SimpleDateTime.t;
-      case _i151.Types:
-        return _i151.Types.t;
-      case _i157.UniqueData:
-        return _i157.UniqueData.t;
+      case _i125.ObjectWithObject:
+        return _i125.ObjectWithObject.t;
+      case _i126.ObjectWithParent:
+        return _i126.ObjectWithParent.t;
+      case _i127.ObjectWithSelfParent:
+        return _i127.ObjectWithSelfParent.t;
+      case _i128.ObjectWithSparseVector:
+        return _i128.ObjectWithSparseVector.t;
+      case _i129.ObjectWithUuid:
+        return _i129.ObjectWithUuid.t;
+      case _i130.ObjectWithVector:
+        return _i130.ObjectWithVector.t;
+      case _i132.RelatedUniqueData:
+        return _i132.RelatedUniqueData.t;
+      case _i133.ScopeNoneFields:
+        return _i133.ScopeNoneFields.t;
+      case _i144.SimpleData:
+        return _i144.SimpleData.t;
+      case _i148.SimpleDateTime:
+        return _i148.SimpleDateTime.t;
+      case _i152.Types:
+        return _i152.Types.t;
+      case _i158.UniqueData:
+        return _i158.UniqueData.t;
     }
     return null;
   }
@@ -11469,7 +11499,7 @@ Map<String, dynamic>? mapRecordToJson(Record? record) {
       ],
     };
   }
-  if (record is (int, _i161.SimpleData)) {
+  if (record is (int, _i162.SimpleData)) {
     return {
       "p": [
         record.$1,
@@ -11499,7 +11529,7 @@ Map<String, dynamic>? mapRecordToJson(Record? record) {
       },
     };
   }
-  if (record is ({_i161.SimpleData data, int number})) {
+  if (record is ({_i162.SimpleData data, int number})) {
     return {
       "n": {
         "data": record.data,
@@ -11507,7 +11537,7 @@ Map<String, dynamic>? mapRecordToJson(Record? record) {
       },
     };
   }
-  if (record is ({_i161.SimpleData? data, int? number})) {
+  if (record is ({_i162.SimpleData? data, int? number})) {
     return {
       "n": {
         "data": record.data,
@@ -11543,7 +11573,7 @@ Map<String, dynamic>? mapRecordToJson(Record? record) {
       ],
     };
   }
-  if (record is (int, {_i161.SimpleData data})) {
+  if (record is (int, {_i162.SimpleData data})) {
     return {
       "p": [
         record.$1,
@@ -11561,14 +11591,14 @@ Map<String, dynamic>? mapRecordToJson(Record? record) {
       ],
     };
   }
-  if (record is ({(_i161.SimpleData, double) namedSubRecord})) {
+  if (record is ({(_i162.SimpleData, double) namedSubRecord})) {
     return {
       "n": {
         "namedSubRecord": mapRecordToJson(record.namedSubRecord),
       },
     };
   }
-  if (record is (_i161.SimpleData, double)) {
+  if (record is (_i162.SimpleData, double)) {
     return {
       "p": [
         record.$1,
@@ -11576,14 +11606,14 @@ Map<String, dynamic>? mapRecordToJson(Record? record) {
       ],
     };
   }
-  if (record is ({(_i161.SimpleData, double)? namedSubRecord})) {
+  if (record is ({(_i162.SimpleData, double)? namedSubRecord})) {
     return {
       "n": {
         "namedSubRecord": mapRecordToJson(record.namedSubRecord),
       },
     };
   }
-  if (record is ((int, String), {(_i161.SimpleData, double) namedSubRecord})) {
+  if (record is ((int, String), {(_i162.SimpleData, double) namedSubRecord})) {
     return {
       "p": [
         mapRecordToJson(record.$1),
@@ -11611,7 +11641,7 @@ Map<String, dynamic>? mapRecordToJson(Record? record) {
   }
   if (record is (
     String,
-    (Map<String, int>, {bool flag, _i161.SimpleData simpleData})
+    (Map<String, int>, {bool flag, _i162.SimpleData simpleData})
   )) {
     return {
       "p": [
@@ -11620,7 +11650,7 @@ Map<String, dynamic>? mapRecordToJson(Record? record) {
       ],
     };
   }
-  if (record is (Map<String, int>, {bool flag, _i161.SimpleData simpleData})) {
+  if (record is (Map<String, int>, {bool flag, _i162.SimpleData simpleData})) {
     return {
       "p": [
         record.$1,
@@ -11645,7 +11675,7 @@ Map<String, dynamic>? mapRecordToJson(Record? record) {
       ],
     };
   }
-  if (record is (_i150.TestEnumStringified,)) {
+  if (record is (_i151.TestEnumStringified,)) {
     return {
       "p": [
         record.$1,
@@ -11659,7 +11689,7 @@ Map<String, dynamic>? mapRecordToJson(Record? record) {
       ],
     };
   }
-  if (record is ({_i150.TestEnumStringified value})) {
+  if (record is ({_i151.TestEnumStringified value})) {
     return {
       "n": {
         "value": record.value,
@@ -11690,7 +11720,7 @@ Map<String, dynamic>? mapRecordToJson(Record? record) {
       },
     };
   }
-  if (record is (_i149.TestEnum,)) {
+  if (record is (_i150.TestEnum,)) {
     return {
       "p": [
         record.$1,
@@ -11718,7 +11748,7 @@ Map<String, dynamic>? mapRecordToJson(Record? record) {
       ],
     };
   }
-  if (record is (_i159.ByteData,)) {
+  if (record is (_i160.ByteData,)) {
     return {
       "p": [
         record.$1,
@@ -11774,21 +11804,21 @@ Map<String, dynamic>? mapRecordToJson(Record? record) {
       ],
     };
   }
-  if (record is (_i143.SimpleData,)) {
+  if (record is (_i144.SimpleData,)) {
     return {
       "p": [
         record.$1,
       ],
     };
   }
-  if (record is ({_i143.SimpleData namedModel})) {
+  if (record is ({_i144.SimpleData namedModel})) {
     return {
       "n": {
         "namedModel": record.namedModel,
       },
     };
   }
-  if (record is (_i143.SimpleData, {_i143.SimpleData namedModel})) {
+  if (record is (_i144.SimpleData, {_i144.SimpleData namedModel})) {
     return {
       "p": [
         record.$1,
@@ -11817,8 +11847,8 @@ Map<String, dynamic>? mapRecordToJson(Record? record) {
     };
   }
   if (record is (
-    (List<(_i143.SimpleData,)>,), {
-    (_i143.SimpleData, Map<String, _i143.SimpleData>) namedNestedRecord
+    (List<(_i144.SimpleData,)>,), {
+    (_i144.SimpleData, Map<String, _i144.SimpleData>) namedNestedRecord
   })) {
     return {
       "p": [
@@ -11829,14 +11859,14 @@ Map<String, dynamic>? mapRecordToJson(Record? record) {
       },
     };
   }
-  if (record is (List<(_i143.SimpleData,)>,)) {
+  if (record is (List<(_i144.SimpleData,)>,)) {
     return {
       "p": [
         mapContainerToJson(record.$1),
       ],
     };
   }
-  if (record is (_i143.SimpleData, Map<String, _i143.SimpleData>)) {
+  if (record is (_i144.SimpleData, Map<String, _i144.SimpleData>)) {
     return {
       "p": [
         record.$1,

--- a/tests/serverpod_test_server/lib/src/models/object_with_nullable_custom_class.spy.yaml
+++ b/tests/serverpod_test_server/lib/src/models/object_with_nullable_custom_class.spy.yaml
@@ -1,0 +1,6 @@
+class: ObjectWithNullableCustomClass
+fields:
+    nullableCustomClassWithoutProtocolSerialization: CustomClassWithoutProtocolSerialization?
+    nullableCustomClassWithProtocolSerialization: CustomClassWithProtocolSerialization?
+    nullableCustomClassWithProtocolSerializationMethod: CustomClassWithProtocolSerializationMethod?
+    nonNullableCustomClass: CustomClassWithProtocolSerialization

--- a/tools/serverpod_cli/lib/src/generator/dart/library_generators/model_library_generator.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart/library_generators/model_library_generator.dart
@@ -1222,14 +1222,9 @@ class SerializableModelLibraryGenerator {
         serverpodUrl(serverCode),
       );
 
-      var toJsonForProtocolExpression = switch (nullableField) {
-        true => fieldExpression
-            .asA(protocolSerialization)
-            .nullSafeProperty(_toJsonForProtocolMethodName),
-        false => fieldExpression
-            .asA(protocolSerialization)
-            .property(_toJsonForProtocolMethodName),
-      };
+      var toJsonForProtocolExpression = fieldExpression
+          .asA(protocolSerialization)
+          .property(_toJsonForProtocolMethodName);
 
       var toJsonExpression = switch (nullableField) {
         true => fieldExpression.nullSafeProperty(_toJsonMethodName),

--- a/tools/serverpod_cli/test/generator/dart/server_code_generator/custom_class_nullable_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/server_code_generator/custom_class_nullable_test.dart
@@ -1,0 +1,148 @@
+import 'package:analyzer/dart/analysis/utilities.dart';
+import 'package:path/path.dart' as path;
+import 'package:serverpod_cli/src/generator/dart/server_code_generator.dart';
+import 'package:test/test.dart';
+
+import '../../../test_util/builders/generator_config_builder.dart';
+import '../../../test_util/builders/model_class_definition_builder.dart';
+import '../../../test_util/builders/serializable_entity_field_definition_builder.dart';
+import '../../../test_util/builders/type_definition_builder.dart';
+import '../../../test_util/compilation_unit_helpers.dart';
+
+const projectName = 'example_project';
+final config = GeneratorConfigBuilder().withName(projectName).build();
+const generator = DartServerCodeGenerator();
+
+void main() {
+  var testClassName = 'Example';
+  var testClassFileName = 'example';
+  var expectedFilePath =
+      path.join('lib', 'src', 'generated', '$testClassFileName.dart');
+
+  group(
+      'Given class $testClassName with nullable custom class field when generating code',
+      () {
+    var models = [
+      ModelClassDefinitionBuilder()
+          .withClassName(testClassName)
+          .withFileName(testClassFileName)
+          .withField(
+            FieldDefinitionBuilder()
+                .withName('nullableCustomClassField')
+                .withType(
+                  TypeDefinitionBuilder()
+                      .withClassName('CustomClass')
+                      .withCustomClass(true)
+                      .withNullable(true)
+                      .build(),
+                )
+                .build(),
+          )
+          .build()
+    ];
+
+    var codeMap = generator.generateSerializableModelsCode(
+      models: models,
+      config: config,
+    );
+
+    var compilationUnit = parseString(content: codeMap[expectedFilePath]!).unit;
+
+    var maybeClassNamedExample = CompilationUnitHelpers.tryFindClassDeclaration(
+      compilationUnit,
+      name: testClassName,
+    );
+
+    test(
+      'then toJsonForProtocol method should not use null-aware operator after type cast for nullable custom class field',
+      () {
+        var toJsonForProtocolMethod =
+            CompilationUnitHelpers.tryFindMethodDeclaration(
+          maybeClassNamedExample!,
+          name: 'toJsonForProtocol',
+        );
+
+        var toJsonForProtocolCode = toJsonForProtocolMethod!.toSource();
+
+        // This regex checks that the generated code does NOT contain the unnecessary null-aware operator
+        // after the type cast. The pattern should be:
+        // (nullableCustomClassField as _i1.ProtocolSerialization).toJsonForProtocol()
+        // NOT:
+        // (nullableCustomClassField as _i1.ProtocolSerialization)?.toJsonForProtocol()
+        var correctPatternRegex = RegExp(
+          r'\(nullableCustomClassField\s+as\s+_i\d+\.ProtocolSerialization\)\.toJsonForProtocol\(\)',
+        );
+
+        var incorrectPatternRegex = RegExp(
+          r'\(nullableCustomClassField\s+as\s+_i\d+\.ProtocolSerialization\)\?\.toJsonForProtocol\(\)',
+        );
+
+        expect(
+          correctPatternRegex.hasMatch(toJsonForProtocolCode),
+          isTrue,
+          reason:
+              'The toJsonForProtocol method should cast nullable custom class field without null-aware operator after the cast.',
+        );
+
+        expect(
+          incorrectPatternRegex.hasMatch(toJsonForProtocolCode),
+          isFalse,
+          reason:
+              'The toJsonForProtocol method should NOT use null-aware operator (?.) after type cast.',
+        );
+      },
+    );
+
+    test(
+      'then toJsonForProtocol method should still use null-aware operator for toJson fallback',
+      () {
+        var toJsonForProtocolMethod =
+            CompilationUnitHelpers.tryFindMethodDeclaration(
+          maybeClassNamedExample!,
+          name: 'toJsonForProtocol',
+        );
+
+        var toJsonForProtocolCode = toJsonForProtocolMethod!.toSource();
+
+        // Check that the fallback toJson call still uses null-aware operator
+        // Pattern: nullableCustomClassField?.toJson()
+        var nullSafeToJsonRegex = RegExp(
+          r'nullableCustomClassField\?\.toJson\(\)',
+        );
+
+        expect(
+          nullSafeToJsonRegex.hasMatch(toJsonForProtocolCode),
+          isTrue,
+          reason:
+              'The toJsonForProtocol method should use null-aware operator for toJson() fallback on nullable fields.',
+        );
+      },
+    );
+
+    test(
+      'then toJsonForProtocol method should handle nullable field correctly in the map',
+      () {
+        var toJsonForProtocolMethod =
+            CompilationUnitHelpers.tryFindMethodDeclaration(
+          maybeClassNamedExample!,
+          name: 'toJsonForProtocol',
+        );
+
+        var toJsonForProtocolCode = toJsonForProtocolMethod!.toSource();
+
+        // Check that the field is only added to the map if it's not null
+        // Pattern should include: if (nullableCustomClassField != null)
+        var nullCheckRegex = RegExp(
+          r'if\s*\(\s*nullableCustomClassField\s*!=\s*null\s*\)',
+        );
+
+        expect(
+          nullCheckRegex.hasMatch(toJsonForProtocolCode),
+          isTrue,
+          reason:
+              'The toJsonForProtocol method should check if nullable field is not null before adding to map.',
+        );
+      },
+    );
+  });
+}


### PR DESCRIPTION
When using custom classes in protocols, an uncessary null-aware operator (`?.`) was added to the generated code in `toJsonForProtocol()`. This PR aims to fix that lint

Fixes https://github.com/serverpod/serverpod/issues/3217

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

