### PR TITLE
fix: Move the `flutter_secure_storage` override to the flutter package level

### DIFF
--- a/tests/bootstrap_project/test/project_test.dart
+++ b/tests/bootstrap_project/test/project_test.dart
@@ -685,10 +685,10 @@ void main() async {
         });
 
         test(
-          'then the root pubspec contains override for flutter secure storage',
+          'then the flutter pubspec contains override for flutter secure storage',
           () {
             final pubspec = File(
-              path.join(tempPath, projectName, 'pubspec.yaml'),
+              path.join(tempPath, flutterDir, 'pubspec.yaml'),
             );
             final content = pubspec.readAsStringSync();
             expect(content, contains('flutter_secure_storage'));

--- a/tools/serverpod_cli/lib/src/create/create.dart
+++ b/tools/serverpod_cli/lib/src/create/create.dart
@@ -472,6 +472,13 @@ Future<void> _copyFlutterUpgrade(
         ),
         type: DependencyType.normal,
       ),
+      (
+        name: 'flutter_secure_storage',
+        source: DependencySource.version(
+          VersionConstraint.parse('^10.0.0'),
+        ),
+        type: DependencyType.override,
+      ),
     ],
   );
 
@@ -485,23 +492,6 @@ Future<void> _copyFlutterUpgrade(
           VersionConstraint.parse(templateVersion),
         ),
         type: DependencyType.normal,
-      ),
-    ],
-  );
-
-  log.debug(
-    'Adding flutter_secure_storage override to root pubspec',
-    newParagraph: true,
-  );
-  _addDependenciesToPubspec(
-    pubspecFile: File(p.join(serverpodDirs.projectDir.path, 'pubspec.yaml')),
-    additions: [
-      (
-        name: 'flutter_secure_storage',
-        source: DependencySource.version(
-          VersionConstraint.parse('^10.0.0'),
-        ),
-        type: DependencyType.override,
       ),
     ],
   );


### PR DESCRIPTION
Fixes impossibility of deploying projects to the Serverpod Cloud due to the mixed Flutter and Dart packages on the workspace overrides.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.