### PR TITLE
feat: Add padding support to EmailSignInWidget

### DIFF
--- a/modules/new_serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_flutter/lib/src/email/email_sign_in_widget.dart
+++ b/modules/new_serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_flutter/lib/src/email/email_sign_in_widget.dart
@@ -102,7 +102,7 @@ class EmailSignInWidget extends StatefulWidget {
   ///
   /// Defaults to 1 minute.
   final Duration resendCountdownDuration;
-   
+
   /// Optional custom padding to apply around the widget's content.
   ///
   /// If null, the widget uses a default padding of 10.0 logical pixels
@@ -197,9 +197,7 @@ class _EmailSignInWidgetState extends State<EmailSignInWidget> {
 
   Widget _buildScreen() {
     return switch (_controller.currentScreen) {
-      EmailFlowScreen.login => LoginForm(
-        controller: _controller,
-      ),
+      EmailFlowScreen.login => LoginForm(controller: _controller),
       EmailFlowScreen.startRegistration => StartRegistrationForm(
         controller: _controller,
         onTermsAndConditionsPressed: widget.onTermsAndConditionsPressed,


### PR DESCRIPTION
I’ve made some improvements to the original EmailSignInWidget. The widget didn’t include any default padding, which caused the UI to look cramped and visually unbalanced. To fix this, I added an optional padding parameter with a sensible default value so the layout looks cleaner and more polished out of the box


Before:

<img width="1243" height="657" alt="before" src="https://github.com/user-attachments/assets/a50bfbd8-c820-477b-928c-cece3ecc1305" />

After: 

<img width="1195" height="641" alt="after" src="https://github.com/user-attachments/assets/366a675e-c6ce-40de-b3de-6ac522fa728e" />

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

_If you have done any breaking changes, make sure to outline them here, so that they can be included in the notes for the next release._