### PR TITLE
chore: Bump sign in with apple dependency.

### DIFF
--- a/modules/new_serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/providers/apple/business/apple_accounts.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/providers/apple/business/apple_accounts.dart
@@ -30,7 +30,7 @@ abstract final class AppleAccounts {
         redirectUri: config.redirectUri,
         teamId: config.teamId,
         keyId: config.keyId,
-        key: ECPrivateKey(config.key),
+        key: config.key,
       ),
     );
 

--- a/modules/new_serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/pubspec.yaml
+++ b/modules/new_serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   http: ">=1.1.0 <2.0.0"
   meta: ^1.11.0
   clock: ^1.1.1
-  sign_in_with_apple_server: ^0.3.0
+  sign_in_with_apple_server: ^1.0.0
   email_validator: ">=2.1.17 <4.0.0"
   pointycastle: ^3.7.4
 

--- a/templates/pubspecs/modules/new_serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/pubspec.yaml
+++ b/templates/pubspecs/modules/new_serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   http: ">=1.1.0 <2.0.0"
   meta: ^1.11.0
   clock: ^1.1.1
-  sign_in_with_apple_server: ^0.3.0
+  sign_in_with_apple_server: ^1.0.0
   email_validator: ">=2.1.17 <4.0.0"
   pointycastle: ^3.7.4
 


### PR DESCRIPTION
Bumps sign in with apple dependency to first major release.


The only breaking change is that the key is passed in as a String instead of an internal type. This is reflected in the second commit.

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None - only internal changes.