### PR TITLE
feat(auth2): Add email address validation for registration requests

### DIFF
--- a/modules/new_serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/providers/email/business/email_accounts.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/providers/email/business/email_accounts.dart
@@ -1,6 +1,7 @@
 import 'dart:typed_data';
 
 import 'package:clock/clock.dart';
+import 'package:email_validator/email_validator.dart';
 import 'package:serverpod/serverpod.dart';
 
 import '../../../generated/protocol.dart';
@@ -115,6 +116,13 @@ abstract final class EmailAccounts {
       transaction,
       (final transaction) async {
         email = email.trim().toLowerCase();
+
+        if (!EmailValidator.validate(email)) {
+          return (
+            result: EmailAccountRequestResult.emailInvalid,
+            accountRequestId: null,
+          );
+        }
 
         final existingAccountCount = await EmailAccount.db.count(
           session,
@@ -670,6 +678,11 @@ enum EmailAccountRequestResult {
   ///
   /// No account request has been created.
   emailAlreadyRegistered,
+
+  /// The given email does not seem valid.
+  ///
+  /// No account request has been created.
+  emailInvalid,
 }
 
 /// Describes the result of a password reset operation.

--- a/modules/new_serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/test/email/integration/email_accounts_account_creation_test.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/test/email/integration/email_accounts_account_creation_test.dart
@@ -3,8 +3,8 @@ import 'package:serverpod/serverpod.dart';
 import 'package:serverpod_auth_idp_server/providers/email.dart';
 import 'package:test/test.dart';
 
-import '../../test_tools/serverpod_test_tools.dart';
 import '../../test_tags.dart';
+import '../../test_tools/serverpod_test_tools.dart';
 import '../test_utils.dart';
 
 void main() {
@@ -21,6 +21,23 @@ void main() {
         EmailAccounts.config = EmailAccountConfig();
 
         await cleanUpEmailAccountDatabaseEntities(session);
+      });
+
+      test(
+          'when trying to create a new account with an invalid email, '
+          'then no account request is created and the correct status returned.',
+          () async {
+        final accountCreationResult = await EmailAccounts.startAccountCreation(
+          session,
+          email: 'test@serverpod',
+          password: 'Afine123Pw!',
+        );
+
+        expect(accountCreationResult.accountRequestId, isNull);
+        expect(
+          accountCreationResult.result,
+          EmailAccountRequestResult.emailInvalid,
+        );
       });
 
       test(


### PR DESCRIPTION
Follow up from https://github.com/serverpod/serverpod/pull/3917#discussion_r2298138768