### PR TITLE
fix: Correctly binds `AuthUsersConfig` to `AnonymousIdp`

### DIFF
--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/providers/anonymous/business/anonymous_idp_config.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/providers/anonymous/business/anonymous_idp_config.dart
@@ -64,6 +64,7 @@ class AnonymousIdpConfig extends IdentityProviderBuilder<AnonymousIdp> {
     return AnonymousIdp(
       this,
       tokenManager: tokenManager,
+      authUsers: authUsers,
       userProfiles: userProfiles,
     );
   }

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/test/anonymous/test_utils/anonymous_idp_test_fixture.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/test/anonymous/test_utils/anonymous_idp_test_fixture.dart
@@ -6,12 +6,16 @@ final class AnonymousIdpTestFixture {
   late final AnonymousIdp anonymousIdp;
   late final TokenManager tokenManager;
   final UserProfiles userProfiles = const UserProfiles();
-  final AuthUsers authUsers = const AuthUsers();
+  final AuthUsers defaultAuthUsers = const AuthUsers();
 
   AnonymousIdpTestFixture({
-    final AnonymousIdpConfig? config,
+    AnonymousIdpConfig? config,
     final TokenManager? tokenManager,
+    AuthUsersConfig? authUsersConfig,
   }) {
+    config ??= const AnonymousIdpConfig();
+    authUsersConfig ??= const AuthUsersConfig();
+    final authUsers = AuthUsers(config: authUsersConfig);
     this.tokenManager =
         tokenManager ??
         AuthServices(
@@ -23,9 +27,10 @@ final class AnonymousIdpTestFixture {
           identityProviderBuilders: [],
         ).tokenManager;
 
-    anonymousIdp = AnonymousIdp(
-      config ?? const AnonymousIdpConfig(),
+    anonymousIdp = config.build(
       tokenManager: this.tokenManager,
+      authUsers: authUsers,
+      userProfiles: userProfiles,
     );
   }
 


### PR DESCRIPTION
Passes a dropped parameter through to `AnonymousIdp`.

Without this, the `AnonymousIdp` does not call any configured before/after AuthUserCreated hooks.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

## Breaking changes

None.