### PR TITLE
fix: Pass public/private flag when generating GCS upload descriptions

### DIFF
--- a/integrations/serverpod_cloud_storage_gcp/lib/src/cloud_storage/google_cloud_storage.dart
+++ b/integrations/serverpod_cloud_storage_gcp/lib/src/cloud_storage/google_cloud_storage.dart
@@ -128,6 +128,7 @@ class GoogleCloudStorage extends CloudStorage {
       uploadDst: path,
       expires: expirationDuration,
       maxFileSize: maxFileSize,
+      public: public,
     );
   }
 


### PR DESCRIPTION
The `createDirectFileUploadDescription` implementation for Google Cloud Storage does not pass the public/private cloud storage configuration flag to `GCPS3Uploader` when generating upload descriptions, resulting in all upload descriptions being generated as public. Files subsequently uploaded with this description are uploaded with the Cloud Stoarge `acl` set to `public-read`.

This behaviour is not expected and represents a security risk if access to the files is not further restricted by other Google Cloud permissions/ACLs.

This is resolved by including `public` when calling `GCPS3Uploader.getDirectUploadDescription(...)`.

This resolves #4588 which was the initial report of this issue.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.