### PR TITLE
chore: Adds warning when server tries to run unregistered future calls

### DIFF
--- a/packages/serverpod/lib/src/server/future_call_manager/future_call_manager.dart
+++ b/packages/serverpod/lib/src/server/future_call_manager/future_call_manager.dart
@@ -200,15 +200,11 @@ class FutureCallManager {
 
       if (futureCall == null) {
         _internalSession.log(
-          'Failed to run unregistered FutureCall. '
-          'Likely causes include: '
-          '1. Existing FutureCall method code was updated causing a name change '
-          'in the generated code and when server restarted, '
-          'the FutureCall was registered with a different name. '
-          '2. If you are using the legacy approach, '
-          'you may have forgotten to register the FutureCall. '
-          'Consider migrating to the typed interface for future calls in this case. '
-          '$entry',
+          'Attempted to run a FutureCall that was not registered. This is likely due '
+          'to changing a FutureCall method after it was scheduled, leading to an '
+          'entry that no longer has a matching method. For legacy future calls, '
+          'make sure they are registered in the server start. Entry: $entry',
+          level: LogLevel.error,
         );
         return null;
       }


### PR DESCRIPTION
This PR adds a warning when the server tries to run an unregistered future call. The warning also recommends migrating to the typed interface for future calls since this [issue](https://github.com/serverpod/serverpod/issues/3485) is more likely with the legacy approach where manual registration of future calls is required.

Fixes [3485](https://github.com/serverpod/serverpod/issues/3485)

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None