### PR TITLE
fix: Ensure dart sdk path is found correctly from compiled code as well

### DIFF
--- a/tools/serverpod_cli/lib/src/analyzer/dart/endpoints_analyzer.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/dart/endpoints_analyzer.dart
@@ -334,6 +334,9 @@ class EndpointsAnalyzer {
   }
 }
 
+/// Find the path to the Dart SDK
+// This is needed to work around this issue with the analyzer package:
+// https://github.com/dart-lang/sdk/issues/48002
 String? _findDartSdk() {
   // If running as a script, resolvedExecutable points to dart binary
   var dartSdk = _sdkPathFromDartExe(Platform.resolvedExecutable);


### PR DESCRIPTION
## Description

Fix Dart SDK discovery for AOT-compiled serverpod CLI.

- `AnalysisContextCollection` cannot auto-detect SDK when running as compiled executable
- Add `_findDartSdk()` to explicitly locate SDK path
- Try `Platform.resolvedExecutable` first (works when running via `dart run`)
- Fall back to `DART_SDK` and `FLUTTER_ROOT` env vars
- Final fallback: locate `dart` via PATH and resolve symlinks
- Handles both pure Dart (`sdk/bin/dart`) and Flutter (`flutter/bin/cache/dart-sdk`) layouts

Fixes #4481

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else.
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

## Breaking changes

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced Dart SDK detection in CLI analysis tools, now automatically resolving SDK paths from multiple sources across all supported platforms. The analyzer intelligently searches for SDK in environment variables, resolved executables, Flutter installations, and system PATH, improving cross-platform compatibility and tool initialization reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->