### PR TITLE
ci: Add dependabot for npm in Serverpod extension

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,9 @@ updates:
     # of open pull requests is limited to 1. This prevents multiple pull requests
     # from being opened for the same dependency.
     open-pull-requests-limit: 1
+  - package-ecosystem: "npm"
+    directory: "tools/serverpod_vscode_extension"
+    schedule:
+      interval: "daily"
+    versioning-strategy: "increase-if-necessary"
+    open-pull-requests-limit: 1


### PR DESCRIPTION
Activates dependabot for the Serverpod extension.

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None: Simple CI update.