### PR TITLE
chore!: Update relic to ^0.10.0

### DIFF
--- a/examples/auth_example/auth_example_server/lib/server.dart
+++ b/examples/auth_example/auth_example_server/lib/server.dart
@@ -2,7 +2,7 @@ import 'dart:io';
 
 import 'package:mailer/mailer.dart';
 import 'package:mailer/smtp_server/gmail.dart';
-import 'package:serverpod/serverpod.dart';
+import 'package:serverpod/serverpod.dart' hide Message;
 
 import 'package:serverpod_auth_server/serverpod_auth_server.dart' as auth;
 

--- a/modules/new_serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/providers/apple/business/apple_idp_utils.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/providers/apple/business/apple_idp_utils.dart
@@ -200,8 +200,8 @@ class AppleIDPUtils {
   Handler serverNotificationHandler(
     final FutureOr<void> Function(AppleServerNotification notification) handler,
   ) {
-    return (final Context ctx) async {
-      final body = await utf8.decodeStream(ctx.request.body.read());
+    return (final Request req) async {
+      final body = await utf8.decodeStream(req.body.read());
 
       final payload = (jsonDecode(body) as Map)['payload'] as String;
 
@@ -211,7 +211,7 @@ class AppleIDPUtils {
 
       await handler(notification);
 
-      return (ctx as RespondableContext).respond(Response.ok());
+      return Response.ok();
     };
   }
 }

--- a/modules/new_serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/providers/apple/business/routes/apple_server_notification_route.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/providers/apple/business/routes/apple_server_notification_route.dart
@@ -13,9 +13,9 @@ class AppleRevokedNotificationRoute extends Route {
         super(methods: {Method.post});
 
   @override
-  FutureOr<HandledContext> handleCall(
+  FutureOr<Result> handleCall(
     final Session _,
-    final RequestContext context,
+    final Request context,
   ) {
     return _utils.revokedNotificationHandler()(context);
   }

--- a/packages/serverpod/lib/serverpod.dart
+++ b/packages/serverpod/lib/serverpod.dart
@@ -15,7 +15,7 @@ export 'package:serverpod/server.dart';
 
 // Web server
 export 'package:serverpod/web_server.dart';
-export 'package:relic/relic.dart' hide ExceptionHandler;
+export 'package:relic/relic.dart';
 
 // Database
 export 'package:serverpod/database.dart';

--- a/packages/serverpod/lib/src/server/endpoint_dispatch.dart
+++ b/packages/serverpod/lib/src/server/endpoint_dispatch.dart
@@ -420,12 +420,12 @@ class StreamParameterDescription<T> {
   StreamParameterDescription({required this.name, required this.nullable});
 }
 
-/// The [Result] of an [Endpoint] method call.
-sealed class Result {}
+/// The [EndpointResult] of an [Endpoint] method call.
+sealed class EndpointResult {}
 
 /// A successful result from an [Endpoint] method call containing the return
 /// value of the call.
-final class ResultSuccess extends Result {
+final class ResultSuccess extends EndpointResult {
   /// The returned value of a successful [Endpoint] method call.
   final dynamic returnValue;
 
@@ -438,7 +438,7 @@ final class ResultSuccess extends Result {
 
 /// The result of a failed [Endpoint] method call where the parameters where not
 /// valid.
-final class ResultInvalidParams extends Result {
+final class ResultInvalidParams extends EndpointResult {
   /// Description of the error.
   final String errorDescription;
 
@@ -453,7 +453,7 @@ final class ResultInvalidParams extends Result {
 
 /// The result of a failed [Endpoint] method call where the
 /// endpoint was not found.
-final class ResultNoSuchEndpoint extends Result {
+final class ResultNoSuchEndpoint extends EndpointResult {
   /// Description of the error.
   final String errorDescription;
 
@@ -537,7 +537,7 @@ enum AuthenticationFailureReason {
 }
 
 /// The result of a failed [Endpoint] method call where authentication failed.
-final class ResultAuthenticationFailed extends Result {
+final class ResultAuthenticationFailed extends EndpointResult {
   /// Description of the error.
   final String errorDescription;
 
@@ -571,7 +571,7 @@ final class ResultAuthenticationFailed extends Result {
 
 /// The result of a failed [Endpoint] method call where an [Exception] was
 /// thrown during execution of the method.
-final class ResultInternalServerError extends Result {
+final class ResultInternalServerError extends EndpointResult {
   /// The Exception that was thrown.
   final String exception;
 
@@ -592,7 +592,7 @@ final class ResultInternalServerError extends Result {
 
 /// The result of a failed [Endpoint] method call, with a custom status code,
 /// and an optional message.
-final class ResultStatusCode extends Result {
+final class ResultStatusCode extends EndpointResult {
   /// The status code to be returned to the client.
   final int statusCode;
 
@@ -609,7 +609,8 @@ final class ResultStatusCode extends Result {
 }
 
 /// The result of a failed [Endpoint] method call, with a custom exception.
-final class ExceptionResult<T extends SerializableException> extends Result {
+final class ExceptionResult<T extends SerializableException>
+    extends EndpointResult {
   /// The exception to be returned to the client.
   final T model;
 

--- a/packages/serverpod/lib/src/web_server/routes/static_route.dart
+++ b/packages/serverpod/lib/src/web_server/routes/static_route.dart
@@ -5,7 +5,7 @@ import 'package:serverpod/serverpod.dart';
 /// Route for serving static assets.
 class StaticRoute extends Route {
   static CacheControlHeader? _defaultFactory(
-    RequestContext ctx,
+    Request ctx,
     FileInfo fileInfo,
   ) =>
       null;
@@ -62,7 +62,6 @@ class StaticRoute extends Route {
   }
 
   @override
-  FutureOr<HandledContext> handleCall(
-          Session session, RequestContext context) =>
+  FutureOr<Result> handleCall(Session session, Request context) =>
       _handler(context);
 }

--- a/packages/serverpod/pubspec.yaml
+++ b/packages/serverpod/pubspec.yaml
@@ -29,7 +29,7 @@ dependencies:
   path: ^1.8.3
   postgres: ^3.4.0
   redis: ^4.0.0
-  relic: ^0.9.1
+  relic: ^0.10.0
   retry: ^3.1.1
   synchronized: ^3.1.0
   system_resources: ^1.6.0

--- a/packages/serverpod_client/pubspec.yaml
+++ b/packages/serverpod_client/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   web_socket_channel: ^3.0.3
 
 dev_dependencies:
-  relic: ^0.9.1
+  relic: ^0.10.0
   serverpod_lints: 3.0.0-alpha.3
   test: ^1.25.5
 

--- a/packages/serverpod_client/test/test_utils/test_http_server.dart
+++ b/packages/serverpod_client/test/test_utils/test_http_server.dart
@@ -37,8 +37,8 @@ abstract class TestHttpServer {
     void Function(Uri httpHost)? onConnected,
     HttpRequestHandler httpRequestHandler,
   ) async {
-    FutureOr<HandledContext> requestHandler(RequestContext context) async {
-      return context.respond(await httpRequestHandler(context.request));
+    FutureOr<Result> requestHandler(Request req) async {
+      return await httpRequestHandler(req);
     }
 
     final server = RelicServer(

--- a/packages/serverpod_client/test/test_utils/test_web_socket_server.dart
+++ b/packages/serverpod_client/test/test_utils/test_web_socket_server.dart
@@ -30,8 +30,8 @@ abstract class TestWebSocketServer {
     void Function(Uri webSocketHost)? onConnected,
     void Function(RelicWebSocket webSocket) webSocketHandler,
   ) async {
-    FutureOr<HandledContext> requestHandler(RequestContext context) async {
-      return context.connect(webSocketHandler);
+    FutureOr<Result> requestHandler(Request req) async {
+      return WebSocketUpgrade(webSocketHandler);
     }
 
     final server = RelicServer(

--- a/templates/pubspecs/packages/serverpod/pubspec.yaml
+++ b/templates/pubspecs/packages/serverpod/pubspec.yaml
@@ -28,7 +28,7 @@ dependencies:
   path: ^1.8.3
   postgres: ^3.4.0
   redis: ^4.0.0
-  relic: ^0.9.1
+  relic: ^0.10.0
   retry: ^3.1.1
   synchronized: ^3.1.0
   system_resources: ^1.6.0

--- a/templates/pubspecs/packages/serverpod_client/pubspec.yaml
+++ b/templates/pubspecs/packages/serverpod_client/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   web_socket_channel: ^3.0.3
 
 dev_dependencies:
-  relic: ^0.9.1
+  relic: ^0.10.0
   serverpod_lints: SERVERPOD_VERSION
   test: ^1.25.5
 

--- a/templates/pubspecs/tests/serverpod_test_server/pubspec.yaml
+++ b/templates/pubspecs/tests/serverpod_test_server/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
   sdk: DART_VERSION
 dependencies:
   http: '>=1.1.0 <2.0.0'
-  relic: ^0.9.1
+  relic: ^0.10.0
   serverpod: SERVERPOD_VERSION
   serverpod_auth_server: SERVERPOD_VERSION
   serverpod_cloud_storage_s3: SERVERPOD_VERSION

--- a/tests/serverpod_test_server/pubspec.yaml
+++ b/tests/serverpod_test_server/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
   sdk: '>=3.5.0 <4.0.0'
 dependencies:
   http: '>=1.1.0 <2.0.0'
-  relic: ^0.9.1
+  relic: ^0.10.0
   serverpod: 3.0.0-alpha.3
   serverpod_auth_server: 3.0.0-alpha.3
   serverpod_cloud_storage_s3: 3.0.0-alpha.3

--- a/tests/serverpod_test_server/test/middleware_test.dart
+++ b/tests/serverpod_test_server/test/middleware_test.dart
@@ -99,15 +99,14 @@ void main() {
 /// Test route that requires authentication (uses ctx.authInfo)
 class TestRoute extends Route {
   @override
-  FutureOr<HandledContext> handleCall(Session session, RequestContext context) {
-    return context.respond(
-        Response.ok(body: Body.fromString(context.authInfo.userIdentifier)));
+  FutureOr<Result> handleCall(Session session, Request req) {
+    return Response.ok(body: Body.fromString(req.authInfo.userIdentifier));
   }
 }
 
 final _authInfoProperty = ContextProperty<AuthenticationInfo>('authInfo');
 
-extension on Context {
+extension on Request {
   AuthenticationInfo get authInfo => _authInfoProperty[this];
 }
 
@@ -115,7 +114,7 @@ class _AuthMiddleware {
   Handler call(Handler next) {
     return (ctx) async {
       final info = await ctx.session.authenticated;
-      if (info == null) return ctx.respond(Response.unauthorized());
+      if (info == null) return Response.unauthorized();
       _authInfoProperty[ctx] = info;
       return next(ctx);
     };


### PR DESCRIPTION
## Changes

- Updated `relic` dependency from `^0.9.1` to `^0.10.0` across all packages and templates

### API Migration
The main breaking change in Relic 0.10.0 is the simplification of the request handling API:

1. Context API removed: `Context`, `RequestContext`, `RespondableContext`, and `HandledContext` have been removed.
2. Direct Request/Response handling: Handlers now work directly with `Request` and return `Response` (or other `Result` sub-types).
3. `context.connect()` replaced with `WebSocketUpgrade`
4. Renamed Result type: Internal `Result` type renamed to `EndpointResult` to avoid conflicts with Relic's `Result`

### Code Changes
- Updated all route handlers to use new signature: `FutureOr<Result> handleCall(Session session, Request req)`
- Replaced `context.respond(response)` with direct `return response`
- Updated WebSocket upgrade handling to use `WebSocketUpgrade` constructor
- Renamed internal `Result` type to `EndpointResult` to avoid naming conflicts
- Updated middleware to work with `Request` directly instead of `Context`
- Added `hide Message` clause to avoid conflicts with mailer package in auth_example

Fixes #?

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

This is a breaking change for users who have custom routes or middleware:

1. Route handlers must update their signature from:
   ```dart
   FutureOr<HandledContext> handleCall(Session session, RequestContext context)
   ```
   to:
   ```dart
   FutureOr<Result> handleCall(Session session, Request request)
   ```

2. Response handling must change from:
   ```dart
   return context.respond(Response.ok(...));
   ```
   to:
   ```dart
   return Response.ok(...);
   ```

3. WebSocket upgrades must change from:
   ```dart
   return context.connect((webSocket) async { ... });
   ```
   to:
   ```dart
   return WebSocketUpgrade((webSocket) async { ... });
   ```

4. Middleware must update to work with `Request` directly instead of `Context`:
   ```dart
   Handler call(Handler next) {
     return (req) async {  // Changed from (ctx)
       // Work with req directly
       return await next(req);
     };
   }
   ```

5. Context properties now attach to `Request` instead of `Context`:
   ```dart
   extension on Request {  // Changed from Context
     Session get session => _sessionProperty[this];
   }
   ```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Modernized internal request and response handling infrastructure for improved maintainability.

* **Chores**
  * Updated the relic dependency to version 0.10.0 for enhanced functionality and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->