### PR TITLE
feat: Expose full RelicRouter interface on WebServer

### DIFF
--- a/packages/serverpod/lib/src/web_server/web_server.dart
+++ b/packages/serverpod/lib/src/web_server/web_server.dart
@@ -64,16 +64,23 @@ class WebServer {
   void addMiddleware(Middleware middleware, String path) =>
       _app.use(path, middleware);
 
-  /// Sets a fallback [route] to use if no other registered [Route] matches
-  /// a request.
+  /// Sets a fallback [route] to use if no other registered [Route] matches a
+  /// request.
   ///
   /// If not set, default behavior is to return "404 Not Found".
+  ///
+  /// Note that if a [Route] **is** matched, but the handler returns 404, then
+  /// the fallback [route] is **not** called. To rewrite 404s you should use
+  /// middleware.
   set fallbackRoute(Route route) =>
       _app.fallback = _ReportExceptionMiddleware(this)(
         _SessionMiddleware(
           serverpod.server,
         )(route.asHandler),
       );
+
+  /// Get access to the full [RelicRouter] for advanced use-cases.
+  RelicRouter get router => _app;
 
   /// Returns true if the webserver has any routes registered.
   bool get hasRoutes => !_app.isEmpty;


### PR DESCRIPTION
Expose `RelicRouter` via `WebServer.router` getter for advanced use-cases. Also clarifies `fallbackRoute` docs to note it's not called when a route matches but returns 404.

Fixes #4346 

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else.
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

## Breaking changes

None.