### PR TITLE
fix: Mark server as not running when HTTP transport dies unexpectedly

### DIFF
--- a/packages/serverpod/lib/src/server/server.dart
+++ b/packages/serverpod/lib/src/server/server.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'dart:io' as io;
 import 'dart:typed_data';
 
+import 'package:meta/meta.dart';
 import 'package:serverpod/serverpod.dart';
 import 'package:serverpod/src/cache/caches.dart';
 import 'package:serverpod/src/server/diagnostic_events/diagnostic_events.dart';
@@ -174,11 +175,16 @@ class Server implements RouterInjectable {
     _authenticationHandler = authenticationHandler;
 
     try {
-      final server = await _app.serve(
-        address: io.InternetAddress.anyIPv6,
+      final httpServer = await bindHttpServer(
+        io.InternetAddress.anyIPv6,
         port: _port,
-        securityContext: _securityContext,
+        context: _securityContext,
       );
+      final adapter = _LifecycleTrackingAdapter(
+        httpServer,
+        onTerminate: _onTransportTerminated,
+      );
+      final server = await _app.run(() => adapter);
       _actualPort = server.port;
       _relicServer = server;
     } catch (e, stackTrace) {
@@ -199,6 +205,29 @@ class Server implements RouterInjectable {
       'Server started on $scheme://localhost:$port',
     );
     return _running;
+  }
+
+  /// Called when the underlying HTTP transport terminates outside of a
+  /// graceful [shutdown] — e.g. when the `HttpServer` request stream emits
+  /// an error (`SocketException: Connection reset by peer`) or completes
+  /// unexpectedly. Flips [_running] to `false` so that health checks and
+  /// consumers of [running] observe the actual transport state instead of
+  /// the stale "start succeeded" latch.
+  ///
+  /// During [shutdown] this is a no-op because [_running] is cleared first,
+  /// preventing duplicate reports when we ourselves close the transport.
+  void _onTransportTerminated(Object? error, StackTrace? stackTrace) {
+    if (!_running) return;
+    _running = false;
+    unawaited(
+      _reportFrameworkException(
+        error ?? StateError('HTTP server request stream closed unexpectedly'),
+        stackTrace ?? StackTrace.current,
+        message:
+            'HTTP transport terminated outside of Server.shutdown(); '
+            'marking server as not running.',
+      ),
+    );
   }
 
   Handler _verboseLogging(Handler next) {
@@ -558,6 +587,11 @@ class Server implements RouterInjectable {
   /// Shuts the server down.
   /// Returns a [Future] that completes when the server is shut down.
   Future<void> shutdown() async {
+    // Flip the running flag *before* closing the transport, so that the
+    // lifecycle-tracking adapter's `handleDone` (which fires when
+    // `_app.close()` drains the request stream) does not misreport the
+    // graceful shutdown as an unexpected crash.
+    _running = false;
     await _app.close();
     var webSockets = _webSockets.values.toList();
     List<Future<void>> webSocketCompletions = [];
@@ -568,7 +602,6 @@ class Server implements RouterInjectable {
 
     // Wait for all WebSockets to close.
     await Future.wait(webSocketCompletions);
-    _running = false;
   }
 
   Future<void> _reportFrameworkException(
@@ -611,5 +644,70 @@ extension ServerInternalMethods on Server {
     AuthenticationHandler authenticationHandler,
   ) {
     _authenticationHandler = authenticationHandler;
+  }
+}
+
+/// Creates a pass-through [StreamTransformer] that invokes [onTerminate]
+/// the first time the underlying stream emits an error or completes.
+///
+/// Subsequent error/done events are forwarded normally but do not trigger
+/// additional `onTerminate` calls, so that a stream which errors and then
+/// closes (the common `HttpServer` failure pattern) only reports once.
+///
+/// Used by [Server.start] to observe the lifecycle of the `HttpServer`
+/// request stream that Relic listens to. Relic's internal listener attaches
+/// no `onError` / `onDone` handlers, so without this transformer an abrupt
+/// transport failure (e.g. `SocketException: Connection reset by peer`)
+/// leaves [Server.running] stuck at `true`. See serverpod/serverpod#3696.
+///
+/// Exposed as `@visibleForTesting` so the tap-and-forward behavior can be
+/// verified in isolation without needing a real bound HTTP server.
+@visibleForTesting
+StreamTransformer<T, T> createTransportLifecycleTransformer<T>({
+  required void Function(Object? error, StackTrace? stackTrace) onTerminate,
+}) {
+  var terminated = false;
+  void notifyOnce(Object? error, StackTrace? stackTrace) {
+    if (terminated) return;
+    terminated = true;
+    onTerminate(error, stackTrace);
+  }
+
+  return StreamTransformer<T, T>.fromHandlers(
+    handleData: (data, sink) => sink.add(data),
+    handleError: (error, stackTrace, sink) {
+      notifyOnce(error, stackTrace);
+      sink.addError(error, stackTrace);
+    },
+    handleDone: (sink) {
+      notifyOnce(null, null);
+      sink.close();
+    },
+  );
+}
+
+/// Wraps an [IOAdapter] and taps into the request stream so that stream
+/// termination (error or done) outside of a graceful shutdown is surfaced
+/// to the caller via `onTerminate`.
+class _LifecycleTrackingAdapter extends IOAdapter {
+  _LifecycleTrackingAdapter(
+    super.server, {
+    required void Function(Object? error, StackTrace? stackTrace) onTerminate,
+  }) : _onTerminate = onTerminate;
+
+  final void Function(Object? error, StackTrace? stackTrace) _onTerminate;
+
+  // [IOAdapter.requests] produces a fresh `HttpServer.map(...)` stream on
+  // each read. Memoize the transformed stream so that we never risk a second
+  // (illegal) subscription on the single-subscription `HttpServer` stream.
+  Stream<AdapterRequest>? _cached;
+
+  @override
+  Stream<AdapterRequest> get requests {
+    return _cached ??= super.requests.transform(
+      createTransportLifecycleTransformer<AdapterRequest>(
+        onTerminate: _onTerminate,
+      ),
+    );
   }
 }

--- a/packages/serverpod/test/server/transport_lifecycle_transformer_test.dart
+++ b/packages/serverpod/test/server/transport_lifecycle_transformer_test.dart
@@ -1,0 +1,138 @@
+import 'dart:async';
+
+import 'package:serverpod/src/server/server.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('createTransportLifecycleTransformer', () {
+    test(
+      'when the source stream closes normally '
+      'then onTerminate is invoked once with null error and null stackTrace',
+      () async {
+        final controller = StreamController<int>();
+        Object? capturedError = _unset;
+        StackTrace? capturedStackTrace = StackTrace.empty;
+        var terminateCount = 0;
+
+        final transformed = controller.stream.transform(
+          createTransportLifecycleTransformer<int>(
+            onTerminate: (error, stackTrace) {
+              terminateCount++;
+              capturedError = error;
+              capturedStackTrace = stackTrace;
+            },
+          ),
+        );
+
+        final received = <int>[];
+        final sub = transformed.listen(received.add);
+
+        controller.add(1);
+        controller.add(2);
+        await controller.close();
+        await sub.cancel();
+
+        expect(received, equals([1, 2]));
+        expect(terminateCount, equals(1));
+        expect(capturedError, isNull);
+        expect(capturedStackTrace, isNull);
+      },
+    );
+
+    test(
+      'when the source stream emits an error '
+      'then onTerminate is invoked with the error and the error is forwarded',
+      () async {
+        final controller = StreamController<int>();
+        Object? capturedError;
+        StackTrace? capturedStackTrace;
+        var terminateCount = 0;
+
+        final transformed = controller.stream.transform(
+          createTransportLifecycleTransformer<int>(
+            onTerminate: (error, stackTrace) {
+              terminateCount++;
+              capturedError = error;
+              capturedStackTrace = stackTrace;
+            },
+          ),
+        );
+
+        Object? receivedError;
+        final sub = transformed.listen(
+          (_) {},
+          onError: (Object error, StackTrace st) {
+            receivedError = error;
+          },
+        );
+
+        final injectedError = StateError('boom');
+        final injectedStack = StackTrace.current;
+        controller.addError(injectedError, injectedStack);
+        await Future<void>.delayed(Duration.zero);
+        await controller.close();
+        await sub.cancel();
+
+        expect(terminateCount, equals(1));
+        expect(capturedError, same(injectedError));
+        expect(capturedStackTrace, same(injectedStack));
+        expect(receivedError, same(injectedError));
+      },
+    );
+
+    test(
+      'when the source stream errors and then closes '
+      'then onTerminate is only invoked once (idempotent)',
+      () async {
+        final controller = StreamController<int>();
+        var terminateCount = 0;
+
+        final transformed = controller.stream.transform(
+          createTransportLifecycleTransformer<int>(
+            onTerminate: (_, _) => terminateCount++,
+          ),
+        );
+
+        final sub = transformed.listen(
+          (_) {},
+          onError: (Object _, StackTrace _) {},
+        );
+
+        controller.addError(StateError('boom'));
+        await Future<void>.delayed(Duration.zero);
+        await controller.close();
+        await sub.cancel();
+
+        expect(terminateCount, equals(1));
+      },
+    );
+
+    test(
+      'when data events arrive before termination '
+      'then each data event is forwarded unchanged',
+      () async {
+        final controller = StreamController<String>();
+        final transformed = controller.stream.transform(
+          createTransportLifecycleTransformer<String>(
+            onTerminate: (_, _) {},
+          ),
+        );
+
+        final received = <String>[];
+        final sub = transformed.listen(received.add);
+
+        controller.add('a');
+        controller.add('b');
+        controller.add('c');
+        await controller.close();
+        await sub.cancel();
+
+        expect(received, equals(['a', 'b', 'c']));
+      },
+    );
+  });
+}
+
+/// Sentinel used to distinguish between "onTerminate was never called" and
+/// "onTerminate was called with a null error".
+const Object _unset = Object();


### PR DESCRIPTION
## Summary

Fixes #3696. When the underlying `HttpServer` request stream terminates unexpectedly (the classic `SocketException: Connection reset by peer` seen under Docker/Linux load — see parent #3371), `Server._running` was left as `true`, so `pod.server.running` reported the server as healthy long after the transport had died. Any user-written `healthCheckHandler` relying on that flag — which the original reporter demonstrated — would never mark the pod unhealthy, defeating container-orchestrator auto-restart.

The bug pre-dates the Relic refactor (#3625) but was hidden by it. In 2.7.0 the fix location was `Server._runServer`'s catch block. After #3625 that method no longer exists; the request loop is owned by Relic's `_RelicServer._startListening`, which subscribes to the adapter's request stream with **no `onError` and no `onDone` handlers**. Stream termination is logged by a top-level zone handler and then silently dropped — neither Relic nor Serverpod transitions any state.

This PR closes the observability gap purely inside Serverpod, without requiring an upstream change to Relic.

## How to reproduce (from issue #3696 / parent #3371)

1. Run Serverpod in a Docker container on Linux (Ubuntu 24 was the reported environment).
2. Drive HTTP traffic with enough connection churn to provoke abrupt socket terminations.
3. Observe the framework logs:
   ```
   Server default stopped
   ERROR: Internal server error. httpSever.listen failed.
   ERROR: SocketException: Connection reset by peer (OS Error: Connection reset by peer, errno = 104), address = ::, port = 8080
   ```
4. From a custom `healthCheckHandler`, query `pod.server.running`:
   ```dart
   Future<List<ServerHealthMetric>> serverHealthCheckHandler(
     Serverpod pod, DateTime timestamp,
   ) async {
     final running = pod.server.running; // <- always true, even after the log above
     final runningInsight = pod.serviceServer.running;
     pod.logVerbose('running: $running, runningInsight: $runningInsight');
     // ...
   }
   ```
5. **Before this PR**: `running == true` forever (bug).
   **After this PR**: `running == false` the moment the transport dies; a framework exception is reported via `Serverpod.internalSubmitEvent` so operators can see *why* the server went down.

## Root cause

Traced in `relic_core-1.2.0/lib/src/relic_server.dart:95-109`:

```dart
Future<void> _startListening() async {
  final adapter = await _adapter;
  catchTopLevelErrors(
    () {
      _subscription = adapter.requests.listen(_handleRequest);
      // ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      // no onError, no onDone — stream termination is invisible
    },
    (error, stackTrace) => logMessage('Asynchronous error\n$error', ...),
  );
}
```

`IOAdapter.requests` (`relic_io-1.2.0/lib/src/adapter/io_adapter.dart:71`) is `_server.map(IOAdapterRequest.new)` — a single-subscription stream derived from the `dart:io` `HttpServer`. When the `HttpServer` errors or closes, Relic's subscription silently goes dark and Serverpod has no signal. `Server._running` is therefore an intent latch ("we successfully bound the port") rather than a state observation ("the transport is currently serving requests").

## Fix

Serverpod now owns the `IOAdapter` and intercepts the stream lifecycle:

1. **`Server.start()`** — replaces `_app.serve(...)` with an explicit `bindHttpServer(...)` + `_LifecycleTrackingAdapter(...)` + `_app.run(() => adapter)`. Happy path is behaviorally identical.
2. **`_LifecycleTrackingAdapter`** — subclasses `IOAdapter` and overrides `requests` to transform the underlying stream with `createTransportLifecycleTransformer`. Caches the transformed stream so the single-subscription `HttpServer` is never subscribed twice.
3. **`createTransportLifecycleTransformer<T>()`** — generic `StreamTransformer` that taps data/error/done and invokes `onTerminate(error?, stackTrace?)` **at most once**. Forwards data, errors, and completion downstream unchanged so Relic's own error logging still runs.
4. **`Server._onTransportTerminated()`** — flips `_running = false` and reports a framework exception. Guarded by `if (!_running) return;` so a stream that errors *and then* closes only reports once, and so graceful shutdowns don't double-report.
5. **`Server.shutdown()`** — now flips `_running = false` *before* calling `_app.close()`, so the adapter's `handleDone` callback during an intentional shutdown is a no-op instead of a false crash alarm.

### Alternative considered: upstream Relic fix
I considered adding a `done` Future to `RelicServer` so Serverpod could `await server.done.then(...)`. That would be architecturally cleaner and benefit all Relic consumers, but it requires an upstream change in `serverpod/relic`, a new Relic release, and a version bump in this repo. The adapter wrapper in this PR is a drop-in fix that works today; the upstream cleanup can still land later without conflicting with this change.

### Caveat: multi-isolate
`RelicApp.run(..., noOfIsolates > 1)` sends the adapter factory across isolates, so a closure-capturing `_LifecycleTrackingAdapter` would not work. Serverpod currently uses single-isolate mode by default and this PR does not change that. If multi-isolate ever becomes a supported Serverpod configuration, the upstream Relic fix becomes the right path.

## Test plan

- [x] New unit tests for `createTransportLifecycleTransformer` in `test/server/transport_lifecycle_transformer_test.dart`:
  - [x] Normal close → `onTerminate(null, null)` called exactly once, all data events forwarded.
  - [x] Stream error → `onTerminate(error, stackTrace)` called with the original error; error forwarded downstream.
  - [x] Error followed by close → `onTerminate` called **only once** (idempotent).
  - [x] Data forwarding preserved unchanged.
- [x] Full `dart analyze lib` passes with no issues.
- [x] Full `dart test` for `packages/serverpod` passes (159 tests).
- [ ] **Reviewer to verify**: reproduce the original Docker/Linux `SocketException` scenario and confirm `pod.server.running` flips to `false` and a framework exception is submitted. I have no reliable local repro of the underlying socket failure; the unit tests cover the lifecycle-transformer contract, and the integration is small enough to audit by eye (`Server.start()` and `Server.shutdown()` ~20 line delta).

## Follow-up not in this PR

- `packages/serverpod/lib/src/web_server/web_server.dart` has the same `_running`-as-intent-latch pattern and the same latent bug. It is out of scope for this issue (#3696 is specifically about the API server's health check) but should probably be given the same treatment in a follow-up — `createTransportLifecycleTransformer` is already shaped to be reused.
- An upstream issue on `serverpod/relic` proposing a `done` signal on `RelicServer` would let Serverpod simplify this wrapper. I have not filed it as part of this PR.