### PR TITLE
fix: Use the database feature flag for runtime settings.

### DIFF
--- a/packages/serverpod/lib/src/server/serverpod.dart
+++ b/packages/serverpod/lib/src/server/serverpod.dart
@@ -258,16 +258,16 @@ class Serverpod {
   /// Updates the runtime settings and writes the new settings to the database.
   Future<void> updateRuntimeSettings(internal.RuntimeSettings settings) async {
     _updateLogSettings(settings);
-    if (Features.enablePersistentLogging) {
+    if (Features.enableDatabase) {
       await _storeRuntimeSettings(settings);
     }
   }
 
   /// Reloads the runtime settings from the database.
   Future<void> reloadRuntimeSettings() async {
-    if (!Features.enablePersistentLogging) {
+    if (!Features.enableDatabase) {
       throw StateError(
-        'Persistent logging is disabled, runtime settings are not stored in '
+        'The database is disabled, runtime settings are not stored in '
         'the database.',
       );
     }


### PR DESCRIPTION
The runtime settings update methods where using a feature flag for persistent logging. But this feature flag is toggled from user input, the runtime settings don't need the persistent logging to function. But it does need the database. I believe this worked originally because the persistent logging feature toggle was managed by the database feature in the initial implementation.

The problem was that if a user turned off persistent logging but had a database, we throw the StateError `Persistent logging is disabled, runtime settings are not stored in the database.`, which clearly is invalid.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

## Breaking changes

none