### PR TITLE
fix: Fix `system_resources` error on Windows when starting Serverpod multiple times

### DIFF
--- a/packages/serverpod/lib/src/server/health_check_manager.dart
+++ b/packages/serverpod/lib/src/server/health_check_manager.dart
@@ -32,6 +32,12 @@ class HealthCheckManager {
   Future<void> start() async {
     _running = true;
 
+    if (Platform.isWindows) {
+      stderr.writeln(
+          'WARNING: CPU and memory usage metrics are not supported on Windows.');
+      return;
+    }
+
     try {
       await SystemResources.init();
     } catch (e) {

--- a/tests/serverpod_test_server/test_integration/startup_test.dart
+++ b/tests/serverpod_test_server/test_integration/startup_test.dart
@@ -1,0 +1,43 @@
+import 'package:serverpod/serverpod.dart';
+import 'package:serverpod_test_server/test_util/test_serverpod.dart';
+import 'package:system_resources/system_resources.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Given a Serverpod server instance', () {
+    late Serverpod server;
+
+    setUp(() {
+      server = IntegrationTestServer.create();
+    });
+
+    tearDown(() async {
+      await server.shutdown(exitProcess: false);
+    });
+
+    // This test had to be coupled to the underlying implementation of the
+    // HealthCheckManager (depending on `SystemResources`) due to it being the
+    // cause for server start issued on Windows.
+    test('when starting Serverpod on any platform, then no error occurs.',
+        () async {
+      await server.start();
+
+      // Await singleton `_libsysres` that causes `ProcessException` zoned
+      // exception in Windows due to missing "uname" command.
+      try {
+        await SystemResources.init();
+      } catch (e) {
+        // If the init has been called from the `start` method, the exception
+        // will not take place here and will throw. Otherwise, if the server
+        // starts with success, the exception will happen here and be ignored.
+      }
+    }, timeout: Timeout(Duration(seconds: 10)));
+
+    test('when starting Serverpod multiple times, then no error occurs.',
+        () async {
+      await server.start();
+      await server.shutdown(exitProcess: false);
+      await server.start();
+    }, timeout: Timeout(Duration(seconds: 10)));
+  });
+}


### PR DESCRIPTION
Quick fix for #3879.

A more permanent alternative might be to hide the [system_resources](https://pub.dev/packages/system_resources) behind a custom package that uses [win32](https://pub.dev/packages/win32) to access Windows resources and provide full API compatibility. Then, this fix can be removed with no harm.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

N/A.