### PR TITLE
chore: Bump the `uuid` package to avoid analyzer issues with Dart 3.11

### DIFF
--- a/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_server/pubspec.yaml
+++ b/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_server/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   pointycastle: '>=3.7.4 <5.0.0'
   serverpod: 3.3.1
   serverpod_shared: 3.3.1
-  uuid: ^4.1.0
+  uuid: ^4.5.3
 
 dev_dependencies:
   serverpod_lints: 3.3.1

--- a/packages/serverpod/pubspec.yaml
+++ b/packages/serverpod/pubspec.yaml
@@ -35,7 +35,7 @@ dependencies:
   serverpod_shared: 3.3.1
   synchronized: ^3.1.0
   system_resources_2: ^2.2.2
-  uuid: ^4.1.0
+  uuid: ^4.5.3
   vm_service: '>=13.0.0 <16.0.0'
   web_socket: ^1.0.1
   yaml: ^3.1.2

--- a/packages/serverpod_serialization/pubspec.yaml
+++ b/packages/serverpod_serialization/pubspec.yaml
@@ -13,7 +13,7 @@ environment:
 
 dependencies:
   meta: ^1.15.0
-  uuid: ^4.1.0
+  uuid: ^4.5.3
   yaml: ^3.1.2
 
 dev_dependencies:

--- a/packages/serverpod_shared/pubspec.yaml
+++ b/packages/serverpod_shared/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
 dev_dependencies:
   serverpod_lints: 3.3.1
   test: ^1.25.5
-  uuid: ^4.1.0
+  uuid: ^4.5.3
 
 dependency_overrides:
   serverpod_lints:

--- a/templates/pubspecs/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_server/pubspec.yaml
+++ b/templates/pubspecs/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_server/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   pointycastle: '>=3.7.4 <5.0.0'
   serverpod: SERVERPOD_VERSION
   serverpod_shared: SERVERPOD_VERSION
-  uuid: ^4.1.0
+  uuid: ^4.5.3
 
 dev_dependencies:
   serverpod_lints: SERVERPOD_VERSION

--- a/templates/pubspecs/packages/serverpod/pubspec.yaml
+++ b/templates/pubspecs/packages/serverpod/pubspec.yaml
@@ -34,7 +34,7 @@ dependencies:
   serverpod_shared: SERVERPOD_VERSION
   synchronized: ^3.1.0
   system_resources_2: ^2.2.2
-  uuid: ^4.1.0
+  uuid: ^4.5.3
   vm_service: '>=13.0.0 <16.0.0'
   web_socket: ^1.0.1
   yaml: ^3.1.2

--- a/templates/pubspecs/packages/serverpod_serialization/pubspec.yaml
+++ b/templates/pubspecs/packages/serverpod_serialization/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 
 dependencies:
   meta: ^1.15.0
-  uuid: ^4.1.0
+  uuid: ^4.5.3
   yaml: ^3.1.2
 
 dev_dependencies:

--- a/templates/pubspecs/packages/serverpod_shared/pubspec.yaml
+++ b/templates/pubspecs/packages/serverpod_shared/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
 dev_dependencies:
   serverpod_lints: SERVERPOD_VERSION
   test: ^1.25.5
-  uuid: ^4.1.0
+  uuid: ^4.5.3
 
 dependency_overrides:
   serverpod_lints:

--- a/templates/pubspecs/tests/bootstrap_project/pubspec.yaml
+++ b/templates/pubspecs/tests/bootstrap_project/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   http: '>=1.1.0 <2.0.0'
   serverpod: SERVERPOD_VERSION
-  uuid: ^4.1.0
+  uuid: ^4.5.3
 
 dev_dependencies:
   lints: '>=3.0.0 <7.0.0'

--- a/templates/pubspecs/tests/serverpod_cli_e2e_test/pubspec.yaml
+++ b/templates/pubspecs/tests/serverpod_cli_e2e_test/pubspec.yaml
@@ -17,7 +17,7 @@ dev_dependencies:
   serverpod_cli: SERVERPOD_VERSION
   serverpod_lints: SERVERPOD_VERSION
   test_descriptor: ^2.0.2
-  uuid: ^4.1.0
+  uuid: ^4.5.3
 
 dependency_overrides:
   serverpod_cli:

--- a/templates/pubspecs/tests/serverpod_test_server/pubspec.yaml
+++ b/templates/pubspecs/tests/serverpod_test_server/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
     path: ../serverpod_test_module/serverpod_test_module_server
   serverpod_test_shared:
     path: ../serverpod_test_shared
-  uuid: ^4.1.0
+  uuid: ^4.5.3
   web: '>=0.3.0 <2.0.0'
   web_socket: ^1.0.1
 

--- a/templates/pubspecs/tools/serverpod_cli/pubspec.yaml
+++ b/templates/pubspecs/tools/serverpod_cli/pubspec.yaml
@@ -37,7 +37,7 @@ dependencies:
   source_span: ^1.10.0
   stream_channel: ^2.1.1
   super_string: ^1.0.3
-  uuid: ^4.1.0
+  uuid: ^4.5.3
   watcher: ^1.0.2
   yaml: ^3.1.2
   yaml_edit: ^2.2.2

--- a/tests/bootstrap_project/pubspec.yaml
+++ b/tests/bootstrap_project/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   http: '>=1.1.0 <2.0.0'
   serverpod: 3.3.1
-  uuid: ^4.1.0
+  uuid: ^4.5.3
 
 dev_dependencies:
   lints: '>=3.0.0 <7.0.0'

--- a/tests/serverpod_cli_e2e_test/pubspec.yaml
+++ b/tests/serverpod_cli_e2e_test/pubspec.yaml
@@ -18,7 +18,7 @@ dev_dependencies:
   serverpod_cli: 3.3.1
   serverpod_lints: 3.3.1
   test_descriptor: ^2.0.2
-  uuid: ^4.1.0
+  uuid: ^4.5.3
 
 dependency_overrides:
   serverpod_cli:

--- a/tests/serverpod_test_server/pubspec.yaml
+++ b/tests/serverpod_test_server/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
     path: ../serverpod_test_module/serverpod_test_module_server
   serverpod_test_shared:
     path: ../serverpod_test_shared
-  uuid: ^4.1.0
+  uuid: ^4.5.3
   web: '>=0.3.0 <2.0.0'
   web_socket: ^1.0.1
 

--- a/tools/serverpod_cli/pubspec.yaml
+++ b/tools/serverpod_cli/pubspec.yaml
@@ -38,7 +38,7 @@ dependencies:
   source_span: ^1.10.0
   stream_channel: ^2.1.1
   super_string: ^1.0.3
-  uuid: ^4.1.0
+  uuid: ^4.5.3
   watcher: ^1.0.2
   yaml: ^3.1.2
   yaml_edit: ^2.2.2


### PR DESCRIPTION
Now that https://github.com/daegalus/dart-uuid/pull/141 is merged and a new version of `dart-uuid` is released, we need to bump its version to avoid issues with the analyzer on version 3.11 (which is used by PANA to score the Serverpod packages).

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.