### PR TITLE
fix: Fix missing `detach`/`detachRow` for nullable named list relations when object side has unnamed relation

### DIFF
--- a/tests/serverpod_test_server/lib/src/generated/changed_id_type/many_to_many/student.dart
+++ b/tests/serverpod_test_server/lib/src/generated/changed_id_type/many_to_many/student.dart
@@ -270,6 +270,10 @@ class StudentUuidRepository {
 
   final attachRow = const StudentUuidAttachRowRepository._();
 
+  final detach = const StudentUuidDetachRepository._();
+
+  final detachRow = const StudentUuidDetachRowRepository._();
+
   /// Returns a list of [StudentUuid]s matching the given query parameters.
   ///
   /// Use [where] to specify which items to include in the return value.
@@ -637,6 +641,60 @@ class StudentUuidAttachRowRepository {
     }
 
     var $enrollmentInt = enrollmentInt.copyWith(studentId: studentUuid.id);
+    await session.db.updateRow<_i2.EnrollmentInt>(
+      $enrollmentInt,
+      columns: [_i2.EnrollmentInt.t.studentId],
+      transaction: transaction,
+    );
+  }
+}
+
+class StudentUuidDetachRepository {
+  const StudentUuidDetachRepository._();
+
+  /// Detaches the relation between this [StudentUuid] and the given [EnrollmentInt]
+  /// by setting the [EnrollmentInt]'s foreign key `studentId` to `null`.
+  ///
+  /// This removes the association between the two models without deleting
+  /// the related record.
+  Future<void> enrollments(
+    _i1.DatabaseSession session,
+    List<_i2.EnrollmentInt> enrollmentInt, {
+    _i1.Transaction? transaction,
+  }) async {
+    if (enrollmentInt.any((e) => e.id == null)) {
+      throw ArgumentError.notNull('enrollmentInt.id');
+    }
+
+    var $enrollmentInt = enrollmentInt
+        .map((e) => e.copyWith(studentId: null))
+        .toList();
+    await session.db.update<_i2.EnrollmentInt>(
+      $enrollmentInt,
+      columns: [_i2.EnrollmentInt.t.studentId],
+      transaction: transaction,
+    );
+  }
+}
+
+class StudentUuidDetachRowRepository {
+  const StudentUuidDetachRowRepository._();
+
+  /// Detaches the relation between this [StudentUuid] and the given [EnrollmentInt]
+  /// by setting the [EnrollmentInt]'s foreign key `studentId` to `null`.
+  ///
+  /// This removes the association between the two models without deleting
+  /// the related record.
+  Future<void> enrollments(
+    _i1.DatabaseSession session,
+    _i2.EnrollmentInt enrollmentInt, {
+    _i1.Transaction? transaction,
+  }) async {
+    if (enrollmentInt.id == null) {
+      throw ArgumentError.notNull('enrollmentInt.id');
+    }
+
+    var $enrollmentInt = enrollmentInt.copyWith(studentId: null);
     await session.db.updateRow<_i2.EnrollmentInt>(
       $enrollmentInt,
       columns: [_i2.EnrollmentInt.t.studentId],

--- a/tests/serverpod_test_server/lib/src/generated/changed_id_type/one_to_many/order.dart
+++ b/tests/serverpod_test_server/lib/src/generated/changed_id_type/one_to_many/order.dart
@@ -342,6 +342,10 @@ class OrderUuidRepository {
 
   final attachRow = const OrderUuidAttachRowRepository._();
 
+  final detach = const OrderUuidDetachRepository._();
+
+  final detachRow = const OrderUuidDetachRowRepository._();
+
   /// Returns a list of [OrderUuid]s matching the given query parameters.
   ///
   /// Use [where] to specify which items to include in the return value.
@@ -732,6 +736,58 @@ class OrderUuidAttachRowRepository {
     }
 
     var $commentInt = commentInt.copyWith(orderId: orderUuid.id);
+    await session.db.updateRow<_i3.CommentInt>(
+      $commentInt,
+      columns: [_i3.CommentInt.t.orderId],
+      transaction: transaction,
+    );
+  }
+}
+
+class OrderUuidDetachRepository {
+  const OrderUuidDetachRepository._();
+
+  /// Detaches the relation between this [OrderUuid] and the given [CommentInt]
+  /// by setting the [CommentInt]'s foreign key `orderId` to `null`.
+  ///
+  /// This removes the association between the two models without deleting
+  /// the related record.
+  Future<void> comments(
+    _i1.DatabaseSession session,
+    List<_i3.CommentInt> commentInt, {
+    _i1.Transaction? transaction,
+  }) async {
+    if (commentInt.any((e) => e.id == null)) {
+      throw ArgumentError.notNull('commentInt.id');
+    }
+
+    var $commentInt = commentInt.map((e) => e.copyWith(orderId: null)).toList();
+    await session.db.update<_i3.CommentInt>(
+      $commentInt,
+      columns: [_i3.CommentInt.t.orderId],
+      transaction: transaction,
+    );
+  }
+}
+
+class OrderUuidDetachRowRepository {
+  const OrderUuidDetachRowRepository._();
+
+  /// Detaches the relation between this [OrderUuid] and the given [CommentInt]
+  /// by setting the [CommentInt]'s foreign key `orderId` to `null`.
+  ///
+  /// This removes the association between the two models without deleting
+  /// the related record.
+  Future<void> comments(
+    _i1.DatabaseSession session,
+    _i3.CommentInt commentInt, {
+    _i1.Transaction? transaction,
+  }) async {
+    if (commentInt.id == null) {
+      throw ArgumentError.notNull('commentInt.id');
+    }
+
+    var $commentInt = commentInt.copyWith(orderId: null);
     await session.db.updateRow<_i3.CommentInt>(
       $commentInt,
       columns: [_i3.CommentInt.t.orderId],

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/many_to_many/student.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/many_to_many/student.dart
@@ -266,6 +266,10 @@ class StudentRepository {
 
   final attachRow = const StudentAttachRowRepository._();
 
+  final detach = const StudentDetachRepository._();
+
+  final detachRow = const StudentDetachRowRepository._();
+
   /// Returns a list of [Student]s matching the given query parameters.
   ///
   /// Use [where] to specify which items to include in the return value.
@@ -633,6 +637,60 @@ class StudentAttachRowRepository {
     }
 
     var $enrollment = enrollment.copyWith(studentId: student.id);
+    await session.db.updateRow<_i2.Enrollment>(
+      $enrollment,
+      columns: [_i2.Enrollment.t.studentId],
+      transaction: transaction,
+    );
+  }
+}
+
+class StudentDetachRepository {
+  const StudentDetachRepository._();
+
+  /// Detaches the relation between this [Student] and the given [Enrollment]
+  /// by setting the [Enrollment]'s foreign key `studentId` to `null`.
+  ///
+  /// This removes the association between the two models without deleting
+  /// the related record.
+  Future<void> enrollments(
+    _i1.DatabaseSession session,
+    List<_i2.Enrollment> enrollment, {
+    _i1.Transaction? transaction,
+  }) async {
+    if (enrollment.any((e) => e.id == null)) {
+      throw ArgumentError.notNull('enrollment.id');
+    }
+
+    var $enrollment = enrollment
+        .map((e) => e.copyWith(studentId: null))
+        .toList();
+    await session.db.update<_i2.Enrollment>(
+      $enrollment,
+      columns: [_i2.Enrollment.t.studentId],
+      transaction: transaction,
+    );
+  }
+}
+
+class StudentDetachRowRepository {
+  const StudentDetachRowRepository._();
+
+  /// Detaches the relation between this [Student] and the given [Enrollment]
+  /// by setting the [Enrollment]'s foreign key `studentId` to `null`.
+  ///
+  /// This removes the association between the two models without deleting
+  /// the related record.
+  Future<void> enrollments(
+    _i1.DatabaseSession session,
+    _i2.Enrollment enrollment, {
+    _i1.Transaction? transaction,
+  }) async {
+    if (enrollment.id == null) {
+      throw ArgumentError.notNull('enrollment.id');
+    }
+
+    var $enrollment = enrollment.copyWith(studentId: null);
     await session.db.updateRow<_i2.Enrollment>(
       $enrollment,
       columns: [_i2.Enrollment.t.studentId],

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/order.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/order.dart
@@ -339,6 +339,10 @@ class OrderRepository {
 
   final attachRow = const OrderAttachRowRepository._();
 
+  final detach = const OrderDetachRepository._();
+
+  final detachRow = const OrderDetachRowRepository._();
+
   /// Returns a list of [Order]s matching the given query parameters.
   ///
   /// Use [where] to specify which items to include in the return value.
@@ -727,6 +731,58 @@ class OrderAttachRowRepository {
     }
 
     var $comment = comment.copyWith(orderId: order.id);
+    await session.db.updateRow<_i3.Comment>(
+      $comment,
+      columns: [_i3.Comment.t.orderId],
+      transaction: transaction,
+    );
+  }
+}
+
+class OrderDetachRepository {
+  const OrderDetachRepository._();
+
+  /// Detaches the relation between this [Order] and the given [Comment]
+  /// by setting the [Comment]'s foreign key `orderId` to `null`.
+  ///
+  /// This removes the association between the two models without deleting
+  /// the related record.
+  Future<void> comments(
+    _i1.DatabaseSession session,
+    List<_i3.Comment> comment, {
+    _i1.Transaction? transaction,
+  }) async {
+    if (comment.any((e) => e.id == null)) {
+      throw ArgumentError.notNull('comment.id');
+    }
+
+    var $comment = comment.map((e) => e.copyWith(orderId: null)).toList();
+    await session.db.update<_i3.Comment>(
+      $comment,
+      columns: [_i3.Comment.t.orderId],
+      transaction: transaction,
+    );
+  }
+}
+
+class OrderDetachRowRepository {
+  const OrderDetachRowRepository._();
+
+  /// Detaches the relation between this [Order] and the given [Comment]
+  /// by setting the [Comment]'s foreign key `orderId` to `null`.
+  ///
+  /// This removes the association between the two models without deleting
+  /// the related record.
+  Future<void> comments(
+    _i1.DatabaseSession session,
+    _i3.Comment comment, {
+    _i1.Transaction? transaction,
+  }) async {
+    if (comment.id == null) {
+      throw ArgumentError.notNull('comment.id');
+    }
+
+    var $comment = comment.copyWith(orderId: null);
     await session.db.updateRow<_i3.Comment>(
       $comment,
       columns: [_i3.Comment.t.orderId],

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/many_to_many/member.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/many_to_many/member.dart
@@ -340,6 +340,10 @@ class MemberRepository {
 
   final attachRow = const MemberAttachRowRepository._();
 
+  final detach = const MemberDetachRepository._();
+
+  final detachRow = const MemberDetachRowRepository._();
+
   /// Returns a list of [Member]s matching the given query parameters.
   ///
   /// Use [where] to specify which items to include in the return value.
@@ -755,6 +759,102 @@ class MemberAttachRowRepository {
     }
 
     var $blocking = blocking.copyWith(blockedId: member.id);
+    await session.db.updateRow<_i2.Blocking>(
+      $blocking,
+      columns: [_i2.Blocking.t.blockedId],
+      transaction: transaction,
+    );
+  }
+}
+
+class MemberDetachRepository {
+  const MemberDetachRepository._();
+
+  /// Detaches the relation between this [Member] and the given [Blocking]
+  /// by setting the [Blocking]'s foreign key `blockedById` to `null`.
+  ///
+  /// This removes the association between the two models without deleting
+  /// the related record.
+  Future<void> blocking(
+    _i1.DatabaseSession session,
+    List<_i2.Blocking> blocking, {
+    _i1.Transaction? transaction,
+  }) async {
+    if (blocking.any((e) => e.id == null)) {
+      throw ArgumentError.notNull('blocking.id');
+    }
+
+    var $blocking = blocking.map((e) => e.copyWith(blockedById: null)).toList();
+    await session.db.update<_i2.Blocking>(
+      $blocking,
+      columns: [_i2.Blocking.t.blockedById],
+      transaction: transaction,
+    );
+  }
+
+  /// Detaches the relation between this [Member] and the given [Blocking]
+  /// by setting the [Blocking]'s foreign key `blockedId` to `null`.
+  ///
+  /// This removes the association between the two models without deleting
+  /// the related record.
+  Future<void> blockedBy(
+    _i1.DatabaseSession session,
+    List<_i2.Blocking> blocking, {
+    _i1.Transaction? transaction,
+  }) async {
+    if (blocking.any((e) => e.id == null)) {
+      throw ArgumentError.notNull('blocking.id');
+    }
+
+    var $blocking = blocking.map((e) => e.copyWith(blockedId: null)).toList();
+    await session.db.update<_i2.Blocking>(
+      $blocking,
+      columns: [_i2.Blocking.t.blockedId],
+      transaction: transaction,
+    );
+  }
+}
+
+class MemberDetachRowRepository {
+  const MemberDetachRowRepository._();
+
+  /// Detaches the relation between this [Member] and the given [Blocking]
+  /// by setting the [Blocking]'s foreign key `blockedById` to `null`.
+  ///
+  /// This removes the association between the two models without deleting
+  /// the related record.
+  Future<void> blocking(
+    _i1.DatabaseSession session,
+    _i2.Blocking blocking, {
+    _i1.Transaction? transaction,
+  }) async {
+    if (blocking.id == null) {
+      throw ArgumentError.notNull('blocking.id');
+    }
+
+    var $blocking = blocking.copyWith(blockedById: null);
+    await session.db.updateRow<_i2.Blocking>(
+      $blocking,
+      columns: [_i2.Blocking.t.blockedById],
+      transaction: transaction,
+    );
+  }
+
+  /// Detaches the relation between this [Member] and the given [Blocking]
+  /// by setting the [Blocking]'s foreign key `blockedId` to `null`.
+  ///
+  /// This removes the association between the two models without deleting
+  /// the related record.
+  Future<void> blockedBy(
+    _i1.DatabaseSession session,
+    _i2.Blocking blocking, {
+    _i1.Transaction? transaction,
+  }) async {
+    if (blocking.id == null) {
+      throw ArgumentError.notNull('blocking.id');
+    }
+
+    var $blocking = blocking.copyWith(blockedId: null);
     await session.db.updateRow<_i2.Blocking>(
       $blocking,
       columns: [_i2.Blocking.t.blockedId],

--- a/tools/serverpod_cli/lib/src/analyzer/models/entity_dependency_resolver.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/entity_dependency_resolver.dart
@@ -26,7 +26,29 @@ class ModelDependencyResolver {
     });
 
     // Then resolve everything else, including relations on inherited ids.
-    modelDefinitions.whereType<ClassDefinition>().forEach((classDefinition) {
+    // Class order still matters: list resolution on the owner reads the element
+    // type's fields, so process list element models before list owners.
+    final classDefs = modelDefinitions.whereType<ClassDefinition>().toList();
+    final originalIndex = {
+      for (var i = 0; i < classDefs.length; i++) classDefs[i]: i,
+    };
+    final modelClasses = classDefs.whereType<ModelClassDefinition>().toList();
+    final topologicalRank = _topologicalRankForListDependencies(
+      modelClasses,
+      modelDefinitions,
+    );
+
+    classDefs.sort((a, b) {
+      if (a is ModelClassDefinition && b is ModelClassDefinition) {
+        final cmp = topologicalRank[a.className]!.compareTo(
+          topologicalRank[b.className]!,
+        );
+        if (cmp != 0) return cmp;
+      }
+      return originalIndex[a]!.compareTo(originalIndex[b]!);
+    });
+
+    for (final classDefinition in classDefs) {
       var fields = classDefinition is ModelClassDefinition
           ? classDefinition.fieldsIncludingInherited
           : classDefinition.fields;
@@ -49,7 +71,74 @@ class ModelDependencyResolver {
           modelDefinitions,
         );
       }
-    });
+    }
+  }
+
+  /// Lower rank = process earlier. For each list field `List<R>`, [R] is
+  /// ordered before the owner so list resolution sees the foreign class ready.
+  static Map<String, int> _topologicalRankForListDependencies(
+    List<ModelClassDefinition> models,
+    List<SerializableModelDefinition> modelDefinitions,
+  ) {
+    final nameToModel = {for (final m in models) m.className: m};
+    final firstOrder = <String, int>{};
+    for (var i = 0; i < modelDefinitions.length; i++) {
+      final m = modelDefinitions[i];
+      if (m is ModelClassDefinition) {
+        firstOrder.putIfAbsent(m.className, () => i);
+      }
+    }
+
+    final inDegree = <String, int>{};
+    final adj = <String, List<String>>{};
+
+    for (final m in models) {
+      inDegree[m.className] = 0;
+    }
+
+    for (final owner in models) {
+      for (final field in owner.fields) {
+        if (field.relation is! UnresolvedListRelationDefinition) continue;
+        if (field.type.generics.isEmpty) continue;
+        final refName = field.type.generics.first.className;
+        if (!nameToModel.containsKey(refName)) continue;
+        if (refName == owner.className) continue;
+        adj.putIfAbsent(refName, () => []).add(owner.className);
+        inDegree[owner.className] = (inDegree[owner.className] ?? 0) + 1;
+      }
+    }
+
+    final ready =
+        models
+            .where((m) => inDegree[m.className] == 0)
+            .map((m) => m.className)
+            .toList()
+          ..sort((a, b) => firstOrder[a]!.compareTo(firstOrder[b]!));
+
+    final rank = <String, int>{};
+    var r = 0;
+    while (ready.isNotEmpty) {
+      final n = ready.removeAt(0);
+      rank[n] = r++;
+      for (final owner in adj[n] ?? []) {
+        inDegree[owner] = inDegree[owner]! - 1;
+        if (inDegree[owner] == 0) {
+          ready.add(owner);
+          ready.sort((a, b) => firstOrder[a]!.compareTo(firstOrder[b]!));
+        }
+      }
+    }
+
+    var next = r;
+    final remaining =
+        models.where((m) => !rank.containsKey(m.className)).toList()..sort(
+          (a, b) =>
+              firstOrder[a.className]!.compareTo(firstOrder[b.className]!),
+        );
+    for (final m in remaining) {
+      rank[m.className] = next++;
+    }
+    return rank;
   }
 
   static void _resolveInheritance(
@@ -511,11 +600,24 @@ class ModelDependencyResolver {
     } else {
       var foreignFields = referenceClass.fields.where((field) {
         var fieldRelation = field.relation;
+        // Include [ObjectRelationDefinition]: the foreign side may already be
+        // resolved when the list side runs (model definition order-dependent).
+        // Include [UnresolvableObjectRelationDefinition]: when the list owner is
+        // processed after the element type, object resolution may fail on the
+        // foreign row until the owner exists; the list side must still see the
+        // object field for nullableRelation (detach) and not only the id field.
         if (!(fieldRelation is UnresolvedObjectRelationDefinition ||
-            fieldRelation is ForeignRelationDefinition)) {
+            fieldRelation is ForeignRelationDefinition ||
+            fieldRelation is ObjectRelationDefinition ||
+            fieldRelation is UnresolvableObjectRelationDefinition)) {
           return false;
         }
-        return fieldRelation?.name == relation.name;
+        if (fieldRelation?.name == relation.name) return true;
+        return _objectFieldPairsWithNamedForeignKey(
+          referenceClass,
+          field,
+          relation.name,
+        );
       });
 
       if (foreignFields.isEmpty) return;
@@ -531,6 +633,12 @@ class ModelDependencyResolver {
         foreignFieldName =
             foreignRelation.fieldName ??
             _createImplicitForeignIdFieldName(foreignField.name);
+      } else if (foreignRelation is ObjectRelationDefinition) {
+        foreignFieldName = foreignField.name;
+      } else if (foreignRelation is UnresolvableObjectRelationDefinition) {
+        foreignFieldName =
+            foreignRelation.objectRelationDefinition.fieldName ??
+            _createImplicitForeignIdFieldName(foreignField.name);
       }
 
       SerializableModelFieldDefinition? foreignContainerField;
@@ -538,6 +646,11 @@ class ModelDependencyResolver {
         foreignRelation.foreignContainerField = fieldDefinition;
         foreignContainerField = foreignRelation.containerField;
       } else if (foreignRelation is UnresolvedObjectRelationDefinition) {
+        foreignContainerField = foreignField;
+      } else if (foreignRelation is ObjectRelationDefinition) {
+        foreignRelation.foreignContainerField = fieldDefinition;
+        foreignContainerField = foreignField;
+      } else if (foreignRelation is UnresolvableObjectRelationDefinition) {
         foreignContainerField = foreignField;
       }
 
@@ -549,7 +662,7 @@ class ModelDependencyResolver {
         fieldName: defaultPrimaryKeyName,
         foreignFieldName: foreignFieldName,
         foreignContainerField: foreignContainerField,
-        nullableRelation: foreignFields.first.type.nullable,
+        nullableRelation: _nullableRelationForListSide(foreignFields),
       );
     }
   }
@@ -569,5 +682,43 @@ class ModelDependencyResolver {
       DatabaseConstants.pgsqlMaxNameLimitation - 2,
     );
     return '${truncatedFieldName}Id';
+  }
+
+  /// Implicit/named object resolution stores [RelationDefinition.name] only on
+  /// the FK field, not on [ObjectRelationDefinition], so list resolution must
+  /// still associate the object field with the named relation for nullableRelation.
+  static bool _objectFieldPairsWithNamedForeignKey(
+    ModelClassDefinition referenceClass,
+    SerializableModelFieldDefinition field,
+    String? relationName,
+  ) {
+    if (relationName == null) return false;
+    final fieldRelation = field.relation;
+    if (fieldRelation is! ObjectRelationDefinition) return false;
+    if (fieldRelation.name != null) return false;
+    return referenceClass.fields.any(
+      (f) =>
+          f.relation is ForeignRelationDefinition &&
+          f.relation?.name == relationName &&
+          f.name == fieldRelation.fieldName,
+    );
+  }
+
+  /// Prefer the object-side field when both it and an injected id field share
+  /// the same relation name (id is non-nullable; optional relations are on the
+  /// object field).
+  static bool _nullableRelationForListSide(
+    Iterable<SerializableModelFieldDefinition> foreignFields,
+  ) {
+    final objectSideFields = foreignFields.where(
+      (f) =>
+          f.relation is ObjectRelationDefinition ||
+          f.relation is UnresolvedObjectRelationDefinition ||
+          f.relation is UnresolvableObjectRelationDefinition,
+    );
+    if (objectSideFields.isNotEmpty) {
+      return objectSideFields.first.type.nullable;
+    }
+    return foreignFields.first.type.nullable;
   }
 }

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/relation/relation_one_to_many_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/relation/relation_one_to_many_test.dart
@@ -385,7 +385,7 @@ void main() {
         class: Employee
         table: employee
         fields:
-          company: 
+          company:
             type: Company?
             relation:
               name: 1
@@ -396,7 +396,7 @@ void main() {
         class: Company
         table: company
         fields:
-          employees: 
+          employees:
             type: List<Employee>?
             relation:
               name: 1
@@ -709,6 +709,400 @@ void main() {
           expect(relation.containerField?.name, 'customer');
         },
       );
+    },
+  );
+
+  group(
+    'Given a named nullable list relation where the child model is processed first and declares the object field before its implicit foreign key, '
+    'when parsing the models',
+    () {
+      var models = [
+        ModelSourceBuilder().withFileName('child').withYaml(
+          '''
+        class: Child
+        table: child
+        fields:
+          parent: Parent?, relation(name=parent_children)
+        ''',
+        ).build(),
+        ModelSourceBuilder().withFileName('parent').withYaml(
+          '''
+        class: Parent
+        table: parent
+        fields:
+          children: List<Child>?, relation(name=parent_children)
+        ''',
+        ).build(),
+      ];
+
+      var collector = CodeGenerationCollector();
+      StatefulAnalyzer analyzer = StatefulAnalyzer(
+        config,
+        models,
+        onErrorsCollector(collector),
+      );
+      var definitions = analyzer.validateAll();
+      var parentDefinition = definitions
+          .whereType<ClassDefinition>()
+          .firstWhere(
+            (d) => d.className == 'Parent',
+          );
+      var childDefinition = definitions.whereType<ClassDefinition>().firstWhere(
+        (d) => d.className == 'Child',
+      );
+
+      var errors = collector.errors;
+      var relation = parentDefinition.findField('children')?.relation;
+
+      test('then no errors are collected.', () {
+        expect(errors, isEmpty);
+      });
+
+      test('then children is a list relation.', () {
+        expect(relation.runtimeType, ListRelationDefinition);
+      });
+
+      test(
+        'then the list relation points to the explicit foreign key field.',
+        () {
+          relation as ListRelationDefinition;
+          expect(relation.foreignFieldName, 'parentId');
+        },
+      );
+
+      test('then nullableRelation stays true on the list relation.', () {
+        relation as ListRelationDefinition;
+        expect(relation.nullableRelation, isTrue);
+      });
+
+      test('then the foreign container field is set on the list relation.', () {
+        relation as ListRelationDefinition;
+        expect(relation.foreignContainerField?.name, 'parent');
+      });
+
+      test('then the object relation points back to the list relation.', () {
+        var objectRelation =
+            childDefinition.findField('parent')?.relation
+                as ObjectRelationDefinition;
+
+        expect(objectRelation.foreignContainerField?.name, 'children');
+      });
+    },
+  );
+
+  group(
+    'Given a named list relation with an implicit child foreign key and child defined before parent '
+    'when analyzing ',
+    () {
+      var models = [
+        ModelSourceBuilder().withFileName('child').withYaml(
+          '''
+        class: Child
+        table: child
+        fields:
+          name: String
+          parent: Parent?, relation(name=parent_children)
+        ''',
+        ).build(),
+        ModelSourceBuilder().withFileName('parent').withYaml(
+          '''
+        class: Parent
+        table: parent
+        fields:
+          children: List<Child>?, relation(name=parent_children)
+        ''',
+        ).build(),
+      ];
+
+      var collector = CodeGenerationCollector();
+      var analyzer = StatefulAnalyzer(
+        config,
+        models,
+        onErrorsCollector(collector),
+      );
+      var definitions = analyzer.validateAll();
+      var parentDefinition = definitions
+          .whereType<ClassDefinition>()
+          .firstWhere(
+            (d) => d.className == 'Parent',
+          );
+      var childDefinition = definitions.whereType<ClassDefinition>().firstWhere(
+        (d) => d.className == 'Child',
+      );
+      var errors = collector.errors;
+      var relation = parentDefinition.findField('children')?.relation;
+
+      test('then no errors are collected.', () {
+        expect(errors, isEmpty);
+      });
+
+      test('then the relation is a list relation.', () {
+        expect(relation.runtimeType, ListRelationDefinition);
+      });
+
+      test('then nullableRelation is false on the list relation.', () {
+        relation as ListRelationDefinition;
+        expect(relation.nullableRelation, isFalse);
+      });
+
+      test('then the list relation points to the implicit foreign key.', () {
+        expect(
+          (relation as ListRelationDefinition).foreignFieldName,
+          'parentId',
+        );
+      });
+
+      test('then the list relation points to the child object field.', () {
+        expect(
+          (relation as ListRelationDefinition).foreignContainerField?.name,
+          'parent',
+        );
+      });
+
+      test('then the child object relation points back to the list field.', () {
+        var objectRelation =
+            childDefinition.findField('parent')?.relation
+                as ObjectRelationDefinition;
+
+        expect(objectRelation.foreignContainerField?.name, 'children');
+      });
+    },
+  );
+
+  group(
+    'Given a named list relation with an implicit child foreign key and parent defined before child '
+    'when analyzing ',
+    () {
+      var models = [
+        ModelSourceBuilder().withFileName('parent').withYaml(
+          '''
+        class: Parent
+        table: parent
+        fields:
+          children: List<Child>?, relation(name=parent_children)
+        ''',
+        ).build(),
+        ModelSourceBuilder().withFileName('child').withYaml(
+          '''
+        class: Child
+        table: child
+        fields:
+          name: String
+          parent: Parent?, relation(name=parent_children)
+        ''',
+        ).build(),
+      ];
+
+      var collector = CodeGenerationCollector();
+      var analyzer = StatefulAnalyzer(
+        config,
+        models,
+        onErrorsCollector(collector),
+      );
+      var definitions = analyzer.validateAll();
+      var parentDefinition = definitions
+          .whereType<ClassDefinition>()
+          .firstWhere(
+            (d) => d.className == 'Parent',
+          );
+      var childDefinition = definitions.whereType<ClassDefinition>().firstWhere(
+        (d) => d.className == 'Child',
+      );
+      var errors = collector.errors;
+      var relation = parentDefinition.findField('children')?.relation;
+
+      test('then no errors are collected.', () {
+        expect(errors, isEmpty);
+      });
+
+      test('then the relation is a list relation.', () {
+        expect(relation.runtimeType, ListRelationDefinition);
+      });
+
+      test('then nullableRelation is true on the list relation.', () {
+        relation as ListRelationDefinition;
+        expect(relation.nullableRelation, isTrue);
+      });
+
+      test('then the list relation points to the implicit foreign key.', () {
+        expect(
+          (relation as ListRelationDefinition).foreignFieldName,
+          'parentId',
+        );
+      });
+
+      test('then the list relation points to the child object field.', () {
+        expect(
+          (relation as ListRelationDefinition).foreignContainerField?.name,
+          'parent',
+        );
+      });
+
+      test('then the child object relation points back to the list field.', () {
+        var objectRelation =
+            childDefinition.findField('parent')?.relation
+                as ObjectRelationDefinition;
+
+        expect(objectRelation.foreignContainerField?.name, 'children');
+      });
+    },
+  );
+
+  group(
+    'Given an optional named list relation with an implicit child foreign key and child defined before parent '
+    'when analyzing ',
+    () {
+      var models = [
+        ModelSourceBuilder().withFileName('child').withYaml(
+          '''
+        class: Child
+        table: child
+        fields:
+          name: String
+          parent: Parent?, relation(name=parent_children, optional=true)
+        ''',
+        ).build(),
+        ModelSourceBuilder().withFileName('parent').withYaml(
+          '''
+        class: Parent
+        table: parent
+        fields:
+          children: List<Child>?, relation(name=parent_children)
+        ''',
+        ).build(),
+      ];
+
+      var collector = CodeGenerationCollector();
+      var analyzer = StatefulAnalyzer(
+        config,
+        models,
+        onErrorsCollector(collector),
+      );
+      var definitions = analyzer.validateAll();
+      var parentDefinition = definitions
+          .whereType<ClassDefinition>()
+          .firstWhere(
+            (d) => d.className == 'Parent',
+          );
+      var childDefinition = definitions.whereType<ClassDefinition>().firstWhere(
+        (d) => d.className == 'Child',
+      );
+      var errors = collector.errors;
+      var relation = parentDefinition.findField('children')?.relation;
+
+      test('then no errors are collected.', () {
+        expect(errors, isEmpty);
+      });
+
+      test('then the relation is a list relation.', () {
+        expect(relation.runtimeType, ListRelationDefinition);
+      });
+
+      test('then nullableRelation is true on the list relation.', () {
+        relation as ListRelationDefinition;
+        expect(relation.nullableRelation, isTrue);
+      });
+
+      test('then the list relation points to the implicit foreign key.', () {
+        expect(
+          (relation as ListRelationDefinition).foreignFieldName,
+          'parentId',
+        );
+      });
+
+      test('then the list relation points to the child object field.', () {
+        expect(
+          (relation as ListRelationDefinition).foreignContainerField?.name,
+          'parent',
+        );
+      });
+
+      test('then the child object relation points back to the list field.', () {
+        var objectRelation =
+            childDefinition.findField('parent')?.relation
+                as ObjectRelationDefinition;
+
+        expect(objectRelation.foreignContainerField?.name, 'children');
+      });
+    },
+  );
+
+  group(
+    'Given an optional named list relation with an implicit child foreign key and parent defined before child '
+    'when analyzing ',
+    () {
+      var models = [
+        ModelSourceBuilder().withFileName('parent').withYaml(
+          '''
+        class: Parent
+        table: parent
+        fields:
+          children: List<Child>?, relation(name=parent_children)
+        ''',
+        ).build(),
+        ModelSourceBuilder().withFileName('child').withYaml(
+          '''
+        class: Child
+        table: child
+        fields:
+          name: String
+          parent: Parent?, relation(name=parent_children, optional=true)
+        ''',
+        ).build(),
+      ];
+
+      var collector = CodeGenerationCollector();
+      var analyzer = StatefulAnalyzer(
+        config,
+        models,
+        onErrorsCollector(collector),
+      );
+      var definitions = analyzer.validateAll();
+      var parentDefinition = definitions
+          .whereType<ClassDefinition>()
+          .firstWhere(
+            (d) => d.className == 'Parent',
+          );
+      var childDefinition = definitions.whereType<ClassDefinition>().firstWhere(
+        (d) => d.className == 'Child',
+      );
+      var errors = collector.errors;
+      var relation = parentDefinition.findField('children')?.relation;
+
+      test('then no errors are collected.', () {
+        expect(errors, isEmpty);
+      });
+
+      test('then the relation is a list relation.', () {
+        expect(relation.runtimeType, ListRelationDefinition);
+      });
+
+      test('then nullableRelation is true on the list relation.', () {
+        relation as ListRelationDefinition;
+        expect(relation.nullableRelation, isTrue);
+      });
+
+      test('then the list relation points to the implicit foreign key.', () {
+        expect(
+          (relation as ListRelationDefinition).foreignFieldName,
+          'parentId',
+        );
+      });
+
+      test('then the list relation points to the child object field.', () {
+        expect(
+          (relation as ListRelationDefinition).foreignContainerField?.name,
+          'parent',
+        );
+      });
+
+      test('then the child object relation points back to the list field.', () {
+        var objectRelation =
+            childDefinition.findField('parent')?.relation
+                as ObjectRelationDefinition;
+
+        expect(objectRelation.foreignContainerField?.name, 'children');
+      });
     },
   );
 


### PR DESCRIPTION
Fixes: #4868

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.