### PR TITLE
fix: Don't double bind the std out streams.

### DIFF
--- a/tools/serverpod_cli/lib/src/commands/run.dart
+++ b/tools/serverpod_cli/lib/src/commands/run.dart
@@ -109,6 +109,9 @@ class RunCommand extends ServerpodCommand<RunOption> {
     final exitCode = await ScriptExecutor.executeScript(
       script,
       workingDirectory,
+      stdout: stdout,
+      stderr: stderr,
+      stdin: stdin,
     );
 
     if (exitCode != 0) {

--- a/tools/serverpod_cli/lib/src/scripts/script_executor.dart
+++ b/tools/serverpod_cli/lib/src/scripts/script_executor.dart
@@ -16,8 +16,11 @@ class ScriptExecutor {
   /// [workingDirectory] - The directory in which to execute the script
   static Future<int> executeScript(
     Script script,
-    Directory workingDirectory,
-  ) async {
+    Directory workingDirectory, {
+    required IOSink stdout,
+    required IOSink stderr,
+    Stream<List<int>>? stdin,
+  }) async {
     final shell = Platform.isWindows ? 'cmd' : 'bash';
     final shellArg = Platform.isWindows ? '/c' : '-c';
 
@@ -42,7 +45,7 @@ class ScriptExecutor {
         });
 
     // Forward stdin to the child process
-    final stdinSubscription = stdin.listen(
+    final stdinSubscription = stdin?.listen(
       process.stdin.add,
       cancelOnError: true,
       onError: (_) {}, // extremely unlikely, but why not
@@ -54,9 +57,9 @@ class ScriptExecutor {
       stderr.addStream(process.stderr),
     ].wait;
     await process.stdin.close();
-    await stdinSubscription.cancel();
+    await stdinSubscription?.cancel();
     await sigSubscription.cancel();
 
-    return process.exitCode;
+    return await process.exitCode;
   }
 }

--- a/tools/serverpod_cli/test/scripts/script_executor_test.dart
+++ b/tools/serverpod_cli/test/scripts/script_executor_test.dart
@@ -23,10 +23,10 @@ Future<ScriptResult> _runScript(
       return await ScriptExecutor.executeScript(
         script,
         workingDirectory,
+        stdout: stdout,
+        stderr: stderr,
       );
     },
-    stdout: () => stdout,
-    stderr: () => stderr,
     stdin: () => stdin,
   );
 


### PR DESCRIPTION
Fixes a recently added issue where we accidentally bound multiple times to std out.

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None, touches functionality that was just introduced.