### PR TITLE
feat: Long lived MCP server

### DIFF
--- a/docs/design/mcp_server.md
+++ b/docs/design/mcp_server.md
@@ -1,8 +1,13 @@
 # Design: MCP Server for `serverpod start --watch`
 
-This document describes the MCP (Model Context Protocol) server exposed by `serverpod start --watch`, allowing AI agents to programmatically interact with the running dev environment.
+This document describes the MCP (Model Context Protocol) integration for `serverpod start --watch`, allowing AI agents to programmatically interact with running dev environments.
 
-The MCP server runs inside the CLI process, alongside the compiler, file watcher, and watch session. It is not part of the server subprocess (the Serverpod application). This keeps dev tooling concerns out of the framework itself - the `serverpod` package should not impose an MCP dependency or dev-time features on the application server. It also means the MCP server has access to the CLI's internal state (the incremental compiler, the server process handle, the restart lifecycle) which the server subprocess does not.
+The integration has two parts:
+
+- A small **per-runner MCP server** that lives inside each `serverpod start --watch` process and exposes operations that need the CLI's in-memory state (currently: `apply_migrations`).
+- A long-lived **bridge MCP server** (`serverpod mcp`) that sits on stdio between the AI client and the runners. It discovers running instances by scanning a shared socket directory, connects to one at a time, and forwards tool calls. The bridge survives runner restarts.
+
+The per-runner server runs inside the CLI process, alongside the compiler, file watcher, and watch session. It is not part of the server subprocess (the Serverpod application). This keeps dev tooling concerns out of the framework itself - the `serverpod` package should not impose an MCP dependency or dev-time features on the application server. It also means the MCP server has access to the CLI's internal state (the incremental compiler, the server process handle, the restart lifecycle) which the server subprocess does not.
 
 ## Motivation
 
@@ -10,35 +15,51 @@ During development with `serverpod start --watch`, file watching, code generatio
 
 These operations currently require stopping the server, re-running with flags, or manual SQL. An MCP server lets AI agents trigger them in-context during a development session.
 
+The bridge layer solves a separate problem: when the runner restarts (e.g. after `apply_migrations`), the runner's MCP socket goes away. AI clients like Claude Code do not automatically reconnect to a dropped MCP server, so without a bridge the integration breaks the moment migrations are applied. A persistent stdio bridge stays up across runner restarts and lets the client `connect` again.
+
 ## Architecture
+
+### Two processes, two MCP servers
+
+```
+AI client (e.g. Claude Code)
+    │  stdio  (long-lived)
+    ▼
+serverpod mcp           ← BridgeMcpServer (this process)
+    │
+    │  scans .../serverpod/serverpod-<pid>-<project>.sock
+    │  connects to one at a time
+    │
+    ▼  unix socket  (re-established on each connect)
+serverpod start --watch ← ServerpodMcpServer (per-runner)
+```
+
+The bridge is **single-instance**: at any moment it forwards to at most one runner. Switching runners is an explicit `disconnect` then `connect` from the client. To bridge multiple AI windows to multiple projects, run one `serverpod mcp` per window.
 
 ### Transport: Unix domain sockets
 
-The MCP server binds to a Unix domain socket (AF_UNIX) rather than TCP or stdio. The socket lives inside `.dart_tool/serverpod/` which is user-owned project-local state, so there is no network exposure, no port conflicts, and no need for explicit permission management. The socket is tied to the CLI process and cleaned up on exit.
+Each runner binds to a Unix domain socket (AF_UNIX) rather than TCP or stdio. This avoids network exposure, port conflicts, and explicit permission management. The bridge connects to that socket as an MCP client and re-exposes the runner over stdio.
 
 Requires Dart 3.11+ for AF_UNIX support on Windows.
 
-### Socket path
+### Shared socket directory
 
-The socket file is stored in the project's tool directory:
-
-```
-<server_dir>/.dart_tool/serverpod/mcp.sock
-```
-
-This is the same directory used for `server.dill` and `vm-service-info.json`. Since the socket is project-scoped, there is no need for PID or project name in the filename - only one `serverpod start --watch` instance runs per project at a time.
-
-### `serverpod mcp`
-
-MCP clients typically communicate over stdio. The `serverpod mcp` command acts as a stdio-to-socket bridge, connecting to the project's `mcp.sock`:
+Sockets live in a shared, per-machine temp directory:
 
 ```
-MCP client  ──stdio──>  serverpod mcp  ──unix socket──>  CLI process
+<systemTemp>/serverpod/
+└── serverpod-<pid>-<project>.sock
 ```
 
-The command auto-detects the server directory the same way `serverpod start` does, and supports `--directory` / `-d` to specify it explicitly.
+- `<systemTemp>` is `Directory.systemTemp.path` (`/tmp` on Linux/macOS, `C:\Users\<user>\AppData\Local\Temp` on Windows).
+- `<pid>` is the runner's OS process id.
+- `<project>` is the serverpod app name (`config.name`, with the `_server` suffix already stripped) sanitized to `[a-z0-9-]+`.
 
-Example MCP config (Claude Code: `.mcp.json`, Cursor: `.cursor/mcp.json`)):
+**Why a shared dir, not project-local.** A bridge process needs to discover all running instances on the machine via a single `Directory.listSync()`. Embedding the PID in the filename means discovery is stat-only - there is no separate manifest file to keep in sync, and stale files are easy to identify by checking whether the PID is still alive.
+
+The bridge cleans up dead-PID sockets opportunistically the next time it scans.
+
+### `serverpod mcp` (the bridge)
 
 ```json
 {
@@ -51,39 +72,84 @@ Example MCP config (Claude Code: `.mcp.json`, Cursor: `.cursor/mcp.json`)):
 }
 ```
 
-### `apply_migrations` tool
+The bridge does not need a `--directory` flag - it discovers running instances by directory scan. The AI client picks one with the `connect` tool.
+
+#### Tools exposed by the bridge
+
+| Tool                | Behavior                                                                                                                                                                                                                       |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `connect`           | Attach to a running instance. `instanceId` accepts the project name or PID shown in `serverpod://instances`. Auto-picks if exactly one instance is running and the argument is omitted. Calling `connect` again switches instances. |
+| `disconnect`        | Detach from the current instance without stopping it.                                                                                                                                                                          |
+| `spawn`             | Start a new `serverpod start --watch` process detached from the bridge. Optional `directory` to choose the server dir; optional `args` appended to the CLI. Polls the socket dir for up to ~10s for the new instance to appear. Does **not** auto-connect. |
+| `stop`              | Send SIGTERM to the named instance. Auto-disconnects if it was the connected one.                                                                                                                                              |
+| `apply_migrations`  | **Forwarded** to the connected instance. Errors with a not-connected message if no instance is attached.                                                                                                                       |
+
+#### Resources exposed by the bridge
+
+| Resource                  | Behavior                                                                                                                                                          |
+| ------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `serverpod://instances`   | JSON list of `{pid, project, socketPath, connected}` for each live runner. Updated when the socket directory changes or when the bridge connects/disconnects.     |
+
+The bridge currently exposes no forwarded state resources. If runner-side resources are added later (e.g. compile state), the bridge will need to declare matching forwarded resources at registration time - `dart_mcp` does not enumerate resources from the upstream automatically.
+
+### `apply_migrations` tool (runner side)
 
 Restarts the server subprocess with `--apply-migrations` added to its arguments. This is a one-shot flag - subsequent restarts and reloads use the original args.
 
-When an MCP client calls `apply_migrations`:
+When an MCP client (the bridge, in practice) calls `apply_migrations`:
 
 1. The watch session resets the compiler and does a full compile.
 1. The server subprocess is stopped and restarted with `--apply-migrations` appended.
 1. The tool returns success/failure status. On compilation failure or reentrancy, the tool returns an error.
 
+The runner's MCP socket survives the server-subprocess restart because the socket is owned by the CLI process, not the server subprocess.
+
 ## Implementation
 
-### MCP socket server
+### Shared helpers (`lib/src/mcp/socket_directory.dart`)
 
-`McpSocketServer` takes a full socket path, binds a `ServerSocket` to a Unix domain address, and converts socket connections to `StreamChannel<String>` using line-delimited JSON-RPC. Only one client connection is active at a time - new connections await shutdown of the previous client before proceeding.
+- `serverpodMcpSocketDir`, `ensureServerpodMcpSocketDir` - the shared dir under `Directory.systemTemp`.
+- `serverpodMcpSocketPath({pid, project})` - canonical filename.
+- `sanitizeProjectName(name)` - `[^a-z0-9-]` -> `-`, collapse runs, strip ends.
+- `listServerpodMcpSockets()` - returns `(pid, project, path)` tuples for every live socket; deletes stale ones whose PID no longer exists. Liveness check: `kill -0 <pid>` on POSIX, `tasklist` on Windows.
+- `socketChannel(Socket)` - wraps a `Socket` in the line-delimited `StreamChannel<String>` that `dart_mcp` expects.
 
-### MCP server
+### Runner side (`lib/src/commands/start/mcp_socket.dart`)
 
-`ServerpodMcpServer` extends `MCPServer` (from the `dart_mcp` package) with the `ToolsSupport` mixin. It registers the `apply_migrations` tool with a callback into the `WatchSession`.
+`McpSocketServer({required project})` derives its socket path from the current `pid` and the sanitized project. `start()` ensures the shared dir exists, binds the `ServerSocket`, and accepts at most one client at a time. `close()` shuts down the active MCP server, destroys the client socket, and unlinks the socket file. New connections wait for any in-flight shutdown to settle and are rejected once `close()` has been called.
+
+`ServerpodMcpServer` (`lib/src/commands/start/mcp_server.dart`) is unchanged: it extends `MCPServer` with `ToolsSupport` and registers `apply_migrations` against a `WatchSession.applyMigration` callback wired by `start.dart`.
+
+### Bridge side (`lib/src/mcp/`)
+
+- `ServerpodMcpBridge` - owns the discovered socket list. `scan()` re-reads the dir; `startWatching()` subscribes to `Directory.watch()` and coalesces bursts into single rescans via `asyncMapBuffer`; `findSocket(id)` matches by project then PID; `dispose()` cancels the watcher.
+- `BridgeMcpServer extends MCPServer with ToolsSupport, ResourcesSupport` - registers `connect`/`disconnect`/`spawn`/`stop`/`apply_migrations` and the `serverpod://instances` resource. Holds at most one `ServerConnection` at a time. Forwarding for `apply_migrations` is a direct `_connection.callTool(...)`. When the upstream connection completes (runner died), bridge state is cleared and the instances resource is updated.
+
+### CLI command (`lib/src/commands/mcp.dart`)
+
+Validates Unix socket support, instantiates `ServerpodMcpBridge`, scans + starts watching, then wires `stdin`/`stdout` to a `BridgeMcpServer` via `dart_mcp`'s `stdioChannel`. Blocks on `server.done` so the process stays up as long as the AI client holds stdin open.
 
 ### Integration with watch mode
 
-In `_startWatchSession()` (start.dart), the MCP socket server is created with a socket path under `serverpodToolDir`. The `apply_migrations` callback is wired to `WatchSession.applyMigration`. The socket is cleaned up on exit.
+In `_startWatchSession()` and `_runTuiBackend()` (`start.dart`), the runner-side `McpSocketServer` is constructed with `project: config.name`. The `apply_migrations` callback is wired to `WatchSession.applyMigration`. The socket is closed on shutdown (signal, TUI quit, or session exit), which removes the file from the shared dir.
 
 ### One-shot migration flag
 
 `WatchSession.applyMigration()` does a full compile, stops the server, and creates a new server with `extraArgs: ['--apply-migrations']`. The method throws on failure (compilation error, already in progress, `--no-fes` mode) so the MCP server can report errors to the client.
 
-### CLI command
-
-The `serverpod mcp` command resolves the server directory via `GeneratorConfig.load()`, connects to `mcp.sock`, and bridges stdin/stdout with cleanup on disconnect.
-
 ## Design Decisions
+
+### Why a shared temp dir rather than project-local sockets
+
+A project-local socket (e.g. under `.dart_tool/serverpod/`) is invisible to a bridge that doesn't already know which projects to watch. Putting all sockets in one well-known directory means the bridge can discover instances with a stat-only scan. The PID embedded in the filename keeps discovery self-correcting (dead PIDs are obviously stale) without a separate manifest or daemon.
+
+### Why a bridge at all
+
+Without a bridge, the MCP connection is bound to the runner's lifetime. Any operation that restarts the runner (notably `apply_migrations`) would tear down the AI client's MCP server, and Claude Code does not auto-reconnect. A persistent stdio bridge breaks that coupling: the runner is ephemeral, the bridge survives, and the client just calls `connect` again.
+
+### Single-instance bridge
+
+Forwarding to one runner at a time keeps tool semantics unambiguous - the client always knows which project an `apply_migrations` call lands on. Multi-attach would force every forwarded tool to grow a target argument and risk silent cross-project effects. Users with multiple projects open run one bridge per AI window.
 
 ### Why only CLI-internal operations are exposed via MCP
 
@@ -97,10 +163,16 @@ Future MCP tool candidates include `server_status` (only the CLI knows whether t
 
 ## Dependencies
 
-- `dart_mcp: ^0.4.x` - MCP server base class, tools/resources support.
+- `dart_mcp: ^0.5.x` - MCP server and client base classes; `stdioChannel` for the bridge transport.
 - `stream_channel` - bidirectional stream abstraction.
+- `stream_transform` - `asyncMapBuffer` for coalescing socket-dir watcher events.
+
+## Migration from the previous design
+
+The previous integration used a project-local socket at `<server>/.dart_tool/serverpod/mcp.sock` and shipped `serverpod mcp` as a transparent stdio-to-socket pipe. That socket path is no longer used. AI client config that just runs `serverpod mcp` continues to work; configs that invoked it from a particular project directory no longer need to - the bridge discovers instances independently of the AI client's working directory.
 
 ## Open Questions
 
 1. Should pressing `a` during watch mode also trigger apply-migration? This requires switching stdin to raw mode, which adds complexity (signal handling, non-TTY environments, Windows). May be better as a follow-up.
-1. Should the MCP server expose resources (e.g. migration status, server state) in addition to tools? This would let AI agents observe state without polling.
+1. Should the runner-side server expose resources (e.g. migration status, server state) in addition to tools? This would let AI agents observe state without polling. Adds bridge work because forwarded resources have to be declared upfront in `dart_mcp`.
+1. Should the bridge auto-reconnect when a previously-connected runner reappears (same project name, new PID)? Today the client must call `connect` again. Auto-reconnect is convenient but can mask runner crashes; keep manual until the friction is concrete.

--- a/docs/design/mcp_server.md
+++ b/docs/design/mcp_server.md
@@ -15,7 +15,7 @@ During development with `serverpod start --watch`, file watching, code generatio
 
 These operations currently require stopping the server, re-running with flags, or manual SQL. An MCP server lets AI agents trigger them in-context during a development session.
 
-The bridge layer solves a separate problem: when the runner restarts (e.g. after `apply_migrations`), the runner's MCP socket goes away. AI clients like Claude Code do not automatically reconnect to a dropped MCP server, so without a bridge the integration breaks the moment migrations are applied. A persistent stdio bridge stays up across runner restarts and lets the client `connect` again.
+The bridge layer solves a separate problem: when the runner process (`serverpod start --watch`) exits or is restarted, the MCP socket it owns goes with it. AI clients do not automatically reconnect to a dropped MCP server, so without a bridge the integration breaks every time the dev process is restarted. A persistent stdio bridge stays up across runner restarts and lets the client `connect` again. The MCP socket is owned by the CLI process, not the pod subprocess, so a pod restart leaves the socket intact.
 
 ## Architecture
 
@@ -25,13 +25,13 @@ The bridge layer solves a separate problem: when the runner restarts (e.g. after
 AI client (e.g. Claude Code)
     │  stdio  (long-lived)
     ▼
-serverpod mcp           ← BridgeMcpServer (this process)
+serverpod mcp             <- BridgeMcpServer (this process)
     │
     │  scans .../serverpod/serverpod-<pid>-<project>.sock
     │  connects to one at a time
     │
     ▼  unix socket  (re-established on each connect)
-serverpod start --watch ← ServerpodMcpServer (per-runner)
+serverpod start --watch   <- ServerpodMcpServer (per-runner)
 ```
 
 The bridge is **single-instance**: at any moment it forwards to at most one runner. Switching runners is an explicit `disconnect` then `connect` from the client. To bridge multiple AI windows to multiple projects, run one `serverpod mcp` per window.
@@ -51,11 +51,13 @@ Sockets live in a shared, per-machine temp directory:
 └── serverpod-<pid>-<project>.sock
 ```
 
-- `<systemTemp>` is `Directory.systemTemp.path` (`/tmp` on Linux/macOS, `C:\Users\<user>\AppData\Local\Temp` on Windows).
+- `<systemTemp>` is `Directory.systemTemp.path` (`/tmp` on Linux when `TMPDIR` is unset, `/var/folders/.../T/` on macOS, `C:\Users\<user>\AppData\Local\Temp` on Windows).
 - `<pid>` is the runner's OS process id.
 - `<project>` is the serverpod app name (`config.name`, with the `_server` suffix already stripped) sanitized to `[a-z0-9-]+`.
 
 **Why a shared dir, not project-local.** A bridge process needs to discover all running instances on the machine via a single `Directory.listSync()`. Embedding the PID in the filename means discovery is stat-only - there is no separate manifest file to keep in sync, and stale files are easy to identify by checking whether the PID is still alive.
+
+**Permissions.** The `serverpod/` directory is created with mode 0700 on POSIX so other local users cannot enter it - on Linux, where `<systemTemp>` is the shared `/tmp`, this is what keeps the per-runner sockets inaccessible to other users on the same machine. The directory is created via `Directory.systemTemp.createTempSync()` (which goes through `mkdtemp(3)` and gives 0700) and then renamed to the canonical name; rename preserves the inode and mode. Since the parent directory blocks traversal, the socket files inside don't need their own restrictive mode. On macOS and Windows the parent path is already per-user, so the 0700 is incidental there.
 
 The bridge cleans up dead-PID sockets opportunistically the next time it scans.
 
@@ -74,26 +76,28 @@ The bridge cleans up dead-PID sockets opportunistically the next time it scans.
 
 The bridge does not need a `--directory` flag - it discovers running instances by directory scan. The AI client picks one with the `connect` tool.
 
-#### Tools exposed by the bridge
+#### Tools and resources exposed by the bridge
 
-| Tool                | Behavior                                                                                                                                                                                                                       |
-| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `connect`           | Attach to a running instance. `instanceId` accepts the project name or PID shown in `serverpod://instances`. Auto-picks if exactly one instance is running and the argument is omitted. Calling `connect` again switches instances. |
-| `disconnect`        | Detach from the current instance without stopping it.                                                                                                                                                                          |
-| `spawn`             | Start a new `serverpod start --watch` process detached from the bridge. Optional `directory` to choose the server dir; optional `args` appended to the CLI. Polls the socket dir for up to ~10s for the new instance to appear. Does **not** auto-connect. |
-| `stop`              | Send SIGTERM to the named instance. Auto-disconnects if it was the connected one.                                                                                                                                              |
-| `apply_migrations`  | **Forwarded** to the connected instance. Errors with a not-connected message if no instance is attached.                                                                                                                       |
-| `create_migration`  | **Forwarded** to the connected instance. Writes migration files for the current model definitions; does not restart the server. Accepts optional `tag` and `force`.                                                           |
-| `hot_reload`        | **Forwarded** to the connected instance. Recompiles the server kernel and hot-reloads the running isolate.                                                                                                                     |
-| `tail_logs`         | **Forwarded** to the connected instance. Returns recent log entries.                                                                                                                                                           |
+The bridge owns four native tools and one native resource. Everything else is **auto-forwarded**: on `connect`, the bridge calls `listTools()` and `listResources()` on the upstream runner and registers a thin forwarder for each item not already owned natively. On `disconnect` the forwarders are unregistered. The MCP `listChanged` capability propagates these registrations to the AI client, so the upstream surface appears and disappears as the connection state changes.
 
-#### Resources exposed by the bridge
+Native tools (always present):
 
-| Resource                  | Behavior                                                                                                                                                          |
-| ------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `serverpod://instances`   | JSON list of `{pid, project, socketPath, connected}` for each live runner. Updated when the socket directory changes or when the bridge connects/disconnects.     |
+| Tool         | Behavior                                                                                                                                                                                                                       |
+| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `connect`    | Attach to a running instance. `instanceId` accepts the project name or PID shown in `serverpod://instances`. Auto-picks if exactly one instance is running and the argument is omitted. Calling `connect` again switches instances. |
+| `disconnect` | Detach from the current instance without stopping it.                                                                                                                                                                          |
+| `spawn`      | Start a new `serverpod start --watch` process detached from the bridge. Optional `directory` to choose the server dir; optional `args` appended to the CLI. Polls the socket dir for up to ~10s for the new instance to appear. Does **not** auto-connect. |
+| `stop`       | Send SIGTERM to the named instance. Auto-disconnects if it was the connected one.                                                                                                                                              |
 
-The bridge currently exposes no forwarded state resources. If runner-side resources are added later (e.g. compile state), the bridge will need to declare matching forwarded resources at registration time - `dart_mcp` does not enumerate resources from the upstream automatically.
+Native resource (always present):
+
+| Resource                | Behavior                                                                                                                                                      |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `serverpod://instances` | JSON list of `{pid, project, socketPath, connected}` for each live runner. Updated when the socket directory changes or when the bridge connects/disconnects. |
+
+Currently auto-forwarded from the runner once connected: the tools `apply_migrations`, `create_migration`, `hot_reload`, `tail_logs`, and the resource `serverpod://vm-service`. Adding a new tool or resource on the runner side requires no bridge changes - it appears in the AI client automatically on the next `connect`. Names that collide with a native bridge tool (`connect`/`disconnect`/`spawn`/`stop`) or URI (`serverpod://instances`) are skipped to keep the bridge's surface authoritative.
+
+For per-resource updates, the bridge subscribes to each forwarded resource on `connect` and re-emits `notifications/resources/updated` upstream. Resources that don't support subscription are silently skipped (reads still work).
 
 ### `apply_migrations` tool (runner side)
 
@@ -126,7 +130,7 @@ The runner's MCP socket survives the server-subprocess restart because the socke
 ### Bridge side (`lib/src/mcp/`)
 
 - `ServerpodMcpBridge` - owns the discovered socket list. `scan()` re-reads the dir; `startWatching()` subscribes to `Directory.watch()` and coalesces bursts into single rescans via `asyncMapBuffer`; `findSocket(id)` matches by project then PID; `dispose()` cancels the watcher.
-- `BridgeMcpServer extends MCPServer with ToolsSupport, ResourcesSupport` - registers `connect`/`disconnect`/`spawn`/`stop`, the forwarded tools (`apply_migrations`, `create_migration`, `hot_reload`, `tail_logs`), and the `serverpod://instances` / `serverpod://vm-service` resources. Holds at most one `ServerConnection` at a time. Forwarding is a direct `_connection.callTool(...)`. When the upstream connection completes (runner died), bridge state is cleared and the instances resource is updated.
+- `BridgeMcpServer extends MCPServer with ToolsSupport, ResourcesSupport` - registers the native tools `connect`/`disconnect`/`spawn`/`stop` and the native `serverpod://instances` resource at construction. On each `connect`, calls `listTools()`/`listResources()` on the upstream `ServerConnection`, then `registerTool` / `addResource` for every item not in the bridge-native deny set, with thin closures that delegate via `_connection.callTool`/`readResource`. The corresponding `unregisterTool`/`removeResource` happens in `_disconnectInternal`, so `listChanged` notifications cleanly publish and unpublish the upstream surface as the connection toggles. When the upstream connection completes (runner died), `_disconnectInternal` runs from the `connection.done` callback so forwarded tools/resources disappear from the AI client.
 
 ### CLI command (`lib/src/commands/mcp.dart`)
 
@@ -148,7 +152,7 @@ A project-local socket (e.g. under `.dart_tool/serverpod/`) is invisible to a br
 
 ### Why a bridge at all
 
-Without a bridge, the MCP connection is bound to the runner's lifetime. Any operation that restarts the runner (notably `apply_migrations`) would tear down the AI client's MCP server, and Claude Code does not auto-reconnect. A persistent stdio bridge breaks that coupling: the runner is ephemeral, the bridge survives, and the client just calls `connect` again.
+Without a bridge, the MCP connection is bound to the runner's lifetime: stopping or restarting the `serverpod start --watch` process tears down the AI client's MCP server, and Claude Code does not auto-reconnect. A persistent stdio bridge breaks that coupling: runners are ephemeral, the bridge survives, and the client just calls `connect` again. (The MCP client never talks to the server subprocess directly, so server restarts triggered by `apply_migrations` or hot reload do not break the connection.)
 
 ### Single-instance bridge
 

--- a/docs/design/mcp_server.md
+++ b/docs/design/mcp_server.md
@@ -4,7 +4,7 @@ This document describes the MCP (Model Context Protocol) integration for `server
 
 The integration has two parts:
 
-- A small **per-runner MCP server** that lives inside each `serverpod start --watch` process and exposes operations that need the CLI's in-memory state (currently: `apply_migrations`).
+- A small **per-runner MCP server** that lives inside each `serverpod start --watch` process and exposes dev operations against that instance (currently: `apply_migrations`, `create_migration`, `hot_reload`, `tail_logs`).
 - A long-lived **bridge MCP server** (`serverpod mcp`) that sits on stdio between the AI client and the runners. It discovers running instances by scanning a shared socket directory, connects to one at a time, and forwards tool calls. The bridge survives runner restarts.
 
 The per-runner server runs inside the CLI process, alongside the compiler, file watcher, and watch session. It is not part of the server subprocess (the Serverpod application). This keeps dev tooling concerns out of the framework itself - the `serverpod` package should not impose an MCP dependency or dev-time features on the application server. It also means the MCP server has access to the CLI's internal state (the incremental compiler, the server process handle, the restart lifecycle) which the server subprocess does not.
@@ -83,6 +83,9 @@ The bridge does not need a `--directory` flag - it discovers running instances b
 | `spawn`             | Start a new `serverpod start --watch` process detached from the bridge. Optional `directory` to choose the server dir; optional `args` appended to the CLI. Polls the socket dir for up to ~10s for the new instance to appear. Does **not** auto-connect. |
 | `stop`              | Send SIGTERM to the named instance. Auto-disconnects if it was the connected one.                                                                                                                                              |
 | `apply_migrations`  | **Forwarded** to the connected instance. Errors with a not-connected message if no instance is attached.                                                                                                                       |
+| `create_migration`  | **Forwarded** to the connected instance. Writes migration files for the current model definitions; does not restart the server. Accepts optional `tag` and `force`.                                                           |
+| `hot_reload`        | **Forwarded** to the connected instance. Recompiles the server kernel and hot-reloads the running isolate.                                                                                                                     |
+| `tail_logs`         | **Forwarded** to the connected instance. Returns recent log entries.                                                                                                                                                           |
 
 #### Resources exposed by the bridge
 
@@ -118,12 +121,12 @@ The runner's MCP socket survives the server-subprocess restart because the socke
 
 `McpSocketServer({required project})` derives its socket path from the current `pid` and the sanitized project. `start()` ensures the shared dir exists, binds the `ServerSocket`, and accepts at most one client at a time. `close()` shuts down the active MCP server, destroys the client socket, and unlinks the socket file. New connections wait for any in-flight shutdown to settle and are rejected once `close()` has been called.
 
-`ServerpodMcpServer` (`lib/src/commands/start/mcp_server.dart`) is unchanged: it extends `MCPServer` with `ToolsSupport` and registers `apply_migrations` against a `WatchSession.applyMigration` callback wired by `start.dart`.
+`ServerpodMcpServer` (`lib/src/commands/start/mcp_server.dart`) extends `MCPServer` with `ToolsSupport` and `ResourcesSupport`. It registers `apply_migrations`, `create_migration`, `hot_reload`, and `tail_logs` tools against callbacks wired by `start.dart` (`WatchSession.applyMigration`, a `createMigrationAction`-backed closure, `WatchSession.forceReload`, and a log-history getter respectively). It also exposes the `serverpod://vm-service` resource.
 
 ### Bridge side (`lib/src/mcp/`)
 
 - `ServerpodMcpBridge` - owns the discovered socket list. `scan()` re-reads the dir; `startWatching()` subscribes to `Directory.watch()` and coalesces bursts into single rescans via `asyncMapBuffer`; `findSocket(id)` matches by project then PID; `dispose()` cancels the watcher.
-- `BridgeMcpServer extends MCPServer with ToolsSupport, ResourcesSupport` - registers `connect`/`disconnect`/`spawn`/`stop`/`apply_migrations` and the `serverpod://instances` resource. Holds at most one `ServerConnection` at a time. Forwarding for `apply_migrations` is a direct `_connection.callTool(...)`. When the upstream connection completes (runner died), bridge state is cleared and the instances resource is updated.
+- `BridgeMcpServer extends MCPServer with ToolsSupport, ResourcesSupport` - registers `connect`/`disconnect`/`spawn`/`stop`, the forwarded tools (`apply_migrations`, `create_migration`, `hot_reload`, `tail_logs`), and the `serverpod://instances` / `serverpod://vm-service` resources. Holds at most one `ServerConnection` at a time. Forwarding is a direct `_connection.callTool(...)`. When the upstream connection completes (runner died), bridge state is cleared and the instances resource is updated.
 
 ### CLI command (`lib/src/commands/mcp.dart`)
 
@@ -131,7 +134,7 @@ Validates Unix socket support, instantiates `ServerpodMcpBridge`, scans + starts
 
 ### Integration with watch mode
 
-In `_startWatchSession()` and `_runTuiBackend()` (`start.dart`), the runner-side `McpSocketServer` is constructed with `project: config.name`. The `apply_migrations` callback is wired to `WatchSession.applyMigration`. The socket is closed on shutdown (signal, TUI quit, or session exit), which removes the file from the shared dir.
+In `_startWatchSession()` and `_runTuiBackend()` (`start.dart`), the runner-side `McpSocketServer` is constructed with `project: config.name`. The `apply_migrations` callback is wired to `WatchSession.applyMigration`; the `create_migration` callback is a closure over `createMigrationAction(config: ...)` (the shared helper also used by the `serverpod create-migration` CLI command and the TUI "Create Migration" button); `hot_reload` is `WatchSession.forceReload`; `tail_logs` reads from `holder.state.logHistory` in the TUI path. The socket is closed on shutdown (signal, TUI quit, or session exit), which removes the file from the shared dir.
 
 ### One-shot migration flag
 
@@ -151,13 +154,14 @@ Without a bridge, the MCP connection is bound to the runner's lifetime. Any oper
 
 Forwarding to one runner at a time keeps tool semantics unambiguous - the client always knows which project an `apply_migrations` call lands on. Multi-attach would force every forwarded tool to grow a target argument and risk silent cross-project effects. Users with multiple projects open run one bridge per AI window.
 
-### Why only CLI-internal operations are exposed via MCP
+### What belongs on the MCP server
 
-The MCP server exposes only operations that require the CLI's internal state. Stateless operations like `serverpod create-migration` or `serverpod generate` are better invoked directly as CLI commands.
+Any operation that the AI agent reaches for mid-session against a running dev environment belongs on the MCP server, whether or not it strictly needs the CLI's in-memory state. Keeping those operations behind the socket gives agents a stable, discoverable interface tied to the specific running instance (no ambiguity about which project directory the action lands in) and avoids forcing the agent to shell out with the right flags and working directory each time.
 
-Agents can discover CLI commands through a skill (a project-level instruction file that teaches the agent about available commands and workflows). This requires no code and no maintenance coupling to CLI flag changes. CLI commands also work without `serverpod start --watch` running; wrapping them in MCP would make them unavailable outside watch mode.
+- Operations that need the CLI's in-memory state (compiler, server lifecycle) - `apply_migrations`, `hot_reload` - must live here.
+- Operations that are conceptually per-instance but don't strictly need in-memory state - `create_migration`, `tail_logs` - are exposed here too. The alternative (shelling out to `serverpod create-migration`) forces a context switch, adds a failure mode where the agent runs in the wrong directory, and makes tool discovery dependent on a shipped skill file.
 
-If an operation needs the CLI's in-memory state, it belongs on the MCP server. Otherwise, it's a CLI command documented via a skill.
+Commands that are project-setup / one-shot / infrastructure (`serverpod create`, `serverpod generate` outside watch mode, `serverpod mcp` itself) stay as CLI commands. They don't belong to a running instance and don't benefit from being forwarded through a socket.
 
 Future MCP tool candidates include `server_status` (only the CLI knows whether the server subprocess is running, compiling, or errored).
 

--- a/tools/serverpod_cli/lib/src/commands/create_migration.dart
+++ b/tools/serverpod_cli/lib/src/commands/create_migration.dart
@@ -4,14 +4,11 @@ import 'package:cli_tools/cli_tools.dart';
 import 'package:config/config.dart';
 import 'package:path/path.dart' as path;
 import 'package:serverpod_cli/analyzer.dart';
-import 'package:serverpod_cli/src/config/serverpod_feature.dart';
+import 'package:serverpod_cli/src/migrations/create_migration_action.dart';
 import 'package:serverpod_cli/src/runner/serverpod_command.dart';
 import 'package:serverpod_cli/src/runner/serverpod_command_runner.dart';
-import 'package:serverpod_cli/src/util/project_name.dart';
 import 'package:serverpod_cli/src/util/serverpod_cli_logger.dart';
 import 'package:serverpod_cli/src/util/string_validators.dart';
-import 'package:serverpod_database/serverpod_database.dart';
-import 'package:serverpod_shared/serverpod_shared.dart' hide ExitException;
 
 enum CreateMigrationOption<V> implements OptionDefinition<V> {
   force(CreateMigrationCommand.forceOption),
@@ -63,8 +60,8 @@ class CreateMigrationCommand extends ServerpodCommand<CreateMigrationOption> {
   Future<void> runWithConfig(
     final Configuration<CreateMigrationOption> commandConfig,
   ) async {
-    bool force = commandConfig.value(CreateMigrationOption.force);
-    String? tag = commandConfig.optionalValue(CreateMigrationOption.tag);
+    final force = commandConfig.value(CreateMigrationOption.force);
+    final tag = commandConfig.optionalValue(CreateMigrationOption.tag);
 
     // Get interactive flag from global configuration
     final interactive = serverpodRunner.globalConfiguration.optionalValue(
@@ -79,91 +76,36 @@ class CreateMigrationCommand extends ServerpodCommand<CreateMigrationOption> {
       throw ExitException(ServerpodCommand.commandInvokedCannotExecute);
     }
 
-    if (!config.isFeatureEnabled(ServerpodFeature.database)) {
-      log.error(
-        'The database feature is not enabled in this project. '
-        'This command cannot be used.',
-      );
-      throw ExitException(ServerpodCommand.commandInvokedCannotExecute);
-    }
-
-    var serverDirectory = Directory(
-      path.joinAll(config.serverPackageDirectoryPathParts),
-    );
-
-    var projectName = await getProjectName(serverDirectory);
-    if (projectName == null) {
-      throw ExitException(ServerpodCommand.commandInvokedCannotExecute);
-    }
-
-    var generator = MigrationGenerator(
-      directory: serverDirectory,
-      projectName: projectName,
-    );
-
-    MigrationVersionArtifacts? migration;
-    bool migrationAborted = false;
-    bool migrationFailed = false;
+    late final CreateMigrationOutcome outcome;
     await log.progress('Creating migration', () async {
-      try {
-        migration = await generator.createMigration(
-          tag: tag,
-          force: force,
-          config: config,
-        );
-      } on MigrationVersionLoadException catch (e) {
-        log.error(
-          'Unable to determine latest database definition due to a corrupted '
-          'migration. Please re-create or remove the migration version and try '
-          'again. Migration version: "${e.versionName}".',
-        );
-        log.error(e.exception);
-        migrationFailed = true;
-      } on GenerateMigrationDatabaseDefinitionException {
-        log.error('Unable to generate database definition for project.');
-        migrationFailed = true;
-      } on MigrationVersionAlreadyExistsException catch (e) {
-        log.error(
-          'Unable to create migration. A directory with the same name already '
-          'exists: "${e.directoryPath}".',
-        );
-        migrationFailed = true;
-      } on MigrationAbortedException {
-        migrationAborted = true;
-      }
-
-      return migration != null;
+      outcome = await createMigrationAction(
+        config: config,
+        tag: tag,
+        force: force,
+      );
+      return switch (outcome) {
+        CreateMigrationCreated() || CreateMigrationNoChanges() => true,
+        CreateMigrationAborted() || CreateMigrationFailed() => false,
+      };
     });
 
-    if (migrationFailed) {
-      throw ExitException.error();
+    switch (outcome) {
+      case CreateMigrationFailed(:final message):
+        log.error(message);
+        throw ExitException.error();
+      case CreateMigrationAborted():
+        throw ExitException.error();
+      case CreateMigrationNoChanges():
+        return;
+      case CreateMigrationCreated(:final migrationDirectory):
+        log.info(
+          'Migration created: ${path.relative(
+            migrationDirectory,
+            from: Directory.current.path,
+          )}',
+          type: TextLogType.bullet,
+        );
+        log.info('Done.', type: TextLogType.success);
     }
-
-    // Migration was aborted due to warnings.
-    if (migrationAborted) {
-      throw ExitException.error();
-    }
-
-    // No changes detected.
-    if (migration == null) {
-      return;
-    }
-
-    // Dart does not infer the type of `migration` to be non-nullable here,
-    // so we use the null-check operator to assert that it is not null.
-    var createdMigration = migration!;
-    var migrationName = createdMigration.version;
-
-    log.info(
-      'Migration created: ${path.relative(
-        MigrationConstants.migrationVersionDirectory(
-          serverDirectory,
-          migrationName,
-        ).path,
-        from: Directory.current.path,
-      )}',
-      type: TextLogType.bullet,
-    );
-    log.info('Done.', type: TextLogType.success);
   }
 }

--- a/tools/serverpod_cli/lib/src/commands/mcp.dart
+++ b/tools/serverpod_cli/lib/src/commands/mcp.dart
@@ -1,12 +1,12 @@
+import 'dart:async';
 import 'dart:io';
 
-import 'package:args/args.dart';
 import 'package:cli_tools/cli_tools.dart';
 import 'package:config/config.dart';
-import 'package:path/path.dart' as p;
-import 'package:serverpod_cli/analyzer.dart';
+import 'package:dart_mcp/stdio.dart';
+import 'package:serverpod_cli/src/mcp/bridge_mcp_server.dart';
+import 'package:serverpod_cli/src/mcp/serverpod_mcp_bridge.dart';
 import 'package:serverpod_cli/src/runner/serverpod_command.dart';
-import 'package:serverpod_cli/src/runner/serverpod_command_runner.dart';
 import 'package:serverpod_cli/src/util/platform_check.dart';
 import 'package:serverpod_cli/src/util/serverpod_cli_logger.dart';
 
@@ -29,89 +29,47 @@ enum McpOption<V> implements OptionDefinition<V> {
   final ConfigOptionBase<V> option;
 }
 
-/// Connects to a running serverpod watch instance's MCP socket and bridges
-/// stdin/stdout for use as an MCP transport.
-class McpCommand extends ServerpodCommand<McpOption> {
+/// Long-lived stdio MCP server that bridges to running
+/// `serverpod start --watch` instances.
+///
+/// Discovers instances via the shared socket directory, lets the client
+/// pick one with the `connect` tool, and forwards tool calls to it.
+/// Survives runner restarts - the client can `connect` again after the
+/// runner comes back up without restarting the bridge.
+class McpCommand extends ServerpodCommand {
   @override
   final name = 'mcp';
 
   @override
   final description =
-      "Create stdio bridge to a running `serverpod start --watch` process's MCP server.";
+      'Start an MCP bridge that discovers running '
+      '`serverpod start --watch` instances and forwards tool calls to one '
+      'at a time.';
 
   @override
   String get invocation => 'serverpod mcp';
 
-  McpCommand() : super(options: McpOption.values);
-
   @override
-  Configuration<McpOption> resolveConfiguration(ArgResults? argResults) {
-    return Configuration.resolveNoExcept(
-      options: options,
-      argResults: argResults,
-      env: envVariables,
-    );
-  }
-
-  @override
-  Future<void> runWithConfig(Configuration<McpOption> commandConfig) async {
-    final directory = commandConfig.value(McpOption.directory);
-
-    final interactive = serverpodRunner.globalConfiguration.optionalValue(
-      GlobalOption.interactive,
-    );
-
-    GeneratorConfig config;
-    try {
-      config = await GeneratorConfig.load(
-        serverRootDir: directory,
-        interactive: interactive,
-      );
-    } catch (e) {
-      log.error('$e');
-      throw ExitException(ServerpodCommand.commandInvokedCannotExecute);
-    }
-
-    final serverDir = p.joinAll(config.serverPackageDirectoryPathParts);
-    final socketPath = p.join(serverDir, '.dart_tool', 'serverpod', 'mcp.sock');
-
-    // Connect to the Unix socket. The existence check is a fast-fail for a
-    // better error message, but the socket could disappear between the check
-    // and the connect (TOCTOU), so we catch SocketException too.
-    if (FileSystemEntity.typeSync(socketPath) ==
-        FileSystemEntityType.notFound) {
+  Future<void> runWithConfig(Configuration commandConfig) async {
+    if (!hasUnixSocketSupport()) {
       log.error(
-        'No running serverpod watch instance found.\n'
-        'Start one with: serverpod start --watch',
+        'The serverpod MCP bridge requires Unix domain socket support, '
+        'which on Windows requires Dart 3.11+ '
+        '(current: ${Platform.version.split(' ').first}).',
       );
       throw ExitException.error();
     }
 
-    Socket socket;
-    try {
-      socket = await connectUnixSocket(socketPath);
-    } on SocketException {
-      log.error(
-        'No running serverpod watch instance found.\n'
-        'Start one with: serverpod start --watch',
-      );
-      throw ExitException.error();
-    }
+    final bridge = ServerpodMcpBridge();
+    await bridge.scan();
+    bridge.startWatching();
 
-    // stdin -> socket. Close socket on stdin EOF so the server sees disconnect.
-    final stdinSub = stdin.listen(
-      socket.add,
-      onDone: () => socket.close(),
-    );
+    final channel = stdioChannel(input: stdin, output: stdout);
+    final server = BridgeMcpServer(channel, bridge: bridge);
 
-    // socket -> stdout (with explicit flush for non-TTY stdout).
-    try {
-      await for (final data in socket) {
-        stdout.add(data);
-        await stdout.flush();
-      }
-    } finally {
-      await stdinSub.cancel();
-    }
+    // Block until the MCP client (stdin) disconnects, then shut everything
+    // down cleanly.
+    await server.done;
+    await bridge.dispose();
   }
 }

--- a/tools/serverpod_cli/lib/src/commands/start.dart
+++ b/tools/serverpod_cli/lib/src/commands/start.dart
@@ -914,25 +914,46 @@ Future<void> _runTuiBackend({
   }
 }
 
+/// Maps a [CreateMigrationOutcome] to a `(message, isError)` pair shared by
+/// the TUI and MCP wrappers. [forceHint] is the surface-specific instruction
+/// for retrying past warnings (e.g. `--force` for the CLI/TUI, `force: true`
+/// for the MCP tool).
+({String message, bool isError}) _describeCreateMigration(
+  CreateMigrationOutcome outcome, {
+  required String forceHint,
+}) {
+  return switch (outcome) {
+    CreateMigrationCreated(:final versionName, :final migrationDirectory) => (
+      message: 'Migration "$versionName" created at $migrationDirectory.',
+      isError: false,
+    ),
+    CreateMigrationNoChanges() => (
+      message: 'No schema changes detected; no migration created.',
+      isError: false,
+    ),
+    CreateMigrationAborted() => (
+      message: 'Migration aborted due to warnings. $forceHint',
+      isError: true,
+    ),
+    CreateMigrationFailed(:final message) => (
+      message: message,
+      isError: true,
+    ),
+  };
+}
+
 /// Runs `create-migration` for the TUI's Create Migration button.
 ///
 /// Logs the outcome; throws on failure so [runTrackedAction] marks the
 /// operation red.
 Future<void> _runCreateMigrationForTui(GeneratorConfig config) async {
   final outcome = await createMigrationAction(config: config);
-  switch (outcome) {
-    case CreateMigrationCreated(:final versionName):
-      log.info('Migration created: $versionName');
-    case CreateMigrationNoChanges():
-      log.info('No schema changes detected; no migration created.');
-    case CreateMigrationAborted():
-      throw Exception(
-        'Migration aborted due to warnings. Run `serverpod create-migration '
-        '--force` to create it anyway.',
-      );
-    case CreateMigrationFailed(:final message):
-      throw Exception(message);
-  }
+  final result = _describeCreateMigration(
+    outcome,
+    forceHint: 'Run `serverpod create-migration --force` to create it anyway.',
+  );
+  if (result.isError) throw Exception(result.message);
+  log.info(result.message);
 }
 
 /// Runs `create-migration` for the MCP `create_migration` tool. Returns a
@@ -947,25 +968,15 @@ Future<CreateMigrationMcpResult> _createMigrationForMcp(
     tag: tag,
     force: force,
   );
-  return switch (outcome) {
-    CreateMigrationCreated(:final versionName, :final migrationDirectory) =>
-      CreateMigrationMcpResult(
-        message:
-            'Migration "$versionName" created at $migrationDirectory. '
-            'Call `apply_migrations` to run it against the database.',
-      ),
-    CreateMigrationNoChanges() => const CreateMigrationMcpResult(
-      message: 'No schema changes detected; no migration created.',
-    ),
-    CreateMigrationAborted() => const CreateMigrationMcpResult(
-      message:
-          'Migration aborted due to warnings. Call again with `force: true` '
-          'to create it anyway.',
-      isError: true,
-    ),
-    CreateMigrationFailed(:final message) => CreateMigrationMcpResult(
-      message: message,
-      isError: true,
-    ),
-  };
+  final result = _describeCreateMigration(
+    outcome,
+    forceHint: 'Call again with `force: true` to create it anyway.',
+  );
+  final followUp = outcome is CreateMigrationCreated
+      ? ' Call `apply_migrations` to run it against the database.'
+      : '';
+  return CreateMigrationMcpResult(
+    message: result.message + followUp,
+    isError: result.isError,
+  );
 }

--- a/tools/serverpod_cli/lib/src/commands/start.dart
+++ b/tools/serverpod_cli/lib/src/commands/start.dart
@@ -377,6 +377,7 @@ Future<int> _runWatchMode({
     serverArgs: serverArgs,
     serverpodToolDir: serverpodToolDir,
     vmServiceInfoFile: vmServiceInfoFile,
+    project: config.name,
     shutdownSignal: shutdownSignal,
     watcher: FileWatcher(
       watchPaths: {
@@ -415,6 +416,7 @@ Future<int> _startWatchSession({
   required List<String> serverArgs,
   required String serverpodToolDir,
   required String vmServiceInfoFile,
+  required String project,
   required Future<int> shutdownSignal,
   required FileWatcher watcher,
   required Set<String> generatedDirPaths,
@@ -504,9 +506,7 @@ Future<int> _startWatchSession({
   // current MCP tools require the compiler and process lifecycle.
   McpSocketServer? mcpSocket;
   if (!noFes) {
-    mcpSocket = McpSocketServer(
-      socketPath: p.join(serverpodToolDir, 'mcp.sock'),
-    );
+    mcpSocket = McpSocketServer(project: project);
     try {
       await mcpSocket.start();
       mcpSocket.connect(onApplyMigration: session.applyMigration);
@@ -817,9 +817,7 @@ Future<void> _runTuiBackend({
 
     // Start MCP socket server.
     McpSocketServer? mcpSocket;
-    mcpSocket = McpSocketServer(
-      socketPath: p.join(serverpodToolDir, 'mcp.sock'),
-    );
+    mcpSocket = McpSocketServer(project: config.name);
     try {
       await mcpSocket.start();
       mcpSocket.connect(onApplyMigration: session.applyMigration);

--- a/tools/serverpod_cli/lib/src/commands/start.dart
+++ b/tools/serverpod_cli/lib/src/commands/start.dart
@@ -820,7 +820,10 @@ Future<void> _runTuiBackend({
     mcpSocket = McpSocketServer(project: config.name);
     try {
       await mcpSocket.start();
-      mcpSocket.connect(onApplyMigration: session.applyMigration);
+      mcpSocket.connect(
+        onApplyMigration: session.applyMigration,
+        getLogHistory: () => holder.state.logHistory.toList(),
+      );
       log.info('MCP server listening on ${mcpSocket.socketPath}');
     } on SocketException catch (e) {
       log.warning('Failed to start MCP server: $e');

--- a/tools/serverpod_cli/lib/src/commands/start.dart
+++ b/tools/serverpod_cli/lib/src/commands/start.dart
@@ -512,6 +512,8 @@ Future<int> _startWatchSession({
       mcpSocket.connect(
         onApplyMigration: session.applyMigration,
         onHotReload: session.forceReload,
+        getVmServiceUri: () => session.vmServiceUri,
+        vmServiceUriChanges: session.vmServiceUriChanges,
       );
       log.info('MCP server listening on ${mcpSocket.socketPath}');
     } on SocketException catch (e) {
@@ -827,6 +829,8 @@ Future<void> _runTuiBackend({
         onApplyMigration: session.applyMigration,
         onHotReload: session.forceReload,
         getLogHistory: () => holder.state.logHistory.toList(),
+        getVmServiceUri: () => session.vmServiceUri,
+        vmServiceUriChanges: session.vmServiceUriChanges,
       );
       log.info('MCP server listening on ${mcpSocket.socketPath}');
     } on SocketException catch (e) {

--- a/tools/serverpod_cli/lib/src/commands/start.dart
+++ b/tools/serverpod_cli/lib/src/commands/start.dart
@@ -509,7 +509,10 @@ Future<int> _startWatchSession({
     mcpSocket = McpSocketServer(project: project);
     try {
       await mcpSocket.start();
-      mcpSocket.connect(onApplyMigration: session.applyMigration);
+      mcpSocket.connect(
+        onApplyMigration: session.applyMigration,
+        onHotReload: session.forceReload,
+      );
       log.info('MCP server listening on ${mcpSocket.socketPath}');
     } on SocketException catch (e) {
       log.warning('Failed to start MCP server: $e');
@@ -822,6 +825,7 @@ Future<void> _runTuiBackend({
       await mcpSocket.start();
       mcpSocket.connect(
         onApplyMigration: session.applyMigration,
+        onHotReload: session.forceReload,
         getLogHistory: () => holder.state.logHistory.toList(),
       );
       log.info('MCP server listening on ${mcpSocket.socketPath}');

--- a/tools/serverpod_cli/lib/src/commands/start.dart
+++ b/tools/serverpod_cli/lib/src/commands/start.dart
@@ -12,6 +12,7 @@ import 'package:serverpod_cli/src/commands/generate.dart';
 import 'package:serverpod_cli/src/commands/messages.dart';
 import 'package:serverpod_cli/src/commands/start/file_watcher.dart';
 import 'package:serverpod_cli/src/commands/start/kernel_compiler.dart';
+import 'package:serverpod_cli/src/commands/start/mcp_server.dart';
 import 'package:serverpod_cli/src/commands/start/mcp_socket.dart';
 import 'package:serverpod_cli/src/commands/start/server_process.dart';
 import 'package:serverpod_cli/src/commands/start/tui/app.dart';
@@ -24,6 +25,7 @@ import 'package:serverpod_cli/src/commands/watcher.dart';
 import 'package:serverpod_cli/src/generator/analyzers.dart';
 import 'package:serverpod_cli/src/generator/generation_staleness.dart';
 import 'package:serverpod_cli/src/generator/isolated_analyzers.dart';
+import 'package:serverpod_cli/src/migrations/create_migration_action.dart';
 import 'package:serverpod_cli/src/runner/serverpod_command.dart';
 import 'package:serverpod_cli/src/runner/serverpod_command_runner.dart';
 import 'package:serverpod_cli/src/util/file_ex.dart';
@@ -373,11 +375,11 @@ Future<int> _runWatchMode({
   }
 
   return _startWatchSession(
+    config: config,
     serverDir: serverDir,
     serverArgs: serverArgs,
     serverpodToolDir: serverpodToolDir,
     vmServiceInfoFile: vmServiceInfoFile,
-    project: config.name,
     shutdownSignal: shutdownSignal,
     watcher: FileWatcher(
       watchPaths: {
@@ -412,11 +414,11 @@ Future<int> _runWatchMode({
 /// The session still runs code generation and triggers VM service reloads
 /// for static file changes.
 Future<int> _startWatchSession({
+  required GeneratorConfig config,
   required String serverDir,
   required List<String> serverArgs,
   required String serverpodToolDir,
   required String vmServiceInfoFile,
-  required String project,
   required Future<int> shutdownSignal,
   required FileWatcher watcher,
   required Set<String> generatedDirPaths,
@@ -506,11 +508,13 @@ Future<int> _startWatchSession({
   // current MCP tools require the compiler and process lifecycle.
   McpSocketServer? mcpSocket;
   if (!noFes) {
-    mcpSocket = McpSocketServer(project: project);
+    mcpSocket = McpSocketServer(project: config.name);
     try {
       await mcpSocket.start();
       mcpSocket.connect(
         onApplyMigration: session.applyMigration,
+        onCreateMigration: ({String? tag, bool force = false}) =>
+            _createMigrationForMcp(config, tag: tag, force: force),
         onHotReload: session.forceReload,
         getVmServiceUri: () => session.vmServiceUri,
         vmServiceUriChanges: session.vmServiceUriChanges,
@@ -827,6 +831,8 @@ Future<void> _runTuiBackend({
       await mcpSocket.start();
       mcpSocket.connect(
         onApplyMigration: session.applyMigration,
+        onCreateMigration: ({String? tag, bool force = false}) =>
+            _createMigrationForMcp(config, tag: tag, force: force),
         onHotReload: session.forceReload,
         getLogHistory: () => holder.state.logHistory.toList(),
         getVmServiceUri: () => session.vmServiceUri,
@@ -873,6 +879,13 @@ Future<void> _runTuiBackend({
     holder.onHotReload = () {
       runTrackedAction(holder, 'Hot reload', session.forceReload);
     };
+    holder.onCreateMigration = () {
+      runTrackedAction(
+        holder,
+        'Creating migration',
+        () => _runCreateMigrationForTui(config),
+      );
+    };
     holder.onApplyMigration = () {
       runTrackedAction(holder, 'Applying migrations', session.applyMigration);
     };
@@ -899,4 +912,60 @@ Future<void> _runTuiBackend({
     log.error('$e', stackTrace: st);
     onExitCode(1);
   }
+}
+
+/// Runs `create-migration` for the TUI's Create Migration button.
+///
+/// Logs the outcome; throws on failure so [runTrackedAction] marks the
+/// operation red.
+Future<void> _runCreateMigrationForTui(GeneratorConfig config) async {
+  final outcome = await createMigrationAction(config: config);
+  switch (outcome) {
+    case CreateMigrationCreated(:final versionName):
+      log.info('Migration created: $versionName');
+    case CreateMigrationNoChanges():
+      log.info('No schema changes detected; no migration created.');
+    case CreateMigrationAborted():
+      throw Exception(
+        'Migration aborted due to warnings. Run `serverpod create-migration '
+        '--force` to create it anyway.',
+      );
+    case CreateMigrationFailed(:final message):
+      throw Exception(message);
+  }
+}
+
+/// Runs `create-migration` for the MCP `create_migration` tool. Returns a
+/// structured result so the MCP server can flag errors.
+Future<CreateMigrationMcpResult> _createMigrationForMcp(
+  GeneratorConfig config, {
+  String? tag,
+  bool force = false,
+}) async {
+  final outcome = await createMigrationAction(
+    config: config,
+    tag: tag,
+    force: force,
+  );
+  return switch (outcome) {
+    CreateMigrationCreated(:final versionName, :final migrationDirectory) =>
+      CreateMigrationMcpResult(
+        message:
+            'Migration "$versionName" created at $migrationDirectory. '
+            'Call `apply_migrations` to run it against the database.',
+      ),
+    CreateMigrationNoChanges() => const CreateMigrationMcpResult(
+      message: 'No schema changes detected; no migration created.',
+    ),
+    CreateMigrationAborted() => const CreateMigrationMcpResult(
+      message:
+          'Migration aborted due to warnings. Call again with `force: true` '
+          'to create it anyway.',
+      isError: true,
+    ),
+    CreateMigrationFailed(:final message) => CreateMigrationMcpResult(
+      message: message,
+      isError: true,
+    ),
+  };
 }

--- a/tools/serverpod_cli/lib/src/commands/start.dart
+++ b/tools/serverpod_cli/lib/src/commands/start.dart
@@ -5,7 +5,7 @@ import 'dart:io';
 import 'package:args/args.dart';
 import 'package:cli_tools/cli_tools.dart';
 import 'package:config/config.dart';
-import 'package:nocterm/nocterm.dart' as nocterm;
+import 'package:nocterm/nocterm.dart';
 import 'package:path/path.dart' as p;
 import 'package:serverpod_cli/analyzer.dart';
 import 'package:serverpod_cli/src/commands/generate.dart';
@@ -633,14 +633,21 @@ Future<int> _runWithTui({
   }
 
   // Block on the TUI.
-  await nocterm.runApp(
-    nocterm.NoctermApp(
-      theme: nocterm.TuiThemeData.dark.copyWith(
-        background: nocterm.Color.defaultColor,
-      ),
-      child: ServerpodWatchApp(
-        holder: holder,
-        onReady: onReady,
+  await runApp(
+    NoctermApp(
+      child: Builder(
+        builder: (context) {
+          var themeData = TuiTheme.of(context);
+          return TuiTheme(
+            data: themeData.copyWith(
+              background: Color.defaultColor,
+            ),
+            child: ServerpodWatchApp(
+              holder: holder,
+              onReady: onReady,
+            ),
+          );
+        },
       ),
     ),
   );
@@ -712,7 +719,7 @@ Future<void> _runTuiBackend({
         log.error('Code generation failed.');
         await (await analyzersFuture).close();
         onExitCode(1);
-        nocterm.shutdownApp(1);
+        shutdownApp(1);
         return;
       }
     }
@@ -732,7 +739,7 @@ Future<void> _runTuiBackend({
       await compiler.dispose();
       log.error('Initial compilation failed.');
       onExitCode(1);
-      nocterm.shutdownApp(1);
+      shutdownApp(1);
       return;
     }
 
@@ -852,7 +859,7 @@ Future<void> _runTuiBackend({
       if (startedDocker) {
         await _stopDockerServices(serverDir);
       }
-      nocterm.shutdownApp(0);
+      shutdownApp(0);
     };
     holder.onHotReload = () {
       runTrackedAction(holder, 'Hot reload', session.forceReload);

--- a/tools/serverpod_cli/lib/src/commands/start/mcp_server.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/mcp_server.dart
@@ -13,6 +13,9 @@ base class ServerpodMcpServer extends MCPServer with ToolsSupport {
   /// Callback to apply pending database migrations.
   Future<void> Function()? onApplyMigration;
 
+  /// Callback to recompile and hot-reload the running server isolate.
+  Future<void> Function()? onHotReload;
+
   /// Returns the current log history snapshot.
   List<Object> Function()? getLogHistory;
 
@@ -27,6 +30,7 @@ base class ServerpodMcpServer extends MCPServer with ToolsSupport {
             '`serverpod start --watch`.',
       ) {
     registerTool(_applyMigrationsTool, _applyMigrations);
+    registerTool(_hotReloadTool, _hotReload);
     registerTool(_tailLogsTool, _tailLogs);
   }
 
@@ -62,6 +66,35 @@ base class ServerpodMcpServer extends MCPServer with ToolsSupport {
     } catch (e) {
       return CallToolResult(
         content: [TextContent(text: 'Failed to apply migrations: $e')],
+        isError: true,
+      );
+    }
+  }
+
+  static final _hotReloadTool = Tool(
+    name: 'hot_reload',
+    description:
+        'Recompile the server kernel and hot-reload the running isolate. '
+        'Falls back to a full restart if reload is not possible.',
+    inputSchema: Schema.object(),
+  );
+
+  Future<CallToolResult> _hotReload(CallToolRequest request) async {
+    final callback = onHotReload;
+    if (callback == null) {
+      return CallToolResult(
+        content: [TextContent(text: 'Watch session not connected.')],
+        isError: true,
+      );
+    }
+    try {
+      await callback();
+      return CallToolResult(
+        content: [TextContent(text: 'Hot reload completed.')],
+      );
+    } catch (e) {
+      return CallToolResult(
+        content: [TextContent(text: 'Hot reload failed: $e')],
         isError: true,
       );
     }

--- a/tools/serverpod_cli/lib/src/commands/start/mcp_server.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/mcp_server.dart
@@ -1,5 +1,9 @@
+import 'dart:convert';
+
 import 'package:dart_mcp/server.dart';
+import 'package:serverpod_cli/src/commands/start/tui/state.dart';
 import 'package:serverpod_cli/src/generated/version.dart';
+import 'package:serverpod_shared/log.dart';
 
 /// MCP server that exposes serverpod dev tools.
 ///
@@ -8,6 +12,9 @@ import 'package:serverpod_cli/src/generated/version.dart';
 base class ServerpodMcpServer extends MCPServer with ToolsSupport {
   /// Callback to apply pending database migrations.
   Future<void> Function()? onApplyMigration;
+
+  /// Returns the current log history snapshot.
+  List<Object> Function()? getLogHistory;
 
   ServerpodMcpServer(super.channel)
     : super.fromStreamChannel(
@@ -20,6 +27,7 @@ base class ServerpodMcpServer extends MCPServer with ToolsSupport {
             '`serverpod start --watch`.',
       ) {
     registerTool(_applyMigrationsTool, _applyMigrations);
+    registerTool(_tailLogsTool, _tailLogs);
   }
 
   static final _applyMigrationsTool = Tool(
@@ -58,4 +66,70 @@ base class ServerpodMcpServer extends MCPServer with ToolsSupport {
       );
     }
   }
+
+  static final _tailLogsTool = Tool(
+    name: 'tail_logs',
+    description:
+        'Return recent log entries from the running watch session '
+        '(structured log entries plus completed operations). Newest last.',
+    inputSchema: Schema.object(
+      properties: {
+        'limit': Schema.int(
+          description: 'Max entries to return (default 200, max 10000).',
+          minimum: 1,
+          maximum: 10000,
+        ),
+      },
+    ),
+  );
+
+  Future<CallToolResult> _tailLogs(CallToolRequest request) async {
+    final get = getLogHistory;
+    if (get == null) {
+      return CallToolResult(
+        content: [TextContent(text: 'Log history not available.')],
+        isError: true,
+      );
+    }
+    final limitArg = request.arguments?['limit'];
+    final limit = switch (limitArg) {
+      int v => v.clamp(1, 10000),
+      _ => 200,
+    };
+    final all = get();
+    final tail = all.length <= limit ? all : all.sublist(all.length - limit);
+    final encoded = tail.map(_encodeLogHistoryItem).toList();
+    return CallToolResult(
+      content: [
+        TextContent(
+          text: jsonEncode(encoded, toEncodable: (o) => o.toString()),
+        ),
+      ],
+    );
+  }
+}
+
+Map<String, Object?> _encodeLogHistoryItem(Object item) {
+  if (item is LogEntry) {
+    return {
+      'type': 'log',
+      'time': item.time.toIso8601String(),
+      'level': item.level.name,
+      'message': item.message,
+      'scope': {'id': item.scope.id, 'label': item.scope.label},
+      if (item.error != null) 'error': item.error.toString(),
+      if (item.stackTrace != null) 'stackTrace': item.stackTrace.toString(),
+      if (item.metadata != null) 'metadata': item.metadata,
+    };
+  }
+  if (item is CompletedOperation) {
+    return {
+      'type': 'operation',
+      'label': item.label,
+      'success': item.success,
+      'durationMs': item.duration.inMilliseconds,
+      'completedAt': item.completedAt.toIso8601String(),
+    };
+  }
+  return {'type': 'unknown', 'value': item.toString()};
 }

--- a/tools/serverpod_cli/lib/src/commands/start/mcp_server.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/mcp_server.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:dart_mcp/server.dart';
@@ -9,7 +10,8 @@ import 'package:serverpod_shared/log.dart';
 ///
 /// Runs inside the CLI process during watch mode, letting AI agents trigger
 /// operations that require explicit intent (like applying migrations).
-base class ServerpodMcpServer extends MCPServer with ToolsSupport {
+base class ServerpodMcpServer extends MCPServer
+    with ToolsSupport, ResourcesSupport {
   /// Callback to apply pending database migrations.
   Future<void> Function()? onApplyMigration;
 
@@ -18,6 +20,11 @@ base class ServerpodMcpServer extends MCPServer with ToolsSupport {
 
   /// Returns the current log history snapshot.
   List<Object> Function()? getLogHistory;
+
+  /// Returns the current HTTP VM service URI, or `null` if not yet available.
+  String? Function()? getVmServiceUri;
+
+  StreamSubscription<void>? _vmServiceUriSub;
 
   ServerpodMcpServer(super.channel)
     : super.fromStreamChannel(
@@ -32,6 +39,25 @@ base class ServerpodMcpServer extends MCPServer with ToolsSupport {
     registerTool(_applyMigrationsTool, _applyMigrations);
     registerTool(_hotReloadTool, _hotReload);
     registerTool(_tailLogsTool, _tailLogs);
+
+    addResource(_vmServiceResource, _readVmService);
+  }
+
+  /// Wires a stream whose events signal that the VM service URI has changed.
+  /// Each event triggers a resource-updated notification for
+  /// `serverpod://vm-service`.
+  set vmServiceUriChanges(Stream<void>? stream) {
+    _vmServiceUriSub?.cancel();
+    _vmServiceUriSub = stream?.listen((_) {
+      if (ready) updateResource(_vmServiceResource);
+    });
+  }
+
+  @override
+  Future<void> shutdown() async {
+    await _vmServiceUriSub?.cancel();
+    _vmServiceUriSub = null;
+    await super.shutdown();
   }
 
   static final _applyMigrationsTool = Tool(
@@ -69,6 +95,28 @@ base class ServerpodMcpServer extends MCPServer with ToolsSupport {
         isError: true,
       );
     }
+  }
+
+  static final _vmServiceResource = Resource(
+    uri: 'serverpod://vm-service',
+    name: 'VM service',
+    description:
+        'Dart VM service HTTP URI for the running server isolate. Stable '
+        'across hot reloads; changes on restart (apply_migrations, crash '
+        'recovery). Subscribe to be notified when the URI changes.',
+    mimeType: 'application/json',
+  );
+
+  ReadResourceResult _readVmService(ReadResourceRequest request) {
+    final uri = getVmServiceUri?.call();
+    return ReadResourceResult(
+      contents: [
+        TextResourceContents(
+          uri: request.uri,
+          text: jsonEncode({'uri': uri}),
+        ),
+      ],
+    );
   }
 
   static final _hotReloadTool = Tool(

--- a/tools/serverpod_cli/lib/src/commands/start/mcp_server.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/mcp_server.dart
@@ -6,6 +6,18 @@ import 'package:serverpod_cli/src/commands/start/tui/state.dart';
 import 'package:serverpod_cli/src/generated/version.dart';
 import 'package:serverpod_shared/log.dart';
 
+/// Result of a `create_migration` MCP call. [message] is returned to the
+/// caller verbatim; [isError] marks the tool result as an error.
+class CreateMigrationMcpResult {
+  const CreateMigrationMcpResult({
+    required this.message,
+    this.isError = false,
+  });
+
+  final String message;
+  final bool isError;
+}
+
 /// MCP server that exposes serverpod dev tools.
 ///
 /// Runs inside the CLI process during watch mode, letting AI agents trigger
@@ -14,6 +26,11 @@ base class ServerpodMcpServer extends MCPServer
     with ToolsSupport, ResourcesSupport {
   /// Callback to apply pending database migrations.
   Future<void> Function()? onApplyMigration;
+
+  /// Callback to create a new migration from the current model definitions.
+  /// Returns a human-readable status message describing the outcome.
+  Future<CreateMigrationMcpResult> Function({String? tag, bool force})?
+  onCreateMigration;
 
   /// Callback to recompile and hot-reload the running server isolate.
   Future<void> Function()? onHotReload;
@@ -37,6 +54,7 @@ base class ServerpodMcpServer extends MCPServer
             '`serverpod start --watch`.',
       ) {
     registerTool(_applyMigrationsTool, _applyMigrations);
+    registerTool(_createMigrationTool, _createMigration);
     registerTool(_hotReloadTool, _hotReload);
     registerTool(_tailLogsTool, _tailLogs);
 
@@ -64,8 +82,8 @@ base class ServerpodMcpServer extends MCPServer
     name: 'apply_migrations',
     description:
         'Apply pending database migrations. The server restarts with '
-        '`--apply-migrations`. Call after creating a migration with '
-        '`serverpod create-migration`.',
+        '`--apply-migrations`. Call after `create_migration` (or '
+        '`serverpod create-migration`) has written the migration files.',
     inputSchema: Schema.object(),
   );
 
@@ -92,6 +110,55 @@ base class ServerpodMcpServer extends MCPServer
     } catch (e) {
       return CallToolResult(
         content: [TextContent(text: 'Failed to apply migrations: $e')],
+        isError: true,
+      );
+    }
+  }
+
+  static final _createMigrationTool = Tool(
+    name: 'create_migration',
+    description:
+        'Create a new database migration from the current model definitions. '
+        'Writes the migration files to disk; does not restart the server or '
+        'apply the migration. Follow up with `apply_migrations` to run it '
+        'against the database.',
+    inputSchema: Schema.object(
+      properties: {
+        'tag': Schema.string(
+          description: 'Optional tag appended to the migration version name.',
+        ),
+        'force': Schema.bool(
+          description:
+              'Create the migration even if warnings are present (data may '
+              'be destroyed).',
+        ),
+      },
+    ),
+  );
+
+  Future<CallToolResult> _createMigration(CallToolRequest request) async {
+    final callback = onCreateMigration;
+    if (callback == null) {
+      return CallToolResult(
+        content: [TextContent(text: 'Watch session not connected.')],
+        isError: true,
+      );
+    }
+
+    final tagArg = request.arguments?['tag'];
+    final forceArg = request.arguments?['force'];
+    final tag = tagArg is String && tagArg.isNotEmpty ? tagArg : null;
+    final force = forceArg is bool ? forceArg : false;
+
+    try {
+      final result = await callback(tag: tag, force: force);
+      return CallToolResult(
+        content: [TextContent(text: result.message)],
+        isError: result.isError ? true : null,
+      );
+    } catch (e) {
+      return CallToolResult(
+        content: [TextContent(text: 'Failed to create migration: $e')],
         isError: true,
       );
     }

--- a/tools/serverpod_cli/lib/src/commands/start/mcp_socket.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/mcp_socket.dart
@@ -27,6 +27,8 @@ class McpSocketServer {
 
   /// Callbacks wired once via [connect].
   Future<void> Function()? _onApplyMigration;
+  Future<CreateMigrationMcpResult> Function({String? tag, bool force})?
+  _onCreateMigration;
   Future<void> Function()? _onHotReload;
   List<Object> Function()? _getLogHistory;
   String? Function()? _getVmServiceUri;
@@ -50,12 +52,15 @@ class McpSocketServer {
   /// after a client connects.
   void connect({
     required Future<void> Function() onApplyMigration,
+    Future<CreateMigrationMcpResult> Function({String? tag, bool force})?
+    onCreateMigration,
     Future<void> Function()? onHotReload,
     List<Object> Function()? getLogHistory,
     String? Function()? getVmServiceUri,
     Stream<void>? vmServiceUriChanges,
   }) {
     _onApplyMigration = onApplyMigration;
+    _onCreateMigration = onCreateMigration;
     _onHotReload = onHotReload;
     _getLogHistory = getLogHistory;
     _getVmServiceUri = getVmServiceUri;
@@ -63,6 +68,7 @@ class McpSocketServer {
     final server = _mcpServer;
     if (server != null) {
       server.onApplyMigration = onApplyMigration;
+      server.onCreateMigration = onCreateMigration;
       server.onHotReload = onHotReload;
       server.getLogHistory = getLogHistory;
       server.getVmServiceUri = getVmServiceUri;
@@ -117,6 +123,7 @@ class McpSocketServer {
 
     // Wire callbacks if already connected.
     server.onApplyMigration = _onApplyMigration;
+    server.onCreateMigration = _onCreateMigration;
     server.onHotReload = _onHotReload;
     server.getLogHistory = _getLogHistory;
     server.getVmServiceUri = _getVmServiceUri;

--- a/tools/serverpod_cli/lib/src/commands/start/mcp_socket.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/mcp_socket.dart
@@ -1,20 +1,24 @@
 import 'dart:async';
-import 'dart:convert';
 import 'dart:io';
 
+import 'package:serverpod_cli/src/mcp/socket_directory.dart';
 import 'package:serverpod_cli/src/util/platform_check.dart';
-import 'package:stream_channel/stream_channel.dart';
 
 import 'mcp_server.dart';
 
 /// Manages a Unix socket that accepts MCP client connections.
 ///
-/// The CLI process listens on a socket file (typically
-/// `.dart_tool/serverpod/mcp.sock`). Clients connect to interact with the
-/// running dev environment via JSON-RPC (MCP protocol). Only one client
-/// connection is active at a time.
+/// Each `serverpod start --watch` process listens on
+/// `<systemTemp>/serverpod/serverpod-<pid>-<project>.sock`. Clients connect
+/// to interact with the running dev environment via JSON-RPC (MCP protocol).
+/// Only one client connection is active at a time.
 class McpSocketServer {
+  /// Sanitized project name embedded in the socket filename.
+  final String project;
+
+  /// Absolute path to this server's socket file.
   final String socketPath;
+
   ServerSocket? _serverSocket;
   Socket? _clientSocket;
   ServerpodMcpServer? _mcpServer;
@@ -24,10 +28,16 @@ class McpSocketServer {
   /// Callback wired once via [connect].
   Future<void> Function()? _onApplyMigration;
 
-  McpSocketServer({required this.socketPath});
+  McpSocketServer({required String project})
+    : project = sanitizeProjectName(project),
+      socketPath = serverpodMcpSocketPath(
+        pid: pid,
+        project: project,
+      );
 
   /// Start listening for connections.
   Future<void> start() async {
+    ensureServerpodMcpSocketDir();
     _serverSocket = await bindUnixSocket(socketPath);
     _serverSocket!.listen(_handleConnection);
   }
@@ -82,7 +92,7 @@ class McpSocketServer {
     _clientSocket?.destroy();
     _clientSocket = socket;
 
-    final channel = _socketChannel(socket);
+    final channel = socketChannel(socket);
     final server = ServerpodMcpServer(channel);
     _mcpServer = server;
 
@@ -101,22 +111,4 @@ class McpSocketServer {
       }),
     );
   }
-}
-
-/// Create a [StreamChannel<String>] from a [Socket] for MCP JSON-RPC.
-///
-/// Same line-delimited protocol as stdio transport.
-StreamChannel<String> _socketChannel(Socket socket) {
-  final inStream = socket
-      .cast<List<int>>()
-      .transform(utf8.decoder)
-      .transform(const LineSplitter());
-
-  final outController = StreamController<String>();
-  outController.stream.listen(
-    (line) => socket.write('$line\n'),
-    onDone: () => socket.close(),
-  );
-
-  return StreamChannel<String>(inStream, outController.sink);
 }

--- a/tools/serverpod_cli/lib/src/commands/start/mcp_socket.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/mcp_socket.dart
@@ -25,8 +25,9 @@ class McpSocketServer {
   Future<void>? _pendingShutdown;
   bool _closing = false;
 
-  /// Callback wired once via [connect].
+  /// Callbacks wired once via [connect].
   Future<void> Function()? _onApplyMigration;
+  List<Object> Function()? _getLogHistory;
 
   McpSocketServer({required String project})
     : project = sanitizeProjectName(project),
@@ -46,9 +47,15 @@ class McpSocketServer {
   /// after a client connects.
   void connect({
     required Future<void> Function() onApplyMigration,
+    List<Object> Function()? getLogHistory,
   }) {
     _onApplyMigration = onApplyMigration;
-    _mcpServer?.onApplyMigration = onApplyMigration;
+    _getLogHistory = getLogHistory;
+    final server = _mcpServer;
+    if (server != null) {
+      server.onApplyMigration = onApplyMigration;
+      server.getLogHistory = getLogHistory;
+    }
   }
 
   /// Shut down the socket server and clean up.
@@ -96,10 +103,9 @@ class McpSocketServer {
     final server = ServerpodMcpServer(channel);
     _mcpServer = server;
 
-    // Wire callback if already connected.
-    if (_onApplyMigration != null) {
-      server.onApplyMigration = _onApplyMigration;
-    }
+    // Wire callbacks if already connected.
+    server.onApplyMigration = _onApplyMigration;
+    server.getLogHistory = _getLogHistory;
 
     // Clean up on disconnect.
     unawaited(

--- a/tools/serverpod_cli/lib/src/commands/start/mcp_socket.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/mcp_socket.dart
@@ -29,6 +29,8 @@ class McpSocketServer {
   Future<void> Function()? _onApplyMigration;
   Future<void> Function()? _onHotReload;
   List<Object> Function()? _getLogHistory;
+  String? Function()? _getVmServiceUri;
+  Stream<void>? _vmServiceUriChanges;
 
   McpSocketServer({required String project})
     : project = sanitizeProjectName(project),
@@ -50,15 +52,21 @@ class McpSocketServer {
     required Future<void> Function() onApplyMigration,
     Future<void> Function()? onHotReload,
     List<Object> Function()? getLogHistory,
+    String? Function()? getVmServiceUri,
+    Stream<void>? vmServiceUriChanges,
   }) {
     _onApplyMigration = onApplyMigration;
     _onHotReload = onHotReload;
     _getLogHistory = getLogHistory;
+    _getVmServiceUri = getVmServiceUri;
+    _vmServiceUriChanges = vmServiceUriChanges;
     final server = _mcpServer;
     if (server != null) {
       server.onApplyMigration = onApplyMigration;
       server.onHotReload = onHotReload;
       server.getLogHistory = getLogHistory;
+      server.getVmServiceUri = getVmServiceUri;
+      server.vmServiceUriChanges = vmServiceUriChanges;
     }
   }
 
@@ -111,6 +119,8 @@ class McpSocketServer {
     server.onApplyMigration = _onApplyMigration;
     server.onHotReload = _onHotReload;
     server.getLogHistory = _getLogHistory;
+    server.getVmServiceUri = _getVmServiceUri;
+    server.vmServiceUriChanges = _vmServiceUriChanges;
 
     // Clean up on disconnect.
     unawaited(

--- a/tools/serverpod_cli/lib/src/commands/start/mcp_socket.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/mcp_socket.dart
@@ -27,6 +27,7 @@ class McpSocketServer {
 
   /// Callbacks wired once via [connect].
   Future<void> Function()? _onApplyMigration;
+  Future<void> Function()? _onHotReload;
   List<Object> Function()? _getLogHistory;
 
   McpSocketServer({required String project})
@@ -47,13 +48,16 @@ class McpSocketServer {
   /// after a client connects.
   void connect({
     required Future<void> Function() onApplyMigration,
+    Future<void> Function()? onHotReload,
     List<Object> Function()? getLogHistory,
   }) {
     _onApplyMigration = onApplyMigration;
+    _onHotReload = onHotReload;
     _getLogHistory = getLogHistory;
     final server = _mcpServer;
     if (server != null) {
       server.onApplyMigration = onApplyMigration;
+      server.onHotReload = onHotReload;
       server.getLogHistory = getLogHistory;
     }
   }
@@ -105,6 +109,7 @@ class McpSocketServer {
 
     // Wire callbacks if already connected.
     server.onApplyMigration = _onApplyMigration;
+    server.onHotReload = _onHotReload;
     server.getLogHistory = _getLogHistory;
 
     // Clean up on disconnect.

--- a/tools/serverpod_cli/lib/src/commands/start/server_process.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/server_process.dart
@@ -52,7 +52,13 @@ class ServerProcess {
   VmService? _vmService;
   String? _mainIsolateId;
 
+  /// The HTTP VM service URI, set once [connectToVmService] has read it from
+  /// the service info file. `null` before the child has published it (or if
+  /// publication failed).
+  String? _vmServiceUri;
+
   final Completer<int> _exitCodeCompleter = Completer<int>();
+  final Completer<void> _vmServiceReady = Completer<void>();
 
   ServerProcess({
     required String serverDir,
@@ -80,6 +86,13 @@ class ServerProcess {
 
   /// The VM service connection, if connected.
   VmService? get vmService => _vmService;
+
+  /// The HTTP VM service URI for this process, or `null` if not yet available.
+  String? get vmServiceUri => _vmServiceUri;
+
+  /// Completes after [connectToVmService] successfully reads the VM service
+  /// URI and connects. Never completes if the URI never resolves.
+  Future<void> get vmServiceReady => _vmServiceReady.future;
 
   /// Completes with the process exit code when the server exits.
   Future<int> get exitCode => _exitCodeCompleter.future;
@@ -170,6 +183,7 @@ class ServerProcess {
       log.warning('VM service URI not found in service info file.');
       return;
     }
+    _vmServiceUri = httpUri;
 
     // The VM service may not be fully ready immediately after printing
     // its URI. Retry a few times with a short delay.
@@ -193,6 +207,8 @@ class ServerProcess {
     final vmService = _vmService!;
     final vm = await vmService.getVM();
     _mainIsolateId = vm.isolates!.first.id!;
+
+    if (!_vmServiceReady.isCompleted) _vmServiceReady.complete();
 
     // Register custom reloadSources service so IDE reload requests
     // go through the FES compilation pipeline.

--- a/tools/serverpod_cli/lib/src/commands/start/tui/app.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/tui/app.dart
@@ -3,7 +3,6 @@ import 'dart:async';
 import 'package:nocterm/nocterm.dart';
 
 import 'main_screen.dart';
-import 'serverpod_theme.dart';
 import 'state.dart';
 
 /// Provides access to the shared [ServerWatchState] and a way to trigger
@@ -123,29 +122,26 @@ class ServerpodWatchAppState extends State<ServerpodWatchApp> {
   Component build(BuildContext context) {
     final state = component.holder.state;
 
-    return ServerpodTheme(
-      data: ServerpodThemeData.dark,
-      child: Focusable(
-        focused: true,
-        onKeyEvent: _handleKeyEvent,
-        child: MainScreen(
-          state: state,
-          showSplash: state.showSplash,
-          logScrollController: logScrollController,
-          rawScrollController: rawScrollController,
-          onToggleHelp: () {
-            state.showHelp = !state.showHelp;
-            _rebuild();
-          },
-          onTabChanged: (index) {
-            state.selectedTab = index;
-            _rebuild();
-          },
-          onHotReload: onHotReload,
-          onCreateMigration: onCreateMigration,
-          onApplyMigration: onApplyMigration,
-          onQuit: onQuit,
-        ),
+    return Focusable(
+      focused: true,
+      onKeyEvent: _handleKeyEvent,
+      child: MainScreen(
+        state: state,
+        showSplash: state.showSplash,
+        logScrollController: logScrollController,
+        rawScrollController: rawScrollController,
+        onToggleHelp: () {
+          state.showHelp = !state.showHelp;
+          _rebuild();
+        },
+        onTabChanged: (index) {
+          state.selectedTab = index;
+          _rebuild();
+        },
+        onHotReload: onHotReload,
+        onCreateMigration: onCreateMigration,
+        onApplyMigration: onApplyMigration,
+        onQuit: onQuit,
       ),
     );
   }

--- a/tools/serverpod_cli/lib/src/commands/start/tui/app.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/tui/app.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:nocterm/nocterm.dart';
+import 'package:stream_transform/stream_transform.dart';
 
 import 'main_screen.dart';
 import 'state.dart';
@@ -12,7 +13,20 @@ import 'state.dart';
 /// a rebuild. This avoids proxying every mutation method and survives
 /// `NoctermApp` rebuilds that recreate the widget state.
 class AppStateHolder {
-  AppStateHolder(this.state);
+  AppStateHolder(this.state) {
+    _dirtySub = _dirtyController.stream
+        .throttle(_rebuildInterval, trailing: true)
+        .listen((_) => _widgetState?._rebuild());
+  }
+
+  /// Throttle window for [markDirty]. A trickle of log events from an
+  /// idle `--verbose` pod (health checks, session logs, VM extension
+  /// events) would otherwise drive one `setState` per event and
+  /// consume a full CPU core. `trailing: true` means the first mark
+  /// in a window renders immediately (keypresses stay responsive),
+  /// and any further marks inside the window coalesce into a single
+  /// trailing rebuild so the final state is never missed.
+  static const _rebuildInterval = Duration(milliseconds: 33);
 
   final ServerWatchState state;
   ServerpodWatchAppState? _widgetState;
@@ -20,6 +34,9 @@ class AppStateHolder {
   VoidCallback? _onCreateMigration;
   VoidCallback? _onApplyMigration;
   VoidCallback? _onQuit;
+
+  final StreamController<void> _dirtyController = StreamController<void>();
+  late final StreamSubscription<void> _dirtySub;
 
   void _attach(ServerpodWatchAppState s) {
     _widgetState = s;
@@ -33,8 +50,17 @@ class AppStateHolder {
     if (_widgetState == s) _widgetState = null;
   }
 
-  /// Trigger a rebuild on the currently mounted state.
-  void markDirty() => _widgetState?._rebuild();
+  /// Schedule a rebuild on the currently mounted state. Coalesced
+  /// via a throttled stream; see [_rebuildInterval].
+  void markDirty() => _dirtyController.add(null);
+
+  /// Releases the dirty-event stream. The holder typically lives for
+  /// the process lifetime, but tests that construct it directly
+  /// should call this so the subscription doesn't outlive the test.
+  Future<void> dispose() async {
+    await _dirtySub.cancel();
+    await _dirtyController.close();
+  }
 
   set onHotReload(VoidCallback? cb) {
     _onHotReload = cb;

--- a/tools/serverpod_cli/lib/src/commands/start/tui/app.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/tui/app.dart
@@ -4,6 +4,7 @@ import 'package:nocterm/nocterm.dart';
 import 'package:stream_transform/stream_transform.dart';
 
 import 'main_screen.dart';
+import 'spinner.dart';
 import 'state.dart';
 
 /// Provides access to the shared [ServerWatchState] and a way to trigger
@@ -26,7 +27,12 @@ class AppStateHolder {
   /// in a window renders immediately (keypresses stay responsive),
   /// and any further marks inside the window coalesce into a single
   /// trailing rebuild so the final state is never missed.
-  static const _rebuildInterval = Duration(milliseconds: 33);
+  ///
+  /// 80ms matches the spinner tick cadence - faster rebuilds aren't
+  /// perceptible since the spinner is the fastest-moving element on
+  /// screen. At ~7ms/frame (layout+paint dominated), 12.5 FPS keeps
+  /// the CPU floor around ~9% vs ~21% at 30 FPS.
+  static const _rebuildInterval = Duration(milliseconds: 80);
 
   final ServerWatchState state;
   ServerpodWatchAppState? _widgetState;
@@ -148,26 +154,29 @@ class ServerpodWatchAppState extends State<ServerpodWatchApp> {
   Component build(BuildContext context) {
     final state = component.holder.state;
 
-    return Focusable(
-      focused: true,
-      onKeyEvent: _handleKeyEvent,
-      child: MainScreen(
-        state: state,
-        showSplash: state.showSplash,
-        logScrollController: logScrollController,
-        rawScrollController: rawScrollController,
-        onToggleHelp: () {
-          state.showHelp = !state.showHelp;
-          _rebuild();
-        },
-        onTabChanged: (index) {
-          state.selectedTab = index;
-          _rebuild();
-        },
-        onHotReload: onHotReload,
-        onCreateMigration: onCreateMigration,
-        onApplyMigration: onApplyMigration,
-        onQuit: onQuit,
+    return SpinnerScope(
+      active: state.activeOperations.isNotEmpty,
+      child: Focusable(
+        focused: true,
+        onKeyEvent: _handleKeyEvent,
+        child: MainScreen(
+          state: state,
+          showSplash: state.showSplash,
+          logScrollController: logScrollController,
+          rawScrollController: rawScrollController,
+          onToggleHelp: () {
+            state.showHelp = !state.showHelp;
+            _rebuild();
+          },
+          onTabChanged: (index) {
+            state.selectedTab = index;
+            _rebuild();
+          },
+          onHotReload: onHotReload,
+          onCreateMigration: onCreateMigration,
+          onApplyMigration: onApplyMigration,
+          onQuit: onQuit,
+        ),
       ),
     );
   }

--- a/tools/serverpod_cli/lib/src/commands/start/tui/components.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/tui/components.dart
@@ -1,11 +1,10 @@
-import 'dart:async';
-
 import 'package:intl/intl.dart';
 import 'package:nocterm/nocterm.dart' hide LogEntry;
 import 'package:serverpod_shared/log.dart';
 
 import 'format_duration.dart';
 import 'serverpod_theme.dart';
+import 'spinner.dart';
 import 'state.dart';
 
 // -- BorderedBox --
@@ -206,46 +205,26 @@ class CompletedOperationWidget extends StatelessComponent {
 // -- TrackedOperationWidget --
 
 /// Renders an active tracked operation with spinner.
-class TrackedOperationWidget extends StatefulComponent {
+///
+/// The spinner frame is driven by a shared [SpinnerScope] higher in the
+/// tree, so any number of concurrent tracked operations share a single
+/// animation controller - one 80ms tick for all of them.
+class TrackedOperationWidget extends StatelessComponent {
   const TrackedOperationWidget({super.key, required this.operation});
 
   final TrackedOperation operation;
 
   @override
-  State<TrackedOperationWidget> createState() => _TrackedOperationWidgetState();
-}
-
-class _TrackedOperationWidgetState extends State<TrackedOperationWidget> {
-  static const _spinnerFrames = '⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏';
-
-  late Timer _timer;
-  int _frameIndex = 0;
-
-  @override
-  void initState() {
-    super.initState();
-    _timer = Timer.periodic(const Duration(milliseconds: 80), (_) {
-      setState(() => _frameIndex++);
-    });
-  }
-
-  @override
-  void dispose() {
-    _timer.cancel();
-    super.dispose();
-  }
-
-  @override
   Component build(BuildContext context) {
     final st = ServerpodTheme.of(context);
-    final op = component.operation;
-    final frame = _spinnerFrames[_frameIndex % _spinnerFrames.length];
 
     return Row(
       children: [
-        Text('  $frame  ', style: TextStyle(color: st.spinner)),
+        const Text('  '),
+        SpinnerIcon(color: st.spinner),
+        const Text('  '),
         const SizedBox(width: 14),
-        Expanded(child: Text('${op.label}...')),
+        Expanded(child: Text('${operation.label}...')),
       ],
     );
   }

--- a/tools/serverpod_cli/lib/src/commands/start/tui/loading_screen.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/tui/loading_screen.dart
@@ -53,6 +53,16 @@ class _LoadingScreenState extends State<LoadingScreen> {
     });
   }
 
+  // Approximate size of the fancy splash content (excluding padding).
+  // "Serverpod" in AsciiFont.standard is ~90 cols wide and 5 rows tall;
+  // subtitle adds 1 spacer + 1 row. Logo (when present) is 12x8.
+  static const int _asciiWidth = 90;
+  static const int _asciiHeight = 7;
+  static const int _logoWidth = 14;
+  static const int _logoHeight = 8;
+  // Breathing room around the splash (outer border + some space).
+  static const int _chromeMargin = 6;
+
   @override
   Component build(BuildContext context) {
     if (_step <= 0 && _fadingOut) return const SizedBox.shrink();
@@ -60,12 +70,56 @@ class _LoadingScreenState extends State<LoadingScreen> {
     final t = _step / _steps;
     final baseColor = Color.lerp(Color.defaultColor, Colors.brightWhite, t)!;
     final highlightColor = Color.lerp(Color.defaultColor, Colors.cyan, t)!;
+    // The splash artwork is designed for dark backgrounds; on light terminals,
+    // pad the whole splash on black so the logo and text stay legible.
+    final isLight = TuiTheme.maybeOf(context)?.brightness == Brightness.light;
 
-    return Center(
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        crossAxisAlignment: CrossAxisAlignment.center,
-        children: [
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final hasLogo = _imageProtocol != null;
+        final neededWidth =
+            _asciiWidth + (hasLogo ? _logoWidth : 0) + _chromeMargin;
+        final neededHeight =
+            (hasLogo ? _logoHeight : _asciiHeight) + _chromeMargin;
+        final fits =
+            constraints.maxWidth >= neededWidth &&
+            constraints.maxHeight >= neededHeight;
+
+        final splash = fits
+            ? _buildFancySplash(
+                t: t,
+                baseColor: baseColor,
+                highlightColor: highlightColor,
+              )
+            : _buildPlainSplash(
+                t: t,
+                baseColor: baseColor,
+                highlightColor: highlightColor,
+              );
+
+        return Center(
+          child: Container(
+            color: isLight ? Colors.black.withOpacity(0.85) : null,
+            padding: isLight
+                ? const EdgeInsets.symmetric(horizontal: 2, vertical: 1)
+                : null,
+            child: splash,
+          ),
+        );
+      },
+    );
+  }
+
+  Component _buildFancySplash({
+    required double t,
+    required Color baseColor,
+    required Color highlightColor,
+  }) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: [
+        if (_imageProtocol != null) ...[
           SizedBox(
             width: 12,
             height: 8,
@@ -77,25 +131,47 @@ class _LoadingScreenState extends State<LoadingScreen> {
             ),
           ),
           const SizedBox(width: 2),
-          Column(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Shimmer(
-                highlightColor: highlightColor,
-                baseColor: baseColor,
-                child: AsciiText(
-                  'Serverpod',
-                  font: AsciiFont.standard,
-                  style: TextStyle(color: baseColor),
-                ),
-              ),
-              const SizedBox(height: 1),
-              _buildSubtitle(t),
-            ],
-          ),
         ],
-      ),
+        Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Shimmer(
+              highlightColor: highlightColor,
+              baseColor: baseColor,
+              child: AsciiText(
+                'Serverpod',
+                font: AsciiFont.standard,
+                style: TextStyle(color: baseColor),
+              ),
+            ),
+            const SizedBox(height: 1),
+            _buildSubtitle(t),
+          ],
+        ),
+      ],
+    );
+  }
+
+  Component _buildPlainSplash({
+    required double t,
+    required Color baseColor,
+    required Color highlightColor,
+  }) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: [
+        Shimmer(
+          highlightColor: highlightColor,
+          baseColor: baseColor,
+          child: Text(
+            'Serverpod',
+            style: TextStyle(color: baseColor, fontWeight: FontWeight.bold),
+          ),
+        ),
+        _buildSubtitle(t),
+      ],
     );
   }
 

--- a/tools/serverpod_cli/lib/src/commands/start/tui/serverpod_theme.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/tui/serverpod_theme.dart
@@ -37,6 +37,28 @@ class ServerpodThemeData {
   /// Trailing divider on completed operations.
   final Color subtleDivider;
 
+  /// Derives a [ServerpodThemeData] from a nocterm [TuiThemeData].
+  ///
+  /// Semantic slots map to the closest [TuiThemeData] role:
+  /// log levels/success/failure use `warning`/`error`/`success`, muted
+  /// elements (debug, divider) use `outline`/`outlineVariant`, and accents
+  /// (active tab, spinner, info) use `primary` while the activation key
+  /// uses `secondary` to stand apart from the active-tab color.
+  factory ServerpodThemeData.fromTuiTheme(TuiThemeData theme) {
+    return ServerpodThemeData(
+      activationKey: theme.secondary,
+      activeTab: theme.primary,
+      spinner: theme.primary,
+      debugLevel: theme.outline,
+      infoLevel: theme.primary,
+      warningLevel: theme.warning,
+      errorLevel: theme.error,
+      success: theme.success,
+      failure: theme.error,
+      subtleDivider: theme.outlineVariant,
+    );
+  }
+
   /// Default dark theme.
   static const dark = ServerpodThemeData(
     activationKey: Colors.magenta,
@@ -65,7 +87,10 @@ class ServerpodTheme extends InheritedComponent {
   static ServerpodThemeData of(BuildContext context) {
     final widget = context
         .dependOnInheritedComponentOfExactType<ServerpodTheme>();
-    return widget?.data ?? ServerpodThemeData.dark;
+    if (widget != null) return widget.data;
+    final tuiTheme = TuiTheme.maybeOf(context);
+    if (tuiTheme != null) return ServerpodThemeData.fromTuiTheme(tuiTheme);
+    return ServerpodThemeData.dark;
   }
 
   @override

--- a/tools/serverpod_cli/lib/src/commands/start/tui/spinner.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/tui/spinner.dart
@@ -1,0 +1,201 @@
+// Vendored from tuid (https://github.com/AstroNvim/tuid)
+// SPDX-License-Identifier: BSD-3-Clause
+import 'package:nocterm/nocterm.dart';
+
+/// Notifier that broadcasts animation ticks to listeners.
+///
+/// Used by [SpinnerIcon] for frame changes, and also available to other
+/// widgets (e.g. live duration displays) that want to piggyback on the
+/// same tick without creating their own timers.
+class SpinnerNotifier {
+  String _value;
+  int _tick = 0;
+  final List<VoidCallback> _listeners = [];
+
+  SpinnerNotifier(this._value);
+
+  String get value => _value;
+  int get tick => _tick;
+
+  set value(String newValue) {
+    if (_value != newValue) {
+      _value = newValue;
+      _tick++;
+      for (final listener in _listeners) {
+        listener();
+      }
+    }
+  }
+
+  void addListener(VoidCallback listener) => _listeners.add(listener);
+  void removeListener(VoidCallback listener) => _listeners.remove(listener);
+  void dispose() => _listeners.clear();
+}
+
+/// Provides shared spinner animation state to descendants.
+///
+/// This allows all spinner icons to share a single animation controller,
+/// avoiding the performance overhead of many independent animations.
+/// Other widgets can access the notifier via [SpinnerScope.of] to
+/// piggyback on the same tick.
+class SpinnerScope extends StatefulComponent {
+  final bool active;
+  final List<String> frames;
+  final Duration frameDuration;
+  final Component child;
+
+  const SpinnerScope({
+    this.active = true,
+    this.frames = runningFrames,
+    this.frameDuration = const Duration(milliseconds: 80),
+    required this.child,
+    super.key,
+  });
+
+  /// Returns the [SpinnerNotifier] from the closest ancestor, or null.
+  static SpinnerNotifier? of(BuildContext context) {
+    return _SpinnerInherited.of(context);
+  }
+
+  @override
+  State<SpinnerScope> createState() => _SpinnerScopeState();
+}
+
+class _SpinnerScopeState extends State<SpinnerScope>
+    with SingleTickerProviderStateMixin {
+  late AnimationController _controller;
+  late SpinnerNotifier _notifier;
+  int _frameIndex = 0;
+  double _prevValue = 0.0;
+
+  @override
+  void initState() {
+    super.initState();
+    _notifier = SpinnerNotifier(component.frames[_frameIndex]);
+    _controller = AnimationController(
+      duration: component.frameDuration,
+      vsync: this,
+    )..addListener(_onTick);
+    if (component.active) {
+      _controller.repeat();
+    }
+  }
+
+  // Advance the frame
+  void _onTick() {
+    final current = _controller.value;
+    if (current < _prevValue) {
+      _frameIndex = (_frameIndex + 1) % component.frames.length;
+      _notifier.value = component.frames[_frameIndex];
+    }
+    _prevValue = current;
+  }
+
+  @override
+  void didUpdateComponent(SpinnerScope oldComponent) {
+    super.didUpdateComponent(oldComponent);
+    if (component.active && !_controller.isAnimating) {
+      _prevValue = 0.0;
+      _controller.repeat();
+    } else if (!component.active && _controller.isAnimating) {
+      _controller.stop();
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller.removeListener(_onTick);
+    _controller.dispose();
+    _notifier.dispose();
+    super.dispose();
+  }
+
+  @override
+  Component build(BuildContext context) {
+    return _SpinnerInherited(notifier: _notifier, child: component.child);
+  }
+}
+
+/// Inherited component that provides the spinner notifier.
+class _SpinnerInherited extends InheritedComponent {
+  final SpinnerNotifier notifier;
+
+  const _SpinnerInherited({required this.notifier, required super.child});
+
+  static SpinnerNotifier? of(BuildContext context) {
+    final state = context
+        .dependOnInheritedComponentOfExactType<_SpinnerInherited>();
+    return state?.notifier;
+  }
+
+  @override
+  bool updateShouldNotify(_SpinnerInherited oldComponent) {
+    // Notifier reference never changes, so never trigger inherited rebuild
+    return notifier != oldComponent.notifier;
+  }
+}
+
+/// Braille frames that circle.
+const runningFrames = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
+
+/// Braille frames that fill upward.
+const setupFrames = [' ', '⣀', '⣤', '⣶', '⣿', '⠿', '⠛', '⠉', ' '];
+
+/// Braille frames that fill downward.
+const teardownFrames = [' ', '⠉', '⠛', '⠿', '⣿', '⣶', '⣤', '⣀', ' '];
+
+/// A spinner icon that uses the shared animation from [SpinnerScope].
+///
+/// If no [SpinnerScope] ancestor exists, displays a static '●' character.
+/// When [frames] is provided, maps the shared tick index to the custom
+/// frame sequence instead of using the default rotating braille pattern.
+class SpinnerIcon extends StatefulComponent {
+  final Color? color;
+
+  /// Custom frame sequence. When null, uses the shared SpinnerScope frames.
+  final List<String>? frames;
+
+  const SpinnerIcon({this.color, this.frames, super.key});
+
+  @override
+  State<SpinnerIcon> createState() => _SpinnerIconState();
+}
+
+class _SpinnerIconState extends State<SpinnerIcon> {
+  SpinnerNotifier? _notifier;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final newNotifier = SpinnerScope.of(context);
+    if (newNotifier != _notifier) {
+      _notifier?.removeListener(_onFrameChanged);
+      _notifier = newNotifier;
+      _notifier?.addListener(_onFrameChanged);
+    }
+  }
+
+  void _onFrameChanged() {
+    if (mounted) setState(() {});
+  }
+
+  @override
+  void dispose() {
+    _notifier?.removeListener(_onFrameChanged);
+    super.dispose();
+  }
+
+  @override
+  Component build(BuildContext context) {
+    final notifier = _notifier;
+    final customFrames = component.frames;
+    final String frame;
+    if (customFrames != null && notifier != null) {
+      frame = customFrames[notifier.tick % customFrames.length];
+    } else {
+      frame = notifier?.value ?? '●';
+    }
+    final color = component.color;
+    return Text(frame, style: color != null ? TextStyle(color: color) : null);
+  }
+}

--- a/tools/serverpod_cli/lib/src/commands/start/watch_session.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/watch_session.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io';
 
 import 'package:path/path.dart' as p;
 import 'package:serverpod_cli/src/commands/generate.dart';
@@ -64,11 +65,40 @@ enum SessionState {
 /// When [compiler] is `null` (--no-fes mode), the session still runs code
 /// generation and triggers VM service reloads for static file changes, but
 /// leaves compilation and hot reload to the IDE.
+/// Decides whether a source `.dart` file change may have altered the protocol
+/// (endpoint or future call class). Used by [WatchSession] to skip generation
+/// when the change is in a pure helper file.
+typedef ProtocolChangeClassifier = Future<bool> Function(String path);
+
+/// Default classifier. Reads the file and looks for endpoint / future-call
+/// class declarations.
+///
+/// Conservative: missing files and I/O errors default to `true` so a deleted
+/// endpoint file still triggers regen to drop stale generated code.
+Future<bool> defaultProtocolChangeClassifier(String path) async {
+  try {
+    final file = File(path);
+    if (!await file.exists()) return true;
+    final contents = await file.readAsString();
+    return _endpointOrFutureCallRegex.hasMatch(contents);
+  } catch (_) {
+    return true;
+  }
+}
+
+/// Matches `extends X` where `X` is any `*Endpoint` class or `FutureCall`/
+/// `FutureCall<...>`-shaped base. Covers user-defined bases like
+/// `BaseEndpoint` so subclassing hierarchies still regen correctly.
+final _endpointOrFutureCallRegex = RegExp(
+  r'\bextends\s+(?:\w*Endpoint|FutureCall)\b',
+);
+
 class WatchSession {
   final KernelCompiler? _compiler;
   final GenerateAction _generate;
   final ServerProcessFactory? _createServer;
   final Set<String> _generatedDirPaths;
+  final ProtocolChangeClassifier _classifyProtocolChange;
 
   final Completer<int> _done = Completer<int>();
 
@@ -93,11 +123,14 @@ class WatchSession {
     ServerProcessFactory? createServer,
     required ServerProcess initialServer,
     required Set<String> generatedDirPaths,
+    ProtocolChangeClassifier classifyProtocolChange =
+        defaultProtocolChangeClassifier,
   }) : _compiler = compiler,
        _generate = generate,
        _createServer = createServer,
        _server = initialServer,
-       _generatedDirPaths = generatedDirPaths {
+       _generatedDirPaths = generatedDirPaths,
+       _classifyProtocolChange = classifyProtocolChange {
     assert(
       (compiler == null) == (createServer == null),
       'compiler and createServer must both be provided or both be null.',
@@ -153,22 +186,29 @@ class WatchSession {
     if (event.modelFiles.isNotEmpty) log.debug('  .spy: ${event.modelFiles}');
     if (event.packageConfigChanged) log.debug('  package_config.json changed');
 
-    // Only source files and model files trigger generation. Generated files
-    // from the watcher are just forwarded to the compiler.
+    // Narrow source files to those that may affect the generated protocol.
+    // Helper files and pure business logic that don't declare endpoints or
+    // future calls can skip the regen step - compile alone picks up their
+    // changes.
+    final protocolSourceFiles = <String>{};
+    for (final f in sourceDartFiles) {
+      if (await _classifyProtocolChange(f)) protocolSourceFiles.add(f);
+    }
+
     final needsGeneration =
-        sourceDartFiles.isNotEmpty || event.modelFiles.isNotEmpty;
+        protocolSourceFiles.isNotEmpty || event.modelFiles.isNotEmpty;
 
     Set<String> genOutputFiles = const {};
     if (needsGeneration) {
       final affectedPaths = {
-        ...sourceDartFiles,
+        ...protocolSourceFiles,
         ...event.modelFiles,
       };
 
       final genRequirements = GenerationRequirements(
         generateModels: event.modelFiles.isNotEmpty,
         generateProtocol:
-            sourceDartFiles.isNotEmpty || event.modelFiles.isNotEmpty,
+            protocolSourceFiles.isNotEmpty || event.modelFiles.isNotEmpty,
       );
 
       final genResult = await _generate(affectedPaths, genRequirements);

--- a/tools/serverpod_cli/lib/src/commands/start/watch_session.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/watch_session.dart
@@ -84,6 +84,9 @@ class WatchSession {
   /// the previous one via [_pending], so concurrent calls execute in order.
   Future<void> _pending = Future.value();
 
+  final StreamController<void> _vmServiceUriChangesController =
+      StreamController<void>.broadcast();
+
   WatchSession({
     KernelCompiler? compiler,
     required GenerateAction generate,
@@ -100,6 +103,7 @@ class WatchSession {
       'compiler and createServer must both be provided or both be null.',
     );
     _monitorExit(initialServer);
+    _trackVmServiceUri(initialServer);
   }
 
   /// Completes when the server exits unexpectedly (crash).
@@ -107,6 +111,14 @@ class WatchSession {
 
   /// Returns `true` if the server is currently running.
   bool get isRunning => !_done.isCompleted;
+
+  /// The current HTTP VM service URI of the running server, or `null` if not
+  /// yet available.
+  String? get vmServiceUri => _server.vmServiceUri;
+
+  /// Fires each time a new server process publishes its VM service URI. The
+  /// URI itself is read via [vmServiceUri]; the stream just signals "changed".
+  Stream<void> get vmServiceUriChanges => _vmServiceUriChangesController.stream;
 
   /// Processes a single (merged) file change event.
   Future<void> handleFileChange(FileChangeEvent event) async {
@@ -363,6 +375,7 @@ class WatchSession {
         extraArgs: ['--apply-migrations'],
       );
       _monitorExit(_server);
+      _trackVmServiceUri(_server);
       log.info('Server restarted with --apply-migrations.');
     } finally {
       _state = SessionState.idle;
@@ -375,6 +388,7 @@ class WatchSession {
       await _server.stop();
       _server = await _createServer!(dillPath);
       _monitorExit(_server);
+      _trackVmServiceUri(_server);
       log.info(serverRestarted);
     } finally {
       _state = SessionState.idle;
@@ -384,6 +398,7 @@ class WatchSession {
   /// Disposes the session: stops server and disposes compiler.
   Future<void> dispose() async {
     _state = SessionState.disposed;
+    await _vmServiceUriChangesController.close();
     await _server.stop();
     await _compiler?.dispose();
   }
@@ -393,6 +408,16 @@ class WatchSession {
       server.exitCode.then((code) {
         if (_state == SessionState.idle && !_done.isCompleted) {
           _done.complete(code);
+        }
+      }),
+    );
+  }
+
+  void _trackVmServiceUri(ServerProcess server) {
+    unawaited(
+      server.vmServiceReady.then((_) {
+        if (_server == server && !_vmServiceUriChangesController.isClosed) {
+          _vmServiceUriChangesController.add(null);
         }
       }),
     );

--- a/tools/serverpod_cli/lib/src/generated/completion_script_carapace.dart
+++ b/tools/serverpod_cli/lib/src/generated/completion_script_carapace.dart
@@ -75,8 +75,6 @@ commands:
       - [stdio, no-stdio]
 
   - name: mcp
-    flags:
-      -d, --directory=: "The server directory (defaults to auto-detect from current directory)."
 
   - name: create-migration
     flags:

--- a/tools/serverpod_cli/lib/src/mcp/bridge_mcp_server.dart
+++ b/tools/serverpod_cli/lib/src/mcp/bridge_mcp_server.dart
@@ -13,8 +13,11 @@ import 'package:serverpod_cli/src/mcp/socket_directory.dart';
 ///
 /// The bridge is long-lived: it survives runner restarts, and lets the
 /// client switch between running instances via the `connect`/`disconnect`
-/// tools. Tool calls that target the runner (`apply_migrations`) are
-/// forwarded over the runner's Unix socket using `dart_mcp`'s client API.
+/// tools. Tools and resources defined on the connected runner are
+/// auto-forwarded: on `connect` the bridge enumerates upstream tools and
+/// resources via `dart_mcp`'s client API, registers a thin forwarder for
+/// each, and unregisters them again on `disconnect`. The MCP capability
+/// `listChanged` propagates these registrations to the AI client.
 base class BridgeMcpServer extends MCPServer
     with ToolsSupport, ResourcesSupport {
   final ServerpodMcpBridge bridge;
@@ -27,22 +30,33 @@ base class BridgeMcpServer extends MCPServer
   String? _connectedId;
   int? _connectedPid;
 
+  /// Tool names owned by the bridge itself; never forwarded from the runner
+  /// even if the runner happens to register a tool with the same name.
+  static const _bridgeNativeToolNames = {
+    'connect',
+    'disconnect',
+    'spawn',
+    'stop',
+  };
+
+  /// Resource URIs owned by the bridge itself; never forwarded.
+  static const _bridgeNativeResourceUris = {'serverpod://instances'};
+
+  /// Forwarded tools registered on the current connection, by name.
+  /// Cleared and unregistered on disconnect.
+  final _forwardedToolNames = <String>{};
+
+  /// Forwarded resources registered on the current connection, by URI.
+  /// Stored as `Resource` (not just URI) so we can call `updateResource`
+  /// when the upstream emits a `notifications/resources/updated`.
+  final _forwardedResources = <String, Resource>{};
+
   static final _instancesResource = Resource(
     uri: 'serverpod://instances',
     name: 'Instances',
     description:
         'List of running `serverpod start --watch` instances discovered '
         'on this machine.',
-    mimeType: 'application/json',
-  );
-
-  static final _vmServiceResource = Resource(
-    uri: 'serverpod://vm-service',
-    name: 'VM service',
-    description:
-        'Dart VM service HTTP URI for the connected serverpod instance. '
-        'Stable across hot reloads; changes on restart. Subscribe to be '
-        'notified when the URI changes.',
     mimeType: 'application/json',
   );
 
@@ -57,20 +71,16 @@ base class BridgeMcpServer extends MCPServer
         instructions:
             'Bridge to a running `serverpod start --watch` instance. Read '
             'serverpod://instances to discover running instances, then call '
-            'the `connect` tool to attach to one. Tools that act on the '
-            'running instance are forwarded over its MCP socket.',
+            'the `connect` tool to attach to one. Tools and resources from '
+            'the connected instance are forwarded over its MCP socket and '
+            'appear here automatically.',
       ) {
     registerTool(_connectTool, _connect);
     registerTool(_disconnectTool, _disconnect);
     registerTool(_spawnTool, _spawn);
     registerTool(_stopTool, _stop);
-    registerTool(_applyMigrationsTool, _forwardApplyMigrations);
-    registerTool(_createMigrationTool, _forwardCreateMigration);
-    registerTool(_hotReloadTool, _forwardHotReload);
-    registerTool(_tailLogsTool, _forwardTailLogs);
 
     addResource(_instancesResource, _readInstances);
-    addResource(_vmServiceResource, _readVmService);
 
     bridge.onSocketsChanged = () {
       if (ready) updateResource(_instancesResource);
@@ -207,25 +217,18 @@ base class BridgeMcpServer extends MCPServer
 
       // Relay resource-updated notifications for forwarded resources.
       _resourceUpdatedSub = connection.resourceUpdated.listen((n) {
-        if (n.uri == _vmServiceResource.uri && ready) {
-          updateResource(_vmServiceResource);
-        }
+        final res = _forwardedResources[n.uri];
+        if (res != null && ready) updateResource(res);
       });
-      try {
-        await connection.subscribeResource(
-          SubscribeRequest(uri: _vmServiceResource.uri),
-        );
-      } catch (_) {
-        // The instance may not support subscription; reads still work.
-      }
 
-      // Drop our state and update the resource if the instance dies on us.
+      await _registerForwardedItems(connection);
+
+      // Drop our state if the instance dies on us. Forwarded tools and
+      // resources are unregistered too so the AI client sees them disappear.
       unawaited(
-        connection.done.then((_) {
+        connection.done.then((_) async {
           if (_connection == connection) {
-            _connection = null;
-            _connectedId = null;
-            _connectedPid = null;
+            await _disconnectInternal();
             if (ready) updateResource(_instancesResource);
           }
         }),
@@ -287,6 +290,16 @@ base class BridgeMcpServer extends MCPServer
     _connectedPid = null;
     await _resourceUpdatedSub?.cancel();
     _resourceUpdatedSub = null;
+
+    for (final name in _forwardedToolNames) {
+      unregisterTool(name);
+    }
+    _forwardedToolNames.clear();
+    for (final uri in _forwardedResources.keys.toList()) {
+      removeResource(uri);
+    }
+    _forwardedResources.clear();
+
     if (conn != null) {
       try {
         await conn.shutdown();
@@ -294,7 +307,64 @@ base class BridgeMcpServer extends MCPServer
         // Already gone.
       }
     }
-    if (ready) updateResource(_vmServiceResource);
+  }
+
+  /// Enumerate the connected runner's tools and resources, register a
+  /// forwarder for each, and subscribe to per-resource updates so they
+  /// surface as `notifications/resources/updated` upstream.
+  ///
+  /// Tools and resources whose name/URI matches a bridge-native item are
+  /// skipped to avoid clobbering the bridge's own surface.
+  Future<void> _registerForwardedItems(ServerConnection connection) async {
+    final tools = await connection.listTools();
+    for (final tool in tools.tools) {
+      if (_bridgeNativeToolNames.contains(tool.name)) continue;
+      registerTool(tool, _makeToolForwarder(tool.name));
+      _forwardedToolNames.add(tool.name);
+    }
+
+    final resources = await connection.listResources();
+    for (final resource in resources.resources) {
+      if (_bridgeNativeResourceUris.contains(resource.uri)) continue;
+      addResource(resource, _makeResourceReader(resource.uri));
+      _forwardedResources[resource.uri] = resource;
+      try {
+        await connection.subscribeResource(
+          SubscribeRequest(uri: resource.uri),
+        );
+      } catch (_) {
+        // Resource may not support subscription; reads still work.
+      }
+    }
+  }
+
+  Future<CallToolResult> Function(CallToolRequest) _makeToolForwarder(
+    String name,
+  ) {
+    return (request) async {
+      if (!_isConnected) return _notConnectedError();
+      return _connection!.callTool(
+        CallToolRequest(name: name, arguments: request.arguments),
+      );
+    };
+  }
+
+  Future<ReadResourceResult> Function(ReadResourceRequest) _makeResourceReader(
+    String uri,
+  ) {
+    return (request) async {
+      if (!_isConnected) {
+        return ReadResourceResult(
+          contents: [
+            TextResourceContents(
+              uri: request.uri,
+              text: jsonEncode({'uri': null, 'error': 'not-connected'}),
+            ),
+          ],
+        );
+      }
+      return _connection!.readResource(ReadResourceRequest(uri: uri));
+    };
   }
 
   // ---------------------------------------------------------------------------
@@ -437,118 +507,8 @@ base class BridgeMcpServer extends MCPServer
   }
 
   // ---------------------------------------------------------------------------
-  // Forwarded tools
+  // Bridge-native resources
   // ---------------------------------------------------------------------------
-
-  static final _applyMigrationsTool = Tool(
-    name: 'apply_migrations',
-    description:
-        'Apply pending database migrations on the connected serverpod '
-        'instance. The server restarts with `--apply-migrations`. Call after '
-        '`create_migration` (or `serverpod create-migration`) has written the '
-        'migration files.',
-    inputSchema: Schema.object(),
-  );
-
-  Future<CallToolResult> _forwardApplyMigrations(
-    CallToolRequest request,
-  ) async {
-    if (!_isConnected) return _notConnectedError();
-    return _connection!.callTool(
-      CallToolRequest(name: 'apply_migrations', arguments: request.arguments),
-    );
-  }
-
-  static final _createMigrationTool = Tool(
-    name: 'create_migration',
-    description:
-        'Create a new database migration from the current model definitions '
-        'on the connected serverpod instance. Writes the migration files to '
-        'disk; does not restart the server or apply the migration. Follow up '
-        'with `apply_migrations` to run it against the database.',
-    inputSchema: Schema.object(
-      properties: {
-        'tag': Schema.string(
-          description: 'Optional tag appended to the migration version name.',
-        ),
-        'force': Schema.bool(
-          description:
-              'Create the migration even if warnings are present (data may '
-              'be destroyed).',
-        ),
-      },
-    ),
-  );
-
-  Future<CallToolResult> _forwardCreateMigration(
-    CallToolRequest request,
-  ) async {
-    if (!_isConnected) return _notConnectedError();
-    return _connection!.callTool(
-      CallToolRequest(name: 'create_migration', arguments: request.arguments),
-    );
-  }
-
-  static final _hotReloadTool = Tool(
-    name: 'hot_reload',
-    description:
-        'Recompile the server kernel and hot-reload the running isolate on '
-        'the connected serverpod instance. Falls back to a full restart if '
-        'reload is not possible.',
-    inputSchema: Schema.object(),
-  );
-
-  Future<CallToolResult> _forwardHotReload(CallToolRequest request) async {
-    if (!_isConnected) return _notConnectedError();
-    return _connection!.callTool(
-      CallToolRequest(name: 'hot_reload', arguments: request.arguments),
-    );
-  }
-
-  static final _tailLogsTool = Tool(
-    name: 'tail_logs',
-    description:
-        'Return recent log entries from the connected serverpod instance '
-        '(structured log entries plus completed operations). Newest last.',
-    inputSchema: Schema.object(
-      properties: {
-        'limit': Schema.int(
-          description: 'Max entries to return (default 200, max 10000).',
-          minimum: 1,
-          maximum: 10000,
-        ),
-      },
-    ),
-  );
-
-  Future<CallToolResult> _forwardTailLogs(CallToolRequest request) async {
-    if (!_isConnected) return _notConnectedError();
-    return _connection!.callTool(
-      CallToolRequest(name: 'tail_logs', arguments: request.arguments),
-    );
-  }
-
-  // ---------------------------------------------------------------------------
-  // Resources
-  // ---------------------------------------------------------------------------
-
-  Future<ReadResourceResult> _readVmService(
-    ReadResourceRequest request,
-  ) async {
-    if (!_isConnected) {
-      return ReadResourceResult(
-        contents: [
-          TextResourceContents(
-            uri: request.uri,
-            text: jsonEncode({'uri': null, 'error': 'not-connected'}),
-          ),
-        ],
-      );
-    }
-    return _connection!.readResource(
-      ReadResourceRequest(uri: _vmServiceResource.uri),
-    );
-  }
 
   ReadResourceResult _readInstances(ReadResourceRequest request) {
     final instances = bridge.sockets

--- a/tools/serverpod_cli/lib/src/mcp/bridge_mcp_server.dart
+++ b/tools/serverpod_cli/lib/src/mcp/bridge_mcp_server.dart
@@ -53,6 +53,7 @@ base class BridgeMcpServer extends MCPServer
     registerTool(_spawnTool, _spawn);
     registerTool(_stopTool, _stop);
     registerTool(_applyMigrationsTool, _forwardApplyMigrations);
+    registerTool(_hotReloadTool, _forwardHotReload);
     registerTool(_tailLogsTool, _forwardTailLogs);
 
     addResource(_instancesResource, _readInstances);
@@ -423,6 +424,22 @@ base class BridgeMcpServer extends MCPServer
     if (!_isConnected) return _notConnectedError();
     return _connection!.callTool(
       CallToolRequest(name: 'apply_migrations', arguments: request.arguments),
+    );
+  }
+
+  static final _hotReloadTool = Tool(
+    name: 'hot_reload',
+    description:
+        'Recompile the server kernel and hot-reload the running isolate on '
+        'the connected serverpod instance. Falls back to a full restart if '
+        'reload is not possible.',
+    inputSchema: Schema.object(),
+  );
+
+  Future<CallToolResult> _forwardHotReload(CallToolRequest request) async {
+    if (!_isConnected) return _notConnectedError();
+    return _connection!.callTool(
+      CallToolRequest(name: 'hot_reload', arguments: request.arguments),
     );
   }
 

--- a/tools/serverpod_cli/lib/src/mcp/bridge_mcp_server.dart
+++ b/tools/serverpod_cli/lib/src/mcp/bridge_mcp_server.dart
@@ -65,6 +65,7 @@ base class BridgeMcpServer extends MCPServer
     registerTool(_spawnTool, _spawn);
     registerTool(_stopTool, _stop);
     registerTool(_applyMigrationsTool, _forwardApplyMigrations);
+    registerTool(_createMigrationTool, _forwardCreateMigration);
     registerTool(_hotReloadTool, _forwardHotReload);
     registerTool(_tailLogsTool, _forwardTailLogs);
 
@@ -444,7 +445,8 @@ base class BridgeMcpServer extends MCPServer
     description:
         'Apply pending database migrations on the connected serverpod '
         'instance. The server restarts with `--apply-migrations`. Call after '
-        'creating a migration with `serverpod create-migration`.',
+        '`create_migration` (or `serverpod create-migration`) has written the '
+        'migration files.',
     inputSchema: Schema.object(),
   );
 
@@ -454,6 +456,36 @@ base class BridgeMcpServer extends MCPServer
     if (!_isConnected) return _notConnectedError();
     return _connection!.callTool(
       CallToolRequest(name: 'apply_migrations', arguments: request.arguments),
+    );
+  }
+
+  static final _createMigrationTool = Tool(
+    name: 'create_migration',
+    description:
+        'Create a new database migration from the current model definitions '
+        'on the connected serverpod instance. Writes the migration files to '
+        'disk; does not restart the server or apply the migration. Follow up '
+        'with `apply_migrations` to run it against the database.',
+    inputSchema: Schema.object(
+      properties: {
+        'tag': Schema.string(
+          description: 'Optional tag appended to the migration version name.',
+        ),
+        'force': Schema.bool(
+          description:
+              'Create the migration even if warnings are present (data may '
+              'be destroyed).',
+        ),
+      },
+    ),
+  );
+
+  Future<CallToolResult> _forwardCreateMigration(
+    CallToolRequest request,
+  ) async {
+    if (!_isConnected) return _notConnectedError();
+    return _connection!.callTool(
+      CallToolRequest(name: 'create_migration', arguments: request.arguments),
     );
   }
 

--- a/tools/serverpod_cli/lib/src/mcp/bridge_mcp_server.dart
+++ b/tools/serverpod_cli/lib/src/mcp/bridge_mcp_server.dart
@@ -87,10 +87,6 @@ base class BridgeMcpServer extends MCPServer
     };
   }
 
-  // ---------------------------------------------------------------------------
-  // Connection state
-  // ---------------------------------------------------------------------------
-
   bool get _isConnected => _connection != null;
 
   CallToolResult _notConnectedError() => CallToolResult(
@@ -104,10 +100,6 @@ base class BridgeMcpServer extends MCPServer
     ],
     isError: true,
   );
-
-  // ---------------------------------------------------------------------------
-  // connect / disconnect
-  // ---------------------------------------------------------------------------
 
   static final _connectTool = Tool(
     name: 'connect',
@@ -367,10 +359,6 @@ base class BridgeMcpServer extends MCPServer
     };
   }
 
-  // ---------------------------------------------------------------------------
-  // spawn / stop
-  // ---------------------------------------------------------------------------
-
   static final _spawnTool = Tool(
     name: 'spawn',
     description:
@@ -505,10 +493,6 @@ base class BridgeMcpServer extends MCPServer
       ],
     );
   }
-
-  // ---------------------------------------------------------------------------
-  // Bridge-native resources
-  // ---------------------------------------------------------------------------
 
   ReadResourceResult _readInstances(ReadResourceRequest request) {
     final instances = bridge.sockets

--- a/tools/serverpod_cli/lib/src/mcp/bridge_mcp_server.dart
+++ b/tools/serverpod_cli/lib/src/mcp/bridge_mcp_server.dart
@@ -36,6 +36,18 @@ base class BridgeMcpServer extends MCPServer
     mimeType: 'application/json',
   );
 
+  static final _vmServiceResource = Resource(
+    uri: 'serverpod://vm-service',
+    name: 'VM service',
+    description:
+        'Dart VM service HTTP URI for the connected serverpod instance. '
+        'Stable across hot reloads; changes on restart. Subscribe to be '
+        'notified when the URI changes.',
+    mimeType: 'application/json',
+  );
+
+  StreamSubscription<ResourceUpdatedNotification>? _resourceUpdatedSub;
+
   BridgeMcpServer(super.channel, {required this.bridge})
     : super.fromStreamChannel(
         implementation: Implementation(
@@ -57,6 +69,7 @@ base class BridgeMcpServer extends MCPServer
     registerTool(_tailLogsTool, _forwardTailLogs);
 
     addResource(_instancesResource, _readInstances);
+    addResource(_vmServiceResource, _readVmService);
 
     bridge.onSocketsChanged = () {
       if (ready) updateResource(_instancesResource);
@@ -191,6 +204,20 @@ base class BridgeMcpServer extends MCPServer
       _connectedId = target.project.isEmpty ? '${target.pid}' : target.project;
       _connectedPid = target.pid;
 
+      // Relay resource-updated notifications for forwarded resources.
+      _resourceUpdatedSub = connection.resourceUpdated.listen((n) {
+        if (n.uri == _vmServiceResource.uri && ready) {
+          updateResource(_vmServiceResource);
+        }
+      });
+      try {
+        await connection.subscribeResource(
+          SubscribeRequest(uri: _vmServiceResource.uri),
+        );
+      } catch (_) {
+        // The instance may not support subscription; reads still work.
+      }
+
       // Drop our state and update the resource if the instance dies on us.
       unawaited(
         connection.done.then((_) {
@@ -257,6 +284,8 @@ base class BridgeMcpServer extends MCPServer
     _connection = null;
     _connectedId = null;
     _connectedPid = null;
+    await _resourceUpdatedSub?.cancel();
+    _resourceUpdatedSub = null;
     if (conn != null) {
       try {
         await conn.shutdown();
@@ -264,6 +293,7 @@ base class BridgeMcpServer extends MCPServer
         // Already gone.
       }
     }
+    if (ready) updateResource(_vmServiceResource);
   }
 
   // ---------------------------------------------------------------------------
@@ -469,6 +499,24 @@ base class BridgeMcpServer extends MCPServer
   // ---------------------------------------------------------------------------
   // Resources
   // ---------------------------------------------------------------------------
+
+  Future<ReadResourceResult> _readVmService(
+    ReadResourceRequest request,
+  ) async {
+    if (!_isConnected) {
+      return ReadResourceResult(
+        contents: [
+          TextResourceContents(
+            uri: request.uri,
+            text: jsonEncode({'uri': null, 'error': 'not-connected'}),
+          ),
+        ],
+      );
+    }
+    return _connection!.readResource(
+      ReadResourceRequest(uri: _vmServiceResource.uri),
+    );
+  }
 
   ReadResourceResult _readInstances(ReadResourceRequest request) {
     final instances = bridge.sockets

--- a/tools/serverpod_cli/lib/src/mcp/bridge_mcp_server.dart
+++ b/tools/serverpod_cli/lib/src/mcp/bridge_mcp_server.dart
@@ -53,6 +53,7 @@ base class BridgeMcpServer extends MCPServer
     registerTool(_spawnTool, _spawn);
     registerTool(_stopTool, _stop);
     registerTool(_applyMigrationsTool, _forwardApplyMigrations);
+    registerTool(_tailLogsTool, _forwardTailLogs);
 
     addResource(_instancesResource, _readInstances);
 
@@ -422,6 +423,29 @@ base class BridgeMcpServer extends MCPServer
     if (!_isConnected) return _notConnectedError();
     return _connection!.callTool(
       CallToolRequest(name: 'apply_migrations', arguments: request.arguments),
+    );
+  }
+
+  static final _tailLogsTool = Tool(
+    name: 'tail_logs',
+    description:
+        'Return recent log entries from the connected serverpod instance '
+        '(structured log entries plus completed operations). Newest last.',
+    inputSchema: Schema.object(
+      properties: {
+        'limit': Schema.int(
+          description: 'Max entries to return (default 200, max 10000).',
+          minimum: 1,
+          maximum: 10000,
+        ),
+      },
+    ),
+  );
+
+  Future<CallToolResult> _forwardTailLogs(CallToolRequest request) async {
+    if (!_isConnected) return _notConnectedError();
+    return _connection!.callTool(
+      CallToolRequest(name: 'tail_logs', arguments: request.arguments),
     );
   }
 

--- a/tools/serverpod_cli/lib/src/mcp/bridge_mcp_server.dart
+++ b/tools/serverpod_cli/lib/src/mcp/bridge_mcp_server.dart
@@ -1,0 +1,456 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:dart_mcp/client.dart';
+import 'package:dart_mcp/server.dart';
+import 'package:serverpod_cli/src/generated/version.dart';
+import 'package:serverpod_cli/src/mcp/serverpod_mcp_bridge.dart';
+import 'package:serverpod_cli/src/mcp/socket_directory.dart';
+
+/// MCP server that bridges a single MCP client (e.g. Claude Code on stdio)
+/// to one running `serverpod start --watch` instance at a time.
+///
+/// The bridge is long-lived: it survives runner restarts, and lets the
+/// client switch between running instances via the `connect`/`disconnect`
+/// tools. Tool calls that target the runner (`apply_migrations`) are
+/// forwarded over the runner's Unix socket using `dart_mcp`'s client API.
+base class BridgeMcpServer extends MCPServer
+    with ToolsSupport, ResourcesSupport {
+  final ServerpodMcpBridge bridge;
+
+  final MCPClient _client = MCPClient(
+    Implementation(name: 'serverpod-bridge', version: templateVersion),
+  );
+
+  ServerConnection? _connection;
+  String? _connectedId;
+  int? _connectedPid;
+
+  static final _instancesResource = Resource(
+    uri: 'serverpod://instances',
+    name: 'Instances',
+    description:
+        'List of running `serverpod start --watch` instances discovered '
+        'on this machine.',
+    mimeType: 'application/json',
+  );
+
+  BridgeMcpServer(super.channel, {required this.bridge})
+    : super.fromStreamChannel(
+        implementation: Implementation(
+          name: 'serverpod-bridge',
+          version: templateVersion,
+        ),
+        instructions:
+            'Bridge to a running `serverpod start --watch` instance. Read '
+            'serverpod://instances to discover running instances, then call '
+            'the `connect` tool to attach to one. Tools that act on the '
+            'running instance are forwarded over its MCP socket.',
+      ) {
+    registerTool(_connectTool, _connect);
+    registerTool(_disconnectTool, _disconnect);
+    registerTool(_spawnTool, _spawn);
+    registerTool(_stopTool, _stop);
+    registerTool(_applyMigrationsTool, _forwardApplyMigrations);
+
+    addResource(_instancesResource, _readInstances);
+
+    bridge.onSocketsChanged = () {
+      if (ready) updateResource(_instancesResource);
+    };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Connection state
+  // ---------------------------------------------------------------------------
+
+  bool get _isConnected => _connection != null;
+
+  CallToolResult _notConnectedError() => CallToolResult(
+    content: [
+      TextContent(
+        text:
+            'Not connected to a serverpod instance. Read serverpod://instances '
+            'and call the `connect` tool first, or call `spawn` to start a '
+            'new `serverpod start --watch` process.',
+      ),
+    ],
+    isError: true,
+  );
+
+  // ---------------------------------------------------------------------------
+  // connect / disconnect
+  // ---------------------------------------------------------------------------
+
+  static final _connectTool = Tool(
+    name: 'connect',
+    description:
+        'Connect to a running `serverpod start --watch` instance. If only '
+        'one instance is running, connects to it automatically when '
+        '`instanceId` is omitted. Otherwise, pass the project name or PID '
+        'shown by `serverpod://instances`.',
+    inputSchema: Schema.object(
+      properties: {
+        'instanceId': Schema.string(
+          description:
+              'Project name or PID of the instance to connect to. Omit to '
+              'auto-connect when exactly one instance is running.',
+        ),
+      },
+    ),
+  );
+
+  Future<CallToolResult> _connect(CallToolRequest request) async {
+    final instanceId = request.arguments?['instanceId'] as String?;
+
+    await bridge.scan();
+    final sockets = bridge.sockets;
+
+    if (sockets.isEmpty) {
+      return CallToolResult(
+        content: [
+          TextContent(
+            text:
+                'No `serverpod start --watch` instances running. Start one '
+                'with the `spawn` tool, or run `serverpod start --watch` in '
+                'another terminal.',
+          ),
+        ],
+        isError: true,
+      );
+    }
+
+    ServerpodMcpSocketInfo? target;
+    if (instanceId != null) {
+      target = bridge.findSocket(instanceId);
+      if (target == null) {
+        return CallToolResult(
+          content: [
+            TextContent(
+              text:
+                  'No instance found matching "$instanceId". '
+                  'Available: ${_describeAvailable(sockets)}',
+            ),
+          ],
+          isError: true,
+        );
+      }
+    } else if (sockets.length == 1) {
+      target = sockets.first;
+    } else {
+      return CallToolResult(
+        content: [
+          TextContent(
+            text:
+                'Multiple instances available. Pass `instanceId`: '
+                '${_describeAvailable(sockets)}',
+          ),
+        ],
+        isError: true,
+      );
+    }
+
+    await _disconnectInternal();
+
+    try {
+      final socket = await Socket.connect(
+        InternetAddress(target.path, type: InternetAddressType.unix),
+        0,
+      );
+      final channel = socketChannel(socket);
+      final connection = _client.connectServer(channel);
+
+      final initResult = await connection.initialize(
+        InitializeRequest(
+          protocolVersion: ProtocolVersion.latestSupported,
+          capabilities: _client.capabilities,
+          clientInfo: _client.implementation,
+        ),
+      );
+
+      if (initResult.protocolVersion?.isSupported != true) {
+        await connection.shutdown();
+        return CallToolResult(
+          content: [
+            TextContent(
+              text:
+                  'Unsupported MCP protocol version reported by instance '
+                  '"${target.project}" (pid ${target.pid}).',
+            ),
+          ],
+          isError: true,
+        );
+      }
+
+      connection.notifyInitialized(InitializedNotification());
+
+      _connection = connection;
+      _connectedId = target.project.isEmpty ? '${target.pid}' : target.project;
+      _connectedPid = target.pid;
+
+      // Drop our state and update the resource if the instance dies on us.
+      unawaited(
+        connection.done.then((_) {
+          if (_connection == connection) {
+            _connection = null;
+            _connectedId = null;
+            _connectedPid = null;
+            if (ready) updateResource(_instancesResource);
+          }
+        }),
+      );
+
+      if (ready) updateResource(_instancesResource);
+
+      return CallToolResult(
+        content: [
+          TextContent(
+            text: jsonEncode({
+              'connected': true,
+              'instanceId': _connectedId,
+              'project': target.project,
+              'pid': target.pid,
+            }),
+          ),
+        ],
+      );
+    } catch (e) {
+      return CallToolResult(
+        content: [TextContent(text: 'Failed to connect: $e')],
+        isError: true,
+      );
+    }
+  }
+
+  static final _disconnectTool = Tool(
+    name: 'disconnect',
+    description:
+        'Detach from the currently connected serverpod instance '
+        'without stopping it.',
+    inputSchema: Schema.object(properties: {}),
+  );
+
+  Future<CallToolResult> _disconnect(CallToolRequest request) async {
+    if (!_isConnected) {
+      return CallToolResult(
+        content: [TextContent(text: 'Not connected.')],
+        isError: true,
+      );
+    }
+    final id = _connectedId;
+    await _disconnectInternal();
+    if (ready) updateResource(_instancesResource);
+    return CallToolResult(
+      content: [
+        TextContent(
+          text: jsonEncode({'disconnected': true, 'instanceId': id}),
+        ),
+      ],
+    );
+  }
+
+  Future<void> _disconnectInternal() async {
+    final conn = _connection;
+    _connection = null;
+    _connectedId = null;
+    _connectedPid = null;
+    if (conn != null) {
+      try {
+        await conn.shutdown();
+      } catch (_) {
+        // Already gone.
+      }
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // spawn / stop
+  // ---------------------------------------------------------------------------
+
+  static final _spawnTool = Tool(
+    name: 'spawn',
+    description:
+        'Start a new `serverpod start --watch` process detached from this '
+        'one. The bridge discovers it via the shared MCP socket directory '
+        'as soon as it advertises itself. Does not auto-connect - call '
+        '`connect` afterwards.',
+    inputSchema: Schema.object(
+      properties: {
+        'directory': Schema.string(
+          description:
+              'Server directory to start in (defaults to the bridge '
+              "process's current working directory).",
+        ),
+        'args': Schema.list(
+          items: Schema.string(description: 'Extra serverpod CLI flag'),
+          description: 'Extra arguments appended to `serverpod start --watch`.',
+        ),
+      },
+    ),
+  );
+
+  Future<CallToolResult> _spawn(CallToolRequest request) async {
+    final directory = request.arguments?['directory'] as String?;
+    final extraArgs =
+        (request.arguments?['args'] as List?)?.cast<String>() ?? const [];
+
+    final args = ['start', '--watch', ...extraArgs];
+
+    try {
+      final process = await Process.start(
+        'serverpod',
+        args,
+        workingDirectory: directory,
+        mode: ProcessStartMode.detached,
+      );
+
+      // Poll the socket directory for the new instance to appear.
+      for (var i = 0; i < 20; i++) {
+        await Future<void>.delayed(const Duration(milliseconds: 500));
+        await bridge.scan();
+        final socket = bridge.sockets
+            .where((s) => s.pid == process.pid)
+            .firstOrNull;
+        if (socket != null) {
+          return CallToolResult(
+            content: [
+              TextContent(
+                text: jsonEncode({
+                  'pid': process.pid,
+                  'project': socket.project,
+                }),
+              ),
+            ],
+          );
+        }
+      }
+
+      return CallToolResult(
+        content: [
+          TextContent(
+            text: jsonEncode({
+              'pid': process.pid,
+              'project': null,
+              'note':
+                  'Process started but did not register an MCP socket within '
+                  '10s. It may still be initializing or have failed early.',
+            }),
+          ),
+        ],
+      );
+    } catch (e) {
+      return CallToolResult(
+        content: [TextContent(text: 'Failed to spawn serverpod: $e')],
+        isError: true,
+      );
+    }
+  }
+
+  static final _stopTool = Tool(
+    name: 'stop',
+    description:
+        'Stop a running `serverpod start --watch` instance by '
+        'sending SIGTERM.',
+    inputSchema: Schema.object(
+      properties: {
+        'instanceId': Schema.string(
+          description: 'Project name or PID of the instance to stop.',
+        ),
+      },
+      required: ['instanceId'],
+    ),
+  );
+
+  Future<CallToolResult> _stop(CallToolRequest request) async {
+    final instanceId = request.arguments?['instanceId'] as String?;
+    if (instanceId == null) {
+      return CallToolResult(
+        content: [TextContent(text: 'Missing required argument: instanceId')],
+        isError: true,
+      );
+    }
+    final socket = bridge.findSocket(instanceId);
+    if (socket == null) {
+      return CallToolResult(
+        content: [
+          TextContent(text: 'No instance found matching "$instanceId".'),
+        ],
+        isError: true,
+      );
+    }
+
+    try {
+      Process.killPid(socket.pid);
+    } catch (_) {
+      // Already gone.
+    }
+
+    if (_connectedPid == socket.pid) {
+      await _disconnectInternal();
+    }
+
+    return CallToolResult(
+      content: [
+        TextContent(
+          text: jsonEncode({
+            'stopped': true,
+            'pid': socket.pid,
+            'project': socket.project,
+          }),
+        ),
+      ],
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Forwarded tools
+  // ---------------------------------------------------------------------------
+
+  static final _applyMigrationsTool = Tool(
+    name: 'apply_migrations',
+    description:
+        'Apply pending database migrations on the connected serverpod '
+        'instance. The server restarts with `--apply-migrations`. Call after '
+        'creating a migration with `serverpod create-migration`.',
+    inputSchema: Schema.object(),
+  );
+
+  Future<CallToolResult> _forwardApplyMigrations(
+    CallToolRequest request,
+  ) async {
+    if (!_isConnected) return _notConnectedError();
+    return _connection!.callTool(
+      CallToolRequest(name: 'apply_migrations', arguments: request.arguments),
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Resources
+  // ---------------------------------------------------------------------------
+
+  ReadResourceResult _readInstances(ReadResourceRequest request) {
+    final instances = bridge.sockets
+        .map(
+          (s) => {
+            'pid': s.pid,
+            'project': s.project,
+            'socketPath': s.path,
+            'connected': _connectedPid == s.pid,
+          },
+        )
+        .toList();
+
+    return ReadResourceResult(
+      contents: [
+        TextResourceContents(uri: request.uri, text: jsonEncode(instances)),
+      ],
+    );
+  }
+
+  String _describeAvailable(List<ServerpodMcpSocketInfo> sockets) {
+    return sockets
+        .map((s) => s.project.isEmpty ? '${s.pid}' : '${s.project} (${s.pid})')
+        .join(', ');
+  }
+}

--- a/tools/serverpod_cli/lib/src/mcp/serverpod_mcp_bridge.dart
+++ b/tools/serverpod_cli/lib/src/mcp/serverpod_mcp_bridge.dart
@@ -1,0 +1,56 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:stream_transform/stream_transform.dart';
+
+import 'socket_directory.dart';
+
+/// Discovers running `serverpod start --watch` instances by scanning the
+/// shared MCP socket directory.
+///
+/// The bridge process owns one of these. It watches the directory for
+/// changes and maintains a list of live sockets, but does not connect to
+/// any instance - that is the bridge MCP server's responsibility.
+class ServerpodMcpBridge {
+  List<ServerpodMcpSocketInfo> _sockets = const [];
+  StreamSubscription<void>? _watchSub;
+
+  /// The currently discovered live sockets.
+  List<ServerpodMcpSocketInfo> get sockets => _sockets;
+
+  /// Called when the socket list changes.
+  void Function()? onSocketsChanged;
+
+  /// Scan for existing serverpod sockets.
+  Future<void> scan() async {
+    _sockets = listServerpodMcpSockets();
+    onSocketsChanged?.call();
+  }
+
+  /// Start watching the shared socket directory for changes.
+  ///
+  /// Coalesces bursts of file events into a single rescan via
+  /// `asyncMapBuffer` so that sockets disappearing and reappearing in quick
+  /// succession produce one notification rather than many.
+  void startWatching() {
+    ensureServerpodMcpSocketDir();
+    _watchSub = Directory(
+      serverpodMcpSocketDir,
+    ).watch().asyncMapBuffer((_) => scan()).listen((_) {});
+  }
+
+  /// Look up a socket by project name or PID string.
+  ///
+  /// Project name is matched first; if no match, the input is interpreted
+  /// as a PID. This lets callers refer to instances by either identifier.
+  ServerpodMcpSocketInfo? findSocket(String id) {
+    return _sockets.where((s) => s.project == id).firstOrNull ??
+        _sockets.where((s) => s.pid.toString() == id).firstOrNull;
+  }
+
+  /// Stop watching.
+  Future<void> dispose() async {
+    await _watchSub?.cancel();
+    _watchSub = null;
+  }
+}

--- a/tools/serverpod_cli/lib/src/mcp/socket_directory.dart
+++ b/tools/serverpod_cli/lib/src/mcp/socket_directory.dart
@@ -62,10 +62,15 @@ List<ServerpodMcpSocketInfo> listServerpodMcpSockets() {
   if (!dir.existsSync()) return const [];
 
   final results = <ServerpodMcpSocketInfo>[];
-  final stale = <File>[];
+  final stalePaths = <String>[];
 
-  for (final entity in dir.listSync()) {
-    if (entity is! File) continue;
+  // followLinks: false - on Windows, AF_UNIX socket files are reparse points
+  // with a tag Dart does not recognize. With the default followLinks: true,
+  // listSync() tries to resolve them, fails, and silently drops the entry.
+  // We also do not filter on FileSystemEntity type: the filename regex is
+  // specific enough, and Windows AF_UNIX entries do not classify cleanly
+  // as File.
+  for (final entity in dir.listSync(followLinks: false)) {
     final name = p.basename(entity.path);
     final match = _socketFilenamePattern.firstMatch(name);
     if (match == null) continue;
@@ -76,13 +81,13 @@ List<ServerpodMcpSocketInfo> listServerpodMcpSockets() {
     if (_isProcessAlive(socketPid)) {
       results.add((pid: socketPid, project: project, path: entity.path));
     } else {
-      stale.add(entity);
+      stalePaths.add(entity.path);
     }
   }
 
-  for (final file in stale) {
+  for (final path in stalePaths) {
     try {
-      file.deleteSync();
+      File(path).deleteSync();
     } on FileSystemException {
       // Ignore - another process may have cleaned it up.
     }
@@ -91,23 +96,26 @@ List<ServerpodMcpSocketInfo> listServerpodMcpSockets() {
   return results;
 }
 
-/// Returns `true` if a process with [pid] is currently alive.
+/// Returns `true` if a process with [checkPid] is currently alive.
 ///
 /// Uses `kill -0` on POSIX (sends no signal, just checks). On Windows, falls
-/// back to `tasklist`.
-bool _isProcessAlive(int pid) {
+/// back to `tasklist`. Short-circuits for the current process to avoid an
+/// unnecessary fork and insulate scans from any tasklist quirks on Windows
+/// CI runners.
+bool _isProcessAlive(int checkPid) {
+  if (checkPid == pid) return true;
   if (Platform.isWindows) {
     final result = Process.runSync('tasklist', [
       '/FI',
-      'PID eq $pid',
+      'PID eq $checkPid',
       '/NH',
       '/FO',
       'CSV',
     ]);
     if (result.exitCode != 0) return false;
-    return (result.stdout as String).contains('"$pid"');
+    return (result.stdout as String).contains('"$checkPid"');
   }
-  return Process.runSync('kill', ['-0', '$pid']).exitCode == 0;
+  return Process.runSync('kill', ['-0', '$checkPid']).exitCode == 0;
 }
 
 /// Wraps [socket] in a [StreamChannel<String>] using line-delimited messages.

--- a/tools/serverpod_cli/lib/src/mcp/socket_directory.dart
+++ b/tools/serverpod_cli/lib/src/mcp/socket_directory.dart
@@ -17,12 +17,24 @@ final serverpodMcpSocketDir = p.join(
 
 /// Ensure [serverpodMcpSocketDir] exists, creating it if necessary.
 ///
-/// On POSIX, [Directory.systemTemp] resolves to `/tmp` when `TMPDIR` is unset
-/// (typical Linux desktop), and a plain `mkdir` would inherit umask (0755) and
-/// expose the dir to other local users. Going through `createTempSync` (which
-/// uses `mkdtemp(3)`) forces 0700, and a `rename` preserves the inode so the
-/// final dir keeps that mode. macOS/Windows already give a per-user temp dir,
-/// but this hardens Linux without any platform-specific calls.
+/// On POSIX, [Directory.systemTemp] resolves to `/tmp` when `TMPDIR` is
+/// unset (typical Linux desktop). A plain `Directory.createSync()` calls
+/// `mkdir(2)`, which derives the new directory's mode from `0777 & ~umask`.
+/// With the typical desktop umask of 0022 that yields mode 0755, leaving
+/// the directory (and the sockets inside it) world-readable. Unix domain
+/// sockets accept any client that can `connect(2)` to the path, so any
+/// other local user could attach to a developer's `serverpod start --watch`
+/// MCP socket and call `apply_migrations`.
+///
+/// `Directory.createTempSync()` is specified to call `mkdtemp(3)`, which
+/// always creates with mode 0700. We then `rename(2)` to the canonical
+/// path: the syscall preserves the inode (and therefore the mode) and
+/// avoids a separate `chmod` step that Dart's `Directory` API does not
+/// expose without `Process.runSync('chmod', ...)`. On `EEXIST` we lose the
+/// race against another runner that created the dir first, which is fine.
+///
+/// macOS and Windows already give each user a private temp dir, but this
+/// path hardens Linux without any platform-specific calls.
 void ensureServerpodMcpSocketDir() {
   final dir = Directory(serverpodMcpSocketDir);
   if (dir.existsSync()) return;
@@ -39,7 +51,11 @@ void ensureServerpodMcpSocketDir() {
 /// Build the canonical socket path for a `serverpod start --watch` instance.
 ///
 /// Project name is sanitized via [sanitizeProjectName] so it is safe to use
-/// in a filename across platforms.
+/// in a filename across platforms. The PID - guaranteed unique per running
+/// process - is the disambiguator: two distinct runners can never produce
+/// the same filename even if their sanitized project names collide. The
+/// project segment is purely for human discoverability in
+/// `serverpod://instances` and the bridge's `connect`/`stop` tools.
 String serverpodMcpSocketPath({required int pid, required String project}) {
   final name = sanitizeProjectName(project);
   final suffix = name.isEmpty ? '' : '-$name';
@@ -49,7 +65,10 @@ String serverpodMcpSocketPath({required int pid, required String project}) {
 /// Sanitize [name] so it is safe to embed in a filename.
 ///
 /// Lower-cases, replaces non-alphanumeric (other than hyphens) with hyphens,
-/// collapses runs of hyphens, and strips leading/trailing hyphens.
+/// collapses runs of hyphens, and strips leading/trailing hyphens. Purely
+/// cosmetic - distinct projects whose sanitized names happen to collide
+/// (e.g. `my_app` and `my-app`) are still uniquely identified by the PID
+/// embedded in the socket filename.
 String sanitizeProjectName(String name) {
   return name
       .toLowerCase()

--- a/tools/serverpod_cli/lib/src/mcp/socket_directory.dart
+++ b/tools/serverpod_cli/lib/src/mcp/socket_directory.dart
@@ -16,10 +16,23 @@ final serverpodMcpSocketDir = p.join(
 );
 
 /// Ensure [serverpodMcpSocketDir] exists, creating it if necessary.
+///
+/// On POSIX, [Directory.systemTemp] resolves to `/tmp` when `TMPDIR` is unset
+/// (typical Linux desktop), and a plain `mkdir` would inherit umask (0755) and
+/// expose the dir to other local users. Going through `createTempSync` (which
+/// uses `mkdtemp(3)`) forces 0700, and a `rename` preserves the inode so the
+/// final dir keeps that mode. macOS/Windows already give a per-user temp dir,
+/// but this hardens Linux without any platform-specific calls.
 void ensureServerpodMcpSocketDir() {
   final dir = Directory(serverpodMcpSocketDir);
-  if (!dir.existsSync()) {
-    dir.createSync(recursive: true);
+  if (dir.existsSync()) return;
+
+  final temp = Directory.systemTemp.createTempSync('serverpod-mcp-init-');
+  try {
+    temp.renameSync(serverpodMcpSocketDir);
+  } on FileSystemException {
+    // Lost the race against another runner that created the dir first.
+    temp.deleteSync();
   }
 }
 

--- a/tools/serverpod_cli/lib/src/mcp/socket_directory.dart
+++ b/tools/serverpod_cli/lib/src/mcp/socket_directory.dart
@@ -1,0 +1,130 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:stream_channel/stream_channel.dart';
+
+/// Shared directory under the system temp folder where every running
+/// `serverpod start --watch` instance advertises its MCP socket.
+///
+/// One directory for all instances on the machine; the bridge scans it to
+/// discover them. Filenames are `serverpod-<pid>-<project>.sock`.
+final serverpodMcpSocketDir = p.join(
+  Directory.systemTemp.path,
+  'serverpod',
+);
+
+/// Ensure [serverpodMcpSocketDir] exists, creating it if necessary.
+void ensureServerpodMcpSocketDir() {
+  final dir = Directory(serverpodMcpSocketDir);
+  if (!dir.existsSync()) {
+    dir.createSync(recursive: true);
+  }
+}
+
+/// Build the canonical socket path for a `serverpod start --watch` instance.
+///
+/// Project name is sanitized via [sanitizeProjectName] so it is safe to use
+/// in a filename across platforms.
+String serverpodMcpSocketPath({required int pid, required String project}) {
+  final name = sanitizeProjectName(project);
+  final suffix = name.isEmpty ? '' : '-$name';
+  return p.join(serverpodMcpSocketDir, 'serverpod-$pid$suffix.sock');
+}
+
+/// Sanitize [name] so it is safe to embed in a filename.
+///
+/// Lower-cases, replaces non-alphanumeric (other than hyphens) with hyphens,
+/// collapses runs of hyphens, and strips leading/trailing hyphens.
+String sanitizeProjectName(String name) {
+  return name
+      .toLowerCase()
+      .replaceAll(RegExp(r'[^a-z0-9-]'), '-')
+      .replaceAll(RegExp(r'-+'), '-')
+      .replaceAll(RegExp(r'^-|-$'), '');
+}
+
+/// Information about a discovered serverpod MCP socket.
+typedef ServerpodMcpSocketInfo = ({int pid, String project, String path});
+
+/// Filename pattern for serverpod MCP sockets in [serverpodMcpSocketDir].
+final RegExp _socketFilenamePattern = RegExp(
+  r'^serverpod-(\d+)(?:-(.+))?\.sock$',
+);
+
+/// List all live serverpod MCP sockets in [serverpodMcpSocketDir].
+///
+/// A socket is considered live if its PID is still running. Stale socket
+/// files for dead PIDs are removed as a side effect.
+List<ServerpodMcpSocketInfo> listServerpodMcpSockets() {
+  final dir = Directory(serverpodMcpSocketDir);
+  if (!dir.existsSync()) return const [];
+
+  final results = <ServerpodMcpSocketInfo>[];
+  final stale = <File>[];
+
+  for (final entity in dir.listSync()) {
+    if (entity is! File) continue;
+    final name = p.basename(entity.path);
+    final match = _socketFilenamePattern.firstMatch(name);
+    if (match == null) continue;
+
+    final socketPid = int.parse(match.group(1)!);
+    final project = match.group(2) ?? '';
+
+    if (_isProcessAlive(socketPid)) {
+      results.add((pid: socketPid, project: project, path: entity.path));
+    } else {
+      stale.add(entity);
+    }
+  }
+
+  for (final file in stale) {
+    try {
+      file.deleteSync();
+    } on FileSystemException {
+      // Ignore - another process may have cleaned it up.
+    }
+  }
+
+  return results;
+}
+
+/// Returns `true` if a process with [pid] is currently alive.
+///
+/// Uses `kill -0` on POSIX (sends no signal, just checks). On Windows, falls
+/// back to `tasklist`.
+bool _isProcessAlive(int pid) {
+  if (Platform.isWindows) {
+    final result = Process.runSync('tasklist', [
+      '/FI',
+      'PID eq $pid',
+      '/NH',
+      '/FO',
+      'CSV',
+    ]);
+    if (result.exitCode != 0) return false;
+    return (result.stdout as String).contains('"$pid"');
+  }
+  return Process.runSync('kill', ['-0', '$pid']).exitCode == 0;
+}
+
+/// Wraps [socket] in a [StreamChannel<String>] using line-delimited messages.
+///
+/// Matches the framing used by `dart_mcp`'s stdio transport so the same
+/// `MCPServer`/`MCPClient` plumbing works over a Unix socket.
+StreamChannel<String> socketChannel(Socket socket) {
+  final inStream = socket
+      .cast<List<int>>()
+      .transform(utf8.decoder)
+      .transform(const LineSplitter());
+
+  final outController = StreamController<String>();
+  outController.stream.listen(
+    (line) => socket.write('$line\n'),
+    onDone: () => socket.close(),
+  );
+
+  return StreamChannel<String>(inStream, outController.sink);
+}

--- a/tools/serverpod_cli/lib/src/migrations/create_migration_action.dart
+++ b/tools/serverpod_cli/lib/src/migrations/create_migration_action.dart
@@ -1,0 +1,117 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as path;
+import 'package:serverpod_cli/analyzer.dart';
+import 'package:serverpod_cli/src/config/serverpod_feature.dart';
+import 'package:serverpod_cli/src/util/project_name.dart';
+import 'package:serverpod_database/serverpod_database.dart';
+import 'package:serverpod_shared/serverpod_shared.dart';
+
+/// Outcome of a [createMigrationAction] call.
+sealed class CreateMigrationOutcome {
+  const CreateMigrationOutcome();
+}
+
+/// A migration was written to disk.
+class CreateMigrationCreated extends CreateMigrationOutcome {
+  const CreateMigrationCreated({
+    required this.versionName,
+    required this.migrationDirectory,
+  });
+
+  /// The name (timestamp + optional tag) of the new migration version.
+  final String versionName;
+
+  /// Absolute path to the new migration's directory.
+  final String migrationDirectory;
+}
+
+/// No schema changes were detected; nothing was written.
+class CreateMigrationNoChanges extends CreateMigrationOutcome {
+  const CreateMigrationNoChanges();
+}
+
+/// The migration was aborted due to warnings and [force] was false.
+class CreateMigrationAborted extends CreateMigrationOutcome {
+  const CreateMigrationAborted();
+}
+
+/// The migration could not be created.
+class CreateMigrationFailed extends CreateMigrationOutcome {
+  const CreateMigrationFailed(this.message);
+
+  /// User-facing description of the failure.
+  final String message;
+}
+
+/// Shared implementation behind the `serverpod create-migration` command, the
+/// TUI's "Create Migration" button, and the `create_migration` MCP tool.
+///
+/// Returns a [CreateMigrationOutcome] describing what happened. The caller is
+/// responsible for logging and formatting the result.
+Future<CreateMigrationOutcome> createMigrationAction({
+  required GeneratorConfig config,
+  String? tag,
+  bool force = false,
+}) async {
+  if (!config.isFeatureEnabled(ServerpodFeature.database)) {
+    return const CreateMigrationFailed(
+      'The database feature is not enabled in this project. '
+      'Migrations cannot be created.',
+    );
+  }
+
+  final serverDirectory = Directory(
+    path.joinAll(config.serverPackageDirectoryPathParts),
+  );
+
+  final projectName = await getProjectName(serverDirectory);
+  if (projectName == null) {
+    return const CreateMigrationFailed(
+      'Unable to determine project name from the server package.',
+    );
+  }
+
+  final generator = MigrationGenerator(
+    directory: serverDirectory,
+    projectName: projectName,
+  );
+
+  MigrationVersionArtifacts? migration;
+  try {
+    migration = await generator.createMigration(
+      tag: tag,
+      force: force,
+      config: config,
+    );
+  } on MigrationVersionLoadException catch (e) {
+    return CreateMigrationFailed(
+      'Unable to determine latest database definition due to a corrupted '
+      'migration. Please re-create or remove the migration version and try '
+      'again. Migration version: "${e.versionName}".\n${e.exception}',
+    );
+  } on GenerateMigrationDatabaseDefinitionException {
+    return const CreateMigrationFailed(
+      'Unable to generate database definition for project.',
+    );
+  } on MigrationVersionAlreadyExistsException catch (e) {
+    return CreateMigrationFailed(
+      'Unable to create migration. A directory with the same name already '
+      'exists: "${e.directoryPath}".',
+    );
+  } on MigrationAbortedException {
+    return const CreateMigrationAborted();
+  }
+
+  if (migration == null) {
+    return const CreateMigrationNoChanges();
+  }
+
+  return CreateMigrationCreated(
+    versionName: migration.version,
+    migrationDirectory: MigrationConstants.migrationVersionDirectory(
+      serverDirectory,
+      migration.version,
+    ).path,
+  );
+}

--- a/tools/serverpod_cli/lib/src/util/platform_check.dart
+++ b/tools/serverpod_cli/lib/src/util/platform_check.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:path/path.dart' as p;
@@ -42,12 +43,37 @@ String shortestPath(String path) {
   return relative.length < normalized.length ? relative : normalized;
 }
 
+/// Maximum number of bytes a Unix domain socket path may occupy on the
+/// current platform.
+///
+/// `sockaddr_un.sun_path` is 104 on macOS/iOS/BSD and 108 on Linux. Windows
+/// AF_UNIX matches the Linux size.
+int maxUnixSocketPathBytes() {
+  if (Platform.isMacOS || Platform.isIOS) return 104;
+  return 108;
+}
+
+/// Throws a [SocketException] if [path] (after shortening) does not fit within
+/// the platform's `sockaddr_un.sun_path`.
+void requireUnixSocketPathFits(String path) {
+  final shortened = shortestPath(path);
+  final bytes = utf8.encode(shortened).length + 1; // extra for NUL byte
+  final limit = maxUnixSocketPathBytes();
+  if (bytes <= limit) return;
+  throw SocketException(
+    'Unix socket path is too long for this platform '
+    '($bytes bytes; max $limit on ${Platform.operatingSystem}). '
+    'Path: $shortened',
+  );
+}
+
 /// Binds a [ServerSocket] to a Unix domain socket at [path].
 ///
 /// Removes any stale socket file before binding and uses [shortestPath] to
-/// minimize the path length (Unix sockets are limited to 104–108 bytes).
+/// minimize the path length.
 Future<ServerSocket> bindUnixSocket(String path) async {
   requireUnixSocketSupport();
+  requireUnixSocketPathFits(path);
 
   // Clean up stale socket file if it exists.
   await File(path).deleteIfExists();
@@ -64,6 +90,7 @@ Future<ServerSocket> bindUnixSocket(String path) async {
 /// to 104–108 bytes).
 Future<Socket> connectUnixSocket(String path) async {
   requireUnixSocketSupport();
+  requireUnixSocketPathFits(path);
 
   return Socket.connect(
     InternetAddress(shortestPath(path), type: InternetAddressType.unix),

--- a/tools/serverpod_cli/test/commands/start/mcp_server_test.dart
+++ b/tools/serverpod_cli/test/commands/start/mcp_server_test.dart
@@ -56,13 +56,13 @@ void main() {
 
     test(
       'when listing tools, '
-      'then apply_migrations and tail_logs are available',
+      'then apply_migrations, hot_reload, and tail_logs are available',
       () async {
         final result = await connection.listTools();
 
         expect(
           result.tools.map((t) => t.name),
-          containsAll(['apply_migrations', 'tail_logs']),
+          containsAll(['apply_migrations', 'hot_reload', 'tail_logs']),
         );
       },
     );

--- a/tools/serverpod_cli/test/commands/start/mcp_server_test.dart
+++ b/tools/serverpod_cli/test/commands/start/mcp_server_test.dart
@@ -56,13 +56,19 @@ void main() {
 
     test(
       'when listing tools, '
-      'then apply_migrations, hot_reload, and tail_logs are available',
+      'then apply_migrations, create_migration, hot_reload, and tail_logs are '
+      'available',
       () async {
         final result = await connection.listTools();
 
         expect(
           result.tools.map((t) => t.name),
-          containsAll(['apply_migrations', 'hot_reload', 'tail_logs']),
+          containsAll([
+            'apply_migrations',
+            'create_migration',
+            'hot_reload',
+            'tail_logs',
+          ]),
         );
       },
     );
@@ -74,6 +80,22 @@ void main() {
         () async {
           final result = await connection.callTool(
             CallToolRequest(name: 'apply_migrations'),
+          );
+
+          expect(result.isError, isTrue);
+          expect(
+            (result.content.first as TextContent).text,
+            contains('not connected'),
+          );
+        },
+      );
+
+      test(
+        'when calling create_migration, '
+        'then it returns an error',
+        () async {
+          final result = await connection.callTool(
+            CallToolRequest(name: 'create_migration'),
           );
 
           expect(result.isError, isTrue);
@@ -124,6 +146,101 @@ void main() {
           expect(
             (result.content.first as TextContent).text,
             contains('database locked'),
+          );
+        },
+      );
+
+      test(
+        'when calling create_migration without args, '
+        'then the callback is invoked with null tag and force=false',
+        () async {
+          String? receivedTag;
+          bool? receivedForce;
+          server.onCreateMigration = ({String? tag, bool force = false}) async {
+            receivedTag = tag;
+            receivedForce = force;
+            return const CreateMigrationMcpResult(
+              message: 'Migration "v1" created at /tmp/v1.',
+            );
+          };
+
+          final result = await connection.callTool(
+            CallToolRequest(name: 'create_migration'),
+          );
+
+          expect(receivedTag, isNull);
+          expect(receivedForce, isFalse);
+          expect(result.isError, isNull);
+          expect(
+            (result.content.first as TextContent).text,
+            contains('Migration "v1" created'),
+          );
+        },
+      );
+
+      test(
+        'when calling create_migration with tag and force, '
+        'then the callback receives them',
+        () async {
+          String? receivedTag;
+          bool? receivedForce;
+          server.onCreateMigration = ({String? tag, bool force = false}) async {
+            receivedTag = tag;
+            receivedForce = force;
+            return const CreateMigrationMcpResult(message: 'ok');
+          };
+
+          await connection.callTool(
+            CallToolRequest(
+              name: 'create_migration',
+              arguments: {'tag': 'add-users', 'force': true},
+            ),
+          );
+
+          expect(receivedTag, 'add-users');
+          expect(receivedForce, isTrue);
+        },
+      );
+
+      test(
+        'when create_migration returns an error result, '
+        'then the tool result is flagged as error',
+        () async {
+          server.onCreateMigration = ({String? tag, bool force = false}) async {
+            return const CreateMigrationMcpResult(
+              message: 'database feature disabled',
+              isError: true,
+            );
+          };
+
+          final result = await connection.callTool(
+            CallToolRequest(name: 'create_migration'),
+          );
+
+          expect(result.isError, isTrue);
+          expect(
+            (result.content.first as TextContent).text,
+            contains('database feature disabled'),
+          );
+        },
+      );
+
+      test(
+        'when the create_migration callback throws, '
+        'then the tool result is an error with the message',
+        () async {
+          server.onCreateMigration = ({String? tag, bool force = false}) async {
+            throw Exception('model parse failed');
+          };
+
+          final result = await connection.callTool(
+            CallToolRequest(name: 'create_migration'),
+          );
+
+          expect(result.isError, isTrue);
+          expect(
+            (result.content.first as TextContent).text,
+            contains('model parse failed'),
           );
         },
       );

--- a/tools/serverpod_cli/test/commands/start/mcp_server_test.dart
+++ b/tools/serverpod_cli/test/commands/start/mcp_server_test.dart
@@ -56,12 +56,14 @@ void main() {
 
     test(
       'when listing tools, '
-      'then apply_migrations is available',
+      'then apply_migrations and tail_logs are available',
       () async {
         final result = await connection.listTools();
 
-        expect(result.tools, hasLength(1));
-        expect(result.tools.first.name, 'apply_migrations');
+        expect(
+          result.tools.map((t) => t.name),
+          containsAll(['apply_migrations', 'tail_logs']),
+        );
       },
     );
 

--- a/tools/serverpod_cli/test/commands/start/mcp_server_test.dart
+++ b/tools/serverpod_cli/test/commands/start/mcp_server_test.dart
@@ -56,8 +56,7 @@ void main() {
 
     test(
       'when listing tools, '
-      'then apply_migrations, create_migration, hot_reload, and tail_logs are '
-      'available',
+      'then apply_migrations, create_migration, hot_reload, and tail_logs are available',
       () async {
         final result = await connection.listTools();
 

--- a/tools/serverpod_cli/test/commands/start/mcp_socket_test.dart
+++ b/tools/serverpod_cli/test/commands/start/mcp_socket_test.dart
@@ -119,10 +119,7 @@ void main() {
               isA<SocketException>().having(
                 (e) => e.message,
                 'message',
-                allOf(
-                  contains('Unix socket path'),
-                  contains('too long'),
-                ),
+                startsWith('Unix socket path is too long for this platform'),
               ),
             ),
           );

--- a/tools/serverpod_cli/test/commands/start/mcp_socket_test.dart
+++ b/tools/serverpod_cli/test/commands/start/mcp_socket_test.dart
@@ -1,7 +1,9 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:path/path.dart' as p;
 import 'package:serverpod_cli/src/commands/start/mcp_socket.dart';
+import 'package:serverpod_cli/src/mcp/socket_directory.dart';
 import 'package:serverpod_cli/src/util/platform_check.dart';
 import 'package:test/test.dart';
 
@@ -93,6 +95,41 @@ void main() {
       },
     );
   });
+
+  group(
+    'Given a project name that pushes the socket path past the platform limit',
+    skip: !hasUnixSocketSupport(),
+    () {
+      test(
+        'when starting an McpSocketServer, '
+        'then start throws a SocketException with an actionable message',
+        () async {
+          // Build a project name long enough that the resulting socket path
+          // exceeds the platform's sun_path limit even after shortening.
+          final budget = maxUnixSocketPathBytes();
+          final templatePath = serverpodMcpSocketPath(pid: pid, project: 'x');
+          final overhead = p.basename(templatePath).length - 1;
+          final projectLen = budget - overhead + 16;
+          final project = 'p' * projectLen;
+
+          final server = McpSocketServer(project: project);
+          await expectLater(
+            server.start,
+            throwsA(
+              isA<SocketException>().having(
+                (e) => e.message,
+                'message',
+                allOf(
+                  contains('Unix socket path'),
+                  contains('too long'),
+                ),
+              ),
+            ),
+          );
+        },
+      );
+    },
+  );
 
   group(
     'Given Windows with Dart < 3.11',

--- a/tools/serverpod_cli/test/commands/start/mcp_socket_test.dart
+++ b/tools/serverpod_cli/test/commands/start/mcp_socket_test.dart
@@ -1,37 +1,38 @@
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:path/path.dart' as p;
 import 'package:serverpod_cli/src/commands/start/mcp_socket.dart';
 import 'package:serverpod_cli/src/util/platform_check.dart';
 import 'package:test/test.dart';
 
 void main() {
   group('Given an McpSocketServer', skip: !hasUnixSocketSupport(), () {
-    late Directory tmpDir;
     late McpSocketServer server;
 
     setUp(() async {
-      tmpDir = await Directory.systemTemp.createTemp('mcp_socket_test_');
-      final socketPath = p.join(tmpDir.path, 'mcp.sock');
-      server = McpSocketServer(socketPath: socketPath);
+      // Project name kept short: macOS limits Unix socket paths to ~104 chars
+      // and the systemTemp prefix can use ~50 of them on its own.
+      server = McpSocketServer(
+        project: 'mst${DateTime.now().microsecondsSinceEpoch % 100000}',
+      );
       await server.start();
     });
 
     tearDown(() async {
       await server.close();
-      if (tmpDir.existsSync()) {
-        tmpDir.deleteSync(recursive: true);
-      }
     });
 
     test(
       'when started, '
-      'then the socket file exists',
+      'then the socket file exists in the shared serverpod socket dir',
       () {
         expect(
           FileSystemEntity.typeSync(server.socketPath),
           isNot(FileSystemEntityType.notFound),
+        );
+        expect(
+          server.socketPath,
+          matches(r'/serverpod/serverpod-\d+-mst\d+\.sock$'),
         );
       },
     );
@@ -101,7 +102,7 @@ void main() {
         'when starting an McpSocketServer, '
         'then it throws a SocketException',
         () async {
-          final server = McpSocketServer(socketPath: 'mcp.sock');
+          final server = McpSocketServer(project: 'unsupported');
           expect(server.start(), throwsA(isA<SocketException>()));
         },
       );

--- a/tools/serverpod_cli/test/commands/start/mcp_socket_test.dart
+++ b/tools/serverpod_cli/test/commands/start/mcp_socket_test.dart
@@ -32,7 +32,7 @@ void main() {
         );
         expect(
           server.socketPath,
-          matches(r'/serverpod/serverpod-\d+-mst\d+\.sock$'),
+          matches(r'[\\/]serverpod[\\/]serverpod-\d+-mst\d+\.sock$'),
         );
       },
     );

--- a/tools/serverpod_cli/test/commands/start/watch_session_test.dart
+++ b/tools/serverpod_cli/test/commands/start/watch_session_test.dart
@@ -731,115 +731,121 @@ void main() {
     );
   });
 
-  group('Given a protocol-change classifier that returns false', () {
-    late _FakeCompiler classifierCompiler;
-    late _FakeServer classifierServer;
-    late List<Set<String>> classifierGenerateCalls;
-    late WatchSession classifierSession;
+  group(
+    'Given a watch session where no dart change is protocol-relevant',
+    () {
+      late _FakeCompiler classifierCompiler;
+      late _FakeServer classifierServer;
+      late List<Set<String>> classifierGenerateCalls;
+      late WatchSession classifierSession;
 
-    setUp(() {
-      classifierCompiler = _FakeCompiler();
-      classifierServer = _FakeServer();
-      classifierGenerateCalls = [];
+      setUp(() {
+        classifierCompiler = _FakeCompiler();
+        classifierServer = _FakeServer();
+        classifierGenerateCalls = [];
 
-      classifierSession = WatchSession(
-        compiler: classifierCompiler,
-        generate: (affectedPaths, requirements) async {
-          classifierGenerateCalls.add(affectedPaths);
-          return (success: true, generatedFiles: <String>{});
+        classifierSession = WatchSession(
+          compiler: classifierCompiler,
+          generate: (affectedPaths, requirements) async {
+            classifierGenerateCalls.add(affectedPaths);
+            return (success: true, generatedFiles: <String>{});
+          },
+          createServer:
+              (String dillPath, {List<String> extraArgs = const []}) async =>
+                  classifierServer,
+          initialServer: classifierServer,
+          generatedDirPaths: {'/generated'},
+          classifyProtocolChange: (_) async => false,
+        );
+      });
+
+      test(
+        'when only a dart file changes, '
+        'then code generation is skipped and only compile + reload run',
+        () async {
+          final event = FileChangeEvent(dartFiles: {'/lib/helper.dart'});
+
+          await classifierSession.handleFileChange(event);
+
+          expect(classifierGenerateCalls, isEmpty);
+          expect(classifierCompiler.calls, [
+            'compile(changed):[/lib/helper.dart]',
+            'accept',
+          ]);
+          expect(classifierServer.calls, ['reload:/out.dill']);
         },
-        createServer:
-            (String dillPath, {List<String> extraArgs = const []}) async =>
-                classifierServer,
-        initialServer: classifierServer,
-        generatedDirPaths: {'/generated'},
-        classifyProtocolChange: (_) async => false,
       );
-    });
 
-    test(
-      'when a non-protocol dart file changes, '
-      'then generation is skipped and only compile + reload run',
-      () async {
-        final event = FileChangeEvent(dartFiles: {'/lib/helper.dart'});
+      test(
+        'when a model file changes alongside a dart file, '
+        'then code generation still runs because model changes always force regeneration',
+        () async {
+          final event = FileChangeEvent(
+            dartFiles: {'/lib/helper.dart'},
+            modelFiles: {'/lib/src/models/user.spy.yaml'},
+          );
 
-        await classifierSession.handleFileChange(event);
+          await classifierSession.handleFileChange(event);
 
-        expect(classifierGenerateCalls, isEmpty);
-        expect(classifierCompiler.calls, [
-          'compile(changed):[/lib/helper.dart]',
-          'accept',
-        ]);
-        expect(classifierServer.calls, ['reload:/out.dill']);
-      },
-    );
-
-    test(
-      'when a model (.spy) file changes alongside a non-protocol dart file, '
-      'then generation still runs (models force regen)',
-      () async {
-        final event = FileChangeEvent(
-          dartFiles: {'/lib/helper.dart'},
-          modelFiles: {'/lib/src/models/user.spy.yaml'},
-        );
-
-        await classifierSession.handleFileChange(event);
-
-        expect(classifierGenerateCalls, hasLength(1));
-        expect(
-          classifierGenerateCalls.first,
-          containsAll(<String>{'/lib/src/models/user.spy.yaml'}),
-        );
-      },
-    );
-  });
-
-  group('Given a protocol-change classifier that returns true', () {
-    late _FakeCompiler classifierCompiler;
-    late _FakeServer classifierServer;
-    late List<Set<String>> classifierGenerateCalls;
-    late WatchSession classifierSession;
-
-    setUp(() {
-      classifierCompiler = _FakeCompiler();
-      classifierServer = _FakeServer();
-      classifierGenerateCalls = [];
-
-      classifierSession = WatchSession(
-        compiler: classifierCompiler,
-        generate: (affectedPaths, requirements) async {
-          classifierGenerateCalls.add(affectedPaths);
-          return (success: true, generatedFiles: <String>{});
+          expect(classifierGenerateCalls, hasLength(1));
+          expect(
+            classifierGenerateCalls.first,
+            containsAll(<String>{'/lib/src/models/user.spy.yaml'}),
+          );
         },
-        createServer:
-            (String dillPath, {List<String> extraArgs = const []}) async =>
-                classifierServer,
-        initialServer: classifierServer,
-        generatedDirPaths: {'/generated'},
-        classifyProtocolChange: (_) async => true,
       );
-    });
+    },
+  );
 
-    test(
-      'when a protocol-relevant dart file changes, '
-      'then generation runs with that file in affectedPaths',
-      () async {
-        final event = FileChangeEvent(dartFiles: {'/lib/endpoints/user.dart'});
+  group(
+    'Given a watch session where every dart change is protocol-relevant',
+    () {
+      late _FakeCompiler classifierCompiler;
+      late _FakeServer classifierServer;
+      late List<Set<String>> classifierGenerateCalls;
+      late WatchSession classifierSession;
 
-        await classifierSession.handleFileChange(event);
+      setUp(() {
+        classifierCompiler = _FakeCompiler();
+        classifierServer = _FakeServer();
+        classifierGenerateCalls = [];
 
-        expect(classifierGenerateCalls, hasLength(1));
-        expect(
-          classifierGenerateCalls.first,
-          {'/lib/endpoints/user.dart'},
+        classifierSession = WatchSession(
+          compiler: classifierCompiler,
+          generate: (affectedPaths, requirements) async {
+            classifierGenerateCalls.add(affectedPaths);
+            return (success: true, generatedFiles: <String>{});
+          },
+          createServer:
+              (String dillPath, {List<String> extraArgs = const []}) async =>
+                  classifierServer,
+          initialServer: classifierServer,
+          generatedDirPaths: {'/generated'},
+          classifyProtocolChange: (_) async => true,
         );
-        expect(classifierCompiler.calls, [
-          'compile(changed):[/lib/endpoints/user.dart]',
-          'accept',
-        ]);
-      },
-    );
-  });
+      });
+
+      test(
+        'when a dart file changes, '
+        'then code generation runs and the changed file is included in '
+        'the regenerated paths',
+        () async {
+          final event = FileChangeEvent(
+            dartFiles: {'/lib/endpoints/user.dart'},
+          );
+
+          await classifierSession.handleFileChange(event);
+
+          expect(classifierGenerateCalls, hasLength(1));
+          expect(classifierGenerateCalls.first, {'/lib/endpoints/user.dart'});
+          expect(classifierCompiler.calls, [
+            'compile(changed):[/lib/endpoints/user.dart]',
+            'accept',
+          ]);
+        },
+      );
+    },
+  );
 
   group('Given defaultProtocolChangeClassifier', () {
     test(

--- a/tools/serverpod_cli/test/commands/start/watch_session_test.dart
+++ b/tools/serverpod_cli/test/commands/start/watch_session_test.dart
@@ -61,6 +61,7 @@ class _FakeCompiler extends Fake implements KernelCompiler {
 class _FakeServer extends Fake implements ServerProcess {
   final List<String> calls = [];
   final Completer<int> _exitCodeCompleter = Completer<int>();
+  final Completer<void> _vmServiceReadyCompleter = Completer<void>();
 
   bool _vmServiceConnected;
   bool reloadSuccess = true;
@@ -75,6 +76,12 @@ class _FakeServer extends Fake implements ServerProcess {
 
   @override
   Future<int> get exitCode => _exitCodeCompleter.future;
+
+  @override
+  Future<void> get vmServiceReady => _vmServiceReadyCompleter.future;
+
+  @override
+  String? get vmServiceUri => null;
 
   /// Completes [exitCode] with the given code, simulating a crash.
   void simulateExit(int code) => _exitCodeCompleter.complete(code);

--- a/tools/serverpod_cli/test/commands/start/watch_session_test.dart
+++ b/tools/serverpod_cli/test/commands/start/watch_session_test.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io';
 
 import 'package:serverpod_cli/src/commands/start/file_watcher.dart';
 import 'package:serverpod_cli/src/commands/start/kernel_compiler.dart';
@@ -726,6 +727,205 @@ void main() {
         await Future<void>.delayed(Duration.zero);
 
         expect(doneCompleted, isFalse);
+      },
+    );
+  });
+
+  group('Given a protocol-change classifier that returns false', () {
+    late _FakeCompiler classifierCompiler;
+    late _FakeServer classifierServer;
+    late List<Set<String>> classifierGenerateCalls;
+    late WatchSession classifierSession;
+
+    setUp(() {
+      classifierCompiler = _FakeCompiler();
+      classifierServer = _FakeServer();
+      classifierGenerateCalls = [];
+
+      classifierSession = WatchSession(
+        compiler: classifierCompiler,
+        generate: (affectedPaths, requirements) async {
+          classifierGenerateCalls.add(affectedPaths);
+          return (success: true, generatedFiles: <String>{});
+        },
+        createServer:
+            (String dillPath, {List<String> extraArgs = const []}) async =>
+                classifierServer,
+        initialServer: classifierServer,
+        generatedDirPaths: {'/generated'},
+        classifyProtocolChange: (_) async => false,
+      );
+    });
+
+    test(
+      'when a non-protocol dart file changes, '
+      'then generation is skipped and only compile + reload run',
+      () async {
+        final event = FileChangeEvent(dartFiles: {'/lib/helper.dart'});
+
+        await classifierSession.handleFileChange(event);
+
+        expect(classifierGenerateCalls, isEmpty);
+        expect(classifierCompiler.calls, [
+          'compile(changed):[/lib/helper.dart]',
+          'accept',
+        ]);
+        expect(classifierServer.calls, ['reload:/out.dill']);
+      },
+    );
+
+    test(
+      'when a model (.spy) file changes alongside a non-protocol dart file, '
+      'then generation still runs (models force regen)',
+      () async {
+        final event = FileChangeEvent(
+          dartFiles: {'/lib/helper.dart'},
+          modelFiles: {'/lib/src/models/user.spy.yaml'},
+        );
+
+        await classifierSession.handleFileChange(event);
+
+        expect(classifierGenerateCalls, hasLength(1));
+        expect(
+          classifierGenerateCalls.first,
+          containsAll(<String>{'/lib/src/models/user.spy.yaml'}),
+        );
+      },
+    );
+  });
+
+  group('Given a protocol-change classifier that returns true', () {
+    late _FakeCompiler classifierCompiler;
+    late _FakeServer classifierServer;
+    late List<Set<String>> classifierGenerateCalls;
+    late WatchSession classifierSession;
+
+    setUp(() {
+      classifierCompiler = _FakeCompiler();
+      classifierServer = _FakeServer();
+      classifierGenerateCalls = [];
+
+      classifierSession = WatchSession(
+        compiler: classifierCompiler,
+        generate: (affectedPaths, requirements) async {
+          classifierGenerateCalls.add(affectedPaths);
+          return (success: true, generatedFiles: <String>{});
+        },
+        createServer:
+            (String dillPath, {List<String> extraArgs = const []}) async =>
+                classifierServer,
+        initialServer: classifierServer,
+        generatedDirPaths: {'/generated'},
+        classifyProtocolChange: (_) async => true,
+      );
+    });
+
+    test(
+      'when a protocol-relevant dart file changes, '
+      'then generation runs with that file in affectedPaths',
+      () async {
+        final event = FileChangeEvent(dartFiles: {'/lib/endpoints/user.dart'});
+
+        await classifierSession.handleFileChange(event);
+
+        expect(classifierGenerateCalls, hasLength(1));
+        expect(
+          classifierGenerateCalls.first,
+          {'/lib/endpoints/user.dart'},
+        );
+        expect(classifierCompiler.calls, [
+          'compile(changed):[/lib/endpoints/user.dart]',
+          'accept',
+        ]);
+      },
+    );
+  });
+
+  group('Given defaultProtocolChangeClassifier', () {
+    test(
+      'when the file does not exist, '
+      'then it returns true (conservative default for deletes)',
+      () async {
+        final result = await defaultProtocolChangeClassifier(
+          '/nonexistent/path/that/does/not/exist.dart',
+        );
+
+        expect(result, isTrue);
+      },
+    );
+
+    test(
+      'when the file contains extends Endpoint, '
+      'then it returns true',
+      () async {
+        final tempDir = await Directory.systemTemp.createTemp('watch_test_');
+        addTearDown(() => tempDir.delete(recursive: true));
+        final file = File('${tempDir.path}/endpoint.dart');
+        await file.writeAsString('''
+import 'package:serverpod/serverpod.dart';
+class MyEndpoint extends Endpoint {
+  Future<String> hello(Session session) async => 'hi';
+}
+''');
+
+        final result = await defaultProtocolChangeClassifier(file.path);
+
+        expect(result, isTrue);
+      },
+    );
+
+    test(
+      'when the file contains extends StreamingEndpoint, '
+      'then it returns true',
+      () async {
+        final tempDir = await Directory.systemTemp.createTemp('watch_test_');
+        addTearDown(() => tempDir.delete(recursive: true));
+        final file = File('${tempDir.path}/stream.dart');
+        await file.writeAsString(
+          'class S extends StreamingEndpoint { }',
+        );
+
+        final result = await defaultProtocolChangeClassifier(file.path);
+
+        expect(result, isTrue);
+      },
+    );
+
+    test(
+      'when the file contains extends FutureCall, '
+      'then it returns true',
+      () async {
+        final tempDir = await Directory.systemTemp.createTemp('watch_test_');
+        addTearDown(() => tempDir.delete(recursive: true));
+        final file = File('${tempDir.path}/fcall.dart');
+        await file.writeAsString(
+          'class F extends FutureCall<MyModel> { }',
+        );
+
+        final result = await defaultProtocolChangeClassifier(file.path);
+
+        expect(result, isTrue);
+      },
+    );
+
+    test(
+      'when the file is pure helper code with no endpoint markers, '
+      'then it returns false',
+      () async {
+        final tempDir = await Directory.systemTemp.createTemp('watch_test_');
+        addTearDown(() => tempDir.delete(recursive: true));
+        final file = File('${tempDir.path}/helper.dart');
+        await file.writeAsString('''
+String greet(String name) => 'Hello, \$name';
+class Counter {
+  int value = 0;
+  void increment() => value++;
+}
+''');
+
+        final result = await defaultProtocolChangeClassifier(file.path);
+
+        expect(result, isFalse);
       },
     );
   });

--- a/tools/serverpod_cli/test/mcp/bridge_mcp_server_test.dart
+++ b/tools/serverpod_cli/test/mcp/bridge_mcp_server_test.dart
@@ -1,0 +1,216 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:dart_mcp/client.dart';
+import 'package:serverpod_cli/src/commands/start/mcp_socket.dart';
+import 'package:serverpod_cli/src/mcp/bridge_mcp_server.dart';
+import 'package:serverpod_cli/src/mcp/serverpod_mcp_bridge.dart';
+import 'package:serverpod_cli/src/util/platform_check.dart';
+import 'package:stream_channel/stream_channel.dart';
+import 'package:test/test.dart';
+
+/// End-to-end test for the bridge:
+///
+///   test client (in-memory channel)
+///       ↕  MCP
+///   BridgeMcpServer
+///       ↕  MCP over Unix socket (real)
+///   McpSocketServer  (with apply_migrations callback)
+///
+/// Verifies the bridge can `connect` to a discovered runner and forward
+/// `apply_migrations` to it.
+void main() {
+  group(
+    'Given a BridgeMcpServer connected to a real runner socket',
+    skip: !hasUnixSocketSupport(),
+    () {
+      late McpSocketServer runner;
+      late ServerpodMcpBridge bridge;
+      late BridgeMcpServer bridgeServer;
+      late ServerConnection client;
+      late String project;
+
+      setUp(() async {
+        // Short project name to stay under macOS Unix-socket path limits
+        // (~104 chars total; systemTemp can already eat ~50).
+        project = 'bt${DateTime.now().microsecondsSinceEpoch % 100000}';
+
+        runner = McpSocketServer(project: project);
+        await runner.start();
+
+        bridge = ServerpodMcpBridge();
+        await bridge.scan();
+
+        // In-memory channel pair for the test client.
+        final clientToBridge = StreamController<String>();
+        final bridgeToClient = StreamController<String>();
+        final bridgeChannel = StreamChannel<String>(
+          clientToBridge.stream,
+          bridgeToClient.sink,
+        );
+        final clientChannel = StreamChannel<String>(
+          bridgeToClient.stream,
+          clientToBridge.sink,
+        );
+
+        bridgeServer = BridgeMcpServer(bridgeChannel, bridge: bridge);
+        client = MCPClient(
+          Implementation(name: 'bridge-test-client', version: '0.0.0'),
+        ).connectServer(clientChannel);
+
+        await client.initialize(
+          InitializeRequest(
+            protocolVersion: ProtocolVersion.latestSupported,
+            capabilities: ClientCapabilities(),
+            clientInfo: Implementation(
+              name: 'bridge-test-client',
+              version: '0.0.0',
+            ),
+          ),
+        );
+      });
+
+      tearDown(() async {
+        await client.shutdown();
+        await bridgeServer.shutdown();
+        await bridge.dispose();
+        await runner.close();
+      });
+
+      test(
+        'when listing tools, '
+        'then connect/disconnect/spawn/stop/apply_migrations are exposed',
+        () async {
+          final result = await client.listTools();
+          final names = result.tools.map((t) => t.name).toSet();
+          expect(
+            names,
+            containsAll(<String>{
+              'connect',
+              'disconnect',
+              'spawn',
+              'stop',
+              'apply_migrations',
+            }),
+          );
+        },
+      );
+
+      test(
+        'when reading serverpod://instances, '
+        'then the runner socket appears in the list',
+        () async {
+          final result = await client.readResource(
+            ReadResourceRequest(uri: 'serverpod://instances'),
+          );
+          final text = (result.contents.first as TextResourceContents).text;
+          final instances = jsonDecode(text) as List;
+
+          final entry = instances.cast<Map<String, dynamic>>().firstWhere(
+            (e) => e['project'] == project,
+          );
+          expect(entry['socketPath'], runner.socketPath);
+          expect(entry['connected'], isFalse);
+        },
+      );
+
+      test(
+        'when calling apply_migrations before connect, '
+        'then the bridge returns a not-connected error',
+        () async {
+          final result = await client.callTool(
+            CallToolRequest(name: 'apply_migrations'),
+          );
+          expect(result.isError, isTrue);
+          expect(
+            (result.content.first as TextContent).text,
+            contains('Not connected'),
+          );
+        },
+      );
+
+      test(
+        'when calling connect then apply_migrations, '
+        'then the runner-side callback is invoked',
+        () async {
+          var called = 0;
+          runner.connect(
+            onApplyMigration: () async {
+              called++;
+            },
+          );
+
+          final connectResult = await client.callTool(
+            CallToolRequest(
+              name: 'connect',
+              arguments: {'instanceId': project},
+            ),
+          );
+          expect(
+            connectResult.isError,
+            anyOf(isNull, isFalse),
+            reason:
+                'connect should succeed: '
+                '${(connectResult.content.first as TextContent).text}',
+          );
+
+          final applyResult = await client.callTool(
+            CallToolRequest(name: 'apply_migrations'),
+          );
+          expect(applyResult.isError, anyOf(isNull, isFalse));
+          expect(called, 1);
+          expect(
+            (applyResult.content.first as TextContent).text,
+            contains('Migrations applied'),
+          );
+        },
+      );
+
+      test(
+        'when connect is called with an unknown instanceId, '
+        'then it returns an error listing available instances',
+        () async {
+          final result = await client.callTool(
+            CallToolRequest(
+              name: 'connect',
+              arguments: {'instanceId': 'no-such-project'},
+            ),
+          );
+          expect(result.isError, isTrue);
+          expect(
+            (result.content.first as TextContent).text,
+            allOf(
+              contains('No instance found'),
+              contains(project),
+            ),
+          );
+        },
+      );
+
+      test(
+        'when disconnect is called after connect, '
+        'then subsequent apply_migrations errors',
+        () async {
+          runner.connect(onApplyMigration: () async {});
+
+          await client.callTool(
+            CallToolRequest(
+              name: 'connect',
+              arguments: {'instanceId': project},
+            ),
+          );
+
+          final disconnectResult = await client.callTool(
+            CallToolRequest(name: 'disconnect'),
+          );
+          expect(disconnectResult.isError, anyOf(isNull, isFalse));
+
+          final applyResult = await client.callTool(
+            CallToolRequest(name: 'apply_migrations'),
+          );
+          expect(applyResult.isError, isTrue);
+        },
+      );
+    },
+  );
+}

--- a/tools/serverpod_cli/test/mcp/bridge_mcp_server_test.dart
+++ b/tools/serverpod_cli/test/mcp/bridge_mcp_server_test.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:dart_mcp/client.dart';
+import 'package:serverpod_cli/src/commands/start/mcp_server.dart';
 import 'package:serverpod_cli/src/commands/start/mcp_socket.dart';
 import 'package:serverpod_cli/src/mcp/bridge_mcp_server.dart';
 import 'package:serverpod_cli/src/mcp/serverpod_mcp_bridge.dart';
@@ -79,7 +80,8 @@ void main() {
 
       test(
         'when listing tools, '
-        'then connect/disconnect/spawn/stop/apply_migrations are exposed',
+        'then connect/disconnect/spawn/stop and the forwarded tools are '
+        'exposed',
         () async {
           final result = await client.listTools();
           final names = result.tools.map((t) => t.name).toSet();
@@ -91,6 +93,9 @@ void main() {
               'spawn',
               'stop',
               'apply_migrations',
+              'create_migration',
+              'hot_reload',
+              'tail_logs',
             }),
           );
         },
@@ -162,6 +167,47 @@ void main() {
           expect(
             (applyResult.content.first as TextContent).text,
             contains('Migrations applied'),
+          );
+        },
+      );
+
+      test(
+        'when calling connect then create_migration with tag and force, '
+        'then the runner-side callback receives the arguments',
+        () async {
+          String? receivedTag;
+          bool? receivedForce;
+          runner.connect(
+            onApplyMigration: () async {},
+            onCreateMigration: ({String? tag, bool force = false}) async {
+              receivedTag = tag;
+              receivedForce = force;
+              return const CreateMigrationMcpResult(
+                message: 'Migration "v1" created at /tmp/v1.',
+              );
+            },
+          );
+
+          await client.callTool(
+            CallToolRequest(
+              name: 'connect',
+              arguments: {'instanceId': project},
+            ),
+          );
+
+          final result = await client.callTool(
+            CallToolRequest(
+              name: 'create_migration',
+              arguments: {'tag': 'add-users', 'force': true},
+            ),
+          );
+
+          expect(result.isError, anyOf(isNull, isFalse));
+          expect(receivedTag, 'add-users');
+          expect(receivedForce, isTrue);
+          expect(
+            (result.content.first as TextContent).text,
+            contains('Migration "v1" created'),
           );
         },
       );

--- a/tools/serverpod_cli/test/mcp/bridge_mcp_server_test.dart
+++ b/tools/serverpod_cli/test/mcp/bridge_mcp_server_test.dart
@@ -79,10 +79,36 @@ void main() {
       });
 
       test(
-        'when listing tools, '
-        'then connect/disconnect/spawn/stop and the forwarded tools are '
-        'exposed',
+        'when listing tools before connect, '
+        'then only the bridge-native tools are exposed',
         () async {
+          final result = await client.listTools();
+          final names = result.tools.map((t) => t.name).toSet();
+          expect(
+            names,
+            containsAll(<String>{'connect', 'disconnect', 'spawn', 'stop'}),
+          );
+          // Forwarded tools are not registered until connect.
+          expect(names, isNot(contains('apply_migrations')));
+          expect(names, isNot(contains('create_migration')));
+          expect(names, isNot(contains('hot_reload')));
+          expect(names, isNot(contains('tail_logs')));
+        },
+      );
+
+      test(
+        'when listing tools after connect, '
+        'then forwarded runner tools also appear',
+        () async {
+          runner.connect(onApplyMigration: () async {});
+
+          await client.callTool(
+            CallToolRequest(
+              name: 'connect',
+              arguments: {'instanceId': project},
+            ),
+          );
+
           final result = await client.listTools();
           final names = result.tools.map((t) => t.name).toSet();
           expect(
@@ -121,16 +147,12 @@ void main() {
 
       test(
         'when calling apply_migrations before connect, '
-        'then the bridge returns a not-connected error',
+        'then it errors because the tool is not yet registered',
         () async {
           final result = await client.callTool(
             CallToolRequest(name: 'apply_migrations'),
           );
           expect(result.isError, isTrue);
-          expect(
-            (result.content.first as TextContent).text,
-            contains('Not connected'),
-          );
         },
       );
 

--- a/tools/serverpod_cli/test/mcp/bridge_mcp_server_test.dart
+++ b/tools/serverpod_cli/test/mcp/bridge_mcp_server_test.dart
@@ -22,7 +22,7 @@ import 'package:test/test.dart';
 /// `apply_migrations` to it.
 void main() {
   group(
-    'Given a BridgeMcpServer connected to a real runner socket',
+    'Given a BridgeMcpServer that has discovered a runner socket',
     skip: !hasUnixSocketSupport(),
     () {
       late McpSocketServer runner;
@@ -79,7 +79,7 @@ void main() {
       });
 
       test(
-        'when listing tools before connect, '
+        'when listing tools, '
         'then only the bridge-native tools are exposed',
         () async {
           final result = await client.listTools();
@@ -93,37 +93,6 @@ void main() {
           expect(names, isNot(contains('create_migration')));
           expect(names, isNot(contains('hot_reload')));
           expect(names, isNot(contains('tail_logs')));
-        },
-      );
-
-      test(
-        'when listing tools after connect, '
-        'then forwarded runner tools also appear',
-        () async {
-          runner.connect(onApplyMigration: () async {});
-
-          await client.callTool(
-            CallToolRequest(
-              name: 'connect',
-              arguments: {'instanceId': project},
-            ),
-          );
-
-          final result = await client.listTools();
-          final names = result.tools.map((t) => t.name).toSet();
-          expect(
-            names,
-            containsAll(<String>{
-              'connect',
-              'disconnect',
-              'spawn',
-              'stop',
-              'apply_migrations',
-              'create_migration',
-              'hot_reload',
-              'tail_logs',
-            }),
-          );
         },
       );
 
@@ -157,84 +126,6 @@ void main() {
       );
 
       test(
-        'when calling connect then apply_migrations, '
-        'then the runner-side callback is invoked',
-        () async {
-          var called = 0;
-          runner.connect(
-            onApplyMigration: () async {
-              called++;
-            },
-          );
-
-          final connectResult = await client.callTool(
-            CallToolRequest(
-              name: 'connect',
-              arguments: {'instanceId': project},
-            ),
-          );
-          expect(
-            connectResult.isError,
-            anyOf(isNull, isFalse),
-            reason:
-                'connect should succeed: '
-                '${(connectResult.content.first as TextContent).text}',
-          );
-
-          final applyResult = await client.callTool(
-            CallToolRequest(name: 'apply_migrations'),
-          );
-          expect(applyResult.isError, anyOf(isNull, isFalse));
-          expect(called, 1);
-          expect(
-            (applyResult.content.first as TextContent).text,
-            contains('Migrations applied'),
-          );
-        },
-      );
-
-      test(
-        'when calling connect then create_migration with tag and force, '
-        'then the runner-side callback receives the arguments',
-        () async {
-          String? receivedTag;
-          bool? receivedForce;
-          runner.connect(
-            onApplyMigration: () async {},
-            onCreateMigration: ({String? tag, bool force = false}) async {
-              receivedTag = tag;
-              receivedForce = force;
-              return const CreateMigrationMcpResult(
-                message: 'Migration "v1" created at /tmp/v1.',
-              );
-            },
-          );
-
-          await client.callTool(
-            CallToolRequest(
-              name: 'connect',
-              arguments: {'instanceId': project},
-            ),
-          );
-
-          final result = await client.callTool(
-            CallToolRequest(
-              name: 'create_migration',
-              arguments: {'tag': 'add-users', 'force': true},
-            ),
-          );
-
-          expect(result.isError, anyOf(isNull, isFalse));
-          expect(receivedTag, 'add-users');
-          expect(receivedForce, isTrue);
-          expect(
-            (result.content.first as TextContent).text,
-            contains('Migration "v1" created'),
-          );
-        },
-      );
-
-      test(
         'when connect is called with an unknown instanceId, '
         'then it returns an error listing available instances',
         () async {
@@ -247,38 +138,128 @@ void main() {
           expect(result.isError, isTrue);
           expect(
             (result.content.first as TextContent).text,
-            allOf(
-              contains('No instance found'),
-              contains(project),
-            ),
+            allOf(contains('No instance found'), contains(project)),
           );
         },
       );
 
-      test(
-        'when disconnect is called after connect, '
-        'then subsequent apply_migrations errors',
-        () async {
-          runner.connect(onApplyMigration: () async {});
+      group('Given the bridge is connected to the runner', () {
+        late int applyMigrationCalls;
+        late String? receivedTag;
+        late bool? receivedForce;
 
-          await client.callTool(
+        setUp(() async {
+          applyMigrationCalls = 0;
+          receivedTag = null;
+          receivedForce = null;
+
+          runner.connect(
+            onApplyMigration: () async {
+              applyMigrationCalls++;
+            },
+            onCreateMigration: ({String? tag, bool force = false}) async {
+              receivedTag = tag;
+              receivedForce = force;
+              return const CreateMigrationMcpResult(
+                message: 'Migration "v1" created at /tmp/v1.',
+              );
+            },
+          );
+
+          final result = await client.callTool(
             CallToolRequest(
               name: 'connect',
               arguments: {'instanceId': project},
             ),
           );
-
-          final disconnectResult = await client.callTool(
-            CallToolRequest(name: 'disconnect'),
+          expect(
+            result.isError,
+            anyOf(isNull, isFalse),
+            reason:
+                'connect should succeed: '
+                '${(result.content.first as TextContent).text}',
           );
-          expect(disconnectResult.isError, anyOf(isNull, isFalse));
+        });
 
-          final applyResult = await client.callTool(
-            CallToolRequest(name: 'apply_migrations'),
+        test(
+          'when listing tools, '
+          'then forwarded runner tools also appear alongside the bridge-native tools',
+          () async {
+            final result = await client.listTools();
+            final names = result.tools.map((t) => t.name).toSet();
+            expect(
+              names,
+              containsAll(<String>{
+                'connect',
+                'disconnect',
+                'spawn',
+                'stop',
+                'apply_migrations',
+                'create_migration',
+                'hot_reload',
+                'tail_logs',
+              }),
+            );
+          },
+        );
+
+        test(
+          'when calling apply_migrations, '
+          'then the runner-side callback is invoked',
+          () async {
+            final result = await client.callTool(
+              CallToolRequest(name: 'apply_migrations'),
+            );
+            expect(result.isError, anyOf(isNull, isFalse));
+            expect(applyMigrationCalls, 1);
+            expect(
+              (result.content.first as TextContent).text,
+              contains('Migrations applied'),
+            );
+          },
+        );
+
+        test(
+          'when calling create_migration with tag and force, '
+          'then the runner-side callback receives the arguments',
+          () async {
+            final result = await client.callTool(
+              CallToolRequest(
+                name: 'create_migration',
+                arguments: {'tag': 'add-users', 'force': true},
+              ),
+            );
+
+            expect(result.isError, anyOf(isNull, isFalse));
+            expect(receivedTag, 'add-users');
+            expect(receivedForce, isTrue);
+            expect(
+              (result.content.first as TextContent).text,
+              contains('Migration "v1" created'),
+            );
+          },
+        );
+
+        group('Given the bridge is then disconnected', () {
+          setUp(() async {
+            final result = await client.callTool(
+              CallToolRequest(name: 'disconnect'),
+            );
+            expect(result.isError, anyOf(isNull, isFalse));
+          });
+
+          test(
+            'when calling apply_migrations, '
+            'then it errors because the forwarded tool has been unregistered',
+            () async {
+              final result = await client.callTool(
+                CallToolRequest(name: 'apply_migrations'),
+              );
+              expect(result.isError, isTrue);
+            },
           );
-          expect(applyResult.isError, isTrue);
-        },
-      );
+        });
+      });
     },
   );
 }

--- a/tools/serverpod_cli/test/mcp/bridge_mcp_server_test.dart
+++ b/tools/serverpod_cli/test/mcp/bridge_mcp_server_test.dart
@@ -240,25 +240,25 @@ void main() {
           },
         );
 
-        group('Given the bridge is then disconnected', () {
-          setUp(() async {
-            final result = await client.callTool(
+        test(
+          'when calling apply_migrations after disconnect, '
+          'then it errors because the forwarded tool has been unregistered',
+          () async {
+            var result = await client.callTool(
               CallToolRequest(name: 'disconnect'),
             );
-            expect(result.isError, anyOf(isNull, isFalse));
-          });
+            expect(
+              result.isError,
+              anyOf(isNull, isFalse),
+              reason: '(precondition)',
+            );
 
-          test(
-            'when calling apply_migrations, '
-            'then it errors because the forwarded tool has been unregistered',
-            () async {
-              final result = await client.callTool(
-                CallToolRequest(name: 'apply_migrations'),
-              );
-              expect(result.isError, isTrue);
-            },
-          );
-        });
+            result = await client.callTool(
+              CallToolRequest(name: 'apply_migrations'),
+            );
+            expect(result.isError, isTrue);
+          },
+        );
       });
     },
   );

--- a/tools/serverpod_cli/test/mcp/socket_directory_test.dart
+++ b/tools/serverpod_cli/test/mcp/socket_directory_test.dart
@@ -1,0 +1,143 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:serverpod_cli/src/mcp/socket_directory.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Given sanitizeProjectName', () {
+    test(
+      'when input has uppercase and underscores, '
+      'then they are lowercased and replaced with hyphens',
+      () {
+        expect(sanitizeProjectName('My_Project'), 'my-project');
+      },
+    );
+
+    test(
+      'when input has runs of separators, '
+      'then they are collapsed and trimmed',
+      () {
+        expect(sanitizeProjectName('--foo___bar---'), 'foo-bar');
+      },
+    );
+
+    test(
+      'when input is empty, '
+      'then output is empty',
+      () {
+        expect(sanitizeProjectName(''), '');
+      },
+    );
+  });
+
+  group('Given serverpodMcpSocketPath', () {
+    test(
+      'when called with a project name, '
+      'then it returns a path under the shared serverpod socket dir',
+      () {
+        final path = serverpodMcpSocketPath(pid: 1234, project: 'My App');
+        expect(p.dirname(path), serverpodMcpSocketDir);
+        expect(p.basename(path), 'serverpod-1234-my-app.sock');
+      },
+    );
+
+    test(
+      'when project name sanitizes to empty, '
+      'then the filename omits the project suffix',
+      () {
+        final path = serverpodMcpSocketPath(pid: 99, project: '___');
+        expect(p.basename(path), 'serverpod-99.sock');
+      },
+    );
+  });
+
+  group('Given listServerpodMcpSockets', () {
+    setUp(() {
+      ensureServerpodMcpSocketDir();
+    });
+
+    test(
+      'when a socket file is present for the current process, '
+      'then it is returned',
+      () async {
+        final path = serverpodMcpSocketPath(pid: pid, project: 'dcur');
+        await _writeStubSocket(path);
+        addTearDown(() => _safeDelete(path));
+
+        final results = listServerpodMcpSockets();
+
+        expect(
+          results.map((s) => s.path),
+          contains(path),
+          reason: 'Live PID socket should be discovered',
+        );
+        final me = results.firstWhere((s) => s.path == path);
+        expect(me.pid, pid);
+        expect(me.project, 'dcur');
+      },
+    );
+
+    test(
+      'when a socket file is present for a non-existent PID, '
+      'then it is removed and not returned',
+      () async {
+        // Pick a PID that won't exist. POSIX maxes out at PID_MAX (e.g.
+        // 99999 on macOS, 4194304 on Linux). 2_000_000_000 is safely beyond.
+        const stalePid = 2000000000;
+        final path = serverpodMcpSocketPath(
+          pid: stalePid,
+          project: 'dstl',
+        );
+        await _writeStubSocket(path);
+        addTearDown(() => _safeDelete(path));
+
+        final results = listServerpodMcpSockets();
+
+        expect(results.where((s) => s.pid == stalePid), isEmpty);
+        expect(
+          File(path).existsSync(),
+          isFalse,
+          reason: 'Stale socket file should be cleaned up',
+        );
+      },
+    );
+
+    test(
+      'when a non-matching file is present, '
+      'then it is ignored',
+      () async {
+        final path = p.join(
+          serverpodMcpSocketDir,
+          'not-a-serverpod-socket.txt',
+        );
+        await File(path).writeAsString('');
+        addTearDown(() => _safeDelete(path));
+
+        final results = listServerpodMcpSockets();
+
+        expect(results.where((s) => s.path == path), isEmpty);
+        expect(
+          File(path).existsSync(),
+          isTrue,
+          reason: 'Non-matching files should not be touched',
+        );
+      },
+    );
+  });
+}
+
+/// Creates a placeholder file at [path]. The real socket binding is not
+/// needed for discovery tests - `listServerpodMcpSockets` only stats the
+/// directory and parses filenames.
+Future<void> _writeStubSocket(String path) async {
+  await File(path).writeAsString('');
+}
+
+void _safeDelete(String path) {
+  try {
+    File(path).deleteSync();
+  } on FileSystemException {
+    // Already gone.
+  }
+}


### PR DESCRIPTION
This PR replaces the project-local, runner-bound MCP server with a **long-lived stdio bridge** that survives runner restarts and discovers `serverpod start --watch` instances at runtime.

Previously each `serverpod start --watch` instance owned an MCP socket under its project's `.dart_tool/serverpod/mcp.sock`, and `serverpod mcp` was a thin stdio-to-socket pipe. Stopping or restarting the runner tore down the AI client's MCP server and Claude Code does not auto-reconnect, so the integration broke on every restart. It also required the AI client to be launched from the right project directory.

`serverpod mcp` is now a persistent bridge. It scans a shared per-machine socket directory, lets the client pick an instance via a `connect` tool, and forwards tool/resource calls. Runners are ephemeral; the bridge stays up across restarts and the client just calls `connect` again.

### Highlights

- **Two-process design.** Runner-side `ServerpodMcpServer` exposes per-instance dev tools; bridge-side `BridgeMcpServer` discovers instances and forwards. Single-instance bridge - one connected runner at a time keeps tool semantics unambiguous.
- **Shared socket directory** at `<systemTemp>/serverpod/serverpod-<pid>-<project>.sock`, created with mode 0700 on POSIX (via `mkdtemp(3)` + rename) so other local users on Linux can't reach the sockets in `/tmp`. Stale sockets for dead PIDs are cleaned up opportunistically on scan. Liveness checks via `kill -0` (POSIX) and `tasklist` (Windows). Windows compatibility for AF_UNIX reparse points is handled in directory listing.
- **Native bridge tools/resource:** `connect`, `disconnect`, `spawn`, `stop`, plus `serverpod://instances`. Auto-picks the runner if exactly one is alive.
- **Auto-forwarding.** On `connect`, the bridge calls `listTools()`/`listResources()` upstream and registers thin forwarders for each item not in the bridge's native deny set, then unregisters them on `disconnect`. New runner-side tools appear in the AI client automatically. Subscribes to forwarded resources to re-emit `resources/updated` upstream.
- **Expanded runner surface.** `apply_migrations` (existing), plus new `create_migration`, `hot_reload`, `tail_logs` tools and the `serverpod://vm-service` resource. `create_migration` shares a new `createMigrationAction` helper with the `serverpod create-migration` CLI command and the TUI "Create Migration" button.

### ~Supporting~ Accidental changes (stuff that should really have been in separate PRs 😬 ) 

- **`serverpod_test`:** `withServerpod` now survives mid-setup failures - if `createTransaction`/`addSavepoint` throws, the transaction stack is unlocked so the next test group starts clean instead of inheriting a half-built transaction. `tearDownAll` runs DB-touching cleanup in parallel and is robust to start-up failure.
- **TUI improvements:** rebuilds throttled to 30 FPS; spinner animation shared via `SpinnerScope` to avoid N independent timers; loading screen falls back to a plain layout in small terminals and pads on black for light terminals; fixes for bright-terminal color handling.
- **Watch session:** skips code generation when a changed `.dart` file cannot affect the protocol (no `extends *Endpoint` or `FutureCall` declaration). Conservative on missing files / I/O errors.
- **Design doc** (`docs/design/mcp_server.md`) rewritten around the two-process bridge model, including a migration note for existing AI client configs.

### Tests

- `bridge_mcp_server_test.dart` covers `connect`/`disconnect`/`spawn`/`stop`, instance auto-pick, switching, auto-forwarding registration/unregistration, and disconnect-on-runner-death.
- `socket_directory_test.dart` covers path construction, project name sanitization, dir-creation race, stale-PID cleanup, and Windows AF_UNIX listing.
- `mcp_server_test.dart` extended for `create_migration`, `hot_reload`, `tail_logs`, and `serverpod://vm-service`.
- `watch_session_test.dart` adds coverage for the protocol-change classifier.

### Issues fixed

_(Please add the relevant issue number(s) - none referenced in commits.)_

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

Note these changes are breaking only in relation to previously release _beta_ versions.

- **Project-local MCP socket removed.** `<server>/.dart_tool/serverpod/mcp.sock` is no longer created or used. Anything that pointed an MCP client directly at that path will stop working - point at `serverpod mcp` instead, which now discovers instances independently of working directory.
- **`serverpod mcp --directory` / `-d` removed.** The bridge does not need a server directory; it scans the shared socket dir. Existing AI client configs that just invoke `serverpod mcp` continue to work; configs that pass `-d` should drop the flag.
- **Bumped `dart_mcp` to `^0.5.x`** (was `^0.4.x`). Adds `stream_transform` as a direct dependency for socket-watcher event coalescing.
- The `serverpod mcp` command no longer fails fast with "no running serverpod watch instance found" - it stays up waiting for one. Scripts that relied on the old non-zero-exit-on-no-instance behavior will need to change.
