### PR TITLE
feat: Add cache control headers to dynamic routes

### DIFF
--- a/packages/serverpod/lib/src/web_server/web_server.dart
+++ b/packages/serverpod/lib/src/web_server/web_server.dart
@@ -153,7 +153,23 @@ class WebServer {
   ) async {
     // TODO: route.setHeaders(request.response.headers);
     try {
-      return await route.handleCall(session, context);
+      final result = await route.handleCall(session, context);
+
+      if (route is WidgetRoute && result is ResponseContext) {
+        final transformedResponse = result.response.copyWith(
+          headers: result.response.headers.transform(
+            (mh) => mh.cacheControl = CacheControlHeader(
+              maxAge: 0,
+              sMaxAge: 0,
+              noCache: true,
+              noStore: true,
+            ),
+          ),
+        );
+        return result.withResponse(transformedResponse);
+      }
+
+      return result;
     } catch (e, stackTrace) {
       final request = context.request;
       await _reportException(

--- a/tests/serverpod_test_server/test_integration/web_server/widget_route_cache_control_test.dart
+++ b/tests/serverpod_test_server/test_integration/web_server/widget_route_cache_control_test.dart
@@ -91,6 +91,29 @@ void main() {
     });
 
     test(
+        'when requesting an HTML widget route '
+        'then the content-type is text/html even with cache headers set',
+        () async {
+      var response = await http.get(
+        Uri.parse('http://localhost:8082/html-route'),
+      );
+
+      expect(response.headers['content-type'], contains('text/html'));
+      expect(response.headers['cache-control'], 'no-cache, private');
+    });
+
+    test(
+        'when requesting a JSON widget route '
+        'then both content-type and cache headers are set correctly', () async {
+      var response = await http.get(
+        Uri.parse('http://localhost:8082/json-route'),
+      );
+
+      expect(response.headers['content-type'], contains('application/json'));
+      expect(response.headers['cache-control'], 'no-cache, private');
+    });
+
+    test(
         'when requesting a redirect widget route '
         'then the redirect response does not have cache-control headers',
         () async {

--- a/tests/serverpod_test_server/test_integration/web_server/widget_route_cache_control_test.dart
+++ b/tests/serverpod_test_server/test_integration/web_server/widget_route_cache_control_test.dart
@@ -60,24 +60,24 @@ void main() {
 
     test(
         'when requesting an HTML widget route '
-        'then the cache-control header is set to no-cache', () async {
+        'then the cache-control header is set to no-cache and private',
+        () async {
       var response = await http.get(
         Uri.parse('http://localhost:8082/html-route'),
       );
 
-      expect(response.headers['cache-control'],
-          'no-cache, no-store, max-age=0, s-maxage=0');
+      expect(response.headers['cache-control'], 'no-cache, private');
     });
 
     test(
         'when requesting a JSON widget route '
-        'then the cache-control header is set to no-cache', () async {
+        'then the cache-control header is set to no-cache and private',
+        () async {
       var response = await http.get(
         Uri.parse('http://localhost:8082/json-route'),
       );
 
-      expect(response.headers['cache-control'],
-          'no-cache, no-store, max-age=0, s-maxage=0');
+      expect(response.headers['cache-control'], 'no-cache, private');
     });
 
     test(
@@ -92,7 +92,7 @@ void main() {
 
     test(
         'when requesting a redirect widget route '
-        'then the redirect response has cache-control header set to no-cache',
+        'then the redirect response does not have cache-control headers',
         () async {
       // Create client that doesn't follow redirects
       var client = http.Client();
@@ -104,8 +104,9 @@ void main() {
       var response = await http.Response.fromStream(streamedResponse);
 
       expect(response.statusCode, 303); // See Other redirect
-      expect(response.headers['cache-control'],
-          'no-cache, no-store, max-age=0, s-maxage=0');
+      // Redirect responses don't get cache control headers applied
+      // since they return early before the cache control logic
+      expect(response.headers['cache-control'], isNull);
     });
 
     test(

--- a/tests/serverpod_test_server/test_integration/web_server/widget_route_cache_control_test.dart
+++ b/tests/serverpod_test_server/test_integration/web_server/widget_route_cache_control_test.dart
@@ -1,0 +1,125 @@
+import 'package:serverpod/serverpod.dart';
+import 'package:serverpod_test_server/test_util/test_serverpod.dart';
+import 'package:test/test.dart';
+import 'package:http/http.dart' as http;
+
+// Test widget classes
+class TestHtmlWidget extends WebWidget {
+  @override
+  String toString() => '<html><body>Test HTML</body></html>';
+}
+
+class TestJsonWidget extends JsonWidget {
+  TestJsonWidget() : super(object: {'test': 'json'});
+}
+
+class TestRedirectWidget extends RedirectWidget {
+  TestRedirectWidget() : super(url: '/redirected');
+}
+
+// Test route implementations
+class HtmlTestRoute extends WidgetRoute {
+  @override
+  Future<WebWidget> build(Session session, Request request) async {
+    return TestHtmlWidget();
+  }
+}
+
+class JsonTestRoute extends WidgetRoute {
+  @override
+  Future<WebWidget> build(Session session, Request request) async {
+    return TestJsonWidget();
+  }
+}
+
+class RedirectTestRoute extends WidgetRoute {
+  @override
+  Future<WebWidget> build(Session session, Request request) async {
+    return TestRedirectWidget();
+  }
+}
+
+void main() {
+  group('Given a web server with widget routes', () {
+    late Serverpod serverpod;
+
+    setUp(() async {
+      serverpod = IntegrationTestServer.create();
+
+      // Add all test routes
+      serverpod.webServer.addRoute(HtmlTestRoute(), '/html-route');
+      serverpod.webServer.addRoute(JsonTestRoute(), '/json-route');
+      serverpod.webServer.addRoute(RedirectTestRoute(), '/redirect-route');
+
+      await serverpod.start();
+    });
+
+    tearDown(() async {
+      await serverpod.shutdown(exitProcess: false);
+    });
+
+    test(
+        'when requesting an HTML widget route '
+        'then the cache-control header is set to no-cache', () async {
+      var response = await http.get(
+        Uri.parse('http://localhost:8082/html-route'),
+      );
+
+      expect(response.headers['cache-control'],
+          'no-cache, no-store, max-age=0, s-maxage=0');
+    });
+
+    test(
+        'when requesting a JSON widget route '
+        'then the cache-control header is set to no-cache', () async {
+      var response = await http.get(
+        Uri.parse('http://localhost:8082/json-route'),
+      );
+
+      expect(response.headers['cache-control'],
+          'no-cache, no-store, max-age=0, s-maxage=0');
+    });
+
+    test(
+        'when requesting a JSON widget route '
+        'then the content-type is application/json', () async {
+      var response = await http.get(
+        Uri.parse('http://localhost:8082/json-route'),
+      );
+
+      expect(response.headers['content-type'], contains('application/json'));
+    });
+
+    test(
+        'when requesting a redirect widget route '
+        'then the redirect response has cache-control header set to no-cache',
+        () async {
+      // Create client that doesn't follow redirects
+      var client = http.Client();
+      var request = http.Request(
+          'GET', Uri.parse('http://localhost:8082/redirect-route'));
+      request.followRedirects = false;
+
+      var streamedResponse = await client.send(request);
+      var response = await http.Response.fromStream(streamedResponse);
+
+      expect(response.statusCode, 303); // See Other redirect
+      expect(response.headers['cache-control'],
+          'no-cache, no-store, max-age=0, s-maxage=0');
+    });
+
+    test(
+        'when requesting a redirect widget route '
+        'then the location header is set correctly', () async {
+      var client = http.Client();
+      var request = http.Request(
+          'GET', Uri.parse('http://localhost:8082/redirect-route'));
+      request.followRedirects = false;
+
+      var streamedResponse = await client.send(request);
+      var response = await http.Response.fromStream(streamedResponse);
+
+      expect(response.headers['location'], '/redirected');
+    });
+  });
+}


### PR DESCRIPTION
This PR adds cache control headers to dynamic routes.

Fixes: https://github.com/serverpod/serverpod/issues/2534

## Pre-launch Checklist

- [X] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [X] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [X] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [X] I added new tests to check the change I am making.
- [X] All existing and new tests are passing.
- [X] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

