### PR TITLE
feat: Support supplying image when user is created.

### DIFF
--- a/modules/new_serverpod_auth/serverpod_auth_core/serverpod_auth_core_server/lib/src/profile/business/user_profiles.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_core/serverpod_auth_core_server/lib/src/profile/business/user_profiles.dart
@@ -56,16 +56,15 @@ abstract final class UserProfiles {
           transaction: transaction,
         );
 
-        if (imageSource != null) {
-          await _setUserImage(
-            session,
-            authUserId,
-            imageSource,
-            transaction: transaction,
-          );
-        }
-
-        final createdProfileModel = createdProfile.toModel();
+        final createdProfileModel = switch (imageSource) {
+          null => createdProfile.toModel(),
+          _ => await _setUserImage(
+              session,
+              authUserId,
+              imageSource,
+              transaction: transaction,
+            ),
+        };
 
         await UserProfileConfig.current.onAfterUserProfileCreated?.call(
           session,

--- a/modules/new_serverpod_auth/serverpod_auth_core/serverpod_auth_core_server/test/profile/integration/user_profiles_test.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_core/serverpod_auth_core_server/test/profile/integration/user_profiles_test.dart
@@ -177,48 +177,72 @@ void main() {
         },
       );
 
-      test(
+      group(
         'when creating a user profile with image url, then image is accessible on user.',
-        () async {
-          await UserProfiles.createUserProfile(
-            session,
-            authUserId,
-            UserProfileData(userName: 'test_user'),
-            imageSource: UserImageFromUrl.parse(
-                'https://serverpod.dev/external-profile-image.png'),
-          );
+        () {
+          late UserProfileModel createdProfile;
+          setUp(() async {
+            createdProfile = await UserProfiles.createUserProfile(
+              session,
+              authUserId,
+              UserProfileData(userName: 'test_user'),
+              imageSource: UserImageFromUrl.parse(
+                  'https://serverpod.dev/external-profile-image.png'),
+            );
+          });
 
-          final foundUserProfile = await UserProfiles.findUserProfileByUserId(
-            session,
-            authUserId,
-          );
+          test('then the returned profile contains the image URL.', () async {
+            expect(
+              createdProfile.imageUrl.toString(),
+              allOf(startsWith('http://localhost'), endsWith('.jpg')),
+            );
+          });
 
-          expect(
-            foundUserProfile.imageUrl.toString(),
-            allOf(startsWith('http://localhost'), endsWith('.jpg')),
-          );
+          test('then image is accessible stored user.', () async {
+            final foundUserProfile = await UserProfiles.findUserProfileByUserId(
+              session,
+              authUserId,
+            );
+
+            expect(
+              foundUserProfile.imageUrl.toString(),
+              allOf(startsWith('http://localhost'), endsWith('.jpg')),
+            );
+          });
         },
       );
 
-      test(
-        'when creating a user profile with image bytes, then image is accessible on user.',
-        () async {
-          await UserProfiles.createUserProfile(
-            session,
-            authUserId,
-            UserProfileData(userName: 'test_user'),
-            imageSource: UserImageFromBytes(onePixelPng),
-          );
+      group(
+        'when creating a user profile with image bytes',
+        () {
+          late UserProfileModel createdProfile;
+          setUp(() async {
+            createdProfile = await UserProfiles.createUserProfile(
+              session,
+              authUserId,
+              UserProfileData(userName: 'test_user'),
+              imageSource: UserImageFromBytes(onePixelPng),
+            );
+          });
 
-          final foundUserProfile = await UserProfiles.findUserProfileByUserId(
-            session,
-            authUserId,
-          );
+          test('then the returned profile contains the image URL.', () async {
+            expect(
+              createdProfile.imageUrl.toString(),
+              allOf(startsWith('http://localhost'), endsWith('.jpg')),
+            );
+          });
 
-          expect(
-            foundUserProfile.imageUrl.toString(),
-            allOf(startsWith('http://localhost'), endsWith('.jpg')),
-          );
+          test('then image is accessible stored user.', () async {
+            final foundUserProfile = await UserProfiles.findUserProfileByUserId(
+              session,
+              authUserId,
+            );
+
+            expect(
+              foundUserProfile.imageUrl.toString(),
+              allOf(startsWith('http://localhost'), endsWith('.jpg')),
+            );
+          });
         },
       );
     },


### PR DESCRIPTION
Adds support for supplying an image through bytes or URL when creating a user profile.

This is used to skip the second step of attaching an image separately when creating a profile.
This is used for the new auth package.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Optionally add a profile image during user creation using either a URL or uploaded image bytes.
  - Automatically fetches, stores, and associates the image with the new profile, returning an accessible image URL.
  - More reliable image handling during profile setup to ensure correct linkage to the user profile.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->