### PR TITLE
fix: Add missing transaction when importing legacy password in bridge package.

### DIFF
--- a/modules/new_serverpod_auth/serverpod_auth_bridge/serverpod_auth_bridge_server/lib/src/business/auth_backwards_compatibility.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_bridge/serverpod_auth_bridge_server/lib/src/business/auth_backwards_compatibility.dart
@@ -96,6 +96,7 @@ abstract final class AuthBackwardsCompatibility {
       await clearLegacyPassword(
         session,
         emailAccountId: emailAccountInfo.emailAccountId,
+        transaction: transaction,
       );
 
       // The account was already migrated without a password, and now we need to


### PR DESCRIPTION
When the bridge package was tested with no password pepper set, it failed on the next step. This revealed that clearing the legacy password was preserved even though the transaction failed.

This PR adds the missing transaction to the missing `clearLegacyPassword` step.

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None, simple bugfix.