### PR TITLE
fix: Fix the firefox setup on the E2E dockerfile

### DIFF
--- a/tests/docker/tests_e2e/Dockerfile-tests
+++ b/tests/docker/tests_e2e/Dockerfile-tests
@@ -4,11 +4,10 @@ FROM dart:3.8.0 AS build
 # Set the working directory
 WORKDIR /app
 
-RUN echo "deb http://deb.debian.org/debian/ unstable main contrib non-free" >> /etc/apt/sources.list.d/debian.list
-RUN apt-get update
-RUN apt-get install --fix-missing -y xvfb
-
-RUN apt-get install -y --no-install-recommends firefox
+RUN echo "deb http://security.debian.org/debian-security bookworm-security main" >> /etc/apt/sources.list.d/debian.list \
+    && apt-get update \
+    && apt-get install --fix-missing -y xvfb firefox-esr \
+    && rm -rf /var/lib/apt/lists/*
 
 # Copy the whole serverpod repo into the container.
 COPY . .


### PR DESCRIPTION
Fixes: #4844

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

_If you have done any breaking changes, make sure to outline them here, so that they can be included in the notes for the next release._