### PR TITLE
feat: Expose a method to clear storage cache on `ClientAuthSessionManager`

### DIFF
--- a/modules/new_serverpod_auth/serverpod_auth_core/serverpod_auth_core_flutter/lib/src/session_manager.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_core/serverpod_auth_core_flutter/lib/src/session_manager.dart
@@ -5,6 +5,7 @@ import 'package:serverpod_auth_core_client/serverpod_auth_core_client.dart';
 
 import 'auth_key_providers/jwt_auth_key_provider.dart';
 import 'auth_key_providers/sas_auth_key_provider.dart';
+import 'storage/cached_client_auth_info_storage.dart';
 import 'storage/client_auth_info_storage.dart';
 import 'storage/secure_client_auth_info_storage.dart';
 
@@ -116,8 +117,15 @@ class ClientAuthSessionManager implements RefresherClientAuthKeyProvider {
     return validateAuthentication();
   }
 
-  /// Restore the current sign in status from the storage.
+  /// Restore the current sign in status from the storage. If the underlying
+  /// storage implements caching, the cache is cleared before restoring the
+  /// value. This method can be called at any time to get the latest value from
+  /// the storage.
   Future<void> restore() async {
+    final storage = this.storage;
+    if (storage is CachedClientAuthInfoStorage) {
+      await storage.clearCache();
+    }
     _authInfo.value = await storage.get();
   }
 

--- a/modules/new_serverpod_auth/serverpod_auth_core/serverpod_auth_core_flutter/lib/src/storage/cached_client_auth_info_storage.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_core/serverpod_auth_core_flutter/lib/src/storage/cached_client_auth_info_storage.dart
@@ -17,6 +17,13 @@ class CachedClientAuthInfoStorage implements ClientAuthInfoStorage {
 
   AuthSuccess? _cachedData;
 
+  /// Clear the cache for the authentication info, if any. The next call to the
+  /// [get] method will perform the operation on the delegate.
+  Future<void> clearCache() async {
+    _cachedData = null;
+    _cached = false;
+  }
+
   @override
   Future<void> set(AuthSuccess? data) async {
     await _delegate.set(data);

--- a/modules/new_serverpod_auth/serverpod_auth_core/serverpod_auth_core_flutter/test/storage/cached_client_auth_info_storage_test.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_core/serverpod_auth_core_flutter/test/storage/cached_client_auth_info_storage_test.dart
@@ -60,6 +60,17 @@ void main() {
       expect(storage.delegate.storageGetHitCount, 1);
     });
 
+    test(
+        'when calling clearCache before get then subsequent get retrieves from delegate storage.',
+        () async {
+      await storage.get();
+
+      await storage.clearCache();
+      await storage.get();
+
+      expect(storage.delegate.storageGetHitCount, 2);
+    });
+
     group('when calling set with a new AuthSuccess data', () {
       final authSuccessNew = _authSuccess.copyWith(token: 'different-token');
 


### PR DESCRIPTION
Implements the quick solution listed on #4037.

The `ClientAuthSessionManager.restore` method now clears the cache to allow external changes in the storage to be picked up by the current session.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

N/A.