### PR TITLE
fix: Fix the flakiness in the sort pubspecs script

### DIFF
--- a/util/sort_pubspec_dependencies
+++ b/util/sort_pubspec_dependencies
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+sort_pubspec() {
+    local pubspec_path="$1"
+
+    if dart run sort_pubspec_dependencies --pubspec-path="$pubspec_path" > /dev/null; then
+        echo "✓ Sorted: $pubspec_path"
+    else
+        echo -e "✗ Failed to sort: $pubspec_path. Contents:\n\n$(cat "$pubspec_path")\n\n"
+    fi
+}
+
+export -f sort_pubspec
+
+echo "Sort all pubspecs dependencies"
+
+# Exclude the top level pubspec.yaml to avoid breaking the `dart run` for other processes.
+pubspecs=$(find . -name "pubspec.yaml" -type f ! -path "./pubspec.yaml")
+echo "$pubspecs" | xargs -P $(util/get_max_cores) -I {} bash -c 'sort_pubspec "{}"'

--- a/util/update_pubspecs
+++ b/util/update_pubspecs
@@ -22,9 +22,7 @@ cd $CLI_DIR
 dart pub get
 cd $BASE
 
-echo "Sort all pubspecs dependencies"
-pubspecs=$(find . -name "pubspec.yaml" -type f)
-echo "$pubspecs" | xargs -P $(util/get_max_cores) -I {} bash -c 'dart run sort_pubspec_dependencies --pubspec-path="{}" > /dev/null'
+./util/sort_pubspec_dependencies
 
 echo "Update all pubspecs. Version is $VERSION (Dart version: $DART_VERSION, Flutter version: $FLUTTER_VERSION)."
 


### PR DESCRIPTION
Fixes: #4335

The fix could be resumed merely in the change of the pubspecs collect command:

```bash
pubspecs=$(find . -name "pubspec.yaml" -type f ! -path "./pubspec.yaml")
```

But, since the current way of sorting was too hidden and expanding with prints allowed understanding the issue, I decided to leave the improvement of using a self-contained script for the sorting.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.