### PR TITLE
fix: Prevent Google lightweight sign-in from automatically shadowing other identity providers

### DIFF
--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_flutter/lib/src/google/google_auth_controller.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_flutter/lib/src/google/google_auth_controller.dart
@@ -72,7 +72,7 @@ class GoogleAuthController extends ChangeNotifier {
     required this.client,
     this.onAuthenticated,
     this.onError,
-    this.attemptLightweightSignIn = true,
+    this.attemptLightweightSignIn = false,
     this.scopes = defaultScopes,
   }) {
     unawaited(_initialize());

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_flutter/lib/src/google/google_sign_in_widget.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_flutter/lib/src/google/google_sign_in_widget.dart
@@ -154,7 +154,7 @@ class GoogleSignInWidget extends StatefulWidget {
     this.client,
     this.onAuthenticated,
     this.onError,
-    this.attemptLightweightSignIn = true,
+    this.attemptLightweightSignIn = false,
     this.scopes = GoogleAuthController.defaultScopes,
     this.type = GSIButtonType.standard,
     this.theme = GSIButtonTheme.outline,


### PR DESCRIPTION
Fixes: #4568

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

Since this is an auxiliary feature that can be enabled using the `attemptLightweightSignIn` parameter and developers won't expect (or know about it) by default, this is not considered a breaking change.