### PR TITLE
fix: Fix missing `tokenExpiresAt` info on `AuthSuccess` for SSS

### DIFF
--- a/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_server/lib/src/session/business/server_side_sessions.dart
+++ b/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_server/lib/src/session/business/server_side_sessions.dart
@@ -215,6 +215,7 @@ class ServerSideSessions {
         secret: secret,
         serverSideSessionId: serverSideSession.id!,
       ),
+      tokenExpiresAt: effectiveExpiresAt,
       authUserId: authUserId,
       scopeNames: scopeNames,
     );


### PR DESCRIPTION
Fixes missing `tokenExpiresAt` information on `AuthSuccess` for server-side sessions even when expiration lifetime is configured.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.