### PR TITLE
fix: Use no-cache for all Flutter web assets

### DIFF
--- a/packages/serverpod/lib/src/web_server/routes/flutter_route.dart
+++ b/packages/serverpod/lib/src/web_server/routes/flutter_route.dart
@@ -9,40 +9,56 @@ import 'package:serverpod/serverpod.dart';
 /// Combines static file serving with automatic fallback to index.html for
 /// client-side routing, plus WASM headers (COOP/COEP) for multi-threading.
 ///
-/// By default, critical Flutter files (index.html, flutter_service_worker.js,
-/// flutter_bootstrap.js, manifest.json, version.json) are served with no-cache
-/// headers to prevent stale app manifests and service workers. All other files
-/// can be cached according to browser heuristics or custom cache control.
-///
-/// To invalidate the cache, change the version in your pubspec.yaml file and
-/// build your Flutter project.
-///
 /// ```dart
 /// pod.webServer.addRoute(
 ///   FlutterRoute(Directory('web/flutter_app')),
 /// );
 /// ```
+///
+/// ## About Caching ..
+///
+/// By default, all files are served with `private, no-cache` headers so the
+/// browser always revalidates with the server via ETag. This is the only safe
+/// default because:
+///
+/// - Flutter's service worker is deprecated and will be removed
+///   (see [flutter#156910](https://github.com/flutter/flutter/issues/156910)).
+///   Since Flutter 3.32, the generated service worker is a self-destructing
+///   stub that provides no caching for either WASM or JS builds.
+/// - Flutter's build output uses fixed filenames (`main.dart.wasm`,
+///   `main.dart.js`, `main.dart.mjs`) with no content hashing, so aggressive
+///   `max-age` caching risks serving stale applications after a rebuild.
+/// - With `no-cache`, the browser still caches files locally but sends a
+///   conditional request (`If-None-Match`) on each load. Unchanged files
+///   receive a `304 Not Modified` response with no body, so the cost is a
+///   round-trip per asset, not a full re-download.
+///
+/// To avoid the round-trip cost if needed, supply a [cacheBustingConfig]
+/// from relic and post-process the Flutter build output to embed content
+/// hashes in asset URLs. Files served through cache busting can then use
+/// `immutable, max-age=31536000` caching via a custom [cacheControlFactory].
+/// For inspiration see [Content-Hashed Caching for Flutter Web (Without a Service Worker)](https://chipsoffury.com/blog/flutter-web-cache-busting-strategy/)
+/// Hopefully this situation will improve in the future.
 class FlutterRoute extends Route {
-  /// Files that should never be cached to prevent issues with stale
-  /// app manifests, service workers, or version mismatches.
-  static const noCacheFiles = {
-    'index.html',
-    'flutter_service_worker.js',
-    'flutter_bootstrap.js',
-    'manifest.json',
-    'version.json',
-  };
-
-  /// The directory containing Flutter web files
+  /// The directory containing Flutter web files.
   final Directory directory;
 
-  /// The index file to use as fallback (defaults to index.html in [directory])
+  /// The index file to use as fallback (defaults to index.html in [directory]).
   final File indexFile;
 
-  /// Cache control factory for static files
+  /// Cache control factory for static files.
+  ///
+  /// Defaults to `private, no-cache` for all files (ETag revalidation on
+  /// every request). Override this when using [cacheBustingConfig] to serve
+  /// cache-busted assets with aggressive caching headers.
   final CacheControlFactory cacheControlFactory;
 
-  /// Cache busting configuration for static files
+  /// Optional cache busting configuration for static files.
+  ///
+  /// When provided, the static file handler strips content hashes from
+  /// incoming URLs before looking up files on disk. Use this together with
+  /// a custom [cacheControlFactory] that returns aggressive caching headers
+  /// for cache-busted assets.
   final CacheBustingConfig? cacheBustingConfig;
 
   /// Creates a new FlutterRoute.
@@ -51,43 +67,18 @@ class FlutterRoute extends Route {
   /// web files. The [indexFile] parameter sets the fallback file for SPA
   /// routing and defaults to `index.html` within the specified directory.
   ///
-  /// Cache behavior can be customized using [cacheControlFactory] for static
-  /// asset headers and [cacheBustingConfig] for cache busting support. If no
-  /// [cacheControlFactory] is provided, a default factory is used that prevents
-  /// caching of critical Flutter files (index.html, flutter_service_worker.js,
-  /// flutter_bootstrap.js, manifest.json, version.json) while allowing other
-  /// files to be cached according to browser heuristics.
-  ///
   /// The [host] parameter restricts this route to a specific virtual host
   /// (defaults to `null`, matching any host).
   FlutterRoute(
     this.directory, {
     File? indexFile,
-    this.cacheControlFactory = _defaultFlutterCacheControl,
+    CacheControlFactory? cacheControlFactory,
     this.cacheBustingConfig,
     super.host,
   }) : indexFile = indexFile ?? File(path.join(directory.path, 'index.html')),
+       cacheControlFactory =
+           cacheControlFactory ?? StaticRoute.privateNoCache(),
        super(methods: {Method.get, Method.head});
-
-  /// Default cache control factory for Flutter web files.
-  ///
-  /// Returns no-cache headers for critical Flutter files to prevent issues
-  /// with stale app manifests, service workers, or version mismatches.
-  /// All other files return null, allowing browser caching heuristics.
-  static CacheControlHeader? _defaultFlutterCacheControl(
-    Request request,
-    FileInfo fileInfo,
-  ) {
-    final filename = path.basename(fileInfo.file.path);
-    if (noCacheFiles.contains(filename)) {
-      return StaticRoute.privateNoCache()(request, fileInfo);
-    }
-
-    return StaticRoute.public(maxAge: const Duration(days: 1))(
-      request,
-      fileInfo,
-    );
-  }
 
   @override
   void injectIn(RelicRouter router) {

--- a/tests/serverpod_test_server/test_integration/web_server/flutter_route_test.dart
+++ b/tests/serverpod_test_server/test_integration/web_server/flutter_route_test.dart
@@ -188,12 +188,7 @@ void main() {
         ),
       );
 
-      pod.webServer.addRoute(
-        FlutterRoute(
-          webDir,
-          cacheControlFactory: StaticRoute.public(maxAge: Duration(hours: 1)),
-        ),
-      );
+      pod.webServer.addRoute(FlutterRoute(webDir));
 
       await pod.start();
       port = pod.webServer.port!;

--- a/tests/serverpod_test_server/test_integration/web_server/flutter_route_test.dart
+++ b/tests/serverpod_test_server/test_integration/web_server/flutter_route_test.dart
@@ -188,7 +188,14 @@ void main() {
         ),
       );
 
-      pod.webServer.addRoute(FlutterRoute(webDir));
+      pod.webServer.addRoute(
+        FlutterRoute(
+          webDir,
+          cacheControlFactory: StaticRoute.public(
+            maxAge: const Duration(hours: 1),
+          ),
+        ),
+      );
 
       await pod.start();
       port = pod.webServer.port!;
@@ -249,7 +256,7 @@ void main() {
     });
 
     test(
-      'Given index.html when requested then no-cache headers are present.',
+      'when index.html is requested then no-cache headers are present',
       () async {
         final response = await client.get(
           Uri.http('localhost:$port', '/index.html'),
@@ -261,7 +268,7 @@ void main() {
     );
 
     test(
-      'Given flutter_service_worker.js when requested then no-cache headers are present.',
+      'when flutter_service_worker.js is requested then no-cache headers are present',
       () async {
         final response = await client.get(
           Uri.http('localhost:$port', '/flutter_service_worker.js'),
@@ -273,7 +280,7 @@ void main() {
     );
 
     test(
-      'Given flutter_bootstrap.js when requested then no-cache headers are present.',
+      'when flutter_bootstrap.js is requested then no-cache headers are present',
       () async {
         final response = await client.get(
           Uri.http('localhost:$port', '/flutter_bootstrap.js'),
@@ -285,7 +292,7 @@ void main() {
     );
 
     test(
-      'Given manifest.json when requested then no-cache headers are present.',
+      'when manifest.json is requested then no-cache headers are present',
       () async {
         final response = await client.get(
           Uri.http('localhost:$port', '/manifest.json'),
@@ -297,7 +304,7 @@ void main() {
     );
 
     test(
-      'Given version.json when requested then no-cache headers are present.',
+      'when version.json is requested then no-cache headers are present',
       () async {
         final response = await client.get(
           Uri.http('localhost:$port', '/version.json'),
@@ -309,26 +316,26 @@ void main() {
     );
 
     test(
-      'Given main.dart.js when requested then cache-control header is public and max-age=86400.',
+      'when main.dart.js is requested then no-cache headers are present',
       () async {
         final response = await client.get(
           Uri.http('localhost:$port', '/main.dart.js'),
         );
         expect(response.statusCode, 200);
-        expect(response.headers['cache-control'], contains('public'));
-        expect(response.headers['cache-control'], contains('max-age=86400'));
+        expect(response.headers['cache-control'], contains('no-cache'));
+        expect(response.headers['cache-control'], contains('private'));
       },
     );
 
     test(
-      'Given assets/image.png when requested then cache-control header is public and max-age=86400.',
+      'when assets/image.png is requested then no-cache headers are present',
       () async {
         final response = await client.get(
           Uri.http('localhost:$port', '/assets/image.png'),
         );
         expect(response.statusCode, 200);
-        expect(response.headers['cache-control'], contains('public'));
-        expect(response.headers['cache-control'], contains('max-age=86400'));
+        expect(response.headers['cache-control'], contains('no-cache'));
+        expect(response.headers['cache-control'], contains('private'));
       },
     );
   });


### PR DESCRIPTION
Default to `private, no-cache` (ETag revalidation) for all files served by `FlutterRoute`.

Flutter's service worker has been deprecated since 3.32 ([flutter#156910](https://github.com/flutter/flutter/issues/156910)) and is now a self-destructing stub that provides no caching for either WASM or JS builds. Since Flutter's build output uses fixed filenames (`main.dart.wasm`, `main.dart.js`) with no content hashing, ETag revalidation is the only safe default to prevent serving stale applications after a rebuild.

Hence the default cache policy for `FlutterRoute` changed from selective `private, no-cache`  (critical files only) + `public, max-age=1day` (all other files) to `private, no-cache` for all files. Users who relied on the previous aggressive caching default should pass a custom `cacheControlFactory`.

The `cacheControlFactory` and `cacheBustingConfig` parameters are retained so users who post-process build output to embed content hashes can opt into aggressive caching.

Fixes #4709
Fixes #5077
## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else.
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

## Breaking changes

This is **NOT** considered a breaking change as it will at most cause a few more roundtrips. Users can add their own `cacheControlFactory` to change the behaviour.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated default caching behavior for static file serving to use more conservative cache control settings (private, no-cache). Custom cache strategies remain configurable.
  * Removed `noCacheFiles` constant from public API.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/serverpod/serverpod/pull/4842)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->