### PR TITLE
chore: Fix marking valid Dart files related to migrations as generated on PRs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,4 +4,6 @@
 **/migrations/** linguist-generated=true
 
 # Compensate for too broad protocol pattern
+**/lib/src/**/migrations/** linguist-generated=false
+**/test/**/migrations/** linguist-generated=false
 tools/serverpod_cli/test/generator/dart/**/protocol/** linguist-generated=false


### PR DESCRIPTION
Due to a too-broad gitatrributes entry regarding migrations, valid Dart files are collapsed by default on PRs, blending in with actual migration files that are mostly ignored on reviews. This fix adds compensation to mark migrations inside `lib/src/` or `test/` as not-generated.

<img width="1379" height="192" alt="image" src="https://github.com/user-attachments/assets/8f5d1afd-5327-4048-8a2d-264ee29d27ae" />

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.