### PR TITLE
chore: Fix CLI deprecated member warnings

### DIFF
--- a/tools/serverpod_cli/test/test_util/compilation_unit_helpers.dart
+++ b/tools/serverpod_cli/test/test_util/compilation_unit_helpers.dart
@@ -29,7 +29,7 @@ abstract class CompilationUnitHelpers {
     required String name,
   }) {
     var declaration = unit.declarations.whereType<ClassDeclaration>().where(
-      (declaration) => declaration.name.toString() == name,
+      (declaration) => declaration.namePart.typeName.lexeme == name,
     );
 
     return declaration.isNotEmpty ? declaration.first : null;
@@ -232,7 +232,7 @@ abstract class CompilationUnitHelpers {
     List<String>? parameters,
     List<String>? superArguments,
   }) {
-    var members = classDeclaration.members
+    var members = classDeclaration.body.childEntities
         .whereType<ConstructorDeclaration>()
         .where((member) => member.name?.toString() == name)
         .where((member) => member._hasMatchingParameters(parameters))
@@ -277,7 +277,7 @@ abstract class CompilationUnitHelpers {
     bool? isStatic,
     String? functionExpression,
   }) {
-    var member = classDeclaration.members
+    var member = classDeclaration.body.childEntities
         .whereType<MethodDeclaration>()
         .where((member) => member.name.toString() == name)
         .where((member) => member._hasMatchingStatic(isStatic))
@@ -352,7 +352,7 @@ abstract class CompilationUnitHelpers {
     bool? isLate,
     String? initializerMethod,
   }) {
-    var member = classDeclaration.members
+    var member = classDeclaration.body.childEntities
         .whereType<FieldDeclaration>()
         .where((member) => member._hasMatchingVariable(name))
         .where((member) => member._hasMatchingType(type))

--- a/tools/serverpod_cli/test/test_util/compilation_unit_matcher/class_matcher/class_matcher.dart
+++ b/tools/serverpod_cli/test/test_util/compilation_unit_matcher/class_matcher/class_matcher.dart
@@ -30,7 +30,7 @@ class _ClassMatcherImpl implements Matcher, ClassMatcher {
 
     final classNames = resolvedItem.declarations
         .whereType<ClassDeclaration>()
-        .map((d) => d.name.lexeme)
+        .map((d) => d.namePart.typeName.lexeme)
         .join(', ');
 
     return mismatchDescription.add(
@@ -69,7 +69,7 @@ class _ClassMatcherImpl implements Matcher, ClassMatcher {
         this,
         resolveMatch: _matchedFeatureValueOf,
         extractValue: (classDeclaration) =>
-            classDeclaration.members.whereType<FieldDeclaration>(),
+            classDeclaration.body.childEntities.whereType<FieldDeclaration>(),
       ),
       fieldName,
       isNullable: isNullable,
@@ -91,7 +91,7 @@ class _ClassMatcherImpl implements Matcher, ClassMatcher {
         this,
         resolveMatch: _matchedFeatureValueOf,
         extractValue: (classDeclaration) =>
-            classDeclaration.members.whereType<MethodDeclaration>(),
+            classDeclaration.body.childEntities.whereType<MethodDeclaration>(),
       ),
       methodName,
       isOverride: isOverride,
@@ -153,8 +153,8 @@ class _ClassMatcherImpl implements Matcher, ClassMatcher {
       ChainableMatcher.createMatcher(
         this,
         resolveMatch: _matchedFeatureValueOf,
-        extractValue: (classDeclaration) =>
-            classDeclaration.members.whereType<ConstructorDeclaration>(),
+        extractValue: (classDeclaration) => classDeclaration.body.childEntities
+            .whereType<ConstructorDeclaration>(),
       ),
       name: constructorName,
       isFactory: isFactory,
@@ -164,6 +164,6 @@ class _ClassMatcherImpl implements Matcher, ClassMatcher {
 
 extension on ClassDeclaration {
   bool _hasMatchingClass(String name) {
-    return this.name.lexeme == name;
+    return namePart.typeName.lexeme == name;
   }
 }


### PR DESCRIPTION
Fixes `analyzer/dart/ast/ast.dart` deprecation warnings for `members` and `name` elements.

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

_If you have done any breaking changes, make sure to outline them here, so that they can be included in the notes for the next release._