### PR TITLE
chore: Invert the token generate step on the publish CI to postpone token expiration

### DIFF
--- a/.github/workflows/publish-serverpod.yaml
+++ b/.github/workflows/publish-serverpod.yaml
@@ -34,9 +34,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Set up Dart SDK
-        uses: dart-lang/setup-dart@v1
-
       - name: Read version files
         id: versions
         run: |
@@ -51,6 +48,9 @@ jobs:
         with:
           flutter-version: ${{ steps.versions.outputs.flutter_version_clean }}
           channel: 'stable'
+
+      - name: Set up Dart SDK
+        uses: dart-lang/setup-dart@v1
 
       - name: Get dependencies for CLI
         run: |


### PR DESCRIPTION
Fixes: #4292

The idea is to create the token after the Flutter setup step, which consumes nearly half of what seems to be the expiration time of the token (5 minutes). Since we publish ~28 packages in 2min30sec, doubling the liveness of the key will open a lot of space before we end up with a similar timeout error.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.