### PR TITLE
fix: Preserve legacy AuthKey ID when migrating sessions to LegacySession

### DIFF
--- a/modules/serverpod_auth/serverpod_auth_bridge/serverpod_auth_bridge_server/lib/src/business/auth_backwards_compatibility.dart
+++ b/modules/serverpod_auth/serverpod_auth_bridge/serverpod_auth_bridge_server/lib/src/business/auth_backwards_compatibility.dart
@@ -133,6 +133,7 @@ abstract class AuthBackwardsCompatibility {
   /// This can later be checked using [authenticationHandler].
   static Future<void> storeLegacySession(
     final Session session, {
+    required final int legacySessionId,
     required final UuidValue authUserId,
 
     /// The legacy session key hash
@@ -144,6 +145,7 @@ abstract class AuthBackwardsCompatibility {
     await LegacySession.db.insertRow(
       session,
       LegacySession(
+        id: legacySessionId,
         authUserId: authUserId,
         hash: sessionKeyHash,
         method: method,

--- a/modules/serverpod_auth/serverpod_auth_migration/serverpod_auth_migration_server/lib/src/business/migrate_user.dart
+++ b/modules/serverpod_auth/serverpod_auth_migration/serverpod_auth_migration_server/lib/src/business/migrate_user.dart
@@ -129,6 +129,7 @@ Future<void> _importSessions(
   for (final authKey in authKeys) {
     await AuthBackwardsCompatibility.storeLegacySession(
       session,
+      legacySessionId: authKey.id!,
       authUserId: newAuthUserId,
       scopeNames: authKey.scopeNames,
       sessionKeyHash: authKey.hash,


### PR DESCRIPTION
Fixes https://github.com/serverpod/serverpod/issues/4649

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

