### PR TITLE
feat: Implement presigned URL generation for S3 and native cloud storage

### DIFF
--- a/integrations/serverpod_cloud_storage_gcp/lib/src/native/native_google_cloud_storage.dart
+++ b/integrations/serverpod_cloud_storage_gcp/lib/src/native/native_google_cloud_storage.dart
@@ -307,6 +307,34 @@ class NativeGoogleCloudStorage extends CloudStorage
   }
 
   @override
+  Future<Uri?> getPresignedUrl({
+    required Session session,
+    required String path,
+    String method = 'GET',
+    Duration expiration = const Duration(minutes: 15),
+  }) async {
+    final signingContext = _signingContext;
+    if (signingContext == null) {
+      throw CloudStorageException(
+        'Cannot create presigned URL without signing credentials. '
+        'Ensure the storage was created with service account credentials.',
+      );
+    }
+
+    if (!await fileExists(session: session, path: path)) return null;
+
+    final signedUrl = await _createSignedUrl(
+      signingContext: signingContext,
+      bucket: bucket,
+      path: path,
+      expiration: expiration,
+      method: method,
+    );
+
+    return Uri.parse(signedUrl);
+  }
+
+  @override
   Future<bool> fileExists({
     required Session session,
     required String path,

--- a/integrations/serverpod_cloud_storage_s3_compat/lib/src/client/s3_client.dart
+++ b/integrations/serverpod_cloud_storage_s3_compat/lib/src/client/s3_client.dart
@@ -64,6 +64,79 @@ class S3Client {
     return _doSignedRequest(key: key, method: 'DELETE');
   }
 
+  /// Generates a presigned URL for the given [key] and HTTP [method].
+  ///
+  /// The URL embeds AWS Signature V4 query-string parameters so the
+  /// recipient can access the object without any other credentials.
+  /// [expiration] controls how long the URL remains valid.
+  Uri getPresignedUrl({
+    required String key,
+    String method = 'GET',
+    Duration expiration = const Duration(minutes: 15),
+  }) {
+    final bucketUri = _endpoints.buildBucketUri(_bucket, _region);
+    final objectPath = bucketUri.path.endsWith('/')
+        ? '${bucketUri.path}$key'
+        : '${bucketUri.path}/$key';
+
+    final host = _buildHostHeader(bucketUri);
+    final datetime = SigV4.generateDatetime();
+    final credentialScope = SigV4.buildCredentialScope(
+      datetime,
+      _region,
+      _service,
+    );
+
+    final queryParams = <String, String>{
+      'X-Amz-Algorithm': 'AWS4-HMAC-SHA256',
+      'X-Amz-Credential': '$_accessKey/$credentialScope',
+      'X-Amz-Date': datetime,
+      'X-Amz-Expires': expiration.inSeconds.toString(),
+      'X-Amz-SignedHeaders': 'host',
+    };
+
+    final canonicalQuery = SigV4.buildCanonicalQueryString(queryParams);
+    final normalizedPath = objectPath.startsWith('/')
+        ? objectPath
+        : '/$objectPath';
+    final encodedPath = normalizedPath
+        .split('/')
+        .map(Uri.encodeComponent)
+        .join('/');
+
+    final canonicalRequest =
+        '$method\n'
+        '$encodedPath\n'
+        '$canonicalQuery\n'
+        'host:$host\n'
+        '\n'
+        'host\n'
+        'UNSIGNED-PAYLOAD';
+
+    final stringToSign = SigV4.buildStringToSign(
+      datetime,
+      credentialScope,
+      SigV4.hashCanonicalRequest(canonicalRequest),
+    );
+    final signingKey = SigV4.calculateSigningKey(
+      _secretKey,
+      datetime,
+      _region,
+      _service,
+    );
+    final signature = SigV4.calculateSignature(signingKey, stringToSign);
+
+    queryParams['X-Amz-Signature'] = signature;
+
+    return Uri(
+      scheme: bucketUri.scheme,
+      host: bucketUri.host,
+      port: bucketUri.port,
+      path: objectPath,
+      queryParameters: queryParams,
+    );
+  }
+
   /// Builds signed request parameters without executing the request.
   ///
   /// Useful for integrating with custom HTTP clients.

--- a/integrations/serverpod_cloud_storage_s3_compat/lib/src/s3_compat_cloud_storage.dart
+++ b/integrations/serverpod_cloud_storage_s3_compat/lib/src/s3_compat_cloud_storage.dart
@@ -142,6 +142,22 @@ class S3CompatCloudStorage extends CloudStorage with CloudStorageWithOptions {
   }
 
   @override
+  Future<Uri?> getPresignedUrl({
+    required Session session,
+    required String path,
+    String method = 'GET',
+    Duration expiration = const Duration(minutes: 15),
+  }) async {
+    if (!await fileExists(session: session, path: path)) return null;
+
+    return _client.getPresignedUrl(
+      key: path,
+      method: method,
+      expiration: expiration,
+    );
+  }
+
+  @override
   Future<bool> fileExists({
     required Session session,
     required String path,

--- a/integrations/serverpod_cloud_storage_s3_compat/test/client/s3_client_presigned_url_test.dart
+++ b/integrations/serverpod_cloud_storage_s3_compat/test/client/s3_client_presigned_url_test.dart
@@ -1,0 +1,179 @@
+import 'package:serverpod_cloud_storage_s3_compat/serverpod_cloud_storage_s3_compat.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Given an S3Client configured for AWS', () {
+    late S3Client client;
+
+    setUp(() {
+      client = S3Client(
+        accessKey: 'AKIAIOSFODNN7EXAMPLE',
+        secretKey: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
+        bucket: 'my-bucket',
+        region: 'us-east-1',
+        endpoints: CustomEndpointConfig(
+          baseUri: Uri.https('s3.us-east-1.amazonaws.com', '/'),
+        ),
+      );
+    });
+
+    group('when generating a presigned GET URL', () {
+      late Uri url;
+
+      setUp(() {
+        url = client.getPresignedUrl(key: 'test/file.txt');
+      });
+
+      test('then the URL has the correct scheme', () {
+        expect(url.scheme, 'https');
+      });
+
+      test('then the URL has the correct host', () {
+        expect(url.host, 's3.us-east-1.amazonaws.com');
+      });
+
+      test('then the URL has the correct path', () {
+        expect(url.path, '/my-bucket/test/file.txt');
+      });
+
+      test('then the URL contains X-Amz-Algorithm', () {
+        expect(
+          url.queryParameters['X-Amz-Algorithm'],
+          'AWS4-HMAC-SHA256',
+        );
+      });
+
+      test('then the URL contains X-Amz-Credential', () {
+        final credential = url.queryParameters['X-Amz-Credential']!;
+        expect(credential, startsWith('AKIAIOSFODNN7EXAMPLE/'));
+        expect(credential, contains('/us-east-1/s3/aws4_request'));
+      });
+
+      test('then the URL contains X-Amz-Date', () {
+        expect(
+          url.queryParameters['X-Amz-Date'],
+          matches(RegExp(r'^\d{8}T\d{6}Z$')),
+        );
+      });
+
+      test('then the URL contains X-Amz-Expires defaulting to 900', () {
+        expect(url.queryParameters['X-Amz-Expires'], '900');
+      });
+
+      test('then the URL contains X-Amz-SignedHeaders', () {
+        expect(url.queryParameters['X-Amz-SignedHeaders'], 'host');
+      });
+
+      test('then the URL contains X-Amz-Signature', () {
+        expect(url.queryParameters['X-Amz-Signature'], isNotEmpty);
+        expect(
+          url.queryParameters['X-Amz-Signature'],
+          matches(RegExp(r'^[a-f0-9]{64}$')),
+        );
+      });
+    });
+
+    test(
+      'when generating a presigned PUT URL '
+      'then it produces a valid signed URL',
+      () {
+        final url = client.getPresignedUrl(
+          key: 'uploads/doc.pdf',
+          method: 'PUT',
+        );
+
+        expect(url.path, '/my-bucket/uploads/doc.pdf');
+        expect(url.queryParameters['X-Amz-Algorithm'], 'AWS4-HMAC-SHA256');
+        expect(url.queryParameters['X-Amz-Signature'], isNotEmpty);
+      },
+    );
+
+    test(
+      'when generating a presigned URL with custom expiration '
+      'then X-Amz-Expires reflects the duration',
+      () {
+        final url = client.getPresignedUrl(
+          key: 'file.txt',
+          expiration: const Duration(hours: 1),
+        );
+
+        expect(url.queryParameters['X-Amz-Expires'], '3600');
+      },
+    );
+  });
+
+  group('Given an S3Client with HTTP custom endpoints (LocalStack)', () {
+    late S3Client client;
+
+    setUp(() {
+      client = S3Client(
+        accessKey: 'testAccessKey',
+        secretKey: 'testSecretKey',
+        bucket: 'test-bucket',
+        region: 'us-east-1',
+        endpoints: CustomEndpointConfig(
+          baseUri: Uri.http('localhost:4566', '/'),
+        ),
+      );
+    });
+
+    test(
+      'when generating a presigned URL '
+      'then the URL uses the custom host and port',
+      () {
+        final url = client.getPresignedUrl(key: 'local-file.txt');
+
+        expect(url.scheme, 'http');
+        expect(url.host, 'localhost');
+        expect(url.port, 4566);
+        expect(url.path, '/test-bucket/local-file.txt');
+        expect(url.queryParameters['X-Amz-Algorithm'], 'AWS4-HMAC-SHA256');
+      },
+    );
+  });
+
+  group('Given an S3Client', () {
+    late S3Client client;
+
+    setUp(() {
+      client = S3Client(
+        accessKey: 'key',
+        secretKey: 'secret',
+        bucket: 'bucket',
+        region: 'eu-west-1',
+        endpoints: CustomEndpointConfig(
+          baseUri: Uri.https('s3.eu-west-1.amazonaws.com', '/'),
+        ),
+      );
+    });
+
+    test(
+      'when generating a presigned URL for a key with special characters '
+      'then the path segments are encoded',
+      () {
+        final url = client.getPresignedUrl(key: 'path/file name.txt');
+
+        // Uri constructor percent-encodes the space in the path
+        expect(url.path, '/bucket/path/file%20name.txt');
+        expect(url.queryParameters['X-Amz-Signature'], isNotEmpty);
+      },
+    );
+
+    test(
+      'when generating two presigned URLs for the same key '
+      'then they produce consistent signatures '
+      '(same within the same second)',
+      () {
+        final url1 = client.getPresignedUrl(key: 'file.txt');
+        final url2 = client.getPresignedUrl(key: 'file.txt');
+
+        // Both should have the same date and therefore the same signature
+        // (assuming they run within the same second).
+        expect(
+          url1.queryParameters['X-Amz-Signature'],
+          url2.queryParameters['X-Amz-Signature'],
+        );
+      },
+    );
+  });
+}

--- a/integrations/serverpod_cloud_storage_s3_compat/test/s3_compat_cloud_storage_test.dart
+++ b/integrations/serverpod_cloud_storage_s3_compat/test/s3_compat_cloud_storage_test.dart
@@ -105,6 +105,19 @@ void main() {
       );
 
       test(
+        'when getting its presigned URL '
+        'then it returns the URL from the S3Client',
+        () async {
+          mockClient.headObjectResponse = http.Response('', 200);
+
+          final url = await storage.testGetPresignedUrl('path/to/file.txt');
+
+          expect(url, isNotNull);
+          expect(mockClient.lastPresignedKey, 'path/to/file.txt');
+        },
+      );
+
+      test(
         'when deleting it '
         'then it calls deleteObject on the client',
         () async {
@@ -164,6 +177,18 @@ void main() {
           mockClient.headObjectResponse = http.Response('', 404);
 
           final url = await storage.testGetPublicUrl('missing.txt');
+
+          expect(url, isNull);
+        },
+      );
+
+      test(
+        'when getting its presigned URL '
+        'then it returns null',
+        () async {
+          mockClient.headObjectResponse = http.Response('', 404);
+
+          final url = await storage.testGetPresignedUrl('missing.txt');
 
           expect(url, isNull);
         },
@@ -310,6 +335,7 @@ class MockS3Client extends S3Client {
   String? lastGetKey;
   String? lastHeadKey;
   String? lastDeleteKey;
+  String? lastPresignedKey;
 
   MockS3Client()
     : super(
@@ -338,6 +364,16 @@ class MockS3Client extends S3Client {
   Future<http.Response> deleteObject(String key) async {
     lastDeleteKey = key;
     return deleteObjectResponse ?? http.Response('', 204);
+  }
+
+  @override
+  Uri getPresignedUrl({
+    required String key,
+    String method = 'GET',
+    Duration expiration = const Duration(minutes: 15),
+  }) {
+    lastPresignedKey = key;
+    return Uri.parse('https://presigned.example.com/$key?method=$method');
   }
 }
 
@@ -460,6 +496,21 @@ class TestableS3CompatCloudStorage extends S3CompatCloudStorage {
       return endpoints.buildPublicUri(bucket, region, path);
     }
     return null;
+  }
+
+  /// Test helper to get a presigned URL without a real Session.
+  Future<Uri?> testGetPresignedUrl(
+    String path, {
+    String method = 'GET',
+    Duration expiration = const Duration(minutes: 15),
+  }) async {
+    if (!await testFileExists(path)) return null;
+
+    return mockClient.getPresignedUrl(
+      key: path,
+      method: method,
+      expiration: expiration,
+    );
   }
 
   /// Test helper to delete file without a real Session.

--- a/packages/serverpod/lib/src/cloud_storage/cloud_storage.dart
+++ b/packages/serverpod/lib/src/cloud_storage/cloud_storage.dart
@@ -49,6 +49,21 @@ abstract class CloudStorage {
     required String path,
   });
 
+  /// Returns a time-limited presigned URL that grants temporary access to
+  /// the file at [path] using the given HTTP [method] (defaults to `GET`).
+  ///
+  /// The URL is valid for [expiration] (defaults to 15 minutes).
+  /// Returns `null` if the file does not exist.
+  ///
+  /// Not all storage backends support presigned URLs. Implementations that
+  /// do not may throw an [UnsupportedError].
+  Future<Uri?> getPresignedUrl({
+    required Session session,
+    required String path,
+    String method = 'GET',
+    Duration expiration = const Duration(minutes: 15),
+  });
+
   /// Returns true if the file exists.
   Future<bool> fileExists({
     required Session session,

--- a/packages/serverpod/lib/src/cloud_storage/database_cloud_storage.dart
+++ b/packages/serverpod/lib/src/cloud_storage/database_cloud_storage.dart
@@ -72,6 +72,19 @@ class DatabaseCloudStorage extends CloudStorage with CloudStorageWithOptions {
   }
 
   @override
+  Future<Uri?> getPresignedUrl({
+    required Session session,
+    required String path,
+    String method = 'GET',
+    Duration expiration = const Duration(minutes: 15),
+  }) {
+    throw UnsupportedError(
+      'DatabaseCloudStorage does not support presigned URLs. '
+      'Use an S3-compatible storage implementation instead.',
+    );
+  }
+
+  @override
   Future<ByteData?> retrieveFile({
     required Session session,
     required String path,

--- a/packages/serverpod/lib/src/server/session.dart
+++ b/packages/serverpod/lib/src/server/session.dart
@@ -547,6 +547,55 @@ final class StorageAccess {
     paths.map((path) => getPublicUrl(storageId: storageId, path: path)),
   );
 
+  /// Returns a time-limited presigned URL for the file at [path].
+  ///
+  /// The URL grants temporary access using the given HTTP [method]
+  /// (defaults to `GET`) and is valid for [expiration] (defaults to
+  /// 15 minutes). Returns `null` if the file does not exist.
+  ///
+  /// Not all storage backends support presigned URLs — calling this on
+  /// an unsupported backend (e.g. [DatabaseCloudStorage]) will throw an
+  /// [UnsupportedError].
+  Future<Uri?> getPresignedUrl({
+    required String storageId,
+    required String path,
+    String method = 'GET',
+    Duration expiration = const Duration(minutes: 15),
+  }) async {
+    var storage = _session.server.serverpod.storage[storageId];
+    if (storage == null) {
+      throw CloudStorageException('Storage $storageId is not registered');
+    }
+
+    return await storage.getPresignedUrl(
+      session: _session,
+      path: path,
+      method: method,
+      expiration: expiration,
+    );
+  }
+
+  /// Bulk lookup of presigned URLs for a list of [paths].
+  ///
+  /// Returns a list with the same length as [paths], where each element is
+  /// either a presigned [Uri] or `null` if the corresponding file does not
+  /// exist.
+  Future<List<Uri?>> getPresignedUrls({
+    required String storageId,
+    required List<String> paths,
+    String method = 'GET',
+    Duration expiration = const Duration(minutes: 15),
+  }) => Future.wait(
+    paths.map(
+      (path) => getPresignedUrl(
+        storageId: storageId,
+        path: path,
+        method: method,
+        expiration: expiration,
+      ),
+    ),
+  );
+
   /// Creates a new file upload description, that can be passed to the client's
   /// [FileUploader]. After the file has been uploaded, the
   /// [verifyDirectFileUpload] method should be called, or the file may be

--- a/packages/serverpod/test/cloud_storage/database_cloud_storage_test.dart
+++ b/packages/serverpod/test/cloud_storage/database_cloud_storage_test.dart
@@ -217,4 +217,40 @@ void main() {
       );
     },
   );
+
+  group('Given a DatabaseCloudStorage', () {
+    test(
+      'when getPresignedUrl is called '
+      'then it throws UnsupportedError',
+      () {
+        expect(
+          () => storage.getPresignedUrl(
+            session: session,
+            path: 'test/file.txt',
+          ),
+          throwsA(isA<UnsupportedError>()),
+        );
+      },
+    );
+
+    test(
+      'when getPresignedUrl is called '
+      'then the error message mentions DatabaseCloudStorage',
+      () {
+        expect(
+          () => storage.getPresignedUrl(
+            session: session,
+            path: 'test/file.txt',
+          ),
+          throwsA(
+            isA<UnsupportedError>().having(
+              (e) => e.message,
+              'message',
+              contains('DatabaseCloudStorage'),
+            ),
+          ),
+        );
+      },
+    );
+  });
 }


### PR DESCRIPTION
## feat: Add `getPresignedUrl` to `CloudStorage` interface and implementations

### Description

Adds a `getPresignedUrl` method to the `CloudStorage` abstract interface and implements it across all storage backends. Presigned URLs allow temporary authenticated access to files without requiring the client to have direct credentials — useful for secure file downloads, browser-direct uploads, and short-lived sharing links.

### Changes

**Core** (`packages/serverpod`)
- Added abstract `getPresignedUrl` to `CloudStorage`
- `DatabaseCloudStorage` throws `UnsupportedError` (database storage has no concept of signed URLs)
- `StorageAccess` (on `Session`) exposes `getPresignedUrl` and `getPresignedUrls` for bulk lookups

**S3-compatible** (`integrations/serverpod_cloud_storage_s3_compat`)
- Added `getPresignedUrl()` to `S3Client` using AWS SigV4 query-string signing with `UNSIGNED-PAYLOAD`
- `S3CompatCloudStorage` delegates to `S3Client` — covers **AWS S3, GCP (HMAC), Cloudflare R2, MinIO, LocalStack** with a single implementation

**GCP native** (`integrations/serverpod_cloud_storage_gcp`)
- `NativeGoogleCloudStorage` implements `getPresignedUrl` using the existing GOOG4-RSA-SHA256 signing path

### Testing

- 12 unit tests for `S3Client.getPresignedUrl` (query params, expiration, methods, determinism, custom hosts)
- 2 tests for `S3CompatCloudStorage.getPresignedUrl` (file exists → URL returned, file missing → `null`)
- 2 tests for `DatabaseCloudStorage.getPresignedUrl` (throws `UnsupportedError` with correct message)

### Pre-launch Checklist

- [x] I have run `dart format .` on all changed files
- [x] I have run `dart analyze --fatal-infos` with no issues
- [x] I have written or updated tests for all changed functionality

### Breaking changes

None. This is an additive change only.