### PR TITLE
ci: Remove the `integration` filter on SQLite tests since there is no concurrency tests job

### DIFF
--- a/tests/docker/tests_sqlite_integration/run_tests.sh
+++ b/tests/docker/tests_sqlite_integration/run_tests.sh
@@ -22,5 +22,5 @@ dart bin/main.dart -m production -r maintenance --apply-migrations
 
 # Run tests
 echo "### Running tests"
-dart test test_integration -x integration --concurrency=1 --reporter=failures-only
+dart test test_integration --concurrency=1 --reporter=failures-only
 checkLastExitCode


### PR DESCRIPTION
On SQLite, we have only one CI job to run all tests with `concurrency=1`. But the `run_tests.sh` followed the same as the `serverpod_test_server`, filtering `-x integration`. In the main test server, this is because there is a parallel concurrency test job that will run with `-t integration`. For SQLite, such job does not exist, so all tests must run with concurrency 1. This PR fixes the ignored tests by removing the test tag filter.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.