### PR TITLE
fix: Handle dynamic types and JSON containers in SerializationManager.deserialize

### DIFF
--- a/packages/serverpod_serialization/lib/src/serialization.dart
+++ b/packages/serverpod_serialization/lib/src/serialization.dart
@@ -106,6 +106,18 @@ abstract class SerializationManager {
       return BigInt.parse(data) as T;
     }
 
+    // Handle dynamic types and already-decoded JSON containers (List, Map).
+    // When deserializing Map<String, dynamic> values, the type parameter is
+    // `dynamic` and runtime types like List<dynamic> or _Map<String, dynamic>
+    // don't match the static _isNullableType checks above.
+    if (t == dynamic) {
+      if (data == null) return data as T;
+      // Already-decoded containers: return as-is when caller asked for dynamic.
+      // Don't do this for typed deserialization — let Protocol subclasses handle it.
+      if (data is List || data is Map) return data as T;
+      return deserialize<T>(data, data.runtimeType);
+    }
+
     throw DeserializationTypeNotFoundException(
       type: t,
     );

--- a/packages/serverpod_serialization/test/deserialize_dynamic_test.dart
+++ b/packages/serverpod_serialization/test/deserialize_dynamic_test.dart
@@ -1,0 +1,201 @@
+import 'package:serverpod_serialization/serverpod_serialization.dart';
+import 'package:test/test.dart';
+
+class _TestProtocol extends SerializationManager {}
+
+void main() {
+  var protocol = _TestProtocol();
+
+  group('Given a null value with dynamic type', () {
+    test(
+      'when deserializing with explicit dynamic type parameter then null is returned',
+      () {
+        final result = protocol.deserialize<dynamic>(null);
+        expect(result, isNull);
+      },
+    );
+
+    test(
+      'when deserializing with explicit dynamic type argument then null is returned',
+      () {
+        final result = protocol.deserialize<dynamic>(null, dynamic);
+        expect(result, isNull);
+      },
+    );
+  });
+
+  group('Given a primitive value with dynamic type', () {
+    test(
+      'when deserializing an integer then the integer is returned',
+      () {
+        final result = protocol.deserialize<dynamic>(42);
+        expect(result, 42);
+      },
+    );
+
+    test(
+      'when deserializing a double then the double is returned',
+      () {
+        final result = protocol.deserialize<dynamic>(3.14);
+        expect(result, 3.14);
+      },
+    );
+
+    test(
+      'when deserializing a string then the string is returned',
+      () {
+        final result = protocol.deserialize<dynamic>('hello');
+        expect(result, 'hello');
+      },
+    );
+
+    test(
+      'when deserializing a boolean then the boolean is returned',
+      () {
+        final result = protocol.deserialize<dynamic>(true);
+        expect(result, isTrue);
+      },
+    );
+  });
+
+  group('Given a List value with dynamic type', () {
+    test(
+      'when deserializing a List<dynamic> with explicit dynamic type then the list is returned',
+      () {
+        final input = <dynamic>[1, 'two', true];
+        final result = protocol.deserialize<dynamic>(input);
+        expect(result, input);
+      },
+    );
+
+    test(
+      'when deserializing a List<int> with explicit dynamic type then the list is returned',
+      () {
+        final input = [1, 2, 3];
+        final result = protocol.deserialize<dynamic>(input);
+        expect(result, input);
+      },
+    );
+
+    test(
+      'when deserializing a nested List with explicit dynamic type then the nested list is returned',
+      () {
+        final input = [
+          [1, 2],
+          [3, 4],
+        ];
+        final result = protocol.deserialize<dynamic>(input);
+        expect(result, input);
+      },
+    );
+  });
+
+  group('Given a Map value with dynamic type', () {
+    test(
+      'when deserializing a Map<String, dynamic> with explicit dynamic type then the map is returned',
+      () {
+        final input = <String, dynamic>{'key': 'value', 'count': 42};
+        final result = protocol.deserialize<dynamic>(input);
+        expect(result, input);
+      },
+    );
+
+    test(
+      'when deserializing a Map<String, dynamic> with null values with explicit dynamic type then the map is returned',
+      () {
+        final input = <String, dynamic>{'key': null, 'count': 0};
+        final result = protocol.deserialize<dynamic>(input);
+        expect(result, input);
+      },
+    );
+
+    test(
+      'when deserializing a Map with nested List values with explicit dynamic type then the map is returned',
+      () {
+        final input = <String, dynamic>{
+          'items': [1, 2, 3],
+          'name': 'test',
+        };
+        final result = protocol.deserialize<dynamic>(input);
+        expect(result, input);
+      },
+    );
+  });
+
+  group('Given a List value passed directly to deserialize', () {
+    test(
+      'when deserializing a List without a type parameter then the list is returned',
+      () {
+        final input = [1, 2, 3];
+        final result = protocol.deserialize(input);
+        expect(result, input);
+      },
+    );
+
+    test(
+      'when deserializing an empty List then an empty list is returned',
+      () {
+        final input = <dynamic>[];
+        final result = protocol.deserialize(input);
+        expect(result, isEmpty);
+      },
+    );
+  });
+
+  group('Given a Map value passed directly to deserialize', () {
+    test(
+      'when deserializing a Map without a type parameter then the map is returned',
+      () {
+        final input = {'a': 1, 'b': 2};
+        final result = protocol.deserialize(input);
+        expect(result, input);
+      },
+    );
+
+    test(
+      'when deserializing an empty Map then an empty map is returned',
+      () {
+        final input = <String, dynamic>{};
+        final result = protocol.deserialize(input);
+        expect(result, isEmpty);
+      },
+    );
+  });
+
+  group(
+    'Given a Map<String, dynamic> field where values are already-decoded JSON containers',
+    () {
+      test(
+        'when deserializing a value that is a List with dynamic type argument then no exception is thrown',
+        () {
+          final listValue = [1, 2, 3];
+          expect(
+            () => protocol.deserialize<dynamic>(listValue, dynamic),
+            returnsNormally,
+          );
+        },
+      );
+
+      test(
+        'when deserializing a value that is a Map with dynamic type argument then no exception is thrown',
+        () {
+          final mapValue = {'nested': 'value'};
+          expect(
+            () => protocol.deserialize<dynamic>(mapValue, dynamic),
+            returnsNormally,
+          );
+        },
+      );
+
+      test(
+        'when deserializing a null value with dynamic type argument then no exception is thrown',
+        () {
+          expect(
+            () => protocol.deserialize<dynamic>(null, dynamic),
+            returnsNormally,
+          );
+        },
+      );
+    },
+  );
+}


### PR DESCRIPTION
Fixes deserialization of `Map<String, dynamic>` fields where values are nested `List` or `Map` objects.

When Serverpod deserializes a model with a `Map<String, dynamic>` field, the generated `fromJson` code calls `deserialize<dynamic>(value)` for each entry. If a value is itself a `List` or `Map` (very common in JSON), the previous code had no matching branch and threw `DeserializationTypeNotFoundException`.

This PR adds a missing `t == dynamic` code path to `SerializationManager.deserialize`:
- **`data == null`**: returns null
- **`data is List` or `data is Map`**: returns the already-decoded container as-is (only when `t == dynamic`, so typed deserialization like `deserialize<UserInfo>` still delegates to Protocol subclasses)
- **Otherwise**: re-dispatches on the runtime type (e.g. `int`, `String`, `double`)

Fixes #2722, #1048, #444, #2600

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None — this adds new handling for previously-unsupported cases that previously threw an exception.