### PR TITLE
chore: Fix typo in `serverpod` name on some packages

### DIFF
--- a/packages/serverpod_service_client/pubspec.yaml
+++ b/packages/serverpod_service_client/pubspec.yaml
@@ -3,7 +3,7 @@
 
 name: serverpod_service_client
 version: 3.2.3
-description: Generated client for the Severpod service protocol.
+description: Generated client for the Serverpod service protocol.
 repository: https://github.com/serverpod/serverpod
 homepage: https://serverpod.dev
 issue_tracker: https://github.com/serverpod/serverpod/issues

--- a/packages/serverpod_shared/pubspec.yaml
+++ b/packages/serverpod_shared/pubspec.yaml
@@ -3,7 +3,7 @@
 
 name: serverpod_shared
 version: 3.2.3
-description: Severpod code that is shared between serverpod and tooling.
+description: Serverpod code that is shared between serverpod and tooling.
 repository: https://github.com/serverpod/serverpod
 homepage: https://serverpod.dev
 issue_tracker: https://github.com/serverpod/serverpod/issues

--- a/packages/serverpod_test/pubspec.yaml
+++ b/packages/serverpod_test/pubspec.yaml
@@ -3,7 +3,7 @@
 
 name: serverpod_test
 version: 3.2.3
-description: Severpod test tools to simplify testing of endpoints.
+description: Serverpod test tools to simplify testing of endpoints.
 repository: https://github.com/serverpod/serverpod
 homepage: https://serverpod.dev
 issue_tracker: https://github.com/serverpod/serverpod/issues

--- a/templates/pubspecs/packages/serverpod_service_client/pubspec.yaml
+++ b/templates/pubspecs/packages/serverpod_service_client/pubspec.yaml
@@ -2,7 +2,7 @@
 
 name: serverpod_service_client
 version: SERVERPOD_VERSION
-description: Generated client for the Severpod service protocol.
+description: Generated client for the Serverpod service protocol.
 repository: https://github.com/serverpod/serverpod
 homepage: https://serverpod.dev
 issue_tracker: https://github.com/serverpod/serverpod/issues

--- a/templates/pubspecs/packages/serverpod_shared/pubspec.yaml
+++ b/templates/pubspecs/packages/serverpod_shared/pubspec.yaml
@@ -2,7 +2,7 @@
 
 name: serverpod_shared
 version: SERVERPOD_VERSION
-description: Severpod code that is shared between serverpod and tooling.
+description: Serverpod code that is shared between serverpod and tooling.
 repository: https://github.com/serverpod/serverpod
 homepage: https://serverpod.dev
 issue_tracker: https://github.com/serverpod/serverpod/issues

--- a/templates/pubspecs/packages/serverpod_test/pubspec.yaml
+++ b/templates/pubspecs/packages/serverpod_test/pubspec.yaml
@@ -2,7 +2,7 @@
 
 name: serverpod_test
 version: SERVERPOD_VERSION
-description: Severpod test tools to simplify testing of endpoints.
+description: Serverpod test tools to simplify testing of endpoints.
 repository: https://github.com/serverpod/serverpod
 homepage: https://serverpod.dev
 issue_tracker: https://github.com/serverpod/serverpod/issues


### PR DESCRIPTION
Small typo fix.

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

_If you have done any breaking changes, make sure to outline them here, so that they can be included in the notes for the next release._