### PR TITLE
chore: Improve the DX when dealing with migration tests

### DIFF
--- a/tests/serverpod_test_server/lib/test_util/migration_test_utils.dart
+++ b/tests/serverpod_test_server/lib/test_util/migration_test_utils.dart
@@ -279,6 +279,9 @@ INSERT INTO "${serverProtocol.DatabaseMigrationVersion.t.tableName}"
       command,
       arguments ?? [],
       workingDirectory: workingDirectory?.path ?? Directory.current.path,
+      environment: {
+        'SERVERPOD_HOME': path.join(Directory.current.path, '..', '..'),
+      },
     );
 
     process.stderr.transform(utf8.decoder).listen(print);


### PR DESCRIPTION
This PR improves the DX when working with migration tests by making them less verbose and able to run from IDE lens' buttons. The verbose arguments were commented out instead of removed to allow easy revert for punctual issues that might need the extra logs.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.