### PR TITLE
docs: Fix wrong hint on IDP auth controllers to navigate to Home using `onAuthenticated`

### DIFF
--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_flutter/lib/src/apple/apple_auth_controller.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_flutter/lib/src/apple/apple_auth_controller.dart
@@ -19,7 +19,10 @@ import 'apple_sign_in_service.dart';
 /// final controller = AppleAuthController(
 ///   client: client,
 ///   onAuthenticated: () {
-///     // Navigate to home screen
+///     // Do something when the user is authenticated.
+///     //
+///     // NOTE: You should not navigate to the home screen here, otherwise
+///     // the user will have to sign in again every time they open the app.
 ///   },
 /// );
 ///

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_flutter/lib/src/email/email_auth_controller.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_flutter/lib/src/email/email_auth_controller.dart
@@ -49,7 +49,10 @@ enum EmailFlowScreen {
 /// final controller = EmailAuthController(
 ///   client: client,
 ///   onAuthenticated: () {
-///     // Navigate to home screen
+///     // Do something when the user is authenticated.
+///     //
+///     // NOTE: You should not navigate to the home screen here, otherwise
+///     // the user will have to sign in again every time they open the app.
 ///   },
 /// );
 ///

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_flutter/lib/src/firebase/firebase_auth_controller.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_flutter/lib/src/firebase/firebase_auth_controller.dart
@@ -16,7 +16,10 @@ import 'firebase_sign_in_service.dart';
 /// final controller = FirebaseAuthController(
 ///   client: client,
 ///   onAuthenticated: () {
-///     // Navigate to home screen
+///     // Do something when the user is authenticated.
+///     //
+///     // NOTE: You should not navigate to the home screen here, otherwise
+///     // the user will have to sign in again every time they open the app.
 ///   },
 /// );
 ///

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_flutter/lib/src/google/google_auth_controller.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_flutter/lib/src/google/google_auth_controller.dart
@@ -19,7 +19,10 @@ import 'google_sign_in_service.dart';
 /// final controller = GoogleAuthController(
 ///   client: client,
 ///   onAuthenticated: () {
-///     // Navigate to home screen
+///     // Do something when the user is authenticated.
+///     //
+///     // NOTE: You should not navigate to the home screen here, otherwise
+///     // the user will have to sign in again every time they open the app.
 ///   },
 /// );
 ///


### PR DESCRIPTION
Small docs fix for all IDP controllers.

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.