### PR TITLE
fix: Gracefully handle file match misses.

### DIFF
--- a/packages/serverpod/lib/src/web_server/web_server.dart
+++ b/packages/serverpod/lib/src/web_server/web_server.dart
@@ -141,7 +141,10 @@ class WebServer {
     return switch (match) {
       RouterMatch<Route>() =>
         _handleRouteCall(match.asMatch.value, session, context),
-      _ => context.respond(Response.notFound()),
+      PathMiss<Route>() => context.respond(Response.notFound()),
+      MethodMiss<Route>() => context.respond(
+          Response(405, body: Body.fromString('Method Not Allowed')),
+        ),
     };
   }
 

--- a/packages/serverpod/lib/src/web_server/web_server.dart
+++ b/packages/serverpod/lib/src/web_server/web_server.dart
@@ -137,13 +137,12 @@ class WebServer {
       request.method,
       uri.path,
     );
-    if (match != null) {
-      final route = match.asMatch.value;
-      return await _handleRouteCall(route, session, context);
-    }
 
-    // No matching patch found
-    return context.respond(Response.notFound());
+    return switch (match) {
+      RouterMatch<Route>() =>
+        _handleRouteCall(match.asMatch.value, session, context),
+      _ => context.respond(Response.notFound()),
+    };
   }
 
   Future<HandledContext> _handleRouteCall(
@@ -314,7 +313,7 @@ extension type ServerpodRouter._(Router<Route> _router) {
       _router.add(route.method.toMethod(), route._matchPath!, route);
 
   /// Looks up a [Route] in the router based on the HTTP method and path.
-  LookupResult<Route>? lookup(Method method, String path) =>
+  LookupResult<Route> lookup(Method method, String path) =>
       _router.lookup(method, path);
 
   /// Checks if the router is empty.


### PR DESCRIPTION
Fixes an issue where file match misses had changed from a nullable type to a specific router type.

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

_If you have done any breaking changes, make sure to outline them here, so that they can be included in the notes for the next release._