### PR TITLE
feat: Add a `~` operator on expressions to perform `NOT` expression

### DIFF
--- a/packages/serverpod/lib/src/database/concepts/expressions.dart
+++ b/packages/serverpod/lib/src/database/concepts/expressions.dart
@@ -33,6 +33,11 @@ class Expression<T> {
     return _OrExpression(this, other);
   }
 
+  /// Database NOT operator.
+  Expression operator ~() {
+    return NotExpression(this);
+  }
+
   /// Iterator for all [Expression]s in the expression.
   /// Iterates elements deterministically depth first.
   Iterable<Expression> get depthFirst sync* {

--- a/packages/serverpod/test/database/expressions/expression_test.dart
+++ b/packages/serverpod/test/database/expressions/expression_test.dart
@@ -60,6 +60,7 @@ void main() {
     var expression2 = const Expression('"A" = "A"');
     var combinedExpression = expression1 & expression2;
     var notWrappedExpression = NotExpression(combinedExpression);
+    var notWrappedExpressionOperator = ~combinedExpression;
 
     test('when toString is called then expression is returned', () {
       expect(
@@ -87,6 +88,11 @@ void main() {
           i++;
         }
       });
+    });
+
+    test('then using operator ~ is equivalent to using NotExpression', () {
+      expect(notWrappedExpression.toString(),
+          notWrappedExpressionOperator.toString());
     });
   });
 

--- a/packages/serverpod/test/database/expressions/expression_test.dart
+++ b/packages/serverpod/test/database/expressions/expression_test.dart
@@ -60,7 +60,6 @@ void main() {
     var expression2 = const Expression('"A" = "A"');
     var combinedExpression = expression1 & expression2;
     var notWrappedExpression = NotExpression(combinedExpression);
-    var notWrappedExpressionOperator = ~combinedExpression;
 
     test('when toString is called then expression is returned', () {
       expect(
@@ -89,10 +88,71 @@ void main() {
         }
       });
     });
+  });
 
-    test('then using operator ~ is equivalent to using NotExpression', () {
-      expect(notWrappedExpression.toString(),
-          notWrappedExpressionOperator.toString());
+  group('Given expressions using the ~ (NOT) operator', () {
+    group('Given one expression wrapped using ~ operator', () {
+      var expression = const Expression('TRUE');
+      var notWrappedExpression = ~expression;
+
+      test('when toString is called then string matches expected.', () {
+        expect(notWrappedExpression.toString(), 'NOT TRUE');
+      });
+
+      test('when subExpression is called then wrapped expression is returned',
+          () {
+        expect(
+            (notWrappedExpression as NotExpression).subExpression, expression);
+      });
+
+      group('when iterating not wrapped expression', () {
+        test('then both expressions are represented.', () {
+          expect(notWrappedExpression.depthFirst, hasLength(2));
+        });
+
+        test('then first expression is NOT expression.', () {
+          expect(notWrappedExpression.depthFirst.first, notWrappedExpression);
+        });
+
+        test('then last expression is wrapped expression.', () {
+          expect(notWrappedExpression.depthFirst.last, expression);
+        });
+      });
+    });
+
+    group('Given a combined expression wrapped using ~ operator', () {
+      var expression1 = const Expression('true = true');
+      var expression2 = const Expression('"A" = "A"');
+      var combinedExpression = expression1 & expression2;
+      var notWrappedExpression = ~combinedExpression;
+
+      test('when toString is called then expression is returned', () {
+        expect(
+          notWrappedExpression.toString(),
+          'NOT (true = true AND "A" = "A")',
+        );
+      });
+
+      group('when iterating not wrapped expression', () {
+        test('then all expressions are represented.', () {
+          expect(notWrappedExpression.depthFirst, hasLength(4));
+        });
+
+        test('then order matches expressions.', () {
+          var expectedExpressions = [
+            notWrappedExpression,
+            combinedExpression,
+            expression1,
+            expression2,
+          ];
+
+          var i = 0;
+          for (var expression in notWrappedExpression.depthFirst) {
+            expect(expression, expectedExpressions[i]);
+            i++;
+          }
+        });
+      });
     });
   });
 


### PR DESCRIPTION
Closes issue #3888.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

N/A.