### PR TITLE
chore: Upgrade relic to 0.13.1

### DIFF
--- a/packages/serverpod/lib/src/server/server.dart
+++ b/packages/serverpod/lib/src/server/server.dart
@@ -204,8 +204,7 @@ class Server implements RouterInjectable {
       try {
         return await next(req);
       } on MaxBodySizeExceeded catch (e) {
-        return Response(
-          io.HttpStatus.requestEntityTooLarge,
+        return Response.contentTooLarge(
           body: Body.fromString(
             'Request size exceeds the maximum allowed size of ${e.maxLength} bytes.',
           ),

--- a/packages/serverpod/pubspec.yaml
+++ b/packages/serverpod/pubspec.yaml
@@ -29,7 +29,7 @@ dependencies:
   path: ^1.8.3
   postgres: ^3.4.0
   redis: ^4.0.0
-  relic: ^0.13.0
+  relic: ^0.13.1
   retry: ^3.1.1
   serverpod_serialization: 3.0.0-rc.4
   serverpod_shared: 3.0.0-rc.4

--- a/packages/serverpod_client/pubspec.yaml
+++ b/packages/serverpod_client/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   web_socket_channel: ^3.0.3
 
 dev_dependencies:
-  relic: ^0.13.0
+  relic: ^0.13.1
   serverpod_lints: 3.0.0-rc.4
   test: ^1.25.5
 

--- a/templates/pubspecs/packages/serverpod/pubspec.yaml
+++ b/templates/pubspecs/packages/serverpod/pubspec.yaml
@@ -28,7 +28,7 @@ dependencies:
   path: ^1.8.3
   postgres: ^3.4.0
   redis: ^4.0.0
-  relic: ^0.13.0
+  relic: ^0.13.1
   retry: ^3.1.1
   serverpod_serialization: SERVERPOD_VERSION
   serverpod_shared: SERVERPOD_VERSION

--- a/templates/pubspecs/packages/serverpod_client/pubspec.yaml
+++ b/templates/pubspecs/packages/serverpod_client/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   web_socket_channel: ^3.0.3
 
 dev_dependencies:
-  relic: ^0.13.0
+  relic: ^0.13.1
   serverpod_lints: SERVERPOD_VERSION
   test: ^1.25.5
 

--- a/templates/pubspecs/tests/serverpod_test_server/pubspec.yaml
+++ b/templates/pubspecs/tests/serverpod_test_server/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
   sdk: DART_VERSION
 dependencies:
   http: '>=1.1.0 <2.0.0'
-  relic: ^0.13.0
+  relic: ^0.13.1
   serverpod: SERVERPOD_VERSION
   serverpod_auth_server: SERVERPOD_VERSION
   serverpod_cloud_storage_s3: SERVERPOD_VERSION

--- a/tests/serverpod_test_server/pubspec.yaml
+++ b/tests/serverpod_test_server/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
   sdk: '^3.8.0'
 dependencies:
   http: '>=1.1.0 <2.0.0'
-  relic: ^0.13.0
+  relic: ^0.13.1
   serverpod: 3.0.0-rc.4
   serverpod_auth_server: 3.0.0-rc.4
   serverpod_cloud_storage_s3: 3.0.0-rc.4


### PR DESCRIPTION
Update relic to 0.13.1. Includes fix for connection management in face of too big requests.