### PR TITLE
fix: Adjust the GitHub IdP icon

### DIFF
--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_flutter/lib/src/github/github_sign_in_button.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_flutter/lib/src/github/github_sign_in_button.dart
@@ -121,7 +121,6 @@ class GitHubSignInButton extends StatelessWidget {
       _getButtonText(),
       style: TextStyle(
         fontSize: size == GitHubButtonSize.large ? 16 : 14,
-        fontWeight: FontWeight.w600,
         color: buttonStyle.foregroundColor,
       ),
     );


### PR DESCRIPTION
This PR fixes the GitHub IdP's icon alignment issue. 

Fixes #4720.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

No breaking changes.