### PR TITLE
fix: Ensure `docker compose down` is run on early Ctrl-C

### DIFF
--- a/tools/serverpod_cli/lib/src/commands/start.dart
+++ b/tools/serverpod_cli/lib/src/commands/start.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
-import 'dart:isolate';
 
 import 'package:args/args.dart';
 import 'package:cli_tools/cli_tools.dart';
@@ -126,6 +125,11 @@ class StartCommand extends ServerpodCommand<StartOption> {
     final serverDir = p.joinAll(config.serverPackageDirectoryPathParts);
     final docker = commandConfig.value(StartOption.docker);
 
+    // Listen for termination signals before starting any services so that
+    // a SIGINT at any point triggers graceful shutdown (including Docker
+    // cleanup) rather than killing the process.
+    final shutdown = _ShutdownSignal();
+
     // Start Docker Compose services if needed.
     var startedDocker = false;
     if (docker) {
@@ -133,24 +137,21 @@ class StartCommand extends ServerpodCommand<StartOption> {
     }
 
     try {
+      // If a signal arrived during Docker startup, skip starting the server.
+      if (shutdown.isShutdown) return;
+
       // Extract passthrough args (everything after '--').
       final serverArgs = argResults?.rest ?? [];
 
       final noFes = commandConfig.value(StartOption.noFes);
 
       if (watch) {
-        // Watch mode: the entire loop (generation, compilation, reload)
-        // runs in one long-lived isolate so analyzers persist and can
-        // be updated incrementally on each file change.
-        final logLevel = log.logLevel;
-        final exitCode = await Isolate.run(
-          () => _runWatchMode(
-            config: config,
-            serverDir: serverDir,
-            serverArgs: serverArgs,
-            logLevel: logLevel,
-            noFes: noFes,
-          ),
+        final exitCode = await _runWatchMode(
+          config: config,
+          serverDir: serverDir,
+          serverArgs: serverArgs,
+          shutdownSignal: shutdown.future,
+          noFes: noFes,
         );
         if (exitCode != 0) throw ExitException(exitCode);
       } else {
@@ -173,6 +174,7 @@ class StartCommand extends ServerpodCommand<StartOption> {
         );
       }
     } finally {
+      shutdown.dispose();
       if (startedDocker) {
         await _stopDockerServices(serverDir);
       }
@@ -291,21 +293,17 @@ class StartCommand extends ServerpodCommand<StartOption> {
   }
 }
 
-/// Runs the entire watch-mode loop in a single isolate.
+/// Runs the entire watch-mode loop.
 ///
 /// Analyzers are created once and updated incrementally on each file change,
 /// avoiding the cost of re-initializing them from scratch every time.
-///
-/// Must be a top-level function so the closure passed to [Isolate.run]
-/// doesn't capture unsendable objects from the call site's scope.
 Future<int> _runWatchMode({
   required GeneratorConfig config,
   required String serverDir,
   required List<String> serverArgs,
-  required LogLevel logLevel,
+  required Future<int> shutdownSignal,
   required bool noFes,
 }) async {
-  log.logLevel = logLevel;
   log.info('Starting server in watch mode...');
 
   final serverpodToolDir = p.join(serverDir, '.dart_tool', 'serverpod');
@@ -348,6 +346,7 @@ Future<int> _runWatchMode({
     serverArgs: serverArgs,
     serverpodToolDir: serverpodToolDir,
     vmServiceInfoFile: vmServiceInfoFile,
+    shutdownSignal: shutdownSignal,
     watcher: FileWatcher(
       watchPaths: {
         p.absolute(p.joinAll(config.libSourcePathParts)),
@@ -385,6 +384,7 @@ Future<int> _startWatchSession({
   required List<String> serverArgs,
   required String serverpodToolDir,
   required String vmServiceInfoFile,
+  required Future<int> shutdownSignal,
   required FileWatcher watcher,
   required Set<String> generatedDirPaths,
   required GenerateAction generate,
@@ -470,40 +470,50 @@ Future<int> _startWatchSession({
       )
       .listen((_) {});
 
-  // Wait for SIGINT/SIGTERM or unexpected server exit.
-  final (signal, teardownSignal) = _onTerminationSignal();
-
   if (session.isRunning) log.info(serverRunning);
 
-  final exitCode = await Future.any([signal, session.done]);
+  final exitCode = await Future.any([shutdownSignal, session.done]);
 
   log.info('Server stopped (exitCode: $exitCode).');
 
   // Clean up.
   await fileChangeSub.cancel();
   await session.dispose();
-  await teardownSignal();
 
   return exitCode;
 }
 
-/// Returns a future that completes with 0 when SIGINT or SIGTERM is received,
-/// and a teardown function to cancel the signal subscriptions.
-(Future<int>, Future<void> Function()) _onTerminationSignal() {
-  final completer = Completer<int>();
-  final sigintSub = ProcessSignal.sigint.watch().listen((_) {
-    if (!completer.isCompleted) completer.complete(0);
-  });
-  final sigtermSub = ProcessSignal.sigterm.watch().listen((_) {
-    if (!completer.isCompleted) completer.complete(0);
-  });
-  return (
-    completer.future,
-    () async {
-      await sigintSub.cancel();
-      await sigtermSub.cancel();
-    },
-  );
+/// Listens for SIGINT/SIGTERM and exposes a [future] that completes when
+/// a termination signal is received.
+///
+/// Call [dispose] to cancel the signal subscriptions.
+class _ShutdownSignal {
+  final Completer<int> _completer = Completer<int>();
+  late final StreamSubscription<void> _sigintSub;
+  late final StreamSubscription<void>? _sigtermSub;
+
+  _ShutdownSignal() {
+    _sigintSub = ProcessSignal.sigint.watch().listen(_complete);
+    if (!Platform.isWindows) {
+      _sigtermSub = ProcessSignal.sigterm.watch().listen(_complete);
+    }
+  }
+
+  void _complete(ProcessSignal _) {
+    if (!_completer.isCompleted) _completer.complete(0);
+  }
+
+  /// Whether a termination signal has been received.
+  bool get isShutdown => _completer.isCompleted;
+
+  /// Completes with 0 when a termination signal is received.
+  Future<int> get future => _completer.future;
+
+  /// Cancels the signal subscriptions.
+  void dispose() {
+    _sigintSub.cancel();
+    _sigtermSub?.cancel();
+  }
 }
 
 /// Checks if a server is already running by reading the VM service info file

--- a/tools/serverpod_cli/lib/src/commands/start/server_process.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/server_process.dart
@@ -177,7 +177,10 @@ class ServerProcess {
         _vmService = await vmServiceConnectUri(wsUri);
         break;
       } on Exception {
-        if (attempt == maxRetries - 1) rethrow;
+        if (attempt == maxRetries - 1) {
+          log.warning('Could not connect to VM service at $wsUri');
+          return;
+        }
         await Future<void>.delayed(const Duration(milliseconds: 200));
       }
     }


### PR DESCRIPTION
Make sure we don't leave containers running, if we started them. Today this can happen if the user sends Ctrl-C to `serverpod start` before startup has completed.

- Run watch mode in the main isolate
- Register signal listener before `docker compose up`
- Skip server startup if a shutdown signal arrived during Docker startup
- Make `connectToVmService` non-throwing (log a warning instead)
- Pass `shutdown` signal as a `Future` to await.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None