### PR TITLE
fix: Incorrect documentation for the email auth endpoint

### DIFF
--- a/modules/serverpod_auth/serverpod_auth_client/lib/src/protocol/client.dart
+++ b/modules/serverpod_auth/serverpod_auth_client/lib/src/protocol/client.dart
@@ -71,7 +71,7 @@ class EndpointApple extends _i1.EndpointRef {
       );
 }
 
-/// Endpoint for handling Sign in with Google.
+/// Endpoint for handling Sign in with Email.
 /// {@category Endpoint}
 class EndpointEmail extends _i1.EndpointRef {
   EndpointEmail(_i1.EndpointCaller caller) : super(caller);

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/endpoints/email_endpoint.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/endpoints/email_endpoint.dart
@@ -7,7 +7,7 @@ import 'package:serverpod_auth_server/serverpod_auth_server.dart';
 
 // const _configFilePath = 'config/google_client_secret.json';
 
-/// Endpoint for handling Sign in with Google.
+/// Endpoint for handling Sign in with Email.
 class EmailEndpoint extends Endpoint {
   /// Authenticates a user with email and password. Returns an
   /// [AuthenticationResponse] with the users information.


### PR DESCRIPTION
In two places the docs says the below endpoint is google related, even though it was Email related. I think the docs where duplicated

_Replace this paragraph with a description of what this PR is changing or adding, and why._

_List which issues are fixed by this PR. You must list at least one issue._

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [X] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [X] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [X] I added new tests to check the change I am making.
- [X] All existing and new tests are passing.
- [X] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

_If you have done any breaking changes, make sure to outline them here, so that they can be included in the notes for the next release._