### PR TITLE
fix: Remove sensitive information being logged on failures

### DIFF
--- a/modules/new_serverpod_auth/serverpod_auth_bridge/serverpod_auth_bridge_server/lib/src/business/legacy_authentication_handler.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_bridge/serverpod_auth_bridge_server/lib/src/business/legacy_authentication_handler.dart
@@ -34,7 +34,7 @@ Future<LegacySession?> resolveLegacySession(
 
     return legacySession;
   } catch (exception, stackTrace) {
-    stderr.writeln('Failed authentication: $exception');
+    stderr.writeln('Failed authentication: ${exception.runtimeType}');
     stderr.writeln('$stackTrace');
     return null;
   }

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/business/authentication_handler.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/business/authentication_handler.dart
@@ -47,7 +47,7 @@ Future<AuthenticationInfo?> authenticationHandler(
       authId: keyIdStr,
     );
   } catch (exception, stackTrace) {
-    stderr.writeln('Failed authentication: $exception');
+    stderr.writeln('Failed authentication: ${exception.runtimeType}');
     stderr.writeln('$stackTrace');
     return null;
   }

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/business/email_auth.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/business/email_auth.dart
@@ -81,7 +81,7 @@ class Emails {
       );
       if (validationResponse is PasswordValidationFailed) {
         session.log(
-          ' - ${validationResponse.passwordHash} saved: ${validationResponse.storedHash}',
+          ' - password validation failed',
           level: LogLevel.debug,
         );
 


### PR DESCRIPTION
Fixes #3848.

Scanning the codebase, found three cases to fix:
- Two of exceptions being logged that might carry sensitive information (like database failed operations). These were fixed by logging only the exception type instead of the full object with its contents.
- One direct log of password hashes on old auth module when e-mail password validation failed. This was replaced by a generic "password validation failed" message.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

Only logging information being changed. Can have a minor impact on debugging workflows, but no actual breaking change.