### PR TITLE
fix: Returns false if the database is enabled but turned off.

### DIFF
--- a/packages/serverpod/lib/src/server/health_check.dart
+++ b/packages/serverpod/lib/src/server/health_check.dart
@@ -53,6 +53,7 @@ Future<ServerHealthResult> defaultHealthCheckMetrics(
       dbResponseTime =
           DateTime.now().difference(startTime).inMicroseconds / 1000000.0;
     } catch (e, stackTrace) {
+      dbHealthy = false;
       pod.internalSubmitEvent(
         ExceptionEvent(e, stackTrace),
         space: OriginSpace.framework,


### PR DESCRIPTION
One-off fix without tests since we have no tests for the area.

If the database was enabled but the check failed with an exception, their would not report as unhealthy.

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed health check system to consistently report database health status as unhealthy when exceptions occur, ensuring all health metrics are properly emitted instead of being omitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->