### PR TITLE
refactor!: Use Headers class instead of Map<String, String> when passing headers

### DIFF
--- a/packages/serverpod/lib/src/server/serverpod.dart
+++ b/packages/serverpod/lib/src/server/serverpod.dart
@@ -323,21 +323,29 @@ class Serverpod {
 
   /// HTTP headers used by all API responses. Defaults to allowing any
   /// cross origin resource sharing (CORS).
-  final Map<String, dynamic> httpResponseHeaders;
+  final Headers httpResponseHeaders;
 
   /// HTTP headers used for OPTIONS responses. These headers are sent in
   /// addition to the [httpResponseHeaders] when the request method is OPTIONS.
-  final Map<String, dynamic> httpOptionsResponseHeaders;
+  final Headers httpOptionsResponseHeaders;
 
-  static const _defaultHttpResponseHeaders = {
-    'Access-Control-Allow-Origin': '*',
-    'Access-Control-Allow-Methods': 'POST',
-  };
+  static final _defaultHttpResponseHeaders = Headers.build((mh) {
+    mh.accessControlAllowOrigin =
+        const AccessControlAllowOriginHeader.wildcard();
+    mh.accessControlAllowMethods =
+        AccessControlAllowMethodsHeader.methods(methods: [Method.post]);
+  });
 
-  static const _defaultHttpOptionsResponseHeaders = {
-    'Access-Control-Allow-Headers':
-        'Content-Type, Authorization, Accept, User-Agent, X-Requested-With',
-  };
+  static final _defaultHttpOptionsResponseHeaders = Headers.build((mh) {
+    mh.accessControlAllowHeaders =
+        AccessControlAllowHeadersHeader.headers(headers: [
+      'Content-Type',
+      'Authorization',
+      'Accept',
+      'User-Agent',
+      'X-Requested-With',
+    ]);
+  });
 
   /// Security context if the insights server is running over https.
   final SecurityContextConfig? _securityContextConfig;
@@ -366,12 +374,16 @@ class Serverpod {
     ServerpodConfig? config,
     this.authenticationHandler,
     this.healthCheckHandler,
-    this.httpResponseHeaders = _defaultHttpResponseHeaders,
-    this.httpOptionsResponseHeaders = _defaultHttpOptionsResponseHeaders,
+    Headers? httpResponseHeaders,
+    Headers? httpOptionsResponseHeaders,
     SecurityContextConfig? securityContextConfig,
     ExperimentalFeatures? experimentalFeatures,
     this.runtimeParametersBuilder,
-  })  : _securityContextConfig = securityContextConfig,
+  })  : httpResponseHeaders =
+            httpResponseHeaders ?? _defaultHttpResponseHeaders,
+        httpOptionsResponseHeaders =
+            httpOptionsResponseHeaders ?? _defaultHttpOptionsResponseHeaders,
+        _securityContextConfig = securityContextConfig,
         _experimental = ExperimentalApi._(
           config: config,
           experimentalFeatures: experimentalFeatures,


### PR DESCRIPTION
## Description

Refactors HTTP header handling to use relic's `Headers` type instead of `Map<String, dynamic>`.

### Changes:

- Updated `httpResponseHeaders` and `httpOptionsResponseHeaders` fields in `Server` and `Serverpod` classes from `Map<String, dynamic>` to `Headers`
- Simplified `_headers()` handler to work directly with `Headers` instances using `Headers.transform()`
- Converted default header constants to use `Headers.build()`

Fixes #4102 

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else.
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

## Breaking changes

Users who directly instantiate `Serverpod` or `Server` with custom headers need to use `Headers.build()` instead of Map literals. Users relying on default headers are not affected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced type safety for HTTP header configuration with improved internal header management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->