### PR TITLE
feat: Implement lazy scanning for future calls in FutureCallManager and FutureCallScanner

### DIFF
--- a/packages/serverpod/lib/src/server/future_call_manager/future_call_manager.dart
+++ b/packages/serverpod/lib/src/server/future_call_manager/future_call_manager.dart
@@ -43,6 +43,7 @@ class FutureCallManager {
 
   late final ServerpodTaskScheduler _scheduler;
   late final FutureCallScanner _scanner;
+  bool _startRequested = false;
 
   /// Creates a new [FutureCallManager]. Typically, this is instantiated
   /// internally by the [Serverpod].
@@ -101,11 +102,18 @@ class FutureCallManager {
     _initializeFutureCall(futureCall, name);
 
     _futureCalls[name] = futureCall;
+
+    if (_startRequested && !_scanner.isRunning) {
+      _scanner.start();
+    }
   }
 
   /// Executes all scheduled future calls that are past their due date. This
   /// method scans the database for overdue tasks and processes them.
   Future<void> runScheduledFutureCalls() async {
+    if (_futureCalls.isEmpty) {
+      return;
+    }
     stdout.writeln('Processing future calls.');
 
     await _scanner.scanFutureCallEntries();
@@ -149,13 +157,20 @@ class FutureCallManager {
   /// Starts the [FutureCallManager], enabling it to monitor the database
   /// for overdue future calls and execute them automatically.
   void start() {
-    _scanner.start();
+    _startRequested = true;
+    if (_futureCalls.isNotEmpty && !_scanner.isRunning) {
+      _scanner.start();
+    }
   }
 
   /// Stops the [FutureCallManager], preventing it from monitoring and
   /// executing overdue future calls.
   Future<void> stop() async {
     await _scanner.stop();
+    _startRequested = false;
+    if (_scanner.isRunning) {
+      await _scanner.stop();
+    }
     await _scheduler.drain();
   }
 

--- a/packages/serverpod/lib/src/server/future_call_manager/future_call_scanner.dart
+++ b/packages/serverpod/lib/src/server/future_call_manager/future_call_scanner.dart
@@ -26,7 +26,11 @@ class FutureCallScanner {
   final DispatchEntries _dispatchEntries;
 
   bool _isStopping = false;
+  bool _isRunning = false;
 
+  /// Whether the scanner is currently running and scheduled to perform
+  /// periodic scans.
+  bool get isRunning => _isRunning;
   var _scanCompleter = Completer<void>()..complete();
 
   /// Creates a new [FutureCallScanner].
@@ -108,6 +112,7 @@ class FutureCallScanner {
       _scanInterval,
       (_) => scanFutureCallEntries(),
     );
+    _isRunning = true;
   }
 
   /// Stops the task scanner.
@@ -117,5 +122,8 @@ class FutureCallScanner {
     _timer?.cancel();
 
     await _scanCompleter.future;
+    _timer = null;
+    _isStopping = false;
+    _isRunning = false;
   }
 }


### PR DESCRIPTION
Serverpod currently attempts to execute future calls even when there are no future calls registered. This leads to unnecessary queries to the database.
This PR enhances the FutureCallManager and FutureCallScanner classes to check if any future calls are registered, and only then run the queries.

Fixes: #4054 


## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.