### PR TITLE
chore: Bumping copilot to version 3.9.0 of Dart

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -31,14 +31,14 @@ jobs:
       - name: Set up Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.24.5'
+          flutter-version: '3.35.2'
           channel: 'stable'
           cache: true
 
       - name: Verify Dart version
         run: |
           dart --version
-          echo "Dart SDK version should be >= 3.5.0"
+          echo "Dart SDK version should be >= 3.9.0"
 
       - name: Install Melos
         run: dart pub global activate melos


### PR DESCRIPTION
While using copilot for a simple PR I noticed that the setup now fails because the required dart version of the repo is 3.7.0 (because of the analyzer package).

This PR bumps the version to Dart 3.9.0 so that we can also enable the use of the Dart MCP server: https://dart.dev/tools/mcp-server

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None - simple Dart version bump for copilot.