### PR TITLE
chore: Bump relic to 0.6.0 in stable branch

### DIFF
--- a/modules/new_serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_client/lib/src/protocol/providers/email/models/exceptions/email_account_login_failure_reason.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_client/lib/src/protocol/providers/email/models/exceptions/email_account_login_failure_reason.dart
@@ -34,6 +34,7 @@ enum EmailAccountLoginFailureReason implements _i1.SerializableModel {
 
   @override
   int toJson() => index;
+
   @override
   String toString() => name;
 }

--- a/modules/new_serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/generated/providers/email/models/exceptions/email_account_login_failure_reason.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/generated/providers/email/models/exceptions/email_account_login_failure_reason.dart
@@ -34,6 +34,7 @@ enum EmailAccountLoginFailureReason implements _i1.SerializableModel {
 
   @override
   int toJson() => index;
+
   @override
   String toString() => name;
 }

--- a/modules/new_serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/providers/apple/business/apple_accounts.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/providers/apple/business/apple_accounts.dart
@@ -157,7 +157,7 @@ abstract final class AppleAccounts {
 
       await handler(notification);
 
-      return (ctx as RespondableContext).withResponse(Response.ok());
+      return (ctx as RespondableContext).respond(Response.ok());
     };
   }
 }

--- a/modules/serverpod_auth/serverpod_auth_client/lib/src/protocol/authentication_fail_reason.dart
+++ b/modules/serverpod_auth/serverpod_auth_client/lib/src/protocol/authentication_fail_reason.dart
@@ -40,6 +40,7 @@ enum AuthenticationFailReason implements _i1.SerializableModel {
 
   @override
   int toJson() => index;
+
   @override
   String toString() => name;
 }

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/authentication_fail_reason.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/authentication_fail_reason.dart
@@ -40,6 +40,7 @@ enum AuthenticationFailReason implements _i1.SerializableModel {
 
   @override
   int toJson() => index;
+
   @override
   String toString() => name;
 }

--- a/modules/serverpod_auth/serverpod_auth_shared_flutter/pubspec.yaml
+++ b/modules/serverpod_auth/serverpod_auth_shared_flutter/pubspec.yaml
@@ -43,6 +43,9 @@ dependency_overrides:
     path: ../../../packages/serverpod_lints
   serverpod_serialization:
     path: ../../../packages/serverpod_serialization
+  # 7.2.0 introduces a breaking change for older versions of flutter.
+  # It depends on Color.toARGB32() which was introduced in Flutter 3.29
+  image_cropper_platform_interface: <7.2.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/packages/serverpod/lib/src/generated/database/column_type.dart
+++ b/packages/serverpod/lib/src/generated/database/column_type.dart
@@ -96,6 +96,7 @@ enum ColumnType implements _i1.SerializableModel {
 
   @override
   int toJson() => index;
+
   @override
   String toString() => name;
 }

--- a/packages/serverpod/lib/src/generated/database/database_migration_action_type.dart
+++ b/packages/serverpod/lib/src/generated/database/database_migration_action_type.dart
@@ -36,6 +36,7 @@ enum DatabaseMigrationActionType implements _i1.SerializableModel {
 
   @override
   String toJson() => name;
+
   @override
   String toString() => name;
 }

--- a/packages/serverpod/lib/src/generated/database/database_migration_warning_type.dart
+++ b/packages/serverpod/lib/src/generated/database/database_migration_warning_type.dart
@@ -36,6 +36,7 @@ enum DatabaseMigrationWarningType implements _i1.SerializableModel {
 
   @override
   String toJson() => name;
+
   @override
   String toString() => name;
 }

--- a/packages/serverpod/lib/src/generated/database/enum_serialization.dart
+++ b/packages/serverpod/lib/src/generated/database/enum_serialization.dart
@@ -30,6 +30,7 @@ enum EnumSerialization implements _i1.SerializableModel {
 
   @override
   int toJson() => index;
+
   @override
   String toString() => name;
 }

--- a/packages/serverpod/lib/src/generated/database/filter/filter_constraint_type.dart
+++ b/packages/serverpod/lib/src/generated/database/filter/filter_constraint_type.dart
@@ -66,6 +66,7 @@ enum FilterConstraintType implements _i1.SerializableModel {
 
   @override
   int toJson() => index;
+
   @override
   String toString() => name;
 }

--- a/packages/serverpod/lib/src/generated/database/foreign_key_action.dart
+++ b/packages/serverpod/lib/src/generated/database/foreign_key_action.dart
@@ -57,6 +57,7 @@ enum ForeignKeyAction implements _i1.SerializableModel {
 
   @override
   int toJson() => index;
+
   @override
   String toString() => name;
 }

--- a/packages/serverpod/lib/src/generated/database/foreign_key_match_type.dart
+++ b/packages/serverpod/lib/src/generated/database/foreign_key_match_type.dart
@@ -42,6 +42,7 @@ enum ForeignKeyMatchType implements _i1.SerializableModel {
 
   @override
   int toJson() => index;
+
   @override
   String toString() => name;
 }

--- a/packages/serverpod/lib/src/generated/database/index_element_definition_type.dart
+++ b/packages/serverpod/lib/src/generated/database/index_element_definition_type.dart
@@ -37,6 +37,7 @@ enum IndexElementDefinitionType implements _i1.SerializableModel {
 
   @override
   int toJson() => index;
+
   @override
   String toString() => name;
 }

--- a/packages/serverpod/lib/src/generated/database/vector_distance_function.dart
+++ b/packages/serverpod/lib/src/generated/database/vector_distance_function.dart
@@ -54,6 +54,7 @@ enum VectorDistanceFunction implements _i1.SerializableModel {
 
   @override
   String toJson() => name;
+
   @override
   String toString() => name;
 }

--- a/packages/serverpod/lib/src/generated/log_level.dart
+++ b/packages/serverpod/lib/src/generated/log_level.dart
@@ -39,6 +39,7 @@ enum LogLevel implements _i1.SerializableModel {
 
   @override
   int toJson() => index;
+
   @override
   String toString() => name;
 }

--- a/packages/serverpod/lib/src/server/server.dart
+++ b/packages/serverpod/lib/src/server/server.dart
@@ -158,7 +158,7 @@ class Server {
             'Internal server error. Request handler failed with exception.',
         request: context.request,
       );
-      return context.withResponse(Response.internalServerError(
+      return context.respond(Response.internalServerError(
         body: Body.fromString('Internal Server Error'),
       ));
     }
@@ -207,7 +207,7 @@ class Server {
         body: Body.fromString(responseBuffer.toString()),
         headers: headers,
       );
-      return context.withResponse(response);
+      return context.respond(response);
     } else if (uri.path == '/websocket') {
       return await _dispatchWebSocketUpgradeRequest(
         context,
@@ -225,7 +225,7 @@ class Server {
     // This OPTIONS check is necessary when making requests from
     // eg `editor.swagger.io`. It ensures proper handling of preflight requests
     // with the OPTIONS method.
-    if (request.method == RequestMethod.options) {
+    if (request.method == Method.options) {
       final combinedHeaders = headers.transform((mh) {
         for (var orh in httpOptionsResponseHeaders.entries) {
           mh[orh.key] = ['${orh.value}'];
@@ -233,7 +233,7 @@ class Server {
         mh.contentLength = 0; // TODO: Why set this explicitly?
       });
 
-      return context.withResponse(Response.ok(headers: combinedHeaders));
+      return context.respond(Response.ok(headers: combinedHeaders));
     }
 
     late final String body;
@@ -245,7 +245,7 @@ class Server {
           // TODO: Log to database?
           io.stderr.writeln('${DateTime.now().toUtc()} ${e.errorDescription}');
         }
-        return context.withResponse(Response(
+        return context.respond(Response(
           io.HttpStatus.requestEntityTooLarge,
           body: Body.fromString(e.errorDescription),
           headers: headers,
@@ -254,7 +254,7 @@ class Server {
         await _reportFrameworkException(e, stackTrace,
             message: 'Internal server error. Failed to read body of request.',
             request: context.request);
-        return context.withResponse(Response.badRequest(
+        return context.respond(Response.badRequest(
           body: Body.fromString('Failed to read request body.'),
           headers: headers,
         ));
@@ -267,7 +267,7 @@ class Server {
     if (serverpod.runtimeSettings.logMalformedCalls) {
       _logMalformedCalls(result);
     }
-    return context.withResponse(_toResponse(result, headers));
+    return context.respond(_toResponse(result, headers));
   }
 
   void _logMalformedCalls(Result result) {

--- a/packages/serverpod/lib/src/web_server/routes/static_directory.dart
+++ b/packages/serverpod/lib/src/web_server/routes/static_directory.dart
@@ -130,7 +130,7 @@ class RouteStaticDirectory extends Route {
 
       final file = File(filePath);
       if (!await file.exists()) {
-        return context.withResponse(Response.notFound());
+        return context.respond(Response.notFound());
       }
 
       // Set mime-type.
@@ -156,7 +156,7 @@ class RouteStaticDirectory extends Route {
         file.openRead().cast(),
         mimeType: mimeType,
       );
-      return context.withResponse(Response.ok(body: body, headers: headers));
+      return context.respond(Response.ok(body: body, headers: headers));
     } catch (e) {
       // Couldn't find or load file.
       rethrow;

--- a/packages/serverpod/pubspec.yaml
+++ b/packages/serverpod/pubspec.yaml
@@ -29,7 +29,7 @@ dependencies:
   path: ^1.8.2
   postgres: ^3.4.0
   redis: ^4.0.0
-  relic: ^0.4.1
+  relic: ^0.6.0
   retry: ^3.1.1
   synchronized: ^3.1.0
   system_resources: ^1.6.0

--- a/packages/serverpod_client/pubspec.yaml
+++ b/packages/serverpod_client/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   web_socket_channel: '>=2.4.0 <4.0.0'
 
 dev_dependencies:
-  relic: ^0.4.1
+  relic: ^0.6.0
   serverpod_lints: 3.0.0-alpha.1
   test: ^1.24.2
 

--- a/packages/serverpod_service_client/lib/src/protocol/database/column_type.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/database/column_type.dart
@@ -96,6 +96,7 @@ enum ColumnType implements _i1.SerializableModel {
 
   @override
   int toJson() => index;
+
   @override
   String toString() => name;
 }

--- a/packages/serverpod_service_client/lib/src/protocol/database/database_migration_action_type.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/database/database_migration_action_type.dart
@@ -36,6 +36,7 @@ enum DatabaseMigrationActionType implements _i1.SerializableModel {
 
   @override
   String toJson() => name;
+
   @override
   String toString() => name;
 }

--- a/packages/serverpod_service_client/lib/src/protocol/database/database_migration_warning_type.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/database/database_migration_warning_type.dart
@@ -36,6 +36,7 @@ enum DatabaseMigrationWarningType implements _i1.SerializableModel {
 
   @override
   String toJson() => name;
+
   @override
   String toString() => name;
 }

--- a/packages/serverpod_service_client/lib/src/protocol/database/enum_serialization.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/database/enum_serialization.dart
@@ -30,6 +30,7 @@ enum EnumSerialization implements _i1.SerializableModel {
 
   @override
   int toJson() => index;
+
   @override
   String toString() => name;
 }

--- a/packages/serverpod_service_client/lib/src/protocol/database/filter/filter_constraint_type.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/database/filter/filter_constraint_type.dart
@@ -66,6 +66,7 @@ enum FilterConstraintType implements _i1.SerializableModel {
 
   @override
   int toJson() => index;
+
   @override
   String toString() => name;
 }

--- a/packages/serverpod_service_client/lib/src/protocol/database/foreign_key_action.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/database/foreign_key_action.dart
@@ -57,6 +57,7 @@ enum ForeignKeyAction implements _i1.SerializableModel {
 
   @override
   int toJson() => index;
+
   @override
   String toString() => name;
 }

--- a/packages/serverpod_service_client/lib/src/protocol/database/foreign_key_match_type.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/database/foreign_key_match_type.dart
@@ -42,6 +42,7 @@ enum ForeignKeyMatchType implements _i1.SerializableModel {
 
   @override
   int toJson() => index;
+
   @override
   String toString() => name;
 }

--- a/packages/serverpod_service_client/lib/src/protocol/database/index_element_definition_type.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/database/index_element_definition_type.dart
@@ -37,6 +37,7 @@ enum IndexElementDefinitionType implements _i1.SerializableModel {
 
   @override
   int toJson() => index;
+
   @override
   String toString() => name;
 }

--- a/packages/serverpod_service_client/lib/src/protocol/database/vector_distance_function.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/database/vector_distance_function.dart
@@ -54,6 +54,7 @@ enum VectorDistanceFunction implements _i1.SerializableModel {
 
   @override
   String toJson() => name;
+
   @override
   String toString() => name;
 }

--- a/packages/serverpod_service_client/lib/src/protocol/log_level.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/log_level.dart
@@ -39,6 +39,7 @@ enum LogLevel implements _i1.SerializableModel {
 
   @override
   int toJson() => index;
+
   @override
   String toString() => name;
 }

--- a/templates/pubspecs/modules/serverpod_auth/serverpod_auth_shared_flutter/pubspec.yaml
+++ b/templates/pubspecs/modules/serverpod_auth/serverpod_auth_shared_flutter/pubspec.yaml
@@ -42,6 +42,9 @@ dependency_overrides:
     path: ../../../packages/serverpod_lints
   serverpod_serialization:
     path: ../../../packages/serverpod_serialization
+  # 7.2.0 introduces a breaking change for older versions of flutter.
+  # It depends on Color.toARGB32() which was introduced in Flutter 3.29
+  image_cropper_platform_interface: <7.2.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/templates/pubspecs/packages/serverpod/pubspec.yaml
+++ b/templates/pubspecs/packages/serverpod/pubspec.yaml
@@ -28,7 +28,7 @@ dependencies:
   path: ^1.8.2
   postgres: ^3.4.0
   redis: ^4.0.0
-  relic: ^0.4.1
+  relic: ^0.6.0
   retry: ^3.1.1
   synchronized: ^3.1.0
   system_resources: ^1.6.0

--- a/templates/pubspecs/packages/serverpod_client/pubspec.yaml
+++ b/templates/pubspecs/packages/serverpod_client/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   web_socket_channel: '>=2.4.0 <4.0.0'
 
 dev_dependencies:
-  relic: ^0.4.1
+  relic: ^0.6.0
   serverpod_lints: SERVERPOD_VERSION
   test: ^1.24.2
 

--- a/templates/pubspecs/tests/serverpod_new_auth_test/serverpod_new_auth_test_flutter/pubspec.yaml
+++ b/templates/pubspecs/tests/serverpod_new_auth_test/serverpod_new_auth_test_flutter/pubspec.yaml
@@ -49,3 +49,6 @@ dependency_overrides:
     path: ../../../packages/serverpod_lints
   serverpod_serialization:
     path: ../../../packages/serverpod_serialization
+  # 7.2.0 introduces a breaking change for older versions of flutter.
+  # It depends on Color.toARGB32() which was introduced in Flutter 3.29
+  image_cropper_platform_interface: <7.2.0

--- a/templates/pubspecs/tests/serverpod_test_flutter/pubspec.yaml
+++ b/templates/pubspecs/tests/serverpod_test_flutter/pubspec.yaml
@@ -32,6 +32,9 @@ dependency_overrides:
     path: ../../packages/serverpod_client
   serverpod_serialization:
     path: ../../packages/serverpod_serialization
+  # 7.2.0 introduces a breaking change for older versions of flutter.
+  # It depends on Color.toARGB32() which was introduced in Flutter 3.29
+  image_cropper_platform_interface: <7.2.0
 
 flutter:
   uses-material-design: true

--- a/templates/pubspecs/tests/serverpod_test_server/pubspec.yaml
+++ b/templates/pubspecs/tests/serverpod_test_server/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
   sdk: DART_VERSION
 dependencies:
   http: '>=1.1.0 <2.0.0'
-  relic: ^0.4.1
+  relic: ^0.6.0
   serverpod: SERVERPOD_VERSION
   serverpod_auth_server: SERVERPOD_VERSION
   serverpod_cloud_storage_s3: SERVERPOD_VERSION

--- a/tests/serverpod_new_auth_test/serverpod_new_auth_test_flutter/pubspec.yaml
+++ b/tests/serverpod_new_auth_test/serverpod_new_auth_test_flutter/pubspec.yaml
@@ -49,3 +49,6 @@ dependency_overrides:
     path: ../../../packages/serverpod_lints
   serverpod_serialization:
     path: ../../../packages/serverpod_serialization
+  # 7.2.0 introduces a breaking change for older versions of flutter.
+  # It depends on Color.toARGB32() which was introduced in Flutter 3.29
+  image_cropper_platform_interface: <7.2.0

--- a/tests/serverpod_test_client/lib/src/protocol/by_index_enum_with_name_value.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/by_index_enum_with_name_value.dart
@@ -30,6 +30,7 @@ enum ByIndexEnumWithNameValue implements _i1.SerializableModel {
 
   @override
   int toJson() => index;
+
   @override
   String toString() => this.name;
 }

--- a/tests/serverpod_test_client/lib/src/protocol/by_name_enum_with_name_value.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/by_name_enum_with_name_value.dart
@@ -30,6 +30,7 @@ enum ByNameEnumWithNameValue implements _i1.SerializableModel {
 
   @override
   String toJson() => this.name;
+
   @override
   String toString() => this.name;
 }

--- a/tests/serverpod_test_client/lib/src/protocol/defaults/enum/enums/by_index_enum.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/defaults/enum/enums/by_index_enum.dart
@@ -30,6 +30,7 @@ enum ByIndexEnum implements _i1.SerializableModel {
 
   @override
   int toJson() => index;
+
   @override
   String toString() => name;
 }

--- a/tests/serverpod_test_client/lib/src/protocol/defaults/enum/enums/by_name_enum.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/defaults/enum/enums/by_name_enum.dart
@@ -30,6 +30,7 @@ enum ByNameEnum implements _i1.SerializableModel {
 
   @override
   String toJson() => name;
+
   @override
   String toString() => name;
 }

--- a/tests/serverpod_test_client/lib/src/protocol/defaults/enum/enums/default_value_enum.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/defaults/enum/enums/default_value_enum.dart
@@ -29,6 +29,7 @@ enum DefaultValueEnum implements _i1.SerializableModel {
 
   @override
   int toJson() => index;
+
   @override
   String toString() => name;
 }

--- a/tests/serverpod_test_client/lib/src/protocol/scopes/serverOnly/default_server_only_enum.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/scopes/serverOnly/default_server_only_enum.dart
@@ -30,6 +30,7 @@ enum DefaultServerOnlyEnum implements _i1.SerializableModel {
 
   @override
   int toJson() => index;
+
   @override
   String toString() => name;
 }

--- a/tests/serverpod_test_client/lib/src/protocol/scopes/serverOnly/not_server_only_enum.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/scopes/serverOnly/not_server_only_enum.dart
@@ -30,6 +30,7 @@ enum NotServerOnlyEnum implements _i1.SerializableModel {
 
   @override
   int toJson() => index;
+
   @override
   String toString() => name;
 }

--- a/tests/serverpod_test_client/lib/src/protocol/test_enum.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/test_enum.dart
@@ -38,6 +38,7 @@ enum TestEnum implements _i1.SerializableModel {
 
   @override
   int toJson() => index;
+
   @override
   String toString() => name;
 }

--- a/tests/serverpod_test_client/lib/src/protocol/test_enum_stringified.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/test_enum_stringified.dart
@@ -34,6 +34,7 @@ enum TestEnumStringified implements _i1.SerializableModel {
 
   @override
   String toJson() => name;
+
   @override
   String toString() => name;
 }

--- a/tests/serverpod_test_flutter/pubspec.yaml
+++ b/tests/serverpod_test_flutter/pubspec.yaml
@@ -33,6 +33,9 @@ dependency_overrides:
     path: ../../packages/serverpod_client
   serverpod_serialization:
     path: ../../packages/serverpod_serialization
+  # 7.2.0 introduces a breaking change for older versions of flutter.
+  # It depends on Color.toARGB32() which was introduced in Flutter 3.29
+  image_cropper_platform_interface: <7.2.0
 
 flutter:
   uses-material-design: true

--- a/tests/serverpod_test_server/lib/src/generated/by_index_enum_with_name_value.dart
+++ b/tests/serverpod_test_server/lib/src/generated/by_index_enum_with_name_value.dart
@@ -30,6 +30,7 @@ enum ByIndexEnumWithNameValue implements _i1.SerializableModel {
 
   @override
   int toJson() => index;
+
   @override
   String toString() => this.name;
 }

--- a/tests/serverpod_test_server/lib/src/generated/by_name_enum_with_name_value.dart
+++ b/tests/serverpod_test_server/lib/src/generated/by_name_enum_with_name_value.dart
@@ -30,6 +30,7 @@ enum ByNameEnumWithNameValue implements _i1.SerializableModel {
 
   @override
   String toJson() => this.name;
+
   @override
   String toString() => this.name;
 }

--- a/tests/serverpod_test_server/lib/src/generated/defaults/enum/enums/by_index_enum.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/enum/enums/by_index_enum.dart
@@ -30,6 +30,7 @@ enum ByIndexEnum implements _i1.SerializableModel {
 
   @override
   int toJson() => index;
+
   @override
   String toString() => name;
 }

--- a/tests/serverpod_test_server/lib/src/generated/defaults/enum/enums/by_name_enum.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/enum/enums/by_name_enum.dart
@@ -30,6 +30,7 @@ enum ByNameEnum implements _i1.SerializableModel {
 
   @override
   String toJson() => name;
+
   @override
   String toString() => name;
 }

--- a/tests/serverpod_test_server/lib/src/generated/defaults/enum/enums/default_value_enum.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/enum/enums/default_value_enum.dart
@@ -29,6 +29,7 @@ enum DefaultValueEnum implements _i1.SerializableModel {
 
   @override
   int toJson() => index;
+
   @override
   String toString() => name;
 }

--- a/tests/serverpod_test_server/lib/src/generated/scopes/serverOnly/default_server_only_enum.dart
+++ b/tests/serverpod_test_server/lib/src/generated/scopes/serverOnly/default_server_only_enum.dart
@@ -30,6 +30,7 @@ enum DefaultServerOnlyEnum implements _i1.SerializableModel {
 
   @override
   int toJson() => index;
+
   @override
   String toString() => name;
 }

--- a/tests/serverpod_test_server/lib/src/generated/scopes/serverOnly/not_server_only_enum.dart
+++ b/tests/serverpod_test_server/lib/src/generated/scopes/serverOnly/not_server_only_enum.dart
@@ -30,6 +30,7 @@ enum NotServerOnlyEnum implements _i1.SerializableModel {
 
   @override
   int toJson() => index;
+
   @override
   String toString() => name;
 }

--- a/tests/serverpod_test_server/lib/src/generated/scopes/serverOnly/server_only_enum.dart
+++ b/tests/serverpod_test_server/lib/src/generated/scopes/serverOnly/server_only_enum.dart
@@ -30,6 +30,7 @@ enum ServerOnlyEnum implements _i1.SerializableModel {
 
   @override
   int toJson() => index;
+
   @override
   String toString() => name;
 }

--- a/tests/serverpod_test_server/lib/src/generated/test_enum.dart
+++ b/tests/serverpod_test_server/lib/src/generated/test_enum.dart
@@ -38,6 +38,7 @@ enum TestEnum implements _i1.SerializableModel {
 
   @override
   int toJson() => index;
+
   @override
   String toString() => name;
 }

--- a/tests/serverpod_test_server/lib/src/generated/test_enum_stringified.dart
+++ b/tests/serverpod_test_server/lib/src/generated/test_enum_stringified.dart
@@ -34,6 +34,7 @@ enum TestEnumStringified implements _i1.SerializableModel {
 
   @override
   String toJson() => name;
+
   @override
   String toString() => name;
 }

--- a/tests/serverpod_test_server/pubspec.yaml
+++ b/tests/serverpod_test_server/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
   sdk: '>=3.5.0 <4.0.0'
 dependencies:
   http: '>=1.1.0 <2.0.0'
-  relic: ^0.4.1
+  relic: ^0.6.0
   serverpod: 3.0.0-alpha.1
   serverpod_auth_server: 3.0.0-alpha.1
   serverpod_cloud_storage_s3: 3.0.0-alpha.1


### PR DESCRIPTION
Bumps relic to 0.6.0 in stable alpha branch to include fixes for routing static resources that was patched in Relic.

**Additional fix**

A dependency override was added to contraint `image_cropper_platform_interface` since a breaking for older flutter versions was introduced in version 7.2.0. Issue here: https://github.com/hnvn/flutter_image_cropper/issues/594

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

External interface should have been kept the same.