### PR TITLE
fix: Add "" around all variables in table warnings

### DIFF
--- a/tools/serverpod_cli/lib/src/database/migration.dart
+++ b/tools/serverpod_cli/lib/src/database/migration.dart
@@ -232,7 +232,7 @@ TableMigration? generateTableMigration(
               table: srcTable.name,
               columns: [srcColumn.name],
               message:
-                  'Column ${srcColumn.name} of table ${srcTable.name} is '
+                  'Column "${srcColumn.name}" of table "${srcTable.name}" is '
                   'modified to be not null. If there are existing rows with '
                   'null values, this migration will fail.',
               destrucive: false,
@@ -249,7 +249,7 @@ TableMigration? generateTableMigration(
             table: srcTable.name,
             columns: [srcColumn.name],
             message:
-                'Column ${srcColumn.name} of table ${srcTable.name} is '
+                'Column "${srcColumn.name}" of table "${srcTable.name}" is '
                 'modified in a way that it must be deleted and recreated.',
             destrucive: true,
           ),

--- a/tools/serverpod_cli/test/database/migration/default_value_test.dart
+++ b/tools/serverpod_cli/test/database/migration/default_value_test.dart
@@ -372,7 +372,7 @@ void main() {
         expect(warnings, hasLength(1));
         expect(
           warnings.first.message,
-          'Column id of table example_table is modified in a way that it '
+          'Column "id" of table "example_table" is modified in a way that it '
           'must be deleted and recreated.',
         );
       });


### PR DESCRIPTION
Fixes a minor issue where sometimes variables were not surrounded by double quotes in migration warnings.

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

_If you have done any breaking changes, make sure to outline them here, so that they can be included in the notes for the next release._