### PR TITLE
feat: Add cache control and last modified to file endpoint in public storage

### DIFF
--- a/packages/serverpod/lib/src/cloud_storage/database_cloud_storage.dart
+++ b/packages/serverpod/lib/src/cloud_storage/database_cloud_storage.dart
@@ -63,6 +63,26 @@ class DatabaseCloudStorage extends CloudStorage {
     );
   }
 
+  /// Returns file's addedTime (when it was uploaded)
+  ///
+  /// May be useful for caching
+  Future<DateTime?> getFileAddedTime(
+      {required Session session, required String path}) async {
+    final query =
+        'SELECT "addedTime" FROM serverpod_cloud_storage WHERE "storageId"=${EscapedExpression(storageId)} AND path=${EscapedExpression(path)} AND verified=${EscapedExpression(true)}';
+
+    try {
+      var result = await session.db.unsafeQuery(query);
+      if (result.isNotEmpty) {
+        return result.first.first as DateTime;
+      }
+    } catch (e) {
+      throw CloudStorageException('Failed to get added time. ($e)');
+    }
+
+    return null;
+  }
+
   @override
   Future<ByteData?> retrieveFile({
     required Session session,

--- a/packages/serverpod/lib/src/cloud_storage/public_endpoint.dart
+++ b/packages/serverpod/lib/src/cloud_storage/public_endpoint.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 import 'dart:typed_data';
 
+import 'package:intl/intl.dart';
 import 'package:path/path.dart' as p;
 import 'package:serverpod/serverpod.dart';
 import 'package:serverpod/src/generated/cloud_storage_direct_upload.dart';
@@ -45,6 +46,18 @@ class CloudStoragePublicEndpoint extends Endpoint {
       response.headers.contentType = ContentType('application', 'x-font-ttf');
     } else if (extension == '.woff') {
       response.headers.contentType = ContentType('application', 'x-font-woff');
+    }
+
+    // Get file added time so that browsers can cache it
+    final addedTime = await DatabaseCloudStorage('public')
+        .getFileAddedTime(session: session, path: path);
+    if (addedTime != null) {
+      // One year, in seconds
+      response.headers.set(HttpHeaders.cacheControlHeader, 'max-age=31557600');
+      response.headers.set(
+          HttpHeaders.lastModifiedHeader,
+          DateFormat("EEE, dd MMM yyyy HH:mm:ss 'GMT'")
+              .format(addedTime.toUtc()));
     }
 
     // Retrieve the file from storage and return it.

--- a/packages/serverpod/pubspec.yaml
+++ b/packages/serverpod/pubspec.yaml
@@ -24,6 +24,7 @@ dependencies:
   collection: ^1.17.1
   crypto: ^3.0.2
   http: '>=1.1.0 <2.0.0'
+  intl: '>=0.10.0 <1.0.0'
   meta: ^1.11.0
   mustache_template: ^2.0.0
   path: ^1.8.2


### PR DESCRIPTION
feat: Add cache control and last modified to file endpoint in public storage

Well, it's not the cleanest PR - had to 'hack' the date in there - but it works :tada:

I added the `getFileAddedTime` to `DatabaseCloudStorage`, followed using SQL queries like other functions, and then used it directly in `public_endpoint.dart`

I also had to add `intl` as a dependency for weird web date formatting - but i've set very loose version constraints

Really hope you guys merge this because i store a lot of images in my db and it slows the whole app as hell 😖😖

Fixes #3926 

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.
