### PR TITLE
fix: Fix Google lightweight sign-in being invoked when user authenticated

### DIFF
--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_flutter/lib/src/google/google_auth_controller.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_flutter/lib/src/google/google_auth_controller.dart
@@ -109,6 +109,8 @@ class GoogleAuthController extends ChangeNotifier {
 
   /// Initializes the Google Sign-In service and sets up auth event listeners.
   Future<void> _initialize() async {
+    if (_isInitialized) return;
+
     try {
       final signIn = await GoogleSignInService.instance.ensureInitialized(
         auth: client.auth,
@@ -119,7 +121,7 @@ class GoogleAuthController extends ChangeNotifier {
         onError: _handleAuthenticationError,
       );
 
-      if (attemptLightweightSignIn) {
+      if (!isAuthenticated && attemptLightweightSignIn) {
         unawaited(signIn.attemptLightweightAuthentication());
       }
 


### PR DESCRIPTION
Fixes: #4437

Fixes the issue where Google lightweight sign-in was being invoked every app start.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.