### PR TITLE
fix: Console log timestamps show actual event time instead of flush time

### DIFF
--- a/packages/serverpod/lib/src/server/log_manager/log_writers.dart
+++ b/packages/serverpod/lib/src/server/log_manager/log_writers.dart
@@ -291,6 +291,7 @@ class TextStdOutLogWriter extends LogWriter {
       error: entry.error,
       stackTrace: entry.stackTrace,
       toStdErr: _isError(entry),
+      time: entry.time,
     );
   }
 
@@ -341,6 +342,7 @@ class TextStdOutLogWriter extends LogWriter {
       },
       error: entry.error,
       stackTrace: entry.stackTrace,
+      time: entry.time,
     );
   }
 
@@ -461,8 +463,9 @@ class TextStdOutLogWriter extends LogWriter {
     required String? error,
     required String? stackTrace,
     bool toStdErr = false,
+    DateTime? time,
   }) {
-    var now = DateTime.now().toUtc();
+    var now = time?.toUtc() ?? DateTime.now().toUtc();
     _write(
       type,
       context: context,


### PR DESCRIPTION
The `_writeFormattedLog` method was using `DateTime.now()` for all log entries, causing console timestamps to show when logs were           
  printed/flushed (end of session) rather than when events actually occurred.                                                                 
                                                                                                                                              
  **Changes:**                                                                                                                                
  - Added optional `time` parameter to `_writeFormattedLog`                                                                                   
  - Pass `entry.time` from `logEntry` (LOG entries)                                                                                           
  - Pass `entry.time` from `openLog` (STREAM OPEN entries)                                                                                    
  - Other log types without a `time` field continue using `DateTime.now()`                                                                    
                                                                                                                                              
  **Before (wrong):** All logs show same timestamp (~03:17:58.908)                                                                            
  2026-01-20 03:17:58.908151Z  LOG  message=Starting sync...                                                                                  
  2026-01-20 03:17:58.908247Z  LOG  message=completed in 47547ms                                                                              
                                                                                                                                              
  **After (correct):** Logs show actual event times                                                                                           
  2026-01-20 03:17:11.360534Z  LOG  message=Starting sync...                                                                                  
  2026-01-20 03:17:58.907920Z  LOG  message=completed in 47547ms                                                                              
                                                                                                                                              
  Fixes #4619                                                                                                                                 
                                                                                                                                              
  **Note on tests:** No unit test added as `_writeFormattedLog` is a private method.