### PR TITLE
Feat: Custom object return for password hash validator and named parameters

### DIFF
--- a/modules/serverpod_auth/serverpod_auth_server/lib/module.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/module.dart
@@ -7,3 +7,4 @@ export 'src/generated/protocol.dart';
 export 'src/util/random_string.dart';
 export 'src/extensions/user_info_extension.dart';
 export 'src/web/routes/route_google_sign_in.dart';
+export 'src/exceptions/password_hash_validator_exception.dart';

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/business/config.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/business/config.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:image/image.dart';
 import 'package:serverpod/server.dart';
 import 'package:serverpod_auth_server/serverpod_auth_server.dart';
+import 'package:serverpod_auth_server/src/exceptions/password_hash_validator_exception.dart';
 
 import 'user_images.dart';
 
@@ -39,13 +40,10 @@ typedef SendValidationEmailCallback = Future<bool> Function(
 typedef PasswordHashGenerator = Future<String> Function(String password);
 
 /// Callback to validate the hash used by [PasswordHashGenerator]
-typedef PasswordHashValidator = Future<bool> Function({
+typedef PasswordHashValidator = Future<PasswordHashValidatorResponse> Function({
   required String password,
   required String email,
   required String hash,
-  void Function({required String passwordHash, required String storedHash})?
-      onValidationFailure,
-  void Function(Object e)? onError,
 });
 
 /// Enum to define the sign-out behavior for the legacy sign out endpoint.
@@ -55,6 +53,31 @@ enum SignOutBehavior {
 
   /// Sign out the user from the current device only.
   currentDevice,
+}
+
+/// Response returned from a [PasswordHashValidator].
+///
+/// Indicates whether password hash validation succeeded and, if it failed,
+/// provides details about the error.
+class PasswordHashValidatorResponse {
+  /// True if the provided password matches the stored hash.
+  ///
+  /// When true, [error] will be null.
+  final bool success;
+
+  /// Optional error describing why validation failed.
+  ///
+  /// This will be non-null only when [success] is false. It may contain
+  /// a [PasswordHashValidationFailedException] when the computed hash does
+  /// not match the stored hash, or a generic [PasswordHashValidatorException]
+  /// if an unexpected error occurred during validation.
+  final PasswordHashValidatorException? error;
+
+  /// Creates a new [PasswordHashValidatorResponse].
+  ///
+  /// Set [success] to true for successful validation and provide [error]
+  /// only for failed validations.
+  PasswordHashValidatorResponse({required this.success, this.error});
 }
 
 /// Configuration options for the Auth module.

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/business/config.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/business/config.dart
@@ -39,10 +39,10 @@ typedef SendValidationEmailCallback = Future<bool> Function(
 typedef PasswordHashGenerator = Future<String> Function(String password);
 
 /// Callback to validate the hash used by [PasswordHashGenerator]
-typedef PasswordHashValidator = Future<bool> Function(
-  String password,
-  String email,
-  String hash, {
+typedef PasswordHashValidator = Future<bool> Function({
+  required String password,
+  required String email,
+  required String hash,
   void Function({required String passwordHash, required String storedHash})?
       onValidationFailure,
   void Function(Object e)? onError,

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/business/email_auth.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/business/email_auth.dart
@@ -25,10 +25,10 @@ Future<String> defaultGeneratePasswordHash(String password) =>
 /// Warning: Using a custom hashing algorithm for passwords
 /// will permanently disrupt compatibility with Serverpod's
 /// password hash validation and migration.
-Future<bool> defaultValidatePasswordHash(
-  String password,
-  String email,
-  String hash, {
+Future<bool> defaultValidatePasswordHash({
+  required String password,
+  required String email,
+  required String hash, 
   void Function({
     required String passwordHash,
     required String storedHash,
@@ -627,9 +627,9 @@ class Emails {
     void Function(Object e)? onError,
   }) =>
       AuthConfig.current.passwordHashValidator(
-        password,
-        email,
-        hash,
+        password: password,
+        email: email,
+        hash: hash,
         onError: onError,
         onValidationFailure: onValidationFailure,
       );

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/business/password_hash.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/business/password_hash.dart
@@ -110,25 +110,21 @@ class PasswordHash {
   ///
   /// If the password does not match the hash, the [onValidationFailure] function
   /// will be called with the hash and the password hash as arguments.
-  Future<bool> validate(
-    String password, {
-    void Function({
-      required String storedHash,
-      required String passwordHash,
-    })? onValidationFailure,
-  }) async {
+  Future<PasswordHashValidatorResponse> validate(String password) async {
     var passwordHash =
         await Isolate.run(() => _hashGenerator.generateHash(password));
 
     if (_hash != passwordHash) {
-      onValidationFailure?.call(
-        storedHash: _hash,
-        passwordHash: passwordHash,
+      return PasswordHashValidatorResponse(
+        success: false,
+        error: PasswordHashValidationFailedException(
+          passwordHash: passwordHash,
+          storedHash: _hash,
+        ),
       );
-      return false;
     }
 
-    return true;
+    return PasswordHashValidatorResponse(success: true);
   }
 
   /// Creates a new password hash using the legacy algorithm.

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/exceptions/password_hash_validator_exception.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/exceptions/password_hash_validator_exception.dart
@@ -1,0 +1,33 @@
+/// Base class for errors that occur during password hash validation.
+class PasswordHashValidatorException implements Exception {
+  /// Creates a new [PasswordHashValidatorException].
+  ///
+  /// [errorMessage] is a human-readable message or an error object describing
+  /// the failure. [stackTrace] is the optional stack trace captured when the
+  /// error was created.
+  PasswordHashValidatorException({this.errorMessage, this.stackTrace});
+
+  /// A human-readable message or error object that describes the failure.
+  final Object? errorMessage;
+
+  /// Optional stack trace associated with this exception.
+  final StackTrace? stackTrace;
+}
+
+/// Thrown when validation of a computed password hash against a stored hash fails.
+class PasswordHashValidationFailedException extends PasswordHashValidatorException {
+  /// Creates a [PasswordHashValidationFailedException].
+  ///
+  /// [passwordHash] is the computed hash of the provided password.
+  /// [storedHash] is the persisted hash being compared against.
+  PasswordHashValidationFailedException({
+    required this.passwordHash,
+    required this.storedHash,
+  });
+
+  /// The computed hash of the candidate password.
+  final String passwordHash;
+
+  /// The stored hash retrieved from persistence for comparison.
+  final String storedHash;
+}

--- a/tests/serverpod_test_server/test_integration/auth_module/email_auth_provider/custom_password_hash_test.dart
+++ b/tests/serverpod_test_server/test_integration/auth_module/email_auth_provider/custom_password_hash_test.dart
@@ -10,10 +10,10 @@ void main() async {
         print('Sending validation email to $email with code $validationCode');
         return true;
       },
-      passwordHashValidator: (
-        password,
-        email,
-        hash, {
+      passwordHashValidator: ({
+        required password,
+        required email,
+        required hash, 
         onError,
         onValidationFailure,
       }) async =>

--- a/tests/serverpod_test_server/test_integration/auth_module/email_auth_provider/custom_password_hash_test.dart
+++ b/tests/serverpod_test_server/test_integration/auth_module/email_auth_provider/custom_password_hash_test.dart
@@ -18,7 +18,7 @@ void main() async {
         onValidationFailure,
       }) async =>
           // Always return true to allow the test to proceed
-          true,
+          PasswordHashValidatorResponse(success: true),
       // Custom password hash generator that does not hash the password
       passwordHashGenerator: (password) async => password,
       extraSaltyHash: false,

--- a/tests/serverpod_test_server/test_integration/auth_module/email_auth_provider/email_auth_provider_test.dart
+++ b/tests/serverpod_test_server/test_integration/auth_module/email_auth_provider/email_auth_provider_test.dart
@@ -349,18 +349,19 @@ void main() async {
       late String actualStoredHash;
       late String actualPasswordHash;
 
-      await Emails.validatePasswordHash(
+      final validationResponse = await Emails.validatePasswordHash(
         'notHunter4',
         'test7@serverpod.dev',
         hunter4PasswordHash,
-        onValidationFailure: ({
-          required String storedHash,
-          required String passwordHash,
-        }) {
-          actualStoredHash = storedHash;
-          actualPasswordHash = passwordHash;
-        },
       );
+
+      if (!validationResponse.success && validationResponse.error != null &&
+          validationResponse.error is PasswordHashValidationFailedException) {
+        final castedError =
+        validationResponse.error as PasswordHashValidationFailedException;
+        actualPasswordHash = castedError.passwordHash;
+        actualStoredHash = castedError.storedHash;
+      }
 
       expect(actualStoredHash, hunter4PasswordHash);
       expect(actualPasswordHash, notHunter4PasswordHash);


### PR DESCRIPTION
Fixes #3698
Closes #3698

## Summary of Changes
- Structured password-hash validation added:
  - New PasswordHashValidatorResponse { success: bool, error?: PasswordHashValidatorException }.
  - New exceptions: PasswordHashValidatorException and PasswordHashValidationFailedException (includes computed vs stored hash for safe debugging).
- Email auth flow updates:
  - Emails.authenticate uses structured validator; safe logging;
- Exports:
  - module.dart now exports password_hash_validator_exception.dart.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking Changes
- Emails.validatePasswordHash return type changed from bool to PasswordHashValidatorResponse.
- PasswordHashValidator typedef updated to:
  - Future<PasswordHashValidatorResponse> Function({required String password, required String email, required String hash})
- Removed callbacks onError and onValidationFailure; callers must inspect response.error instead.
