### PR TITLE
fix: Undo the deprecation of the `healthCheckHandler` since it provides metrics for Insights

### DIFF
--- a/packages/serverpod/lib/src/server/serverpod.dart
+++ b/packages/serverpod/lib/src/server/serverpod.dart
@@ -84,8 +84,12 @@ class Serverpod {
   /// check remotely if all services the server is depending on is up and
   /// running.
   ///
-  /// Deprecated: Use [HealthConfig] with custom [HealthIndicator]
-  /// implementations instead. This will be removed in a future version.
+  /// This parameter serves two purposes:
+  /// 1. Registering custom health checks on the legacy health endpoint.
+  /// 2. Registering custom health metrics that are stored in the database.
+  ///
+  /// For the first purpose, this parameter is deprecated in favor of the
+  /// [HealthConfig] with custom [HealthIndicator] implementations.
   final HealthCheckHandler? healthCheckHandler;
 
   /// Configuration for the health check system.


### PR DESCRIPTION
Reverts the deprecation due to our docs stating that it can be used to provide metrics that will be stored and presented on Insights - although this last part is missing on the app.  Then, we can't deprecate it in favor of the new `HealthConfig` since it won't be used for storing metrics.

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.