### PR TITLE
refactor: Move the column rename from `TableMigration` to `ColumnMigration`

### DIFF
--- a/packages/serverpod_database/lib/src/generated/column_migration.dart
+++ b/packages/serverpod_database/lib/src/generated/column_migration.dart
@@ -16,6 +16,7 @@ import 'package:serverpod_database/serverpod_database.dart' as _i2;
 abstract class ColumnMigration implements _i1.SerializableModel {
   ColumnMigration._({
     required this.columnName,
+    this.newColumnName,
     required this.addNullable,
     required this.removeNullable,
     required this.changeDefault,
@@ -25,6 +26,7 @@ abstract class ColumnMigration implements _i1.SerializableModel {
 
   factory ColumnMigration({
     required String columnName,
+    String? newColumnName,
     required bool addNullable,
     required bool removeNullable,
     required bool changeDefault,
@@ -35,6 +37,7 @@ abstract class ColumnMigration implements _i1.SerializableModel {
   factory ColumnMigration.fromJson(Map<String, dynamic> jsonSerialization) {
     return ColumnMigration(
       columnName: jsonSerialization['columnName'] as String,
+      newColumnName: jsonSerialization['newColumnName'] as String?,
       addNullable: _i1.BoolJsonExtension.fromJson(
         jsonSerialization['addNullable'],
       ),
@@ -53,6 +56,8 @@ abstract class ColumnMigration implements _i1.SerializableModel {
 
   String columnName;
 
+  String? newColumnName;
+
   bool addNullable;
 
   bool removeNullable;
@@ -68,6 +73,7 @@ abstract class ColumnMigration implements _i1.SerializableModel {
   @_i1.useResult
   ColumnMigration copyWith({
     String? columnName,
+    String? newColumnName,
     bool? addNullable,
     bool? removeNullable,
     bool? changeDefault,
@@ -79,6 +85,7 @@ abstract class ColumnMigration implements _i1.SerializableModel {
     return {
       '__className__': 'serverpod.ColumnMigration',
       'columnName': columnName,
+      if (newColumnName != null) 'newColumnName': newColumnName,
       'addNullable': addNullable,
       'removeNullable': removeNullable,
       'changeDefault': changeDefault,
@@ -98,6 +105,7 @@ class _Undefined {}
 class _ColumnMigrationImpl extends ColumnMigration {
   _ColumnMigrationImpl({
     required String columnName,
+    String? newColumnName,
     required bool addNullable,
     required bool removeNullable,
     required bool changeDefault,
@@ -105,6 +113,7 @@ class _ColumnMigrationImpl extends ColumnMigration {
     _i2.ColumnType? newType,
   }) : super._(
          columnName: columnName,
+         newColumnName: newColumnName,
          addNullable: addNullable,
          removeNullable: removeNullable,
          changeDefault: changeDefault,
@@ -118,6 +127,7 @@ class _ColumnMigrationImpl extends ColumnMigration {
   @override
   ColumnMigration copyWith({
     String? columnName,
+    Object? newColumnName = _Undefined,
     bool? addNullable,
     bool? removeNullable,
     bool? changeDefault,
@@ -126,6 +136,9 @@ class _ColumnMigrationImpl extends ColumnMigration {
   }) {
     return ColumnMigration(
       columnName: columnName ?? this.columnName,
+      newColumnName: newColumnName is String?
+          ? newColumnName
+          : this.newColumnName,
       addNullable: addNullable ?? this.addNullable,
       removeNullable: removeNullable ?? this.removeNullable,
       changeDefault: changeDefault ?? this.changeDefault,

--- a/packages/serverpod_database/lib/src/generated/table_migration.dart
+++ b/packages/serverpod_database/lib/src/generated/table_migration.dart
@@ -22,7 +22,6 @@ abstract class TableMigration implements _i1.SerializableModel {
     required this.addColumns,
     required this.deleteColumns,
     required this.modifyColumns,
-    this.renameColumns,
     required this.addIndexes,
     required this.deleteIndexes,
     required this.addForeignKeys,
@@ -38,7 +37,6 @@ abstract class TableMigration implements _i1.SerializableModel {
     required List<_i2.ColumnDefinition> addColumns,
     required List<String> deleteColumns,
     required List<_i2.ColumnMigration> modifyColumns,
-    Map<String, String>? renameColumns,
     required List<_i2.IndexDefinition> addIndexes,
     required List<String> deleteIndexes,
     required List<_i2.ForeignKeyDefinition> addForeignKeys,
@@ -61,11 +59,6 @@ abstract class TableMigration implements _i1.SerializableModel {
       modifyColumns: _i2.Protocol().deserialize<List<_i2.ColumnMigration>>(
         jsonSerialization['modifyColumns'],
       ),
-      renameColumns: jsonSerialization['renameColumns'] == null
-          ? null
-          : _i2.Protocol().deserialize<Map<String, String>>(
-              jsonSerialization['renameColumns'],
-            ),
       addIndexes: _i2.Protocol().deserialize<List<_i2.IndexDefinition>>(
         jsonSerialization['addIndexes'],
       ),
@@ -99,8 +92,6 @@ abstract class TableMigration implements _i1.SerializableModel {
 
   List<_i2.ColumnMigration> modifyColumns;
 
-  Map<String, String>? renameColumns;
-
   List<_i2.IndexDefinition> addIndexes;
 
   List<String> deleteIndexes;
@@ -122,7 +113,6 @@ abstract class TableMigration implements _i1.SerializableModel {
     List<_i2.ColumnDefinition>? addColumns,
     List<String>? deleteColumns,
     List<_i2.ColumnMigration>? modifyColumns,
-    Map<String, String>? renameColumns,
     List<_i2.IndexDefinition>? addIndexes,
     List<String>? deleteIndexes,
     List<_i2.ForeignKeyDefinition>? addForeignKeys,
@@ -140,7 +130,6 @@ abstract class TableMigration implements _i1.SerializableModel {
       'addColumns': addColumns.toJson(valueToJson: (v) => v.toJson()),
       'deleteColumns': deleteColumns.toJson(),
       'modifyColumns': modifyColumns.toJson(valueToJson: (v) => v.toJson()),
-      if (renameColumns != null) 'renameColumns': renameColumns?.toJson(),
       'addIndexes': addIndexes.toJson(valueToJson: (v) => v.toJson()),
       'deleteIndexes': deleteIndexes.toJson(),
       'addForeignKeys': addForeignKeys.toJson(valueToJson: (v) => v.toJson()),
@@ -166,7 +155,6 @@ class _TableMigrationImpl extends TableMigration {
     required List<_i2.ColumnDefinition> addColumns,
     required List<String> deleteColumns,
     required List<_i2.ColumnMigration> modifyColumns,
-    Map<String, String>? renameColumns,
     required List<_i2.IndexDefinition> addIndexes,
     required List<String> deleteIndexes,
     required List<_i2.ForeignKeyDefinition> addForeignKeys,
@@ -180,7 +168,6 @@ class _TableMigrationImpl extends TableMigration {
          addColumns: addColumns,
          deleteColumns: deleteColumns,
          modifyColumns: modifyColumns,
-         renameColumns: renameColumns,
          addIndexes: addIndexes,
          deleteIndexes: deleteIndexes,
          addForeignKeys: addForeignKeys,
@@ -200,7 +187,6 @@ class _TableMigrationImpl extends TableMigration {
     List<_i2.ColumnDefinition>? addColumns,
     List<String>? deleteColumns,
     List<_i2.ColumnMigration>? modifyColumns,
-    Object? renameColumns = _Undefined,
     List<_i2.IndexDefinition>? addIndexes,
     List<String>? deleteIndexes,
     List<_i2.ForeignKeyDefinition>? addForeignKeys,
@@ -219,17 +205,6 @@ class _TableMigrationImpl extends TableMigration {
       modifyColumns:
           modifyColumns ??
           this.modifyColumns.map((e0) => e0.copyWith()).toList(),
-      renameColumns: renameColumns is Map<String, String>?
-          ? renameColumns
-          : this.renameColumns?.map(
-              (
-                key0,
-                value0,
-              ) => MapEntry(
-                key0,
-                value0,
-              ),
-            ),
       addIndexes:
           addIndexes ?? this.addIndexes.map((e0) => e0.copyWith()).toList(),
       deleteIndexes:

--- a/packages/serverpod_database/lib/src/models/column_migration.spy.yaml
+++ b/packages/serverpod_database/lib/src/models/column_migration.spy.yaml
@@ -1,6 +1,7 @@
 class: ColumnMigration
 fields:
   columnName: String
+  newColumnName: String?
 
   addNullable: bool
   removeNullable: bool

--- a/packages/serverpod_database/lib/src/models/table_migration.spy.yaml
+++ b/packages/serverpod_database/lib/src/models/table_migration.spy.yaml
@@ -8,7 +8,6 @@ fields:
   addColumns: List<ColumnDefinition>
   deleteColumns: List<String>
   modifyColumns: List<ColumnMigration>
-  renameColumns: Map<String, String>?
 
   addIndexes: List<IndexDefinition>
   deleteIndexes: List<String>

--- a/tools/serverpod_cli/lib/src/database/dialects/postgres.dart
+++ b/tools/serverpod_cli/lib/src/database/dialects/postgres.dart
@@ -503,10 +503,10 @@ extension PostgresTableMigrationPgSqlGenerator on TableMigration {
     }
 
     // Rename columns (must happen before add/modify to avoid naming conflicts)
-    if (renameColumns != null) {
-      for (var entry in renameColumns!.entries) {
-        var fromName = entry.key;
-        var toName = entry.value;
+    for (var modifiedColumn in modifyColumns) {
+      var fromName = modifiedColumn.columnName;
+      var toName = modifiedColumn.newColumnName;
+      if (toName != null && toName != fromName) {
         out += 'ALTER TABLE "$name" RENAME COLUMN "$fromName" TO "$toName";\n';
       }
     }
@@ -522,7 +522,7 @@ extension PostgresTableMigrationPgSqlGenerator on TableMigration {
       out += alterColumn.toPgSql(
         tableName: name,
         columnDefinition: targetColumns.firstWhere(
-          (c) => c.name == alterColumn.columnName,
+          (c) => c.name == alterColumn.physicalName,
         ),
       );
     }
@@ -549,6 +549,11 @@ extension PostgresTableMigrationPgSqlGenerator on TableMigration {
 }
 
 extension PostgresColumnMigrationPgSqlGenerator on ColumnMigration {
+  /// The physical name of the column to be used in the SQL statements, taking
+  /// renames into consideration. Ensure that any using statement happen after
+  /// the rename statements.
+  String get physicalName => newColumnName ?? columnName;
+
   String toPgSql({
     required String tableName,
     required ColumnDefinition columnDefinition,
@@ -556,17 +561,17 @@ extension PostgresColumnMigrationPgSqlGenerator on ColumnMigration {
     var out = '';
     if (addNullable) {
       out +=
-          'ALTER TABLE "$tableName" ALTER COLUMN "$columnName"'
+          'ALTER TABLE "$tableName" ALTER COLUMN "$physicalName"'
           ' DROP NOT NULL;\n';
     } else if (removeNullable) {
       out +=
-          'ALTER TABLE "$tableName" ALTER COLUMN "$columnName"'
+          'ALTER TABLE "$tableName" ALTER COLUMN "$physicalName"'
           ' SET NOT NULL;\n';
     }
     if (changeDefault) {
       if (newDefault == null) {
         out +=
-            'ALTER TABLE "$tableName" ALTER COLUMN "$columnName"'
+            'ALTER TABLE "$tableName" ALTER COLUMN "$physicalName"'
             ' DROP DEFAULT;\n';
         return out;
       } else {
@@ -575,7 +580,7 @@ extension PostgresColumnMigrationPgSqlGenerator on ColumnMigration {
           tableName,
         );
         out +=
-            'ALTER TABLE "$tableName" ALTER COLUMN "$columnName"'
+            'ALTER TABLE "$tableName" ALTER COLUMN "$physicalName"'
             ' SET DEFAULT $newDefaultSql;\n';
       }
     }

--- a/tools/serverpod_cli/lib/src/database/dialects/sqlite.dart
+++ b/tools/serverpod_cli/lib/src/database/dialects/sqlite.dart
@@ -331,7 +331,7 @@ extension SqliteTableMigrationSqlGeneration on TableMigration {
     );
 
     final needsRebuild =
-        modifyColumns.isNotEmpty ||
+        modifyColumns.hasColumnMigrationThatRequiresRebuild ||
         deleteForeignKeys.isNotEmpty ||
         addForeignKeys.isNotEmpty ||
         addColumns.any((c) => c.addColumnNeedsRebuild(targetTable));
@@ -352,10 +352,11 @@ extension SqliteTableMigrationSqlGeneration on TableMigration {
     }
 
     // Rename columns (must happen before add to avoid name collisions)
-    if (renameColumns != null) {
-      for (var entry in renameColumns!.entries) {
-        out +=
-            'ALTER TABLE "$name" RENAME COLUMN "${entry.key}" TO "${entry.value}";\n';
+    for (var modifiedColumn in modifyColumns) {
+      var fromName = modifiedColumn.columnName;
+      var toName = modifiedColumn.newColumnName;
+      if (toName != null && toName != fromName) {
+        out += 'ALTER TABLE "$name" RENAME COLUMN "$fromName" TO "$toName";\n';
       }
     }
 
@@ -371,6 +372,7 @@ extension SqliteTableMigrationSqlGeneration on TableMigration {
       out += addIndex.toSql(tableName: name);
     }
 
+    out += '\n';
     return out;
   }
 
@@ -406,15 +408,10 @@ extension SqliteTableMigrationSqlGeneration on TableMigration {
       final colListNew = copyColumns.map((c) => '"${c.name}"').join(', ');
       final selectList = copyColumns
           .map((c) {
-            final sourceName = _sqliteSourceColumnNameForInsert(
-              c.name,
-              renameColumns,
-            );
-            final newType = modifyColumns
-                .where((m) => m.columnName == c.name)
-                .firstOrNull
-                ?.newType;
-            return switch (newType) {
+            final columnMigration = _getColumnMigrationByName(c.name);
+            final sourceName = columnMigration?.columnName ?? c.name;
+
+            return switch (columnMigration?.newType) {
               ColumnType.jsonb => 'jsonb("$sourceName")',
               ColumnType.json => 'json("$sourceName")',
               _ => '"$sourceName"',
@@ -447,6 +444,28 @@ extension SqliteTableMigrationSqlGeneration on TableMigration {
     out += '\n';
 
     return out;
+  }
+
+  /// Returns the [ColumnMigration] for [targetColumnName].
+  ///
+  /// Prefer a rename whose destination is [targetColumnName] over an in-place
+  /// change on a column that kept that name, so the copy uses the correct
+  /// source column name when both could match.
+  ColumnMigration? _getColumnMigrationByName(String targetColumnName) {
+    // Find column migrations for renamed columns.
+    for (final columnMigration in modifyColumns) {
+      if (columnMigration.newColumnName == targetColumnName) {
+        return columnMigration;
+      }
+    }
+    // Find column migrations for in-place changes.
+    for (final columnMigration in modifyColumns) {
+      if (columnMigration.newColumnName == null &&
+          columnMigration.columnName == targetColumnName) {
+        return columnMigration;
+      }
+    }
+    return null;
   }
 }
 
@@ -523,19 +542,16 @@ extension on ColumnType {
   };
 }
 
-/// Returns the physical column name on the source table for [targetColumnName]
-/// when copying into a rebuilt table, accounting for pending renames.
-String _sqliteSourceColumnNameForInsert(
-  String targetColumnName,
-  Map<String, String>? renameColumns,
-) {
-  if (renameColumns == null) return targetColumnName;
-  for (final entry in renameColumns.entries) {
-    if (entry.value == targetColumnName) {
-      return entry.key;
-    }
-  }
-  return targetColumnName;
+extension on List<ColumnMigration> {
+  /// Whether any of the column migrations require a table rebuild. The only
+  /// operation that does not require a table rebuild is a column rename.
+  bool get hasColumnMigrationThatRequiresRebuild => any(
+    (m) =>
+        m.addNullable ||
+        m.removeNullable ||
+        m.changeDefault ||
+        m.newType != null,
+  );
 }
 
 String _sqlRemoveMigrationVersion(List<DatabaseMigrationVersionModel> modules) {

--- a/tools/serverpod_cli/lib/src/database/extensions.dart
+++ b/tools/serverpod_cli/lib/src/database/extensions.dart
@@ -96,7 +96,6 @@ extension TableDiffComparisons on TableMigration {
       addColumns.isEmpty &&
       deleteColumns.isEmpty &&
       modifyColumns.isEmpty &&
-      (renameColumns?.isEmpty ?? true) &&
       addIndexes.isEmpty &&
       deleteIndexes.isEmpty &&
       addForeignKeys.isEmpty &&

--- a/tools/serverpod_cli/lib/src/database/migration.dart
+++ b/tools/serverpod_cli/lib/src/database/migration.dart
@@ -241,7 +241,7 @@ TableMigration? generateTableMigration(
       continue;
     }
     // The column name must be the same for the like comparison.
-    if (!srcColumn.copyWith(name: dstColumn.name).like(dstColumn)) {
+    if (!srcColumn.like(dstColumn)) {
       if (srcColumn.canMigrateTo(dstColumn)) {
         // Column can be modified
         var addNullable = !srcColumn.isNullable && dstColumn.isNullable;
@@ -264,7 +264,10 @@ TableMigration? generateTableMigration(
 
         modifyColumns.add(
           ColumnMigration(
-            columnName: dstColumn.name,
+            columnName: srcColumn.name,
+            newColumnName: srcColumn.name != dstColumn.name
+                ? dstColumn.name
+                : null,
             addNullable: addNullable,
             removeNullable: removeNullable,
             changeDefault: changeDefault,
@@ -405,7 +408,6 @@ TableMigration? generateTableMigration(
     deleteColumns: deleteColumns,
     addColumns: addColumns,
     modifyColumns: modifyColumns,
-    renameColumns: renameColumns.isEmpty ? null : renameColumns,
     deleteIndexes: deleteIndexes,
     addIndexes: addIndexes,
     deleteForeignKeys: deleteForeignKeys,

--- a/tools/serverpod_cli/test/database/migration/column_rename_test.dart
+++ b/tools/serverpod_cli/test/database/migration/column_rename_test.dart
@@ -55,8 +55,15 @@ void main() {
       test('then no rename is detected (drop and add instead).', () {
         var action = migration.actions.first;
         var tableMigration = action.alterTable;
-        expect(tableMigration!.renameColumns ?? {}, isEmpty);
-        expect(tableMigration.deleteColumns, contains(oldColumnName));
+
+        expect(
+          tableMigration!.modifyColumns.where((m) => m.newColumnName != null),
+          isEmpty,
+        );
+        expect(
+          tableMigration.deleteColumns,
+          contains(oldColumnName),
+        );
         expect(
           tableMigration.addColumns.any((c) => c.name == newColumnName),
           isTrue,
@@ -120,9 +127,12 @@ void main() {
     test('then the table migration includes a rename.', () {
       var action = migration.actions.first;
       var tableMigration = action.alterTable;
+
       expect(tableMigration, isNotNull);
-      expect(tableMigration!.renameColumns, hasLength(1));
-      expect(tableMigration.renameColumns![oldColumnName], newColumnName);
+      expect(tableMigration!.modifyColumns, hasLength(1));
+      var columnMigration = tableMigration.modifyColumns.first;
+      expect(columnMigration.columnName, oldColumnName);
+      expect(columnMigration.newColumnName, newColumnName);
     });
 
     test('then the column is not in addColumns list.', () {
@@ -210,9 +220,19 @@ void main() {
       test('then both renames are detected.', () {
         var action = migration.actions.first;
         var tableMigration = action.alterTable;
-        expect(tableMigration!.renameColumns, hasLength(2));
-        expect(tableMigration.renameColumns![oldName1], newName1);
-        expect(tableMigration.renameColumns![oldName2], newName2);
+        expect(tableMigration!.modifyColumns, hasLength(2));
+
+        var firstColumnMigration = tableMigration.modifyColumns.firstWhere(
+          (m) => m.columnName == oldName1,
+        );
+        expect(firstColumnMigration.columnName, oldName1);
+        expect(firstColumnMigration.newColumnName, newName1);
+
+        var secondColumnMigration = tableMigration.modifyColumns.firstWhere(
+          (m) => m.columnName == oldName2,
+        );
+        expect(secondColumnMigration.columnName, oldName2);
+        expect(secondColumnMigration.newColumnName, newName2);
       });
     },
   );
@@ -269,7 +289,8 @@ void main() {
         var alterTableActionsWithRename = migration.actions.where(
           (a) =>
               a.type == DatabaseMigrationActionType.alterTable &&
-              a.alterTable?.renameColumns != null,
+              a.alterTable != null &&
+              a.alterTable!.modifyColumns.any((m) => m.newColumnName != null),
         );
         expect(alterTableActionsWithRename, isEmpty);
       });
@@ -355,14 +376,17 @@ void main() {
       test('then the rename is detected.', () {
         var action = migration.actions.first;
         var tableMigration = action.alterTable;
-        expect(tableMigration!.renameColumns![oldColumnName], newColumnName);
+        var columnMigration = tableMigration!.modifyColumns.first;
+        expect(columnMigration.columnName, oldColumnName);
+        expect(columnMigration.newColumnName, newColumnName);
       });
 
       test('then a modify column action is also created.', () {
         var action = migration.actions.first;
         var tableMigration = action.alterTable;
         expect(tableMigration!.modifyColumns, hasLength(1));
-        expect(tableMigration.modifyColumns.first.columnName, newColumnName);
+        expect(tableMigration.modifyColumns.first.columnName, oldColumnName);
+        expect(tableMigration.modifyColumns.first.newColumnName, newColumnName);
         expect(tableMigration.modifyColumns.first.addNullable, isTrue);
       });
     },
@@ -418,16 +442,22 @@ void main() {
       test('then the rename is detected.', () {
         var action = migration.actions.first;
         var tableMigration = action.alterTable;
-        expect(tableMigration!.renameColumns![oldColumnName], newColumnName);
+        var columnMigration = tableMigration!.modifyColumns.first;
+
+        expect(columnMigration.columnName, oldColumnName);
+        expect(columnMigration.newColumnName, newColumnName);
       });
 
       test('then a modify column action is also created.', () {
         var action = migration.actions.first;
         var tableMigration = action.alterTable;
+
         expect(tableMigration!.modifyColumns, hasLength(1));
-        expect(tableMigration.modifyColumns.first.columnName, newColumnName);
-        expect(tableMigration.modifyColumns.first.changeDefault, isTrue);
-        expect(tableMigration.modifyColumns.first.newDefault, defaultValue);
+        var columnMigration = tableMigration.modifyColumns.first;
+        expect(columnMigration.columnName, oldColumnName);
+        expect(columnMigration.newColumnName, newColumnName);
+        expect(columnMigration.changeDefault, isTrue);
+        expect(columnMigration.newDefault, defaultValue);
       });
     },
   );
@@ -510,8 +540,11 @@ void main() {
     test('then the rename is detected.', () {
       var action = migration.actions.first;
       var tableMigration = action.alterTable;
-      expect(tableMigration!.renameColumns, hasLength(1));
-      expect(tableMigration.renameColumns![renamedOldName], renamedNewName);
+      var columnMigration = tableMigration!.modifyColumns.firstWhere(
+        (m) => m.columnName == renamedOldName,
+      );
+      expect(columnMigration.columnName, renamedOldName);
+      expect(columnMigration.newColumnName, renamedNewName);
     });
 
     test('then the added column is detected.', () {
@@ -532,16 +565,11 @@ void main() {
     test('then the unchanged column is not in any change lists.', () {
       var action = migration.actions.first;
       var tableMigration = action.alterTable;
-      expect(
-        tableMigration!.renameColumns?.containsKey(unchangedColumnName) ??
-            false,
-        isFalse,
-      );
-      expect(
-        tableMigration.renameColumns?.containsValue(unchangedColumnName) ??
-            false,
-        isFalse,
-      );
+
+      for (var columnMigration in tableMigration!.modifyColumns) {
+        expect(columnMigration.columnName, isNot(unchangedColumnName));
+        expect(columnMigration.newColumnName, isNot(unchangedColumnName));
+      }
       expect(
         tableMigration.deleteColumns,
         isNot(contains(unchangedColumnName)),


### PR DESCRIPTION
This PR fixes a misplacement of the column rename migration that was on the `TableMigration` instead of in the more suitable `ColumnMigration`. This fixes the inconsistency of having to compare the tables by mocking the name to avoid a rename diff.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

This PR does change a public interface, but it is not a breaking change since the column rename was only released on a beta version.