### PR TITLE
feat: Add a `MutexRefresherClientAuthKeyProvider` to avoid concurrent refreshes

### DIFF
--- a/packages/serverpod_client/lib/src/auth_key_provider.dart
+++ b/packages/serverpod_client/lib/src/auth_key_provider.dart
@@ -9,28 +9,49 @@ abstract interface class ClientAuthKeyProvider {
 }
 
 /// Provides the authentication key for the client, with a method to refresh it.
-abstract class RefresherClientAuthKeyProvider implements ClientAuthKeyProvider {
-  /// Authentication header value getter that must be implemented. This getter
-  /// must get the header value directly from the source, without any locking.
-  /// The [authHeaderValue] getter will handle refreshing the key if needed,
-  /// with a lock to avoid concurrent refresh attempts.
-  Future<String?> get notLockedAuthHeaderValue;
-
-  @override
-  Future<String?> get authHeaderValue async {
-    // TODO: In the beginning of the getter, check validity and refresh if it is
-    // about to expire. Either way, before refreshing, check again if it's still
-    // about to expire to avoid racing conditions when multiple endpoints try to
-    // refresh and one has already refreshed. Then skip refresh and return true.
-
-    // TODO: Use Completer to implement a lock under the future of the getter to
-    // avoid multiple concurrent refresh attempts.
-    return await notLockedAuthHeaderValue;
-  }
-
+abstract interface class RefresherClientAuthKeyProvider
+    implements ClientAuthKeyProvider {
   /// Refreshes the authentication key. If the refresh is successful, should
   /// return true to retry requests that failed due to authentication errors.
   /// Be sure to annotate the refresh endpoint with @unauthenticatedClientCall
   /// to avoid a deadlock on the [authHeaderValue] getter on refresh call.
   Future<bool> refreshAuthKey();
+}
+
+/// A [RefresherClientAuthKeyProvider] decorator that adds a mutex lock to
+/// prevent concurrent refresh calls. Actual auth header getter and refresh
+/// logic is delegated to the [_delegate] provider.
+class MutexRefresherClientAuthKeyProvider
+    implements RefresherClientAuthKeyProvider {
+  final RefresherClientAuthKeyProvider _delegate;
+
+  /// Creates a new [MutexRefresherClientAuthKeyProvider].
+  MutexRefresherClientAuthKeyProvider(this._delegate);
+
+  /// Shared future that serves as a lock to prevent concurrent refresh calls.
+  Future<bool>? _pendingRefresh;
+
+  @override
+  Future<String?> get authHeaderValue async {
+    await refreshAuthKey();
+    return _delegate.authHeaderValue;
+  }
+
+  /// Refreshes the authentication key with locking to prevent concurrent calls.
+  @override
+  Future<bool> refreshAuthKey() async {
+    final pendingRefresh = _pendingRefresh;
+    if (pendingRefresh != null) return pendingRefresh;
+
+    final refreshFuture = _delegate.refreshAuthKey();
+    _pendingRefresh = refreshFuture;
+
+    try {
+      return await refreshFuture;
+    } finally {
+      if (identical(_pendingRefresh, refreshFuture)) {
+        _pendingRefresh = null;
+      }
+    }
+  }
 }

--- a/packages/serverpod_client/lib/src/client_method_stream_manager.dart
+++ b/packages/serverpod_client/lib/src/client_method_stream_manager.dart
@@ -89,13 +89,12 @@ final class ClientMethodStreamManager {
       // A first failure here with 401 can be due to an access token expiration.
       // We will retry only once in such case, and only if the `authKeyProvider`
       // exposes a `refreshAuthKey` method (like JWT).
-      final shouldRefreshAuth =
-          e.responseType == OpenMethodStreamResponseType.authenticationFailed &&
-              authKeyProvider is RefresherClientAuthKeyProvider &&
-              await authKeyProvider.refreshAuthKey();
-
-      if (shouldRefreshAuth) {
-        return _openMethodStream(connectionDetails);
+      if (e.responseType == OpenMethodStreamResponseType.authenticationFailed &&
+          authKeyProvider is RefresherClientAuthKeyProvider) {
+        final refreshResult = await authKeyProvider.refreshAuthKey();
+        if (refreshResult == RefreshAuthKeyResult.success) {
+          return _openMethodStream(connectionDetails);
+        }
       }
       rethrow;
     }

--- a/packages/serverpod_client/lib/src/serverpod_client_shared.dart
+++ b/packages/serverpod_client/lib/src/serverpod_client_shared.dart
@@ -484,12 +484,12 @@ abstract class ServerpodClientShared extends EndpointCaller {
       // A first failure here with 401 can be due to an access token expiration.
       // We will retry only once in such case, and only if the `authKeyProvider`
       // exposes a `refreshAuthKey` method (like JWT).
-      final shouldRefreshAuth = keyProvider is RefresherClientAuthKeyProvider &&
-          await keyProvider.refreshAuthKey();
-
-      if (shouldRefreshAuth) {
-        return _callServerEndpoint(endpoint, method, args,
-            authenticated: authenticated);
+      if (keyProvider is RefresherClientAuthKeyProvider) {
+        final refreshResult = await keyProvider.refreshAuthKey();
+        if (refreshResult == RefreshAuthKeyResult.success) {
+          return _callServerEndpoint(endpoint, method, args,
+              authenticated: authenticated);
+        }
       }
       rethrow;
     }

--- a/packages/serverpod_client/test/integration/call_server_endpoint_retry_test.dart
+++ b/packages/serverpod_client/test/integration/call_server_endpoint_retry_test.dart
@@ -73,9 +73,8 @@ void main() {
         onConnected: (host) => httpHost = host,
       );
 
-      authKeyProvider = TestRefresherAuthKeyProvider(
-        initialAuthKey: 'initial-token',
-      );
+      authKeyProvider = TestRefresherAuthKeyProvider();
+      authKeyProvider.setAuthKey('initial-token');
 
       client = TestServerpodClient(
         host: httpHost,
@@ -111,7 +110,10 @@ void main() {
         Response.ok(body: Body.fromString('"success"')),
       ];
 
-      authKeyProvider.setRefreshResult(true);
+      authKeyProvider.setRefresh(() {
+        authKeyProvider.updateAuthKey();
+        return true;
+      });
 
       final result = await client.callServerEndpoint<String>(
         'test',
@@ -133,7 +135,7 @@ void main() {
         Response.unauthorized(),
       ];
 
-      authKeyProvider.setRefreshResult(false);
+      authKeyProvider.setRefresh(() => false);
 
       await expectLater(
         client.callServerEndpoint<String>('test', 'method', {'arg': 'value'}),
@@ -153,7 +155,10 @@ void main() {
         Response.unauthorized(),
       ];
 
-      authKeyProvider.setRefreshResult(true);
+      authKeyProvider.setRefresh(() {
+        authKeyProvider.updateAuthKey();
+        return true;
+      });
 
       await expectLater(
         client.callServerEndpoint<String>('test', 'method', {'arg': 'value'}),

--- a/packages/serverpod_client/test/integration/call_server_endpoint_retry_test.dart
+++ b/packages/serverpod_client/test/integration/call_server_endpoint_retry_test.dart
@@ -112,7 +112,7 @@ void main() {
 
       authKeyProvider.setRefresh(() {
         authKeyProvider.updateAuthKey();
-        return true;
+        return RefreshAuthKeyResult.success;
       });
 
       final result = await client.callServerEndpoint<String>(
@@ -135,7 +135,7 @@ void main() {
         Response.unauthorized(),
       ];
 
-      authKeyProvider.setRefresh(() => false);
+      authKeyProvider.setRefresh(() => RefreshAuthKeyResult.failedOther);
 
       await expectLater(
         client.callServerEndpoint<String>('test', 'method', {'arg': 'value'}),
@@ -157,7 +157,7 @@ void main() {
 
       authKeyProvider.setRefresh(() {
         authKeyProvider.updateAuthKey();
-        return true;
+        return RefreshAuthKeyResult.success;
       });
 
       await expectLater(

--- a/packages/serverpod_client/test/integration/open_method_stream_retry_test.dart
+++ b/packages/serverpod_client/test/integration/open_method_stream_retry_test.dart
@@ -159,7 +159,7 @@ void main() {
 
       authKeyProvider.setRefresh(() {
         authKeyProvider.updateAuthKey();
-        return true;
+        return RefreshAuthKeyResult.success;
       });
 
       var connectionDetails = MethodStreamConnectionDetailsBuilder()
@@ -181,7 +181,7 @@ void main() {
         OpenMethodStreamResponseType.authenticationFailed,
       ];
 
-      authKeyProvider.setRefresh(() => false);
+      authKeyProvider.setRefresh(() => RefreshAuthKeyResult.failedOther);
 
       var connectionDetails = MethodStreamConnectionDetailsBuilder()
           .withAuthKeyProvider(authKeyProvider)
@@ -208,7 +208,7 @@ void main() {
 
       authKeyProvider.setRefresh(() {
         authKeyProvider.updateAuthKey();
-        return true;
+        return RefreshAuthKeyResult.success;
       });
 
       var connectionDetails = MethodStreamConnectionDetailsBuilder()

--- a/packages/serverpod_client/test/integration/open_method_stream_retry_test.dart
+++ b/packages/serverpod_client/test/integration/open_method_stream_retry_test.dart
@@ -92,9 +92,8 @@ void main() {
 
     setUp(() async {
       receivedCmds = [];
-      authKeyProvider = TestRefresherAuthKeyProvider(
-        initialAuthKey: 'initial-token',
-      );
+      authKeyProvider = TestRefresherAuthKeyProvider();
+      authKeyProvider.setAuthKey('initial-token');
 
       closeServer = await TestWebSocketServer.startServer(
         webSocketHandler: (webSocket) {
@@ -158,7 +157,10 @@ void main() {
         OpenMethodStreamResponseType.success,
       ];
 
-      authKeyProvider.setRefreshResult(true);
+      authKeyProvider.setRefresh(() {
+        authKeyProvider.updateAuthKey();
+        return true;
+      });
 
       var connectionDetails = MethodStreamConnectionDetailsBuilder()
           .withAuthKeyProvider(authKeyProvider)
@@ -179,7 +181,7 @@ void main() {
         OpenMethodStreamResponseType.authenticationFailed,
       ];
 
-      authKeyProvider.setRefreshResult(false);
+      authKeyProvider.setRefresh(() => false);
 
       var connectionDetails = MethodStreamConnectionDetailsBuilder()
           .withAuthKeyProvider(authKeyProvider)
@@ -204,7 +206,10 @@ void main() {
         OpenMethodStreamResponseType.authenticationFailed,
       ];
 
-      authKeyProvider.setRefreshResult(true);
+      authKeyProvider.setRefresh(() {
+        authKeyProvider.updateAuthKey();
+        return true;
+      });
 
       var connectionDetails = MethodStreamConnectionDetailsBuilder()
           .withAuthKeyProvider(authKeyProvider)

--- a/packages/serverpod_client/test/mutex_refresher_client_auth_key_provider_test.dart
+++ b/packages/serverpod_client/test/mutex_refresher_client_auth_key_provider_test.dart
@@ -1,0 +1,146 @@
+import 'dart:async';
+
+import 'package:serverpod_client/serverpod_client.dart';
+import 'package:test/test.dart';
+
+void main() {
+  late TestRefresherAuthKeyProvider delegate;
+  late MutexRefresherClientAuthKeyProvider provider;
+
+  setUp(() {
+    delegate = TestRefresherAuthKeyProvider();
+    provider = MutexRefresherClientAuthKeyProvider(delegate);
+  });
+
+  group('Given a mutex protected auth key provider with an initial token', () {
+    setUp(() {
+      delegate.setAuthKey('initial-token');
+    });
+
+    test('when refresh fails then returns original auth header value.',
+        () async {
+      delegate.setRefresh(() => false);
+
+      final result = await provider.authHeaderValue;
+
+      expect(result, 'initial-token');
+      expect(delegate.refreshCallCount, 1);
+    });
+
+    test('when refresh succeeds then returns new auth header value.', () async {
+      delegate.setRefresh(() {
+        delegate.updateAuthKey();
+        return true;
+      });
+
+      final result = await provider.authHeaderValue;
+
+      expect(result, 'refreshed-token-1');
+      expect(delegate.refreshCallCount, 1);
+    });
+
+    test(
+        'when multiple refreshAuthKey calls are made concurrently '
+        'then only one call performs refresh due to locking.', () async {
+      delegate.setRefresh(() async {
+        await Future.delayed(const Duration(milliseconds: 50));
+        delegate.updateAuthKey();
+        return true;
+      });
+
+      final futures = List.generate(3, (_) => provider.refreshAuthKey());
+      final results = await Future.wait(futures);
+
+      expect(results, everyElement(true));
+      expect(delegate.refreshCallCount, 1);
+    });
+
+    test(
+        'when multiple authHeaderValue calls are made concurrently '
+        'then only one call performs refresh due to locking.', () async {
+      delegate.setRefresh(() async {
+        await Future.delayed(const Duration(milliseconds: 50));
+        delegate.updateAuthKey();
+        return true;
+      });
+
+      final futures = List.generate(3, (_) => provider.authHeaderValue);
+      final results = await Future.wait(futures);
+
+      expect(results, everyElement('refreshed-token-1'));
+      expect(delegate.refreshCallCount, 1);
+    });
+
+    test(
+        'when refresh is already in progress and new call is made '
+        'then it waits for existing refresh to complete and no new refresh is started.',
+        () async {
+      delegate.setRefresh(() async {
+        await Future.delayed(const Duration(milliseconds: 200));
+        delegate.updateAuthKey();
+        return true;
+      });
+
+      final firstRefresh = provider.refreshAuthKey();
+      await Future.delayed(const Duration(milliseconds: 50));
+
+      final secondRefresh = provider.refreshAuthKey();
+      final results = await Future.wait([firstRefresh, secondRefresh]);
+
+      expect(results, [true, true]);
+      expect(delegate.refreshCallCount, 1);
+    });
+
+    test(
+        'when multiple refreshAuthKey calls are made concurrently and refresh fails '
+        'then all calls return false and no new refresh is started.', () async {
+      delegate.setRefresh(() async {
+        await Future.delayed(const Duration(milliseconds: 50));
+        return false;
+      });
+
+      final futures = List.generate(3, (_) => provider.refreshAuthKey());
+      final results = await Future.wait(futures);
+
+      expect(results, everyElement(false));
+      expect(delegate.refreshCallCount, 1);
+    });
+
+    test(
+        'when refreshing throws an exception '
+        'then refreshAuthKey rethrows the exception.', () async {
+      delegate.setRefresh(() => throw Exception('Refresh failed'));
+
+      await expectLater(provider.refreshAuthKey(), throwsA(isA<Exception>()));
+      expect(delegate.refreshCallCount, 1);
+    });
+
+    test(
+        'when refreshing throws an exception '
+        'then authHeaderValue rethrows the exception.', () async {
+      delegate.setRefresh(() => throw Exception('Refresh failed'));
+
+      await expectLater(provider.authHeaderValue, throwsA(isA<Exception>()));
+      expect(delegate.refreshCallCount, 1);
+    });
+  });
+}
+
+class TestRefresherAuthKeyProvider implements RefresherClientAuthKeyProvider {
+  String? _authKey;
+  late FutureOr<bool> Function() _refresh;
+  int refreshCallCount = 0;
+
+  void setAuthKey(String? key) => _authKey = key;
+  void setRefresh(FutureOr<bool> Function() refresh) => _refresh = refresh;
+  void updateAuthKey() => _authKey = 'refreshed-token-$refreshCallCount';
+
+  @override
+  Future<String?> get authHeaderValue async => _authKey;
+
+  @override
+  Future<bool> refreshAuthKey() async {
+    refreshCallCount++;
+    return _refresh();
+  }
+}

--- a/packages/serverpod_client/test/mutex_refresher_client_auth_key_provider_test.dart
+++ b/packages/serverpod_client/test/mutex_refresher_client_auth_key_provider_test.dart
@@ -21,7 +21,7 @@ void main() {
 
     test('when refresh fails then returns original auth header value.',
         () async {
-      delegate.setRefresh(() => false);
+      delegate.setRefresh(() => RefreshAuthKeyResult.failedOther);
 
       final result = await provider.authHeaderValue;
 
@@ -32,7 +32,7 @@ void main() {
     test('when refresh succeeds then returns new auth header value.', () async {
       delegate.setRefresh(() {
         delegate.updateAuthKey();
-        return true;
+        return RefreshAuthKeyResult.success;
       });
 
       final result = await provider.authHeaderValue;
@@ -47,13 +47,13 @@ void main() {
       delegate.setRefresh(() async {
         await Future.delayed(const Duration(milliseconds: 50));
         delegate.updateAuthKey();
-        return true;
+        return RefreshAuthKeyResult.success;
       });
 
       final futures = List.generate(3, (_) => provider.refreshAuthKey());
       final results = await Future.wait(futures);
 
-      expect(results, everyElement(true));
+      expect(results, everyElement(RefreshAuthKeyResult.success));
       expect(delegate.refreshCallCount, 1);
     });
 
@@ -63,7 +63,7 @@ void main() {
       delegate.setRefresh(() async {
         await Future.delayed(const Duration(milliseconds: 50));
         delegate.updateAuthKey();
-        return true;
+        return RefreshAuthKeyResult.success;
       });
 
       final futures = List.generate(3, (_) => provider.authHeaderValue);
@@ -80,7 +80,7 @@ void main() {
       delegate.setRefresh(() async {
         await Future.delayed(const Duration(milliseconds: 200));
         delegate.updateAuthKey();
-        return true;
+        return RefreshAuthKeyResult.success;
       });
 
       final firstRefresh = provider.refreshAuthKey();
@@ -89,7 +89,7 @@ void main() {
       final secondRefresh = provider.refreshAuthKey();
       final results = await Future.wait([firstRefresh, secondRefresh]);
 
-      expect(results, [true, true]);
+      expect(results, everyElement(RefreshAuthKeyResult.success));
       expect(delegate.refreshCallCount, 1);
     });
 
@@ -98,13 +98,13 @@ void main() {
         'then all calls return false and no new refresh is started.', () async {
       delegate.setRefresh(() async {
         await Future.delayed(const Duration(milliseconds: 50));
-        return false;
+        return RefreshAuthKeyResult.failedOther;
       });
 
       final futures = List.generate(3, (_) => provider.refreshAuthKey());
       final results = await Future.wait(futures);
 
-      expect(results, everyElement(false));
+      expect(results, everyElement(RefreshAuthKeyResult.failedOther));
       expect(delegate.refreshCallCount, 1);
     });
 

--- a/packages/serverpod_client/test/mutex_refresher_client_auth_key_provider_test.dart
+++ b/packages/serverpod_client/test/mutex_refresher_client_auth_key_provider_test.dart
@@ -3,6 +3,8 @@ import 'dart:async';
 import 'package:serverpod_client/serverpod_client.dart';
 import 'package:test/test.dart';
 
+import 'test_utils/test_auth_key_providers.dart';
+
 void main() {
   late TestRefresherAuthKeyProvider delegate;
   late MutexRefresherClientAuthKeyProvider provider;
@@ -23,7 +25,7 @@ void main() {
 
       final result = await provider.authHeaderValue;
 
-      expect(result, 'initial-token');
+      expect(result, 'Bearer initial-token');
       expect(delegate.refreshCallCount, 1);
     });
 
@@ -35,7 +37,7 @@ void main() {
 
       final result = await provider.authHeaderValue;
 
-      expect(result, 'refreshed-token-1');
+      expect(result, 'Bearer refreshed-token-1');
       expect(delegate.refreshCallCount, 1);
     });
 
@@ -67,7 +69,7 @@ void main() {
       final futures = List.generate(3, (_) => provider.authHeaderValue);
       final results = await Future.wait(futures);
 
-      expect(results, everyElement('refreshed-token-1'));
+      expect(results, everyElement('Bearer refreshed-token-1'));
       expect(delegate.refreshCallCount, 1);
     });
 
@@ -124,23 +126,4 @@ void main() {
       expect(delegate.refreshCallCount, 1);
     });
   });
-}
-
-class TestRefresherAuthKeyProvider implements RefresherClientAuthKeyProvider {
-  String? _authKey;
-  late FutureOr<bool> Function() _refresh;
-  int refreshCallCount = 0;
-
-  void setAuthKey(String? key) => _authKey = key;
-  void setRefresh(FutureOr<bool> Function() refresh) => _refresh = refresh;
-  void updateAuthKey() => _authKey = 'refreshed-token-$refreshCallCount';
-
-  @override
-  Future<String?> get authHeaderValue async => _authKey;
-
-  @override
-  Future<bool> refreshAuthKey() async {
-    refreshCallCount++;
-    return _refresh();
-  }
 }

--- a/packages/serverpod_client/test/test_utils/test_auth_key_providers.dart
+++ b/packages/serverpod_client/test/test_utils/test_auth_key_providers.dart
@@ -1,7 +1,7 @@
 import 'package:serverpod_client/serverpod_client.dart';
 
 /// Test auth key provider that supports refresh functionality.
-class TestRefresherAuthKeyProvider extends RefresherClientAuthKeyProvider {
+class TestRefresherAuthKeyProvider implements RefresherClientAuthKeyProvider {
   String? _authKey;
   bool? _refreshResult;
   final List<String> refreshLog = [];
@@ -12,7 +12,7 @@ class TestRefresherAuthKeyProvider extends RefresherClientAuthKeyProvider {
   }) : _authKey = initialAuthKey?.wrapAsBearerAuthHeader();
 
   @override
-  Future<String?> get notLockedAuthHeaderValue async => _authKey;
+  Future<String?> get authHeaderValue async => _authKey;
 
   @override
   Future<bool> refreshAuthKey() async {

--- a/packages/serverpod_client/test/test_utils/test_auth_key_providers.dart
+++ b/packages/serverpod_client/test/test_utils/test_auth_key_providers.dart
@@ -5,12 +5,12 @@ import 'package:serverpod_client/serverpod_client.dart';
 /// Test auth key provider that supports refresh functionality.
 class TestRefresherAuthKeyProvider implements RefresherClientAuthKeyProvider {
   String? _authKey;
-  late FutureOr<bool> Function() _refresh;
+  late FutureOr<RefreshAuthKeyResult> Function() _refresh;
   int refreshCallCount = 0;
 
   void setAuthKey(String? key) => _authKey = key?.wrapAsBearerAuthHeader();
   void updateAuthKey() => setAuthKey('refreshed-token-$refreshCallCount');
-  void setRefresh(FutureOr<bool> Function() refresh) {
+  void setRefresh(FutureOr<RefreshAuthKeyResult> Function() refresh) {
     _refresh = refresh;
   }
 
@@ -18,7 +18,7 @@ class TestRefresherAuthKeyProvider implements RefresherClientAuthKeyProvider {
   Future<String?> get authHeaderValue async => _authKey;
 
   @override
-  Future<bool> refreshAuthKey() async {
+  Future<RefreshAuthKeyResult> refreshAuthKey() async {
     refreshCallCount++;
     return _refresh();
   }

--- a/packages/serverpod_client/test/test_utils/test_auth_key_providers.dart
+++ b/packages/serverpod_client/test/test_utils/test_auth_key_providers.dart
@@ -1,15 +1,18 @@
+import 'dart:async';
+
 import 'package:serverpod_client/serverpod_client.dart';
 
 /// Test auth key provider that supports refresh functionality.
 class TestRefresherAuthKeyProvider implements RefresherClientAuthKeyProvider {
   String? _authKey;
-  bool? _refreshResult;
-  final List<String> refreshLog = [];
+  late FutureOr<bool> Function() _refresh;
   int refreshCallCount = 0;
 
-  TestRefresherAuthKeyProvider({
-    String? initialAuthKey,
-  }) : _authKey = initialAuthKey?.wrapAsBearerAuthHeader();
+  void setAuthKey(String? key) => _authKey = key?.wrapAsBearerAuthHeader();
+  void updateAuthKey() => setAuthKey('refreshed-token-$refreshCallCount');
+  void setRefresh(FutureOr<bool> Function() refresh) {
+    _refresh = refresh;
+  }
 
   @override
   Future<String?> get authHeaderValue async => _authKey;
@@ -17,23 +20,7 @@ class TestRefresherAuthKeyProvider implements RefresherClientAuthKeyProvider {
   @override
   Future<bool> refreshAuthKey() async {
     refreshCallCount++;
-    refreshLog.add('Refresh attempt $refreshCallCount');
-
-    final refreshResult = _refreshResult;
-    if (refreshResult == null) {
-      throw StateError(
-        'Refresh result not set. Call "setRefreshResult" on the test provider '
-        'before refreshing.',
-      );
-    } else if (refreshResult) {
-      _authKey = 'refreshed-token-$refreshCallCount'.wrapAsBearerAuthHeader();
-    }
-
-    return refreshResult;
-  }
-
-  void setRefreshResult(bool result) {
-    _refreshResult = result;
+    return _refresh();
   }
 }
 


### PR DESCRIPTION
This work is part of the solution to #3674.

As a follow-up of #3927, this PR adds a `RefresherAuthKeyProvider` that uses a mutex lock to avoid concurrent refresh attempts. It also prevents subsequent refreshes when a refresh operation fails with unauthorized for a given key - such as when a refresh token is invalid.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

The `refreshAuthKey` signature has changed, but it is still unused in the codebase and it is not expected to already be used externally.