### PR TITLE
fix: Preserve ORDER BY in nested includeList queries with LIMIT

### DIFF
--- a/packages/serverpod_database/lib/src/adapters/postgres/sql_query_builder.dart
+++ b/packages/serverpod_database/lib/src/adapters/postgres/sql_query_builder.dart
@@ -119,6 +119,7 @@ class SelectQueryBuilder {
         listQueryAdditions,
         limit: _limit,
         offset: _offset,
+        orderBy: _orderBy,
       );
     }
 
@@ -130,6 +131,7 @@ class SelectQueryBuilder {
     _ListQueryAdditions listQueryAdditions, {
     required int? limit,
     required int? offset,
+    List<Order>? orderBy,
   }) {
     var wrappedBaseQueryAlias = '_base_query_sorting_and_ordering';
     var partitionedQueryAlias = '_partitioned_list_by_parent_id';
@@ -138,8 +140,10 @@ class SelectQueryBuilder {
 
     String query = 'WITH $wrappedBaseQueryAlias AS ($baseQuery)';
 
+    var windowOrderBy = _buildWindowOrderByClause(orderBy, wrappedBaseQueryAlias);
+
     query +=
-        ', $partitionedQueryAlias AS (SELECT *, row_number() OVER ( PARTITION BY $wrappedBaseQueryAlias."$relationalFieldName") AS row_number FROM $wrappedBaseQueryAlias)';
+        ', $partitionedQueryAlias AS (SELECT *, row_number() OVER ( PARTITION BY $wrappedBaseQueryAlias."$relationalFieldName"$windowOrderBy) AS row_number FROM $wrappedBaseQueryAlias)';
 
     var rowLimitClause = _buildMultiRowLimitClause(limit, offset);
 
@@ -147,6 +151,27 @@ class SelectQueryBuilder {
         ' SELECT * FROM $partitionedQueryAlias WHERE row_number $rowLimitClause';
 
     return query;
+  }
+
+  String _buildWindowOrderByClause(List<Order>? orderBy, String tableAlias) {
+    if (orderBy == null || orderBy.isEmpty) {
+      return '';
+    }
+
+    var orderClauses = orderBy.map((order) {
+      var column = order.column;
+      var alias = truncateIdentifier(
+        column.fieldQueryAlias,
+        DatabaseConstants.pgsqlMaxNameLimitation,
+      );
+      var clause = '$tableAlias."$alias"';
+      if (order.orderDescending) {
+        clause += ' DESC';
+      }
+      return clause;
+    }).join(', ');
+
+    return ' ORDER BY $orderClauses';
   }
 
   String _buildMultiRowLimitClause(int? limit, int? offset) {

--- a/packages/serverpod_database/lib/src/adapters/postgres/sql_query_builder.dart
+++ b/packages/serverpod_database/lib/src/adapters/postgres/sql_query_builder.dart
@@ -140,7 +140,10 @@ class SelectQueryBuilder {
 
     String query = 'WITH $wrappedBaseQueryAlias AS ($baseQuery)';
 
-    var windowOrderBy = _buildWindowOrderByClause(orderBy, wrappedBaseQueryAlias);
+    var windowOrderBy = _buildWindowOrderByClause(
+      orderBy,
+      wrappedBaseQueryAlias,
+    );
 
     query +=
         ', $partitionedQueryAlias AS (SELECT *, row_number() OVER ( PARTITION BY $wrappedBaseQueryAlias."$relationalFieldName"$windowOrderBy) AS row_number FROM $wrappedBaseQueryAlias)';
@@ -158,18 +161,20 @@ class SelectQueryBuilder {
       return '';
     }
 
-    var orderClauses = orderBy.map((order) {
-      var column = order.column;
-      var alias = truncateIdentifier(
-        column.fieldQueryAlias,
-        DatabaseConstants.pgsqlMaxNameLimitation,
-      );
-      var clause = '$tableAlias."$alias"';
-      if (order.orderDescending) {
-        clause += ' DESC';
-      }
-      return clause;
-    }).join(', ');
+    var orderClauses = orderBy
+        .map((order) {
+          var column = order.column;
+          var alias = truncateIdentifier(
+            column.fieldQueryAlias,
+            DatabaseConstants.pgsqlMaxNameLimitation,
+          );
+          var clause = '$tableAlias."$alias"';
+          if (order.orderDescending) {
+            clause += ' DESC';
+          }
+          return clause;
+        })
+        .join(', ');
 
     return ' ORDER BY $orderClauses';
   }

--- a/packages/serverpod_database/lib/src/adapters/postgres/sql_query_builder.dart
+++ b/packages/serverpod_database/lib/src/adapters/postgres/sql_query_builder.dart
@@ -162,6 +162,7 @@ class SelectQueryBuilder {
     }
 
     var orderClauses = orderBy
+        .where((order) => order.column is! ColumnCount)
         .map((order) {
           var column = order.column;
           var alias = truncateIdentifier(
@@ -175,6 +176,10 @@ class SelectQueryBuilder {
           return clause;
         })
         .join(', ');
+
+    if (orderClauses.isEmpty) {
+      return '';
+    }
 
     return ' ORDER BY $orderClauses';
   }

--- a/packages/serverpod_database/test/sql_query_builder_test.dart
+++ b/packages/serverpod_database/test/sql_query_builder_test.dart
@@ -1267,7 +1267,7 @@ void main() {
 
       expect(
         query,
-        'WITH _base_query_sorting_and_ordering AS (SELECT "citizen"."id" AS "citizen.id" FROM "citizen" WHERE "citizen"."id" IN (1, 2, 3) ORDER BY "citizen"."id" DESC), _partitioned_list_by_parent_id AS (SELECT *, row_number() OVER ( PARTITION BY _base_query_sorting_and_ordering."citizen.id" ORDER BY _base_query_sorting_and_ordering."citizen.id" DESC) FROM _base_query_sorting_and_ordering) SELECT * FROM _partitioned_list_by_parent_id WHERE row_number BETWEEN 1 AND 10',
+        'WITH _base_query_sorting_and_ordering AS (SELECT "citizen"."id" AS "citizen.id" FROM "citizen" WHERE "citizen"."id" IN (1, 2, 3) ORDER BY "citizen"."id" DESC NULLS FIRST), _partitioned_list_by_parent_id AS (SELECT *, row_number() OVER ( PARTITION BY _base_query_sorting_and_ordering."citizen.id" ORDER BY _base_query_sorting_and_ordering."citizen.id" DESC) AS row_number FROM _base_query_sorting_and_ordering) SELECT * FROM _partitioned_list_by_parent_id WHERE row_number BETWEEN 1 AND 10',
       );
     },
   );
@@ -1301,7 +1301,7 @@ void main() {
 
       expect(
         query,
-        'WITH _base_query_sorting_and_ordering AS (SELECT "citizen"."id" AS "citizen.id", "citizen"."name" AS "citizen.name" FROM "citizen" WHERE "citizen"."id" IN (1, 2, 3) ORDER BY "citizen"."name", "citizen"."id" DESC), _partitioned_list_by_parent_id AS (SELECT *, row_number() OVER ( PARTITION BY _base_query_sorting_and_ordering."citizen.id" ORDER BY _base_query_sorting_and_ordering."citizen.name", _base_query_sorting_and_ordering."citizen.id" DESC) FROM _base_query_sorting_and_ordering) SELECT * FROM _partitioned_list_by_parent_id WHERE row_number BETWEEN 1 AND 5',
+        'WITH _base_query_sorting_and_ordering AS (SELECT "citizen"."id" AS "citizen.id", "citizen"."name" AS "citizen.name" FROM "citizen" WHERE "citizen"."id" IN (1, 2, 3) ORDER BY "citizen"."name" ASC NULLS LAST, "citizen"."id" DESC NULLS FIRST), _partitioned_list_by_parent_id AS (SELECT *, row_number() OVER ( PARTITION BY _base_query_sorting_and_ordering."citizen.id" ORDER BY _base_query_sorting_and_ordering."citizen.name", _base_query_sorting_and_ordering."citizen.id" DESC) AS row_number FROM _base_query_sorting_and_ordering) SELECT * FROM _partitioned_list_by_parent_id WHERE row_number BETWEEN 1 AND 5',
       );
     },
   );

--- a/packages/serverpod_database/test/sql_query_builder_test.dart
+++ b/packages/serverpod_database/test/sql_query_builder_test.dart
@@ -1243,4 +1243,66 @@ void main() {
       });
     });
   });
+
+  test(
+    'Given a select query with a filtered result set and an order by and a limit when building then the query window function includes the ORDER BY clause.',
+    () {
+      var manyTable = _TableWithManyRelation(
+        relationAlias: 'citizens',
+        tableName: 'country',
+        tableRelation: TableRelation([
+          TableRelationEntry(
+            relationAlias: 'citizens',
+            field: ColumnInt('citizenId', citizenTable),
+            foreignField: ColumnInt('id', citizenTable),
+          ),
+        ]),
+      );
+
+      var query = SelectQueryBuilder(table: citizenTable)
+          .withWhereRelationInResultSet({1, 2, 3}, manyTable)
+          .withOrderBy([Order(column: citizenTable.id, orderDescending: true)])
+          .withLimit(10)
+          .build();
+
+      expect(
+        query,
+        'WITH _base_query_sorting_and_ordering AS (SELECT "citizen"."id" AS "citizen.id" FROM "citizen" WHERE "citizen"."id" IN (1, 2, 3) ORDER BY "citizen"."id" DESC), _partitioned_list_by_parent_id AS (SELECT *, row_number() OVER ( PARTITION BY _base_query_sorting_and_ordering."citizen.id" ORDER BY _base_query_sorting_and_ordering."citizen.id" DESC) FROM _base_query_sorting_and_ordering) SELECT * FROM _partitioned_list_by_parent_id WHERE row_number BETWEEN 1 AND 10',
+      );
+    },
+  );
+
+  test(
+    'Given a select query with a filtered result set and multiple order by columns and a limit when building then the query window function includes all ORDER BY columns.',
+    () {
+      var manyTable = _TableWithManyRelation(
+        relationAlias: 'citizens',
+        tableName: 'country',
+        tableRelation: TableRelation([
+          TableRelationEntry(
+            relationAlias: 'citizens',
+            field: ColumnInt('citizenId', citizenTable),
+            foreignField: ColumnInt('id', citizenTable),
+          ),
+        ]),
+      );
+
+      var nameColumn = ColumnString('name', citizenTable);
+
+      var query = SelectQueryBuilder(table: citizenTable)
+          .withSelectFields([citizenTable.id, nameColumn])
+          .withWhereRelationInResultSet({1, 2, 3}, manyTable)
+          .withOrderBy([
+            Order(column: nameColumn, orderDescending: false),
+            Order(column: citizenTable.id, orderDescending: true),
+          ])
+          .withLimit(5)
+          .build();
+
+      expect(
+        query,
+        'WITH _base_query_sorting_and_ordering AS (SELECT "citizen"."id" AS "citizen.id", "citizen"."name" AS "citizen.name" FROM "citizen" WHERE "citizen"."id" IN (1, 2, 3) ORDER BY "citizen"."name", "citizen"."id" DESC), _partitioned_list_by_parent_id AS (SELECT *, row_number() OVER ( PARTITION BY _base_query_sorting_and_ordering."citizen.id" ORDER BY _base_query_sorting_and_ordering."citizen.name", _base_query_sorting_and_ordering."citizen.id" DESC) FROM _base_query_sorting_and_ordering) SELECT * FROM _partitioned_list_by_parent_id WHERE row_number BETWEEN 1 AND 5',
+      );
+    },
+  );
 }

--- a/packages/serverpod_database/test/sql_query_builder_test.dart
+++ b/packages/serverpod_database/test/sql_query_builder_test.dart
@@ -1261,7 +1261,7 @@ void main() {
 
       var query = SelectQueryBuilder(table: citizenTable)
           .withWhereRelationInResultSet({1, 2, 3}, manyTable)
-          .withOrderBy([Order(column: citizenTable.id, orderDescending: true)])
+          .withOrderBy([citizenTable.id.desc()])
           .withLimit(10)
           .build();
 
@@ -1293,8 +1293,8 @@ void main() {
           .withSelectFields([citizenTable.id, nameColumn])
           .withWhereRelationInResultSet({1, 2, 3}, manyTable)
           .withOrderBy([
-            Order(column: nameColumn, orderDescending: false),
-            Order(column: citizenTable.id, orderDescending: true),
+            nameColumn.asc(),
+            citizenTable.id.desc(),
           ])
           .withLimit(5)
           .build();

--- a/tests/serverpod_test_server/test_integration/database_operations/entity_relations/one_to_many/find/list_include_test.dart
+++ b/tests/serverpod_test_server/test_integration/database_operations/entity_relations/one_to_many/find/list_include_test.dart
@@ -1178,9 +1178,10 @@ void main() async {
       // where the CTE's materialized order is not preserved, which is the
       // root cause of issue #4110.
       await session.db.transaction((transaction) async {
-        await session.db.unsafeExecute(
-          'SET LOCAL enable_sort = off;',
-          transaction: transaction,
+        await transaction.setRuntimeParameters(
+          (params) => [
+            MapRuntimeParameters({'enable_sort': false}),
+          ],
         );
 
         // Query pattern matching the original issue:

--- a/tests/serverpod_test_server/test_integration/database_operations/entity_relations/one_to_many/find/list_include_test.dart
+++ b/tests/serverpod_test_server/test_integration/database_operations/entity_relations/one_to_many/find/list_include_test.dart
@@ -1029,8 +1029,7 @@ void main() async {
         city.id!,
         include: City.include(
           citizens: Person.includeList(
-            orderBy: (t) => t.name,
-            orderDescending: true,
+            orderBy: (t) => t.name.desc(),
             limit: 2,
           ),
         ),

--- a/tests/serverpod_test_server/test_integration/database_operations/entity_relations/one_to_many/find/list_include_test.dart
+++ b/tests/serverpod_test_server/test_integration/database_operations/entity_relations/one_to_many/find/list_include_test.dart
@@ -1045,4 +1045,187 @@ void main() async {
       );
     },
   );
+
+  test(
+    'Given a deeply nested includeList with orderBy and limit when querying with include then the innermost list is correctly ordered and limited.',
+    () async {
+      // Mirrors the original issue structure: Node -> Sensor -> Data
+      // Using: City -> Organization (includeList) -> include -> Person (includeList with orderBy + limit)
+      var city = await City.db.insertRow(session, City(name: 'Stockholm'));
+
+      var orgAlpha = await Organization.db.insertRow(
+        session,
+        Organization(name: 'Alpha'),
+      );
+      var orgBeta = await Organization.db.insertRow(
+        session,
+        Organization(name: 'Beta'),
+      );
+
+      await City.db.attach.organizations(session, city, [orgAlpha, orgBeta]);
+
+      // Create people and attach in non-alphabetical order
+      var alice = await Person.db.insertRow(session, Person(name: 'Alice'));
+      var bob = await Person.db.insertRow(session, Person(name: 'Bob'));
+      var charlie = await Person.db.insertRow(session, Person(name: 'Charlie'));
+      var diana = await Person.db.insertRow(session, Person(name: 'Diana'));
+
+      var eve = await Person.db.insertRow(session, Person(name: 'Eve'));
+      var frank = await Person.db.insertRow(session, Person(name: 'Frank'));
+      var grace = await Person.db.insertRow(session, Person(name: 'Grace'));
+
+      await Organization.db.attach.people(session, orgAlpha, [
+        diana, // Intentionally non-alphabetical
+        alice,
+        charlie,
+        bob,
+      ]);
+
+      await Organization.db.attach.people(session, orgBeta, [
+        grace,
+        eve,
+        frank,
+      ]);
+
+      // Query pattern matching the original issue:
+      // find -> includeList -> include -> includeList(orderBy, limit)
+      var result = await City.db.findById(
+        session,
+        city.id!,
+        include: City.include(
+          organizations: Organization.includeList(
+            orderBy: (t) => t.name,
+            include: Organization.include(
+              people: Person.includeList(
+                orderBy: (t) => t.name,
+                limit: 2,
+              ),
+            ),
+          ),
+        ),
+      );
+
+      expect(result?.organizations, hasLength(2));
+
+      // Alpha comes first alphabetically
+      var alphaResult = result?.organizations?.first;
+      expect(alphaResult?.name, 'Alpha');
+      expect(alphaResult?.people, hasLength(2));
+      expect(
+        alphaResult?.people?.map((e) => e.name).toList(),
+        ['Alice', 'Bob'],
+        reason: 'Expected first 2 people alphabetically: Alice, Bob',
+      );
+
+      // Beta comes second
+      var betaResult = result?.organizations?.last;
+      expect(betaResult?.name, 'Beta');
+      expect(betaResult?.people, hasLength(2));
+      expect(
+        betaResult?.people?.map((e) => e.name).toList(),
+        ['Eve', 'Frank'],
+        reason: 'Expected first 2 people alphabetically: Eve, Frank',
+      );
+    },
+  );
+
+  test(
+    'Given a list relation with orderBy and limit when sorting is disabled in PostgreSQL then the ORM query still returns correctly ordered rows.',
+    () async {
+      var city = await City.db.insertRow(session, City(name: 'TestCity'));
+
+      var org1 = await Organization.db.insertRow(
+        session,
+        Organization(name: 'Org1'),
+      );
+      var org2 = await Organization.db.insertRow(
+        session,
+        Organization(name: 'Org2'),
+      );
+
+      await City.db.attach.organizations(session, city, [org1, org2]);
+
+      // Insert many persons per organization in reverse alphabetical order.
+      // This creates heap storage where the physical order is opposite to
+      // the desired sort order.
+      var names1 = List.generate(
+        50,
+        (i) => 'Person_${(99 - i).toString().padLeft(2, '0')}',
+      );
+      var names2 = List.generate(
+        50,
+        (i) => 'Member_${(99 - i).toString().padLeft(2, '0')}',
+      );
+
+      var persons1 = <Person>[];
+      for (var name in names1) {
+        persons1.add(
+          await Person.db.insertRow(session, Person(name: name)),
+        );
+      }
+      var persons2 = <Person>[];
+      for (var name in names2) {
+        persons2.add(
+          await Person.db.insertRow(session, Person(name: name)),
+        );
+      }
+
+      await Organization.db.attach.people(session, org1, persons1);
+      await Organization.db.attach.people(session, org2, persons2);
+
+      // Disable sorting to force PostgreSQL to use hash-based operations
+      // for the window function's PARTITION BY. This simulates conditions
+      // where the CTE's materialized order is not preserved, which is the
+      // root cause of issue #4110.
+      await session.db.transaction((transaction) async {
+        await session.db.unsafeExecute(
+          'SET LOCAL enable_sort = off;',
+          transaction: transaction,
+        );
+
+        // Query pattern matching the original issue:
+        // find -> includeList -> include -> includeList(orderBy, limit)
+        var result = await City.db.findById(
+          session,
+          city.id!,
+          include: City.include(
+            organizations: Organization.includeList(
+              orderBy: (t) => t.name,
+              include: Organization.include(
+                people: Person.includeList(
+                  orderBy: (t) => t.name,
+                  limit: 3,
+                ),
+              ),
+            ),
+          ),
+          transaction: transaction,
+        );
+
+        expect(result?.organizations, hasLength(2));
+
+        var org1Result = result?.organizations?.firstWhere(
+          (o) => o.name == 'Org1',
+        );
+        expect(org1Result?.people, hasLength(3));
+        expect(
+          org1Result?.people?.map((e) => e.name).toList(),
+          ['Person_50', 'Person_51', 'Person_52'],
+          reason:
+              'Expected first 3 people alphabetically: Person_50, Person_51, Person_52',
+        );
+
+        var org2Result = result?.organizations?.firstWhere(
+          (o) => o.name == 'Org2',
+        );
+        expect(org2Result?.people, hasLength(3));
+        expect(
+          org2Result?.people?.map((e) => e.name).toList(),
+          ['Member_50', 'Member_51', 'Member_52'],
+          reason:
+              'Expected first 3 people alphabetically: Member_50, Member_51, Member_52',
+        );
+      });
+    },
+  );
 }

--- a/tests/serverpod_test_server/test_integration/database_operations/entity_relations/one_to_many/find/list_include_test.dart
+++ b/tests/serverpod_test_server/test_integration/database_operations/entity_relations/one_to_many/find/list_include_test.dart
@@ -932,4 +932,117 @@ void main() async {
       expect(city?.citizens?.map((e) => e.id), [person3.id, person2.id]);
     },
   );
+
+  test(
+    'Given a list relation with many rows when including the list with orderBy and a constraining limit then the result contains the correctly ordered first N rows.',
+    () async {
+      var stockholm = await City.db.insertRow(session, City(name: 'Stockholm'));
+      var gothenburg = await City.db.insertRow(
+        session,
+        City(name: 'Gothenburg'),
+      );
+
+      // Create persons with names that sort alphabetically: Alice, Bob, Charlie, Diana
+      var alice = await Person.db.insertRow(session, Person(name: 'Alice'));
+      var bob = await Person.db.insertRow(session, Person(name: 'Bob'));
+      var charlie = await Person.db.insertRow(session, Person(name: 'Charlie'));
+      var diana = await Person.db.insertRow(session, Person(name: 'Diana'));
+
+      // Create persons for second city: Eve, Frank, Grace
+      var eve = await Person.db.insertRow(session, Person(name: 'Eve'));
+      var frank = await Person.db.insertRow(session, Person(name: 'Frank'));
+      var grace = await Person.db.insertRow(session, Person(name: 'Grace'));
+
+      await City.db.attach.citizens(session, stockholm, [
+        diana, // Intentionally attach in non-alphabetical order
+        alice,
+        charlie,
+        bob,
+      ]);
+
+      await City.db.attach.citizens(session, gothenburg, [
+        grace,
+        eve,
+        frank,
+      ]);
+
+      // Query with orderBy name ascending and limit 2
+      // Should return first 2 alphabetically: Alice, Bob for Stockholm
+      // and Eve, Frank for Gothenburg
+      var cities = await City.db.find(
+        session,
+        orderBy: (t) => t.name,
+        include: City.include(
+          citizens: Person.includeList(
+            orderBy: (t) => t.name,
+            limit: 2,
+          ),
+        ),
+      );
+
+      expect(cities, hasLength(2));
+
+      // Gothenburg comes first alphabetically
+      var gothenburgResult = cities.first;
+      expect(gothenburgResult.name, 'Gothenburg');
+      expect(gothenburgResult.citizens, hasLength(2));
+      expect(
+        gothenburgResult.citizens?.map((e) => e.name).toList(),
+        ['Eve', 'Frank'],
+        reason: 'Expected first 2 citizens alphabetically: Eve, Frank',
+      );
+
+      // Stockholm comes second
+      var stockholmResult = cities.last;
+      expect(stockholmResult.name, 'Stockholm');
+      expect(stockholmResult.citizens, hasLength(2));
+      expect(
+        stockholmResult.citizens?.map((e) => e.name).toList(),
+        ['Alice', 'Bob'],
+        reason: 'Expected first 2 citizens alphabetically: Alice, Bob',
+      );
+    },
+  );
+
+  test(
+    'Given a list relation with many rows when including the list with orderBy descending and a constraining limit then the result contains the correctly ordered first N rows.',
+    () async {
+      var city = await City.db.insertRow(session, City(name: 'Stockholm'));
+
+      // Create persons with names that sort alphabetically: Alice, Bob, Charlie, Diana
+      var alice = await Person.db.insertRow(session, Person(name: 'Alice'));
+      var bob = await Person.db.insertRow(session, Person(name: 'Bob'));
+      var charlie = await Person.db.insertRow(session, Person(name: 'Charlie'));
+      var diana = await Person.db.insertRow(session, Person(name: 'Diana'));
+
+      await City.db.attach.citizens(session, city, [
+        bob, // Intentionally attach in non-alphabetical order
+        diana,
+        alice,
+        charlie,
+      ]);
+
+      // Query with orderBy name descending and limit 2
+      // Should return first 2 reverse-alphabetically: Diana, Charlie
+      var result = await City.db.findById(
+        session,
+        city.id!,
+        include: City.include(
+          citizens: Person.includeList(
+            orderBy: (t) => t.name,
+            orderDescending: true,
+            limit: 2,
+          ),
+        ),
+      );
+
+      expect(result?.citizens, hasLength(2));
+      expect(
+        result?.citizens?.map((e) => e.name).toList(),
+        ['Diana', 'Charlie'],
+        reason:
+            'Expected first 2 citizens reverse-alphabetically: Diana, Charlie',
+      );
+    },
+  );
 }

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/test_integration/database_operations/entity_relations/one_to_many/find/list_include_test.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/test_integration/database_operations/entity_relations/one_to_many/find/list_include_test.dart
@@ -931,4 +931,200 @@ void main() async {
       expect(city?.citizens?.map((e) => e.id), [person3.id, person2.id]);
     },
   );
+
+  test(
+    'Given a list relation with many rows when including the list with orderBy and a constraining limit then the result contains the correctly ordered first N rows.',
+    () async {
+      var stockholm = await City.db.insertRow(session, City(name: 'Stockholm'));
+      var gothenburg = await City.db.insertRow(
+        session,
+        City(name: 'Gothenburg'),
+      );
+
+      // Create persons with names that sort alphabetically: Alice, Bob, Charlie, Diana
+      var alice = await Person.db.insertRow(session, Person(name: 'Alice'));
+      var bob = await Person.db.insertRow(session, Person(name: 'Bob'));
+      var charlie = await Person.db.insertRow(session, Person(name: 'Charlie'));
+      var diana = await Person.db.insertRow(session, Person(name: 'Diana'));
+
+      // Create persons for second city: Eve, Frank, Grace
+      var eve = await Person.db.insertRow(session, Person(name: 'Eve'));
+      var frank = await Person.db.insertRow(session, Person(name: 'Frank'));
+      var grace = await Person.db.insertRow(session, Person(name: 'Grace'));
+
+      await City.db.attach.citizens(session, stockholm, [
+        diana, // Intentionally attach in non-alphabetical order
+        alice,
+        charlie,
+        bob,
+      ]);
+
+      await City.db.attach.citizens(session, gothenburg, [
+        grace,
+        eve,
+        frank,
+      ]);
+
+      // Query with orderBy name ascending and limit 2
+      // Should return first 2 alphabetically: Alice, Bob for Stockholm
+      // and Eve, Frank for Gothenburg
+      var cities = await City.db.find(
+        session,
+        orderBy: (t) => t.name,
+        include: City.include(
+          citizens: Person.includeList(
+            orderBy: (t) => t.name,
+            limit: 2,
+          ),
+        ),
+      );
+
+      expect(cities, hasLength(2));
+
+      // Gothenburg comes first alphabetically
+      var gothenburgResult = cities.first;
+      expect(gothenburgResult.name, 'Gothenburg');
+      expect(gothenburgResult.citizens, hasLength(2));
+      expect(
+        gothenburgResult.citizens?.map((e) => e.name).toList(),
+        ['Eve', 'Frank'],
+        reason: 'Expected first 2 citizens alphabetically: Eve, Frank',
+      );
+
+      // Stockholm comes second
+      var stockholmResult = cities.last;
+      expect(stockholmResult.name, 'Stockholm');
+      expect(stockholmResult.citizens, hasLength(2));
+      expect(
+        stockholmResult.citizens?.map((e) => e.name).toList(),
+        ['Alice', 'Bob'],
+        reason: 'Expected first 2 citizens alphabetically: Alice, Bob',
+      );
+    },
+  );
+
+  test(
+    'Given a list relation with many rows when including the list with orderBy descending and a constraining limit then the result contains the correctly ordered first N rows.',
+    () async {
+      var city = await City.db.insertRow(session, City(name: 'Stockholm'));
+
+      // Create persons with names that sort alphabetically: Alice, Bob, Charlie, Diana
+      var alice = await Person.db.insertRow(session, Person(name: 'Alice'));
+      var bob = await Person.db.insertRow(session, Person(name: 'Bob'));
+      var charlie = await Person.db.insertRow(session, Person(name: 'Charlie'));
+      var diana = await Person.db.insertRow(session, Person(name: 'Diana'));
+
+      await City.db.attach.citizens(session, city, [
+        bob, // Intentionally attach in non-alphabetical order
+        diana,
+        alice,
+        charlie,
+      ]);
+
+      // Query with orderBy name descending and limit 2
+      // Should return first 2 reverse-alphabetically: Diana, Charlie
+      var result = await City.db.findById(
+        session,
+        city.id!,
+        include: City.include(
+          citizens: Person.includeList(
+            orderBy: (t) => t.name,
+            orderDescending: true,
+            limit: 2,
+          ),
+        ),
+      );
+
+      expect(result?.citizens, hasLength(2));
+      expect(
+        result?.citizens?.map((e) => e.name).toList(),
+        ['Diana', 'Charlie'],
+        reason:
+            'Expected first 2 citizens reverse-alphabetically: Diana, Charlie',
+      );
+    },
+  );
+
+  test(
+    'Given a deeply nested includeList with orderBy and limit when querying with include then the innermost list is correctly ordered and limited.',
+    () async {
+      // Mirrors the original issue structure: Node -> Sensor -> Data
+      // Using: City -> Organization (includeList) -> include -> Person (includeList with orderBy + limit)
+      var city = await City.db.insertRow(session, City(name: 'Stockholm'));
+
+      var orgAlpha = await Organization.db.insertRow(
+        session,
+        Organization(name: 'Alpha'),
+      );
+      var orgBeta = await Organization.db.insertRow(
+        session,
+        Organization(name: 'Beta'),
+      );
+
+      await City.db.attach.organizations(session, city, [orgAlpha, orgBeta]);
+
+      // Create people and attach in non-alphabetical order
+      var alice = await Person.db.insertRow(session, Person(name: 'Alice'));
+      var bob = await Person.db.insertRow(session, Person(name: 'Bob'));
+      var charlie = await Person.db.insertRow(session, Person(name: 'Charlie'));
+      var diana = await Person.db.insertRow(session, Person(name: 'Diana'));
+
+      var eve = await Person.db.insertRow(session, Person(name: 'Eve'));
+      var frank = await Person.db.insertRow(session, Person(name: 'Frank'));
+      var grace = await Person.db.insertRow(session, Person(name: 'Grace'));
+
+      await Organization.db.attach.people(session, orgAlpha, [
+        diana, // Intentionally non-alphabetical
+        alice,
+        charlie,
+        bob,
+      ]);
+
+      await Organization.db.attach.people(session, orgBeta, [
+        grace,
+        eve,
+        frank,
+      ]);
+
+      // Query pattern matching the original issue:
+      // find -> includeList -> include -> includeList(orderBy, limit)
+      var result = await City.db.findById(
+        session,
+        city.id!,
+        include: City.include(
+          organizations: Organization.includeList(
+            orderBy: (t) => t.name,
+            include: Organization.include(
+              people: Person.includeList(
+                orderBy: (t) => t.name,
+                limit: 2,
+              ),
+            ),
+          ),
+        ),
+      );
+
+      expect(result?.organizations, hasLength(2));
+
+      // Alpha comes first alphabetically
+      var alphaResult = result?.organizations?.first;
+      expect(alphaResult?.name, 'Alpha');
+      expect(alphaResult?.people, hasLength(2));
+      expect(
+        alphaResult?.people?.map((e) => e.name).toList(),
+        ['Alice', 'Bob'],
+        reason: 'Expected first 2 people alphabetically: Alice, Bob',
+      );
+
+      // Beta comes second
+      var betaResult = result?.organizations?.last;
+      expect(betaResult?.name, 'Beta');
+      expect(betaResult?.people, hasLength(2));
+      expect(
+        betaResult?.people?.map((e) => e.name).toList(),
+        ['Eve', 'Frank'],
+        reason: 'Expected first 2 people alphabetically: Eve, Frank',
+      );
+    },
+  );
 }

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/test_integration/database_operations/entity_relations/one_to_many/find/list_include_test.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/test_integration/database_operations/entity_relations/one_to_many/find/list_include_test.dart
@@ -1028,8 +1028,7 @@ void main() async {
         city.id!,
         include: City.include(
           citizens: Person.includeList(
-            orderBy: (t) => t.name,
-            orderDescending: true,
+            orderBy: (t) => t.name.desc(),
             limit: 2,
           ),
         ),


### PR DESCRIPTION
The ROW_NUMBER() window function was missing an ORDER BY clause, causing row numbers to be assigned in arbitrary order within each partition. This meant that LIMIT would return incorrect rows even when orderBy was specified.

Fixes #4110 

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes
None