### PR TITLE
feat: Adds sending of pings in streaming connections.

### DIFF
--- a/packages/serverpod_client/lib/src/client_method_stream_manager.dart
+++ b/packages/serverpod_client/lib/src/client_method_stream_manager.dart
@@ -603,7 +603,6 @@ final class ClientMethodStreamManager {
 
     _pingTimer = Timer.periodic(_pingInterval, (_) {
       if (_webSocket == null) return;
-      print('Sending ping');
       _addMessageToWebSocket(PingCommand.buildMessage());
     });
 

--- a/packages/serverpod_client/lib/src/client_method_stream_manager.dart
+++ b/packages/serverpod_client/lib/src/client_method_stream_manager.dart
@@ -11,6 +11,9 @@ import 'package:web_socket_channel/web_socket_channel.dart';
 /// Manages the connection to the server for method streams.
 @internal
 final class ClientMethodStreamManager {
+  static const Duration _defaultPingInterval = Duration(seconds: 20);
+  static const Duration _defaultIdleTimeout = Duration(seconds: 40);
+
   /// The WebSocket channel used to communicate with the server.
   /// If null, no connection is open.
   WebSocketChannel? _webSocket;
@@ -24,6 +27,18 @@ final class ClientMethodStreamManager {
   /// Timer used to cancel the connection attempt if it takes too long.
   /// If null, no connection attempt is in progress.
   Timer? _connectionTimer;
+
+  /// Timer used to send periodic pings to the server.
+  Timer? _pingTimer;
+
+  /// Timer used to detect idle connections with no inbound messages.
+  Timer? _idleTimeoutTimer;
+
+  /// Timestamp of the last received message.
+  DateTime? _lastMessageReceivedAt;
+
+  final Duration _pingInterval;
+  final Duration _idleTimeout;
 
   /// Completer that is completed when the handshake is complete.
   Completer _handshakeComplete = Completer();
@@ -50,15 +65,20 @@ final class ClientMethodStreamManager {
     required Duration connectionTimeout,
     required Uri webSocketHost,
     required SerializationManager serializationManager,
+    @visibleForTesting Duration? pingInterval,
+    @visibleForTesting Duration? idleTimeout,
   }) : _webSocketHost = webSocketHost,
        _connectionTimeout = connectionTimeout,
-       _serializationManager = serializationManager;
+       _serializationManager = serializationManager,
+       _pingInterval = pingInterval ?? _defaultPingInterval,
+       _idleTimeout = idleTimeout ?? _defaultIdleTimeout;
 
   /// Closes all open connections and streams
   ///
   /// If an error is provided, it will be added to all inbound streams.
   Future<void> closeAllConnections([Object? error]) async {
     await _lock.synchronized(() async {
+      _cancelConnectionTimer();
       var webSocket = _webSocket;
       _webSocket = null;
       await _closeAllStreams(error);
@@ -185,6 +205,11 @@ final class ClientMethodStreamManager {
   void _cancelConnectionTimer() {
     _connectionTimer?.cancel();
     _connectionTimer = null;
+    _pingTimer?.cancel();
+    _pingTimer = null;
+    _idleTimeoutTimer?.cancel();
+    _idleTimeoutTimer = null;
+    _lastMessageReceivedAt = null;
   }
 
   /// Closes all streams and controllers.
@@ -464,6 +489,7 @@ final class ClientMethodStreamManager {
     MethodStreamException closeException = const WebSocketClosedException();
     try {
       await for (String jsonData in webSocket.stream) {
+        _resetIdleTimeout();
         if (!_handshakeComplete.isCompleted) {
           _handshakeComplete.complete();
         }
@@ -555,6 +581,7 @@ final class ClientMethodStreamManager {
         (e, s) => throw ConnectionAttemptTimedOutException(),
       );
       _webSocket = webSocket;
+      _startKeepAlive();
     });
   }
 
@@ -567,6 +594,44 @@ final class ClientMethodStreamManager {
     }
 
     webSocket.sink.add(message);
+  }
+
+  void _startKeepAlive() {
+    _pingTimer?.cancel();
+    _idleTimeoutTimer?.cancel();
+    _lastMessageReceivedAt = DateTime.now();
+
+    _pingTimer = Timer.periodic(_pingInterval, (_) {
+      if (_webSocket == null) return;
+      print('Sending ping');
+      _addMessageToWebSocket(PingCommand.buildMessage());
+    });
+
+    _idleTimeoutTimer = Timer(_idleTimeout, _handleIdleTimeout);
+  }
+
+  void _resetIdleTimeout() {
+    _lastMessageReceivedAt = DateTime.now();
+    _idleTimeoutTimer?.cancel();
+    _idleTimeoutTimer = Timer(_idleTimeout, _handleIdleTimeout);
+  }
+
+  void _handleIdleTimeout() {
+    var lastMessageReceivedAt = _lastMessageReceivedAt;
+    if (lastMessageReceivedAt == null) return;
+    var elapsed = DateTime.now().difference(lastMessageReceivedAt);
+    if (elapsed < _idleTimeout) {
+      var remaining = _idleTimeout - elapsed;
+      _idleTimeoutTimer?.cancel();
+      _idleTimeoutTimer = Timer(remaining, _handleIdleTimeout);
+      return;
+    }
+
+    unawaited(
+      closeAllConnections(
+        const MethodStreamIdleTimeoutException(),
+      ),
+    );
   }
 }
 

--- a/packages/serverpod_client/lib/src/method_stream/method_stream_manager_exceptions.dart
+++ b/packages/serverpod_client/lib/src/method_stream/method_stream_manager_exceptions.dart
@@ -88,3 +88,14 @@ class ConnectionClosedException extends MethodStreamException {
     return 'Method stream connection closed with an error';
   }
 }
+
+/// Thrown if the method stream connection is idle for too long.
+class MethodStreamIdleTimeoutException extends MethodStreamException {
+  /// Creates a new [MethodStreamIdleTimeoutException].
+  const MethodStreamIdleTimeoutException();
+
+  @override
+  String toString() {
+    return 'Method stream connection idle timeout';
+  }
+}


### PR DESCRIPTION
Adds keepalive pings and idle-timeout detection for method streams sent from the client. It surfaces a specific `MethodStreamIdleTimeoutException` when no inbound messages are received within the timeout.

Pings are sent every 20 seconds. If no message has been received in 40 seconds, the connection is considered idle. The timeouts are currently not configurable (we may want to do that in a future PR).

Fixes #4684

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

No breaking changes.