### PR TITLE
fix: Standardize email button font to match Google button

### DIFF
--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_flutter/lib/src/common/widgets/buttons/action_button.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_flutter/lib/src/common/widgets/buttons/action_button.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
 
 import '../loading_indicator.dart';
 
@@ -28,7 +29,10 @@ class ActionButton extends StatelessWidget {
         padding: const EdgeInsets.symmetric(vertical: 8),
         foregroundColor: Theme.of(context).colorScheme.onPrimary,
         backgroundColor: Theme.of(context).colorScheme.primary,
-        textStyle: Theme.of(context).textTheme.bodyLarge,
+        textStyle: GoogleFonts.roboto(
+          fontSize: 14,
+          letterSpacing: 0.7,
+        ),
         shape: const StadiumBorder(),
         fixedSize: const Size(double.infinity, 48),
       ),


### PR DESCRIPTION
Changed email sign-in button to use Roboto font (fontSize: 14,
letterSpacing: 0.7) to match Google sign-in button styling.

Apple button uses native Apple font per branding guidelines. Google button uses Roboto per branding guidelines. Email button now uses Roboto for consistency.

Fixes #4571

_Replace this paragraph with a description of what this PR is changing or adding, and why._

_List which issues are fixed by this PR. You must list at least one issue._

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

_If you have done any breaking changes, make sure to outline them here, so that they can be included in the notes for the next release._