### PR TITLE
fix: Fix minor typos and import order on auth migration package

### DIFF
--- a/modules/new_serverpod_auth/serverpod_auth_bridge/serverpod_auth_bridge_client/lib/src/protocol/protocol.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_bridge/serverpod_auth_bridge_client/lib/src/protocol/protocol.dart
@@ -11,9 +11,9 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
-import 'package:serverpod_auth_idp_client/serverpod_auth_idp_client.dart'
-    as _i2;
 import 'package:serverpod_auth_core_client/serverpod_auth_core_client.dart'
+    as _i2;
+import 'package:serverpod_auth_idp_client/serverpod_auth_idp_client.dart'
     as _i3;
 export 'client.dart';
 
@@ -45,11 +45,11 @@ class Protocol extends _i1.SerializationManager {
     if (className != null) return className;
     className = _i2.Protocol().getClassNameForObject(data);
     if (className != null) {
-      return 'serverpod_auth_idp.$className';
+      return 'serverpod_auth_core.$className';
     }
     className = _i3.Protocol().getClassNameForObject(data);
     if (className != null) {
-      return 'serverpod_auth_core.$className';
+      return 'serverpod_auth_idp.$className';
     }
     return null;
   }
@@ -60,12 +60,12 @@ class Protocol extends _i1.SerializationManager {
     if (dataClassName is! String) {
       return super.deserializeByClassName(data);
     }
-    if (dataClassName.startsWith('serverpod_auth_idp.')) {
-      data['className'] = dataClassName.substring(19);
-      return _i2.Protocol().deserializeByClassName(data);
-    }
     if (dataClassName.startsWith('serverpod_auth_core.')) {
       data['className'] = dataClassName.substring(20);
+      return _i2.Protocol().deserializeByClassName(data);
+    }
+    if (dataClassName.startsWith('serverpod_auth_idp.')) {
+      data['className'] = dataClassName.substring(19);
       return _i3.Protocol().deserializeByClassName(data);
     }
     return super.deserializeByClassName(data);

--- a/modules/new_serverpod_auth/serverpod_auth_bridge/serverpod_auth_bridge_server/lib/src/generated/endpoints.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_bridge/serverpod_auth_bridge_server/lib/src/generated/endpoints.dart
@@ -12,9 +12,9 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../endpoints/session_migration_endpoint.dart' as _i2;
-import 'package:serverpod_auth_idp_server/serverpod_auth_idp_server.dart'
-    as _i3;
 import 'package:serverpod_auth_core_server/serverpod_auth_core_server.dart'
+    as _i3;
+import 'package:serverpod_auth_idp_server/serverpod_auth_idp_server.dart'
     as _i4;
 
 class Endpoints extends _i1.EndpointDispatch {
@@ -53,9 +53,9 @@ class Endpoints extends _i1.EndpointDispatch {
         )
       },
     );
-    modules['serverpod_auth_idp'] = _i3.Endpoints()
+    modules['serverpod_auth_core'] = _i3.Endpoints()
       ..initializeEndpoints(server);
-    modules['serverpod_auth_core'] = _i4.Endpoints()
+    modules['serverpod_auth_idp'] = _i4.Endpoints()
       ..initializeEndpoints(server);
   }
 }

--- a/modules/new_serverpod_auth/serverpod_auth_bridge/serverpod_auth_bridge_server/lib/src/generated/protocol.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_bridge/serverpod_auth_bridge_server/lib/src/generated/protocol.dart
@@ -12,9 +12,9 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'package:serverpod/protocol.dart' as _i2;
-import 'package:serverpod_auth_idp_server/serverpod_auth_idp_server.dart'
-    as _i3;
 import 'package:serverpod_auth_core_server/serverpod_auth_core_server.dart'
+    as _i3;
+import 'package:serverpod_auth_idp_server/serverpod_auth_idp_server.dart'
     as _i4;
 import 'legacy_email_password.dart' as _i5;
 import 'legacy_external_user_identifier.dart' as _i6;
@@ -299,11 +299,11 @@ class Protocol extends _i1.SerializationManagerServer {
     }
     className = _i3.Protocol().getClassNameForObject(data);
     if (className != null) {
-      return 'serverpod_auth_idp.$className';
+      return 'serverpod_auth_core.$className';
     }
     className = _i4.Protocol().getClassNameForObject(data);
     if (className != null) {
-      return 'serverpod_auth_core.$className';
+      return 'serverpod_auth_idp.$className';
     }
     return null;
   }
@@ -327,12 +327,12 @@ class Protocol extends _i1.SerializationManagerServer {
       data['className'] = dataClassName.substring(10);
       return _i2.Protocol().deserializeByClassName(data);
     }
-    if (dataClassName.startsWith('serverpod_auth_idp.')) {
-      data['className'] = dataClassName.substring(19);
-      return _i3.Protocol().deserializeByClassName(data);
-    }
     if (dataClassName.startsWith('serverpod_auth_core.')) {
       data['className'] = dataClassName.substring(20);
+      return _i3.Protocol().deserializeByClassName(data);
+    }
+    if (dataClassName.startsWith('serverpod_auth_idp.')) {
+      data['className'] = dataClassName.substring(19);
       return _i4.Protocol().deserializeByClassName(data);
     }
     return super.deserializeByClassName(data);

--- a/modules/new_serverpod_auth/serverpod_auth_bridge/serverpod_auth_bridge_server/pubspec.yaml
+++ b/modules/new_serverpod_auth/serverpod_auth_bridge/serverpod_auth_bridge_server/pubspec.yaml
@@ -14,8 +14,8 @@ dependencies:
   meta: ^1.11.0
   pointycastle: '>=3.7.4 <5.0.0'
   serverpod: 3.0.0-alpha.1
-  serverpod_auth_idp_server: 3.0.0-alpha.1
   serverpod_auth_core_server: 3.0.0-alpha.1
+  serverpod_auth_idp_server: 3.0.0-alpha.1
   serverpod_shared: 3.0.0-alpha.1
 
 dev_dependencies:
@@ -26,10 +26,10 @@ dev_dependencies:
 dependency_overrides:
   serverpod:
     path: ../../../../packages/serverpod
-  serverpod_auth_idp_server:
-    path: ../../serverpod_auth_idp/serverpod_auth_idp_server
   serverpod_auth_core_server:
     path: ../../serverpod_auth_core/serverpod_auth_core_server
+  serverpod_auth_idp_server:
+    path: ../../serverpod_auth_idp/serverpod_auth_idp_server
   serverpod_lints:
     path: ../../../../packages/serverpod_lints
   serverpod_serialization:

--- a/modules/new_serverpod_auth/serverpod_auth_migration/serverpod_auth_migration_client/lib/src/protocol/protocol.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_migration/serverpod_auth_migration_client/lib/src/protocol/protocol.dart
@@ -13,9 +13,9 @@
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import 'package:serverpod_auth_bridge_client/serverpod_auth_bridge_client.dart'
     as _i2;
-import 'package:serverpod_auth_idp_client/serverpod_auth_idp_client.dart'
-    as _i3;
 import 'package:serverpod_auth_core_client/serverpod_auth_core_client.dart'
+    as _i3;
+import 'package:serverpod_auth_idp_client/serverpod_auth_idp_client.dart'
     as _i4;
 import 'package:serverpod_auth_client/serverpod_auth_client.dart' as _i5;
 export 'client.dart';
@@ -58,11 +58,11 @@ class Protocol extends _i1.SerializationManager {
     }
     className = _i3.Protocol().getClassNameForObject(data);
     if (className != null) {
-      return 'serverpod_auth_idp.$className';
+      return 'serverpod_auth_core.$className';
     }
     className = _i4.Protocol().getClassNameForObject(data);
     if (className != null) {
-      return 'serverpod_auth_core.$className';
+      return 'serverpod_auth_idp.$className';
     }
     className = _i5.Protocol().getClassNameForObject(data);
     if (className != null) {
@@ -81,12 +81,12 @@ class Protocol extends _i1.SerializationManager {
       data['className'] = dataClassName.substring(22);
       return _i2.Protocol().deserializeByClassName(data);
     }
-    if (dataClassName.startsWith('serverpod_auth_idp.')) {
-      data['className'] = dataClassName.substring(19);
-      return _i3.Protocol().deserializeByClassName(data);
-    }
     if (dataClassName.startsWith('serverpod_auth_core.')) {
       data['className'] = dataClassName.substring(20);
+      return _i3.Protocol().deserializeByClassName(data);
+    }
+    if (dataClassName.startsWith('serverpod_auth_idp.')) {
+      data['className'] = dataClassName.substring(19);
       return _i4.Protocol().deserializeByClassName(data);
     }
     if (dataClassName.startsWith('serverpod_auth.')) {

--- a/modules/new_serverpod_auth/serverpod_auth_migration/serverpod_auth_migration_server/lib/src/generated/endpoints.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_migration/serverpod_auth_migration_server/lib/src/generated/endpoints.dart
@@ -13,9 +13,9 @@
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'package:serverpod_auth_bridge_server/serverpod_auth_bridge_server.dart'
     as _i2;
-import 'package:serverpod_auth_idp_server/serverpod_auth_idp_server.dart'
-    as _i3;
 import 'package:serverpod_auth_core_server/serverpod_auth_core_server.dart'
+    as _i3;
+import 'package:serverpod_auth_idp_server/serverpod_auth_idp_server.dart'
     as _i4;
 import 'package:serverpod_auth_server/serverpod_auth_server.dart' as _i5;
 
@@ -24,9 +24,9 @@ class Endpoints extends _i1.EndpointDispatch {
   void initializeEndpoints(_i1.Server server) {
     modules['serverpod_auth_bridge'] = _i2.Endpoints()
       ..initializeEndpoints(server);
-    modules['serverpod_auth_idp'] = _i3.Endpoints()
+    modules['serverpod_auth_core'] = _i3.Endpoints()
       ..initializeEndpoints(server);
-    modules['serverpod_auth_core'] = _i4.Endpoints()
+    modules['serverpod_auth_idp'] = _i4.Endpoints()
       ..initializeEndpoints(server);
     modules['serverpod_auth'] = _i5.Endpoints()..initializeEndpoints(server);
   }

--- a/modules/new_serverpod_auth/serverpod_auth_migration/serverpod_auth_migration_server/lib/src/generated/protocol.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_migration/serverpod_auth_migration_server/lib/src/generated/protocol.dart
@@ -14,9 +14,9 @@ import 'package:serverpod/serverpod.dart' as _i1;
 import 'package:serverpod/protocol.dart' as _i2;
 import 'package:serverpod_auth_bridge_server/serverpod_auth_bridge_server.dart'
     as _i3;
-import 'package:serverpod_auth_idp_server/serverpod_auth_idp_server.dart'
-    as _i4;
 import 'package:serverpod_auth_core_server/serverpod_auth_core_server.dart'
+    as _i4;
+import 'package:serverpod_auth_idp_server/serverpod_auth_idp_server.dart'
     as _i5;
 import 'package:serverpod_auth_server/serverpod_auth_server.dart' as _i6;
 import 'migrated_user.dart' as _i7;
@@ -176,11 +176,11 @@ class Protocol extends _i1.SerializationManagerServer {
     }
     className = _i4.Protocol().getClassNameForObject(data);
     if (className != null) {
-      return 'serverpod_auth_idp.$className';
+      return 'serverpod_auth_core.$className';
     }
     className = _i5.Protocol().getClassNameForObject(data);
     if (className != null) {
-      return 'serverpod_auth_core.$className';
+      return 'serverpod_auth_idp.$className';
     }
     className = _i6.Protocol().getClassNameForObject(data);
     if (className != null) {
@@ -206,12 +206,12 @@ class Protocol extends _i1.SerializationManagerServer {
       data['className'] = dataClassName.substring(22);
       return _i3.Protocol().deserializeByClassName(data);
     }
-    if (dataClassName.startsWith('serverpod_auth_idp.')) {
-      data['className'] = dataClassName.substring(19);
-      return _i4.Protocol().deserializeByClassName(data);
-    }
     if (dataClassName.startsWith('serverpod_auth_core.')) {
       data['className'] = dataClassName.substring(20);
+      return _i4.Protocol().deserializeByClassName(data);
+    }
+    if (dataClassName.startsWith('serverpod_auth_idp.')) {
+      data['className'] = dataClassName.substring(19);
       return _i5.Protocol().deserializeByClassName(data);
     }
     if (dataClassName.startsWith('serverpod_auth.')) {

--- a/modules/new_serverpod_auth/serverpod_auth_migration/serverpod_auth_migration_server/pubspec.yaml
+++ b/modules/new_serverpod_auth/serverpod_auth_migration/serverpod_auth_migration_server/pubspec.yaml
@@ -13,8 +13,8 @@ dependencies:
   meta: ^1.11.0
   serverpod: 3.0.0-alpha.1
   serverpod_auth_bridge_server: 3.0.0-alpha.1
-  serverpod_auth_idp_server: 3.0.0-alpha.1
   serverpod_auth_core_server: 3.0.0-alpha.1
+  serverpod_auth_idp_server: 3.0.0-alpha.1
   serverpod_auth_server: 3.0.0-alpha.1
   serverpod_shared: 3.0.0-alpha.1
 
@@ -28,10 +28,10 @@ dependency_overrides:
     path: ../../../../packages/serverpod
   serverpod_auth_bridge_server:
     path: ../../serverpod_auth_bridge/serverpod_auth_bridge_server
-  serverpod_auth_idp_server:
-    path: ../../serverpod_auth_idp/serverpod_auth_idp_server
   serverpod_auth_core_server:
     path: ../../serverpod_auth_core/serverpod_auth_core_server
+  serverpod_auth_idp_server:
+    path: ../../serverpod_auth_idp/serverpod_auth_idp_server
   serverpod_auth_server:
     path: ../../../serverpod_auth/serverpod_auth_server
   serverpod_lints:

--- a/templates/pubspecs/modules/new_serverpod_auth/serverpod_auth_bridge/serverpod_auth_bridge_server/pubspec.yaml
+++ b/templates/pubspecs/modules/new_serverpod_auth/serverpod_auth_bridge/serverpod_auth_bridge_server/pubspec.yaml
@@ -13,8 +13,8 @@ dependencies:
   meta: ^1.11.0
   pointycastle: '>=3.7.4 <5.0.0'
   serverpod: SERVERPOD_VERSION
-  serverpod_auth_idp_server: SERVERPOD_VERSION
   serverpod_auth_core_server: SERVERPOD_VERSION
+  serverpod_auth_idp_server: SERVERPOD_VERSION
   serverpod_shared: SERVERPOD_VERSION
 
 dev_dependencies:
@@ -25,10 +25,10 @@ dev_dependencies:
 dependency_overrides:
   serverpod:
     path: ../../../../packages/serverpod
-  serverpod_auth_idp_server:
-    path: ../../serverpod_auth_idp/serverpod_auth_idp_server
   serverpod_auth_core_server:
     path: ../../serverpod_auth_core/serverpod_auth_core_server
+  serverpod_auth_idp_server:
+    path: ../../serverpod_auth_idp/serverpod_auth_idp_server
   serverpod_lints:
     path: ../../../../packages/serverpod_lints
   serverpod_serialization:

--- a/templates/pubspecs/modules/new_serverpod_auth/serverpod_auth_migration/serverpod_auth_migration_server/pubspec.yaml
+++ b/templates/pubspecs/modules/new_serverpod_auth/serverpod_auth_migration/serverpod_auth_migration_server/pubspec.yaml
@@ -12,8 +12,8 @@ dependencies:
   meta: ^1.11.0
   serverpod: SERVERPOD_VERSION
   serverpod_auth_bridge_server: SERVERPOD_VERSION
-  serverpod_auth_idp_server: SERVERPOD_VERSION
   serverpod_auth_core_server: SERVERPOD_VERSION
+  serverpod_auth_idp_server: SERVERPOD_VERSION
   serverpod_auth_server: SERVERPOD_VERSION
   serverpod_shared: SERVERPOD_VERSION
 
@@ -27,10 +27,10 @@ dependency_overrides:
     path: ../../../../packages/serverpod
   serverpod_auth_bridge_server:
     path: ../../serverpod_auth_bridge/serverpod_auth_bridge_server
-  serverpod_auth_idp_server:
-    path: ../../serverpod_auth_idp/serverpod_auth_idp_server
   serverpod_auth_core_server:
     path: ../../serverpod_auth_core/serverpod_auth_core_server
+  serverpod_auth_idp_server:
+    path: ../../serverpod_auth_idp/serverpod_auth_idp_server
   serverpod_auth_server:
     path: ../../../serverpod_auth/serverpod_auth_server
   serverpod_lints:

--- a/templates/pubspecs/tests/serverpod_new_auth_test/serverpod_new_auth_test_server/pubspec.yaml
+++ b/templates/pubspecs/tests/serverpod_new_auth_test/serverpod_new_auth_test_server/pubspec.yaml
@@ -11,9 +11,9 @@ environment:
 dependencies:
   serverpod: SERVERPOD_VERSION
   serverpod_auth_bridge_server: SERVERPOD_VERSION
+  serverpod_auth_core_server: SERVERPOD_VERSION
   serverpod_auth_idp_server: SERVERPOD_VERSION
   serverpod_auth_migration_server: SERVERPOD_VERSION
-  serverpod_auth_core_server: SERVERPOD_VERSION
   serverpod_auth_server: SERVERPOD_VERSION
 
 dev_dependencies:
@@ -26,12 +26,12 @@ dependency_overrides:
     path: ../../../packages/serverpod
   serverpod_auth_bridge_server:
     path: ../../../modules/new_serverpod_auth/serverpod_auth_bridge/serverpod_auth_bridge_server
+  serverpod_auth_core_server:
+    path: ../../../modules/new_serverpod_auth/serverpod_auth_core/serverpod_auth_core_server
   serverpod_auth_idp_server:
     path: ../../../modules/new_serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server
   serverpod_auth_migration_server:
     path: ../../../modules/new_serverpod_auth/serverpod_auth_migration/serverpod_auth_migration_server
-  serverpod_auth_core_server:
-    path: ../../../modules/new_serverpod_auth/serverpod_auth_core/serverpod_auth_core_server
   serverpod_auth_server:
     path: ../../../modules/serverpod_auth/serverpod_auth_server
   serverpod_cli:

--- a/tests/serverpod_new_auth_test/serverpod_new_auth_test_client/lib/src/protocol/client.dart
+++ b/tests/serverpod_new_auth_test/serverpod_new_auth_test_client/lib/src/protocol/client.dart
@@ -470,19 +470,19 @@ class EndpointUserProfile extends _i1.EndpointRef {
 class Modules {
   Modules(Client client) {
     serverpod_auth_bridge = _i7.Caller(client);
+    serverpod_auth_core = _i5.Caller(client);
     serverpod_auth_idp = _i8.Caller(client);
     serverpod_auth_migration = _i9.Caller(client);
-    serverpod_auth_core = _i5.Caller(client);
     auth = _i3.Caller(client);
   }
 
   late final _i7.Caller serverpod_auth_bridge;
 
+  late final _i5.Caller serverpod_auth_core;
+
   late final _i8.Caller serverpod_auth_idp;
 
   late final _i9.Caller serverpod_auth_migration;
-
-  late final _i5.Caller serverpod_auth_core;
 
   late final _i3.Caller auth;
 }
@@ -560,9 +560,9 @@ class Client extends _i1.ServerpodClientShared {
   @override
   Map<String, _i1.ModuleEndpointCaller> get moduleLookup => {
         'serverpod_auth_bridge': modules.serverpod_auth_bridge,
+        'serverpod_auth_core': modules.serverpod_auth_core,
         'serverpod_auth_idp': modules.serverpod_auth_idp,
         'serverpod_auth_migration': modules.serverpod_auth_migration,
-        'serverpod_auth_core': modules.serverpod_auth_core,
         'auth': modules.auth,
       };
 }

--- a/tests/serverpod_new_auth_test/serverpod_new_auth_test_client/lib/src/protocol/client.dart
+++ b/tests/serverpod_new_auth_test/serverpod_new_auth_test_client/lib/src/protocol/client.dart
@@ -92,10 +92,10 @@ class EndpointEmailAccountBackwardsCompatibilityTest extends _i1.EndpointRef {
   ///
   /// Since the server runs with the backwards compatible auth handler, both
   /// old session keys will work post migration.
-  _i2.Future<String?> sessionUserIdentifer() =>
+  _i2.Future<String?> sessionUserIdentifier() =>
       caller.callServerEndpoint<String?>(
         'emailAccountBackwardsCompatibilityTest',
-        'sessionUserIdentifer',
+        'sessionUserIdentifier',
         {},
       );
 

--- a/tests/serverpod_new_auth_test/serverpod_new_auth_test_client/lib/src/protocol/protocol.dart
+++ b/tests/serverpod_new_auth_test/serverpod_new_auth_test_client/lib/src/protocol/protocol.dart
@@ -13,11 +13,11 @@
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import 'package:serverpod_auth_bridge_client/serverpod_auth_bridge_client.dart'
     as _i2;
-import 'package:serverpod_auth_idp_client/serverpod_auth_idp_client.dart'
-    as _i3;
-import 'package:serverpod_auth_migration_client/serverpod_auth_migration_client.dart'
-    as _i4;
 import 'package:serverpod_auth_core_client/serverpod_auth_core_client.dart'
+    as _i3;
+import 'package:serverpod_auth_idp_client/serverpod_auth_idp_client.dart'
+    as _i4;
+import 'package:serverpod_auth_migration_client/serverpod_auth_migration_client.dart'
     as _i5;
 import 'package:serverpod_auth_client/serverpod_auth_client.dart' as _i6;
 export 'client.dart';
@@ -66,15 +66,15 @@ class Protocol extends _i1.SerializationManager {
     }
     className = _i3.Protocol().getClassNameForObject(data);
     if (className != null) {
-      return 'serverpod_auth_idp.$className';
+      return 'serverpod_auth_core.$className';
     }
     className = _i4.Protocol().getClassNameForObject(data);
     if (className != null) {
-      return 'serverpod_auth_migration.$className';
+      return 'serverpod_auth_idp.$className';
     }
     className = _i5.Protocol().getClassNameForObject(data);
     if (className != null) {
-      return 'serverpod_auth_core.$className';
+      return 'serverpod_auth_migration.$className';
     }
     className = _i6.Protocol().getClassNameForObject(data);
     if (className != null) {
@@ -93,16 +93,16 @@ class Protocol extends _i1.SerializationManager {
       data['className'] = dataClassName.substring(22);
       return _i2.Protocol().deserializeByClassName(data);
     }
+    if (dataClassName.startsWith('serverpod_auth_core.')) {
+      data['className'] = dataClassName.substring(20);
+      return _i3.Protocol().deserializeByClassName(data);
+    }
     if (dataClassName.startsWith('serverpod_auth_idp.')) {
       data['className'] = dataClassName.substring(19);
-      return _i3.Protocol().deserializeByClassName(data);
+      return _i4.Protocol().deserializeByClassName(data);
     }
     if (dataClassName.startsWith('serverpod_auth_migration.')) {
       data['className'] = dataClassName.substring(25);
-      return _i4.Protocol().deserializeByClassName(data);
-    }
-    if (dataClassName.startsWith('serverpod_auth_core.')) {
-      data['className'] = dataClassName.substring(20);
       return _i5.Protocol().deserializeByClassName(data);
     }
     if (dataClassName.startsWith('serverpod_auth.')) {

--- a/tests/serverpod_new_auth_test/serverpod_new_auth_test_flutter/test/session_manager_migration_test.dart
+++ b/tests/serverpod_new_auth_test/serverpod_new_auth_test_flutter/test/session_manager_migration_test.dart
@@ -70,7 +70,7 @@ void main() {
 
       expect(
         await legacySessionClient.emailAccountBackwardsCompatibilityTest
-            .sessionUserIdentifer(),
+            .sessionUserIdentifier(),
         isNull, // old sessions do not work before migration
       );
 
@@ -85,7 +85,7 @@ void main() {
 
       expect(
         await legacySessionClient.emailAccountBackwardsCompatibilityTest
-            .sessionUserIdentifer(),
+            .sessionUserIdentifier(),
         isNull, // the session has not been migrated yet
       );
 
@@ -105,7 +105,7 @@ void main() {
 
       expect(
         await newSessionClient.emailAccountBackwardsCompatibilityTest
-            .sessionUserIdentifer(),
+            .sessionUserIdentifier(),
         newAuthUserId!.uuid,
       );
     },

--- a/tests/serverpod_new_auth_test/serverpod_new_auth_test_server/lib/src/endpoints/email_account_backwards_compatibility_endpoint.dart
+++ b/tests/serverpod_new_auth_test/serverpod_new_auth_test_server/lib/src/endpoints/email_account_backwards_compatibility_endpoint.dart
@@ -81,7 +81,7 @@ class EmailAccountBackwardsCompatibilityTestEndpoint extends Endpoint {
   ///
   /// Since the server runs with the backwards compatible auth handler, both
   /// old session keys will work post migration.
-  Future<String?> sessionUserIdentifer(final Session session) async {
+  Future<String?> sessionUserIdentifier(final Session session) async {
     return (await session.authenticated)?.userIdentifier;
   }
 

--- a/tests/serverpod_new_auth_test/serverpod_new_auth_test_server/lib/src/endpoints/google_account_backwards_compatibility_test_endpoint.dart
+++ b/tests/serverpod_new_auth_test/serverpod_new_auth_test_server/lib/src/endpoints/google_account_backwards_compatibility_test_endpoint.dart
@@ -1,6 +1,5 @@
 import 'package:serverpod/serverpod.dart';
 import 'package:serverpod_auth_bridge_server/serverpod_auth_bridge_server.dart';
-import 'package:serverpod_auth_idp_server/core.dart';
 import 'package:serverpod_auth_idp_server/providers/google.dart';
 
 /// Endpoint for Google-based authentication, which automatically imports legacy

--- a/tests/serverpod_new_auth_test/serverpod_new_auth_test_server/lib/src/generated/endpoints.dart
+++ b/tests/serverpod_new_auth_test/serverpod_new_auth_test_server/lib/src/generated/endpoints.dart
@@ -205,8 +205,8 @@ class Endpoints extends _i1.EndpointDispatch {
             userId: params['userId'],
           ),
         ),
-        'sessionUserIdentifer': _i1.MethodConnector(
-          name: 'sessionUserIdentifer',
+        'sessionUserIdentifier': _i1.MethodConnector(
+          name: 'sessionUserIdentifier',
           params: {},
           call: (
             _i1.Session session,
@@ -214,7 +214,7 @@ class Endpoints extends _i1.EndpointDispatch {
           ) async =>
               (endpoints['emailAccountBackwardsCompatibilityTest']
                       as _i2.EmailAccountBackwardsCompatibilityTestEndpoint)
-                  .sessionUserIdentifer(session),
+                  .sessionUserIdentifier(session),
         ),
         'checkLegacyPassword': _i1.MethodConnector(
           name: 'checkLegacyPassword',

--- a/tests/serverpod_new_auth_test/serverpod_new_auth_test_server/lib/src/generated/endpoints.dart
+++ b/tests/serverpod_new_auth_test/serverpod_new_auth_test_server/lib/src/generated/endpoints.dart
@@ -24,11 +24,11 @@ import 'package:uuid/uuid_value.dart' as _i9;
 import 'dart:typed_data' as _i10;
 import 'package:serverpod_auth_bridge_server/serverpod_auth_bridge_server.dart'
     as _i11;
-import 'package:serverpod_auth_idp_server/serverpod_auth_idp_server.dart'
-    as _i12;
-import 'package:serverpod_auth_migration_server/serverpod_auth_migration_server.dart'
-    as _i13;
 import 'package:serverpod_auth_core_server/serverpod_auth_core_server.dart'
+    as _i12;
+import 'package:serverpod_auth_idp_server/serverpod_auth_idp_server.dart'
+    as _i13;
+import 'package:serverpod_auth_migration_server/serverpod_auth_migration_server.dart'
     as _i14;
 import 'package:serverpod_auth_server/serverpod_auth_server.dart' as _i15;
 
@@ -701,11 +701,11 @@ class Endpoints extends _i1.EndpointDispatch {
     );
     modules['serverpod_auth_bridge'] = _i11.Endpoints()
       ..initializeEndpoints(server);
-    modules['serverpod_auth_idp'] = _i12.Endpoints()
+    modules['serverpod_auth_core'] = _i12.Endpoints()
       ..initializeEndpoints(server);
-    modules['serverpod_auth_migration'] = _i13.Endpoints()
+    modules['serverpod_auth_idp'] = _i13.Endpoints()
       ..initializeEndpoints(server);
-    modules['serverpod_auth_core'] = _i14.Endpoints()
+    modules['serverpod_auth_migration'] = _i14.Endpoints()
       ..initializeEndpoints(server);
     modules['serverpod_auth'] = _i15.Endpoints()..initializeEndpoints(server);
   }

--- a/tests/serverpod_new_auth_test/serverpod_new_auth_test_server/lib/src/generated/protocol.dart
+++ b/tests/serverpod_new_auth_test/serverpod_new_auth_test_server/lib/src/generated/protocol.dart
@@ -14,11 +14,11 @@ import 'package:serverpod/serverpod.dart' as _i1;
 import 'package:serverpod/protocol.dart' as _i2;
 import 'package:serverpod_auth_bridge_server/serverpod_auth_bridge_server.dart'
     as _i3;
-import 'package:serverpod_auth_idp_server/serverpod_auth_idp_server.dart'
-    as _i4;
-import 'package:serverpod_auth_migration_server/serverpod_auth_migration_server.dart'
-    as _i5;
 import 'package:serverpod_auth_core_server/serverpod_auth_core_server.dart'
+    as _i4;
+import 'package:serverpod_auth_idp_server/serverpod_auth_idp_server.dart'
+    as _i5;
+import 'package:serverpod_auth_migration_server/serverpod_auth_migration_server.dart'
     as _i6;
 import 'package:serverpod_auth_server/serverpod_auth_server.dart' as _i7;
 
@@ -82,15 +82,15 @@ class Protocol extends _i1.SerializationManagerServer {
     }
     className = _i4.Protocol().getClassNameForObject(data);
     if (className != null) {
-      return 'serverpod_auth_idp.$className';
+      return 'serverpod_auth_core.$className';
     }
     className = _i5.Protocol().getClassNameForObject(data);
     if (className != null) {
-      return 'serverpod_auth_migration.$className';
+      return 'serverpod_auth_idp.$className';
     }
     className = _i6.Protocol().getClassNameForObject(data);
     if (className != null) {
-      return 'serverpod_auth_core.$className';
+      return 'serverpod_auth_migration.$className';
     }
     className = _i7.Protocol().getClassNameForObject(data);
     if (className != null) {
@@ -113,16 +113,16 @@ class Protocol extends _i1.SerializationManagerServer {
       data['className'] = dataClassName.substring(22);
       return _i3.Protocol().deserializeByClassName(data);
     }
+    if (dataClassName.startsWith('serverpod_auth_core.')) {
+      data['className'] = dataClassName.substring(20);
+      return _i4.Protocol().deserializeByClassName(data);
+    }
     if (dataClassName.startsWith('serverpod_auth_idp.')) {
       data['className'] = dataClassName.substring(19);
-      return _i4.Protocol().deserializeByClassName(data);
+      return _i5.Protocol().deserializeByClassName(data);
     }
     if (dataClassName.startsWith('serverpod_auth_migration.')) {
       data['className'] = dataClassName.substring(25);
-      return _i5.Protocol().deserializeByClassName(data);
-    }
-    if (dataClassName.startsWith('serverpod_auth_core.')) {
-      data['className'] = dataClassName.substring(20);
       return _i6.Protocol().deserializeByClassName(data);
     }
     if (dataClassName.startsWith('serverpod_auth.')) {

--- a/tests/serverpod_new_auth_test/serverpod_new_auth_test_server/lib/src/generated/protocol.yaml
+++ b/tests/serverpod_new_auth_test/serverpod_new_auth_test_server/lib/src/generated/protocol.yaml
@@ -4,7 +4,7 @@ emailAccountBackwardsCompatibilityTest:
   - migrateUser:
   - getNewAuthUserId:
   - deleteLegacyAuthData:
-  - sessionUserIdentifer:
+  - sessionUserIdentifier:
   - checkLegacyPassword:
 emailAccount:
   - login:

--- a/tests/serverpod_new_auth_test/serverpod_new_auth_test_server/pubspec.yaml
+++ b/tests/serverpod_new_auth_test/serverpod_new_auth_test_server/pubspec.yaml
@@ -12,9 +12,9 @@ environment:
 dependencies:
   serverpod: 3.0.0-alpha.1
   serverpod_auth_bridge_server: 3.0.0-alpha.1
+  serverpod_auth_core_server: 3.0.0-alpha.1
   serverpod_auth_idp_server: 3.0.0-alpha.1
   serverpod_auth_migration_server: 3.0.0-alpha.1
-  serverpod_auth_core_server: 3.0.0-alpha.1
   serverpod_auth_server: 3.0.0-alpha.1
 
 dev_dependencies:
@@ -27,12 +27,12 @@ dependency_overrides:
     path: ../../../packages/serverpod
   serverpod_auth_bridge_server:
     path: ../../../modules/new_serverpod_auth/serverpod_auth_bridge/serverpod_auth_bridge_server
+  serverpod_auth_core_server:
+    path: ../../../modules/new_serverpod_auth/serverpod_auth_core/serverpod_auth_core_server
   serverpod_auth_idp_server:
     path: ../../../modules/new_serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server
   serverpod_auth_migration_server:
     path: ../../../modules/new_serverpod_auth/serverpod_auth_migration/serverpod_auth_migration_server
-  serverpod_auth_core_server:
-    path: ../../../modules/new_serverpod_auth/serverpod_auth_core/serverpod_auth_core_server
   serverpod_auth_server:
     path: ../../../modules/serverpod_auth/serverpod_auth_server
   serverpod_cli:

--- a/tests/serverpod_new_auth_test/serverpod_new_auth_test_server/test/integration/email_account_endpoint_test.dart
+++ b/tests/serverpod_new_auth_test/serverpod_new_auth_test_server/test/integration/email_account_endpoint_test.dart
@@ -292,7 +292,7 @@ void main() {
             sessionBuilder,
             passwordResetRequestId: passwordResetRequestId,
             verificationCode: verificationCode,
-            newPassword: 'Newpassword123!',
+            newPassword: 'NewPassword123!',
           );
 
           final authInfo = await AuthSessions.authenticationHandler(
@@ -313,7 +313,7 @@ void main() {
     (final sessionBuilder, final endpoints) {
       const email = 'test@serverpod.dev';
       const oldPassword = 'Foobar123!';
-      const newPassword = 'Barfoo789?';
+      const newPassword = 'BarFoo789?';
 
       late UuidValue authUserId;
       late String loginSessionKey;

--- a/tests/serverpod_new_auth_test/serverpod_new_auth_test_server/test/integration/test_tools/serverpod_test_tools.dart
+++ b/tests/serverpod_new_auth_test/serverpod_new_auth_test_server/test/integration/test_tools/serverpod_test_tools.dart
@@ -331,19 +331,19 @@ class _EmailAccountBackwardsCompatibilityTestEndpoint {
     });
   }
 
-  _i3.Future<String?> sessionUserIdentifer(
+  _i3.Future<String?> sessionUserIdentifier(
       _i1.TestSessionBuilder sessionBuilder) async {
     return _i1.callAwaitableFunctionAndHandleExceptions(() async {
       var _localUniqueSession =
           (sessionBuilder as _i1.InternalTestSessionBuilder).internalBuild(
         endpoint: 'emailAccountBackwardsCompatibilityTest',
-        method: 'sessionUserIdentifer',
+        method: 'sessionUserIdentifier',
       );
       try {
         var _localCallContext = await _endpointDispatch.getMethodCallContext(
           createSessionCallback: (_) => _localUniqueSession,
           endpointPath: 'emailAccountBackwardsCompatibilityTest',
-          methodName: 'sessionUserIdentifer',
+          methodName: 'sessionUserIdentifier',
           parameters: _i1.testObjectToJson({}),
           serializationManager: _serializationManager,
         );


### PR DESCRIPTION
While working on #3674, I stumbled upon this minor fixes, that are better to be applied here separate from unrelated work.

Fixes a `Indentifer` typo on endpoints of bridge package and the import sort order for two new auth related packages.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

N/A