### PR TITLE
fix: Fix `signOut` not completing locally on network/server errors

### DIFF
--- a/modules/new_serverpod_auth/serverpod_auth_core/serverpod_auth_core_flutter/lib/src/session_manager.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_core/serverpod_auth_core_flutter/lib/src/session_manager.dart
@@ -164,15 +164,16 @@ class ClientAuthSessionManager implements RefresherClientAuthKeyProvider {
         case false:
           await caller.status.signOutDevice();
       }
-
-      // Must be updated after the signout for the server to receive the header
-      // info and recognize the signing out user. Otherwise, the call to the
-      // status endpoint will go with no user info and no signout will be done.
-      await updateSignedInUser(null);
-
       return true;
     } catch (e) {
       return false;
+    } finally {
+      // Must be updated after the signout for the server to receive the header
+      // info and recognize the signing out user. Otherwise, the call to the
+      // status endpoint will go with no user info and no signout will be done.
+      // Called from finally block to ensure the device is disconnected, even
+      // if the call to the server fails.
+      await updateSignedInUser(null);
     }
   }
 


### PR DESCRIPTION
Fix sign out methods on client not disconnecting the application when server is unreachable.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.