### PR TITLE
fix: Disable concurrency for recurring future call tests

### DIFF
--- a/tests/serverpod_test_server/test_integration/future_calls/recurring_future_calls_manager_test.dart
+++ b/tests/serverpod_test_server/test_integration/future_calls/recurring_future_calls_manager_test.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:serverpod/protocol.dart' show FutureCallEntry;
 import 'package:serverpod/serverpod.dart';
 import 'package:serverpod_test_server/src/generated/protocol.dart';
+import 'package:serverpod_test_server/test_util/test_tags.dart';
 import 'package:test/test.dart';
 
 import '../test_tools/serverpod_test_tools.dart';
@@ -20,6 +21,7 @@ class CompleterTestCall extends FutureCall<SimpleData> {
 void main() async {
   withServerpod(
     'Given FutureCallManager with registered recurring cron FutureCall that is due',
+    testGroupTagsOverride: [TestTags.concurrencyOneTestTag],
     rollbackDatabase: RollbackDatabase.disabled,
     (sessionBuilder, _) {
       late FutureCallManager futureCallManager;
@@ -176,6 +178,7 @@ void main() async {
 
   withServerpod(
     'Given FutureCallManager with registered recurring interval FutureCall that is due',
+    testGroupTagsOverride: [TestTags.concurrencyOneTestTag],
     rollbackDatabase: RollbackDatabase.disabled,
     (sessionBuilder, _) {
       late FutureCallManager futureCallManager;
@@ -335,6 +338,7 @@ void main() async {
 
   withServerpod(
     'Given FutureCallManager with non-recurring FutureCall',
+    testGroupTagsOverride: [TestTags.concurrencyOneTestTag],
     rollbackDatabase: RollbackDatabase.disabled,
     (sessionBuilder, _) {
       late FutureCallManager futureCallManager;


### PR DESCRIPTION
Disable concurrent runs for recurring future call integration tests to fix flakiness first observed [here](https://github.com/serverpod/serverpod/pull/4973/changes/8872c481160c309354dca37dbc588cdee1c28f17)

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None