### PR TITLE
feat: Added support for Cloudflare R2 storage

### DIFF
--- a/integrations/serverpod_cloud_storage_r2/CHANGELOG.md
+++ b/integrations/serverpod_cloud_storage_r2/CHANGELOG.md
@@ -1,0 +1,7 @@
+## 3.0.0-alpha.1
+
+- Initial release of Cloudflare R2 integration for Serverpod
+- Support for basic file operations (upload, download, delete)
+- Direct upload support with both POST multipart and PUT presigned URL methods
+- S3-compatible API integration
+- Public and private file access modes

--- a/integrations/serverpod_cloud_storage_r2/README.md
+++ b/integrations/serverpod_cloud_storage_r2/README.md
@@ -1,0 +1,141 @@
+# Serverpod Cloud Storage R2
+
+This package provides Cloudflare R2 cloud storage integration for Serverpod applications.
+
+## Features
+
+- **File Operations**: Upload, download, delete files in Cloudflare R2
+- **Direct Upload Support**: PUT (presigned URL) method optimized for R2
+- **Public/Private Files**: Support for both public and private file access
+- **S3 Compatibility**: Uses S3-compatible API for seamless integration
+
+## Setup
+
+### 1. Add dependency
+
+Add this to your `pubspec.yaml`:
+
+```yaml
+dependencies:
+  serverpod_cloud_storage_r2: ^3.0.0-alpha.1
+```
+
+### 2. Configure R2 credentials
+
+Set your Cloudflare R2 credentials as environment variables:
+
+```bash
+SERVERPOD_R2_ACCESS_KEY_ID=your_r2_access_key
+SERVERPOD_R2_SECRET_KEY=your_r2_secret_key
+```
+
+### 3. Initialize storage
+
+```dart
+import 'package:serverpod_cloud_storage_r2/serverpod_cloud_storage_r2.dart';
+
+// In your server configuration
+final r2Storage = R2CloudStorage(
+  serverpod: serverpod,
+  storageId: 'public',
+  public: true,
+  region: 'auto', // R2 uses 'auto' region
+  bucket: 'my-r2-bucket',
+  accountId: 'your-cloudflare-account-id',
+);
+
+// Register the storage
+serverpod.storage.register(r2Storage);
+```
+
+## Usage
+
+### Basic file operations
+
+```dart
+// Store a file
+await serverpod.storage.storeFile(
+  session: session,
+  storageId: 'public',
+  path: 'uploads/image.jpg',
+  byteData: imageData,
+);
+
+// Retrieve a file
+final fileData = await serverpod.storage.retrieveFile(
+  session: session,
+  storageId: 'public', 
+  path: 'uploads/image.jpg',
+);
+
+// Get public URL
+final url = await serverpod.storage.getPublicUrl(
+  session: session,
+  storageId: 'public',
+  path: 'uploads/image.jpg',
+);
+
+// Delete a file
+await serverpod.storage.deleteFile(
+  session: session,
+  storageId: 'public',
+  path: 'uploads/image.jpg',
+);
+```
+
+### Direct upload (client-side)
+
+R2 uses PUT presigned URLs for direct uploads:
+
+#### Standard Direct Upload
+
+```dart
+// Get upload description (returns PUT presigned URL)
+final uploadDescription = await serverpod.storage.createDirectFileUploadDescription(
+  session: session,
+  storageId: 'public',
+  path: 'uploads/client-file.jpg',
+);
+// This returns a JSON with url, method: "PUT", etc.
+```
+
+#### Direct Presigned URL (Alternative)
+
+```dart
+// Cast to R2CloudStorage to access R2-specific methods
+final r2Storage = serverpod.storage.get('public') as R2CloudStorage;
+
+// Get presigned PUT URL directly
+final uploadUrl = await r2Storage.createDirectFileUploadUrl(
+  session: session,
+  path: 'uploads/client-file.jpg',
+  contentType: 'image/jpeg',
+);
+```
+
+## Configuration Options
+
+- `accountId`: Your Cloudflare account ID (required)
+- `bucket`: R2 bucket name (required)
+- `region`: Region (defaults to 'auto' for R2)
+- `public`: Whether files should be publicly accessible
+- `publicHost`: Custom public hostname (defaults to `bucket.account-id.r2.dev`)
+
+## Environment Variables
+
+| Variable | Description | Required |
+|----------|-------------|----------|
+| `SERVERPOD_R2_ACCESS_KEY_ID` | R2 access key ID | Yes |
+| `SERVERPOD_R2_SECRET_KEY` | R2 secret access key | Yes |
+
+## Differences from S3
+
+- **Endpoint**: Uses Cloudflare R2 endpoints (`account-id.r2.cloudflarestorage.com`)
+- **Region**: Uses 'auto' instead of specific AWS regions
+- **Upload Method**: Uses PUT requests instead of POST multipart (R2 doesn't support POST multipart)
+- **PUT Upload**: Includes additional `createDirectFileUploadUrl()` method for presigned PUT URLs
+- **Public URLs**: Uses R2 public hostname format (`bucket.account-id.r2.dev`)
+
+## Development
+
+This package is built on top of the S3-compatible API and reuses much of the AWS SDK functionality for signing requests.

--- a/integrations/serverpod_cloud_storage_r2/analysis_options.yaml
+++ b/integrations/serverpod_cloud_storage_r2/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: ../../analysis_options_global.yaml

--- a/integrations/serverpod_cloud_storage_r2/lib/serverpod_cloud_storage_r2.dart
+++ b/integrations/serverpod_cloud_storage_r2/lib/serverpod_cloud_storage_r2.dart
@@ -1,0 +1,6 @@
+/// Support for doing something awesome.
+///
+/// More dartdocs go here.
+library;
+
+export 'src/cloud_storage.dart/r2_cloud_storage.dart';

--- a/integrations/serverpod_cloud_storage_r2/lib/src/cloud_storage.dart/r2_cloud_storage.dart
+++ b/integrations/serverpod_cloud_storage_r2/lib/src/cloud_storage.dart/r2_cloud_storage.dart
@@ -1,0 +1,167 @@
+import 'dart:typed_data';
+
+import 'package:serverpod/serverpod.dart';
+import '../cloudflare_r2_client/client/client.dart';
+import '../cloudflare_r2_upload/cloudflare_r2_upload.dart';
+
+/// Concrete implementation of Cloudflare R2 cloud storage for use with Serverpod.
+class R2CloudStorage extends CloudStorage {
+  late final String _r2AccessKeyId;
+  late final String _r2SecretKey;
+  final String region;
+  final String bucket;
+  final String accountId;
+  final bool public;
+  late final String publicHost;
+
+  late final CloudflareR2Client _r2Client;
+
+  /// Creates a new [R2CloudStorage] reference.
+  R2CloudStorage({
+    required Serverpod serverpod,
+    required String storageId,
+    required this.public,
+    required this.region,
+    required this.bucket,
+    required this.accountId,
+    String? publicHost,
+  }) : super(storageId) {
+    serverpod.loadCustomPasswords([
+      (envName: 'SERVERPOD_R2_ACCESS_KEY_ID', alias: 'R2AccessKeyId'),
+      (envName: 'SERVERPOD_R2_SECRET_KEY', alias: 'R2SecretKey'),
+    ]);
+
+    var r2AccessKeyId = serverpod.getPassword('R2AccessKeyId');
+    var r2SecretKey = serverpod.getPassword('R2SecretKey');
+
+    if (r2AccessKeyId == null) {
+      throw StateError('R2AccessKeyId must be configured in your passwords.');
+    }
+
+    if (r2SecretKey == null) {
+      throw StateError('R2SecretKey must be configured in your passwords.');
+    }
+
+    _r2AccessKeyId = r2AccessKeyId;
+    _r2SecretKey = r2SecretKey;
+
+    // Create client
+    _r2Client = CloudflareR2Client(
+      accessKey: _r2AccessKeyId,
+      secretKey: _r2SecretKey,
+      bucketId: bucket,
+      accountId: accountId,
+      region: region,
+    );
+
+    this.publicHost = publicHost ?? '$bucket.$accountId.r2.dev';
+  }
+
+  @override
+  Future<void> storeFile({
+    required Session session,
+    required String path,
+    required ByteData byteData,
+    DateTime? expiration,
+    bool verified = true,
+  }) async {
+    await CloudflareR2Uploader.uploadData(
+      accessKey: _r2AccessKeyId,
+      secretKey: _r2SecretKey,
+      bucket: bucket,
+      accountId: accountId,
+      region: region,
+      data: byteData,
+      uploadDst: path,
+      public: public,
+    );
+  }
+
+  @override
+  Future<ByteData?> retrieveFile({
+    required Session session,
+    required String path,
+  }) async {
+    final response = await _r2Client.getObject(path);
+    if (response.statusCode == 200) {
+      return ByteData.view(response.bodyBytes.buffer);
+    }
+    return null;
+  }
+
+  @override
+  Future<Uri?> getPublicUrl({
+    required Session session,
+    required String path,
+  }) async {
+    if (await fileExists(session: session, path: path)) {
+      return Uri.parse('https://$publicHost/$path');
+    }
+    return null;
+  }
+
+  @override
+  Future<bool> fileExists({
+    required Session session,
+    required String path,
+  }) async {
+    var response = await _r2Client.headObject(path);
+    return response.statusCode == 200;
+  }
+
+  @override
+  Future<void> deleteFile({
+    required Session session,
+    required String path,
+  }) async {
+    await _r2Client.deleteObject(path);
+  }
+
+  @override
+  Future<String?> createDirectFileUploadDescription({
+    required Session session,
+    required String path,
+    Duration expirationDuration = const Duration(minutes: 10),
+    int maxFileSize = 10 * 1024 * 1024,
+  }) async {
+    return await CloudflareR2Uploader.getDirectUploadDescription(
+      accessKey: _r2AccessKeyId,
+      secretKey: _r2SecretKey,
+      bucket: bucket,
+      accountId: accountId,
+      region: region,
+      uploadDst: path,
+      expires: expirationDuration,
+      maxFileSize: maxFileSize,
+      public: public,
+    );
+  }
+
+  /// Creates a presigned PUT URL for direct file upload to R2.
+  /// This is an alternative to the POST-based multipart upload.
+  Future<String?> createDirectFileUploadUrl({
+    required Session session,
+    required String path,
+    Duration expirationDuration = const Duration(minutes: 10),
+    String? contentType,
+  }) async {
+    return await CloudflareR2Uploader.getDirectUploadUrl(
+      accessKey: _r2AccessKeyId,
+      secretKey: _r2SecretKey,
+      bucket: bucket,
+      accountId: accountId,
+      region: region,
+      uploadDst: path,
+      expires: expirationDuration,
+      contentType: contentType,
+    );
+  }
+
+  @override
+  Future<bool> verifyDirectFileUpload({
+    required Session session,
+    required String path,
+  }) async {
+    return fileExists(session: session, path: path);
+  }
+}

--- a/integrations/serverpod_cloud_storage_r2/lib/src/cloudflare_r2_client/client/client.dart
+++ b/integrations/serverpod_cloud_storage_r2/lib/src/cloudflare_r2_client/client/client.dart
@@ -1,0 +1,200 @@
+import 'dart:convert';
+
+import 'package:amazon_cognito_identity_dart_2/sig_v4.dart';
+import 'package:built_value/serializer.dart';
+import 'exceptions.dart';
+import 'package:http/http.dart';
+import 'package:xml2json/xml2json.dart';
+
+import '../model/list_bucket_result.dart';
+import '../model/list_bucket_result_parker.dart';
+
+class CloudflareR2Client {
+  final String _secretKey;
+  final String _accessKey;
+  final String _host;
+  final String _region;
+  final String _bucketId;
+  final String _accountId;
+  final String? _sessionToken;
+  final Client _client;
+
+  static const _service = "s3";
+
+  /// Creates a new CloudflareR2Client instance.
+  ///
+  /// @param secretKey The secret key. Required.
+  /// @param accessKey The access key. Required.
+  /// @param bucketId The bucket. Required.
+  /// @param accountId The Cloudflare account ID. Required.
+  /// @param host The host, defaults to R2 endpoint format.
+  /// @param region The region. Optional for R2, defaults to 'auto'.
+  /// @param sessionToken The session token. Optional.
+  /// @param client The http client. Optional. Useful for debugging.
+  CloudflareR2Client(
+      {required String secretKey,
+      required String accessKey,
+      required String bucketId,
+      required String accountId,
+      String? host,
+      String? region,
+      String? sessionToken,
+      Client? client})
+      : _accessKey = accessKey,
+        _secretKey = secretKey,
+        _host = host ?? "$accountId.r2.cloudflarestorage.com",
+        _bucketId = bucketId,
+        _region = region ?? 'auto',
+        _accountId = accountId,
+        _sessionToken = sessionToken,
+        _client = client ?? Client();
+
+  Future<ListBucketResult?> listObjects(
+      {String? prefix, String? delimiter, int? maxKeys}) async {
+    final response = await _doSignedGetRequest(key: '', queryParams: {
+      "list-type": "2",
+      if (prefix != null) "prefix": prefix,
+      if (delimiter != null) "delimiter": delimiter,
+      if (maxKeys != null) "maxKeys": maxKeys.toString(),
+    });
+    _checkResponseError(response);
+    return _parseListObjectResponse(response.body);
+  }
+
+  Future<Response> getObject(String key) {
+    return _doSignedGetRequest(key: key);
+  }
+
+  Future<Response> headObject(String key) {
+    return _doSignedHeadRequest(key: key);
+  }
+
+  Future<Response> deleteObject(String key) {
+    return _doSignedDeleteRequest(key: key);
+  }
+
+  String keytoPath(String key) =>
+      '/$key'.split('/').map(Uri.encodeQueryComponent).join('/');
+
+  ///Returns a [SignedRequestParams] object containing the uri and the HTTP headers
+  ///needed to do a signed GET request to Cloudflare R2. Does not actually execute a request.
+  ///You can use this method to integrate this client with an HTTP client of your choice.
+  SignedRequestParams buildSignedParams(
+      {required String key,
+      Map<String, String>? queryParams,
+      String method = 'GET'}) {
+    final unencodedPath = "$_bucketId/$key";
+    final uri = Uri.https(_host, unencodedPath, queryParams);
+    final payload = SigV4.hashCanonicalRequest('');
+    final datetime = SigV4.generateDatetime();
+    final credentialScope =
+        SigV4.buildCredentialScope(datetime, _region, _service);
+
+    final canonicalQuery = SigV4.buildCanonicalQueryString(queryParams);
+    final canonicalRequest = '''$method
+${'/$unencodedPath'.split('/').map(Uri.encodeComponent).join('/')}
+$canonicalQuery
+host:$_host
+x-amz-content-sha256:$payload
+x-amz-date:$datetime${_sessionToken != null ? '\nx-amz-security-token:$_sessionToken' : ''}
+
+host;x-amz-content-sha256;x-amz-date${_sessionToken != null ? ';x-amz-security-token' : ''}
+$payload''';
+
+    final stringToSign = SigV4.buildStringToSign(datetime, credentialScope,
+        SigV4.hashCanonicalRequest(canonicalRequest));
+    final signingKey =
+        SigV4.calculateSigningKey(_secretKey, datetime, _region, _service);
+    final signature = SigV4.calculateSignature(signingKey, stringToSign);
+
+    final authorization = [
+      'AWS4-HMAC-SHA256 Credential=$_accessKey/$credentialScope',
+      'SignedHeaders=host;x-amz-content-sha256;x-amz-date${_sessionToken != null ? ';x-amz-security-token' : ''}',
+      'Signature=$signature',
+    ].join(',');
+
+    final headers = {
+      'Authorization': authorization,
+      'x-amz-content-sha256': payload,
+      'x-amz-date': datetime,
+    };
+
+    if (_sessionToken != null) {
+      headers['x-amz-security-token'] = _sessionToken!;
+    }
+
+    return SignedRequestParams(uri, headers);
+  }
+
+  Future<Response> _doSignedGetRequest({
+    required String key,
+    Map<String, String>? queryParams,
+  }) async {
+    final SignedRequestParams params =
+        buildSignedParams(key: key, queryParams: queryParams);
+    return _client.get(params.uri, headers: params.headers);
+  }
+
+  Future<Response> _doSignedHeadRequest({
+    required String key,
+    Map<String, String>? queryParams,
+  }) async {
+    final SignedRequestParams params =
+        buildSignedParams(key: key, queryParams: queryParams, method: 'HEAD');
+    return _client.head(params.uri, headers: params.headers);
+  }
+
+  Future<Response> _doSignedDeleteRequest({
+    required String key,
+    Map<String, String>? queryParams,
+  }) async {
+    final SignedRequestParams params =
+        buildSignedParams(key: key, queryParams: queryParams, method: 'DELETE');
+    return _client.delete(params.uri, headers: params.headers);
+  }
+
+  void _checkResponseError(Response response) {
+    if (response.statusCode >= 200 && response.statusCode <= 300) {
+      return;
+    }
+    switch (response.statusCode) {
+      case 403:
+        throw NoPermissionsException(response);
+      default:
+        throw R2Exception(response);
+    }
+  }
+}
+
+class SignedRequestParams {
+  final Uri uri;
+  final Map<String, String> headers;
+
+  const SignedRequestParams(this.uri, this.headers);
+}
+
+/// R2 list bucket response string -> [ListBucketResult] object,
+/// this function should be called via [compute]
+ListBucketResult? _parseListObjectResponse(String responseXml) {
+  //parse xml
+  final Xml2Json myTransformer = Xml2Json();
+  myTransformer.parse(responseXml);
+  //convert xml to json
+  String jsonString = myTransformer.toParker();
+  //parse json to src.model objects
+  try {
+    ListBucketResult? parsedObj =
+        ListBucketResultParker.fromJson(jsonString).result;
+
+    return parsedObj;
+  } on DeserializationError {
+    //fix for https://github.com/diagnosia/flutter_aws_s3_client/issues/6
+    //issue due to json/xml transform: Lists with 1 element are transformed to json objects instead of lists
+    final fixedJson = json.decode(jsonString);
+
+    fixedJson["ListBucketResult"]
+        ["Contents"] = [fixedJson["ListBucketResult"]["Contents"]];
+
+    return ListBucketResultParker.fromJsonMap(fixedJson).result;
+  }
+}

--- a/integrations/serverpod_cloud_storage_r2/lib/src/cloudflare_r2_client/client/client.dart
+++ b/integrations/serverpod_cloud_storage_r2/lib/src/cloudflare_r2_client/client/client.dart
@@ -120,7 +120,7 @@ $payload''';
     };
 
     if (_sessionToken != null) {
-      headers['x-amz-security-token'] = _sessionToken!;
+      headers['x-amz-security-token'] = _sessionToken;
     }
 
     return SignedRequestParams(uri, headers);

--- a/integrations/serverpod_cloud_storage_r2/lib/src/cloudflare_r2_client/client/exceptions.dart
+++ b/integrations/serverpod_cloud_storage_r2/lib/src/cloudflare_r2_client/client/exceptions.dart
@@ -1,0 +1,26 @@
+import 'package:http/http.dart';
+
+class R2Exception implements Exception {
+  final Response response;
+
+  R2Exception(this.response);
+
+  @override
+  String toString() {
+    return '''$devDebugHint: ${runtimeType.toString()}{
+    statusCode: ${response.statusCode},
+    body: ${response.body},
+    headers: ${response.headers}
+    }''';
+  }
+
+  String get devDebugHint => "We got an unexpected response from Cloudflare R2: ";
+}
+
+class NoPermissionsException extends R2Exception {
+  NoPermissionsException(super.response);
+
+  @override
+  String get devDebugHint =>
+      "Cloudflare R2 returned a 403 status code. Please make sure you have the right permissions for this request";
+}

--- a/integrations/serverpod_cloud_storage_r2/lib/src/cloudflare_r2_client/model/list_bucket_result.dart
+++ b/integrations/serverpod_cloud_storage_r2/lib/src/cloudflare_r2_client/model/list_bucket_result.dart
@@ -1,0 +1,49 @@
+import 'dart:convert';
+
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/built_value.dart';
+import 'package:built_value/serializer.dart';
+import 'list_bucket_result_contents.dart';
+
+import 'serializers.dart';
+
+part 'list_bucket_result.g.dart';
+
+abstract class ListBucketResult
+    implements Built<ListBucketResult, ListBucketResultBuilder> {
+  ListBucketResult._();
+
+  factory ListBucketResult([Function(ListBucketResultBuilder b)? updates]) =
+      _$ListBucketResult;
+
+  @BuiltValueField(wireName: 'Name')
+  String get name;
+
+  @BuiltValueField(wireName: 'Prefix')
+  String? get prefix;
+
+  @BuiltValueField(wireName: 'MaxKeys')
+  String get maxKeys;
+
+  @BuiltValueField(wireName: 'KeyCount')
+  String? get keyCount;
+
+  @BuiltValueField(wireName: 'IsTruncated')
+  String? get isTruncated;
+
+  @BuiltValueField(wireName: 'Contents')
+  BuiltList<Contents>? get contents;
+
+  String toJson() {
+    return json
+        .encode(serializers.serializeWith(ListBucketResult.serializer, this));
+  }
+
+  static ListBucketResult fromJson(String jsonString) {
+    return serializers.deserializeWith(
+        ListBucketResult.serializer, json.decode(jsonString))!;
+  }
+
+  static Serializer<ListBucketResult> get serializer =>
+      _$listBucketResultSerializer;
+}

--- a/integrations/serverpod_cloud_storage_r2/lib/src/cloudflare_r2_client/model/list_bucket_result.g.dart
+++ b/integrations/serverpod_cloud_storage_r2/lib/src/cloudflare_r2_client/model/list_bucket_result.g.dart
@@ -1,0 +1,270 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: library_private_types_in_public_api, no_leading_underscores_for_local_identifiers, use_string_in_part_of_directives
+
+part of 'list_bucket_result.dart';
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+Serializer<ListBucketResult> _$listBucketResultSerializer =
+    _$ListBucketResultSerializer();
+
+class _$ListBucketResultSerializer
+    implements StructuredSerializer<ListBucketResult> {
+  @override
+  final Iterable<Type> types = const [ListBucketResult, _$ListBucketResult];
+  @override
+  final String wireName = 'ListBucketResult';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, ListBucketResult object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'Name',
+      serializers.serialize(object.name, specifiedType: const FullType(String)),
+      'MaxKeys',
+      serializers.serialize(object.maxKeys,
+          specifiedType: const FullType(String)),
+    ];
+    Object? value;
+    value = object.prefix;
+    if (value != null) {
+      result
+        ..add('Prefix')
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
+    }
+    value = object.keyCount;
+    if (value != null) {
+      result
+        ..add('KeyCount')
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
+    }
+    value = object.isTruncated;
+    if (value != null) {
+      result
+        ..add('IsTruncated')
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
+    }
+    value = object.contents;
+    if (value != null) {
+      result
+        ..add('Contents')
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(BuiltList, [FullType(Contents)])));
+    }
+    return result;
+  }
+
+  @override
+  ListBucketResult deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = ListBucketResultBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'Name':
+          result.name = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String;
+          break;
+        case 'Prefix':
+          result.prefix = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String;
+          break;
+        case 'MaxKeys':
+          result.maxKeys = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String;
+          break;
+        case 'KeyCount':
+          result.keyCount = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String;
+          break;
+        case 'IsTruncated':
+          result.isTruncated = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String;
+          break;
+        case 'Contents':
+          result.contents.replace(serializers.deserialize(value,
+                  specifiedType:
+                      const FullType(BuiltList, [FullType(Contents)]))!
+              as BuiltList<Object>);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$ListBucketResult extends ListBucketResult {
+  @override
+  final String name;
+  @override
+  final String? prefix;
+  @override
+  final String maxKeys;
+  @override
+  final String? keyCount;
+  @override
+  final String? isTruncated;
+  @override
+  final BuiltList<Contents>? contents;
+
+  factory _$ListBucketResult(
+          [void Function(ListBucketResultBuilder)? updates]) =>
+      (ListBucketResultBuilder()..update(updates)).build();
+
+  _$ListBucketResult._(
+      {required this.name,
+      this.prefix,
+      required this.maxKeys,
+      this.keyCount,
+      this.isTruncated,
+      this.contents})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(name, 'ListBucketResult', 'name');
+    BuiltValueNullFieldError.checkNotNull(
+        maxKeys, 'ListBucketResult', 'maxKeys');
+  }
+
+  @override
+  ListBucketResult rebuild(void Function(ListBucketResultBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  ListBucketResultBuilder toBuilder() =>
+      ListBucketResultBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is ListBucketResult &&
+        name == other.name &&
+        prefix == other.prefix &&
+        maxKeys == other.maxKeys &&
+        keyCount == other.keyCount &&
+        isTruncated == other.isTruncated &&
+        contents == other.contents;
+  }
+
+  @override
+  int get hashCode {
+    return $jf($jc(
+        $jc(
+            $jc(
+                $jc($jc($jc(0, name.hashCode), prefix.hashCode),
+                    maxKeys.hashCode),
+                keyCount.hashCode),
+            isTruncated.hashCode),
+        contents.hashCode));
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper('ListBucketResult')
+          ..add('name', name)
+          ..add('prefix', prefix)
+          ..add('maxKeys', maxKeys)
+          ..add('keyCount', keyCount)
+          ..add('isTruncated', isTruncated)
+          ..add('contents', contents))
+        .toString();
+  }
+}
+
+class ListBucketResultBuilder
+    implements Builder<ListBucketResult, ListBucketResultBuilder> {
+  _$ListBucketResult? _$v;
+
+  String? _name;
+  String? get name => _$this._name;
+  set name(String? name) => _$this._name = name;
+
+  String? _prefix;
+  String? get prefix => _$this._prefix;
+  set prefix(String? prefix) => _$this._prefix = prefix;
+
+  String? _maxKeys;
+  String? get maxKeys => _$this._maxKeys;
+  set maxKeys(String? maxKeys) => _$this._maxKeys = maxKeys;
+
+  String? _keyCount;
+  String? get keyCount => _$this._keyCount;
+  set keyCount(String? keyCount) => _$this._keyCount = keyCount;
+
+  String? _isTruncated;
+  String? get isTruncated => _$this._isTruncated;
+  set isTruncated(String? isTruncated) => _$this._isTruncated = isTruncated;
+
+  ListBuilder<Contents>? _contents;
+  ListBuilder<Contents> get contents =>
+      _$this._contents ??= ListBuilder<Contents>();
+  set contents(ListBuilder<Contents>? contents) => _$this._contents = contents;
+
+  ListBucketResultBuilder();
+
+  ListBucketResultBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _name = $v.name;
+      _prefix = $v.prefix;
+      _maxKeys = $v.maxKeys;
+      _keyCount = $v.keyCount;
+      _isTruncated = $v.isTruncated;
+      _contents = $v.contents?.toBuilder();
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(ListBucketResult other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$ListBucketResult;
+  }
+
+  @override
+  void update(void Function(ListBucketResultBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  _$ListBucketResult build() {
+    _$ListBucketResult _$result;
+    try {
+      _$result = _$v ??
+          _$ListBucketResult._(
+              name: BuiltValueNullFieldError.checkNotNull(
+                  name, 'ListBucketResult', 'name'),
+              prefix: prefix,
+              maxKeys: BuiltValueNullFieldError.checkNotNull(
+                  maxKeys, 'ListBucketResult', 'maxKeys'),
+              keyCount: keyCount,
+              isTruncated: isTruncated,
+              contents: _contents?.build());
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'contents';
+        _contents?.build();
+      } catch (e) {
+        throw BuiltValueNestedFieldError(
+            'ListBucketResult', _$failedField, e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,lines_longer_than_80_chars,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new

--- a/integrations/serverpod_cloud_storage_r2/lib/src/cloudflare_r2_client/model/list_bucket_result_contents.dart
+++ b/integrations/serverpod_cloud_storage_r2/lib/src/cloudflare_r2_client/model/list_bucket_result_contents.dart
@@ -1,0 +1,40 @@
+import 'dart:convert';
+
+import 'package:built_value/built_value.dart';
+import 'package:built_value/serializer.dart';
+
+import 'serializers.dart';
+
+part 'list_bucket_result_contents.g.dart';
+
+abstract class Contents implements Built<Contents, ContentsBuilder> {
+  Contents._();
+
+  factory Contents([Function(ContentsBuilder b)? updates]) = _$Contents;
+
+  @BuiltValueField(wireName: 'Key')
+  String? get key;
+
+  @BuiltValueField(wireName: 'LastModified')
+  String? get lastModified;
+
+  @BuiltValueField(wireName: 'ETag')
+  String? get eTag;
+
+  @BuiltValueField(wireName: 'Size')
+  String? get size;
+
+  @BuiltValueField(wireName: 'StorageClass')
+  String? get storageClass;
+
+  String toJson() {
+    return json.encode(serializers.serializeWith(Contents.serializer, this));
+  }
+
+  static Contents fromJson(String jsonString) {
+    return serializers.deserializeWith(
+        Contents.serializer, json.decode(jsonString))!;
+  }
+
+  static Serializer<Contents> get serializer => _$contentsSerializer;
+}

--- a/integrations/serverpod_cloud_storage_r2/lib/src/cloudflare_r2_client/model/list_bucket_result_contents.g.dart
+++ b/integrations/serverpod_cloud_storage_r2/lib/src/cloudflare_r2_client/model/list_bucket_result_contents.g.dart
@@ -1,0 +1,222 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: library_private_types_in_public_api, no_leading_underscores_for_local_identifiers, use_string_in_part_of_directives
+
+part of 'list_bucket_result_contents.dart';
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+Serializer<Contents> _$contentsSerializer = _$ContentsSerializer();
+
+class _$ContentsSerializer implements StructuredSerializer<Contents> {
+  @override
+  final Iterable<Type> types = const [Contents, _$Contents];
+  @override
+  final String wireName = 'Contents';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, Contents object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[];
+    Object? value;
+    value = object.key;
+    if (value != null) {
+      result
+        ..add('Key')
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
+    }
+    value = object.lastModified;
+    if (value != null) {
+      result
+        ..add('LastModified')
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
+    }
+    value = object.eTag;
+    if (value != null) {
+      result
+        ..add('ETag')
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
+    }
+    value = object.size;
+    if (value != null) {
+      result
+        ..add('Size')
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
+    }
+    value = object.storageClass;
+    if (value != null) {
+      result
+        ..add('StorageClass')
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
+    }
+    return result;
+  }
+
+  @override
+  Contents deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = ContentsBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'Key':
+          result.key = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String;
+          break;
+        case 'LastModified':
+          result.lastModified = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String;
+          break;
+        case 'ETag':
+          result.eTag = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String;
+          break;
+        case 'Size':
+          result.size = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String;
+          break;
+        case 'StorageClass':
+          result.storageClass = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$Contents extends Contents {
+  @override
+  final String? key;
+  @override
+  final String? lastModified;
+  @override
+  final String? eTag;
+  @override
+  final String? size;
+  @override
+  final String? storageClass;
+
+  factory _$Contents([void Function(ContentsBuilder)? updates]) =>
+      (ContentsBuilder()..update(updates)).build();
+
+  _$Contents._(
+      {this.key, this.lastModified, this.eTag, this.size, this.storageClass})
+      : super._();
+
+  @override
+  Contents rebuild(void Function(ContentsBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  ContentsBuilder toBuilder() => ContentsBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is Contents &&
+        key == other.key &&
+        lastModified == other.lastModified &&
+        eTag == other.eTag &&
+        size == other.size &&
+        storageClass == other.storageClass;
+  }
+
+  @override
+  int get hashCode {
+    return $jf($jc(
+        $jc(
+            $jc($jc($jc(0, key.hashCode), lastModified.hashCode),
+                eTag.hashCode),
+            size.hashCode),
+        storageClass.hashCode));
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper('Contents')
+          ..add('key', key)
+          ..add('lastModified', lastModified)
+          ..add('eTag', eTag)
+          ..add('size', size)
+          ..add('storageClass', storageClass))
+        .toString();
+  }
+}
+
+class ContentsBuilder implements Builder<Contents, ContentsBuilder> {
+  _$Contents? _$v;
+
+  String? _key;
+  String? get key => _$this._key;
+  set key(String? key) => _$this._key = key;
+
+  String? _lastModified;
+  String? get lastModified => _$this._lastModified;
+  set lastModified(String? lastModified) => _$this._lastModified = lastModified;
+
+  String? _eTag;
+  String? get eTag => _$this._eTag;
+  set eTag(String? eTag) => _$this._eTag = eTag;
+
+  String? _size;
+  String? get size => _$this._size;
+  set size(String? size) => _$this._size = size;
+
+  String? _storageClass;
+  String? get storageClass => _$this._storageClass;
+  set storageClass(String? storageClass) => _$this._storageClass = storageClass;
+
+  ContentsBuilder();
+
+  ContentsBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _key = $v.key;
+      _lastModified = $v.lastModified;
+      _eTag = $v.eTag;
+      _size = $v.size;
+      _storageClass = $v.storageClass;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(Contents other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$Contents;
+  }
+
+  @override
+  void update(void Function(ContentsBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  _$Contents build() {
+    final _$result = _$v ??
+        _$Contents._(
+            key: key,
+            lastModified: lastModified,
+            eTag: eTag,
+            size: size,
+            storageClass: storageClass);
+    replace(_$result);
+    return _$result;
+  }
+}
+
+// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,lines_longer_than_80_chars,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new

--- a/integrations/serverpod_cloud_storage_r2/lib/src/cloudflare_r2_client/model/list_bucket_result_parker.dart
+++ b/integrations/serverpod_cloud_storage_r2/lib/src/cloudflare_r2_client/model/list_bucket_result_parker.dart
@@ -1,0 +1,39 @@
+import 'dart:convert';
+
+import 'package:built_value/built_value.dart';
+import 'package:built_value/serializer.dart';
+
+import 'list_bucket_result.dart';
+import 'serializers.dart';
+
+part 'list_bucket_result_parker.g.dart';
+
+abstract class ListBucketResultParker
+    implements Built<ListBucketResultParker, ListBucketResultParkerBuilder> {
+  ListBucketResultParker._();
+
+  @BuiltValueField(wireName: "ListBucketResult")
+  ListBucketResult? get result;
+
+  factory ListBucketResultParker(
+          [Function(ListBucketResultParkerBuilder b)? updates]) =
+      _$ListBucketResultParker;
+
+  String toJson() {
+    return json
+        .encode(serializers.serializeWith(ListBucketResult.serializer, this));
+  }
+
+  static ListBucketResultParker fromJson(String jsonString) {
+    return serializers.deserializeWith(
+        ListBucketResultParker.serializer, json.decode(jsonString))!;
+  }
+
+  static ListBucketResultParker fromJsonMap(Map<String, dynamic> jsonMap) {
+    return serializers.deserializeWith(
+        ListBucketResultParker.serializer, jsonMap)!;
+  }
+
+  static Serializer<ListBucketResultParker> get serializer =>
+      _$listBucketResultParkerSerializer;
+}

--- a/integrations/serverpod_cloud_storage_r2/lib/src/cloudflare_r2_client/model/list_bucket_result_parker.g.dart
+++ b/integrations/serverpod_cloud_storage_r2/lib/src/cloudflare_r2_client/model/list_bucket_result_parker.g.dart
@@ -1,0 +1,154 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: library_private_types_in_public_api, no_leading_underscores_for_local_identifiers
+
+part of 'list_bucket_result_parker.dart';
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+Serializer<ListBucketResultParker> _$listBucketResultParkerSerializer =
+    _$ListBucketResultParkerSerializer();
+
+class _$ListBucketResultParkerSerializer
+    implements StructuredSerializer<ListBucketResultParker> {
+  @override
+  final Iterable<Type> types = const [
+    ListBucketResultParker,
+    _$ListBucketResultParker
+  ];
+  @override
+  final String wireName = 'ListBucketResultParker';
+
+  @override
+  Iterable<Object?> serialize(
+      Serializers serializers, ListBucketResultParker object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[];
+    Object? value;
+    value = object.result;
+    if (value != null) {
+      result
+        ..add('ListBucketResult')
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(ListBucketResult)));
+    }
+    return result;
+  }
+
+  @override
+  ListBucketResultParker deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = ListBucketResultParkerBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'ListBucketResult':
+          result.result.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(ListBucketResult))!
+              as ListBucketResult);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$ListBucketResultParker extends ListBucketResultParker {
+  @override
+  final ListBucketResult? result;
+
+  factory _$ListBucketResultParker(
+          [void Function(ListBucketResultParkerBuilder)? updates]) =>
+      (ListBucketResultParkerBuilder()..update(updates)).build();
+
+  _$ListBucketResultParker._({this.result}) : super._();
+
+  @override
+  ListBucketResultParker rebuild(
+          void Function(ListBucketResultParkerBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  ListBucketResultParkerBuilder toBuilder() =>
+      ListBucketResultParkerBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is ListBucketResultParker && result == other.result;
+  }
+
+  @override
+  int get hashCode {
+    return $jf($jc(0, result.hashCode));
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper('ListBucketResultParker')
+          ..add('result', result))
+        .toString();
+  }
+}
+
+class ListBucketResultParkerBuilder
+    implements Builder<ListBucketResultParker, ListBucketResultParkerBuilder> {
+  _$ListBucketResultParker? _$v;
+
+  ListBucketResultBuilder? _result;
+  ListBucketResultBuilder get result =>
+      _$this._result ??= ListBucketResultBuilder();
+  set result(ListBucketResultBuilder? result) => _$this._result = result;
+
+  ListBucketResultParkerBuilder();
+
+  ListBucketResultParkerBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _result = $v.result?.toBuilder();
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(ListBucketResultParker other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$ListBucketResultParker;
+  }
+
+  @override
+  void update(void Function(ListBucketResultParkerBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  _$ListBucketResultParker build() {
+    _$ListBucketResultParker _$result;
+    try {
+      _$result = _$v ?? _$ListBucketResultParker._(result: _result?.build());
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'result';
+        _result?.build();
+      } catch (e) {
+        throw BuiltValueNestedFieldError(
+            'ListBucketResultParker', _$failedField, e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,lines_longer_than_80_chars,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new

--- a/integrations/serverpod_cloud_storage_r2/lib/src/cloudflare_r2_client/model/serializers.dart
+++ b/integrations/serverpod_cloud_storage_r2/lib/src/cloudflare_r2_client/model/serializers.dart
@@ -1,0 +1,13 @@
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/serializer.dart';
+import 'package:built_value/standard_json_plugin.dart';
+
+import 'list_bucket_result.dart';
+import 'list_bucket_result_contents.dart';
+import 'list_bucket_result_parker.dart';
+
+part 'serializers.g.dart';
+
+@SerializersFor([ListBucketResultParker])
+Serializers serializers =
+    (_$serializers.toBuilder()..addPlugin(StandardJsonPlugin())).build();

--- a/integrations/serverpod_cloud_storage_r2/lib/src/cloudflare_r2_client/model/serializers.g.dart
+++ b/integrations/serverpod_cloud_storage_r2/lib/src/cloudflare_r2_client/model/serializers.g.dart
@@ -1,0 +1,17 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'serializers.dart';
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+Serializers _$serializers = (Serializers().toBuilder()
+      ..add(Contents.serializer)
+      ..add(ListBucketResult.serializer)
+      ..add(ListBucketResultParker.serializer)
+      ..addBuilderFactory(const FullType(BuiltList, [FullType(Contents)]),
+          () => ListBuilder<Contents>()))
+    .build();
+
+// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,lines_longer_than_80_chars,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new

--- a/integrations/serverpod_cloud_storage_r2/lib/src/cloudflare_r2_upload/cloudflare_r2_upload.dart
+++ b/integrations/serverpod_cloud_storage_r2/lib/src/cloudflare_r2_upload/cloudflare_r2_upload.dart
@@ -1,0 +1,283 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:amazon_cognito_identity_dart_2/sig_v4.dart';
+import 'package:http/http.dart' as http;
+import 'package:path/path.dart' as path;
+
+/// Utility function to detect MIME type from file extension
+String _detectMimeType(String fileName) {
+  final ext = path.extension(fileName).toLowerCase();
+  
+  final mimeTypes = {
+    '.jpg': 'image/jpeg',
+    '.jpeg': 'image/jpeg',
+    '.png': 'image/png',
+    '.gif': 'image/gif',
+    '.webp': 'image/webp',
+    '.svg': 'image/svg+xml',
+    '.pdf': 'application/pdf',
+    '.txt': 'text/plain',
+    '.html': 'text/html',
+    '.css': 'text/css',
+    '.js': 'application/javascript',
+    '.json': 'application/json',
+    '.xml': 'application/xml',
+    '.mp4': 'video/mp4',
+    '.mp3': 'audio/mpeg',
+    '.wav': 'audio/wav',
+    '.zip': 'application/zip',
+    '.doc': 'application/msword',
+    '.docx': 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+    '.xls': 'application/vnd.ms-excel',
+    '.xlsx': 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  };
+  
+  return mimeTypes[ext] ?? 'application/octet-stream';
+}
+
+/// Convenience class for uploading files to Cloudflare R2
+class CloudflareR2Uploader {
+  /// Upload a file using PUT method, returning the file's public URL on success.
+  static Future<String?> uploadFile({
+    /// R2 access key
+    required String accessKey,
+
+    /// R2 secret key
+    required String secretKey,
+
+    /// The name of the R2 storage bucket to upload to
+    required String bucket,
+
+    /// The file to upload
+    required File file,
+
+    /// The path to upload the file to (e.g. "uploads/public")
+    required String uploadDst,
+
+    /// The R2 account ID
+    required String accountId,
+
+    /// The region (defaults to 'auto' for R2)
+    String region = 'auto',
+  }) async {
+    final fileBytes = await file.readAsBytes();
+    return uploadData(
+      accessKey: accessKey,
+      secretKey: secretKey,
+      bucket: bucket,
+      data: ByteData.view(fileBytes.buffer),
+      uploadDst: uploadDst,
+      accountId: accountId,
+      region: region,
+    );
+  }
+
+  /// Upload data using PUT method, returning the file's public URL on success.
+  static Future<String?> uploadData({
+    /// R2 access key
+    required String accessKey,
+
+    /// R2 secret key
+    required String secretKey,
+
+    /// The name of the R2 storage bucket to upload to
+    required String bucket,
+
+    /// The data to upload
+    required ByteData data,
+
+    /// The path to upload the file to (e.g. "uploads/public")
+    String destDir = '',
+
+    /// The R2 account ID
+    required String accountId,
+
+    /// The region (defaults to 'auto' for R2)
+    String region = 'auto',
+
+    /// The filename to upload as
+    required String uploadDst,
+    bool public = true,
+  }) async {
+    final host = '$accountId.r2.cloudflarestorage.com';
+    final objectKey = '$bucket/$uploadDst';
+    
+    final datetime = SigV4.generateDatetime();
+    final credentialScope = SigV4.buildCredentialScope(datetime, region, 's3');
+    final payloadHash = SigV4.hashCanonicalRequest(
+      String.fromCharCodes(data.buffer.asUint8List())
+    );
+
+    final canonicalRequest = '''PUT
+/$objectKey
+
+host:$host
+x-amz-content-sha256:$payloadHash
+x-amz-date:$datetime
+
+host;x-amz-content-sha256;x-amz-date
+$payloadHash''';
+
+    final stringToSign = SigV4.buildStringToSign(
+      datetime,
+      credentialScope,
+      SigV4.hashCanonicalRequest(canonicalRequest),
+    );
+
+    final signingKey = SigV4.calculateSigningKey(secretKey, datetime, region, 's3');
+    final signature = SigV4.calculateSignature(signingKey, stringToSign);
+    
+    final authorization = 'AWS4-HMAC-SHA256 Credential=$accessKey/$credentialScope, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature=$signature';
+
+    final uri = Uri.https(host, '/$objectKey');
+    
+    try {
+      final response = await http.put(
+        uri,
+        headers: {
+          'Authorization': authorization,
+          'x-amz-content-sha256': payloadHash,
+          'x-amz-date': datetime,
+          'host': host,
+        },
+        body: data.buffer.asUint8List(),
+      );
+
+      if (response.statusCode >= 400) {
+        stderr.writeln(
+            'Failed to upload to Cloudflare R2, status: ${response.statusCode}, reason: ${response.reasonPhrase}');
+        stderr.writeln('Response body: ${response.body}');
+        return null;
+      }
+
+      if (response.statusCode == 200 || response.statusCode == 204) {
+        return 'https://$host/$objectKey';
+      }
+    } catch (e) {
+      stderr.writeln('Failed to upload to Cloudflare R2, with exception:');
+      stderr.writeln(e);
+      return null;
+    }
+    return null;
+  }
+
+  /// Get direct upload description using PUT method (recommended for R2)
+  static Future<String?> getDirectUploadDescription({
+    /// R2 access key
+    required String accessKey,
+
+    /// R2 secret key
+    required String secretKey,
+
+    /// The name of the R2 storage bucket to upload to
+    required String bucket,
+
+    /// The R2 account ID
+    required String accountId,
+
+    /// The region (defaults to 'auto' for R2)
+    String region = 'auto',
+
+    /// The filename to upload as
+    required String uploadDst,
+    Duration expires = const Duration(minutes: 10),
+    int maxFileSize = 10 * 1024 * 1024,
+    bool public = true,
+  }) async {
+    // For R2, we use PUT presigned URLs instead of POST multipart
+    final uploadUrl = await getDirectUploadUrl(
+      accessKey: accessKey,
+      secretKey: secretKey,
+      bucket: bucket,
+      accountId: accountId,
+      region: region,
+      uploadDst: uploadDst,
+      expires: expires,
+    );
+
+    if (uploadUrl == null) return null;
+
+    final fileName = path.basename(uploadDst);
+    final contentType = _detectMimeType(fileName);
+    
+    var uploadDescriptionData = {
+      'url': uploadUrl,
+      'type': 'binary',
+      'method': 'PUT',
+      'file-name': fileName,
+      'headers': {
+        'Content-Type': contentType,
+      },
+    };
+
+    return jsonEncode(uploadDescriptionData);
+  }
+
+  /// Get direct upload URL for PUT method (presigned URL)
+  /// This is the preferred method for R2 as it's simpler for client implementations
+  static Future<String?> getDirectUploadUrl({
+    /// R2 access key
+    required String accessKey,
+
+    /// R2 secret key
+    required String secretKey,
+
+    /// The name of the R2 storage bucket to upload to
+    required String bucket,
+
+    /// The R2 account ID
+    required String accountId,
+
+    /// The region (defaults to 'auto' for R2)
+    String region = 'auto',
+
+    /// The filename to upload as
+    required String uploadDst,
+    Duration expires = const Duration(minutes: 10),
+    String? contentType,
+  }) async {
+    final host = '$accountId.r2.cloudflarestorage.com';
+    final objectKey = '$bucket/$uploadDst';
+    
+    final datetime = SigV4.generateDatetime();
+    final credentialScope = SigV4.buildCredentialScope(datetime, region, 's3');
+    
+    final queryParams = <String, String>{
+      'X-Amz-Algorithm': 'AWS4-HMAC-SHA256',
+      'X-Amz-Credential': '$accessKey/$credentialScope',
+      'X-Amz-Date': datetime,
+      'X-Amz-Expires': expires.inSeconds.toString(),
+      'X-Amz-SignedHeaders': 'host',
+    };
+    
+    if (contentType != null) {
+      queryParams['X-Amz-ContentType'] = contentType;
+    }
+
+    final canonicalQuery = SigV4.buildCanonicalQueryString(queryParams);
+    final canonicalRequest = '''PUT
+/$objectKey
+$canonicalQuery
+host:$host
+
+host
+UNSIGNED-PAYLOAD''';
+
+    final stringToSign = SigV4.buildStringToSign(
+      datetime,
+      credentialScope,
+      SigV4.hashCanonicalRequest(canonicalRequest),
+    );
+
+    final signingKey = SigV4.calculateSigningKey(secretKey, datetime, region, 's3');
+    final signature = SigV4.calculateSignature(signingKey, stringToSign);
+    
+    queryParams['X-Amz-Signature'] = signature;
+    
+    final uri = Uri.https(host, '/$objectKey', queryParams);
+
+    return uri.toString();
+  }
+}

--- a/integrations/serverpod_cloud_storage_r2/lib/src/cloudflare_r2_upload/policy.dart
+++ b/integrations/serverpod_cloud_storage_r2/lib/src/cloudflare_r2_upload/policy.dart
@@ -1,0 +1,63 @@
+import 'dart:convert';
+
+import 'package:amazon_cognito_identity_dart_2/sig_v4.dart';
+
+class Policy {
+  String expiration;
+  String region;
+  String bucket;
+  String key;
+  String credential;
+  String datetime;
+  int maxFileSize;
+  bool public;
+
+  Policy(this.key, this.bucket, this.datetime, this.expiration, this.credential,
+      this.maxFileSize,
+      {this.region = 'auto', this.public = true});
+
+  factory Policy.fromR2PresignedPost(
+    String key,
+    String bucket,
+    String accessKeyId,
+    int expiryMinutes,
+    int maxFileSize, {
+    String region = 'auto',
+    bool public = true,
+  }) {
+    final datetime = SigV4.generateDatetime();
+    final expiration = (DateTime.now())
+        .add(Duration(minutes: expiryMinutes))
+        .toUtc()
+        .toString()
+        .split(' ')
+        .join('T');
+    final cred =
+        '$accessKeyId/${SigV4.buildCredentialScope(datetime, region, 's3')}';
+
+    return Policy(key, bucket, datetime, expiration, cred, maxFileSize,
+        region: region, public: public);
+  }
+
+  String encode() {
+    final bytes = utf8.encode(toString());
+    return base64.encode(bytes);
+  }
+
+  @override
+  String toString() {
+    return '''
+{ "expiration": "$expiration",
+  "conditions": [
+    {"bucket": "$bucket"},
+    ["starts-with", "\$key", "$key"],
+    {"acl": "${public ? 'public-read' : 'private'}"},
+    ["content-length-range", 1, $maxFileSize],
+    {"x-amz-credential": "$credential"},
+    {"x-amz-algorithm": "AWS4-HMAC-SHA256"},
+    {"x-amz-date": "$datetime" }
+  ]
+}
+''';
+  }
+}

--- a/integrations/serverpod_cloud_storage_r2/pubspec.yaml
+++ b/integrations/serverpod_cloud_storage_r2/pubspec.yaml
@@ -1,0 +1,32 @@
+# This file is generated. Do not modify, instead edit the files in the templates/pubspecs directory.
+# Mode: development
+
+name: serverpod_cloud_storage_r2
+description: Serverpod integration for Cloudflare R2 cloud storage
+version: 3.0.0-alpha.1
+repository: https://github.com/serverpod/serverpod
+homepage: https://serverpod.dev
+issue_tracker: https://github.com/serverpod/serverpod/issues
+
+environment:
+  sdk: '>=3.5.0 <4.0.0'
+
+dependencies:
+  serverpod: 3.0.0-alpha.1
+  amazon_cognito_identity_dart_2: ^3.5.0
+  http: '>=1.1.0 <2.0.0'
+  built_collection: ^5.1.1
+  built_value: ^8.4.4
+  path: ^1.8.3
+  xml2json: ^6.0.0
+
+dev_dependencies:
+  lints: '>=3.0.0 <7.0.0'
+
+dependency_overrides:
+  serverpod:
+    path: ../../packages/serverpod
+  serverpod_serialization:
+    path: ../../packages/serverpod_serialization
+  serverpod_shared:
+    path: ../../packages/serverpod_shared

--- a/packages/serverpod_client/lib/src/file_uploader.dart
+++ b/packages/serverpod_client/lib/src/file_uploader.dart
@@ -42,17 +42,24 @@ class FileUploader {
     try {
       switch (_uploadDescription.type) {
         case _UploadType.binary:
-          final request = http.StreamedRequest('POST', _uploadDescription.url);
-          request.headers.addAll({
+          final request = http.StreamedRequest(_uploadDescription.method, _uploadDescription.url);
+          
+          // Set default headers
+          final defaultHeaders = {
             'Content-Type': 'application/octet-stream',
             'Accept': '*/*',
-          });
+          };
+          
+          // Add default headers first, then override with custom headers
+          request.headers.addAll(defaultHeaders);
+          request.headers.addAll(_uploadDescription.headers);
+          
           request.contentLength = length;
           unawaited(stream.pipe(request.sink));
 
           var response = await request.send();
 
-          return response.statusCode == 200;
+          return response.statusCode == 200 || response.statusCode == 204;
 
         case _UploadType.multipart:
           var multipartFile = switch (length) {
@@ -63,7 +70,7 @@ class FileUploader {
                 filename: _uploadDescription.fileName),
           };
 
-          var request = http.MultipartRequest('POST', _uploadDescription.url);
+          var request = http.MultipartRequest(_uploadDescription.method, _uploadDescription.url);
           request.files.add(multipartFile);
           for (var key in _uploadDescription.requestFields.keys) {
             request.fields[key] = _uploadDescription.requestFields[key]!;
@@ -71,7 +78,7 @@ class FileUploader {
 
           var response = await request.send();
 
-          return response.statusCode == 204;
+          return response.statusCode == 200 || response.statusCode == 204;
       }
     } catch (e) {
       // TODO: Shouldn't we log something here?
@@ -88,9 +95,11 @@ enum _UploadType {
 class _UploadDescription {
   late _UploadType type;
   late Uri url;
+  late String method;
   String? field;
   String? fileName;
   Map<String, String> requestFields = {};
+  Map<String, String> headers = {};
 
   _UploadDescription(String description) {
     var data = jsonDecode(description);
@@ -106,6 +115,12 @@ class _UploadDescription {
     }
 
     url = Uri.parse(data['url']);
+    method = data['method'] ?? 'POST'; // Default to POST for backward compatibility
+    
+    // Parse headers if provided
+    if (data['headers'] != null) {
+      headers = (data['headers'] as Map).cast<String, String>();
+    }
 
     if (type == _UploadType.multipart) {
       field = data['field'];


### PR DESCRIPTION
Hi Serverpod team!

I wanted to create support for Cloudflare R2 as a storage backend. My first attempt was just to allow the endpoint to be overridden since I was under the impression the two APIs were basically interchangeable, but I learned that Cloudflare uses PUT requests while S3 allows for POST (which is what the s3 integration uses). 

My next attempt (which I'm PRing with here) was to create a new integration called `serverpod_cloud_storage_r2` which uses the same pattern as the s3 integration as well as the AWS same library (`amazon_cognito_identity_dart_2`) for identity. It was important to me that no new packages would be required for this implementation.

Additionally, i needed to modify the serverpod_client FileUploader class to optionally allow overriding the method when uploading the file to the bucket. It is able to parse this from the upload description but falls back to POST by default.

In doing this, I noticed that the mimetypes were always application/octet-stream (I believe for S3 as well) so I've included a helper function that will detect the mime based on the extension of the file. I did not incorporate this change with the other two integrations.  

In the spirit of following the patterns of the s3 integration, I did not add tests. I assume this was purposefully omitted previously because it would require an S3 bucket / credentials for the tests to run. Would be happy to do so (I'd just need a bit of guidance on the best way to manage keys and such for this and I'd just follow the same test cases as the database upload).

Additionally, I believe this new integration will also support users who want to use other s3 alternatives such as minos or hetzner because they also use PUT requests. I haven't taken the time to test these out yet but I expect it should work – or at least be very close.

Here is an example implementation. See the integration's readme for more details!

server.dart
```
import 'package:serverpod_cloud_storage_r2/serverpod_cloud_storage_r2.dart' as r2;

pod.addCloudStorage(r2.R2CloudStorage(
    serverpod: pod,
    storageId: 'public',
    public: true,
    region: 'auto',
    bucket: 'my-bucket',
    accountId: "cloudflare-account-id",
    publicHost: "https://mydomain.com",
  ));
  ```

> The asset endpoint doesn't require any changes from what is in serverpod's docs.
> The flutter app doesn't require any changes either from what is in serverpod's docs.

Thanks for considering this PR and I hope you're having a great time at Flutter & Friends!