### PR TITLE
fix: Add missing method annotations to solve `strict_top_level_inference` lint errors

### DIFF
--- a/tools/serverpod_cli/lib/src/analyzer/models/validation/model_relations.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/validation/model_relations.dart
@@ -30,7 +30,7 @@ class ParsedModelsCollection {
 
   Set<String> get moduleNames => modules;
 
-  bool classNameExists(name) => findAllByClassName(name).isNotEmpty;
+  bool classNameExists(String name) => findAllByClassName(name).isNotEmpty;
 
   Map<String, List<SerializableModelDefinition>> _createTableNameMap(
     List<SerializableModelDefinition> models,

--- a/tools/serverpod_cli/test/test_util/compilation_unit_matcher/argument_matcher/argument_matcher.dart
+++ b/tools/serverpod_cli/test/test_util/compilation_unit_matcher/argument_matcher/argument_matcher.dart
@@ -75,7 +75,7 @@ class _ArgumentMatcherImpl extends Matcher implements ArgumentMatcher {
   }
 
   @override
-  bool matches(item, Map matchState) {
+  bool matches(dynamic item, Map matchState) {
     var arguments = _featureValueOf(item);
     if (arguments == null) return false;
 
@@ -88,7 +88,7 @@ class _ArgumentMatcherImpl extends Matcher implements ArgumentMatcher {
     return filteredArguments.isNotEmpty;
   }
 
-  Iterable<Expression>? _featureValueOf(actual) {
+  Iterable<Expression>? _featureValueOf(dynamic actual) {
     var match = _parent.matchedFeatureValueOf(actual);
     if (match == null) return null;
 

--- a/tools/serverpod_cli/test/test_util/compilation_unit_matcher/class_matcher/class_matcher.dart
+++ b/tools/serverpod_cli/test/test_util/compilation_unit_matcher/class_matcher/class_matcher.dart
@@ -130,7 +130,7 @@ class _ClassMatcherImpl implements Matcher, ClassMatcher {
         .firstOrNull;
   }
 
-  ClassDeclaration? _matchedFeatureValueOf(actual) {
+  ClassDeclaration? _matchedFeatureValueOf(dynamic actual) {
     var classDecl = _featureValueOf(actual);
     if (classDecl == null) return null;
 

--- a/tools/serverpod_cli/test/test_util/compilation_unit_matcher/constructor_matcher/constructor_matcher.dart
+++ b/tools/serverpod_cli/test/test_util/compilation_unit_matcher/constructor_matcher/constructor_matcher.dart
@@ -70,7 +70,7 @@ class _ConstructorMatcherImpl implements Matcher, ConstructorMatcher {
   }
 
   @override
-  bool matches(item, Map matchState) {
+  bool matches(dynamic item, Map matchState) {
     var constructor = _featureValueOf(item);
     return _matches(constructor);
   }
@@ -140,7 +140,7 @@ class _ConstructorMatcherImpl implements Matcher, ConstructorMatcher {
     );
   }
 
-  ConstructorDeclaration? _featureValueOf(actual) {
+  ConstructorDeclaration? _featureValueOf(dynamic actual) {
     var match = parent.matchedFeatureValueOf(actual);
     if (match == null) return null;
 

--- a/tools/serverpod_cli/test/test_util/compilation_unit_matcher/extends_matcher/extends_matcher.dart
+++ b/tools/serverpod_cli/test/test_util/compilation_unit_matcher/extends_matcher/extends_matcher.dart
@@ -13,7 +13,7 @@ class _ExtendsMatcherImpl implements Matcher, ExtendsMatcher {
 
   @override
   Description describeMismatch(
-    item,
+    dynamic item,
     Description mismatchDescription,
     Map matchState,
     bool verbose,
@@ -39,12 +39,12 @@ class _ExtendsMatcherImpl implements Matcher, ExtendsMatcher {
   }
 
   @override
-  bool matches(item, Map matchState) {
+  bool matches(dynamic item, Map matchState) {
     var extendsClause = _featureValueOf(item);
     return _matches(extendsClause);
   }
 
-  ExtendsClause? _featureValueOf(actual) {
+  ExtendsClause? _featureValueOf(dynamic actual) {
     var match = _parent.matchedFeatureValueOf(actual);
     if (match == null) return null;
 

--- a/tools/serverpod_cli/test/test_util/compilation_unit_matcher/field_initializer_matcher/field_initializer_matcher.dart
+++ b/tools/serverpod_cli/test/test_util/compilation_unit_matcher/field_initializer_matcher/field_initializer_matcher.dart
@@ -36,7 +36,7 @@ class _InitializerMatcherImpl implements Matcher, InitializerMatcher {
   }
 
   @override
-  bool matches(item, Map matchState) {
+  bool matches(dynamic item, Map matchState) {
     return _matches(_featureValueOf(item));
   }
 
@@ -55,14 +55,14 @@ class _InitializerMatcherImpl implements Matcher, InitializerMatcher {
     return _withArgument(value, parameterType: _PositionalParameter());
   }
 
-  ConstructorFieldInitializer? _featureValueOf(actual) {
+  ConstructorFieldInitializer? _featureValueOf(dynamic actual) {
     var match = parent.matchedFeatureValueOf(actual);
     if (match == null) return null;
 
     return match.value.where((e) => e._hasMatchingName(fieldName)).firstOrNull;
   }
 
-  ConstructorFieldInitializer? _matchedFeatureValueOf(actual) {
+  ConstructorFieldInitializer? _matchedFeatureValueOf(dynamic actual) {
     var initializer = _featureValueOf(actual);
     if (initializer == null) return null;
 
@@ -71,7 +71,7 @@ class _InitializerMatcherImpl implements Matcher, InitializerMatcher {
     return initializer;
   }
 
-  bool _matches(item) {
+  bool _matches(dynamic item) {
     return item != null;
   }
 

--- a/tools/serverpod_cli/test/test_util/compilation_unit_matcher/field_matcher/field_matcher.dart
+++ b/tools/serverpod_cli/test/test_util/compilation_unit_matcher/field_matcher/field_matcher.dart
@@ -84,7 +84,7 @@ class _FieldMatcherImpl extends Matcher implements FieldMatcher {
   }
 
   @override
-  bool matches(item, Map matchState) {
+  bool matches(dynamic item, Map matchState) {
     var field = _featureValueOf(item);
     if (field is! FieldDeclaration) return false;
 
@@ -96,7 +96,7 @@ class _FieldMatcherImpl extends Matcher implements FieldMatcher {
     return true;
   }
 
-  FieldDeclaration? _featureValueOf(actual) {
+  FieldDeclaration? _featureValueOf(dynamic actual) {
     var match = parent.matchedFeatureValueOf(actual);
     if (match == null) return null;
 

--- a/tools/serverpod_cli/test/test_util/compilation_unit_matcher/generic_matcher/generic_matcher.dart
+++ b/tools/serverpod_cli/test/test_util/compilation_unit_matcher/generic_matcher/generic_matcher.dart
@@ -13,7 +13,7 @@ class _GenericMatcherImpl implements Matcher, GenericMatcher {
 
   @override
   Description describeMismatch(
-    item,
+    dynamic item,
     Description mismatchDescription,
     Map matchState,
     bool verbose,
@@ -39,14 +39,14 @@ class _GenericMatcherImpl implements Matcher, GenericMatcher {
   }
 
   @override
-  bool matches(item, Map matchState) {
+  bool matches(dynamic item, Map matchState) {
     var typeParameters = _featureValueOf(item);
     if (typeParameters == null) return false;
 
     return typeParameters.where((e) => e.toSource() == _generic).isNotEmpty;
   }
 
-  Iterable<TypeAnnotation>? _featureValueOf(actual) {
+  Iterable<TypeAnnotation>? _featureValueOf(dynamic actual) {
     var match = _parent.matchedFeatureValueOf(actual);
     if (match == null) return null;
 

--- a/tools/serverpod_cli/test/test_util/compilation_unit_matcher/method_matcher/method_matcher.dart
+++ b/tools/serverpod_cli/test/test_util/compilation_unit_matcher/method_matcher/method_matcher.dart
@@ -72,7 +72,7 @@ class _MethodMatcherImpl extends Matcher implements MethodMatcher {
   }
 
   @override
-  bool matches(item, Map matchState) {
+  bool matches(dynamic item, Map matchState) {
     var method = _featureValueOf(item);
     return _matches(method);
   }
@@ -96,7 +96,7 @@ class _MethodMatcherImpl extends Matcher implements MethodMatcher {
     );
   }
 
-  MethodDeclaration? _featureValueOf(actual) {
+  MethodDeclaration? _featureValueOf(dynamic actual) {
     var match = _parent.matchedFeatureValueOf(actual);
     if (match == null) return null;
 

--- a/tools/serverpod_cli/test/test_util/compilation_unit_matcher/parameter_matcher/parameter_matcher.dart
+++ b/tools/serverpod_cli/test/test_util/compilation_unit_matcher/parameter_matcher/parameter_matcher.dart
@@ -97,7 +97,7 @@ class _ParameterMatcherImpl extends Matcher implements ParameterMatcher {
   }
 
   @override
-  bool matches(item, Map matchState) {
+  bool matches(dynamic item, Map matchState) {
     var parameter = _featureValueOf(item);
     if (parameter is! FormalParameter) return false;
 
@@ -108,7 +108,7 @@ class _ParameterMatcherImpl extends Matcher implements ParameterMatcher {
     return true;
   }
 
-  FormalParameter? _featureValueOf(actual) {
+  FormalParameter? _featureValueOf(dynamic actual) {
     var match = parent.matchedFeatureValueOf(actual);
     if (match == null) return null;
 

--- a/tools/serverpod_cli/test/test_util/compilation_unit_matcher/super_initializer_matcher/super_initializer_matcher.dart
+++ b/tools/serverpod_cli/test/test_util/compilation_unit_matcher/super_initializer_matcher/super_initializer_matcher.dart
@@ -35,7 +35,7 @@ class _SuperInitializerMatcherImpl implements Matcher, SuperInitializerMatcher {
   }
 
   @override
-  bool matches(item, Map matchState) {
+  bool matches(dynamic item, Map matchState) {
     return _matches(_featureValueOf(item));
   }
 
@@ -54,14 +54,14 @@ class _SuperInitializerMatcherImpl implements Matcher, SuperInitializerMatcher {
     return _withArgument(name, parameterType: _PositionalParameter());
   }
 
-  SuperConstructorInvocation? _featureValueOf(actual) {
+  SuperConstructorInvocation? _featureValueOf(dynamic actual) {
     var match = parent.matchedFeatureValueOf(actual);
     if (match == null) return null;
 
     return match.value;
   }
 
-  SuperConstructorInvocation? _matchedFeatureValueOf(actual) {
+  SuperConstructorInvocation? _matchedFeatureValueOf(dynamic actual) {
     var superConstructorInvocation = _featureValueOf(actual);
     if (superConstructorInvocation == null) return null;
 
@@ -70,7 +70,7 @@ class _SuperInitializerMatcherImpl implements Matcher, SuperInitializerMatcher {
     return superConstructorInvocation;
   }
 
-  bool _matches(item) {
+  bool _matches(dynamic item) {
     return item != null;
   }
 


### PR DESCRIPTION
Fixes `strict_top_level_inference` lint errors due to missing annotation on some test utilities of the `serverpod_cli` package. By removing the linter warnings, the "problems" panel on IDEs gets cleaner and targeted to issues on the current development at hand.

Although the rule is not enforced in the analyzer for the package, it is still highlighted as info on the IDE, and suppressing it could lead to creating more methods with no annotation to be fixed in the future.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

N/A.