### PR TITLE
fix: Avoid flutter_build script calling rm on windows

### DIFF
--- a/templates/pubspecs/templates/serverpod_templates/projectname_server/pubspec.yaml
+++ b/templates/pubspecs/templates/serverpod_templates/projectname_server/pubspec.yaml
@@ -31,9 +31,15 @@ serverpod:
     # Starts the server and applies migrations
     start: dart bin/main.dart --apply-migrations
 
-    # Build the Flutter web app and move it to the server's web directory
-    # 
-    # Unfortunately, we can't use the `-o` flag directly because of an error
-    # that happens on windows. Issue is tracked in the flutter
-    # repository here: https://github.com/flutter/flutter/issues/157886
-    flutter_build: cd ../projectname_flutter && flutter build web --base-href /app/ --wasm && rm -rf ../projectname_server/web/app && mv build/web/ ../projectname_server/web/app
+    # Build the Flutter web app and copy it to the server's web directory.
+    # Windows uses xcopy since flutter's --output flag doesn't work there.
+    # See: https://github.com/flutter/flutter/issues/157886
+    flutter_build:
+      windows: >-
+        (if exist web\app rmdir /S /Q web\app)
+        & cd /D ..\projectname_flutter
+        && flutter build web --base-href /app/ --wasm
+        && xcopy /E /I /Y build\web ..\projectname_server\web\app
+      posix: |
+        cd ../projectname_flutter
+        flutter build web --base-href /app/ --wasm --output ../projectname_server/web/app

--- a/templates/serverpod_templates/projectname_server/pubspec.yaml
+++ b/templates/serverpod_templates/projectname_server/pubspec.yaml
@@ -31,9 +31,15 @@ serverpod:
     # Starts the server and applies migrations
     start: dart bin/main.dart --apply-migrations
 
-    # Build the Flutter web app and move it to the server's web directory
-    # 
-    # Unfortunately, we can't use the `-o` flag directly because of an error
-    # that happens on windows. Issue is tracked in the flutter
-    # repository here: https://github.com/flutter/flutter/issues/157886
-    flutter_build: cd ../projectname_flutter && flutter build web --base-href /app/ --wasm && rm -rf ../projectname_server/web/app && mv build/web/ ../projectname_server/web/app
+    # Build the Flutter web app and copy it to the server's web directory.
+    # Windows uses xcopy since flutter's --output flag doesn't work there.
+    # See: https://github.com/flutter/flutter/issues/157886
+    flutter_build:
+      windows: >-
+        (if exist web\app rmdir /S /Q web\app)
+        & cd /D ..\projectname_flutter
+        && flutter build web --base-href /app/ --wasm
+        && xcopy /E /I /Y build\web ..\projectname_server\web\app
+      posix: |
+        cd ../projectname_flutter
+        flutter build web --base-href /app/ --wasm --output ../projectname_server/web/app


### PR DESCRIPTION
Adds platform-specific `flutter_build` scripts for the server template.

- Replaces single cross-platform command with separate `windows` and `posix` variants
- Windows script uses native commands (`rmdir`, `xcopy`, backslash paths)
- POSIX script uses the `--output` flag directly (works on non-Windows platforms)

Fixes #4489
Fixes #4466

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Flutter build configuration with platform-specific handling for Windows and POSIX systems.
  * Enhanced build process reliability and cross-platform output directory management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->