### PR TITLE
chore: Bump version range of pointycastle

### DIFF
--- a/modules/new_serverpod_auth/serverpod_auth_bridge/serverpod_auth_bridge_server/pubspec.yaml
+++ b/modules/new_serverpod_auth/serverpod_auth_bridge/serverpod_auth_bridge_server/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 dependencies:
   crypto: ^3.0.2
   meta: ^1.11.0
-  pointycastle: ^3.7.4
+  pointycastle: '>=3.7.4 <5.0.0'
   serverpod: 3.0.0-alpha.1
   serverpod_auth_idp_server: 3.0.0-alpha.1
   serverpod_auth_core_server: 3.0.0-alpha.1

--- a/modules/new_serverpod_auth/serverpod_auth_core/serverpod_auth_core_server/pubspec.yaml
+++ b/modules/new_serverpod_auth/serverpod_auth_core/serverpod_auth_core_server/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   clock: ^1.1.1
   dart_jsonwebtoken: ^3.1.0
   crypto: ^3.0.2
-  pointycastle: ^3.7.4
+  pointycastle: '>=3.7.4 <5.0.0'
   meta: ^1.11.0
   serverpod: 3.0.0-alpha.1
   serverpod_shared: 3.0.0-alpha.1

--- a/modules/new_serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/pubspec.yaml
+++ b/modules/new_serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
   clock: ^1.1.1
   sign_in_with_apple_server: ^0.3.0
   email_validator: ">=2.1.17 <4.0.0"
-  pointycastle: ^3.7.4
+  pointycastle: '>=3.7.4 <5.0.0'
 
 dev_dependencies:
   serverpod_lints: 3.0.0-alpha.1

--- a/modules/serverpod_auth/serverpod_auth_server/pubspec.yaml
+++ b/modules/serverpod_auth/serverpod_auth_server/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
   http: '>=1.1.0 <2.0.0'
   image: ^4.0.15
   jose: ^0.3.3
-  pointycastle: ^3.7.4
+  pointycastle: '>=3.7.4 <5.0.0'
 
 dev_dependencies:
   serverpod_lints: 3.0.0-alpha.1

--- a/templates/pubspecs/modules/new_serverpod_auth/serverpod_auth_bridge/serverpod_auth_bridge_server/pubspec.yaml
+++ b/templates/pubspecs/modules/new_serverpod_auth/serverpod_auth_bridge/serverpod_auth_bridge_server/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 dependencies:
   crypto: ^3.0.2
   meta: ^1.11.0
-  pointycastle: ^3.7.4
+  pointycastle: '>=3.7.4 <5.0.0'
   serverpod: SERVERPOD_VERSION
   serverpod_auth_idp_server: SERVERPOD_VERSION
   serverpod_auth_core_server: SERVERPOD_VERSION

--- a/templates/pubspecs/modules/new_serverpod_auth/serverpod_auth_core/serverpod_auth_core_server/pubspec.yaml
+++ b/templates/pubspecs/modules/new_serverpod_auth/serverpod_auth_core/serverpod_auth_core_server/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   clock: ^1.1.1
   dart_jsonwebtoken: ^3.1.0
   crypto: ^3.0.2
-  pointycastle: ^3.7.4
+  pointycastle: '>=3.7.4 <5.0.0'
   meta: ^1.11.0
   serverpod: SERVERPOD_VERSION
   serverpod_shared: SERVERPOD_VERSION

--- a/templates/pubspecs/modules/new_serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/pubspec.yaml
+++ b/templates/pubspecs/modules/new_serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   clock: ^1.1.1
   sign_in_with_apple_server: ^0.3.0
   email_validator: ">=2.1.17 <4.0.0"
-  pointycastle: ^3.7.4
+  pointycastle: '>=3.7.4 <5.0.0'
 
 dev_dependencies:
   serverpod_lints: SERVERPOD_VERSION

--- a/templates/pubspecs/modules/serverpod_auth/serverpod_auth_server/pubspec.yaml
+++ b/templates/pubspecs/modules/serverpod_auth/serverpod_auth_server/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
   http: '>=1.1.0 <2.0.0'
   image: ^4.0.15
   jose: ^0.3.3
-  pointycastle: ^3.7.4
+  pointycastle: '>=3.7.4 <5.0.0'
 
 dev_dependencies:
   serverpod_lints: SERVERPOD_VERSION


### PR DESCRIPTION
Widens the version range of pointycastle to allow the 4.0.0 release.

None of the breaking changes touch the code we use.

Didn't go with a strict bump since the 4.0.0 release has failed CI runs in their repo.

Pub.dev: https://pub.dev/packages/pointycastle
Github: https://github.com/bcgit/pc-dart

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None - Should provide the same functionality.