### PR TITLE
chore: Bump image_cropper

### DIFF
--- a/modules/serverpod_auth/serverpod_auth_shared_flutter/pubspec.yaml
+++ b/modules/serverpod_auth/serverpod_auth_shared_flutter/pubspec.yaml
@@ -23,7 +23,7 @@ dependencies:
   file_picker: '>=8.1.0 <11.0.0'
 
   # See https://pub.dev/packages/image_cropper for installation instructions.
-  image_cropper: '>=7.0.0 <10.0.0'
+  image_cropper: '>=7.0.0 <12.0.0'
 
   # See https://pub.dev/packages/image_picker for installation instructions.
   image_picker: ^1.0.0

--- a/templates/pubspecs/modules/serverpod_auth/serverpod_auth_shared_flutter/pubspec.yaml
+++ b/templates/pubspecs/modules/serverpod_auth/serverpod_auth_shared_flutter/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
   file_picker: '>=8.1.0 <11.0.0'
 
   # See https://pub.dev/packages/image_cropper for installation instructions.
-  image_cropper: '>=7.0.0 <10.0.0'
+  image_cropper: '>=7.0.0 <12.0.0'
 
   # See https://pub.dev/packages/image_picker for installation instructions.
   image_picker: ^1.0.0


### PR DESCRIPTION
Widens the image cropper range to allow the newly released version 11 (and also 10).

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

The major changes seems to be in a different part of the API.