### PR TITLE
fix: Fix futures left with unhandled across async gaps on the codebase

### DIFF
--- a/packages/serverpod/lib/src/endpoints/insights.dart
+++ b/packages/serverpod/lib/src/endpoints/insights.dart
@@ -101,9 +101,8 @@ class InsightsEndpoint extends Endpoint {
         orderBy: MessageLogEntry.t.order,
       );
 
-      var logRows = await futureLogRows;
-      var queryRows = await futureQueryRows;
-      var messageRows = await futureMessageRows;
+      final (logRows, queryRows, messageRows) =
+          await (futureLogRows, futureQueryRows, futureMessageRows).wait;
 
       sessionLogInfo.add(
         SessionLogInfo(

--- a/packages/serverpod_client/test/mutex_refresher_client_auth_key_provider_test.dart
+++ b/packages/serverpod_client/test/mutex_refresher_client_auth_key_provider_test.dart
@@ -185,9 +185,11 @@ void main() {
       delegate.setRefresh(() => throw Exception('Refresh failed'));
 
       final futures = List.generate(3, (_) => provider.refreshAuthKey());
-      for (final future in futures) {
-        await expectLater(future, throwsA(isA<Exception>()));
-      }
+
+      await [
+        for (final future in futures)
+          expectLater(future, throwsA(isA<Exception>()))
+      ].wait;
       expect(delegate.refreshCallCount, 1);
     });
 
@@ -206,13 +208,12 @@ void main() {
       delegate.setRefresh(() => throw Exception('Refresh failed'));
 
       final futures = List.generate(3, (_) => provider.authHeaderValue);
-      for (final future in futures) {
-        await expectLater(future, throwsA(isA<Exception>()));
-      }
+
+      await [
+        for (final future in futures)
+          expectLater(future, throwsA(isA<Exception>()))
+      ].wait;
       expect(delegate.refreshCallCount, 1);
-    },
-        skip: const bool.fromEnvironment('dart.tool.dart2wasm')
-            ? 'Failing on WASM due to https://github.com/dart-lang/sdk/issues/61483'
-            : null);
+    });
   });
 }

--- a/tests/serverpod_test_server/test_e2e/method_streaming/open_stream_test.dart
+++ b/tests/serverpod_test_server/test_e2e/method_streaming/open_stream_test.dart
@@ -17,9 +17,9 @@ void main() {
       streamCompleteFutures.add(stream.last);
     }
 
-    for (var future in streamCompleteFutures) {
-      await expectLater(future, completes);
-    }
+    await [
+      for (var future in streamCompleteFutures) expectLater(future, completes)
+    ].wait;
   });
 
   test(
@@ -50,8 +50,8 @@ void main() {
       );
     }
 
-    for (var future in streamCompleteFutures) {
-      await expectLater(future, completes);
-    }
+    await [
+      for (var future in streamCompleteFutures) expectLater(future, completes)
+    ].wait;
   });
 }


### PR DESCRIPTION
Fixes the flaky test marked to skip on #3966 with the advice from the https://github.com/dart-lang/sdk/issues/61483 issue. Other similar cases were also fixed across the codebase.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

N/A.