### PR TITLE
fix: Session log duration unit display (#4617)

### DIFF
--- a/packages/serverpod/lib/src/generated/session_log_entry.dart
+++ b/packages/serverpod/lib/src/generated/session_log_entry.dart
@@ -93,8 +93,8 @@ abstract class SessionLogEntry
   /// The method this session is associated with, if any.
   String? method;
 
-  /// The running time of this session. May be null if the session is still
-  /// active.
+  /// The running time of this session, in seconds. May be null if the session
+  /// is still active.
   double? duration;
 
   /// The number of queries performed during this session.
@@ -455,8 +455,8 @@ class SessionLogEntryTable extends _i1.Table<int?> {
   /// The method this session is associated with, if any.
   late final _i1.ColumnString method;
 
-  /// The running time of this session. May be null if the session is still
-  /// active.
+  /// The running time of this session, in seconds. May be null if the session
+  /// is still active.
   late final _i1.ColumnDouble duration;
 
   /// The number of queries performed during this session.

--- a/packages/serverpod/lib/src/models/session_log_entry.spy.yaml
+++ b/packages/serverpod/lib/src/models/session_log_entry.spy.yaml
@@ -17,8 +17,8 @@ fields:
   ### The method this session is associated with, if any.
   method: String?
 
-  ### The running time of this session. May be null if the session is still
-  ### active.
+  ### The running time of this session, in seconds. May be null if the session
+  ### is still active.
   duration: double?
 
   ### The number of queries performed during this session.

--- a/packages/serverpod/lib/src/server/log_manager/log_writers.dart
+++ b/packages/serverpod/lib/src/server/log_manager/log_writers.dart
@@ -228,12 +228,19 @@ class JsonStdOutLogWriter extends LogWriter {
 class TextStdOutLogWriter extends LogWriter {
   static bool headersWritten = false;
 
-  /// Formats a duration value expressed in seconds so that it is easy to
-  /// read in logs. Very short durations will be printed using microseconds
-  /// while longer ones will switch to milliseconds or seconds.
-  static String _printDuration(double? seconds) {
-    if (seconds == null) return 'n/a';
-    var micros = (seconds * Duration.microsecondsPerSecond).round();
+  /// Converts a duration value expressed in seconds to a [Duration].
+  static Duration? _secondsToDuration(double? seconds) {
+    if (seconds == null) return null;
+    var microseconds = (seconds * Duration.microsecondsPerSecond);
+    return Duration(microseconds: microseconds.round());
+  }
+
+  /// Formats a [Duration] so that it is easy to read in logs. Very short
+  /// durations will be printed using microseconds while longer ones will
+  /// switch to milliseconds or seconds.
+  static String _printDuration(Duration? duration) {
+    if (duration == null) return 'n/a';
+    var micros = duration.inMicroseconds;
     if (micros < 1000) {
       // Ignore required because dart does not understand that "µ" is a valid
       // character in a string.
@@ -317,7 +324,7 @@ class TextStdOutLogWriter extends LogWriter {
       id: _logId,
       fields: {
         'id': entry.id,
-        'duration': _printDuration(entry.duration),
+        'duration': _printDuration(_secondsToDuration(entry.duration)),
         'query': entry.query,
       },
       error: entry.error,
@@ -355,7 +362,7 @@ class TextStdOutLogWriter extends LogWriter {
           fields: {
             'user': entry.userId,
             'queries': entry.numQueries,
-            'duration': _printDuration(entry.duration),
+            'duration': _printDuration(_secondsToDuration(entry.duration)),
           },
           error: entry.error,
           stackTrace: entry.stackTrace,
@@ -368,7 +375,7 @@ class TextStdOutLogWriter extends LogWriter {
           id: _logId,
           fields: {
             'queries': entry.numQueries,
-            'duration': _printDuration(entry.duration),
+            'duration': _printDuration(_secondsToDuration(entry.duration)),
           },
           error: entry.error,
           stackTrace: entry.stackTrace,
@@ -382,7 +389,7 @@ class TextStdOutLogWriter extends LogWriter {
           fields: {
             'user': entry.userId,
             'queries': entry.numQueries,
-            'duration': _printDuration(entry.duration),
+            'duration': _printDuration(_secondsToDuration(entry.duration)),
           },
           error: entry.error,
           stackTrace: entry.stackTrace,
@@ -397,7 +404,7 @@ class TextStdOutLogWriter extends LogWriter {
           fields: {
             'user': entry.userId,
             'queries': entry.numQueries,
-            'duration': _printDuration(entry.duration),
+            'duration': _printDuration(_secondsToDuration(entry.duration)),
           },
           error: entry.error,
           stackTrace: entry.stackTrace,
@@ -410,7 +417,7 @@ class TextStdOutLogWriter extends LogWriter {
           id: _logId,
           fields: {
             'queries': entry.numQueries,
-            'duration': _printDuration(entry.duration),
+            'duration': _printDuration(_secondsToDuration(entry.duration)),
           },
           error: entry.error,
           stackTrace: entry.stackTrace,
@@ -425,7 +432,7 @@ class TextStdOutLogWriter extends LogWriter {
           fields: {
             'sessionType': _session.runtimeType.toString(),
             'queries': entry.numQueries,
-            'duration': _printDuration(entry.duration),
+            'duration': _printDuration(_secondsToDuration(entry.duration)),
           },
           error: entry.error,
           stackTrace: entry.stackTrace,

--- a/packages/serverpod_service_client/lib/src/protocol/session_log_entry.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/session_log_entry.dart
@@ -87,8 +87,8 @@ abstract class SessionLogEntry implements _i1.SerializableModel {
   /// The method this session is associated with, if any.
   String? method;
 
-  /// The running time of this session. May be null if the session is still
-  /// active.
+  /// The running time of this session, in seconds. May be null if the session
+  /// is still active.
   double? duration;
 
   /// The number of queries performed during this session.


### PR DESCRIPTION
The `_printDuration` method in `log_writers.dart` was treating duration values as milliseconds, but Serverpod stores all durations in seconds (as documented in `LogSettings`). This caused durations to display with incorrect units - e.g., a 47.6 second FutureCall displayed  as "47.6ms" instead of "47.6s".                                                                                                             
                                                                                                                                              
  **Changes:**                                                                                                                                
  - Updated doc comment from "milliseconds" to "seconds"                                                                                      
  - Renamed parameter from `milliseconds` to `seconds`                                                                                        
  - Changed multiplier from `Duration.microsecondsPerMillisecond` to `Duration.microsecondsPerSecond`                                         
                                                                                                                                              
  Fixes #4617                                                                                                                                 
                                                                                                                                              
  **Note on tests:** No unit test was added because `_printDuration` is a private method.