### PR TITLE
fix: Truncate message passed to `log.error` to prevent hanging on formatter issues

### DIFF
--- a/tools/serverpod_cli/lib/src/generator/code_generator.dart
+++ b/tools/serverpod_cli/lib/src/generator/code_generator.dart
@@ -54,7 +54,13 @@ extension GenerateCode on Library {
         trailingCommas: TrailingCommas.preserve,
       ).format('$_fileHeader${ignoreForFile.isEmpty ? '\n' : ''}$code');
     } on FormatterException catch (e) {
-      log.error(e.toString());
+      const maxErrorLength = 4000;
+      final message = e.toString();
+      log.error(
+        message.length > maxErrorLength
+            ? '${message.substring(0, maxErrorLength)}\n\n... (truncated, ${message.length - maxErrorLength} more characters)'
+            : message,
+      );
     }
     return code;
   }


### PR DESCRIPTION
While developing #4856, I faced an unexplained slowdown when generating the code for the `serverpod_test_server` project. Running with the debugger, it became apparent that the slowdown was caused by the `wordWrap` implementation in the `super_string` package (invoked by `cli_tools`).

The issue was coming from this line:

```dart
    // 52:59:tools/serverpod_cli/lib/src/generator/code_generator.dart
    try {
      return DartFormatter(
        languageVersion: Version(3, 8, 0),
        trailingCommas: TrailingCommas.preserve,
      ).format('$_fileHeader${ignoreForFile.isEmpty ? '\n' : ''}$code');
    } on FormatterException catch (e) {
      log.error(e.toString());  // <-- Here.
    }
```

Turns out that a formatting error in the generated code was leading to a 90k+ character string (the `Protocol.dart` file of the `serverpod_test_server` project) being passed to `log.error`, which then invokes `wordWrap` on it. And the `wordWrap` implementation has a very poor complexity, making it O(n³) for a line with n words.

```dart
  // 346:387:super_string.dart
  String wordWrap(
      {int width = 75, String lineBreak = '\n', bool cutWord = false}) {
    final List<String> words = trim().split(RegExp(r' |\n|\t'));
    ...
    while (words.isNotEmpty) {
      for (int i = 0; i < words.length; i++) {
        final String line = words
            .getRange(0, words.length - i)
            .reduce((value, element) => '$value $element');
        ...
      }
    }
```

To prevent this from happening in the future, this PR truncates the error message to 4000 characters before passing it to `log.error`.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.