### PR TITLE
fix: Encode records properly if they have Serializable objects inside

### DIFF
--- a/tools/serverpod_cli/lib/src/generator/dart/library_generators/library_generator.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart/library_generators/library_generator.dart
@@ -1448,6 +1448,10 @@ extension on TypeDefinition {
             ),
           ] else
             Code('$name.\$${index + 1}'),
+          if (!positionalField.isSerializedValue)
+            positionalField.nullable
+                ? const Code('?.toJson()')
+                : const Code('.toJson()'),
           const Code(','),
         ],
         const Code('],'),


### PR DESCRIPTION
Encode records properly if they have Serializable objects inside

I hope i get these properties well enough. Not sure if the nullable logic is okay, but it looks so for me

Fixes #4135 

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced JSON serialization to properly handle null-safety in Record types, ensuring correct encoding of all field types during data transformation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->