### PR TITLE
fix: Export VerificationCodeConfig in serverpod_auth_idp_flutter

### DIFF
--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_flutter/lib/serverpod_auth_idp_flutter.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_flutter/lib/serverpod_auth_idp_flutter.dart
@@ -21,7 +21,6 @@ export 'src/common/oauth2_pkce/oauth2_pkce_result.dart';
 export 'src/common/oauth2_pkce/oauth2_pkce_util.dart';
 export 'src/email/email_auth_controller.dart';
 export 'src/email/email_sign_in_widget.dart';
-export 'src/email/forms/verification.dart' show VerificationCodeConfig;
 export 'src/github/github_auth_controller.dart';
 export 'src/github/github_sign_in_button.dart';
 export 'src/github/github_sign_in_service.dart';

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_flutter/lib/src/email/email_sign_in_widget.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_flutter/lib/src/email/email_sign_in_widget.dart
@@ -11,6 +11,8 @@ import 'forms/password_reset_complete.dart';
 import 'forms/registration_complete.dart';
 import 'forms/verification.dart';
 
+export './forms/verification.dart' show VerificationCodeConfig;
+
 /// A widget that provides email-based authentication functionality.
 ///
 /// The widget can manage its own authentication state, or you can provide an


### PR DESCRIPTION
VerificationCodeConfig is required to customize EmailSignInWidget (e.g., changing code length), but it's currently hidden in src/. This PR exports it to the public API.

Fix #4672

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

## Breaking changes

No