### PR TITLE
feat: Switch to `Bearer` token for `authorization` header

### DIFF
--- a/modules/serverpod_auth/serverpod_auth_shared_flutter/lib/src/authentication_key_manager.dart
+++ b/modules/serverpod_auth/serverpod_auth_shared_flutter/lib/src/authentication_key_manager.dart
@@ -5,7 +5,9 @@ const _prefsKey = 'serverpod_authentication_key';
 
 /// Implementation of a Serverpod [AuthenticationKeyManager] specifically for
 /// Flutter. Authentication key is stored in the [SharedPreferences].
-class FlutterAuthenticationKeyManager extends AuthenticationKeyManager {
+class FlutterAuthenticationKeyManager
+    // ignore: deprecated_member_use
+    extends BackwardsCompatibleAuthKeyManager {
   bool _initialized = false;
   String? _authenticationKey;
 

--- a/packages/serverpod/lib/src/server/session.dart
+++ b/packages/serverpod/lib/src/server/session.dart
@@ -433,7 +433,7 @@ class StreamingSession extends Session {
     this.queryParameters = queryParameters;
 
     // Get the authentication key, if any
-    _authenticationKey = unwrapAuthHeaderValue(queryParameters['auth']);
+    _authenticationKey = queryParameters['auth'];
   }
 
   /// Updates the authentication key for the streaming session.

--- a/packages/serverpod_client/lib/src/auth_key_manager.dart
+++ b/packages/serverpod_client/lib/src/auth_key_manager.dart
@@ -18,10 +18,10 @@ abstract class AuthenticationKeyManager {
     return toHeaderValue(key);
   }
 
-  /// Converts an authentication key to a format that can be used in a transport header.
-  /// The default implementation encodes and wraps the key in a 'Basic' scheme.
-  /// (This will automatically be unwrapped again on the server side
-  /// before being handed to the authentication handler.)
+  /// Converts an authentication key to a format that can be used in a transport
+  /// header. The default implementation encodes and wraps the key in a 'Bearer'
+  /// scheme. This will automatically be unwrapped again on the server side
+  /// before being handed to the authentication handler.
   ///
   /// To use a different scheme, override this method.
   /// The value must be compliant with the HTTP header format defined in
@@ -29,6 +29,20 @@ abstract class AuthenticationKeyManager {
   /// See:
   /// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Authorization
   /// https://httpwg.org/specs/rfc9110.html#field.authorization
+  Future<String?> toHeaderValue(String? key) async {
+    if (key == null) return null;
+    return wrapAsBearerAuthHeaderValue(key);
+  }
+}
+
+/// Manages keys for authentication with the server using the Basic auth scheme.
+@Deprecated('Use AuthenticationKeyManager instead.')
+abstract class BackwardsCompatibleAuthKeyManager
+    extends AuthenticationKeyManager {
+  /// Converts an authentication key to a format that can be used in a transport
+  /// header. Overrides the default implementation of 'Bearer' scheme to ensure
+  /// backwards compatibility with the previous default 'Basic' scheme.
+  @override
   Future<String?> toHeaderValue(String? key) async {
     if (key == null) return null;
     return wrapAsBasicAuthHeaderValue(key);


### PR DESCRIPTION
Closes issue #3841.

There is one minor unrelated change on `packages/serverpod/lib/src/server/session.dart` to remove the unwrap call - never used, as auth is passed in plain text, not base64 encoded. It was identified while analyzing with @SandPod and was causing confusion on understanding the authentication workflow.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

For clients using the old authentication packages and a custom `AuthenticationKeyManager` extension, the extended class must be changed to `BackwardsCompatibleAuthKeyManager` to keep using `Basic` authorization header. No change is needed for clients using the default `FlutterAuthenticationKeyManager` implementation.