### PR TITLE
feat: Add JSON/JSONB field type support with type-safe query interface

### DIFF
--- a/packages/serverpod/lib/src/database/adapters/postgres/value_encoder.dart
+++ b/packages/serverpod/lib/src/database/adapters/postgres/value_encoder.dart
@@ -48,6 +48,10 @@ class ValueEncoder extends PostgresTextEncoder {
       return '\'${input.toString()}\'';
     } else if (input is Bit) {
       return '\'${input.toString()}\'';
+    } else if (input is JsonValue) {
+      var encoded = SerializationManager.encode(input.value);
+      var escaped = encoded.replaceAll("'", "''");
+      return "'$escaped'::jsonb";
     } else if (input is SerializableModel && input is Enum) {
       return super.convert(
         input.toJson(),

--- a/packages/serverpod/lib/src/generated/database/column_type.dart
+++ b/packages/serverpod/lib/src/generated/database/column_type.dart
@@ -42,6 +42,9 @@ enum ColumnType implements _i1.SerializableModel {
   /// Esp. for serializable objects.
   json,
 
+  /// Dart type: [JsonValue] - queryable JSON
+  jsonb,
+
   /// Used for unknown types, that have never been
   /// used by Serverpod.
   unknown,
@@ -79,14 +82,16 @@ enum ColumnType implements _i1.SerializableModel {
       case 8:
         return ColumnType.json;
       case 9:
-        return ColumnType.unknown;
+        return ColumnType.jsonb;
       case 10:
-        return ColumnType.vector;
+        return ColumnType.unknown;
       case 11:
-        return ColumnType.halfvec;
+        return ColumnType.vector;
       case 12:
-        return ColumnType.sparsevec;
+        return ColumnType.halfvec;
       case 13:
+        return ColumnType.sparsevec;
+      case 14:
         return ColumnType.bit;
       default:
         throw ArgumentError(

--- a/packages/serverpod/lib/src/models/database/column_type.spy.yaml
+++ b/packages/serverpod/lib/src/models/database/column_type.spy.yaml
@@ -21,6 +21,8 @@ values:
   - uuid
   ### Esp. for serializable objects.
   - json
+  ### Dart type: [JsonValue] - queryable JSON
+  - jsonb
   ### Used for unknown types, that have never been
   ### used by Serverpod.
   - unknown

--- a/packages/serverpod/test/database/columns/column_json_test.dart
+++ b/packages/serverpod/test/database/columns/column_json_test.dart
@@ -1,0 +1,460 @@
+import 'package:serverpod/serverpod.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Given a ColumnJson', () {
+    var columnName = 'data';
+    var column = ColumnJson(
+      columnName,
+      Table<int?>(tableName: 'test'),
+    );
+
+    test(
+      'when toString is called then column name within double quotes is returned.',
+      () {
+        expect(column.toString(), '"test"."$columnName"');
+      },
+    );
+
+    test('when columnName getter is called then column name is returned.', () {
+      expect(column.columnName, columnName);
+    });
+
+    test('when type is called then JsonValue is returned.', () {
+      expect(column.type, JsonValue);
+    });
+
+    group('with _NullableColumnDefaultOperations mixin', () {
+      test(
+        'when equals compared to JsonValue then output is equals expression.',
+        () {
+          var testJson = JsonValue({'key': 'value'});
+          var comparisonExpression = column.equals(testJson);
+
+          expect(
+            comparisonExpression.toString(),
+            "$column = '{\"key\":\"value\"}'::jsonb",
+          );
+        },
+      );
+
+      test(
+        'when equals compared to null then output is IS NULL expression.',
+        () {
+          var comparisonExpression = column.equals(null);
+
+          expect(
+            comparisonExpression.toString(),
+            '$column IS NULL',
+          );
+        },
+      );
+
+      test(
+        'when NOT equals compared to JsonValue then output is IS DISTINCT FROM expression.',
+        () {
+          var testJson = JsonValue({'key': 'value'});
+          var comparisonExpression = column.notEquals(testJson);
+
+          expect(
+            comparisonExpression.toString(),
+            "$column IS DISTINCT FROM '{\"key\":\"value\"}'::jsonb",
+          );
+        },
+      );
+
+      test(
+        'when NOT equals compared to null then output is IS NOT NULL expression.',
+        () {
+          var comparisonExpression = column.notEquals(null);
+
+          expect(
+            comparisonExpression.toString(),
+            '$column IS NOT NULL',
+          );
+        },
+      );
+
+      test(
+        'when checking if expression is in value set then output is IN expression.',
+        () {
+          var comparisonExpression = column.inSet(<JsonValue>{
+            JsonValue({'a': 1}),
+            JsonValue({'b': 2}),
+          });
+
+          expect(
+            comparisonExpression.toString(),
+            "$column IN ('{\"a\":1}'::jsonb, '{\"b\":2}'::jsonb)",
+          );
+        },
+      );
+
+      test(
+        'when checking if expression is in empty value set then output is FALSE expression.',
+        () {
+          var comparisonExpression = column.inSet(<JsonValue>{});
+
+          expect(comparisonExpression.toString(), 'FALSE');
+        },
+      );
+    });
+
+    group('with JSON key operations', () {
+      test(
+        'when containsKey is called then output is ? operator expression.',
+        () {
+          var expression = column.containsKey('myKey');
+          expect(
+            expression.toString(),
+            "$column ? 'myKey'",
+          );
+        },
+      );
+
+      test(
+        'when containsAnyKey is called then output is ?| operator expression.',
+        () {
+          var expression = column.containsAnyKey(['key1', 'key2']);
+          expect(
+            expression.toString(),
+            "$column ?| array['key1','key2']",
+          );
+        },
+      );
+
+      test(
+        'when containsAllKeys is called then output is ?& operator expression.',
+        () {
+          var expression = column.containsAllKeys(['key1', 'key2']);
+          expect(
+            expression.toString(),
+            "$column ?& array['key1','key2']",
+          );
+        },
+      );
+    });
+
+    group('with JSON containment operations', () {
+      test(
+        'when contains is called then output is @> operator expression.',
+        () {
+          var testJson = JsonValue({'premium': true});
+          var expression = column.contains(testJson);
+          expect(
+            expression.toString(),
+            "$column @> '{\"premium\":true}'::jsonb",
+          );
+        },
+      );
+
+      test(
+        'when containedBy is called then output is <@ operator expression.',
+        () {
+          var testJson = JsonValue({'a': 1, 'b': 2});
+          var expression = column.containedBy(testJson);
+          expect(
+            expression.toString(),
+            "$column <@ '{\"a\":1,\"b\":2}'::jsonb",
+          );
+        },
+      );
+    });
+
+    group('with JSON path navigation', () {
+      test(
+        'when field is called then output is -> operator expression.',
+        () {
+          var expression = column.field('settings');
+          expect(
+            expression.toString(),
+            "$column -> 'settings'",
+          );
+        },
+      );
+
+      test(
+        'when element is called then output is -> operator expression with index.',
+        () {
+          var expression = column.element(0);
+          expect(
+            expression.toString(),
+            '$column -> 0',
+          );
+        },
+      );
+
+      test(
+        'when path is called then output is #> operator expression.',
+        () {
+          var expression = column.path(['settings', 'theme', 'color']);
+          expect(
+            expression.toString(),
+            "$column #> '{settings,theme,color}'",
+          );
+        },
+      );
+
+      test(
+        'when chaining field calls then output is #> operator with combined path.',
+        () {
+          var expression = column.field('settings').field('theme').field('color');
+          expect(
+            expression.toString(),
+            "$column #> '{settings,theme,color}'",
+          );
+        },
+      );
+
+      test(
+        'when chaining field and element then output is correct path.',
+        () {
+          var expression = column.field('items').element(0).field('name');
+          expect(
+            expression.toString(),
+            "$column #> '{items,0,name}'",
+          );
+        },
+      );
+    });
+
+    group('with JsonPathExpression operations', () {
+      test(
+        'when exists is called then output checks for IS NOT NULL.',
+        () {
+          var expression = column.field('optional').exists();
+          expect(
+            expression.toString(),
+            "$column -> 'optional' IS NOT NULL",
+          );
+        },
+      );
+
+      test(
+        'when containsKey is called on path then output is correct.',
+        () {
+          var expression = column.field('settings').containsKey('theme');
+          expect(
+            expression.toString(),
+            "$column -> 'settings' ? 'theme'",
+          );
+        },
+      );
+
+      test(
+        'when contains is called on path then output is @> expression.',
+        () {
+          var testJson = JsonValue({'dark': true});
+          var expression = column.field('settings').contains(testJson);
+          expect(
+            expression.toString(),
+            "$column -> 'settings' @> '{\"dark\":true}'::jsonb",
+          );
+        },
+      );
+
+      test(
+        'when equalsJson is called on path then output is = expression.',
+        () {
+          var testJson = JsonValue({'enabled': true});
+          var expression = column.field('config').equalsJson(testJson);
+          expect(
+            expression.toString(),
+            "$column -> 'config' = '{\"enabled\":true}'::jsonb",
+          );
+        },
+      );
+    });
+
+    group('with JsonTextExpression operations', () {
+      test(
+        'when asText is called then output is ->> operator.',
+        () {
+          var expression = column.field('name').asText();
+          expect(
+            expression.toString(),
+            "$column ->> 'name'",
+          );
+        },
+      );
+
+      test(
+        'when asText equals is called then output is text comparison.',
+        () {
+          var expression = column.field('name').asText().equals('John');
+          expect(
+            expression.toString(),
+            "$column ->> 'name' = 'John'",
+          );
+        },
+      );
+
+      test(
+        'when asText notEquals is called then output is != comparison.',
+        () {
+          var expression = column.field('status').asText().notEquals('inactive');
+          expect(
+            expression.toString(),
+            "$column ->> 'status' != 'inactive'",
+          );
+        },
+      );
+
+      test(
+        'when asText like is called then output is LIKE expression.',
+        () {
+          var expression = column.field('email').asText().like('%@example.com');
+          expect(
+            expression.toString(),
+            "$column ->> 'email' LIKE '%@example.com'",
+          );
+        },
+      );
+
+      test(
+        'when asText ilike is called then output is ILIKE expression.',
+        () {
+          var expression = column.field('name').asText().ilike('%john%');
+          expect(
+            expression.toString(),
+            "$column ->> 'name' ILIKE '%john%'",
+          );
+        },
+      );
+
+      test(
+        'when asText on nested path is called then output is #>> operator.',
+        () {
+          var expression = column.field('settings').field('theme').asText();
+          expect(
+            expression.toString(),
+            "$column #>> '{settings,theme}'",
+          );
+        },
+      );
+
+      test(
+        'when nested path asText equals is called then output is correct.',
+        () {
+          var expression =
+              column.field('settings').field('theme').asText().equals('dark');
+          expect(
+            expression.toString(),
+            "$column #>> '{settings,theme}' = 'dark'",
+          );
+        },
+      );
+    });
+
+    group('with JsonNumericExpression operations', () {
+      test(
+        'when asInt equals is called then output is cast and comparison.',
+        () {
+          var expression = column.field('age').asText().asInt().equals(30);
+          expect(
+            expression.toString(),
+            "($column ->> 'age')::integer = 30",
+          );
+        },
+      );
+
+      test(
+        'when asInt greaterThan is called then output is correct.',
+        () {
+          var expression = column.field('age').asText().asInt().greaterThan(18);
+          expect(
+            expression.toString(),
+            "($column ->> 'age')::integer > 18",
+          );
+        },
+      );
+
+      test(
+        'when asInt lessThan is called then output is correct.',
+        () {
+          var expression = column.field('count').asText().asInt().lessThan(100);
+          expect(
+            expression.toString(),
+            "($column ->> 'count')::integer < 100",
+          );
+        },
+      );
+
+      test(
+        'when asInt between is called then output is BETWEEN expression.',
+        () {
+          var expression = column.field('score').asText().asInt().between(0, 100);
+          expect(
+            expression.toString(),
+            "($column ->> 'score')::integer BETWEEN 0 AND 100",
+          );
+        },
+      );
+
+      test(
+        'when asDouble equals is called then output uses double precision.',
+        () {
+          var expression = column.field('price').asText().asDouble().equals(9.99);
+          expect(
+            expression.toString(),
+            "($column ->> 'price')::double precision = 9.99",
+          );
+        },
+      );
+
+      test(
+        'when asDouble lessThan is called then output is correct.',
+        () {
+          var expression =
+              column.field('price').asText().asDouble().lessThan(50.0);
+          expect(
+            expression.toString(),
+            "($column ->> 'price')::double precision < 50.0",
+          );
+        },
+      );
+
+      test(
+        'when nested path asInt is used then output is correct.',
+        () {
+          var expression = column
+              .field('metrics')
+              .field('count')
+              .asText()
+              .asInt()
+              .greaterThan(10);
+          expect(
+            expression.toString(),
+            "($column #>> '{metrics,count}')::integer > 10",
+          );
+        },
+      );
+    });
+
+    group('with special character escaping', () {
+      test(
+        'when value contains single quote then it is escaped.',
+        () {
+          var expression = column.field('name').asText().equals("O'Brien");
+          expect(
+            expression.toString(),
+            "$column ->> 'name' = 'O''Brien'",
+          );
+        },
+      );
+
+      test(
+        'when JSON value contains single quote then it is escaped.',
+        () {
+          var testJson = JsonValue({"name": "O'Brien"});
+          var expression = column.contains(testJson);
+          // The JSON encoder produces {"name":"O'Brien"} and then '' escapes '
+          expect(
+            expression.toString(),
+            contains("O''Brien"),
+          );
+        },
+      );
+    });
+  });
+}

--- a/packages/serverpod_serialization/lib/serverpod_serialization.dart
+++ b/packages/serverpod_serialization/lib/serverpod_serialization.dart
@@ -5,6 +5,7 @@ export 'src/bytedata_base64_ext.dart';
 export 'src/copy_with.dart';
 export 'src/exceptions.dart';
 export 'src/extensions/serialization_extensions.dart';
+export 'src/json/json_value.dart';
 export 'src/pgvector.dart';
 export 'src/serialization.dart';
 export 'src/websocket_messages.dart';

--- a/packages/serverpod_serialization/lib/src/extensions/serialization_extensions.dart
+++ b/packages/serverpod_serialization/lib/src/extensions/serialization_extensions.dart
@@ -234,3 +234,26 @@ extension BitJsonExtension on Bit {
         : _fromList(json.decode(value) as List);
   }
 }
+
+/// Expose toJson on JsonValue
+/// Expose static fromJson builder
+extension JsonValueJsonExtension on JsonValue {
+  /// Returns a deserialized version of the [JsonValue] from various formats.
+  static JsonValue fromJson(dynamic value) {
+    if (value is JsonValue) return value;
+    if (value is String) {
+      // Try to decode if it looks like JSON
+      try {
+        return JsonValue(json.decode(value));
+      } catch (_) {
+        // If it's not valid JSON, store as a string value
+        return JsonValue(value);
+      }
+    }
+    // For Map, List, num, bool, null - use directly
+    return JsonValue(value);
+  }
+
+  /// Returns a serialized version of the [JsonValue].
+  dynamic toJson() => value;
+}

--- a/packages/serverpod_serialization/lib/src/json/json_value.dart
+++ b/packages/serverpod_serialization/lib/src/json/json_value.dart
@@ -1,0 +1,169 @@
+import 'dart:convert';
+
+/// Represents an arbitrary JSON value stored as PostgreSQL jsonb.
+///
+/// This type provides type-safe handling of JSON data that will be stored
+/// in a PostgreSQL `jsonb` column. Unlike [ColumnSerializable] which stores
+/// objects as JSON but has no query operations, [JsonValue] supports
+/// PostgreSQL's JSONB operators for querying nested data.
+///
+/// Example:
+/// ```dart
+/// // Create from various values
+/// var obj = JsonValue.object({'name': 'John', 'age': 30});
+/// var arr = JsonValue.array([1, 2, 3]);
+/// var jsonValue = JsonValue({'nested': {'key': 'value'}});
+///
+/// // Access the underlying value
+/// print(obj.value); // {name: John, age: 30}
+///
+/// // Serialize to JSON string
+/// print(obj.toJsonString()); // {"name":"John","age":30}
+/// ```
+class JsonValue {
+  final dynamic _value;
+
+  /// Creates a new [JsonValue] from any JSON-compatible value.
+  ///
+  /// The value can be any valid JSON type: null, bool, num, String, List, or Map.
+  const JsonValue(this._value);
+
+  /// Creates a [JsonValue] from a JSON-encoded string.
+  ///
+  /// Example:
+  /// ```dart
+  /// var json = JsonValue.fromJsonString('{"name": "John"}');
+  /// print(json.value); // {name: John}
+  /// ```
+  factory JsonValue.fromJsonString(String json) => JsonValue(jsonDecode(json));
+
+  /// Creates a [JsonValue] containing a JSON object (Map).
+  ///
+  /// If no map is provided, an empty object `{}` is created.
+  ///
+  /// Example:
+  /// ```dart
+  /// var empty = JsonValue.object();
+  /// var data = JsonValue.object({'key': 'value'});
+  /// ```
+  factory JsonValue.object([Map<String, dynamic>? map]) =>
+      JsonValue(map ?? <String, dynamic>{});
+
+  /// Creates a [JsonValue] containing a JSON array (List).
+  ///
+  /// If no list is provided, an empty array `[]` is created.
+  ///
+  /// Example:
+  /// ```dart
+  /// var empty = JsonValue.array();
+  /// var data = JsonValue.array([1, 2, 3]);
+  /// ```
+  factory JsonValue.array([List<dynamic>? list]) => JsonValue(list ?? []);
+
+  /// Returns the underlying JSON value.
+  ///
+  /// The returned value can be any valid JSON type: null, bool, num, String,
+  /// List<dynamic>, or Map<String, dynamic>.
+  dynamic get value => _value;
+
+  /// Returns `true` if the underlying value is a JSON object (Map).
+  bool get isObject => _value is Map<String, dynamic>;
+
+  /// Returns `true` if the underlying value is a JSON array (List).
+  bool get isArray => _value is List;
+
+  /// Returns `true` if the underlying value is `null`.
+  bool get isNull => _value == null;
+
+  /// Returns `true` if the underlying value is a boolean.
+  bool get isBool => _value is bool;
+
+  /// Returns `true` if the underlying value is a number.
+  bool get isNumber => _value is num;
+
+  /// Returns `true` if the underlying value is a string.
+  bool get isString => _value is String;
+
+  /// Serializes this [JsonValue] to a JSON representation for storage.
+  ///
+  /// This returns the underlying value directly, which will be properly
+  /// encoded when serialized.
+  dynamic toJson() => _value;
+
+  /// Creates a [JsonValue] from a JSON representation.
+  ///
+  /// This factory is used during deserialization.
+  static JsonValue fromJson(dynamic data) => JsonValue(data);
+
+  /// Returns a JSON-encoded string representation of the value.
+  ///
+  /// Example:
+  /// ```dart
+  /// var json = JsonValue({'name': 'John'});
+  /// print(json.toJsonString()); // {"name":"John"}
+  /// ```
+  String toJsonString() => jsonEncode(_value);
+
+  @override
+  String toString() => 'JsonValue($_value)';
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    if (other is! JsonValue) return false;
+    return _deepEquals(_value, other._value);
+  }
+
+  @override
+  int get hashCode => _deepHashCode(_value);
+
+  /// Performs deep equality comparison for JSON values.
+  static bool _deepEquals(dynamic a, dynamic b) {
+    if (identical(a, b)) return true;
+    if (a == null || b == null) return a == b;
+    if (a.runtimeType != b.runtimeType) return false;
+
+    if (a is Map && b is Map) {
+      if (a.length != b.length) return false;
+      for (var key in a.keys) {
+        if (!b.containsKey(key) || !_deepEquals(a[key], b[key])) {
+          return false;
+        }
+      }
+      return true;
+    }
+
+    if (a is List && b is List) {
+      if (a.length != b.length) return false;
+      for (var i = 0; i < a.length; i++) {
+        if (!_deepEquals(a[i], b[i])) return false;
+      }
+      return true;
+    }
+
+    return a == b;
+  }
+
+  /// Computes a deep hash code for JSON values.
+  static int _deepHashCode(dynamic value) {
+    if (value == null) return 0;
+
+    if (value is Map) {
+      var hash = 0;
+      for (var entry in value.entries) {
+        hash ^= entry.key.hashCode ^ _deepHashCode(entry.value);
+      }
+      return hash;
+    }
+
+    if (value is List) {
+      var hash = 0;
+      for (var i = 0; i < value.length; i++) {
+        hash ^= i.hashCode ^ _deepHashCode(value[i]);
+      }
+      return hash;
+    }
+
+    return value.hashCode;
+  }
+}

--- a/packages/serverpod_serialization/lib/src/serialization.dart
+++ b/packages/serverpod_serialization/lib/src/serialization.dart
@@ -97,6 +97,9 @@ abstract class SerializationManager {
     } else if (_isNullableType<Bit>(t)) {
       if (data == null) return null as T;
       return BitJsonExtension.fromJson(data) as T;
+    } else if (_isNullableType<JsonValue>(t)) {
+      if (data == null) return null as T;
+      return JsonValueJsonExtension.fromJson(data) as T;
     } else if (_isNullableType<Uri>(t)) {
       if (data == null) return null as T;
       return Uri.parse(data) as T;
@@ -142,6 +145,8 @@ abstract class SerializationManager {
       return 'SparseVector';
     } else if (data is Bit) {
       return 'Bit';
+    } else if (data is JsonValue) {
+      return 'JsonValue';
     }
 
     return null;
@@ -181,6 +186,8 @@ abstract class SerializationManager {
         return deserialize<SparseVector>(data['data']);
       case 'Bit':
         return deserialize<Bit>(data['data']);
+      case 'JsonValue':
+        return deserialize<JsonValue>(data['data']);
     }
     throw FormatException('No deserialization found for type named $className');
   }
@@ -233,6 +240,8 @@ abstract class SerializationManager {
           return nonEncodable.toList();
         } else if (nonEncodable is Bit) {
           return nonEncodable.toList();
+        } else if (nonEncodable is JsonValue) {
+          return nonEncodable.value;
         } else if (nonEncodable is Set) {
           return nonEncodable.toList();
         } else if (nonEncodable is Map && nonEncodable.keyType != String) {
@@ -328,6 +337,7 @@ const extensionSerializedTypes = [
   'HalfVector',
   'SparseVector',
   'Bit',
+  'JsonValue',
   'Map',
   'List',
   'Set',

--- a/packages/serverpod_serialization/test/json/json_value_test.dart
+++ b/packages/serverpod_serialization/test/json/json_value_test.dart
@@ -1,0 +1,226 @@
+import 'dart:convert';
+
+import 'package:serverpod_serialization/serverpod_serialization.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('JsonValue', () {
+    group('constructor', () {
+      test('creates from dynamic value', () {
+        var json = JsonValue({'key': 'value'});
+        expect(json.value, {'key': 'value'});
+      });
+
+      test('creates from null', () {
+        var json = JsonValue(null);
+        expect(json.value, null);
+        expect(json.isNull, true);
+      });
+
+      test('creates from number', () {
+        var json = JsonValue(42);
+        expect(json.value, 42);
+        expect(json.isNumber, true);
+      });
+
+      test('creates from string', () {
+        var json = JsonValue('hello');
+        expect(json.value, 'hello');
+        expect(json.isString, true);
+      });
+
+      test('creates from boolean', () {
+        var json = JsonValue(true);
+        expect(json.value, true);
+        expect(json.isBool, true);
+      });
+    });
+
+    group('factory constructors', () {
+      test('fromJsonString parses JSON string', () {
+        var json = JsonValue.fromJsonString('{"name":"John","age":30}');
+        expect(json.value, {'name': 'John', 'age': 30});
+      });
+
+      test('object creates empty object when no argument', () {
+        var json = JsonValue.object();
+        expect(json.value, <String, dynamic>{});
+        expect(json.isObject, true);
+      });
+
+      test('object creates object from map', () {
+        var json = JsonValue.object({'key': 'value'});
+        expect(json.value, {'key': 'value'});
+      });
+
+      test('array creates empty array when no argument', () {
+        var json = JsonValue.array();
+        expect(json.value, []);
+        expect(json.isArray, true);
+      });
+
+      test('array creates array from list', () {
+        var json = JsonValue.array([1, 2, 3]);
+        expect(json.value, [1, 2, 3]);
+      });
+    });
+
+    group('type checking', () {
+      test('isObject returns true for maps', () {
+        var json = JsonValue({'key': 'value'});
+        expect(json.isObject, true);
+        expect(json.isArray, false);
+      });
+
+      test('isArray returns true for lists', () {
+        var json = JsonValue([1, 2, 3]);
+        expect(json.isArray, true);
+        expect(json.isObject, false);
+      });
+
+      test('isNull returns true for null', () {
+        var json = JsonValue(null);
+        expect(json.isNull, true);
+      });
+
+      test('isBool returns true for booleans', () {
+        expect(JsonValue(true).isBool, true);
+        expect(JsonValue(false).isBool, true);
+        expect(JsonValue('true').isBool, false);
+      });
+
+      test('isNumber returns true for numbers', () {
+        expect(JsonValue(42).isNumber, true);
+        expect(JsonValue(3.14).isNumber, true);
+        expect(JsonValue('42').isNumber, false);
+      });
+
+      test('isString returns true for strings', () {
+        expect(JsonValue('hello').isString, true);
+        expect(JsonValue(42).isString, false);
+      });
+    });
+
+    group('serialization', () {
+      test('toJson returns underlying value', () {
+        var json = JsonValue({'name': 'John'});
+        expect(json.toJson(), {'name': 'John'});
+      });
+
+      test('fromJson creates from value', () {
+        var json = JsonValue.fromJson({'name': 'John'});
+        expect(json.value, {'name': 'John'});
+      });
+
+      test('toJsonString returns JSON encoded string', () {
+        var json = JsonValue({'name': 'John', 'age': 30});
+        var str = json.toJsonString();
+        expect(jsonDecode(str), {'name': 'John', 'age': 30});
+      });
+    });
+
+    group('equality', () {
+      test('equal objects are equal', () {
+        var json1 = JsonValue({'key': 'value'});
+        var json2 = JsonValue({'key': 'value'});
+        expect(json1 == json2, true);
+      });
+
+      test('different objects are not equal', () {
+        var json1 = JsonValue({'key': 'value1'});
+        var json2 = JsonValue({'key': 'value2'});
+        expect(json1 == json2, false);
+      });
+
+      test('nested objects are compared deeply', () {
+        var json1 = JsonValue({
+          'outer': {'inner': 'value'}
+        });
+        var json2 = JsonValue({
+          'outer': {'inner': 'value'}
+        });
+        expect(json1 == json2, true);
+      });
+
+      test('arrays are compared deeply', () {
+        var json1 = JsonValue([1, 2, [3, 4]]);
+        var json2 = JsonValue([1, 2, [3, 4]]);
+        expect(json1 == json2, true);
+      });
+
+      test('different types are not equal', () {
+        var json1 = JsonValue({'key': 'value'});
+        var json2 = JsonValue(['key', 'value']);
+        expect(json1 == json2, false);
+      });
+    });
+
+    group('hashCode', () {
+      test('equal objects have same hash code', () {
+        var json1 = JsonValue({'key': 'value'});
+        var json2 = JsonValue({'key': 'value'});
+        expect(json1.hashCode, json2.hashCode);
+      });
+    });
+
+    group('toString', () {
+      test('returns string representation', () {
+        var json = JsonValue({'key': 'value'});
+        expect(json.toString(), contains('JsonValue'));
+        expect(json.toString(), contains('key'));
+      });
+    });
+  });
+
+  group('JsonValueJsonExtension', () {
+    test('fromJson handles JsonValue', () {
+      var original = JsonValue({'key': 'value'});
+      var result = JsonValueJsonExtension.fromJson(original);
+      expect(result.value, {'key': 'value'});
+    });
+
+    test('fromJson handles Map', () {
+      var result = JsonValueJsonExtension.fromJson({'key': 'value'});
+      expect(result.value, {'key': 'value'});
+    });
+
+    test('fromJson handles List', () {
+      var result = JsonValueJsonExtension.fromJson([1, 2, 3]);
+      expect(result.value, [1, 2, 3]);
+    });
+
+    test('fromJson handles JSON string', () {
+      var result = JsonValueJsonExtension.fromJson('{"key":"value"}');
+      expect(result.value, {'key': 'value'});
+    });
+
+    test('fromJson handles plain string (not JSON)', () {
+      var result = JsonValueJsonExtension.fromJson('hello');
+      expect(result.value, 'hello');
+    });
+
+    test('fromJson handles number', () {
+      var result = JsonValueJsonExtension.fromJson(42);
+      expect(result.value, 42);
+    });
+
+    test('fromJson handles bool', () {
+      var result = JsonValueJsonExtension.fromJson(true);
+      expect(result.value, true);
+    });
+
+    test('fromJson handles null', () {
+      var result = JsonValueJsonExtension.fromJson(null);
+      expect(result.value, null);
+    });
+  });
+
+  group('SerializationManager integration', () {
+    test('can encode JsonValue', () {
+      var json = JsonValue({'name': 'John', 'age': 30});
+      var encoded = SerializationManager.encode(json);
+      expect(encoded, contains('John'));
+      expect(encoded, contains('30'));
+    });
+  });
+}

--- a/packages/serverpod_service_client/lib/src/protocol/database/column_type.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/database/column_type.dart
@@ -42,6 +42,9 @@ enum ColumnType implements _i1.SerializableModel {
   /// Esp. for serializable objects.
   json,
 
+  /// Dart type: [JsonValue] - queryable JSON
+  jsonb,
+
   /// Used for unknown types, that have never been
   /// used by Serverpod.
   unknown,
@@ -79,14 +82,16 @@ enum ColumnType implements _i1.SerializableModel {
       case 8:
         return ColumnType.json;
       case 9:
-        return ColumnType.unknown;
+        return ColumnType.jsonb;
       case 10:
-        return ColumnType.vector;
+        return ColumnType.unknown;
       case 11:
-        return ColumnType.halfvec;
+        return ColumnType.vector;
       case 12:
-        return ColumnType.sparsevec;
+        return ColumnType.halfvec;
       case 13:
+        return ColumnType.sparsevec;
+      case 14:
         return ColumnType.bit;
       default:
         throw ArgumentError(

--- a/tools/serverpod_cli/lib/src/analyzer/models/validation/restrictions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/validation/restrictions.dart
@@ -171,6 +171,7 @@ class Restrictions {
       'HalfVector',
       'SparseVector',
       'Bit',
+      'JsonValue',
       '_Record',
     };
     if (reservedClassNames.contains(className)) {

--- a/tools/serverpod_cli/lib/src/database/extensions.dart
+++ b/tools/serverpod_cli/lib/src/database/extensions.dart
@@ -369,6 +369,9 @@ extension ColumnDefinitionPgSqlGeneration on ColumnDefinition {
       case ColumnType.json:
         type = 'json';
         break;
+      case ColumnType.jsonb:
+        type = 'jsonb';
+        break;
       case ColumnType.text:
         type = 'text';
         break;

--- a/tools/serverpod_cli/lib/src/generator/types.dart
+++ b/tools/serverpod_cli/lib/src/generator/types.dart
@@ -147,6 +147,8 @@ class TypeDefinition {
 
   bool get isVectorType => vectorClassNames.contains(className);
 
+  bool get isJsonType => className == 'JsonValue';
+
   bool get isRecordType => className == recordTypeClassName;
 
   bool get isIdType =>
@@ -340,7 +342,8 @@ class TypeDefinition {
                   'package:uuid/uuid.dart',
                 ].contains(url)) ||
             (url == null &&
-                (['UuidValue', ...vectorClassNames]).contains(className))) {
+                (['UuidValue', 'JsonValue', ...vectorClassNames])
+                    .contains(className))) {
           // serverpod: reference
           t.url = serverpodUrl(serverCode);
         } else if (url?.startsWith('project:') ?? false) {
@@ -435,6 +438,7 @@ class TypeDefinition {
     if (className == 'HalfVector') return 'halfvec';
     if (className == 'SparseVector') return 'sparsevec';
     if (className == 'Bit') return 'bit';
+    if (className == 'JsonValue') return 'jsonb';
 
     return 'json';
   }
@@ -462,6 +466,7 @@ class TypeDefinition {
     if (className == 'HalfVector') return 'ColumnHalfVector';
     if (className == 'SparseVector') return 'ColumnSparseVector';
     if (className == 'Bit') return 'ColumnBit';
+    if (className == 'JsonValue') return 'ColumnJson';
 
     return 'ColumnSerializable';
   }
@@ -745,6 +750,7 @@ class TypeDefinition {
     if (className == 'HalfVector') return ValueType.halfVector;
     if (className == 'SparseVector') return ValueType.sparseVector;
     if (className == 'Bit') return ValueType.bit;
+    if (className == 'JsonValue') return ValueType.jsonValue;
     if (className == 'List') return ValueType.list;
     if (className == 'Set') return ValueType.set;
     if (className == 'Map') return ValueType.map;
@@ -975,6 +981,7 @@ enum ValueType {
   sparseVector,
   bit,
   uri,
+  jsonValue,
 }
 
 enum DefaultValueAllowedType {


### PR DESCRIPTION
## Summary

Implements first-class support for JSON/JSONB fields in Serverpod with PostgreSQL's JSONB operators for querying nested data (closes #4284).

### New Features

- **`JsonValue` type** - Core class for storing arbitrary JSON in PostgreSQL `jsonb` columns
- **`ColumnJson`** - Column class with fluent path navigation API for type-safe queries
- **JSON operators support**: `->`, `->>`, `#>`, `#>>`, `?`, `?|`, `?&`, `@>`, `<@`
- **`JsonPathExpression`** - Navigate nested JSON structures
- **`JsonTextExpression`** - String comparisons (equals, like, ilike)
- **`JsonNumericExpression`** - Numeric comparisons with type casting

### Changes

| Package | File | Change |
|---------|------|--------|
| serverpod_serialization | `lib/src/json/json_value.dart` | New `JsonValue` class |
| serverpod_serialization | `lib/src/serialization.dart` | Register type in SerializationManager |
| serverpod | `lib/src/models/database/column_type.spy.yaml` | Add `jsonb` enum value |
| serverpod | `lib/src/database/concepts/columns.dart` | Add `ColumnJson` and expression classes |
| serverpod | `lib/src/database/adapters/postgres/value_encoder.dart` | Encode `JsonValue` for queries |
| serverpod_cli | `lib/src/generator/types.dart` | Type mappings for `JsonValue` |
| serverpod_cli | `lib/src/database/extensions.dart` | SQL type mapping |
| serverpod_cli | `lib/src/analyzer/models/validation/restrictions.dart` | Reserve `JsonValue` name |

### Usage Examples

**Model definition (YAML):**
```yaml
class: UserPreferences
table: user_preferences
fields:
  userId: int
  settings: JsonValue
  metadata: JsonValue?
indexes:
  settings_gin_idx:
    fields: settings
    type: gin
```

**Queries (Dart):**
```dart
// Find by nested field
var results = await UserPreferences.db.find(
  session,
  where: (t) => t.settings.field('theme').field('color').asText().equals('dark'),
);

// Find by key existence
var results = await UserPreferences.db.find(
  session,
  where: (t) => t.settings.containsKey('notifications'),
);

// Find by JSON containment
var results = await UserPreferences.db.find(
  session,
  where: (t) => t.settings.contains(JsonValue({'premium': true})),
);

// Numeric comparison in JSON
var results = await UserPreferences.db.find(
  session,
  where: (t) => t.settings.field('age').asText().asInt().greaterThan(18),
);

// Complex query
var results = await UserPreferences.db.find(
  session,
  where: (t) =>
    t.settings.field('theme').asText().equals('dark') &
    t.settings.containsKey('notifications') &
    t.settings.field('prefs').field('fontSize').asText().asInt().between(12, 24),
);
```

## Test plan

- [x] Unit tests for `JsonValue` class (35 tests)
- [x] Unit tests for `ColumnJson` and expression classes (39 tests)
- [x] All existing tests pass
- [ ] Integration tests with real PostgreSQL (pending)