### PR TITLE
fix: Initialize endpoints on Server start.

### DIFF
--- a/packages/serverpod/lib/src/server/server.dart
+++ b/packages/serverpod/lib/src/server/server.dart
@@ -127,6 +127,14 @@ class Server {
   /// Returns true if the server was started successfully.
   Future<bool> start() async {
     try {
+      endpoints.initializeEndpoints(this);
+    } catch (e, stackTrace) {
+      await _reportFrameworkException(e, stackTrace,
+          message: 'Failed to initialize endpoints.');
+      return false;
+    }
+
+    try {
       final server = RelicServer(() => IOAdapter.bind(
             io.InternetAddress.anyIPv6,
             port: _port,

--- a/packages/serverpod/lib/src/server/serverpod.dart
+++ b/packages/serverpod/lib/src/server/serverpod.dart
@@ -537,7 +537,6 @@ class Serverpod {
       httpOptionsResponseHeaders: httpOptionsResponseHeaders,
       securityContext: _securityContextConfig?.apiServer,
     );
-    endpoints.initializeEndpoints(server);
 
     _internalSession = InternalSession(server: server, enableLogging: false);
 
@@ -933,7 +932,6 @@ class Serverpod {
       httpOptionsResponseHeaders: httpOptionsResponseHeaders,
       securityContext: _securityContextConfig?.insightsServer,
     );
-    endpoints.initializeEndpoints(insightsServer);
 
     return insightsServer;
   }


### PR DESCRIPTION
Moves the initialize call for endpoint from the Serverpod constructor to the server start sequence.

This enables adding dependencies on global state to be configured before the endpoint is constructed.

This will be used in the new auth modules to ensure that AuthConfig is initialized before the endpoint is initialized, enabling us to throw an exception when the server is started with invalid configuration.

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

We don't give a guarantee today when the endpoint is initialized, so this should not be something that users are depending on.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server startup reliability with enhanced error handling for endpoint initialization failures. Server will now properly report and prevent startup if initialization encounters issues.

* **Refactor**
  * Consolidated endpoint initialization logic to execute at a single point during server startup for more predictable initialization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->