### PR TITLE
feat: Infer database dialect from the CLI without manual config

### DIFF
--- a/packages/serverpod_shared/lib/src/config.dart
+++ b/packages/serverpod_shared/lib/src/config.dart
@@ -1073,6 +1073,27 @@ Map? _databaseConfigMap(Map configMap, Map<String, String> environment) {
   ]);
 }
 
+/// Infer the database dialect from one run-mode config map (the body of
+/// `config/<runMode>.yaml`), using the same `database` merging rules as
+/// [ServerpodConfig.loadFromMap].
+///
+/// Returns `null` when there is no database section or it is empty after
+/// merging environment variables. Uses a placeholder password so PostgreSQL
+/// configs can be parsed without a `passwords.yaml` file (for example in the
+/// CLI).
+DatabaseDialect? inferDatabaseDialectFromConfigMap(
+  Map<dynamic, dynamic> configMap, {
+  Map<String, String> environment = const {},
+}) {
+  final dbSetup = _databaseConfigMap(configMap, environment);
+  if (dbSetup == null) return null;
+  return DatabaseConfig._fromJson(
+    dbSetup,
+    {ServerpodPassword.databasePassword.configKey: '__placeholder__'},
+    ServerpodConfigMap.database,
+  ).dialect;
+}
+
 Map? _redisConfigMap(Map configMap, Map<String, String> environment) {
   var redisConfig = configMap[ServerpodConfigMap.redis] ?? {};
 

--- a/packages/serverpod_shared/test/infer_database_dialect_test.dart
+++ b/packages/serverpod_shared/test/infer_database_dialect_test.dart
@@ -1,0 +1,89 @@
+import 'package:serverpod_shared/serverpod_shared.dart';
+import 'package:test/test.dart';
+import 'package:yaml/yaml.dart';
+
+void main() {
+  test(
+    'Given no database section when inferring dialect then result is null.',
+    () {
+      expect(
+        inferDatabaseDialectFromConfigMap({
+          'apiServer': {
+            'port': 8080,
+            'publicHost': 'localhost',
+            'publicPort': 8080,
+            'publicScheme': 'http',
+          },
+        }),
+        isNull,
+      );
+    },
+  );
+
+  test(
+    'Given empty database section when inferring dialect then result is null.',
+    () {
+      expect(
+        inferDatabaseDialectFromConfigMap({'database': {}}),
+        isNull,
+      );
+    },
+  );
+
+  test(
+    'Given SQLite filePath when inferring dialect then result is sqlite.',
+    () {
+      expect(
+        inferDatabaseDialectFromConfigMap({
+          'database': {'filePath': 'app.db'},
+        }),
+        DatabaseDialect.sqlite,
+      );
+    },
+  );
+
+  test(
+    'Given PostgreSQL-shaped database when inferring dialect then result is postgres.',
+    () {
+      expect(
+        inferDatabaseDialectFromConfigMap({
+          'database': {
+            'host': 'localhost',
+            'port': 5432,
+            'name': 'db',
+            'user': 'u',
+          },
+        }),
+        DatabaseDialect.postgres,
+      );
+    },
+  );
+
+  test(
+    'Given YAML from loadYaml when inferring dialect then result is sqlite.',
+    () {
+      final doc = loadYaml('''
+database:
+  filePath: data/app.db
+''');
+      expect(
+        inferDatabaseDialectFromConfigMap(
+          Map<dynamic, dynamic>.from(doc as Map),
+        ),
+        DatabaseDialect.sqlite,
+      );
+    },
+  );
+
+  test(
+    'Given invalid database section when inferring then an exception is thrown.',
+    () {
+      expect(
+        () => inferDatabaseDialectFromConfigMap({
+          'database': {'host': 'only-host'},
+        }),
+        throwsException,
+      );
+    },
+  );
+}

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/config/generator.yaml
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/config/generator.yaml
@@ -1,7 +1,5 @@
 type: server
 
-databaseDialect: sqlite
-
 client_package_path: ../serverpod_test_sqlite_client
 server_test_tools_path: test_integration/test_tools
 

--- a/tools/serverpod_cli/lib/src/commands/create_migration.dart
+++ b/tools/serverpod_cli/lib/src/commands/create_migration.dart
@@ -73,7 +73,8 @@ class CreateMigrationCommand extends ServerpodCommand<CreateMigrationOption> {
     GeneratorConfig config;
     try {
       config = await GeneratorConfig.load(interactive: interactive);
-    } catch (_) {
+    } catch (e) {
+      log.error('$e');
       throw ExitException(ServerpodCommand.commandInvokedCannotExecute);
     }
 

--- a/tools/serverpod_cli/lib/src/commands/create_repair_migration.dart
+++ b/tools/serverpod_cli/lib/src/commands/create_repair_migration.dart
@@ -78,7 +78,8 @@ class CreateRepairMigrationCommand
     GeneratorConfig config;
     try {
       config = await GeneratorConfig.load(interactive: interactive);
-    } catch (_) {
+    } catch (e) {
+      log.error('$e');
       throw ExitException(ServerpodCommand.commandInvokedCannotExecute);
     }
 

--- a/tools/serverpod_cli/lib/src/config/config.dart
+++ b/tools/serverpod_cli/lib/src/config/config.dart
@@ -467,18 +467,7 @@ class GeneratorConfig implements ModelLoadConfig {
       ...CommandLineExperimentalFeatures.instance.features,
     ];
 
-    var databaseDialect = DatabaseDialect.postgres;
-    final maybeDatabaseDialect = generatorConfig['databaseDialect'];
-    if (maybeDatabaseDialect != null) {
-      if (maybeDatabaseDialect is! String ||
-          !DatabaseDialect.values.any((d) => d.name == maybeDatabaseDialect)) {
-        throw SourceSpanFormatException(
-          'Invalid database dialect: "$maybeDatabaseDialect".',
-          maybeDatabaseDialect is YamlNode ? maybeDatabaseDialect.span : null,
-        );
-      }
-      databaseDialect = DatabaseDialect.values.byName(maybeDatabaseDialect);
-    }
+    var databaseDialect = await _inferDatabaseDialectFromConfigs(serverRootDir);
 
     return GeneratorConfig(
       name: name,
@@ -496,6 +485,55 @@ class GeneratorConfig implements ModelLoadConfig {
       databaseDialect: databaseDialect,
       experimentalFeatures: enabledExperimentalFeatures,
     );
+  }
+
+  static Future<DatabaseDialect> _inferDatabaseDialectFromConfigs(
+    String serverRootDir,
+  ) async {
+    final configDir = Directory(p.join(serverRootDir, 'config'));
+    if (!await configDir.exists()) {
+      return DatabaseDialect.postgres;
+    }
+
+    final dialectsByFile = <String, DatabaseDialect>{};
+    await for (final entity in configDir.list(followLinks: false)) {
+      if (entity is! File) continue;
+      final basename = p.basename(entity.path);
+      if (!(basename.endsWith('.yaml') || basename.endsWith('.yml')) ||
+          basename.startsWith('generator.') ||
+          basename.startsWith('passwords.')) {
+        continue;
+      }
+
+      final yamlRoot = loadYaml(await entity.readAsString());
+      if (yamlRoot == null || yamlRoot is! Map) continue;
+
+      final dialect = inferDatabaseDialectFromConfigMap(
+        Map<dynamic, dynamic>.from(yamlRoot),
+        environment: Platform.environment,
+      );
+      if (dialect != null) {
+        dialectsByFile[basename] = dialect;
+      }
+    }
+
+    if (dialectsByFile.isEmpty) {
+      return DatabaseDialect.postgres;
+    }
+
+    final dialects = dialectsByFile.values.toSet();
+    if (dialects.length > 1) {
+      final details = dialectsByFile.entries
+          .map((e) => '${e.key} (${e.value.name})')
+          .sorted()
+          .join(', ');
+      throw StateError(
+        'Inconsistent database dialects across run-mode config files: $details. '
+        'A Serverpod project must use a single database dialect in all run modes.',
+      );
+    }
+
+    return dialects.single;
   }
 
   static List<ServerpodFeature> _enabledFeatures(File file, YamlMap config) {
@@ -725,4 +763,8 @@ String _stripPackage(String package) {
     return strippedPackage.substring(0, strippedPackage.length - 7);
   }
   return package;
+}
+
+extension on Iterable<String> {
+  List<String> sorted() => toList()..sort();
 }

--- a/tools/serverpod_cli/test/integration/generator_config/database_dialect_config_test.dart
+++ b/tools/serverpod_cli/test/integration/generator_config/database_dialect_config_test.dart
@@ -4,7 +4,6 @@ import 'package:serverpod_cli/src/config/config.dart';
 import 'package:serverpod_cli/src/config/experimental_feature.dart';
 import 'package:serverpod_cli/src/util/serverpod_cli_logger.dart';
 import 'package:serverpod_shared/serverpod_shared.dart';
-import 'package:source_span/source_span.dart';
 import 'package:test/test.dart';
 import 'package:test_descriptor/test_descriptor.dart' as d;
 
@@ -27,13 +26,10 @@ void main() {
   });
 
   test(
-    'Given a generator.yaml without database dialect key when loading GeneratorConfig then database dialect is postgres by default.',
+    'Given no run-mode database config when loading GeneratorConfig then database dialect is postgres.',
     () async {
       var projectDir = createMockServerpodProject(
         projectName: 'my_project',
-        generatorYamlContent: '''
-type: server
-''',
       );
       await projectDir.create();
 
@@ -47,14 +43,42 @@ type: server
   );
 
   test(
-    'Given a generator.yaml with database dialect set to postgres when loading GeneratorConfig then database dialect is postgres.',
+    'Given SQLite database in a run-mode YAML when loading GeneratorConfig then dialect is sqlite.',
     () async {
       var projectDir = createMockServerpodProject(
         projectName: 'my_project',
-        generatorYamlContent: '''
-type: server
-databaseDialect: postgres
+        runModeYamlFiles: {
+          'development.yaml': '''
+database:
+  filePath: app.db
 ''',
+        },
+      );
+      await projectDir.create();
+
+      var config = await GeneratorConfig.load(
+        serverRootDir: path.join(d.sandbox, 'project', 'my_project_server'),
+        interactive: false,
+      );
+
+      expect(config.databaseDialect, DatabaseDialect.sqlite);
+    },
+  );
+
+  test(
+    'Given PostgreSQL database in a run-mode YAML when loading GeneratorConfig then dialect is postgres.',
+    () async {
+      var projectDir = createMockServerpodProject(
+        projectName: 'my_project',
+        runModeYamlFiles: {
+          'development.yaml': '''
+database:
+  host: localhost
+  port: 5432
+  name: testDb
+  user: test
+''',
+        },
       );
       await projectDir.create();
 
@@ -68,14 +92,23 @@ databaseDialect: postgres
   );
 
   test(
-    'Given a generator.yaml with database dialect set to unsupported dialect when loading GeneratorConfig then an exception is thrown.',
+    'Given conflicting database dialects across run-mode YAMLs when loading GeneratorConfig then StateError is thrown.',
     () async {
       var projectDir = createMockServerpodProject(
         projectName: 'my_project',
-        generatorYamlContent: '''
-        type: server
-        databaseDialect: unsupported
-        ''',
+        runModeYamlFiles: {
+          'development.yaml': '''
+database:
+  host: localhost
+  port: 5432
+  name: testDb
+  user: test
+''',
+          'test.yaml': '''
+database:
+  filePath: test.db
+''',
+        },
       );
       await projectDir.create();
 
@@ -85,10 +118,12 @@ databaseDialect: postgres
           interactive: false,
         ),
         throwsA(
-          isA<SourceSpanFormatException>().having(
+          isA<StateError>().having(
             (e) => e.message,
             'message',
-            equals('Invalid database dialect: "unsupported".'),
+            'Inconsistent database dialects across run-mode config files: '
+                'development.yaml (postgres), test.yaml (sqlite). A Serverpod '
+                'project must use a single database dialect in all run modes.',
           ),
         ),
       );
@@ -98,9 +133,13 @@ databaseDialect: postgres
 
 d.DirectoryDescriptor createMockServerpodProject({
   String projectName = 'my_project',
-  String? generatorYamlContent,
+  Map<String, String> runModeYamlFiles = const {},
 }) {
   var serverDirContents = <d.Descriptor>[
+    d.dir('config', [
+      for (final entry in runModeYamlFiles.entries)
+        d.file(entry.key, entry.value),
+    ]),
     d.file('pubspec.yaml', '''
 name: ${projectName}_server
 dependencies:
@@ -131,14 +170,6 @@ dependencies:
 '''),
     ]),
   ];
-
-  if (generatorYamlContent != null) {
-    serverDirContents.add(
-      d.dir('config', [
-        d.file('generator.yaml', generatorYamlContent),
-      ]),
-    );
-  }
 
   var clientDir = d.dir('${projectName}_client', [
     d.file('pubspec.yaml', '''


### PR DESCRIPTION
Closes: #4956

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None, the `databaseDialect` keyword had not yet been released to the public.