### PR TITLE
chore: Mark generated files with .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,6 @@
 **/generated/** linguist-generated=true
 **/protocol/** linguist-generated=true
 **/serverpod_test_tools.dart linguist-generated=true
+
+# Compensate for too broad protocol pattern
+tools/serverpod_cli/test/generator/dart/**/protocol/** linguist-generated=false


### PR DESCRIPTION
This PR marks generated files as such in `.gitattributes`.

I believe marking files with linguist-generated=true in `.gitattributes` will make GitHub collapse them as default in PR reviews.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

## Breaking changes

None