### PR TITLE
chore: Upgrade `sqlparser` and lock the lib version to avoid breaking changes

### DIFF
--- a/packages/serverpod_database/lib/src/adapters/sqlite/database_connection.dart
+++ b/packages/serverpod_database/lib/src/adapters/sqlite/database_connection.dart
@@ -6,7 +6,6 @@ import 'package:serverpod_shared/serverpod_shared.dart';
 // We only use the `source_span` package to generated expected inputs for the
 // `sqlparser` package, which depends on it for public interfaces.
 // ignore: depend_on_referenced_packages
-import 'package:source_span/source_span.dart';
 import 'package:sqlite3/common.dart' hide Session;
 import 'package:sqlite_async/sqlite_async.dart';
 import 'package:sqlparser/sqlparser.dart'
@@ -16,8 +15,7 @@ import 'package:sqlparser/sqlparser.dart'
         CommitStatement,
         DeleteStatement,
         InsertStatement,
-        InvalidStatement,
-        SemicolonSeparatedStatements,
+        ParserEntrypoint,
         SqlEngine,
         Statement,
         UpdateStatement;
@@ -1246,43 +1244,32 @@ class SqliteDatabaseConnection extends DatabaseConnection<SqlitePoolManager> {
         });
   }
 
-  /// Parses [sql] into statements using [SqlEngine.parseMultiple] (tokenizer
+  /// Parses [sql] into statements using [SqlEngine.parse] (tokenizer
   /// aware of comments and strings). If that does not yield statements, runs
-  /// the whole script as a single [InvalidStatement] so SQLite still executes
-  /// it (no character-level splitting).
+  /// the whole script as a single statement so SQLite still executes it (no
+  /// character-level splitting).
   static List<_ParsedSqlStatement> _parseSqlScript(String sql) {
     final trimmed = sql.trim();
     if (trimmed.isEmpty) return [];
     if (!trimmed.contains(';')) {
       return [_parseOneStatement(trimmed)];
     }
-    final span = SourceFile.fromString(trimmed).span(0);
-    final result = _sqlEngine.parseMultiple(span);
-    final rootNode = result.rootNode;
+    final result = _sqlEngine.parse(ParserEntrypoint.multiple, trimmed);
 
-    switch (rootNode) {
-      case SemicolonSeparatedStatements block:
-        final out = <_ParsedSqlStatement>[];
-        for (final stmt in block.statements) {
-          final text = _stripTrailingSemicolon(result.lexemeOfNode(stmt));
-          if (text.isEmpty) continue;
-          out.add(_ParsedSqlStatement(text: text, ast: stmt));
-        }
-        if (out.isNotEmpty) return out;
-      case Statement stmt:
-        return [_ParsedSqlStatement(text: trimmed, ast: stmt)];
+    final out = <_ParsedSqlStatement>[];
+    for (final stmt in result.rootNode.statements) {
+      final text = _stripTrailingSemicolon(result.lexemeOfNode(stmt));
+      if (text.isEmpty) continue;
+      out.add(_ParsedSqlStatement(text: text, ast: stmt));
     }
-
-    return [_ParsedSqlStatement(text: trimmed, ast: InvalidStatement())];
+    if (out.isNotEmpty) return out;
+    return [_parseOneStatement(trimmed)];
   }
 
   static _ParsedSqlStatement _parseOneStatement(String sql) {
-    final result = _sqlEngine.parse(sql);
+    final result = _sqlEngine.parse(ParserEntrypoint.statement, sql);
     final root = result.rootNode;
-    if (root is Statement) {
-      return _ParsedSqlStatement(text: sql, ast: root);
-    }
-    return _ParsedSqlStatement(text: sql, ast: InvalidStatement());
+    return _ParsedSqlStatement(text: sql, ast: root);
   }
 
   static String _stripTrailingSemicolon(String sql) {

--- a/packages/serverpod_database/pubspec.yaml
+++ b/packages/serverpod_database/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   serverpod_shared: 3.5.0-beta.3
   sqlite3: ^2.9.4
   sqlite_async: ^0.13.1
-  sqlparser: ^0.43.1
+  sqlparser: '>=0.44.3 <0.45.0'
 
 dev_dependencies:
   serverpod_lints: 3.5.0-beta.3

--- a/packages/serverpod_database/pubspec.yaml
+++ b/packages/serverpod_database/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   serverpod_shared: 3.5.0-beta.3
   sqlite3: ^2.9.4
   sqlite_async: ^0.13.1
-  sqlparser: '>=0.44.3 <0.45.0'
+  sqlparser: ^0.44.3
 
 dev_dependencies:
   serverpod_lints: 3.5.0-beta.3

--- a/templates/pubspecs/packages/serverpod_database/pubspec.yaml
+++ b/templates/pubspecs/packages/serverpod_database/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   serverpod_shared: SERVERPOD_VERSION
   sqlite3: ^2.9.4
   sqlite_async: ^0.13.1
-  sqlparser: ^0.43.1
+  sqlparser: '>=0.44.3 <0.45.0'
 
 dev_dependencies:
   serverpod_lints: SERVERPOD_VERSION

--- a/templates/pubspecs/packages/serverpod_database/pubspec.yaml
+++ b/templates/pubspecs/packages/serverpod_database/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   serverpod_shared: SERVERPOD_VERSION
   sqlite3: ^2.9.4
   sqlite_async: ^0.13.1
-  sqlparser: '>=0.44.3 <0.45.0'
+  sqlparser: ^0.44.3
 
 dev_dependencies:
   serverpod_lints: SERVERPOD_VERSION


### PR DESCRIPTION
A new minor version of `sqlparser` was just released [with the removal of the `parseMultiple` method](https://github.com/simolus3/drift/commit/fbc733ed07538640f3de961e6de757d626d04aca#diff-ebeae2424ee28d30fde515969f50fe09663ef7c4a75997559f666dbf0b62012b) that we were using. This PR fixes the upgrade.

Replaces PR #4958.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.