### PR TITLE
fix: Bump minimum date_picker version to exclude the broken release

### DIFF
--- a/modules/legacy/serverpod_auth/serverpod_auth_shared_flutter/pubspec.yaml
+++ b/modules/legacy/serverpod_auth/serverpod_auth_shared_flutter/pubspec.yaml
@@ -14,7 +14,7 @@ environment:
 
 dependencies:
   cached_network_image: ^3.2.3
-  file_picker: '>=8.1.0 <11.0.0'
+  file_picker: '>=10.3.10 <11.0.0'
   flutter:
     sdk: flutter
   image: ^4.0.15

--- a/modules/legacy/serverpod_chat/serverpod_chat_flutter/pubspec.yaml
+++ b/modules/legacy/serverpod_chat/serverpod_chat_flutter/pubspec.yaml
@@ -13,7 +13,7 @@ environment:
   flutter: '^3.32.0'
 
 dependencies:
-  file_picker: '>=8.1.0 <11.0.0'
+  file_picker: '>=10.3.10 <11.0.0'
   flutter:
     sdk: flutter
   intl: '>=0.19.0 <0.21.0'

--- a/templates/pubspecs/modules/legacy/serverpod_auth/serverpod_auth_shared_flutter/pubspec.yaml
+++ b/templates/pubspecs/modules/legacy/serverpod_auth/serverpod_auth_shared_flutter/pubspec.yaml
@@ -13,7 +13,7 @@ environment:
 
 dependencies:
   cached_network_image: ^3.2.3
-  file_picker: '>=8.1.0 <11.0.0'
+  file_picker: '>=10.3.10 <11.0.0'
   flutter:
     sdk: flutter
   image: ^4.0.15

--- a/templates/pubspecs/modules/legacy/serverpod_chat/serverpod_chat_flutter/pubspec.yaml
+++ b/templates/pubspecs/modules/legacy/serverpod_chat/serverpod_chat_flutter/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
   flutter: FLUTTER_VERSION
 
 dependencies:
-  file_picker: '>=8.1.0 <11.0.0'
+  file_picker: '>=10.3.10 <11.0.0'
   flutter:
     sdk: flutter
   intl: '>=0.19.0 <0.21.0'


### PR DESCRIPTION
This PR fixes the CI failures on the main branch caused by `file_picker` version `10.3.9`, which accidentally removed the `FilePicker.platform` static getter. This was a breaking change that has been reverted in version 10.3.10.

The fix updates the file_picker dependency constraint from `>=8.1.0 <11.0.0` to `>=10.3.10 <11.0.0` to ensure the broken version is never resolved.

Affected packages:
- serverpod_auth_shared_flutter
- serverpod_chat_flutter

Reference: file_picker changelog (https://pub.dev/packages/file_picker/changelog) - version 10.3.10 notes: "Reverted breaking changes accidentally introduced in 10.3.9 to maintain Semantic Versioning compliance."

Fixes #4651

Pre-launch Checklist
- [x] I read the Contribute (https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the Dart Style Guide (https://dart.dev/guides/language/effective-dart/style) and formatted the code with dart format (https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] No documentation update.
- [x] I made sure existing tests are passing.
- [x] No breaking changes.