### PR TITLE
fix: Ensure consistent copy behavior for flutter_build script.

### DIFF
--- a/templates/pubspecs/templates/serverpod_templates/projectname_server/pubspec.yaml
+++ b/templates/pubspecs/templates/serverpod_templates/projectname_server/pubspec.yaml
@@ -36,4 +36,4 @@ serverpod:
     # Unfortunately, we can't use the `-o` flag directly because of an error
     # that happens on windows. Issue is tracked in the flutter
     # repository here: https://github.com/flutter/flutter/issues/157886
-    flutter_build: rm -rf web/app && cd ../projectname_flutter && flutter build web --base-href /app/ --wasm && mv build/web/ ../projectname_server/web/app
+    flutter_build: cd ../projectname_flutter && flutter build web --base-href /app/ --wasm && rm -rf ../projectname_server/web/app && mv build/web/ ../projectname_server/web/app

--- a/templates/serverpod_templates/projectname_server/pubspec.yaml
+++ b/templates/serverpod_templates/projectname_server/pubspec.yaml
@@ -36,4 +36,4 @@ serverpod:
     # Unfortunately, we can't use the `-o` flag directly because of an error
     # that happens on windows. Issue is tracked in the flutter
     # repository here: https://github.com/flutter/flutter/issues/157886
-    flutter_build: rm -rf web/app && cd ../projectname_flutter && flutter build web --base-href /app/ --wasm && mv build/web/ ../projectname_server/web/app
+    flutter_build: cd ../projectname_flutter && flutter build web --base-href /app/ --wasm && rm -rf ../projectname_server/web/app && mv build/web/ ../projectname_server/web/app


### PR DESCRIPTION
If the directory existed, the build script would place the contents inside of a web folder inside of the directory.
If it didn't exist it would correctly create an app folder with the contents.

This PR modified the behavior so that it becomes consistent.

CI should inform us if this works as expected on Windows.

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None, fixes an unreleased script.