### PR TITLE
refactor: Move the `websocketPingInterval` config to the `apiServer` section

### DIFF
--- a/packages/serverpod_shared/lib/src/config.dart
+++ b/packages/serverpod_shared/lib/src/config.dart
@@ -244,7 +244,7 @@ class ServerpodConfig {
     );
 
     var websocketPingInterval = _readWebsocketPingInterval(
-      configMap,
+      apiConfig,
       environment,
     );
 
@@ -321,6 +321,7 @@ class ServerpodConfig {
     FutureCallConfig? futureCall,
     bool? futureCallExecutionEnabled,
     bool? validateHeaders,
+    Duration? websocketPingInterval,
   }) {
     return ServerpodConfig(
       apiServer: apiServer ?? this.apiServer,
@@ -345,6 +346,8 @@ class ServerpodConfig {
       futureCallExecutionEnabled:
           futureCallExecutionEnabled ?? this.futureCallExecutionEnabled,
       validateHeaders: validateHeaders ?? this.validateHeaders,
+      websocketPingInterval:
+          websocketPingInterval ?? this.websocketPingInterval,
     );
   }
 
@@ -1161,14 +1164,14 @@ bool _readValidateHeaders(
 }
 
 Duration _readWebsocketPingInterval(
-  Map<dynamic, dynamic> configMap,
+  Map<dynamic, dynamic>? apiServerConfigMap,
   Map<String, String> environment,
 ) {
   final envVariable = ServerpodEnv.websocketPingInterval.envVariable;
   final configKey = ServerpodEnv.websocketPingInterval.configKey;
 
-  var websocketPingInterval = configMap[configKey];
-  var sourceDescription = '$configKey from configuration';
+  var websocketPingInterval = apiServerConfigMap?[configKey];
+  var sourceDescription = '$configKey from apiServer configuration';
 
   if (environment[envVariable] != null) {
     websocketPingInterval = environment[envVariable];

--- a/packages/serverpod_shared/lib/src/environment_variables.dart
+++ b/packages/serverpod_shared/lib/src/environment_variables.dart
@@ -242,6 +242,8 @@ enum ServerpodEnv {
       (ServerpodEnv.apiPublicHost) => 'SERVERPOD_API_SERVER_PUBLIC_HOST',
       (ServerpodEnv.apiPublicPort) => 'SERVERPOD_API_SERVER_PUBLIC_PORT',
       (ServerpodEnv.apiPublicScheme) => 'SERVERPOD_API_SERVER_PUBLIC_SCHEME',
+      (ServerpodEnv.websocketPingInterval) =>
+        'SERVERPOD_API_SERVER_WEBSOCKET_PING_INTERVAL',
       (ServerpodEnv.insightsPort) => 'SERVERPOD_INSIGHTS_SERVER_PORT',
       (ServerpodEnv.insightsPublicHost) =>
         'SERVERPOD_INSIGHTS_SERVER_PUBLIC_HOST',
@@ -273,8 +275,6 @@ enum ServerpodEnv {
       (ServerpodEnv.applyMigrations) => 'SERVERPOD_APPLY_MIGRATIONS',
       (ServerpodEnv.applyRepairMigration) => 'SERVERPOD_APPLY_REPAIR_MIGRATION',
       (ServerpodEnv.validateHeaders) => 'SERVERPOD_VALIDATE_HEADERS',
-      (ServerpodEnv.websocketPingInterval) =>
-        'SERVERPOD_WEBSOCKET_PING_INTERVAL',
     };
   }
 }

--- a/packages/serverpod_shared/test/config_test.dart
+++ b/packages/serverpod_shared/test/config_test.dart
@@ -1845,7 +1845,7 @@ apiServer:
   publicHost: localhost
   publicPort: 8080
   publicScheme: http
-websocketPingInterval: 15
+  websocketPingInterval: 15
 ''';
 
       var config = ServerpodConfig.loadFromMap(
@@ -1868,7 +1868,7 @@ apiServer:
   publicHost: localhost
   publicPort: 8080
   publicScheme: http
-websocketPingInterval: 15
+  websocketPingInterval: 15
 ''';
 
       var config = ServerpodConfig.loadFromMap(
@@ -1877,7 +1877,7 @@ websocketPingInterval: 15
         passwords,
         loadYaml(serverpodConfig),
         environment: {
-          'SERVERPOD_WEBSOCKET_PING_INTERVAL': '20',
+          'SERVERPOD_API_SERVER_WEBSOCKET_PING_INTERVAL': '20',
         },
       );
 
@@ -1894,7 +1894,7 @@ websocketPingInterval: 15
         passwords,
         {},
         environment: {
-          'SERVERPOD_WEBSOCKET_PING_INTERVAL': '10',
+          'SERVERPOD_API_SERVER_WEBSOCKET_PING_INTERVAL': '10',
         },
       );
 
@@ -1912,7 +1912,7 @@ websocketPingInterval: 15
           passwords,
           {},
           environment: {
-            'SERVERPOD_WEBSOCKET_PING_INTERVAL': 'invalid',
+            'SERVERPOD_API_SERVER_WEBSOCKET_PING_INTERVAL': 'invalid',
           },
         ),
         throwsA(
@@ -1920,7 +1920,7 @@ websocketPingInterval: 15
             (e) => e.toString(),
             'message',
             contains(
-              'Invalid SERVERPOD_WEBSOCKET_PING_INTERVAL from environment variable: invalid',
+              'Invalid SERVERPOD_API_SERVER_WEBSOCKET_PING_INTERVAL from environment variable: invalid',
             ),
           ),
         ),
@@ -1938,7 +1938,7 @@ websocketPingInterval: 15
           passwords,
           {},
           environment: {
-            'SERVERPOD_WEBSOCKET_PING_INTERVAL': '0',
+            'SERVERPOD_API_SERVER_WEBSOCKET_PING_INTERVAL': '0',
           },
         ),
         throwsA(
@@ -1946,7 +1946,7 @@ websocketPingInterval: 15
             (e) => e.toString(),
             'message',
             contains(
-              'Invalid SERVERPOD_WEBSOCKET_PING_INTERVAL from environment variable: 0',
+              'Invalid SERVERPOD_API_SERVER_WEBSOCKET_PING_INTERVAL from environment variable: 0',
             ),
           ),
         ),
@@ -1964,7 +1964,7 @@ websocketPingInterval: 15
           passwords,
           {},
           environment: {
-            'SERVERPOD_WEBSOCKET_PING_INTERVAL': '-5',
+            'SERVERPOD_API_SERVER_WEBSOCKET_PING_INTERVAL': '-5',
           },
         ),
         throwsA(
@@ -1972,7 +1972,7 @@ websocketPingInterval: 15
             (e) => e.toString(),
             'message',
             contains(
-              'Invalid SERVERPOD_WEBSOCKET_PING_INTERVAL from environment variable: -5. '
+              'Invalid SERVERPOD_API_SERVER_WEBSOCKET_PING_INTERVAL from environment variable: -5. '
               'Expected a positive integer greater than 0.',
             ),
           ),
@@ -1990,7 +1990,7 @@ apiServer:
   publicHost: localhost
   publicPort: 8080
   publicScheme: http
-websocketPingInterval: 0
+  websocketPingInterval: 0
 ''';
 
       expect(
@@ -2005,7 +2005,7 @@ websocketPingInterval: 0
             (e) => e.toString(),
             'message',
             contains(
-              'Invalid websocketPingInterval from configuration: 0. '
+              'Invalid websocketPingInterval from apiServer configuration: 0. '
               'Expected a positive integer greater than 0.',
             ),
           ),

--- a/tests/bootstrap_project/test/config_validation_e2e_test.dart
+++ b/tests/bootstrap_project/test/config_validation_e2e_test.dart
@@ -66,7 +66,7 @@ void main() async {
           ['bin/main.dart'],
           workingDirectory: commandRoot,
           environment: {
-            'SERVERPOD_WEBSOCKET_PING_INTERVAL': '-1',
+            'SERVERPOD_API_SERVER_WEBSOCKET_PING_INTERVAL': '-1',
           },
         );
 
@@ -74,7 +74,7 @@ void main() async {
         expect(
           result.stderr.toString(),
           contains(
-            'Error loading ServerpodConfig: Invalid SERVERPOD_WEBSOCKET_PING_INTERVAL '
+            'Error loading ServerpodConfig: Invalid SERVERPOD_API_SERVER_WEBSOCKET_PING_INTERVAL '
             'from environment variable: -1. Expected a positive integer greater than 0',
           ),
         );
@@ -90,7 +90,7 @@ void main() async {
           ['bin/main.dart'],
           workingDirectory: commandRoot,
           environment: {
-            'SERVERPOD_WEBSOCKET_PING_INTERVAL': '0',
+            'SERVERPOD_API_SERVER_WEBSOCKET_PING_INTERVAL': '0',
           },
         );
 
@@ -98,7 +98,7 @@ void main() async {
         expect(
           result.stderr.toString(),
           contains(
-            'Error loading ServerpodConfig: Invalid SERVERPOD_WEBSOCKET_PING_INTERVAL '
+            'Error loading ServerpodConfig: Invalid SERVERPOD_API_SERVER_WEBSOCKET_PING_INTERVAL '
             'from environment variable: 0. Expected a positive integer greater than 0',
           ),
         );
@@ -114,7 +114,7 @@ void main() async {
           ['bin/main.dart'],
           workingDirectory: commandRoot,
           environment: {
-            'SERVERPOD_WEBSOCKET_PING_INTERVAL': 'invalid',
+            'SERVERPOD_API_SERVER_WEBSOCKET_PING_INTERVAL': 'invalid',
           },
         );
 
@@ -122,7 +122,7 @@ void main() async {
         expect(
           result.stderr.toString(),
           contains(
-            'Error loading ServerpodConfig: Invalid SERVERPOD_WEBSOCKET_PING_INTERVAL '
+            'Error loading ServerpodConfig: Invalid SERVERPOD_API_SERVER_WEBSOCKET_PING_INTERVAL '
             'from environment variable: invalid. Expected a positive integer',
           ),
         );
@@ -138,7 +138,7 @@ void main() async {
           ['bin/main.dart', '--role', 'maintenance'],
           workingDirectory: commandRoot,
           environment: {
-            'SERVERPOD_WEBSOCKET_PING_INTERVAL': '15',
+            'SERVERPOD_API_SERVER_WEBSOCKET_PING_INTERVAL': '15',
           },
         );
 

--- a/tests/serverpod_test_server/test_integration/serverpod_config_validation_test.dart
+++ b/tests/serverpod_test_server/test_integration/serverpod_config_validation_test.dart
@@ -20,7 +20,7 @@ void main() {
               passwords,
               {},
               environment: {
-                'SERVERPOD_WEBSOCKET_PING_INTERVAL': '-1',
+                'SERVERPOD_API_SERVER_WEBSOCKET_PING_INTERVAL': '-1',
               },
             ),
             throwsA(
@@ -28,7 +28,7 @@ void main() {
                 (e) => e.toString(),
                 'message',
                 contains(
-                  'Invalid SERVERPOD_WEBSOCKET_PING_INTERVAL from environment '
+                  'Invalid SERVERPOD_API_SERVER_WEBSOCKET_PING_INTERVAL from environment '
                   'variable: -1. Expected a positive integer greater than 0.',
                 ),
               ),
@@ -48,7 +48,7 @@ void main() {
               passwords,
               {},
               environment: {
-                'SERVERPOD_WEBSOCKET_PING_INTERVAL': '0',
+                'SERVERPOD_API_SERVER_WEBSOCKET_PING_INTERVAL': '0',
               },
             ),
             throwsA(
@@ -56,7 +56,7 @@ void main() {
                 (e) => e.toString(),
                 'message',
                 contains(
-                  'Invalid SERVERPOD_WEBSOCKET_PING_INTERVAL from environment '
+                  'Invalid SERVERPOD_API_SERVER_WEBSOCKET_PING_INTERVAL from environment '
                   'variable: 0. Expected a positive integer greater than 0.',
                 ),
               ),
@@ -76,7 +76,7 @@ void main() {
               passwords,
               {},
               environment: {
-                'SERVERPOD_WEBSOCKET_PING_INTERVAL': 'invalid',
+                'SERVERPOD_API_SERVER_WEBSOCKET_PING_INTERVAL': 'invalid',
               },
             ),
             throwsA(
@@ -84,7 +84,7 @@ void main() {
                 (e) => e.toString(),
                 'message',
                 contains(
-                  'Invalid SERVERPOD_WEBSOCKET_PING_INTERVAL from environment '
+                  'Invalid SERVERPOD_API_SERVER_WEBSOCKET_PING_INTERVAL from environment '
                   'variable: invalid. Expected a positive integer greater than 0.',
                 ),
               ),
@@ -103,7 +103,7 @@ void main() {
             passwords,
             {},
             environment: {
-              'SERVERPOD_WEBSOCKET_PING_INTERVAL': '15',
+              'SERVERPOD_API_SERVER_WEBSOCKET_PING_INTERVAL': '15',
             },
           );
 


### PR DESCRIPTION
While writing the docs for the feature introduced with #4625, it felt like the config was kind of misplaced. This PR moves it to where it lives: the API server.

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None, since the config has not yet been released.