### PR TITLE
fix: Fix constraints drop failing on Postgres due to already removed columns

### DIFF
--- a/tools/serverpod_cli/lib/src/database/dialects/postgres.dart
+++ b/tools/serverpod_cli/lib/src/database/dialects/postgres.dart
@@ -475,9 +475,10 @@ extension PostgresTableMigrationPgSqlGenerator on TableMigration {
       out += 'DROP INDEX "$deleteIndex";\n';
     }
 
-    // Drop foreign keys
+    // Drop foreign keys. Uses IF EXISTS to avoid a hard failure for constraints
+    // of dropped tables or columns.
     for (var deleteKey in deleteForeignKeys) {
-      out += 'ALTER TABLE "$name" DROP CONSTRAINT "$deleteKey";\n';
+      out += 'ALTER TABLE "$name" DROP CONSTRAINT IF EXISTS "$deleteKey";\n';
     }
 
     // Drop columns

--- a/tools/serverpod_cli/lib/src/database/migration.dart
+++ b/tools/serverpod_cli/lib/src/database/migration.dart
@@ -77,7 +77,6 @@ DatabaseMigration generateDatabaseMigration({
         srcTable,
         dstTable,
         warnings,
-        deleteTables: deleteTables,
       );
       if (diff == null) {
         // Table was modified, but cannot be migrated. Recreate the table.
@@ -184,9 +183,8 @@ bool _sameColumns(List<String> columns1, List<String> columns2) {
 TableMigration? generateTableMigration(
   TableDefinition srcTable,
   TableDefinition dstTable,
-  List<DatabaseMigrationWarning> warnings, {
-  Set<String> deleteTables = const {},
-}) {
+  List<DatabaseMigrationWarning> warnings,
+) {
   var dstByFieldId = <String, ColumnDefinition>{
     for (var c in dstTable.columns) c.effectiveFieldName: c,
   };
@@ -360,11 +358,6 @@ TableMigration? generateTableMigration(
   var deleteForeignKeys = <String>[];
   for (var srcKey in srcTable.foreignKeys) {
     if (!dstTable.containsForeignKeyNamed(srcKey.constraintName)) {
-      // Skip FKs referencing a table being dropped in this migration.
-      // DROP TABLE ... CASCADE automatically drops all foreign key constraints
-      // that reference the dropped table, so generating an explicit
-      // DROP CONSTRAINT would fail with "constraint does not exist".
-      if (deleteTables.contains(srcKey.referenceTable)) continue;
       deleteForeignKeys.add(srcKey.constraintName);
     }
   }

--- a/tools/serverpod_cli/test/database/extentions/migration_with_many_to_many_relation_pgsql_code_generation_test.dart
+++ b/tools/serverpod_cli/test/database/extentions/migration_with_many_to_many_relation_pgsql_code_generation_test.dart
@@ -396,23 +396,22 @@ fields:
       ); // should not be dropped
       var dropTableTargetIndex = psql.indexOf('DROP TABLE "target"');
       var dropSourceConstraint = psql.indexOf(
-        'ALTER TABLE "source" DROP CONSTRAINT "source_fk_0"',
+        'ALTER TABLE "source" DROP CONSTRAINT IF EXISTS "source_fk_0"',
       );
-      var dropSourceColumnPointingTotarget = psql.indexOf(
+      var dropSourceColumnPointingToTarget = psql.indexOf(
         'ALTER TABLE "source" DROP COLUMN "targetId"',
       );
       var createNewTargetTable = psql.indexOf('CREATE TABLE "target_new"');
 
       expect(dropTableSourceIndex, -1);
       expect(dropTableTargetIndex, greaterThanOrEqualTo(0));
-      // DROP TABLE "target" CASCADE automatically drops "source_fk_0", so no
-      // explicit DROP CONSTRAINT should be generated.
-      expect(dropSourceConstraint, -1);
-      expect(dropSourceColumnPointingTotarget, greaterThanOrEqualTo(0));
+      expect(dropSourceConstraint, greaterThanOrEqualTo(0));
+      expect(dropSourceColumnPointingToTarget, greaterThanOrEqualTo(0));
       expect(createNewTargetTable, greaterThanOrEqualTo(0));
 
-      expect(dropTableTargetIndex, lessThan(dropSourceColumnPointingTotarget));
-      expect(dropSourceColumnPointingTotarget, lessThan(createNewTargetTable));
+      expect(dropTableTargetIndex, lessThan(dropSourceConstraint));
+      expect(dropSourceConstraint, lessThan(dropSourceColumnPointingToTarget));
+      expect(dropSourceColumnPointingToTarget, lessThan(createNewTargetTable));
     },
   );
 }

--- a/tools/serverpod_cli/test/database/extentions/migration_with_many_to_many_relation_sqlite_code_generation_test.dart
+++ b/tools/serverpod_cli/test/database/extentions/migration_with_many_to_many_relation_sqlite_code_generation_test.dart
@@ -405,19 +405,20 @@ fields:
       var dropSourceConstraint = sqlite.indexOf(
         'ALTER TABLE "source" DROP CONSTRAINT "source_fk_0"',
       );
-      var dropSourceColumnPointingTotarget = sqlite.indexOf(
+      var dropSourceColumnPointingToTarget = sqlite.indexOf(
         'ALTER TABLE "source" DROP COLUMN "targetId"',
       );
       var createNewTargetTable = sqlite.indexOf('CREATE TABLE "target_new"');
 
-      expect(dropTableSourceIndex, -1);
+      expect(dropTableSourceIndex, greaterThanOrEqualTo(0));
       expect(dropTableTargetIndex, greaterThanOrEqualTo(0));
       expect(dropSourceConstraint, -1);
-      expect(dropSourceColumnPointingTotarget, greaterThanOrEqualTo(0));
+      // Table rebuild removes the FK column without a separate DROP COLUMN.
+      expect(dropSourceColumnPointingToTarget, -1);
       expect(createNewTargetTable, greaterThanOrEqualTo(0));
 
-      expect(dropTableTargetIndex, lessThan(dropSourceColumnPointingTotarget));
-      expect(dropSourceColumnPointingTotarget, lessThan(createNewTargetTable));
+      expect(dropTableTargetIndex, lessThan(dropTableSourceIndex));
+      expect(dropTableSourceIndex, lessThan(createNewTargetTable));
     },
   );
 }

--- a/tools/serverpod_cli/test/database/migration/remove_table_and_foreign_key_test.dart
+++ b/tools/serverpod_cli/test/database/migration/remove_table_and_foreign_key_test.dart
@@ -72,17 +72,17 @@ void main() {
       );
 
       test(
-        'then the generated SQL should NOT contain an explicit DROP CONSTRAINT '
-        'for the foreign key because DROP TABLE CASCADE automatically drops '
-        'all dependent foreign key constraints.',
+        'then the generated SQL uses DROP CONSTRAINT IF EXISTS to avoid a hard '
+        'failure for already removed constraints after DROP TABLE CASCADE.',
         () {
           expect(
             psql,
-            isNot(contains('DROP CONSTRAINT "parent_entity_fk_0"')),
+            contains(
+              'ALTER TABLE "parent_entity" DROP CONSTRAINT IF EXISTS "parent_entity_fk_0"',
+            ),
             reason:
-                'DROP TABLE "child_entity" CASCADE automatically drops '
-                '"parent_entity_fk_0". Generating an explicit DROP CONSTRAINT '
-                'after that would fail with: constraint does not exist.',
+                'DROP CONSTRAINT IF EXISTS is used to avoid a hard failure '
+                'for already removed constraints after DROP TABLE CASCADE.',
           );
         },
       );
@@ -582,6 +582,173 @@ void main() {
             reason:
                 'alterTable should add a foreign key with constraintName main_table_fk_0 referencing table_c',
           );
+        },
+      );
+
+      test(
+        'then the generated SQL should use IF EXISTS when dropping main_table_fk_0 '
+        'after DROP TABLE table_b CASCADE.',
+        () {
+          var psql = migration.toPgSql(
+            databaseDefinition: targetDefinition,
+            installedModules: [],
+            removedModules: [],
+          );
+
+          expect(
+            psql,
+            contains(
+              'ALTER TABLE "main_table" DROP CONSTRAINT IF EXISTS "main_table_fk_0"',
+            ),
+          );
+          expect(psql, contains('DROP TABLE "table_b" CASCADE'));
+        },
+      );
+    },
+  );
+
+  group(
+    'Given a table that references another table by foreign key, '
+    'when the referenced table is dropped and replaced by a new table and the '
+    'referencing table uses a new column while reusing the same constraint name,',
+    () {
+      var sourceDefinition = DatabaseDefinitionBuilder()
+          .withDefaultModules()
+          .withTable(
+            TableDefinitionBuilder().withName('old_server_settings').build(),
+          )
+          .withTable(
+            TableDefinitionBuilder()
+                .withName('global_settings')
+                .withColumn(
+                  ColumnDefinitionBuilder()
+                      .withName('jdfServerSettingsId')
+                      .withColumnType(ColumnType.bigint)
+                      .withIsNullable(true)
+                      .build(),
+                )
+                .withForeignKey(
+                  ForeignKeyDefinition(
+                    constraintName: 'global_settings_fk_0',
+                    columns: ['jdfServerSettingsId'],
+                    referenceTable: 'old_server_settings',
+                    referenceTableSchema: 'public',
+                    referenceColumns: ['id'],
+                    onUpdate: ForeignKeyAction.noAction,
+                    onDelete: ForeignKeyAction.noAction,
+                    matchType: null,
+                  ),
+                )
+                .build(),
+          )
+          .build();
+
+      var targetDefinition = DatabaseDefinitionBuilder()
+          .withDefaultModules()
+          .withTable(
+            TableDefinitionBuilder().withName('new_server_settings').build(),
+          )
+          .withTable(
+            TableDefinitionBuilder()
+                .withName('global_settings')
+                .withColumn(
+                  ColumnDefinitionBuilder()
+                      .withName('globalServerSettingsId')
+                      .withColumnType(ColumnType.bigint)
+                      .withIsNullable(true)
+                      .build(),
+                )
+                .withForeignKey(
+                  ForeignKeyDefinition(
+                    constraintName: 'global_settings_fk_0',
+                    columns: ['globalServerSettingsId'],
+                    referenceTable: 'new_server_settings',
+                    referenceTableSchema: 'public',
+                    referenceColumns: ['id'],
+                    onUpdate: ForeignKeyAction.noAction,
+                    onDelete: ForeignKeyAction.noAction,
+                    matchType: null,
+                  ),
+                )
+                .build(),
+          )
+          .build();
+
+      late var migration = generateDatabaseMigration(
+        databaseSource: sourceDefinition,
+        databaseTarget: targetDefinition,
+      );
+
+      test(
+        'then the alter action for global_settings lists the old foreign key '
+        'so SQLite can apply the schema change.',
+        () {
+          var alterAction = migration.actions.firstWhere(
+            (action) =>
+                action.type == DatabaseMigrationActionType.alterTable &&
+                action.alterTable?.name == 'global_settings',
+            orElse: () => DatabaseMigrationAction(
+              type: DatabaseMigrationActionType.createTable,
+            ),
+          );
+
+          expect(
+            alterAction.alterTable?.deleteForeignKeys,
+            contains('global_settings_fk_0'),
+          );
+        },
+      );
+
+      test(
+        'then the generated SQL uses DROP CONSTRAINT IF EXISTS for '
+        'global_settings_fk_0 after DROP TABLE old_server_settings CASCADE.',
+        () {
+          var psql = migration.toPgSql(
+            databaseDefinition: targetDefinition,
+            installedModules: [],
+            removedModules: [],
+          );
+
+          expect(
+            psql,
+            contains(
+              'ALTER TABLE "global_settings" DROP CONSTRAINT IF EXISTS '
+              '"global_settings_fk_0"',
+            ),
+          );
+          expect(psql, contains('DROP TABLE "old_server_settings" CASCADE'));
+          expect(psql, contains('CREATE TABLE "new_server_settings"'));
+          expect(
+            psql,
+            contains(
+              'ADD CONSTRAINT "global_settings_fk_0"',
+            ),
+          );
+          expect(
+            psql,
+            contains('REFERENCES "new_server_settings"("id")'),
+          );
+        },
+      );
+
+      test(
+        'then DROP TABLE old_server_settings CASCADE must appear before '
+        'ALTER TABLE global_settings.',
+        () {
+          var psql = migration.toPgSql(
+            databaseDefinition: targetDefinition,
+            installedModules: [],
+            removedModules: [],
+          );
+
+          var dropOldIndex = psql.indexOf(
+            'DROP TABLE "old_server_settings" CASCADE',
+          );
+          var alterGlobalIndex = psql.indexOf('ALTER TABLE "global_settings"');
+
+          expect(dropOldIndex, greaterThanOrEqualTo(0));
+          expect(alterGlobalIndex, greaterThanOrEqualTo(0));
+          expect(dropOldIndex, lessThan(alterGlobalIndex));
         },
       );
     },

--- a/tools/serverpod_cli/test/database/migration/remove_table_and_foreign_key_test.dart
+++ b/tools/serverpod_cli/test/database/migration/remove_table_and_foreign_key_test.dart
@@ -244,8 +244,8 @@ void main() {
       );
 
       test(
-        'then the alter action for grant_allowance should NOT explicitly drop '
-        'the foreign key because DROP TABLE CASCADE handles it.',
+        'then the alter action for grant_allowance should list the foreign key '
+        'to drop so each dialect can react accordingly.',
         () {
           var alterAction = migration.actions.firstWhere(
             (action) =>
@@ -258,10 +258,7 @@ void main() {
 
           expect(
             alterAction.alterTable?.deleteForeignKeys,
-            isNot(contains('grant_bundle_allowances_fk')),
-            reason:
-                'DROP TABLE "grant_bundle" CASCADE automatically drops the '
-                'foreign key constraint, so it must not be explicitly dropped.',
+            contains('grant_bundle_allowances_fk'),
           );
         },
       );


### PR DESCRIPTION
Issue reported on Interestellar Slack of migrations failing due to drop constraints being generated after a table or column has already dropped them through `CASCADE`.

As a side-effect, this PR also fixes the constraints for SQLite, since a previous CASCADE delete fix had changed the diff layer (which would be valid only for Postgres).

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.