### PR TITLE
fix: Avoid triggering auth event listener when refreshing the JWT token

### DIFF
--- a/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_client/lib/src/session_manager.dart
+++ b/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_client/lib/src/session_manager.dart
@@ -83,7 +83,7 @@ class ClientAuthSessionManager implements RefresherClientAuthKeyProvider {
           // ensure that the latest auth from the storage is used. This is
           // required for web if another tab has rotated the refresh token,
           // since the storage is shared between tabs.
-          invalidateCachedAuthInfo: restore,
+          invalidateCachedAuthInfo: _resetCachedAuthInfo,
           refreshEndpoint: caller.client
               .getEndpointOfType<EndpointRefreshJwtTokens>(),
         );
@@ -146,12 +146,16 @@ class ClientAuthSessionManager implements RefresherClientAuthKeyProvider {
   /// value. This method can be called at any time to get the latest value from
   /// the storage.
   Future<void> restore() async {
+    await _resetCachedAuthInfo();
+    onAuthInfoChanged?.call(_authInfo);
+  }
+
+  Future<void> _resetCachedAuthInfo() async {
     final storage = this.storage;
     if (storage is CachedClientAuthSuccessStorage) {
       await storage.clearCache();
     }
     _authInfo = await storage.get();
-    onAuthInfoChanged?.call(_authInfo);
   }
 
   /// Updates the signed in user on the storage and for open connections.

--- a/tests/serverpod_auth_test/serverpod_auth_test_server/test/integration/jwt_cached_refresh_token_rotation.dart
+++ b/tests/serverpod_auth_test/serverpod_auth_test_server/test/integration/jwt_cached_refresh_token_rotation.dart
@@ -14,6 +14,7 @@ void main() {
   late client_auth.CachedClientAuthSuccessStorage cachedStorage;
   late client_auth.AuthSuccess oldAuthSuccess;
   late client_auth.AuthSuccess newAuthSuccess;
+  var onAuthInfoChangedCalls = 0;
 
   final jwtConfig = server_auth.JwtConfig(
     refreshTokenHashPepper: 'test-pepper-jwt-cached-storage-integration',
@@ -33,6 +34,7 @@ void main() {
     'Given JWT auth, a client with cached storage and an expiring refresh token that is changed directly on the storage layer to a non-expiring refresh token ',
     (final sessionBuilder, final endpoints) {
       setUp(() async {
+        onAuthInfoChangedCalls = 0;
         final session = sessionBuilder.build();
         final pod = session.serverpod;
         pod.initializeAuthServices(tokenManagerBuilders: [jwtConfig]);
@@ -40,6 +42,7 @@ void main() {
         client = Client('http://localhost:${session.server.port}/')
           ..authSessionManager = client_auth.ClientAuthSessionManager(
             storage: cachedStorage,
+            onAuthInfoChanged: (_) => onAuthInfoChangedCalls++,
           );
 
         final userId = await client.authTest.createTestUser();
@@ -71,7 +74,10 @@ void main() {
 
       group('when calling refresh ', () {
         late RefreshAuthKeyResult refreshResult;
+        late int onAuthInfoCallsBeforeRefresh;
+
         setUp(() async {
+          onAuthInfoCallsBeforeRefresh = onAuthInfoChangedCalls;
           refreshResult = await client.auth.refreshAuthKey();
         });
 
@@ -91,6 +97,14 @@ void main() {
             );
           },
         );
+
+        test(
+          'then onAuthInfoChanged receives no update when refresh only resets '
+          'the cache and skips the network refresh.',
+          () {
+            expect(onAuthInfoChangedCalls, onAuthInfoCallsBeforeRefresh);
+          },
+        );
       });
     },
   );
@@ -99,6 +113,7 @@ void main() {
     'Given JWT auth, a client with cached storage and an expiring refresh token that is changed directly on the storage layer to a another expiring refresh token ',
     (final sessionBuilder, final endpoints) {
       setUp(() async {
+        onAuthInfoChangedCalls = 0;
         final session = sessionBuilder.build();
         final pod = session.serverpod;
         pod.initializeAuthServices(tokenManagerBuilders: [jwtConfig]);
@@ -106,6 +121,7 @@ void main() {
         client = Client('http://localhost:${session.server.port}/')
           ..authSessionManager = client_auth.ClientAuthSessionManager(
             storage: cachedStorage,
+            onAuthInfoChanged: (_) => onAuthInfoChangedCalls++,
           );
 
         final userId = await client.authTest.createTestUser();
@@ -137,7 +153,10 @@ void main() {
 
       group('when calling refresh ', () {
         late RefreshAuthKeyResult refreshResult;
+        late int onAuthInfoCallsBeforeRefresh;
+
         setUp(() async {
+          onAuthInfoCallsBeforeRefresh = onAuthInfoChangedCalls;
           refreshResult = await client.auth.refreshAuthKey();
         });
 
@@ -156,6 +175,14 @@ void main() {
               client.auth.authInfo?.refreshToken,
               isNot(newAuthSuccess.refreshToken),
             );
+          },
+        );
+
+        test(
+          'then onAuthInfoChanged is invoked once when the rotated token is '
+          'persisted after refresh.',
+          () {
+            expect(onAuthInfoChangedCalls, onAuthInfoCallsBeforeRefresh + 1);
           },
         );
       });


### PR DESCRIPTION
Fixes: #4954

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.