### PR TITLE
fix: Fix flaky last database operation test by making it non-concurrent

### DIFF
--- a/tests/serverpod_test_server/test_integration/database_operations/last_database_operation_test.dart
+++ b/tests/serverpod_test_server/test_integration/database_operations/last_database_operation_test.dart
@@ -1,82 +1,88 @@
 import 'package:serverpod/serverpod.dart';
 import 'package:serverpod_test_server/src/generated/protocol.dart';
 import 'package:test/test.dart';
+import 'package:serverpod_test_server/test_util/test_tags.dart';
 
 import '../test_tools/serverpod_test_tools.dart';
 
 void main() async {
-  withServerpod('Given a running server', enableSessionLogging: false, (
-    sessionBuilder,
-    endpoints,
-  ) {
-    late Session session;
-    late Serverpod serverpod;
+  withServerpod(
+    'Given a running server',
+    testGroupTagsOverride: [TestTags.concurrencyOneTestTag],
+    enableSessionLogging: false,
+    (
+      sessionBuilder,
+      endpoints,
+    ) {
+      late Session session;
+      late Serverpod serverpod;
 
-    setUp(() {
-      session = sessionBuilder.build();
-      serverpod = session.serverpod;
-    });
+      setUp(() {
+        session = sessionBuilder.build();
+        serverpod = session.serverpod;
+      });
 
-    test('when server starts '
-        'then lastDatabaseOperationTime is set due to startup routines', () {
-      expect(serverpod.lastDatabaseOperationTime, isNotNull);
-    });
+      test('when server starts '
+          'then lastDatabaseOperationTime is set due to startup routines', () {
+        expect(serverpod.lastDatabaseOperationTime, isNotNull);
+      });
 
-    test('when no database operations are performed '
-        'then lastDatabaseOperationTime is not updated', () async {
-      final beforeOperation = serverpod.lastDatabaseOperationTime!;
+      test('when no database operations are performed '
+          'then lastDatabaseOperationTime is not updated', () async {
+        final beforeOperation = serverpod.lastDatabaseOperationTime!;
 
-      await Future.delayed(const Duration(seconds: 2));
-      expect(serverpod.lastDatabaseOperationTime, equals(beforeOperation));
-    });
+        await Future.delayed(const Duration(seconds: 2));
+        expect(serverpod.lastDatabaseOperationTime, equals(beforeOperation));
+      });
 
-    test('when performing any database operation '
-        'then lastDatabaseOperationTime is updated', () async {
-      final beforeOperation = serverpod.lastDatabaseOperationTime!;
+      test('when performing any database operation '
+          'then lastDatabaseOperationTime is updated', () async {
+        final beforeOperation = serverpod.lastDatabaseOperationTime!;
 
-      await SimpleData.db.insertRow(session, SimpleData(num: 1));
+        await SimpleData.db.insertRow(session, SimpleData(num: 1));
 
-      final afterOperation = serverpod.lastDatabaseOperationTime!;
-      expect(afterOperation.isAfter(beforeOperation), isTrue);
-    });
+        final afterOperation = serverpod.lastDatabaseOperationTime!;
+        expect(afterOperation.isAfter(beforeOperation), isTrue);
+      });
 
-    test('when performing a database operation that fails '
-        'then lastDatabaseOperationTime is still updated', () async {
-      final row = await SimpleData.db.insertRow(session, SimpleData(num: 1));
-      final beforeOperation = serverpod.lastDatabaseOperationTime!;
+      test('when performing a database operation that fails '
+          'then lastDatabaseOperationTime is still updated', () async {
+        final row = await SimpleData.db.insertRow(session, SimpleData(num: 1));
+        final beforeOperation = serverpod.lastDatabaseOperationTime!;
 
-      await expectLater(
-        SimpleData.db.insertRow(session, row),
-        throwsA(isA<DatabaseException>()),
-      );
+        await expectLater(
+          SimpleData.db.insertRow(session, row),
+          throwsA(isA<DatabaseException>()),
+        );
 
-      final afterOperation = serverpod.lastDatabaseOperationTime!;
-      expect(afterOperation.isAfter(beforeOperation), isTrue);
-    });
+        final afterOperation = serverpod.lastDatabaseOperationTime!;
+        expect(afterOperation.isAfter(beforeOperation), isTrue);
+      });
 
-    test('when performing multiple database operations '
-        'then lastDatabaseOperationTime is updated after each one', () async {
-      final beforeOperation = serverpod.lastDatabaseOperationTime!;
+      test('when performing multiple database operations '
+          'then lastDatabaseOperationTime is updated after each one', () async {
+        final beforeOperation = serverpod.lastDatabaseOperationTime!;
 
-      await SimpleData.db.insertRow(session, SimpleData(num: 2));
-      final firstOperationTime = serverpod.lastDatabaseOperationTime;
-      expect(firstOperationTime!.isAfter(beforeOperation), isTrue);
+        await SimpleData.db.insertRow(session, SimpleData(num: 2));
+        final firstOperationTime = serverpod.lastDatabaseOperationTime;
+        expect(firstOperationTime!.isAfter(beforeOperation), isTrue);
 
-      final row = (await SimpleData.db.findFirstRow(session))!;
-      final secondOperationTime = serverpod.lastDatabaseOperationTime;
-      expect(secondOperationTime!.isAfter(firstOperationTime), isTrue);
+        final row = (await SimpleData.db.findFirstRow(session))!;
+        final secondOperationTime = serverpod.lastDatabaseOperationTime;
+        expect(secondOperationTime!.isAfter(firstOperationTime), isTrue);
 
-      await SimpleData.db.updateRow(session, row..num = 3);
-      final thirdOperationTime = serverpod.lastDatabaseOperationTime;
-      expect(thirdOperationTime!.isAfter(secondOperationTime), isTrue);
+        await SimpleData.db.updateRow(session, row..num = 3);
+        final thirdOperationTime = serverpod.lastDatabaseOperationTime;
+        expect(thirdOperationTime!.isAfter(secondOperationTime), isTrue);
 
-      await SimpleData.db.deleteRow(session, row);
-      final fourthOperationTime = serverpod.lastDatabaseOperationTime;
-      expect(fourthOperationTime!.isAfter(thirdOperationTime), isTrue);
+        await SimpleData.db.deleteRow(session, row);
+        final fourthOperationTime = serverpod.lastDatabaseOperationTime;
+        expect(fourthOperationTime!.isAfter(thirdOperationTime), isTrue);
 
-      await SimpleData.db.count(session);
-      final fifthOperationTime = serverpod.lastDatabaseOperationTime;
-      expect(fifthOperationTime!.isAfter(fourthOperationTime), isTrue);
-    });
-  });
+        await SimpleData.db.count(session);
+        final fifthOperationTime = serverpod.lastDatabaseOperationTime;
+        expect(fifthOperationTime!.isAfter(fourthOperationTime), isTrue);
+      });
+    },
+  );
 }


### PR DESCRIPTION
Fixes: #4560

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

_If you have done any breaking changes, make sure to outline them here, so that they can be included in the notes for the next release._