### PR TITLE
chore: Use defaults for Dart analyzer language settings

### DIFF
--- a/modules/serverpod_auth/serverpod_auth_server/analysis_options.yaml
+++ b/modules/serverpod_auth/serverpod_auth_server/analysis_options.yaml
@@ -9,10 +9,3 @@ linter:
     prefer_final_locals: false
     prefer_final_parameters: false
     sort_pub_dependencies: false
-
-analyzer:
-  language:
-    # Temporary disable the following so that each can be fixed one by one.
-    strict-casts: false
-    strict-inference: false
-    strict-raw-types: false

--- a/packages/serverpod/analysis_options.yaml
+++ b/packages/serverpod/analysis_options.yaml
@@ -12,10 +12,3 @@ linter:
     prefer_final_locals: false
     prefer_final_parameters: false
     sort_pub_dependencies: false
-
-analyzer:
-  language:
-    # Temporary disable the following so that each can be fixed one by one.
-    strict-casts: false
-    strict-inference: false
-    strict-raw-types: false

--- a/packages/serverpod_client/analysis_options.yaml
+++ b/packages/serverpod_client/analysis_options.yaml
@@ -8,10 +8,3 @@ linter:
     prefer_final_locals: false
     prefer_final_parameters: false
     sort_pub_dependencies: false
-
-analyzer:
-  language:
-    # Temporary disable the following so that each can be fixed one by one.
-    strict-casts: false
-    strict-inference: false
-    strict-raw-types: false

--- a/packages/serverpod_lints/lib/internal.yaml
+++ b/packages/serverpod_lints/lib/internal.yaml
@@ -18,9 +18,3 @@ linter:
     sort_pub_dependencies: true
     unawaited_futures: true
     unnecessary_final: false
-
-analyzer:
-  language:
-    strict-casts: true
-    strict-inference: true
-    strict-raw-types: true

--- a/packages/serverpod_serialization/analysis_options.yaml
+++ b/packages/serverpod_serialization/analysis_options.yaml
@@ -9,10 +9,3 @@ linter:
     prefer_final_locals: false
     prefer_final_parameters: false
     sort_pub_dependencies: false
-
-analyzer:
-  language:
-    # Temporary disable the following so that each can be fixed one by one.
-    strict-casts: false
-    strict-inference: false
-    strict-raw-types: false

--- a/packages/serverpod_service_client/analysis_options.yaml
+++ b/packages/serverpod_service_client/analysis_options.yaml
@@ -7,9 +7,3 @@ linter:
     prefer_final_locals: false
     prefer_final_parameters: false
     sort_pub_dependencies: false
-
-analyzer:
-  language:
-    # Temporary disable the following so that each can be fixed one by one.
-    strict-casts: false
-    strict-inference: false

--- a/packages/serverpod_shared/analysis_options.yaml
+++ b/packages/serverpod_shared/analysis_options.yaml
@@ -8,10 +8,3 @@ linter:
     prefer_final_locals: false
     prefer_final_parameters: false
     sort_pub_dependencies: false
-
-analyzer:
-  language:
-    # Temporary disable the following so that each can be fixed one by one.
-    strict-casts: false
-    strict-inference: false
-    strict-raw-types: false

--- a/packages/serverpod_test/analysis_options.yaml
+++ b/packages/serverpod_test/analysis_options.yaml
@@ -8,10 +8,3 @@ linter:
     prefer_final_locals: false
     prefer_final_parameters: false
     sort_pub_dependencies: false
-
-analyzer:
-  language:
-    # Temporary disable the following so that each can be fixed one by one.
-    strict-casts: false
-    strict-inference: false
-    strict-raw-types: false

--- a/tools/serverpod_cli/analysis_options.yaml
+++ b/tools/serverpod_cli/analysis_options.yaml
@@ -2,11 +2,6 @@ include: package:serverpod_lints/cli.yaml
 analyzer:
   exclude:
     - test/integration/util/test_assets/pubspec_helpers/conditionally_ignored/pubspec.yaml
-  language:
-    # Temporary disable the following so that each can be fixed one by one.
-    strict-casts: false
-    strict-inference: false
-    strict-raw-types: false
 
 linter:
   rules:


### PR DESCRIPTION
Use defaults for Dart analyzer language settings. Instead of enabling strict-casts, strict-inference, and strict-raw-types language rules centrally in serverpod_lints, and then disabling them again in each serverpod package, don't specify them at all and use the Dart defaults.

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

n/a