### PR TITLE
fix: Enhance IDP configuration constructors to accept additional params

### DIFF
--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/providers/github/business/github_idp_config.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/providers/github/business/github_idp_config.dart
@@ -149,11 +149,13 @@ class GitHubIdpConfig extends IdentityProviderBuilder<GitHubIdp> {
 /// ```
 class GitHubIdpConfigFromPasswords extends GitHubIdpConfig {
   /// Creates a new [GitHubIdpConfigFromPasswords] instance.
-  GitHubIdpConfigFromPasswords()
-    : super(
-        clientId: Serverpod.instance.getPasswordOrThrow('githubClientId'),
-        clientSecret: Serverpod.instance.getPasswordOrThrow(
-          'githubClientSecret',
-        ),
-      );
+  GitHubIdpConfigFromPasswords({
+    super.githubAccountDetailsValidation,
+    super.getExtraGitHubInfoCallback,
+  }) : super(
+         clientId: Serverpod.instance.getPasswordOrThrow('githubClientId'),
+         clientSecret: Serverpod.instance.getPasswordOrThrow(
+           'githubClientSecret',
+         ),
+       );
 }

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/providers/google/business/google_idp_config.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/providers/google/business/google_idp_config.dart
@@ -92,12 +92,14 @@ class GoogleIdpConfig extends IdentityProviderBuilder<GoogleIdp> {
 /// This constructor requires that a [Serverpod] instance has already been initialized.
 class GoogleIdpConfigFromPasswords extends GoogleIdpConfig {
   /// Creates a new [GoogleIdpConfigFromPasswords] instance.
-  GoogleIdpConfigFromPasswords()
-    : super(
-        clientSecret: GoogleClientSecret.fromJsonString(
-          Serverpod.instance.getPasswordOrThrow('googleClientSecret'),
-        ),
-      );
+  GoogleIdpConfigFromPasswords({
+    super.googleAccountDetailsValidation,
+    super.getExtraGoogleInfoCallback,
+  }) : super(
+         clientSecret: GoogleClientSecret.fromJsonString(
+           Serverpod.instance.getPasswordOrThrow('googleClientSecret'),
+         ),
+       );
 }
 
 /// Contains information about the credentials for the server to access Google's

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/providers/microsoft/business/microsoft_idp_config.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/providers/microsoft/business/microsoft_idp_config.dart
@@ -179,12 +179,15 @@ class MicrosoftIdpConfig extends IdentityProviderBuilder<MicrosoftIdp> {
 /// ```
 class MicrosoftIdpConfigFromPasswords extends MicrosoftIdpConfig {
   /// Creates a new [MicrosoftIdpConfigFromPasswords] instance.
-  MicrosoftIdpConfigFromPasswords()
-    : super(
-        clientId: Serverpod.instance.getPasswordOrThrow('microsoftClientId'),
-        clientSecret: Serverpod.instance.getPasswordOrThrow(
-          'microsoftClientSecret',
-        ),
-        tenant: Serverpod.instance.getPassword('microsoftTenant') ?? 'common',
-      );
+  MicrosoftIdpConfigFromPasswords({
+    super.fetchProfilePhoto,
+    super.microsoftAccountDetailsValidation,
+    super.getExtraMicrosoftInfoCallback,
+  }) : super(
+         clientId: Serverpod.instance.getPasswordOrThrow('microsoftClientId'),
+         clientSecret: Serverpod.instance.getPasswordOrThrow(
+           'microsoftClientSecret',
+         ),
+         tenant: Serverpod.instance.getPassword('microsoftTenant') ?? 'common',
+       );
 }


### PR DESCRIPTION
This PR fixes the small bug mentioned here:
https://github.com/serverpod/serverpod_docs/pull/418#discussion_r2813272423

The following providers were already correct or did not require optional parameters:
- firebase
- anonymous
- apple
- email
- passkey

The following providers have now been fixed:
- github
- google
- microsoft

**Note:** Facebook has been fixed in its own PR.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

No Breaking changes.