### PR TITLE
fix: Fix concurrent reads without transaction not being allowed from within a transaction zone on SQLite

### DIFF
--- a/packages/serverpod_database/lib/src/adapters/sqlite/database_connection.dart
+++ b/packages/serverpod_database/lib/src/adapters/sqlite/database_connection.dart
@@ -38,6 +38,8 @@ class SqliteDatabaseConnection extends DatabaseConnection<SqlitePoolManager> {
 
   static final _sqlEngine = SqlEngine();
 
+  Zone? _currentTransactionParentZone;
+
   SqliteDatabase get _db => poolManager.database;
 
   @override
@@ -776,6 +778,10 @@ class SqliteDatabaseConnection extends DatabaseConnection<SqlitePoolManager> {
     required DatabaseSession session,
   }) async {
     try {
+      // Set a reference to the parent zone (outside the transaction) to allow
+      // for concurrent reads to operate while a write lock is held. Will skip
+      // assigning if already set to preserve the highest parent zone.
+      _currentTransactionParentZone ??= Zone.current;
       return await _db.writeTransaction<R>((tx) async {
         var transaction = _SqliteTransaction(tx, session);
         final result = await transactionFunction(transaction);
@@ -786,6 +792,8 @@ class SqliteDatabaseConnection extends DatabaseConnection<SqlitePoolManager> {
       });
     } on _TransactionCancelledException catch (e) {
       return e.result;
+    } finally {
+      _currentTransactionParentZone = null;
     }
   }
 
@@ -874,18 +882,25 @@ class SqliteDatabaseConnection extends DatabaseConnection<SqlitePoolManager> {
     }
 
     try {
-      ResultSet? result;
+      late ResultSet result;
 
       poolManager.lastDatabaseOperationTime = startTime;
 
       if (sqliteTx != null) {
-        result = await sqliteTx.execute(statement, parameters);
+        result = parsed.isSelectStatement
+            ? await sqliteTx.getAll(statement, parameters)
+            : await sqliteTx.execute(statement, parameters);
       } else {
-        if (parsed.isSelectStatement) {
-          result = await _db.getAll(statement, parameters);
-        } else {
-          result = await _db.execute(statement, parameters);
+        Future<ResultSet> runQuery() async {
+          return parsed.isSelectStatement
+              ? await _db.getAll(statement, parameters ?? const [])
+              : await _db.execute(statement, parameters ?? const []);
         }
+
+        final transactionParentZone = _currentTransactionParentZone;
+        result = (parsed.isSelectStatement && transactionParentZone != null)
+            ? await transactionParentZone.fork().run(runQuery)
+            : await runQuery();
       }
 
       _logQuery(session, statement, stopwatch, numRowsAffected: result.length);
@@ -1421,6 +1436,13 @@ class _SqliteTransaction implements Transaction {
     if (_isCancelled) return;
     _isCancelled = true;
     await _ctx.execute('ROLLBACK');
+  }
+
+  Future<ResultSet> getAll(
+    String query, [
+    List<Object?> parameters = const [],
+  ]) {
+    return _ctx.getAll(query, parameters);
   }
 
   Future<ResultSet> execute(

--- a/packages/serverpod_database/lib/src/adapters/sqlite/sqlite_exceptions.dart
+++ b/packages/serverpod_database/lib/src/adapters/sqlite/sqlite_exceptions.dart
@@ -35,7 +35,12 @@ final class _SqliteDatabaseQueryException extends DatabaseQueryException {
   factory _SqliteDatabaseQueryException.fromSqliteException(Object e) {
     if (e is! SqliteException) {
       int? code;
-      if (e.toString().toLowerCase().contains('recursive lock')) code = 6;
+      if ([
+        'recursive lock',
+        'LockError',
+      ].any((s) => e.toString().contains(s))) {
+        code = 6;
+      }
       return _SqliteDatabaseQueryException(e.toString(), code: code.toString());
     }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/test_integration/database_operations/transactions/find_test.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/test_integration/database_operations/transactions/find_test.dart
@@ -96,8 +96,7 @@ void main() async {
     );
 
     test(
-      'when calling `find` without transaction '
-      'then an exception is thrown because SQLite does not allow recursive locks',
+      'when calling `find` without transaction then does not find the object',
       () async {
         await session.db.transaction((transaction) async {
           await UniqueData.db.insertRow(
@@ -106,16 +105,11 @@ void main() async {
             transaction: transaction,
           );
 
-          await expectLater(
-            UniqueData.db.find(session),
-            throwsA(
-              isA<DatabaseQueryException>().having(
-                (e) => e.code,
-                'code',
-                SqliteErrorCode.objectInUse,
-              ),
-            ),
+          var data = await UniqueData.db.find(
+            session,
           );
+
+          expect(data, hasLength(0));
         });
       },
     );
@@ -143,6 +137,25 @@ void main() async {
     );
 
     test(
+      'when calling `findFirstRow` without transaction then does not find the object',
+      () async {
+        await session.db.transaction((transaction) async {
+          await UniqueData.db.insertRow(
+            session,
+            UniqueData(number: 111, email: 'test@serverpod.com'),
+            transaction: transaction,
+          );
+
+          var data = await UniqueData.db.findFirstRow(
+            session,
+          );
+
+          expect(data, equals(null));
+        });
+      },
+    );
+
+    test(
       'when calling `findById` with transaction then does find the object',
       () async {
         await session.db.transaction((transaction) async {
@@ -161,6 +174,26 @@ void main() async {
           expect(fetchedData, isNot(equals(null)));
           expect(fetchedData?.number, 111);
           expect(fetchedData?.email, 'test@serverpod.com');
+        });
+      },
+    );
+
+    test(
+      'when calling `find` without transaction then does not find the object',
+      () async {
+        await session.db.transaction((transaction) async {
+          var insertedData = await UniqueData.db.insertRow(
+            session,
+            UniqueData(number: 111, email: 'test@serverpod.com'),
+            transaction: transaction,
+          );
+
+          var data = await UniqueData.db.findById(
+            session,
+            insertedData.id!,
+          );
+
+          expect(data, equals(null));
         });
       },
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/test_integration/database_operations/transactions/transaction_concurrency_test.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/test_integration/database_operations/transactions/transaction_concurrency_test.dart
@@ -1,0 +1,93 @@
+import 'dart:async';
+
+import 'package:serverpod_test_sqlite_server/src/generated/protocol.dart';
+import 'package:serverpod_test_server/test_util/test_tags.dart';
+import 'package:test/test.dart';
+
+import '../../test_tools/serverpod_test_tools.dart';
+
+void main() {
+  withServerpod(
+    'Given a write transaction and a read operation made concurrently without a transaction from the same zone',
+    // Rollbacks must be disabled or SQLite will have the test transaction.
+    rollbackDatabase: RollbackDatabase.disabled,
+    testGroupTagsOverride: [TestTags.concurrencyOneTestTag],
+    (sessionBuilder, endpoints) {
+      var session = sessionBuilder.build();
+
+      late Future<void> writeTransaction;
+      late Completer<void> finishedWriting;
+      late Completer<void> finishTransaction;
+
+      setUp(() async {
+        finishedWriting = Completer<void>();
+        finishTransaction = Completer<void>();
+
+        await SimpleData.db.insertRow(
+          session,
+          SimpleData(num: 117),
+        );
+
+        writeTransaction = session.db.transaction((transaction) async {
+          await SimpleData.db.insertRow(
+            session,
+            SimpleData(num: 118),
+            transaction: transaction,
+          );
+
+          // Operation made on the same zone as the active transaction.
+          // This is forbidden by default on `sqlite_async` driver.
+          final simpleDatas = await SimpleData.db.find(session);
+          expect(simpleDatas, hasLength(1));
+          expect(simpleDatas.first.num, 117);
+
+          finishedWriting.complete();
+          await finishTransaction.future;
+        });
+      });
+
+      tearDown(() async {
+        if (!finishTransaction.isCompleted) {
+          finishTransaction.complete();
+
+          // Await to ensure the transaction is finished. We can't use
+          // await writeTransaction because, if it fails, the test will hang.
+          // In success cases, this is a no-op, since the transaction will have
+          // already completed.
+          await Future.delayed(const Duration(milliseconds: 100));
+        }
+
+        await SimpleData.db.deleteWhere(
+          session,
+          where: (t) => t.num.inSet({117, 118}),
+        );
+      });
+
+      test(
+        'when awaiting the operation then the it succeeds.',
+        () async {
+          finishTransaction.complete();
+          await expectLater(writeTransaction, completes);
+        },
+      );
+
+      test(
+        'when performing another read operation concurrently then both succeed.',
+        () async {
+          // This operation succeeds regardless of the transaction.
+          final simpleDatas = await SimpleData.db.find(session);
+          expect(simpleDatas, hasLength(1));
+          expect(simpleDatas.first.num, 117);
+
+          finishTransaction.complete();
+          await finishedWriting.future;
+          await expectLater(writeTransaction, completes);
+
+          final newSimpleDatas = await SimpleData.db.find(session);
+          expect(newSimpleDatas, hasLength(2));
+          expect(newSimpleDatas.map((s) => s.num), containsAll([117, 118]));
+        },
+      );
+    },
+  );
+}

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/test_integration/test_tools/transaction_correctness_test.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/test_integration/test_tools/transaction_correctness_test.dart
@@ -335,65 +335,63 @@ void main() {
     },
   );
 
-  group('Demonstrate transaction difference between prod and test tools', () {
-    withServerpod(
-      'Given transaction call in test with database rollbacks enabled (default)',
-      (sessionBuilder, endpoints) {
-        var session = sessionBuilder.build();
-        test(
-          'when database exception occurs '
-          'then transaction WILL NOT throw exception if it was caught in the transaction',
-          () async {
-            var future = session.db.transaction((tx) async {
-              var data = UniqueData(number: 1, email: 'test@test.com');
-              try {
-                await UniqueData.db.insertRow(session, data);
-                await UniqueData.db.insertRow(session, data);
-              } catch (_) {}
-            });
+  withServerpod(
+    'Given transaction call in test with database rollbacks enabled (default)',
+    (sessionBuilder, endpoints) {
+      var session = sessionBuilder.build();
+      test(
+        'when database exception occurs '
+        'then transaction WILL NOT throw exception if it was caught in the transaction',
+        () async {
+          var future = session.db.transaction((tx) async {
+            var data = UniqueData(number: 1, email: 'test@test.com');
+            try {
+              await UniqueData.db.insertRow(session, data);
+              await UniqueData.db.insertRow(session, data);
+            } catch (_) {}
+          });
 
-            // NOTE: On SQLite, this is the behavior both with or without
-            // rollbacks enabled, since the driver does not poison the
-            // surrounding transaction when the error is caught.
-            await expectLater(future, completes);
-          },
+          // NOTE: On SQLite, this is the behavior both with or without
+          // rollbacks enabled, since the driver does not poison the
+          // surrounding transaction when the error is caught.
+          await expectLater(future, completes);
+        },
+      );
+    },
+  );
+
+  withServerpod(
+    'Given transaction call in test with database rollbacks disabled',
+    rollbackDatabase: RollbackDatabase.disabled,
+    testGroupTagsOverride: [TestTags.concurrencyOneTestTag],
+    (sessionBuilder, endpoints) {
+      var session = sessionBuilder.build();
+
+      tearDown(() async {
+        await UniqueData.db.deleteWhere(
+          session,
+          where: (t) => t.email.equals('test@test.com'),
         );
-      },
-    );
+      });
 
-    withServerpod(
-      'Given transaction call in test with database rollbacks disabled',
-      (sessionBuilder, endpoints) {
-        var session = sessionBuilder.build();
+      test(
+        'when database exception occurs '
+        'then transaction will complete if it was caught in the transaction',
+        () async {
+          var future = session.db.transaction((tx) async {
+            var data = UniqueData(number: 1, email: 'test@test.com');
+            try {
+              await UniqueData.db.insertRow(session, data, transaction: tx);
+              await UniqueData.db.insertRow(session, data, transaction: tx);
+            } catch (_) {}
+          });
 
-        tearDown(() async {
-          await UniqueData.db.deleteWhere(
-            session,
-            where: (t) => t.email.equals('test@test.com'),
-          );
-        });
-
-        test(
-          'when database exception occurs '
-          'then transaction will complete if it was caught in the transaction',
-          () async {
-            var future = session.db.transaction((tx) async {
-              var data = UniqueData(number: 1, email: 'test@test.com');
-              try {
-                await UniqueData.db.insertRow(session, data, transaction: tx);
-                await UniqueData.db.insertRow(session, data, transaction: tx);
-              } catch (_) {}
-            });
-
-            // NOTE: This behavior differs from PostgreSQL because SQLite does
-            // not poison the surrounding transaction when an error that happen
-            // inside a transaction is caught.
-            await expectLater(future, completes);
-          },
-        );
-      },
-      rollbackDatabase: RollbackDatabase.disabled,
-      testGroupTagsOverride: [TestTags.concurrencyOneTestTag],
-    );
-  });
+          // NOTE: This behavior differs from PostgreSQL because SQLite does
+          // not poison the surrounding transaction when an error that happen
+          // inside a transaction is caught.
+          await expectLater(future, completes);
+        },
+      );
+    },
+  );
 }


### PR DESCRIPTION
For the SQLite implementation, we skipped the support of reading without a transaction from inside a transaction due to `sqlite_async` not supporting this natively. But, this is only forbidden in SQLite if the read comes from the same zone as the transaction.

From [`sqlite_async` tests](https://github.com/powersync-ja/sqlite_async.dart/blob/399dbf47df07fe10bef5582de6de362e35ea309c/packages/sqlite_async/test/native/basic_test.dart#L208-L237), the way to bypass this is to run the query in a forked zone of the transaction parent zone.

```dart
    test(
        'should allow read-only db calls within transaction callback in separate zone',
        () async {
      final db = await testUtils.setupDatabase(path: path);
      await createTables(db);

      // Get a reference to the parent zone (outside the transaction).
      final zone = Zone.current;

      // Each of these are fine, since it could use a separate connection.
      // Note: In highly concurrent cases, it could exhaust the connection pool and cause a deadlock.

      await db.writeTransaction((tx) async {
        // Use the parent zone to avoid the "recursive lock" error.
        await zone.fork().run(() async {
          await db.getAll('SELECT * FROM test_data');
        });
      });

      await db.readTransaction((tx) async {
        await zone.fork().run(() async {
          await db.getAll('SELECT * FROM test_data');
        });
      });

      await db.readTransaction((tx) async {
        await zone.fork().run(() async {
          await db.execute('SELECT * FROM test_data');
        });
      });
```

This PR applies this approach to the SQLite implementation.

For testing, the original `find` tests were restored (equally to the `serverpod_test_server` package), but I preferred also adding a separate one targeting concurrent transactions to add more details on this fix, in case the implementation needs to be revisited in the future.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.