### PR TITLE
chore: Remove console logging from the `serverpod_test_server` to make it less verbose

### DIFF
--- a/tests/serverpod_test_server/config/production.yaml
+++ b/tests/serverpod_test_server/config/production.yaml
@@ -29,4 +29,4 @@ redis:
 
 sessionLogs:
   persistentEnabled: true
-  consoleEnabled: true
+  consoleEnabled: false

--- a/tests/serverpod_test_server/config/test.yaml
+++ b/tests/serverpod_test_server/config/test.yaml
@@ -31,6 +31,6 @@ redis:
 
 sessionLogs:
   persistentEnabled: true
-  consoleEnabled: true
+  consoleEnabled: false
 
 futureCallExecutionEnabled: false

--- a/tests/serverpod_test_server/test_integration/test_tools/session_correctness_test.dart
+++ b/tests/serverpod_test_server/test_integration/test_tools/session_correctness_test.dart
@@ -1,9 +1,8 @@
 import 'dart:async';
-import 'dart:io';
 
 import 'package:serverpod/serverpod.dart';
 import 'package:serverpod_test_server/src/endpoints/test_tools.dart';
-import 'package:serverpod_test_server/test_util/mock_stdout.dart';
+import 'package:serverpod_test_server/test_util/logging_utils.dart';
 import 'package:test/test.dart';
 
 import 'serverpod_test_tools.dart';
@@ -41,24 +40,25 @@ void main() {
       );
 
       test(
-        'when method logs to session then can be observered in stdout',
+        'when method logs to session then the log can be observed persistently',
         () async {
-          var stdout = MockStdout();
-          await IOOverrides.runZoned(
-            () async {
-              await endpoints.testTools.logMessageWithSession(
-                sessionBuilder.copyWith(
-                  enableLogging: true,
-                ),
-              );
-            },
-            stdout: () => stdout,
-            stderr: () => stdout,
+          final querySession = sessionBuilder.build();
+          await LoggingUtil.clearAllLogs(querySession);
+
+          await endpoints.testTools.logMessageWithSession(
+            sessionBuilder.copyWith(
+              enableLogging: true,
+            ),
           );
 
+          final logs = await LoggingUtil.findAllLogs(querySession);
+          final messages = logs
+              .expand((info) => info.logs)
+              .map((l) => l.message);
+
           expect(
-            stdout.output,
-            contains('"message":"test session log in endpoint"'),
+            messages,
+            anyElement(contains('test session log in endpoint')),
           );
         },
       );


### PR DESCRIPTION
Remove console logging from the test framework to make the output of the integration tests more usable. No coverage is lost, since the tests that validate the log to console behavior already use a custom `ServerpodConfig` that overrides the flag as needed.

Logs on `Serverpod integration tests (server)` reduced from 2162 lines to 1379 with this change. On CI it is still noisy, but the scoped execution of integration tests locally is now completely clean.

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.