### PR TITLE
fix: Handle Web redirection for Apple Sign In

### DIFF
--- a/examples/auth/auth_server/config/template.passwords.yaml
+++ b/examples/auth/auth_server/config/template.passwords.yaml
@@ -37,6 +37,10 @@ development:
   appleTeamId: 'YOUR_APPLE_TEAM_ID'
   appleKeyId: 'YOUR_APPLE_KEY_ID'
   appleKey: 'YOUR_APPLE_KEY'
+  # Optional: needed for Android callback redirects.
+  appleAndroidPackageIdentifier: 'YOUR_ANDROID_PACKAGE_IDENTIFIER'
+  # Optional: needed for Web callback redirects when using server callback route.
+  appleWebRedirectUri: 'YOUR_WEB_REDIRECT_URI'
 
   # Facebook Sign In configuration
   facebookAppId: 'YOUR_FACEBOOK_APP_ID'

--- a/examples/auth/auth_server/lib/server.dart
+++ b/examples/auth/auth_server/lib/server.dart
@@ -54,6 +54,8 @@ void run(List<String> args) async {
     teamId: pod.getPassword('appleTeamId')!,
     keyId: pod.getPassword('appleKeyId')!,
     key: pod.getPassword('appleKey')!,
+    androidPackageIdentifier: pod.getPassword('appleAndroidPackageIdentifier'),
+    webRedirectUri: pod.getPassword('appleWebRedirectUri'),
   );
 
   final emailIdpConfig = EmailIdpConfig(

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/providers/apple/business/apple_idp.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/providers/apple/business/apple_idp.dart
@@ -141,6 +141,7 @@ class AppleIdp {
   Route webAuthenticationCallbackRoute() => AppleWebAuthenticationCallbackRoute(
     utils: utils,
     androidPackageIdentifier: config.androidPackageIdentifier,
+    webRedirectUri: config.webRedirectUri,
   );
 }
 

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/providers/apple/business/apple_idp_config.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/providers/apple/business/apple_idp_config.dart
@@ -32,6 +32,12 @@ class AppleIdpConfig extends IdentityProviderBuilder<AppleIdp> {
   /// clients.
   final String? androidPackageIdentifier;
 
+  /// The web app URL to redirect to after receiving Apple's web callback.
+  ///
+  /// Required for web Sign in with Apple to work when the server callback
+  /// route is used as Apple's redirect URI.
+  final String? webRedirectUri;
+
   /// Creates a new Sign in with Apple configuration.
   const AppleIdpConfig({
     required this.serviceIdentifier,
@@ -41,6 +47,7 @@ class AppleIdpConfig extends IdentityProviderBuilder<AppleIdp> {
     required this.keyId,
     required this.key,
     this.androidPackageIdentifier,
+    this.webRedirectUri,
   });
 
   @override
@@ -78,6 +85,7 @@ class AppleIdpConfigFromPasswords extends AppleIdpConfig {
         androidPackageIdentifier: Serverpod.instance.getPassword(
           'appleAndroidPackageIdentifier',
         ),
+        webRedirectUri: Serverpod.instance.getPassword('appleWebRedirectUri'),
       );
 }
 

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/test/config/from_passwords_config_test.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/test/config/from_passwords_config_test.dart
@@ -361,6 +361,8 @@ test:
     PrivateKeyContentHereBase64EncodedDataExample1234567890
     abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ
     -----END PRIVATE KEY-----
+  appleAndroidPackageIdentifier: 'com.example.app'
+  appleWebRedirectUri: 'https://example.com/auth/apple/web-complete'
 ''',
           ),
         ]).create();
@@ -383,6 +385,11 @@ test:
         () {
           final config = AppleIdpConfigFromPasswords();
           expect(config, isA<AppleIdpConfig>());
+          expect(config.androidPackageIdentifier, 'com.example.app');
+          expect(
+            config.webRedirectUri,
+            'https://example.com/auth/apple/web-complete',
+          );
         },
       );
     },


### PR DESCRIPTION
This PR adds support for Apple Sign In OAuth callbacks on Web. When Apple redirects back to the server after authentication in a browser, the server now redirects to the configured web URL with callback parameters so the sign-in flow can complete.

**Changelog**
- Added optional `webRedirectUri` field to `AppleIdpConfig` (can be set via `appleWebRedirectUri` password key)
- Updated `AppleWebAuthenticationCallbackRoute` to:
  - Redirect Web clients with `303 See Other` to the configured `webRedirectUri`, forwarding callback parameters in the query string
  - Return `500` with a helpful error message when `webRedirectUri` is not configured
  - Keep Android intent redirection behavior and normalize empty-body handling in redirect URLs
- Updated auth example configuration to include optional Apple redirect values:
  - `appleAndroidPackageIdentifier`
  - `appleWebRedirectUri`
- Added/updated tests for:
  - Web callback redirection behavior (including empty body and encoded values)
  - Missing `webRedirectUri` configuration handling
  - `AppleIdpConfigFromPasswords` loading `webRedirectUri` (and Android package identifier)

**Fixes #4586 (Web support only, Android was added in #4661)**

**Pre-launch Checklist**
- [x] I read the Contribute (https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the Dart Style Guide (https://dart.dev/guides/language/effective-dart/style) and formatted the code with dart format (https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with ///), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

**Breaking changes**
None. The `webRedirectUri` configuration is optional and existing code will continue to work unchanged.