### PR TITLE
fix: Fix JWT access tokens not being unique if generated in the same second

### DIFF
--- a/modules/new_serverpod_auth/serverpod_auth_core/serverpod_auth_core_server/lib/src/jwt/business/jwt_util.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_core/serverpod_auth_core_server/lib/src/jwt/business/jwt_util.dart
@@ -18,10 +18,12 @@ class JwtUtil {
 
   /// Creates a new JWT for the given refresh token.
   ///
-  /// The auth user ID is set as `subject`.
-  /// The refresh token's ID for which this access token is generated is set as `jwtId`.
-  /// If scopes are present on the fresh token configuration, they will be set on a claim named "dev.serverpod.scopeNames".
-  /// Any extra claims configured with the refresh token will be added as top-level claims.
+  /// The auth user ID is set as `subject`. An UUID `jwtId` is generated for
+  /// each access token to ensure token uniqueness. The refresh token's ID is
+  /// stored in the claim "dev.serverpod.refreshTokenId". If scopes are present
+  /// on the refresh token configuration, they will be set on a claim named
+  /// "dev.serverpod.scopeNames". Any extra claims configured with the refresh
+  /// token will be added as top-level claims.
   String createJwt(final RefreshToken refreshToken) {
     final extraClaims = refreshToken.extraClaims != null
         ? (jsonDecode(refreshToken.extraClaims!) as Map).cast<String, dynamic>()
@@ -49,8 +51,9 @@ class JwtUtil {
         ...?extraClaims,
         if (refreshToken.scopeNames.isNotEmpty)
           _serverpodScopeNamesClaimKey: refreshToken.scopeNames.toList(),
+        _serverpodRefreshTokenIdClaimKey: refreshToken.id!.toString(),
       },
-      jwtId: refreshToken.id!.toString(),
+      jwtId: const Uuid().v4obj().toString(),
       subject: refreshToken.authUserId.toString(),
       issuer: _issuer,
     );
@@ -77,13 +80,15 @@ class JwtUtil {
   /// In practice, when this is used via [AuthenticationTokens.authenticationHandler], these errors will all be caught and a `null` `AuthenticationInfo?` will be returned instead.
   VerifiedJwtData verifyJwt(final String accessToken) {
     final jwt = _verifyJwt(accessToken);
+    final allClaims = (jwt.payload as Map).cast<String, dynamic>();
 
     final UuidValue refreshTokenId;
     try {
-      refreshTokenId = UuidValue.withValidation(jwt.jwtId!);
+      final tokenStr = allClaims[_serverpodRefreshTokenIdClaimKey] as String;
+      refreshTokenId = UuidValue.withValidation(tokenStr);
     } catch (e) {
       throw ArgumentError(
-        'The refresh token ID could not be read from the JWT\'s `id` claim: "${jwt.jwtId}"',
+        "The refresh token ID could not be read from the JWT's `$_serverpodRefreshTokenIdClaimKey` claim.",
         'accessToken',
       );
     }
@@ -100,8 +105,7 @@ class JwtUtil {
 
     final Set<Scope> scopes;
     try {
-      final scopeNamesClaim =
-          (jwt.payload as Map)[_serverpodScopeNamesClaimKey];
+      final scopeNamesClaim = allClaims[_serverpodScopeNamesClaimKey];
       final scopeNames = scopeNamesClaim != null
           ? (scopeNamesClaim as List).cast<String>()
           : const <String>[];
@@ -116,11 +120,11 @@ class JwtUtil {
       );
     }
 
-    final allClaims = (jwt.payload as Map).cast<String, dynamic>();
     final extraClaims = Map.fromEntries(
       allClaims.entries.where((final e) =>
           !_registeredClaims.contains(e.key) &&
-          e.key != _serverpodScopeNamesClaimKey),
+          e.key != _serverpodScopeNamesClaimKey &&
+          e.key != _serverpodRefreshTokenIdClaimKey),
     );
 
     return (
@@ -169,9 +173,16 @@ class JwtUtil {
     'jti',
   };
 
+  /// Prefix for Serverpod-specific JWT claims.
   static const _serverpodClaimPrefix = 'dev.serverpod.';
+
+  /// Claim for Serverpod scopes embedded in the access token.
   static const _serverpodScopeNamesClaimKey =
       '${_serverpodClaimPrefix}scopeNames';
+
+  /// Claim carrying the RefreshToken ID associated with this access token.
+  static const _serverpodRefreshTokenIdClaimKey =
+      '${_serverpodClaimPrefix}refreshTokenId';
 }
 
 /// The data successfully verified and extracted from a JWT token.

--- a/modules/new_serverpod_auth/serverpod_auth_core/serverpod_auth_core_server/test/jwt/jwt_util_test.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_core/serverpod_auth_core_server/test/jwt/jwt_util_test.dart
@@ -34,6 +34,15 @@ void main() {
           isNotEmpty,
         );
       });
+
+      test(
+          'when two JWTs are created within the same second, then they are unique.',
+          () {
+        final refreshToken = _createRefreshToken();
+        final jwt1 = jwtUtil.createJwt(refreshToken);
+        final jwt2 = jwtUtil.createJwt(refreshToken);
+        expect(jwt1, isNot(jwt2));
+      });
     });
 
     group('a refresh token containing a reserved claim,', () {
@@ -109,10 +118,17 @@ void main() {
       });
 
       test(
-          "when the JWT is decoded, then it will contain the `RefreshToken`'s ID as `jwtId`.",
+          'when the JWT is decoded, then it contains an unique `jwtId` that is different from the refresh token ID.',
+          () {
+        expect(JWT.decode(jwt).jwtId, isNotNull);
+        expect(JWT.decode(jwt).jwtId, isNot(refreshToken.id!.toString()));
+      });
+
+      test(
+          'when the JWT is decoded, then it contains the refresh token ID claim.',
           () {
         expect(
-          JWT.decode(jwt).jwtId,
+          (JWT.decode(jwt).payload as Map)['dev.serverpod.refreshTokenId'],
           refreshToken.id!.toString(),
         );
       });


### PR DESCRIPTION
Fixes #3964.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

N/A.