### PR TITLE
fix: Add missing `configOverride` forward to the test server

### DIFF
--- a/examples/middleware/middleware_server/test/integration/test_tools/serverpod_test_tools.dart
+++ b/examples/middleware/middleware_server/test/integration/test_tools/serverpod_test_tools.dart
@@ -117,6 +117,7 @@ void withServerpod(
       serverpodLoggingMode: serverpodLoggingMode,
       testServerOutputMode: testServerOutputMode,
       experimentalFeatures: experimentalFeatures,
+      configOverride: configOverride,
       runtimeParametersBuilder: runtimeParametersBuilder,
     ),
     maybeRollbackDatabase: rollbackDatabase,

--- a/modules/legacy/serverpod_auth/serverpod_auth_server/test/integration/test_tools/serverpod_test_tools.dart
+++ b/modules/legacy/serverpod_auth/serverpod_auth_server/test/integration/test_tools/serverpod_test_tools.dart
@@ -124,6 +124,7 @@ void withServerpod(
       serverpodLoggingMode: serverpodLoggingMode,
       testServerOutputMode: testServerOutputMode,
       experimentalFeatures: experimentalFeatures,
+      configOverride: configOverride,
       runtimeParametersBuilder: runtimeParametersBuilder,
     ),
     maybeRollbackDatabase: rollbackDatabase,

--- a/modules/serverpod_auth/serverpod_auth_bridge/serverpod_auth_bridge_server/test/integration/test_tools/serverpod_test_tools.dart
+++ b/modules/serverpod_auth/serverpod_auth_bridge/serverpod_auth_bridge_server/test/integration/test_tools/serverpod_test_tools.dart
@@ -125,6 +125,7 @@ void withServerpod(
       serverpodLoggingMode: serverpodLoggingMode,
       testServerOutputMode: testServerOutputMode,
       experimentalFeatures: experimentalFeatures,
+      configOverride: configOverride,
       runtimeParametersBuilder: runtimeParametersBuilder,
     ),
     maybeRollbackDatabase: rollbackDatabase,

--- a/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_server/test/serverpod_test_tools.dart
+++ b/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_server/test/serverpod_test_tools.dart
@@ -118,6 +118,7 @@ void withServerpod(
       serverpodLoggingMode: serverpodLoggingMode,
       testServerOutputMode: testServerOutputMode,
       experimentalFeatures: experimentalFeatures,
+      configOverride: configOverride,
       runtimeParametersBuilder: runtimeParametersBuilder,
     ),
     maybeRollbackDatabase: rollbackDatabase,

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/test/test_tools/serverpod_test_tools.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/test/test_tools/serverpod_test_tools.dart
@@ -115,6 +115,7 @@ void withServerpod(
       serverpodLoggingMode: serverpodLoggingMode,
       testServerOutputMode: testServerOutputMode,
       experimentalFeatures: experimentalFeatures,
+      configOverride: configOverride,
       runtimeParametersBuilder: runtimeParametersBuilder,
     ),
     maybeRollbackDatabase: rollbackDatabase,

--- a/modules/serverpod_auth/serverpod_auth_migration/serverpod_auth_migration_server/test/integration/test_tools/serverpod_test_tools.dart
+++ b/modules/serverpod_auth/serverpod_auth_migration/serverpod_auth_migration_server/test/integration/test_tools/serverpod_test_tools.dart
@@ -115,6 +115,7 @@ void withServerpod(
       serverpodLoggingMode: serverpodLoggingMode,
       testServerOutputMode: testServerOutputMode,
       experimentalFeatures: experimentalFeatures,
+      configOverride: configOverride,
       runtimeParametersBuilder: runtimeParametersBuilder,
     ),
     maybeRollbackDatabase: rollbackDatabase,

--- a/tests/serverpod_auth_test/serverpod_auth_test_server/test/integration/test_tools/serverpod_test_tools.dart
+++ b/tests/serverpod_auth_test/serverpod_auth_test_server/test/integration/test_tools/serverpod_test_tools.dart
@@ -123,6 +123,7 @@ void withServerpod(
       serverpodLoggingMode: serverpodLoggingMode,
       testServerOutputMode: testServerOutputMode,
       experimentalFeatures: experimentalFeatures,
+      configOverride: configOverride,
       runtimeParametersBuilder: runtimeParametersBuilder,
     ),
     maybeRollbackDatabase: rollbackDatabase,

--- a/tests/serverpod_test_module/serverpod_test_module_server/test/integration/test_tools/serverpod_test_tools.dart
+++ b/tests/serverpod_test_module/serverpod_test_module_server/test/integration/test_tools/serverpod_test_tools.dart
@@ -122,6 +122,7 @@ void withServerpod(
       serverpodLoggingMode: serverpodLoggingMode,
       testServerOutputMode: testServerOutputMode,
       experimentalFeatures: experimentalFeatures,
+      configOverride: configOverride,
       runtimeParametersBuilder: runtimeParametersBuilder,
     ),
     maybeRollbackDatabase: rollbackDatabase,

--- a/tests/serverpod_test_nonvector/serverpod_test_nonvector_server/test/integration/test_tools/serverpod_test_tools.dart
+++ b/tests/serverpod_test_nonvector/serverpod_test_nonvector_server/test/integration/test_tools/serverpod_test_tools.dart
@@ -118,6 +118,7 @@ void withServerpod(
       serverpodLoggingMode: serverpodLoggingMode,
       testServerOutputMode: testServerOutputMode,
       experimentalFeatures: experimentalFeatures,
+      configOverride: configOverride,
       runtimeParametersBuilder: runtimeParametersBuilder,
     ),
     maybeRollbackDatabase: rollbackDatabase,

--- a/tests/serverpod_test_server/test_integration/test_tools/config_override_test.dart
+++ b/tests/serverpod_test_server/test_integration/test_tools/config_override_test.dart
@@ -1,0 +1,49 @@
+import 'package:test/test.dart';
+
+import 'serverpod_test_tools.dart';
+
+void main() {
+  const overriddenId = 'from-with-serverpod-callback';
+
+  withServerpod(
+    'Given withServerpod initialized with a config override callback, ',
+    configOverride: (config) => config.copyWith(
+      serverId: overriddenId,
+      healthCheckInterval: Duration.zero,
+    ),
+    (sessionBuilder, _) {
+      test(
+        'when reading the config from the built session '
+        'then it matches the overridden config.',
+        () {
+          final session = sessionBuilder.build();
+          expect(session.serverpod.config.serverId, equals(overriddenId));
+          expect(session.serverpod.serverId, equals(overriddenId));
+          expect(
+            session.serverpod.config.healthCheckInterval,
+            equals(Duration.zero),
+          );
+        },
+      );
+    },
+  );
+
+  withServerpod(
+    'Given withServerpod initialized without config override, ',
+    (sessionBuilder, _) {
+      test(
+        'when reading the config from the built session '
+        'then it matches the default config.',
+        () {
+          final session = sessionBuilder.build();
+          expect(session.serverpod.config.serverId, equals('default'));
+          expect(session.serverpod.serverId, equals('default'));
+          expect(
+            session.serverpod.config.healthCheckInterval,
+            equals(const Duration(minutes: 1)),
+          );
+        },
+      );
+    },
+  );
+}

--- a/tests/serverpod_test_server/test_integration/test_tools/serverpod_test_tools.dart
+++ b/tests/serverpod_test_server/test_integration/test_tools/serverpod_test_tools.dart
@@ -167,6 +167,7 @@ void withServerpod(
       serverpodLoggingMode: serverpodLoggingMode,
       testServerOutputMode: testServerOutputMode,
       experimentalFeatures: experimentalFeatures,
+      configOverride: configOverride,
       runtimeParametersBuilder: runtimeParametersBuilder,
     ),
     maybeRollbackDatabase: rollbackDatabase,

--- a/tools/serverpod_cli/lib/src/generator/dart/library_generators/server_test_tools_generator.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart/library_generators/server_test_tools_generator.dart
@@ -817,6 +817,7 @@ class ServerTestToolsGenerator {
                         'serverpodLoggingMode': refer('serverpodLoggingMode'),
                         'testServerOutputMode': refer('testServerOutputMode'),
                         'experimentalFeatures': refer('experimentalFeatures'),
+                        'configOverride': refer('configOverride'),
                         if (config.isFeatureEnabled(ServerpodFeature.database))
                           'runtimeParametersBuilder': refer(
                             'runtimeParametersBuilder',


### PR DESCRIPTION
Fix required as a follow-up of #4925.

It was missing wire the `configOverride` callback to the `TestServerpod` constructor on the generated code.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.