### PR TITLE
fix: Add missing export of `DeepCollectionEquality` on `serverpod_serialization` for shared models

### DIFF
--- a/packages/serverpod_serialization/lib/serverpod_serialization.dart
+++ b/packages/serverpod_serialization/lib/serverpod_serialization.dart
@@ -1,3 +1,4 @@
+export 'package:collection/collection.dart' show DeepCollectionEquality;
 export 'package:meta/meta.dart' show useResult, immutable;
 export 'package:uuid/uuid.dart';
 

--- a/packages/serverpod_serialization/pubspec.yaml
+++ b/packages/serverpod_serialization/pubspec.yaml
@@ -12,6 +12,7 @@ environment:
   sdk: '^3.8.0'
 
 dependencies:
+  collection: ^1.19.0
   meta: ^1.15.0
   uuid: ^4.5.3
   yaml: ^3.1.2

--- a/templates/pubspecs/packages/serverpod_serialization/pubspec.yaml
+++ b/templates/pubspecs/packages/serverpod_serialization/pubspec.yaml
@@ -11,6 +11,7 @@ environment:
   sdk: DART_VERSION
 
 dependencies:
+  collection: ^1.19.0
   meta: ^1.15.0
   uuid: ^4.5.3
   yaml: ^3.1.2


### PR DESCRIPTION
Shared package models with `List` fields fail to compile because the generated code references `DeepCollectionEquality` through the `serverpod_serialization` import, which doesn't export it.

The server package already handles this:

```dart
// serverpod.dart
export 'package:collection/collection.dart' show DeepCollectionEquality;
```

But `serverpod_serialization` doesn't, and since shared packages depend on `serverpod_serialization` (not `serverpod`), the generated `==` / `hashCode` breaks for any model with a List field.

### Steps to reproduce

1. Set up a shared package (https://docs.serverpod.dev/concepts/shared-packages)
2. Add a model with a List field
3. Run `serverpod generate`
4. Shared generated code fails: `The name 'DeepCollectionEquality' isn't a class`

### Changes

- Added `collection` dependency to `serverpod_serialization/pubspec.yaml` (and its template)
- Added the matching export to `serverpod_serialization/lib/serverpod_serialization.dart`

Same single-line export the server package already uses.