### PR TITLE
chore: Bump relic in stable branch

### DIFF
--- a/modules/new_serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/providers/apple/business/apple_accounts.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/providers/apple/business/apple_accounts.dart
@@ -157,7 +157,7 @@ abstract final class AppleAccounts {
 
       await handler(notification);
 
-      return (ctx as RespondableContext).withResponse(Response.ok());
+      return (ctx as RespondableContext).respond(Response.ok());
     };
   }
 }

--- a/packages/serverpod/lib/src/server/server.dart
+++ b/packages/serverpod/lib/src/server/server.dart
@@ -158,7 +158,7 @@ class Server {
             'Internal server error. Request handler failed with exception.',
         request: context.request,
       );
-      return context.withResponse(Response.internalServerError(
+      return context.respond(Response.internalServerError(
         body: Body.fromString('Internal Server Error'),
       ));
     }
@@ -207,7 +207,7 @@ class Server {
         body: Body.fromString(responseBuffer.toString()),
         headers: headers,
       );
-      return context.withResponse(response);
+      return context.respond(response);
     } else if (uri.path == '/websocket') {
       return await _dispatchWebSocketUpgradeRequest(
         context,
@@ -225,7 +225,7 @@ class Server {
     // This OPTIONS check is necessary when making requests from
     // eg `editor.swagger.io`. It ensures proper handling of preflight requests
     // with the OPTIONS method.
-    if (request.method == RequestMethod.options) {
+    if (request.method == Method.options) {
       final combinedHeaders = headers.transform((mh) {
         for (var orh in httpOptionsResponseHeaders.entries) {
           mh[orh.key] = ['${orh.value}'];
@@ -233,7 +233,7 @@ class Server {
         mh.contentLength = 0; // TODO: Why set this explicitly?
       });
 
-      return context.withResponse(Response.ok(headers: combinedHeaders));
+      return context.respond(Response.ok(headers: combinedHeaders));
     }
 
     late final String body;
@@ -245,7 +245,7 @@ class Server {
           // TODO: Log to database?
           io.stderr.writeln('${DateTime.now().toUtc()} ${e.errorDescription}');
         }
-        return context.withResponse(Response(
+        return context.respond(Response(
           io.HttpStatus.requestEntityTooLarge,
           body: Body.fromString(e.errorDescription),
           headers: headers,
@@ -254,7 +254,7 @@ class Server {
         await _reportFrameworkException(e, stackTrace,
             message: 'Internal server error. Failed to read body of request.',
             request: context.request);
-        return context.withResponse(Response.badRequest(
+        return context.respond(Response.badRequest(
           body: Body.fromString('Failed to read request body.'),
           headers: headers,
         ));
@@ -267,7 +267,7 @@ class Server {
     if (serverpod.runtimeSettings.logMalformedCalls) {
       _logMalformedCalls(result);
     }
-    return context.withResponse(_toResponse(result, headers));
+    return context.respond(_toResponse(result, headers));
   }
 
   void _logMalformedCalls(Result result) {

--- a/packages/serverpod/lib/src/web_server/routes/static_directory.dart
+++ b/packages/serverpod/lib/src/web_server/routes/static_directory.dart
@@ -130,7 +130,7 @@ class RouteStaticDirectory extends Route {
 
       final file = File(filePath);
       if (!await file.exists()) {
-        return context.withResponse(Response.notFound());
+        return context.respond(Response.notFound());
       }
 
       // Set mime-type.
@@ -156,7 +156,7 @@ class RouteStaticDirectory extends Route {
         file.openRead().cast(),
         mimeType: mimeType,
       );
-      return context.withResponse(Response.ok(body: body, headers: headers));
+      return context.respond(Response.ok(body: body, headers: headers));
     } catch (e) {
       // Couldn't find or load file.
       rethrow;

--- a/packages/serverpod/pubspec.yaml
+++ b/packages/serverpod/pubspec.yaml
@@ -29,7 +29,7 @@ dependencies:
   path: ^1.8.2
   postgres: ^3.4.0
   redis: ^4.0.0
-  relic: ^0.4.1
+  relic: ^0.6.0
   retry: ^3.1.1
   synchronized: ^3.1.0
   system_resources: ^1.6.0

--- a/packages/serverpod_client/pubspec.yaml
+++ b/packages/serverpod_client/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   web_socket_channel: '>=2.4.0 <4.0.0'
 
 dev_dependencies:
-  relic: ^0.4.1
+  relic: ^0.6.0
   serverpod_lints: 3.0.0-alpha.1
   test: ^1.24.2
 

--- a/templates/pubspecs/packages/serverpod/pubspec.yaml
+++ b/templates/pubspecs/packages/serverpod/pubspec.yaml
@@ -28,7 +28,7 @@ dependencies:
   path: ^1.8.2
   postgres: ^3.4.0
   redis: ^4.0.0
-  relic: ^0.4.1
+  relic: ^0.6.0
   retry: ^3.1.1
   synchronized: ^3.1.0
   system_resources: ^1.6.0

--- a/templates/pubspecs/packages/serverpod_client/pubspec.yaml
+++ b/templates/pubspecs/packages/serverpod_client/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   web_socket_channel: '>=2.4.0 <4.0.0'
 
 dev_dependencies:
-  relic: ^0.4.1
+  relic: ^0.6.0
   serverpod_lints: SERVERPOD_VERSION
   test: ^1.24.2
 

--- a/templates/pubspecs/tests/serverpod_test_server/pubspec.yaml
+++ b/templates/pubspecs/tests/serverpod_test_server/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
   sdk: DART_VERSION
 dependencies:
   http: '>=1.1.0 <2.0.0'
-  relic: ^0.4.1
+  relic: ^0.6.0
   serverpod: SERVERPOD_VERSION
   serverpod_auth_server: SERVERPOD_VERSION
   serverpod_cloud_storage_s3: SERVERPOD_VERSION

--- a/tests/serverpod_test_server/pubspec.yaml
+++ b/tests/serverpod_test_server/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
   sdk: '>=3.5.0 <4.0.0'
 dependencies:
   http: '>=1.1.0 <2.0.0'
-  relic: ^0.4.1
+  relic: ^0.6.0
   serverpod: 3.0.0-alpha.1
   serverpod_auth_server: 3.0.0-alpha.1
   serverpod_cloud_storage_s3: 3.0.0-alpha.1


### PR DESCRIPTION
Bumps relic to 0.6.0 so that Cloud gets the fix for static assets.

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

External interfaces are kept the same.