### PR TITLE
perf: Replace Protocol.deserialize<T> if-chain with static Map dispatch

### DIFF
--- a/examples/auth/auth_client/lib/src/protocol/protocol.dart
+++ b/examples/auth/auth_client/lib/src/protocol/protocol.dart
@@ -27,6 +27,24 @@ class Protocol extends _i1.SerializationManager {
 
   static final Protocol _instance = Protocol._().._registerHostProtocols();
 
+  static final Map<Type, dynamic Function(dynamic, Protocol)> _deserializers =
+      _buildDeserializers();
+
+  static Map<Type, dynamic Function(dynamic, Protocol)> _buildDeserializers() {
+    final map = <Type, dynamic Function(dynamic, Protocol)>{};
+    map[_i2.Greeting] = (data, protocol) => _i2.Greeting.fromJson(data);
+    map[_i1.getType<_i2.Greeting?>()] = (data, protocol) =>
+        (data != null ? _i2.Greeting.fromJson(data) : null);
+    map[_i1.getType<({_i3.ByteData challenge, _i1.UuidValue id})>()] =
+        (data, protocol) => (
+          challenge: protocol.deserialize<_i3.ByteData>(
+            ((data as Map)['n'] as Map)['challenge'],
+          ),
+          id: protocol.deserialize<_i1.UuidValue>(data['n']['id']),
+        );
+    return map;
+  }
+
   static String? getClassNameFromObjectJson(dynamic data) {
     if (data is! Map) return null;
     final className = data['__className__'] as String?;
@@ -54,20 +72,9 @@ class Protocol extends _i1.SerializationManager {
       }
     }
 
-    if (t == _i2.Greeting) {
-      return _i2.Greeting.fromJson(data) as T;
-    }
-    if (t == _i1.getType<_i2.Greeting?>()) {
-      return (data != null ? _i2.Greeting.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<({_i3.ByteData challenge, _i1.UuidValue id})>()) {
-      return (
-            challenge: deserialize<_i3.ByteData>(
-              ((data as Map)['n'] as Map)['challenge'],
-            ),
-            id: deserialize<_i1.UuidValue>(data['n']['id']),
-          )
-          as T;
+    final fn = _deserializers[t];
+    if (fn != null) {
+      return fn(data, this) as T;
     }
     try {
       return _i4.Protocol().deserialize<T>(data, t);

--- a/examples/auth/auth_client/lib/src/protocol/protocol.dart
+++ b/examples/auth/auth_client/lib/src/protocol/protocol.dart
@@ -12,12 +12,12 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
-import 'greeting.dart' as _i2;
-import 'dart:typed_data' as _i3;
 import 'package:serverpod_auth_idp_client/serverpod_auth_idp_client.dart'
-    as _i4;
+    as _i2;
 import 'package:serverpod_auth_core_client/serverpod_auth_core_client.dart'
-    as _i5;
+    as _i3;
+import 'greeting.dart' as _i4;
+import 'dart:typed_data' as _i5;
 export 'greeting.dart';
 export 'client.dart';
 
@@ -27,6 +27,9 @@ class Protocol extends _i1.SerializationManager {
   factory Protocol() => _instance;
 
   static final Protocol _instance = Protocol._().._registerHostProtocols();
+
+  static final Map<Type, dynamic Function(dynamic, Protocol)> _deserializers =
+      _buildDeserializers();
 
   static String? getClassNameFromObjectJson(dynamic data) {
     if (data is! Map) return null;
@@ -55,33 +58,22 @@ class Protocol extends _i1.SerializationManager {
       }
     }
 
-    if (t == _i2.Greeting) {
-      return _i2.Greeting.fromJson(data) as T;
-    }
-    if (t == _i1.getType<_i2.Greeting?>()) {
-      return (data != null ? _i2.Greeting.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<({_i3.ByteData challenge, _i1.UuidValue id})>()) {
-      return (
-            challenge: deserialize<_i3.ByteData>(
-              ((data as Map)['n'] as Map)['challenge'],
-            ),
-            id: deserialize<_i1.UuidValue>(data['n']['id']),
-          )
-          as T;
+    final fn = _deserializers[t];
+    if (fn != null) {
+      return fn(data, this) as T;
     }
     try {
-      return _i4.Protocol().deserialize<T>(data, t);
+      return _i2.Protocol().deserialize<T>(data, t);
     } on _i1.DeserializationTypeNotFoundException catch (_) {}
     try {
-      return _i5.Protocol().deserialize<T>(data, t);
+      return _i3.Protocol().deserialize<T>(data, t);
     } on _i1.DeserializationTypeNotFoundException catch (_) {}
     return super.deserialize<T>(data, t);
   }
 
   static String? getClassNameForType(Type type) {
     return switch (type) {
-      _i2.Greeting => 'Greeting',
+      _i4.Greeting => 'Greeting',
       _ => null,
     };
   }
@@ -96,16 +88,16 @@ class Protocol extends _i1.SerializationManager {
     }
 
     switch (data) {
-      case _i2.Greeting():
+      case _i4.Greeting():
         return 'Greeting';
     }
-    className = _i4.Protocol().getClassNameForObject(data);
+    className = _i2.Protocol().getClassNameForObject(data);
     if (className != null) {
       return className.contains('.')
           ? className
           : 'serverpod_auth_idp.$className';
     }
-    className = _i5.Protocol().getClassNameForObject(data);
+    className = _i3.Protocol().getClassNameForObject(data);
     if (className != null) {
       return className.contains('.')
           ? className
@@ -121,22 +113,22 @@ class Protocol extends _i1.SerializationManager {
       return super.deserializeByClassName(data);
     }
     if (dataClassName == 'Greeting') {
-      return deserialize<_i2.Greeting>(data['data']);
+      return deserialize<_i4.Greeting>(data['data']);
     }
     if (dataClassName.startsWith('serverpod_auth_idp.')) {
       data['className'] = dataClassName.substring(19);
-      return _i4.Protocol().deserializeByClassName(data);
+      return _i2.Protocol().deserializeByClassName(data);
     }
     if (dataClassName.startsWith('serverpod_auth_core.')) {
       data['className'] = dataClassName.substring(20);
-      return _i5.Protocol().deserializeByClassName(data);
+      return _i3.Protocol().deserializeByClassName(data);
     }
     return super.deserializeByClassName(data);
   }
 
   void _registerHostProtocols() {
-    _i4.Protocol().registerHostProtocol('auth', this);
-    _i5.Protocol().registerHostProtocol('auth', this);
+    _i2.Protocol().registerHostProtocol('auth', this);
+    _i3.Protocol().registerHostProtocol('auth', this);
   }
 
   @override
@@ -151,7 +143,7 @@ class Protocol extends _i1.SerializationManager {
     if (record == null) {
       return null;
     }
-    if (record is ({_i3.ByteData challenge, _i1.UuidValue id})) {
+    if (record is ({_i5.ByteData challenge, _i1.UuidValue id})) {
       return {
         "n": {
           "challenge": record.challenge.toJson(),
@@ -160,10 +152,10 @@ class Protocol extends _i1.SerializationManager {
       };
     }
     try {
-      return _i4.Protocol().mapRecordToJson(record);
+      return _i2.Protocol().mapRecordToJson(record);
     } catch (_) {}
     try {
-      return _i5.Protocol().mapRecordToJson(record);
+      return _i3.Protocol().mapRecordToJson(record);
     } catch (_) {}
     throw Exception('Unsupported record type ${record.runtimeType}');
   }
@@ -218,5 +210,20 @@ class Protocol extends _i1.SerializationManager {
     }
 
     return obj;
+  }
+
+  static Map<Type, dynamic Function(dynamic, Protocol)> _buildDeserializers() {
+    final map = <Type, dynamic Function(dynamic, Protocol)>{};
+    map[_i4.Greeting] = (data, protocol) => _i4.Greeting.fromJson(data);
+    map[_i1.getType<_i4.Greeting?>()] = (data, protocol) =>
+        (data != null ? _i4.Greeting.fromJson(data) : null);
+    map[_i1.getType<({_i5.ByteData challenge, _i1.UuidValue id})>()] =
+        (data, protocol) => (
+          challenge: protocol.deserialize<_i5.ByteData>(
+            ((data as Map)['n'] as Map)['challenge'],
+          ),
+          id: protocol.deserialize<_i1.UuidValue>(data['n']['id']),
+        );
+    return map;
   }
 }

--- a/examples/auth/auth_server/lib/src/generated/protocol.dart
+++ b/examples/auth/auth_server/lib/src/generated/protocol.dart
@@ -33,6 +33,24 @@ class Protocol extends _i1.DatabaseSerializationManager {
     ..._i2.Protocol.targetTableDefinitions,
   ];
 
+  static final Map<Type, dynamic Function(dynamic, Protocol)> _deserializers =
+      _buildDeserializers();
+
+  static Map<Type, dynamic Function(dynamic, Protocol)> _buildDeserializers() {
+    final map = <Type, dynamic Function(dynamic, Protocol)>{};
+    map[_i5.Greeting] = (data, protocol) => _i5.Greeting.fromJson(data);
+    map[_i1.getType<_i5.Greeting?>()] = (data, protocol) =>
+        (data != null ? _i5.Greeting.fromJson(data) : null);
+    map[_i1.getType<({_i6.ByteData challenge, _i1.UuidValue id})>()] =
+        (data, protocol) => (
+          challenge: protocol.deserialize<_i6.ByteData>(
+            ((data as Map)['n'] as Map)['challenge'],
+          ),
+          id: protocol.deserialize<_i1.UuidValue>(data['n']['id']),
+        );
+    return map;
+  }
+
   static String? getClassNameFromObjectJson(dynamic data) {
     if (data is! Map) return null;
     final className = data['__className__'] as String?;
@@ -60,20 +78,9 @@ class Protocol extends _i1.DatabaseSerializationManager {
       }
     }
 
-    if (t == _i5.Greeting) {
-      return _i5.Greeting.fromJson(data) as T;
-    }
-    if (t == _i1.getType<_i5.Greeting?>()) {
-      return (data != null ? _i5.Greeting.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<({_i6.ByteData challenge, _i1.UuidValue id})>()) {
-      return (
-            challenge: deserialize<_i6.ByteData>(
-              ((data as Map)['n'] as Map)['challenge'],
-            ),
-            id: deserialize<_i1.UuidValue>(data['n']['id']),
-          )
-          as T;
+    final fn = _deserializers[t];
+    if (fn != null) {
+      return fn(data, this) as T;
     }
     try {
       return _i3.Protocol().deserialize<T>(data, t);

--- a/examples/auth/auth_server/lib/src/generated/protocol.dart
+++ b/examples/auth/auth_server/lib/src/generated/protocol.dart
@@ -28,6 +28,9 @@ class Protocol extends _i1.DatabaseSerializationManager {
 
   static final Protocol _instance = Protocol._().._registerHostProtocols();
 
+  static final Map<Type, dynamic Function(dynamic, Protocol)> _deserializers =
+      _buildDeserializers();
+
   static List<_i2.TableDefinition> get targetTableDefinitions => [
     ..._i3.Protocol.targetTableDefinitions,
     ..._i4.Protocol.targetTableDefinitions,
@@ -61,20 +64,9 @@ class Protocol extends _i1.DatabaseSerializationManager {
       }
     }
 
-    if (t == _i5.Greeting) {
-      return _i5.Greeting.fromJson(data) as T;
-    }
-    if (t == _i1.getType<_i5.Greeting?>()) {
-      return (data != null ? _i5.Greeting.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<({_i6.ByteData challenge, _i1.UuidValue id})>()) {
-      return (
-            challenge: deserialize<_i6.ByteData>(
-              ((data as Map)['n'] as Map)['challenge'],
-            ),
-            id: deserialize<_i1.UuidValue>(data['n']['id']),
-          )
-          as T;
+    final fn = _deserializers[t];
+    if (fn != null) {
+      return fn(data, this) as T;
     }
     try {
       return _i3.Protocol().deserialize<T>(data, t);
@@ -262,5 +254,20 @@ class Protocol extends _i1.DatabaseSerializationManager {
     }
 
     return obj;
+  }
+
+  static Map<Type, dynamic Function(dynamic, Protocol)> _buildDeserializers() {
+    final map = <Type, dynamic Function(dynamic, Protocol)>{};
+    map[_i5.Greeting] = (data, protocol) => _i5.Greeting.fromJson(data);
+    map[_i1.getType<_i5.Greeting?>()] = (data, protocol) =>
+        (data != null ? _i5.Greeting.fromJson(data) : null);
+    map[_i1.getType<({_i6.ByteData challenge, _i1.UuidValue id})>()] =
+        (data, protocol) => (
+          challenge: protocol.deserialize<_i6.ByteData>(
+            ((data as Map)['n'] as Map)['challenge'],
+          ),
+          id: protocol.deserialize<_i1.UuidValue>(data['n']['id']),
+        );
+    return map;
   }
 }

--- a/examples/legacy/auth_example/auth_example_client/lib/src/protocol/protocol.dart
+++ b/examples/legacy/auth_example/auth_example_client/lib/src/protocol/protocol.dart
@@ -23,6 +23,17 @@ class Protocol extends _i1.SerializationManager {
 
   static final Protocol _instance = Protocol._().._registerHostProtocols();
 
+  static final Map<Type, dynamic Function(dynamic, Protocol)> _deserializers =
+      _buildDeserializers();
+
+  static Map<Type, dynamic Function(dynamic, Protocol)> _buildDeserializers() {
+    final map = <Type, dynamic Function(dynamic, Protocol)>{};
+    map[_i2.Example] = (data, protocol) => _i2.Example.fromJson(data);
+    map[_i1.getType<_i2.Example?>()] = (data, protocol) =>
+        (data != null ? _i2.Example.fromJson(data) : null);
+    return map;
+  }
+
   static String? getClassNameFromObjectJson(dynamic data) {
     if (data is! Map) return null;
     final className = data['__className__'] as String?;
@@ -50,11 +61,9 @@ class Protocol extends _i1.SerializationManager {
       }
     }
 
-    if (t == _i2.Example) {
-      return _i2.Example.fromJson(data) as T;
-    }
-    if (t == _i1.getType<_i2.Example?>()) {
-      return (data != null ? _i2.Example.fromJson(data) : null) as T;
+    final fn = _deserializers[t];
+    if (fn != null) {
+      return fn(data, this) as T;
     }
     try {
       return _i3.Protocol().deserialize<T>(data, t);

--- a/examples/legacy/auth_example/auth_example_client/lib/src/protocol/protocol.dart
+++ b/examples/legacy/auth_example/auth_example_client/lib/src/protocol/protocol.dart
@@ -12,8 +12,8 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
-import 'example.dart' as _i2;
-import 'package:serverpod_auth_client/serverpod_auth_client.dart' as _i3;
+import 'package:serverpod_auth_client/serverpod_auth_client.dart' as _i2;
+import 'example.dart' as _i3;
 export 'example.dart';
 export 'client.dart';
 
@@ -23,6 +23,9 @@ class Protocol extends _i1.SerializationManager {
   factory Protocol() => _instance;
 
   static final Protocol _instance = Protocol._().._registerHostProtocols();
+
+  static final Map<Type, dynamic Function(dynamic, Protocol)> _deserializers =
+      _buildDeserializers();
 
   static String? getClassNameFromObjectJson(dynamic data) {
     if (data is! Map) return null;
@@ -51,21 +54,19 @@ class Protocol extends _i1.SerializationManager {
       }
     }
 
-    if (t == _i2.Example) {
-      return _i2.Example.fromJson(data) as T;
-    }
-    if (t == _i1.getType<_i2.Example?>()) {
-      return (data != null ? _i2.Example.fromJson(data) : null) as T;
+    final fn = _deserializers[t];
+    if (fn != null) {
+      return fn(data, this) as T;
     }
     try {
-      return _i3.Protocol().deserialize<T>(data, t);
+      return _i2.Protocol().deserialize<T>(data, t);
     } on _i1.DeserializationTypeNotFoundException catch (_) {}
     return super.deserialize<T>(data, t);
   }
 
   static String? getClassNameForType(Type type) {
     return switch (type) {
-      _i2.Example => 'Example',
+      _i3.Example => 'Example',
       _ => null,
     };
   }
@@ -83,10 +84,10 @@ class Protocol extends _i1.SerializationManager {
     }
 
     switch (data) {
-      case _i2.Example():
+      case _i3.Example():
         return 'Example';
     }
-    className = _i3.Protocol().getClassNameForObject(data);
+    className = _i2.Protocol().getClassNameForObject(data);
     if (className != null) {
       return className.contains('.') ? className : 'serverpod_auth.$className';
     }
@@ -100,17 +101,17 @@ class Protocol extends _i1.SerializationManager {
       return super.deserializeByClassName(data);
     }
     if (dataClassName == 'Example') {
-      return deserialize<_i2.Example>(data['data']);
+      return deserialize<_i3.Example>(data['data']);
     }
     if (dataClassName.startsWith('serverpod_auth.')) {
       data['className'] = dataClassName.substring(15);
-      return _i3.Protocol().deserializeByClassName(data);
+      return _i2.Protocol().deserializeByClassName(data);
     }
     return super.deserializeByClassName(data);
   }
 
   void _registerHostProtocols() {
-    _i3.Protocol().registerHostProtocol('auth_example', this);
+    _i2.Protocol().registerHostProtocol('auth_example', this);
   }
 
   @override
@@ -126,8 +127,16 @@ class Protocol extends _i1.SerializationManager {
       return null;
     }
     try {
-      return _i3.Protocol().mapRecordToJson(record);
+      return _i2.Protocol().mapRecordToJson(record);
     } catch (_) {}
     throw Exception('Unsupported record type ${record.runtimeType}');
+  }
+
+  static Map<Type, dynamic Function(dynamic, Protocol)> _buildDeserializers() {
+    final map = <Type, dynamic Function(dynamic, Protocol)>{};
+    map[_i3.Example] = (data, protocol) => _i3.Example.fromJson(data);
+    map[_i1.getType<_i3.Example?>()] = (data, protocol) =>
+        (data != null ? _i3.Example.fromJson(data) : null);
+    return map;
   }
 }

--- a/examples/legacy/auth_example/auth_example_server/lib/src/generated/protocol.dart
+++ b/examples/legacy/auth_example/auth_example_server/lib/src/generated/protocol.dart
@@ -28,6 +28,17 @@ class Protocol extends _i1.DatabaseSerializationManager {
     ..._i2.Protocol.targetTableDefinitions,
   ];
 
+  static final Map<Type, dynamic Function(dynamic, Protocol)> _deserializers =
+      _buildDeserializers();
+
+  static Map<Type, dynamic Function(dynamic, Protocol)> _buildDeserializers() {
+    final map = <Type, dynamic Function(dynamic, Protocol)>{};
+    map[_i4.Example] = (data, protocol) => _i4.Example.fromJson(data);
+    map[_i1.getType<_i4.Example?>()] = (data, protocol) =>
+        (data != null ? _i4.Example.fromJson(data) : null);
+    return map;
+  }
+
   static String? getClassNameFromObjectJson(dynamic data) {
     if (data is! Map) return null;
     final className = data['__className__'] as String?;
@@ -55,11 +66,9 @@ class Protocol extends _i1.DatabaseSerializationManager {
       }
     }
 
-    if (t == _i4.Example) {
-      return _i4.Example.fromJson(data) as T;
-    }
-    if (t == _i1.getType<_i4.Example?>()) {
-      return (data != null ? _i4.Example.fromJson(data) : null) as T;
+    final fn = _deserializers[t];
+    if (fn != null) {
+      return fn(data, this) as T;
     }
     try {
       return _i3.Protocol().deserialize<T>(data, t);

--- a/examples/legacy/auth_example/auth_example_server/lib/src/generated/protocol.dart
+++ b/examples/legacy/auth_example/auth_example_server/lib/src/generated/protocol.dart
@@ -24,6 +24,9 @@ class Protocol extends _i1.DatabaseSerializationManager {
 
   static final Protocol _instance = Protocol._().._registerHostProtocols();
 
+  static final Map<Type, dynamic Function(dynamic, Protocol)> _deserializers =
+      _buildDeserializers();
+
   static List<_i2.TableDefinition> get targetTableDefinitions => [
     ..._i3.Protocol.targetTableDefinitions,
     ..._i2.Protocol.targetTableDefinitions,
@@ -56,11 +59,9 @@ class Protocol extends _i1.DatabaseSerializationManager {
       }
     }
 
-    if (t == _i4.Example) {
-      return _i4.Example.fromJson(data) as T;
-    }
-    if (t == _i1.getType<_i4.Example?>()) {
-      return (data != null ? _i4.Example.fromJson(data) : null) as T;
+    final fn = _deserializers[t];
+    if (fn != null) {
+      return fn(data, this) as T;
     }
     try {
       return _i3.Protocol().deserialize<T>(data, t);
@@ -166,5 +167,13 @@ class Protocol extends _i1.DatabaseSerializationManager {
       return _i3.Protocol().mapRecordToJson(record);
     } catch (_) {}
     throw Exception('Unsupported record type ${record.runtimeType}');
+  }
+
+  static Map<Type, dynamic Function(dynamic, Protocol)> _buildDeserializers() {
+    final map = <Type, dynamic Function(dynamic, Protocol)>{};
+    map[_i4.Example] = (data, protocol) => _i4.Example.fromJson(data);
+    map[_i1.getType<_i4.Example?>()] = (data, protocol) =>
+        (data != null ? _i4.Example.fromJson(data) : null);
+    return map;
   }
 }

--- a/examples/legacy/chat/chat_client/lib/src/protocol/protocol.dart
+++ b/examples/legacy/chat/chat_client/lib/src/protocol/protocol.dart
@@ -25,6 +25,20 @@ class Protocol extends _i1.SerializationManager {
 
   static final Protocol _instance = Protocol._().._registerHostProtocols();
 
+  static final Map<Type, dynamic Function(dynamic, Protocol)> _deserializers =
+      _buildDeserializers();
+
+  static Map<Type, dynamic Function(dynamic, Protocol)> _buildDeserializers() {
+    final map = <Type, dynamic Function(dynamic, Protocol)>{};
+    map[_i2.Channel] = (data, protocol) => _i2.Channel.fromJson(data);
+    map[_i1.getType<_i2.Channel?>()] = (data, protocol) =>
+        (data != null ? _i2.Channel.fromJson(data) : null);
+    map[List<_i3.Channel>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i3.Channel>(e))
+        .toList();
+    return map;
+  }
+
   static String? getClassNameFromObjectJson(dynamic data) {
     if (data is! Map) return null;
     final className = data['__className__'] as String?;
@@ -52,15 +66,9 @@ class Protocol extends _i1.SerializationManager {
       }
     }
 
-    if (t == _i2.Channel) {
-      return _i2.Channel.fromJson(data) as T;
-    }
-    if (t == _i1.getType<_i2.Channel?>()) {
-      return (data != null ? _i2.Channel.fromJson(data) : null) as T;
-    }
-    if (t == List<_i3.Channel>) {
-      return (data as List).map((e) => deserialize<_i3.Channel>(e)).toList()
-          as T;
+    final fn = _deserializers[t];
+    if (fn != null) {
+      return fn(data, this) as T;
     }
     try {
       return _i4.Protocol().deserialize<T>(data, t);

--- a/examples/legacy/chat/chat_server/lib/src/generated/protocol.dart
+++ b/examples/legacy/chat/chat_server/lib/src/generated/protocol.dart
@@ -61,6 +61,20 @@ class Protocol extends _i1.DatabaseSerializationManager {
     ..._i2.Protocol.targetTableDefinitions,
   ];
 
+  static final Map<Type, dynamic Function(dynamic, Protocol)> _deserializers =
+      _buildDeserializers();
+
+  static Map<Type, dynamic Function(dynamic, Protocol)> _buildDeserializers() {
+    final map = <Type, dynamic Function(dynamic, Protocol)>{};
+    map[_i5.Channel] = (data, protocol) => _i5.Channel.fromJson(data);
+    map[_i1.getType<_i5.Channel?>()] = (data, protocol) =>
+        (data != null ? _i5.Channel.fromJson(data) : null);
+    map[List<_i6.Channel>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i6.Channel>(e))
+        .toList();
+    return map;
+  }
+
   static String? getClassNameFromObjectJson(dynamic data) {
     if (data is! Map) return null;
     final className = data['__className__'] as String?;
@@ -88,15 +102,9 @@ class Protocol extends _i1.DatabaseSerializationManager {
       }
     }
 
-    if (t == _i5.Channel) {
-      return _i5.Channel.fromJson(data) as T;
-    }
-    if (t == _i1.getType<_i5.Channel?>()) {
-      return (data != null ? _i5.Channel.fromJson(data) : null) as T;
-    }
-    if (t == List<_i6.Channel>) {
-      return (data as List).map((e) => deserialize<_i6.Channel>(e)).toList()
-          as T;
+    final fn = _deserializers[t];
+    if (fn != null) {
+      return fn(data, this) as T;
     }
     try {
       return _i3.Protocol().deserialize<T>(data, t);

--- a/examples/middleware/middleware_client/lib/src/protocol/protocol.dart
+++ b/examples/middleware/middleware_client/lib/src/protocol/protocol.dart
@@ -22,6 +22,17 @@ class Protocol extends _i1.SerializationManager {
 
   static final Protocol _instance = Protocol._();
 
+  static final Map<Type, dynamic Function(dynamic, Protocol)> _deserializers =
+      _buildDeserializers();
+
+  static Map<Type, dynamic Function(dynamic, Protocol)> _buildDeserializers() {
+    final map = <Type, dynamic Function(dynamic, Protocol)>{};
+    map[_i2.Greeting] = (data, protocol) => _i2.Greeting.fromJson(data);
+    map[_i1.getType<_i2.Greeting?>()] = (data, protocol) =>
+        (data != null ? _i2.Greeting.fromJson(data) : null);
+    return map;
+  }
+
   static String? getClassNameFromObjectJson(dynamic data) {
     if (data is! Map) return null;
     final className = data['__className__'] as String?;
@@ -49,11 +60,9 @@ class Protocol extends _i1.SerializationManager {
       }
     }
 
-    if (t == _i2.Greeting) {
-      return _i2.Greeting.fromJson(data) as T;
-    }
-    if (t == _i1.getType<_i2.Greeting?>()) {
-      return (data != null ? _i2.Greeting.fromJson(data) : null) as T;
+    final fn = _deserializers[t];
+    if (fn != null) {
+      return fn(data, this) as T;
     }
     return super.deserialize<T>(data, t);
   }

--- a/examples/middleware/middleware_client/lib/src/protocol/protocol.dart
+++ b/examples/middleware/middleware_client/lib/src/protocol/protocol.dart
@@ -23,6 +23,9 @@ class Protocol extends _i1.SerializationManager {
 
   static final Protocol _instance = Protocol._();
 
+  static final Map<Type, dynamic Function(dynamic, Protocol)> _deserializers =
+      _buildDeserializers();
+
   static String? getClassNameFromObjectJson(dynamic data) {
     if (data is! Map) return null;
     final className = data['__className__'] as String?;
@@ -50,11 +53,9 @@ class Protocol extends _i1.SerializationManager {
       }
     }
 
-    if (t == _i2.Greeting) {
-      return _i2.Greeting.fromJson(data) as T;
-    }
-    if (t == _i1.getType<_i2.Greeting?>()) {
-      return (data != null ? _i2.Greeting.fromJson(data) : null) as T;
+    final fn = _deserializers[t];
+    if (fn != null) {
+      return fn(data, this) as T;
     }
     return super.deserialize<T>(data, t);
   }
@@ -107,5 +108,13 @@ class Protocol extends _i1.SerializationManager {
       return null;
     }
     throw Exception('Unsupported record type ${record.runtimeType}');
+  }
+
+  static Map<Type, dynamic Function(dynamic, Protocol)> _buildDeserializers() {
+    final map = <Type, dynamic Function(dynamic, Protocol)>{};
+    map[_i2.Greeting] = (data, protocol) => _i2.Greeting.fromJson(data);
+    map[_i1.getType<_i2.Greeting?>()] = (data, protocol) =>
+        (data != null ? _i2.Greeting.fromJson(data) : null);
+    return map;
   }
 }

--- a/examples/middleware/middleware_server/lib/src/generated/protocol.dart
+++ b/examples/middleware/middleware_server/lib/src/generated/protocol.dart
@@ -26,6 +26,17 @@ class Protocol extends _i1.DatabaseSerializationManager {
     ..._i2.Protocol.targetTableDefinitions,
   ];
 
+  static final Map<Type, dynamic Function(dynamic, Protocol)> _deserializers =
+      _buildDeserializers();
+
+  static Map<Type, dynamic Function(dynamic, Protocol)> _buildDeserializers() {
+    final map = <Type, dynamic Function(dynamic, Protocol)>{};
+    map[_i3.Greeting] = (data, protocol) => _i3.Greeting.fromJson(data);
+    map[_i1.getType<_i3.Greeting?>()] = (data, protocol) =>
+        (data != null ? _i3.Greeting.fromJson(data) : null);
+    return map;
+  }
+
   static String? getClassNameFromObjectJson(dynamic data) {
     if (data is! Map) return null;
     final className = data['__className__'] as String?;
@@ -53,11 +64,9 @@ class Protocol extends _i1.DatabaseSerializationManager {
       }
     }
 
-    if (t == _i3.Greeting) {
-      return _i3.Greeting.fromJson(data) as T;
-    }
-    if (t == _i1.getType<_i3.Greeting?>()) {
-      return (data != null ? _i3.Greeting.fromJson(data) : null) as T;
+    final fn = _deserializers[t];
+    if (fn != null) {
+      return fn(data, this) as T;
     }
     try {
       return _i2.Protocol().deserialize<T>(data, t);

--- a/examples/middleware/middleware_server/lib/src/generated/protocol.dart
+++ b/examples/middleware/middleware_server/lib/src/generated/protocol.dart
@@ -23,6 +23,9 @@ class Protocol extends _i1.DatabaseSerializationManager {
 
   static final Protocol _instance = Protocol._();
 
+  static final Map<Type, dynamic Function(dynamic, Protocol)> _deserializers =
+      _buildDeserializers();
+
   static List<_i2.TableDefinition> get targetTableDefinitions => [
     ..._i2.Protocol.targetTableDefinitions,
   ];
@@ -54,11 +57,9 @@ class Protocol extends _i1.DatabaseSerializationManager {
       }
     }
 
-    if (t == _i3.Greeting) {
-      return _i3.Greeting.fromJson(data) as T;
-    }
-    if (t == _i1.getType<_i3.Greeting?>()) {
-      return (data != null ? _i3.Greeting.fromJson(data) : null) as T;
+    final fn = _deserializers[t];
+    if (fn != null) {
+      return fn(data, this) as T;
     }
     try {
       return _i2.Protocol().deserialize<T>(data, t);
@@ -140,5 +141,13 @@ class Protocol extends _i1.DatabaseSerializationManager {
       return _i2.Protocol().mapRecordToJson(record);
     } catch (_) {}
     throw Exception('Unsupported record type ${record.runtimeType}');
+  }
+
+  static Map<Type, dynamic Function(dynamic, Protocol)> _buildDeserializers() {
+    final map = <Type, dynamic Function(dynamic, Protocol)>{};
+    map[_i3.Greeting] = (data, protocol) => _i3.Greeting.fromJson(data);
+    map[_i1.getType<_i3.Greeting?>()] = (data, protocol) =>
+        (data != null ? _i3.Greeting.fromJson(data) : null);
+    return map;
   }
 }

--- a/modules/legacy/serverpod_auth/serverpod_auth_client/lib/src/protocol/protocol.dart
+++ b/modules/legacy/serverpod_auth/serverpod_auth_client/lib/src/protocol/protocol.dart
@@ -50,6 +50,67 @@ class Protocol extends _i1.SerializationManager {
 
   final Map<String, _i1.SerializationManager> _hostProtocols = {};
 
+  static final Map<Type, dynamic Function(dynamic, Protocol)> _deserializers =
+      _buildDeserializers();
+
+  static Map<Type, dynamic Function(dynamic, Protocol)> _buildDeserializers() {
+    final map = <Type, dynamic Function(dynamic, Protocol)>{};
+    map[_i2.AppleAuthInfo] = (data, protocol) =>
+        _i2.AppleAuthInfo.fromJson(data);
+    map[_i3.AuthKey] = (data, protocol) => _i3.AuthKey.fromJson(data);
+    map[_i4.AuthenticationFailReason] = (data, protocol) =>
+        _i4.AuthenticationFailReason.fromJson(data);
+    map[_i5.AuthenticationResponse] = (data, protocol) =>
+        _i5.AuthenticationResponse.fromJson(data);
+    map[_i6.EmailAuth] = (data, protocol) => _i6.EmailAuth.fromJson(data);
+    map[_i7.EmailCreateAccountRequest] = (data, protocol) =>
+        _i7.EmailCreateAccountRequest.fromJson(data);
+    map[_i8.EmailFailedSignIn] = (data, protocol) =>
+        _i8.EmailFailedSignIn.fromJson(data);
+    map[_i9.EmailPasswordReset] = (data, protocol) =>
+        _i9.EmailPasswordReset.fromJson(data);
+    map[_i10.EmailReset] = (data, protocol) => _i10.EmailReset.fromJson(data);
+    map[_i11.GoogleRefreshToken] = (data, protocol) =>
+        _i11.GoogleRefreshToken.fromJson(data);
+    map[_i12.UserImage] = (data, protocol) => _i12.UserImage.fromJson(data);
+    map[_i13.UserInfo] = (data, protocol) => _i13.UserInfo.fromJson(data);
+    map[_i14.UserInfoPublic] = (data, protocol) =>
+        _i14.UserInfoPublic.fromJson(data);
+    map[_i15.UserSettingsConfig] = (data, protocol) =>
+        _i15.UserSettingsConfig.fromJson(data);
+    map[_i1.getType<_i2.AppleAuthInfo?>()] = (data, protocol) =>
+        (data != null ? _i2.AppleAuthInfo.fromJson(data) : null);
+    map[_i1.getType<_i3.AuthKey?>()] = (data, protocol) =>
+        (data != null ? _i3.AuthKey.fromJson(data) : null);
+    map[_i1.getType<_i4.AuthenticationFailReason?>()] = (data, protocol) =>
+        (data != null ? _i4.AuthenticationFailReason.fromJson(data) : null);
+    map[_i1.getType<_i5.AuthenticationResponse?>()] = (data, protocol) =>
+        (data != null ? _i5.AuthenticationResponse.fromJson(data) : null);
+    map[_i1.getType<_i6.EmailAuth?>()] = (data, protocol) =>
+        (data != null ? _i6.EmailAuth.fromJson(data) : null);
+    map[_i1.getType<_i7.EmailCreateAccountRequest?>()] = (data, protocol) =>
+        (data != null ? _i7.EmailCreateAccountRequest.fromJson(data) : null);
+    map[_i1.getType<_i8.EmailFailedSignIn?>()] = (data, protocol) =>
+        (data != null ? _i8.EmailFailedSignIn.fromJson(data) : null);
+    map[_i1.getType<_i9.EmailPasswordReset?>()] = (data, protocol) =>
+        (data != null ? _i9.EmailPasswordReset.fromJson(data) : null);
+    map[_i1.getType<_i10.EmailReset?>()] = (data, protocol) =>
+        (data != null ? _i10.EmailReset.fromJson(data) : null);
+    map[_i1.getType<_i11.GoogleRefreshToken?>()] = (data, protocol) =>
+        (data != null ? _i11.GoogleRefreshToken.fromJson(data) : null);
+    map[_i1.getType<_i12.UserImage?>()] = (data, protocol) =>
+        (data != null ? _i12.UserImage.fromJson(data) : null);
+    map[_i1.getType<_i13.UserInfo?>()] = (data, protocol) =>
+        (data != null ? _i13.UserInfo.fromJson(data) : null);
+    map[_i1.getType<_i14.UserInfoPublic?>()] = (data, protocol) =>
+        (data != null ? _i14.UserInfoPublic.fromJson(data) : null);
+    map[_i1.getType<_i15.UserSettingsConfig?>()] = (data, protocol) =>
+        (data != null ? _i15.UserSettingsConfig.fromJson(data) : null);
+    map[List<String>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<String>(e)).toList();
+    return map;
+  }
+
   void registerHostProtocol(
     String projectName,
     _i1.SerializationManager protocol,
@@ -86,99 +147,9 @@ class Protocol extends _i1.SerializationManager {
       }
     }
 
-    if (t == _i2.AppleAuthInfo) {
-      return _i2.AppleAuthInfo.fromJson(data) as T;
-    }
-    if (t == _i3.AuthKey) {
-      return _i3.AuthKey.fromJson(data) as T;
-    }
-    if (t == _i4.AuthenticationFailReason) {
-      return _i4.AuthenticationFailReason.fromJson(data) as T;
-    }
-    if (t == _i5.AuthenticationResponse) {
-      return _i5.AuthenticationResponse.fromJson(data) as T;
-    }
-    if (t == _i6.EmailAuth) {
-      return _i6.EmailAuth.fromJson(data) as T;
-    }
-    if (t == _i7.EmailCreateAccountRequest) {
-      return _i7.EmailCreateAccountRequest.fromJson(data) as T;
-    }
-    if (t == _i8.EmailFailedSignIn) {
-      return _i8.EmailFailedSignIn.fromJson(data) as T;
-    }
-    if (t == _i9.EmailPasswordReset) {
-      return _i9.EmailPasswordReset.fromJson(data) as T;
-    }
-    if (t == _i10.EmailReset) {
-      return _i10.EmailReset.fromJson(data) as T;
-    }
-    if (t == _i11.GoogleRefreshToken) {
-      return _i11.GoogleRefreshToken.fromJson(data) as T;
-    }
-    if (t == _i12.UserImage) {
-      return _i12.UserImage.fromJson(data) as T;
-    }
-    if (t == _i13.UserInfo) {
-      return _i13.UserInfo.fromJson(data) as T;
-    }
-    if (t == _i14.UserInfoPublic) {
-      return _i14.UserInfoPublic.fromJson(data) as T;
-    }
-    if (t == _i15.UserSettingsConfig) {
-      return _i15.UserSettingsConfig.fromJson(data) as T;
-    }
-    if (t == _i1.getType<_i2.AppleAuthInfo?>()) {
-      return (data != null ? _i2.AppleAuthInfo.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i3.AuthKey?>()) {
-      return (data != null ? _i3.AuthKey.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i4.AuthenticationFailReason?>()) {
-      return (data != null ? _i4.AuthenticationFailReason.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i5.AuthenticationResponse?>()) {
-      return (data != null ? _i5.AuthenticationResponse.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i6.EmailAuth?>()) {
-      return (data != null ? _i6.EmailAuth.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i7.EmailCreateAccountRequest?>()) {
-      return (data != null
-              ? _i7.EmailCreateAccountRequest.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i8.EmailFailedSignIn?>()) {
-      return (data != null ? _i8.EmailFailedSignIn.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i9.EmailPasswordReset?>()) {
-      return (data != null ? _i9.EmailPasswordReset.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i10.EmailReset?>()) {
-      return (data != null ? _i10.EmailReset.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i11.GoogleRefreshToken?>()) {
-      return (data != null ? _i11.GoogleRefreshToken.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i12.UserImage?>()) {
-      return (data != null ? _i12.UserImage.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i13.UserInfo?>()) {
-      return (data != null ? _i13.UserInfo.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i14.UserInfoPublic?>()) {
-      return (data != null ? _i14.UserInfoPublic.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i15.UserSettingsConfig?>()) {
-      return (data != null ? _i15.UserSettingsConfig.fromJson(data) : null)
-          as T;
-    }
-    if (t == List<String>) {
-      return (data as List).map((e) => deserialize<String>(e)).toList() as T;
+    final fn = _deserializers[t];
+    if (fn != null) {
+      return fn(data, this) as T;
     }
     return super.deserialize<T>(data, t);
   }

--- a/modules/legacy/serverpod_auth/serverpod_auth_client/lib/src/protocol/protocol.dart
+++ b/modules/legacy/serverpod_auth/serverpod_auth_client/lib/src/protocol/protocol.dart
@@ -51,6 +51,9 @@ class Protocol extends _i1.SerializationManager {
 
   final Set<_i1.SerializationManager> _hostProtocols = {};
 
+  static final Map<Type, dynamic Function(dynamic, Protocol)> _deserializers =
+      _buildDeserializers();
+
   void registerHostProtocol(
     String projectName,
     _i1.SerializationManager protocol,
@@ -87,99 +90,9 @@ class Protocol extends _i1.SerializationManager {
       }
     }
 
-    if (t == _i2.AppleAuthInfo) {
-      return _i2.AppleAuthInfo.fromJson(data) as T;
-    }
-    if (t == _i3.AuthKey) {
-      return _i3.AuthKey.fromJson(data) as T;
-    }
-    if (t == _i4.AuthenticationFailReason) {
-      return _i4.AuthenticationFailReason.fromJson(data) as T;
-    }
-    if (t == _i5.AuthenticationResponse) {
-      return _i5.AuthenticationResponse.fromJson(data) as T;
-    }
-    if (t == _i6.EmailAuth) {
-      return _i6.EmailAuth.fromJson(data) as T;
-    }
-    if (t == _i7.EmailCreateAccountRequest) {
-      return _i7.EmailCreateAccountRequest.fromJson(data) as T;
-    }
-    if (t == _i8.EmailFailedSignIn) {
-      return _i8.EmailFailedSignIn.fromJson(data) as T;
-    }
-    if (t == _i9.EmailPasswordReset) {
-      return _i9.EmailPasswordReset.fromJson(data) as T;
-    }
-    if (t == _i10.EmailReset) {
-      return _i10.EmailReset.fromJson(data) as T;
-    }
-    if (t == _i11.GoogleRefreshToken) {
-      return _i11.GoogleRefreshToken.fromJson(data) as T;
-    }
-    if (t == _i12.UserImage) {
-      return _i12.UserImage.fromJson(data) as T;
-    }
-    if (t == _i13.UserInfo) {
-      return _i13.UserInfo.fromJson(data) as T;
-    }
-    if (t == _i14.UserInfoPublic) {
-      return _i14.UserInfoPublic.fromJson(data) as T;
-    }
-    if (t == _i15.UserSettingsConfig) {
-      return _i15.UserSettingsConfig.fromJson(data) as T;
-    }
-    if (t == _i1.getType<_i2.AppleAuthInfo?>()) {
-      return (data != null ? _i2.AppleAuthInfo.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i3.AuthKey?>()) {
-      return (data != null ? _i3.AuthKey.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i4.AuthenticationFailReason?>()) {
-      return (data != null ? _i4.AuthenticationFailReason.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i5.AuthenticationResponse?>()) {
-      return (data != null ? _i5.AuthenticationResponse.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i6.EmailAuth?>()) {
-      return (data != null ? _i6.EmailAuth.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i7.EmailCreateAccountRequest?>()) {
-      return (data != null
-              ? _i7.EmailCreateAccountRequest.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i8.EmailFailedSignIn?>()) {
-      return (data != null ? _i8.EmailFailedSignIn.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i9.EmailPasswordReset?>()) {
-      return (data != null ? _i9.EmailPasswordReset.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i10.EmailReset?>()) {
-      return (data != null ? _i10.EmailReset.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i11.GoogleRefreshToken?>()) {
-      return (data != null ? _i11.GoogleRefreshToken.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i12.UserImage?>()) {
-      return (data != null ? _i12.UserImage.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i13.UserInfo?>()) {
-      return (data != null ? _i13.UserInfo.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i14.UserInfoPublic?>()) {
-      return (data != null ? _i14.UserInfoPublic.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i15.UserSettingsConfig?>()) {
-      return (data != null ? _i15.UserSettingsConfig.fromJson(data) : null)
-          as T;
-    }
-    if (t == List<String>) {
-      return (data as List).map((e) => deserialize<String>(e)).toList() as T;
+    final fn = _deserializers[t];
+    if (fn != null) {
+      return fn(data, this) as T;
     }
     return super.deserialize<T>(data, t);
   }
@@ -372,5 +285,63 @@ class Protocol extends _i1.SerializationManager {
       return null;
     }
     throw Exception('Unsupported record type ${record.runtimeType}');
+  }
+
+  static Map<Type, dynamic Function(dynamic, Protocol)> _buildDeserializers() {
+    final map = <Type, dynamic Function(dynamic, Protocol)>{};
+    map[_i2.AppleAuthInfo] = (data, protocol) =>
+        _i2.AppleAuthInfo.fromJson(data);
+    map[_i3.AuthKey] = (data, protocol) => _i3.AuthKey.fromJson(data);
+    map[_i4.AuthenticationFailReason] = (data, protocol) =>
+        _i4.AuthenticationFailReason.fromJson(data);
+    map[_i5.AuthenticationResponse] = (data, protocol) =>
+        _i5.AuthenticationResponse.fromJson(data);
+    map[_i6.EmailAuth] = (data, protocol) => _i6.EmailAuth.fromJson(data);
+    map[_i7.EmailCreateAccountRequest] = (data, protocol) =>
+        _i7.EmailCreateAccountRequest.fromJson(data);
+    map[_i8.EmailFailedSignIn] = (data, protocol) =>
+        _i8.EmailFailedSignIn.fromJson(data);
+    map[_i9.EmailPasswordReset] = (data, protocol) =>
+        _i9.EmailPasswordReset.fromJson(data);
+    map[_i10.EmailReset] = (data, protocol) => _i10.EmailReset.fromJson(data);
+    map[_i11.GoogleRefreshToken] = (data, protocol) =>
+        _i11.GoogleRefreshToken.fromJson(data);
+    map[_i12.UserImage] = (data, protocol) => _i12.UserImage.fromJson(data);
+    map[_i13.UserInfo] = (data, protocol) => _i13.UserInfo.fromJson(data);
+    map[_i14.UserInfoPublic] = (data, protocol) =>
+        _i14.UserInfoPublic.fromJson(data);
+    map[_i15.UserSettingsConfig] = (data, protocol) =>
+        _i15.UserSettingsConfig.fromJson(data);
+    map[_i1.getType<_i2.AppleAuthInfo?>()] = (data, protocol) =>
+        (data != null ? _i2.AppleAuthInfo.fromJson(data) : null);
+    map[_i1.getType<_i3.AuthKey?>()] = (data, protocol) =>
+        (data != null ? _i3.AuthKey.fromJson(data) : null);
+    map[_i1.getType<_i4.AuthenticationFailReason?>()] = (data, protocol) =>
+        (data != null ? _i4.AuthenticationFailReason.fromJson(data) : null);
+    map[_i1.getType<_i5.AuthenticationResponse?>()] = (data, protocol) =>
+        (data != null ? _i5.AuthenticationResponse.fromJson(data) : null);
+    map[_i1.getType<_i6.EmailAuth?>()] = (data, protocol) =>
+        (data != null ? _i6.EmailAuth.fromJson(data) : null);
+    map[_i1.getType<_i7.EmailCreateAccountRequest?>()] = (data, protocol) =>
+        (data != null ? _i7.EmailCreateAccountRequest.fromJson(data) : null);
+    map[_i1.getType<_i8.EmailFailedSignIn?>()] = (data, protocol) =>
+        (data != null ? _i8.EmailFailedSignIn.fromJson(data) : null);
+    map[_i1.getType<_i9.EmailPasswordReset?>()] = (data, protocol) =>
+        (data != null ? _i9.EmailPasswordReset.fromJson(data) : null);
+    map[_i1.getType<_i10.EmailReset?>()] = (data, protocol) =>
+        (data != null ? _i10.EmailReset.fromJson(data) : null);
+    map[_i1.getType<_i11.GoogleRefreshToken?>()] = (data, protocol) =>
+        (data != null ? _i11.GoogleRefreshToken.fromJson(data) : null);
+    map[_i1.getType<_i12.UserImage?>()] = (data, protocol) =>
+        (data != null ? _i12.UserImage.fromJson(data) : null);
+    map[_i1.getType<_i13.UserInfo?>()] = (data, protocol) =>
+        (data != null ? _i13.UserInfo.fromJson(data) : null);
+    map[_i1.getType<_i14.UserInfoPublic?>()] = (data, protocol) =>
+        (data != null ? _i14.UserInfoPublic.fromJson(data) : null);
+    map[_i1.getType<_i15.UserSettingsConfig?>()] = (data, protocol) =>
+        (data != null ? _i15.UserSettingsConfig.fromJson(data) : null);
+    map[List<String>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<String>(e)).toList();
+    return map;
   }
 }

--- a/modules/legacy/serverpod_auth/serverpod_auth_server/lib/src/generated/protocol.dart
+++ b/modules/legacy/serverpod_auth/serverpod_auth_server/lib/src/generated/protocol.dart
@@ -519,6 +519,67 @@ class Protocol extends _i1.DatabaseSerializationManager {
 
   final Map<String, _i1.SerializationManager> _hostProtocols = {};
 
+  static final Map<Type, dynamic Function(dynamic, Protocol)> _deserializers =
+      _buildDeserializers();
+
+  static Map<Type, dynamic Function(dynamic, Protocol)> _buildDeserializers() {
+    final map = <Type, dynamic Function(dynamic, Protocol)>{};
+    map[_i3.AppleAuthInfo] = (data, protocol) =>
+        _i3.AppleAuthInfo.fromJson(data);
+    map[_i4.AuthKey] = (data, protocol) => _i4.AuthKey.fromJson(data);
+    map[_i5.AuthenticationFailReason] = (data, protocol) =>
+        _i5.AuthenticationFailReason.fromJson(data);
+    map[_i6.AuthenticationResponse] = (data, protocol) =>
+        _i6.AuthenticationResponse.fromJson(data);
+    map[_i7.EmailAuth] = (data, protocol) => _i7.EmailAuth.fromJson(data);
+    map[_i8.EmailCreateAccountRequest] = (data, protocol) =>
+        _i8.EmailCreateAccountRequest.fromJson(data);
+    map[_i9.EmailFailedSignIn] = (data, protocol) =>
+        _i9.EmailFailedSignIn.fromJson(data);
+    map[_i10.EmailPasswordReset] = (data, protocol) =>
+        _i10.EmailPasswordReset.fromJson(data);
+    map[_i11.EmailReset] = (data, protocol) => _i11.EmailReset.fromJson(data);
+    map[_i12.GoogleRefreshToken] = (data, protocol) =>
+        _i12.GoogleRefreshToken.fromJson(data);
+    map[_i13.UserImage] = (data, protocol) => _i13.UserImage.fromJson(data);
+    map[_i14.UserInfo] = (data, protocol) => _i14.UserInfo.fromJson(data);
+    map[_i15.UserInfoPublic] = (data, protocol) =>
+        _i15.UserInfoPublic.fromJson(data);
+    map[_i16.UserSettingsConfig] = (data, protocol) =>
+        _i16.UserSettingsConfig.fromJson(data);
+    map[_i1.getType<_i3.AppleAuthInfo?>()] = (data, protocol) =>
+        (data != null ? _i3.AppleAuthInfo.fromJson(data) : null);
+    map[_i1.getType<_i4.AuthKey?>()] = (data, protocol) =>
+        (data != null ? _i4.AuthKey.fromJson(data) : null);
+    map[_i1.getType<_i5.AuthenticationFailReason?>()] = (data, protocol) =>
+        (data != null ? _i5.AuthenticationFailReason.fromJson(data) : null);
+    map[_i1.getType<_i6.AuthenticationResponse?>()] = (data, protocol) =>
+        (data != null ? _i6.AuthenticationResponse.fromJson(data) : null);
+    map[_i1.getType<_i7.EmailAuth?>()] = (data, protocol) =>
+        (data != null ? _i7.EmailAuth.fromJson(data) : null);
+    map[_i1.getType<_i8.EmailCreateAccountRequest?>()] = (data, protocol) =>
+        (data != null ? _i8.EmailCreateAccountRequest.fromJson(data) : null);
+    map[_i1.getType<_i9.EmailFailedSignIn?>()] = (data, protocol) =>
+        (data != null ? _i9.EmailFailedSignIn.fromJson(data) : null);
+    map[_i1.getType<_i10.EmailPasswordReset?>()] = (data, protocol) =>
+        (data != null ? _i10.EmailPasswordReset.fromJson(data) : null);
+    map[_i1.getType<_i11.EmailReset?>()] = (data, protocol) =>
+        (data != null ? _i11.EmailReset.fromJson(data) : null);
+    map[_i1.getType<_i12.GoogleRefreshToken?>()] = (data, protocol) =>
+        (data != null ? _i12.GoogleRefreshToken.fromJson(data) : null);
+    map[_i1.getType<_i13.UserImage?>()] = (data, protocol) =>
+        (data != null ? _i13.UserImage.fromJson(data) : null);
+    map[_i1.getType<_i14.UserInfo?>()] = (data, protocol) =>
+        (data != null ? _i14.UserInfo.fromJson(data) : null);
+    map[_i1.getType<_i15.UserInfoPublic?>()] = (data, protocol) =>
+        (data != null ? _i15.UserInfoPublic.fromJson(data) : null);
+    map[_i1.getType<_i16.UserSettingsConfig?>()] = (data, protocol) =>
+        (data != null ? _i16.UserSettingsConfig.fromJson(data) : null);
+    map[List<String>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<String>(e)).toList();
+    return map;
+  }
+
   void registerHostProtocol(
     String projectName,
     _i1.SerializationManager protocol,
@@ -555,100 +616,9 @@ class Protocol extends _i1.DatabaseSerializationManager {
       }
     }
 
-    if (t == _i3.AppleAuthInfo) {
-      return _i3.AppleAuthInfo.fromJson(data) as T;
-    }
-    if (t == _i4.AuthKey) {
-      return _i4.AuthKey.fromJson(data) as T;
-    }
-    if (t == _i5.AuthenticationFailReason) {
-      return _i5.AuthenticationFailReason.fromJson(data) as T;
-    }
-    if (t == _i6.AuthenticationResponse) {
-      return _i6.AuthenticationResponse.fromJson(data) as T;
-    }
-    if (t == _i7.EmailAuth) {
-      return _i7.EmailAuth.fromJson(data) as T;
-    }
-    if (t == _i8.EmailCreateAccountRequest) {
-      return _i8.EmailCreateAccountRequest.fromJson(data) as T;
-    }
-    if (t == _i9.EmailFailedSignIn) {
-      return _i9.EmailFailedSignIn.fromJson(data) as T;
-    }
-    if (t == _i10.EmailPasswordReset) {
-      return _i10.EmailPasswordReset.fromJson(data) as T;
-    }
-    if (t == _i11.EmailReset) {
-      return _i11.EmailReset.fromJson(data) as T;
-    }
-    if (t == _i12.GoogleRefreshToken) {
-      return _i12.GoogleRefreshToken.fromJson(data) as T;
-    }
-    if (t == _i13.UserImage) {
-      return _i13.UserImage.fromJson(data) as T;
-    }
-    if (t == _i14.UserInfo) {
-      return _i14.UserInfo.fromJson(data) as T;
-    }
-    if (t == _i15.UserInfoPublic) {
-      return _i15.UserInfoPublic.fromJson(data) as T;
-    }
-    if (t == _i16.UserSettingsConfig) {
-      return _i16.UserSettingsConfig.fromJson(data) as T;
-    }
-    if (t == _i1.getType<_i3.AppleAuthInfo?>()) {
-      return (data != null ? _i3.AppleAuthInfo.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i4.AuthKey?>()) {
-      return (data != null ? _i4.AuthKey.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i5.AuthenticationFailReason?>()) {
-      return (data != null ? _i5.AuthenticationFailReason.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i6.AuthenticationResponse?>()) {
-      return (data != null ? _i6.AuthenticationResponse.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i7.EmailAuth?>()) {
-      return (data != null ? _i7.EmailAuth.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i8.EmailCreateAccountRequest?>()) {
-      return (data != null
-              ? _i8.EmailCreateAccountRequest.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i9.EmailFailedSignIn?>()) {
-      return (data != null ? _i9.EmailFailedSignIn.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i10.EmailPasswordReset?>()) {
-      return (data != null ? _i10.EmailPasswordReset.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i11.EmailReset?>()) {
-      return (data != null ? _i11.EmailReset.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i12.GoogleRefreshToken?>()) {
-      return (data != null ? _i12.GoogleRefreshToken.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i13.UserImage?>()) {
-      return (data != null ? _i13.UserImage.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i14.UserInfo?>()) {
-      return (data != null ? _i14.UserInfo.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i15.UserInfoPublic?>()) {
-      return (data != null ? _i15.UserInfoPublic.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i16.UserSettingsConfig?>()) {
-      return (data != null ? _i16.UserSettingsConfig.fromJson(data) : null)
-          as T;
-    }
-    if (t == List<String>) {
-      return (data as List).map((e) => deserialize<String>(e)).toList() as T;
+    final fn = _deserializers[t];
+    if (fn != null) {
+      return fn(data, this) as T;
     }
     try {
       return _i2.Protocol().deserialize<T>(data, t);

--- a/modules/legacy/serverpod_auth/serverpod_auth_server/lib/src/generated/protocol.dart
+++ b/modules/legacy/serverpod_auth/serverpod_auth_server/lib/src/generated/protocol.dart
@@ -51,6 +51,9 @@ class Protocol extends _i1.DatabaseSerializationManager {
 
   final Set<_i1.SerializationManager> _hostProtocols = {};
 
+  static final Map<Type, dynamic Function(dynamic, Protocol)> _deserializers =
+      _buildDeserializers();
+
   static List<_i2.TableDefinition> get targetTableDefinitions => [
     _i2.TableDefinition(
       name: 'serverpod_auth_key',
@@ -556,100 +559,9 @@ class Protocol extends _i1.DatabaseSerializationManager {
       }
     }
 
-    if (t == _i3.AppleAuthInfo) {
-      return _i3.AppleAuthInfo.fromJson(data) as T;
-    }
-    if (t == _i4.AuthKey) {
-      return _i4.AuthKey.fromJson(data) as T;
-    }
-    if (t == _i5.AuthenticationFailReason) {
-      return _i5.AuthenticationFailReason.fromJson(data) as T;
-    }
-    if (t == _i6.AuthenticationResponse) {
-      return _i6.AuthenticationResponse.fromJson(data) as T;
-    }
-    if (t == _i7.EmailAuth) {
-      return _i7.EmailAuth.fromJson(data) as T;
-    }
-    if (t == _i8.EmailCreateAccountRequest) {
-      return _i8.EmailCreateAccountRequest.fromJson(data) as T;
-    }
-    if (t == _i9.EmailFailedSignIn) {
-      return _i9.EmailFailedSignIn.fromJson(data) as T;
-    }
-    if (t == _i10.EmailPasswordReset) {
-      return _i10.EmailPasswordReset.fromJson(data) as T;
-    }
-    if (t == _i11.EmailReset) {
-      return _i11.EmailReset.fromJson(data) as T;
-    }
-    if (t == _i12.GoogleRefreshToken) {
-      return _i12.GoogleRefreshToken.fromJson(data) as T;
-    }
-    if (t == _i13.UserImage) {
-      return _i13.UserImage.fromJson(data) as T;
-    }
-    if (t == _i14.UserInfo) {
-      return _i14.UserInfo.fromJson(data) as T;
-    }
-    if (t == _i15.UserInfoPublic) {
-      return _i15.UserInfoPublic.fromJson(data) as T;
-    }
-    if (t == _i16.UserSettingsConfig) {
-      return _i16.UserSettingsConfig.fromJson(data) as T;
-    }
-    if (t == _i1.getType<_i3.AppleAuthInfo?>()) {
-      return (data != null ? _i3.AppleAuthInfo.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i4.AuthKey?>()) {
-      return (data != null ? _i4.AuthKey.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i5.AuthenticationFailReason?>()) {
-      return (data != null ? _i5.AuthenticationFailReason.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i6.AuthenticationResponse?>()) {
-      return (data != null ? _i6.AuthenticationResponse.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i7.EmailAuth?>()) {
-      return (data != null ? _i7.EmailAuth.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i8.EmailCreateAccountRequest?>()) {
-      return (data != null
-              ? _i8.EmailCreateAccountRequest.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i9.EmailFailedSignIn?>()) {
-      return (data != null ? _i9.EmailFailedSignIn.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i10.EmailPasswordReset?>()) {
-      return (data != null ? _i10.EmailPasswordReset.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i11.EmailReset?>()) {
-      return (data != null ? _i11.EmailReset.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i12.GoogleRefreshToken?>()) {
-      return (data != null ? _i12.GoogleRefreshToken.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i13.UserImage?>()) {
-      return (data != null ? _i13.UserImage.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i14.UserInfo?>()) {
-      return (data != null ? _i14.UserInfo.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i15.UserInfoPublic?>()) {
-      return (data != null ? _i15.UserInfoPublic.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i16.UserSettingsConfig?>()) {
-      return (data != null ? _i16.UserSettingsConfig.fromJson(data) : null)
-          as T;
-    }
-    if (t == List<String>) {
-      return (data as List).map((e) => deserialize<String>(e)).toList() as T;
+    final fn = _deserializers[t];
+    if (fn != null) {
+      return fn(data, this) as T;
     }
     try {
       return _i2.Protocol().deserialize<T>(data, t);
@@ -889,5 +801,63 @@ class Protocol extends _i1.DatabaseSerializationManager {
       return _i2.Protocol().mapRecordToJson(record);
     } catch (_) {}
     throw Exception('Unsupported record type ${record.runtimeType}');
+  }
+
+  static Map<Type, dynamic Function(dynamic, Protocol)> _buildDeserializers() {
+    final map = <Type, dynamic Function(dynamic, Protocol)>{};
+    map[_i3.AppleAuthInfo] = (data, protocol) =>
+        _i3.AppleAuthInfo.fromJson(data);
+    map[_i4.AuthKey] = (data, protocol) => _i4.AuthKey.fromJson(data);
+    map[_i5.AuthenticationFailReason] = (data, protocol) =>
+        _i5.AuthenticationFailReason.fromJson(data);
+    map[_i6.AuthenticationResponse] = (data, protocol) =>
+        _i6.AuthenticationResponse.fromJson(data);
+    map[_i7.EmailAuth] = (data, protocol) => _i7.EmailAuth.fromJson(data);
+    map[_i8.EmailCreateAccountRequest] = (data, protocol) =>
+        _i8.EmailCreateAccountRequest.fromJson(data);
+    map[_i9.EmailFailedSignIn] = (data, protocol) =>
+        _i9.EmailFailedSignIn.fromJson(data);
+    map[_i10.EmailPasswordReset] = (data, protocol) =>
+        _i10.EmailPasswordReset.fromJson(data);
+    map[_i11.EmailReset] = (data, protocol) => _i11.EmailReset.fromJson(data);
+    map[_i12.GoogleRefreshToken] = (data, protocol) =>
+        _i12.GoogleRefreshToken.fromJson(data);
+    map[_i13.UserImage] = (data, protocol) => _i13.UserImage.fromJson(data);
+    map[_i14.UserInfo] = (data, protocol) => _i14.UserInfo.fromJson(data);
+    map[_i15.UserInfoPublic] = (data, protocol) =>
+        _i15.UserInfoPublic.fromJson(data);
+    map[_i16.UserSettingsConfig] = (data, protocol) =>
+        _i16.UserSettingsConfig.fromJson(data);
+    map[_i1.getType<_i3.AppleAuthInfo?>()] = (data, protocol) =>
+        (data != null ? _i3.AppleAuthInfo.fromJson(data) : null);
+    map[_i1.getType<_i4.AuthKey?>()] = (data, protocol) =>
+        (data != null ? _i4.AuthKey.fromJson(data) : null);
+    map[_i1.getType<_i5.AuthenticationFailReason?>()] = (data, protocol) =>
+        (data != null ? _i5.AuthenticationFailReason.fromJson(data) : null);
+    map[_i1.getType<_i6.AuthenticationResponse?>()] = (data, protocol) =>
+        (data != null ? _i6.AuthenticationResponse.fromJson(data) : null);
+    map[_i1.getType<_i7.EmailAuth?>()] = (data, protocol) =>
+        (data != null ? _i7.EmailAuth.fromJson(data) : null);
+    map[_i1.getType<_i8.EmailCreateAccountRequest?>()] = (data, protocol) =>
+        (data != null ? _i8.EmailCreateAccountRequest.fromJson(data) : null);
+    map[_i1.getType<_i9.EmailFailedSignIn?>()] = (data, protocol) =>
+        (data != null ? _i9.EmailFailedSignIn.fromJson(data) : null);
+    map[_i1.getType<_i10.EmailPasswordReset?>()] = (data, protocol) =>
+        (data != null ? _i10.EmailPasswordReset.fromJson(data) : null);
+    map[_i1.getType<_i11.EmailReset?>()] = (data, protocol) =>
+        (data != null ? _i11.EmailReset.fromJson(data) : null);
+    map[_i1.getType<_i12.GoogleRefreshToken?>()] = (data, protocol) =>
+        (data != null ? _i12.GoogleRefreshToken.fromJson(data) : null);
+    map[_i1.getType<_i13.UserImage?>()] = (data, protocol) =>
+        (data != null ? _i13.UserImage.fromJson(data) : null);
+    map[_i1.getType<_i14.UserInfo?>()] = (data, protocol) =>
+        (data != null ? _i14.UserInfo.fromJson(data) : null);
+    map[_i1.getType<_i15.UserInfoPublic?>()] = (data, protocol) =>
+        (data != null ? _i15.UserInfoPublic.fromJson(data) : null);
+    map[_i1.getType<_i16.UserSettingsConfig?>()] = (data, protocol) =>
+        (data != null ? _i16.UserSettingsConfig.fromJson(data) : null);
+    map[List<String>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<String>(e)).toList();
+    return map;
   }
 }

--- a/modules/legacy/serverpod_chat/serverpod_chat_client/lib/src/protocol/protocol.dart
+++ b/modules/legacy/serverpod_chat/serverpod_chat_client/lib/src/protocol/protocol.dart
@@ -45,6 +45,71 @@ class Protocol extends _i1.SerializationManager {
 
   final Map<String, _i1.SerializationManager> _hostProtocols = {};
 
+  static final Map<Type, dynamic Function(dynamic, Protocol)> _deserializers =
+      _buildDeserializers();
+
+  static Map<Type, dynamic Function(dynamic, Protocol)> _buildDeserializers() {
+    final map = <Type, dynamic Function(dynamic, Protocol)>{};
+    map[_i2.ChatJoinChannel] = (data, protocol) =>
+        _i2.ChatJoinChannel.fromJson(data);
+    map[_i3.ChatJoinChannelFailed] = (data, protocol) =>
+        _i3.ChatJoinChannelFailed.fromJson(data);
+    map[_i4.ChatJoinedChannel] = (data, protocol) =>
+        _i4.ChatJoinedChannel.fromJson(data);
+    map[_i5.ChatLeaveChannel] = (data, protocol) =>
+        _i5.ChatLeaveChannel.fromJson(data);
+    map[_i6.ChatMessage] = (data, protocol) => _i6.ChatMessage.fromJson(data);
+    map[_i7.ChatMessageAttachment] = (data, protocol) =>
+        _i7.ChatMessageAttachment.fromJson(data);
+    map[_i8.ChatMessageAttachmentUploadDescription] = (data, protocol) =>
+        _i8.ChatMessageAttachmentUploadDescription.fromJson(data);
+    map[_i9.ChatMessageChunk] = (data, protocol) =>
+        _i9.ChatMessageChunk.fromJson(data);
+    map[_i10.ChatMessagePost] = (data, protocol) =>
+        _i10.ChatMessagePost.fromJson(data);
+    map[_i11.ChatReadMessage] = (data, protocol) =>
+        _i11.ChatReadMessage.fromJson(data);
+    map[_i12.ChatRequestMessageChunk] = (data, protocol) =>
+        _i12.ChatRequestMessageChunk.fromJson(data);
+    map[_i1.getType<_i2.ChatJoinChannel?>()] = (data, protocol) =>
+        (data != null ? _i2.ChatJoinChannel.fromJson(data) : null);
+    map[_i1.getType<_i3.ChatJoinChannelFailed?>()] = (data, protocol) =>
+        (data != null ? _i3.ChatJoinChannelFailed.fromJson(data) : null);
+    map[_i1.getType<_i4.ChatJoinedChannel?>()] = (data, protocol) =>
+        (data != null ? _i4.ChatJoinedChannel.fromJson(data) : null);
+    map[_i1.getType<_i5.ChatLeaveChannel?>()] = (data, protocol) =>
+        (data != null ? _i5.ChatLeaveChannel.fromJson(data) : null);
+    map[_i1.getType<_i6.ChatMessage?>()] = (data, protocol) =>
+        (data != null ? _i6.ChatMessage.fromJson(data) : null);
+    map[_i1.getType<_i7.ChatMessageAttachment?>()] = (data, protocol) =>
+        (data != null ? _i7.ChatMessageAttachment.fromJson(data) : null);
+    map[_i1.getType<_i8.ChatMessageAttachmentUploadDescription?>()] =
+        (data, protocol) => (data != null
+        ? _i8.ChatMessageAttachmentUploadDescription.fromJson(data)
+        : null);
+    map[_i1.getType<_i9.ChatMessageChunk?>()] = (data, protocol) =>
+        (data != null ? _i9.ChatMessageChunk.fromJson(data) : null);
+    map[_i1.getType<_i10.ChatMessagePost?>()] = (data, protocol) =>
+        (data != null ? _i10.ChatMessagePost.fromJson(data) : null);
+    map[_i1.getType<_i11.ChatReadMessage?>()] = (data, protocol) =>
+        (data != null ? _i11.ChatReadMessage.fromJson(data) : null);
+    map[_i1.getType<_i12.ChatRequestMessageChunk?>()] = (data, protocol) =>
+        (data != null ? _i12.ChatRequestMessageChunk.fromJson(data) : null);
+    map[List<_i7.ChatMessageAttachment>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i7.ChatMessageAttachment>(e))
+        .toList();
+    map[_i1.getType<List<_i7.ChatMessageAttachment>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i7.ChatMessageAttachment>(e))
+              .toList()
+        : null);
+    map[List<_i6.ChatMessage>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i6.ChatMessage>(e))
+        .toList();
+    return map;
+  }
+
   void registerHostProtocol(
     String projectName,
     _i1.SerializationManager protocol,
@@ -81,95 +146,9 @@ class Protocol extends _i1.SerializationManager {
       }
     }
 
-    if (t == _i2.ChatJoinChannel) {
-      return _i2.ChatJoinChannel.fromJson(data) as T;
-    }
-    if (t == _i3.ChatJoinChannelFailed) {
-      return _i3.ChatJoinChannelFailed.fromJson(data) as T;
-    }
-    if (t == _i4.ChatJoinedChannel) {
-      return _i4.ChatJoinedChannel.fromJson(data) as T;
-    }
-    if (t == _i5.ChatLeaveChannel) {
-      return _i5.ChatLeaveChannel.fromJson(data) as T;
-    }
-    if (t == _i6.ChatMessage) {
-      return _i6.ChatMessage.fromJson(data) as T;
-    }
-    if (t == _i7.ChatMessageAttachment) {
-      return _i7.ChatMessageAttachment.fromJson(data) as T;
-    }
-    if (t == _i8.ChatMessageAttachmentUploadDescription) {
-      return _i8.ChatMessageAttachmentUploadDescription.fromJson(data) as T;
-    }
-    if (t == _i9.ChatMessageChunk) {
-      return _i9.ChatMessageChunk.fromJson(data) as T;
-    }
-    if (t == _i10.ChatMessagePost) {
-      return _i10.ChatMessagePost.fromJson(data) as T;
-    }
-    if (t == _i11.ChatReadMessage) {
-      return _i11.ChatReadMessage.fromJson(data) as T;
-    }
-    if (t == _i12.ChatRequestMessageChunk) {
-      return _i12.ChatRequestMessageChunk.fromJson(data) as T;
-    }
-    if (t == _i1.getType<_i2.ChatJoinChannel?>()) {
-      return (data != null ? _i2.ChatJoinChannel.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i3.ChatJoinChannelFailed?>()) {
-      return (data != null ? _i3.ChatJoinChannelFailed.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i4.ChatJoinedChannel?>()) {
-      return (data != null ? _i4.ChatJoinedChannel.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i5.ChatLeaveChannel?>()) {
-      return (data != null ? _i5.ChatLeaveChannel.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i6.ChatMessage?>()) {
-      return (data != null ? _i6.ChatMessage.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i7.ChatMessageAttachment?>()) {
-      return (data != null ? _i7.ChatMessageAttachment.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i8.ChatMessageAttachmentUploadDescription?>()) {
-      return (data != null
-              ? _i8.ChatMessageAttachmentUploadDescription.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i9.ChatMessageChunk?>()) {
-      return (data != null ? _i9.ChatMessageChunk.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i10.ChatMessagePost?>()) {
-      return (data != null ? _i10.ChatMessagePost.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i11.ChatReadMessage?>()) {
-      return (data != null ? _i11.ChatReadMessage.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i12.ChatRequestMessageChunk?>()) {
-      return (data != null ? _i12.ChatRequestMessageChunk.fromJson(data) : null)
-          as T;
-    }
-    if (t == List<_i7.ChatMessageAttachment>) {
-      return (data as List)
-              .map((e) => deserialize<_i7.ChatMessageAttachment>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i7.ChatMessageAttachment>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i7.ChatMessageAttachment>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i6.ChatMessage>) {
-      return (data as List).map((e) => deserialize<_i6.ChatMessage>(e)).toList()
-          as T;
+    final fn = _deserializers[t];
+    if (fn != null) {
+      return fn(data, this) as T;
     }
     try {
       return _i13.Protocol().deserialize<T>(data, t);

--- a/modules/legacy/serverpod_chat/serverpod_chat_server/lib/src/generated/protocol.dart
+++ b/modules/legacy/serverpod_chat/serverpod_chat_server/lib/src/generated/protocol.dart
@@ -171,6 +171,71 @@ class Protocol extends _i1.DatabaseSerializationManager {
 
   final Map<String, _i1.SerializationManager> _hostProtocols = {};
 
+  static final Map<Type, dynamic Function(dynamic, Protocol)> _deserializers =
+      _buildDeserializers();
+
+  static Map<Type, dynamic Function(dynamic, Protocol)> _buildDeserializers() {
+    final map = <Type, dynamic Function(dynamic, Protocol)>{};
+    map[_i4.ChatJoinChannel] = (data, protocol) =>
+        _i4.ChatJoinChannel.fromJson(data);
+    map[_i5.ChatJoinChannelFailed] = (data, protocol) =>
+        _i5.ChatJoinChannelFailed.fromJson(data);
+    map[_i6.ChatJoinedChannel] = (data, protocol) =>
+        _i6.ChatJoinedChannel.fromJson(data);
+    map[_i7.ChatLeaveChannel] = (data, protocol) =>
+        _i7.ChatLeaveChannel.fromJson(data);
+    map[_i8.ChatMessage] = (data, protocol) => _i8.ChatMessage.fromJson(data);
+    map[_i9.ChatMessageAttachment] = (data, protocol) =>
+        _i9.ChatMessageAttachment.fromJson(data);
+    map[_i10.ChatMessageAttachmentUploadDescription] = (data, protocol) =>
+        _i10.ChatMessageAttachmentUploadDescription.fromJson(data);
+    map[_i11.ChatMessageChunk] = (data, protocol) =>
+        _i11.ChatMessageChunk.fromJson(data);
+    map[_i12.ChatMessagePost] = (data, protocol) =>
+        _i12.ChatMessagePost.fromJson(data);
+    map[_i13.ChatReadMessage] = (data, protocol) =>
+        _i13.ChatReadMessage.fromJson(data);
+    map[_i14.ChatRequestMessageChunk] = (data, protocol) =>
+        _i14.ChatRequestMessageChunk.fromJson(data);
+    map[_i1.getType<_i4.ChatJoinChannel?>()] = (data, protocol) =>
+        (data != null ? _i4.ChatJoinChannel.fromJson(data) : null);
+    map[_i1.getType<_i5.ChatJoinChannelFailed?>()] = (data, protocol) =>
+        (data != null ? _i5.ChatJoinChannelFailed.fromJson(data) : null);
+    map[_i1.getType<_i6.ChatJoinedChannel?>()] = (data, protocol) =>
+        (data != null ? _i6.ChatJoinedChannel.fromJson(data) : null);
+    map[_i1.getType<_i7.ChatLeaveChannel?>()] = (data, protocol) =>
+        (data != null ? _i7.ChatLeaveChannel.fromJson(data) : null);
+    map[_i1.getType<_i8.ChatMessage?>()] = (data, protocol) =>
+        (data != null ? _i8.ChatMessage.fromJson(data) : null);
+    map[_i1.getType<_i9.ChatMessageAttachment?>()] = (data, protocol) =>
+        (data != null ? _i9.ChatMessageAttachment.fromJson(data) : null);
+    map[_i1.getType<_i10.ChatMessageAttachmentUploadDescription?>()] =
+        (data, protocol) => (data != null
+        ? _i10.ChatMessageAttachmentUploadDescription.fromJson(data)
+        : null);
+    map[_i1.getType<_i11.ChatMessageChunk?>()] = (data, protocol) =>
+        (data != null ? _i11.ChatMessageChunk.fromJson(data) : null);
+    map[_i1.getType<_i12.ChatMessagePost?>()] = (data, protocol) =>
+        (data != null ? _i12.ChatMessagePost.fromJson(data) : null);
+    map[_i1.getType<_i13.ChatReadMessage?>()] = (data, protocol) =>
+        (data != null ? _i13.ChatReadMessage.fromJson(data) : null);
+    map[_i1.getType<_i14.ChatRequestMessageChunk?>()] = (data, protocol) =>
+        (data != null ? _i14.ChatRequestMessageChunk.fromJson(data) : null);
+    map[List<_i9.ChatMessageAttachment>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i9.ChatMessageAttachment>(e))
+        .toList();
+    map[_i1.getType<List<_i9.ChatMessageAttachment>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i9.ChatMessageAttachment>(e))
+              .toList()
+        : null);
+    map[List<_i8.ChatMessage>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i8.ChatMessage>(e))
+        .toList();
+    return map;
+  }
+
   void registerHostProtocol(
     String projectName,
     _i1.SerializationManager protocol,
@@ -207,95 +272,9 @@ class Protocol extends _i1.DatabaseSerializationManager {
       }
     }
 
-    if (t == _i4.ChatJoinChannel) {
-      return _i4.ChatJoinChannel.fromJson(data) as T;
-    }
-    if (t == _i5.ChatJoinChannelFailed) {
-      return _i5.ChatJoinChannelFailed.fromJson(data) as T;
-    }
-    if (t == _i6.ChatJoinedChannel) {
-      return _i6.ChatJoinedChannel.fromJson(data) as T;
-    }
-    if (t == _i7.ChatLeaveChannel) {
-      return _i7.ChatLeaveChannel.fromJson(data) as T;
-    }
-    if (t == _i8.ChatMessage) {
-      return _i8.ChatMessage.fromJson(data) as T;
-    }
-    if (t == _i9.ChatMessageAttachment) {
-      return _i9.ChatMessageAttachment.fromJson(data) as T;
-    }
-    if (t == _i10.ChatMessageAttachmentUploadDescription) {
-      return _i10.ChatMessageAttachmentUploadDescription.fromJson(data) as T;
-    }
-    if (t == _i11.ChatMessageChunk) {
-      return _i11.ChatMessageChunk.fromJson(data) as T;
-    }
-    if (t == _i12.ChatMessagePost) {
-      return _i12.ChatMessagePost.fromJson(data) as T;
-    }
-    if (t == _i13.ChatReadMessage) {
-      return _i13.ChatReadMessage.fromJson(data) as T;
-    }
-    if (t == _i14.ChatRequestMessageChunk) {
-      return _i14.ChatRequestMessageChunk.fromJson(data) as T;
-    }
-    if (t == _i1.getType<_i4.ChatJoinChannel?>()) {
-      return (data != null ? _i4.ChatJoinChannel.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i5.ChatJoinChannelFailed?>()) {
-      return (data != null ? _i5.ChatJoinChannelFailed.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i6.ChatJoinedChannel?>()) {
-      return (data != null ? _i6.ChatJoinedChannel.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i7.ChatLeaveChannel?>()) {
-      return (data != null ? _i7.ChatLeaveChannel.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i8.ChatMessage?>()) {
-      return (data != null ? _i8.ChatMessage.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i9.ChatMessageAttachment?>()) {
-      return (data != null ? _i9.ChatMessageAttachment.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i10.ChatMessageAttachmentUploadDescription?>()) {
-      return (data != null
-              ? _i10.ChatMessageAttachmentUploadDescription.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i11.ChatMessageChunk?>()) {
-      return (data != null ? _i11.ChatMessageChunk.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i12.ChatMessagePost?>()) {
-      return (data != null ? _i12.ChatMessagePost.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i13.ChatReadMessage?>()) {
-      return (data != null ? _i13.ChatReadMessage.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i14.ChatRequestMessageChunk?>()) {
-      return (data != null ? _i14.ChatRequestMessageChunk.fromJson(data) : null)
-          as T;
-    }
-    if (t == List<_i9.ChatMessageAttachment>) {
-      return (data as List)
-              .map((e) => deserialize<_i9.ChatMessageAttachment>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i9.ChatMessageAttachment>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i9.ChatMessageAttachment>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i8.ChatMessage>) {
-      return (data as List).map((e) => deserialize<_i8.ChatMessage>(e)).toList()
-          as T;
+    final fn = _deserializers[t];
+    if (fn != null) {
+      return fn(data, this) as T;
     }
     try {
       return _i3.Protocol().deserialize<T>(data, t);

--- a/modules/serverpod_auth/serverpod_auth_bridge/serverpod_auth_bridge_client/lib/src/protocol/protocol.dart
+++ b/modules/serverpod_auth/serverpod_auth_bridge/serverpod_auth_bridge_client/lib/src/protocol/protocol.dart
@@ -34,6 +34,35 @@ class Protocol extends _i1.SerializationManager {
 
   final Map<String, _i1.SerializationManager> _hostProtocols = {};
 
+  static final Map<Type, dynamic Function(dynamic, Protocol)> _deserializers =
+      _buildDeserializers();
+
+  static Map<Type, dynamic Function(dynamic, Protocol)> _buildDeserializers() {
+    final map = <Type, dynamic Function(dynamic, Protocol)>{};
+    map[_i2.LegacyAuthenticationFailReason] = (data, protocol) =>
+        _i2.LegacyAuthenticationFailReason.fromJson(data);
+    map[_i3.LegacyAuthenticationResponse] = (data, protocol) =>
+        _i3.LegacyAuthenticationResponse.fromJson(data);
+    map[_i4.LegacyUserInfo] = (data, protocol) =>
+        _i4.LegacyUserInfo.fromJson(data);
+    map[_i5.LegacyUserSettingsConfig] = (data, protocol) =>
+        _i5.LegacyUserSettingsConfig.fromJson(data);
+    map[_i1
+        .getType<_i2.LegacyAuthenticationFailReason?>()] = (data, protocol) =>
+        (data != null
+        ? _i2.LegacyAuthenticationFailReason.fromJson(data)
+        : null);
+    map[_i1.getType<_i3.LegacyAuthenticationResponse?>()] = (data, protocol) =>
+        (data != null ? _i3.LegacyAuthenticationResponse.fromJson(data) : null);
+    map[_i1.getType<_i4.LegacyUserInfo?>()] = (data, protocol) =>
+        (data != null ? _i4.LegacyUserInfo.fromJson(data) : null);
+    map[_i1.getType<_i5.LegacyUserSettingsConfig?>()] = (data, protocol) =>
+        (data != null ? _i5.LegacyUserSettingsConfig.fromJson(data) : null);
+    map[List<String>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<String>(e)).toList();
+    return map;
+  }
+
   void registerHostProtocol(
     String projectName,
     _i1.SerializationManager protocol,
@@ -70,39 +99,9 @@ class Protocol extends _i1.SerializationManager {
       }
     }
 
-    if (t == _i2.LegacyAuthenticationFailReason) {
-      return _i2.LegacyAuthenticationFailReason.fromJson(data) as T;
-    }
-    if (t == _i3.LegacyAuthenticationResponse) {
-      return _i3.LegacyAuthenticationResponse.fromJson(data) as T;
-    }
-    if (t == _i4.LegacyUserInfo) {
-      return _i4.LegacyUserInfo.fromJson(data) as T;
-    }
-    if (t == _i5.LegacyUserSettingsConfig) {
-      return _i5.LegacyUserSettingsConfig.fromJson(data) as T;
-    }
-    if (t == _i1.getType<_i2.LegacyAuthenticationFailReason?>()) {
-      return (data != null
-              ? _i2.LegacyAuthenticationFailReason.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i3.LegacyAuthenticationResponse?>()) {
-      return (data != null
-              ? _i3.LegacyAuthenticationResponse.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i4.LegacyUserInfo?>()) {
-      return (data != null ? _i4.LegacyUserInfo.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i5.LegacyUserSettingsConfig?>()) {
-      return (data != null ? _i5.LegacyUserSettingsConfig.fromJson(data) : null)
-          as T;
-    }
-    if (t == List<String>) {
-      return (data as List).map((e) => deserialize<String>(e)).toList() as T;
+    final fn = _deserializers[t];
+    if (fn != null) {
+      return fn(data, this) as T;
     }
     try {
       return _i6.Protocol().deserialize<T>(data, t);

--- a/modules/serverpod_auth/serverpod_auth_bridge/serverpod_auth_bridge_client/lib/src/protocol/protocol.dart
+++ b/modules/serverpod_auth/serverpod_auth_bridge/serverpod_auth_bridge_client/lib/src/protocol/protocol.dart
@@ -12,14 +12,14 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
-import 'legacy_authentication_fail_reason.dart' as _i2;
-import 'legacy_authentication_response.dart' as _i3;
-import 'legacy_user_info.dart' as _i4;
-import 'legacy_user_settings_config.dart' as _i5;
 import 'package:serverpod_auth_core_client/serverpod_auth_core_client.dart'
-    as _i6;
+    as _i2;
 import 'package:serverpod_auth_idp_client/serverpod_auth_idp_client.dart'
-    as _i7;
+    as _i3;
+import 'legacy_authentication_fail_reason.dart' as _i4;
+import 'legacy_authentication_response.dart' as _i5;
+import 'legacy_user_info.dart' as _i6;
+import 'legacy_user_settings_config.dart' as _i7;
 export 'legacy_authentication_fail_reason.dart';
 export 'legacy_authentication_response.dart';
 export 'legacy_user_info.dart';
@@ -34,6 +34,9 @@ class Protocol extends _i1.SerializationManager {
   static final Protocol _instance = Protocol._();
 
   final Set<_i1.SerializationManager> _hostProtocols = {};
+
+  static final Map<Type, dynamic Function(dynamic, Protocol)> _deserializers =
+      _buildDeserializers();
 
   void registerHostProtocol(
     String projectName,
@@ -71,55 +74,25 @@ class Protocol extends _i1.SerializationManager {
       }
     }
 
-    if (t == _i2.LegacyAuthenticationFailReason) {
-      return _i2.LegacyAuthenticationFailReason.fromJson(data) as T;
-    }
-    if (t == _i3.LegacyAuthenticationResponse) {
-      return _i3.LegacyAuthenticationResponse.fromJson(data) as T;
-    }
-    if (t == _i4.LegacyUserInfo) {
-      return _i4.LegacyUserInfo.fromJson(data) as T;
-    }
-    if (t == _i5.LegacyUserSettingsConfig) {
-      return _i5.LegacyUserSettingsConfig.fromJson(data) as T;
-    }
-    if (t == _i1.getType<_i2.LegacyAuthenticationFailReason?>()) {
-      return (data != null
-              ? _i2.LegacyAuthenticationFailReason.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i3.LegacyAuthenticationResponse?>()) {
-      return (data != null
-              ? _i3.LegacyAuthenticationResponse.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i4.LegacyUserInfo?>()) {
-      return (data != null ? _i4.LegacyUserInfo.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i5.LegacyUserSettingsConfig?>()) {
-      return (data != null ? _i5.LegacyUserSettingsConfig.fromJson(data) : null)
-          as T;
-    }
-    if (t == List<String>) {
-      return (data as List).map((e) => deserialize<String>(e)).toList() as T;
+    final fn = _deserializers[t];
+    if (fn != null) {
+      return fn(data, this) as T;
     }
     try {
-      return _i6.Protocol().deserialize<T>(data, t);
+      return _i2.Protocol().deserialize<T>(data, t);
     } on _i1.DeserializationTypeNotFoundException catch (_) {}
     try {
-      return _i7.Protocol().deserialize<T>(data, t);
+      return _i3.Protocol().deserialize<T>(data, t);
     } on _i1.DeserializationTypeNotFoundException catch (_) {}
     return super.deserialize<T>(data, t);
   }
 
   static String? getClassNameForType(Type type) {
     return switch (type) {
-      _i2.LegacyAuthenticationFailReason => 'LegacyAuthenticationFailReason',
-      _i3.LegacyAuthenticationResponse => 'LegacyAuthenticationResponse',
-      _i4.LegacyUserInfo => 'LegacyUserInfo',
-      _i5.LegacyUserSettingsConfig => 'LegacyUserSettingsConfig',
+      _i4.LegacyAuthenticationFailReason => 'LegacyAuthenticationFailReason',
+      _i5.LegacyAuthenticationResponse => 'LegacyAuthenticationResponse',
+      _i6.LegacyUserInfo => 'LegacyUserInfo',
+      _i7.LegacyUserSettingsConfig => 'LegacyUserSettingsConfig',
       _ => null,
     };
   }
@@ -137,13 +110,13 @@ class Protocol extends _i1.SerializationManager {
     }
 
     switch (data) {
-      case _i2.LegacyAuthenticationFailReason():
+      case _i4.LegacyAuthenticationFailReason():
         return 'LegacyAuthenticationFailReason';
-      case _i3.LegacyAuthenticationResponse():
+      case _i5.LegacyAuthenticationResponse():
         return 'LegacyAuthenticationResponse';
-      case _i4.LegacyUserInfo():
+      case _i6.LegacyUserInfo():
         return 'LegacyUserInfo';
-      case _i5.LegacyUserSettingsConfig():
+      case _i7.LegacyUserSettingsConfig():
         return 'LegacyUserSettingsConfig';
     }
     return null;
@@ -156,16 +129,16 @@ class Protocol extends _i1.SerializationManager {
       return super.deserializeByClassName(data);
     }
     if (dataClassName == 'LegacyAuthenticationFailReason') {
-      return deserialize<_i2.LegacyAuthenticationFailReason>(data['data']);
+      return deserialize<_i4.LegacyAuthenticationFailReason>(data['data']);
     }
     if (dataClassName == 'LegacyAuthenticationResponse') {
-      return deserialize<_i3.LegacyAuthenticationResponse>(data['data']);
+      return deserialize<_i5.LegacyAuthenticationResponse>(data['data']);
     }
     if (dataClassName == 'LegacyUserInfo') {
-      return deserialize<_i4.LegacyUserInfo>(data['data']);
+      return deserialize<_i6.LegacyUserInfo>(data['data']);
     }
     if (dataClassName == 'LegacyUserSettingsConfig') {
-      return deserialize<_i5.LegacyUserSettingsConfig>(data['data']);
+      return deserialize<_i7.LegacyUserSettingsConfig>(data['data']);
     }
     return super.deserializeByClassName(data);
   }
@@ -242,11 +215,37 @@ class Protocol extends _i1.SerializationManager {
       return null;
     }
     try {
-      return _i6.Protocol().mapRecordToJson(record);
+      return _i2.Protocol().mapRecordToJson(record);
     } catch (_) {}
     try {
-      return _i7.Protocol().mapRecordToJson(record);
+      return _i3.Protocol().mapRecordToJson(record);
     } catch (_) {}
     throw Exception('Unsupported record type ${record.runtimeType}');
+  }
+
+  static Map<Type, dynamic Function(dynamic, Protocol)> _buildDeserializers() {
+    final map = <Type, dynamic Function(dynamic, Protocol)>{};
+    map[_i4.LegacyAuthenticationFailReason] = (data, protocol) =>
+        _i4.LegacyAuthenticationFailReason.fromJson(data);
+    map[_i5.LegacyAuthenticationResponse] = (data, protocol) =>
+        _i5.LegacyAuthenticationResponse.fromJson(data);
+    map[_i6.LegacyUserInfo] = (data, protocol) =>
+        _i6.LegacyUserInfo.fromJson(data);
+    map[_i7.LegacyUserSettingsConfig] = (data, protocol) =>
+        _i7.LegacyUserSettingsConfig.fromJson(data);
+    map[_i1
+        .getType<_i4.LegacyAuthenticationFailReason?>()] = (data, protocol) =>
+        (data != null
+        ? _i4.LegacyAuthenticationFailReason.fromJson(data)
+        : null);
+    map[_i1.getType<_i5.LegacyAuthenticationResponse?>()] = (data, protocol) =>
+        (data != null ? _i5.LegacyAuthenticationResponse.fromJson(data) : null);
+    map[_i1.getType<_i6.LegacyUserInfo?>()] = (data, protocol) =>
+        (data != null ? _i6.LegacyUserInfo.fromJson(data) : null);
+    map[_i1.getType<_i7.LegacyUserSettingsConfig?>()] = (data, protocol) =>
+        (data != null ? _i7.LegacyUserSettingsConfig.fromJson(data) : null);
+    map[List<String>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<String>(e)).toList();
+    return map;
   }
 }

--- a/modules/serverpod_auth/serverpod_auth_bridge/serverpod_auth_bridge_server/lib/src/generated/protocol.dart
+++ b/modules/serverpod_auth/serverpod_auth_bridge/serverpod_auth_bridge_server/lib/src/generated/protocol.dart
@@ -208,6 +208,49 @@ class Protocol extends _i1.DatabaseSerializationManager {
 
   final Map<String, _i1.SerializationManager> _hostProtocols = {};
 
+  static final Map<Type, dynamic Function(dynamic, Protocol)> _deserializers =
+      _buildDeserializers();
+
+  static Map<Type, dynamic Function(dynamic, Protocol)> _buildDeserializers() {
+    final map = <Type, dynamic Function(dynamic, Protocol)>{};
+    map[_i5.LegacyAuthenticationFailReason] = (data, protocol) =>
+        _i5.LegacyAuthenticationFailReason.fromJson(data);
+    map[_i6.LegacyAuthenticationResponse] = (data, protocol) =>
+        _i6.LegacyAuthenticationResponse.fromJson(data);
+    map[_i7.LegacyEmailPassword] = (data, protocol) =>
+        _i7.LegacyEmailPassword.fromJson(data);
+    map[_i8.LegacyExternalUserIdentifier] = (data, protocol) =>
+        _i8.LegacyExternalUserIdentifier.fromJson(data);
+    map[_i9.LegacySession] = (data, protocol) =>
+        _i9.LegacySession.fromJson(data);
+    map[_i10.LegacyUserInfo] = (data, protocol) =>
+        _i10.LegacyUserInfo.fromJson(data);
+    map[_i11.LegacyUserSettingsConfig] = (data, protocol) =>
+        _i11.LegacyUserSettingsConfig.fromJson(data);
+    map[_i1
+        .getType<_i5.LegacyAuthenticationFailReason?>()] = (data, protocol) =>
+        (data != null
+        ? _i5.LegacyAuthenticationFailReason.fromJson(data)
+        : null);
+    map[_i1.getType<_i6.LegacyAuthenticationResponse?>()] = (data, protocol) =>
+        (data != null ? _i6.LegacyAuthenticationResponse.fromJson(data) : null);
+    map[_i1.getType<_i7.LegacyEmailPassword?>()] = (data, protocol) =>
+        (data != null ? _i7.LegacyEmailPassword.fromJson(data) : null);
+    map[_i1.getType<_i8.LegacyExternalUserIdentifier?>()] = (data, protocol) =>
+        (data != null ? _i8.LegacyExternalUserIdentifier.fromJson(data) : null);
+    map[_i1.getType<_i9.LegacySession?>()] = (data, protocol) =>
+        (data != null ? _i9.LegacySession.fromJson(data) : null);
+    map[_i1.getType<_i10.LegacyUserInfo?>()] = (data, protocol) =>
+        (data != null ? _i10.LegacyUserInfo.fromJson(data) : null);
+    map[_i1.getType<_i11.LegacyUserSettingsConfig?>()] = (data, protocol) =>
+        (data != null ? _i11.LegacyUserSettingsConfig.fromJson(data) : null);
+    map[Set<String>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<String>(e)).toSet();
+    map[List<String>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<String>(e)).toList();
+    return map;
+  }
+
   void registerHostProtocol(
     String projectName,
     _i1.SerializationManager protocol,
@@ -244,66 +287,9 @@ class Protocol extends _i1.DatabaseSerializationManager {
       }
     }
 
-    if (t == _i5.LegacyAuthenticationFailReason) {
-      return _i5.LegacyAuthenticationFailReason.fromJson(data) as T;
-    }
-    if (t == _i6.LegacyAuthenticationResponse) {
-      return _i6.LegacyAuthenticationResponse.fromJson(data) as T;
-    }
-    if (t == _i7.LegacyEmailPassword) {
-      return _i7.LegacyEmailPassword.fromJson(data) as T;
-    }
-    if (t == _i8.LegacyExternalUserIdentifier) {
-      return _i8.LegacyExternalUserIdentifier.fromJson(data) as T;
-    }
-    if (t == _i9.LegacySession) {
-      return _i9.LegacySession.fromJson(data) as T;
-    }
-    if (t == _i10.LegacyUserInfo) {
-      return _i10.LegacyUserInfo.fromJson(data) as T;
-    }
-    if (t == _i11.LegacyUserSettingsConfig) {
-      return _i11.LegacyUserSettingsConfig.fromJson(data) as T;
-    }
-    if (t == _i1.getType<_i5.LegacyAuthenticationFailReason?>()) {
-      return (data != null
-              ? _i5.LegacyAuthenticationFailReason.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i6.LegacyAuthenticationResponse?>()) {
-      return (data != null
-              ? _i6.LegacyAuthenticationResponse.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i7.LegacyEmailPassword?>()) {
-      return (data != null ? _i7.LegacyEmailPassword.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i8.LegacyExternalUserIdentifier?>()) {
-      return (data != null
-              ? _i8.LegacyExternalUserIdentifier.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i9.LegacySession?>()) {
-      return (data != null ? _i9.LegacySession.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i10.LegacyUserInfo?>()) {
-      return (data != null ? _i10.LegacyUserInfo.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i11.LegacyUserSettingsConfig?>()) {
-      return (data != null
-              ? _i11.LegacyUserSettingsConfig.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == Set<String>) {
-      return (data as List).map((e) => deserialize<String>(e)).toSet() as T;
-    }
-    if (t == List<String>) {
-      return (data as List).map((e) => deserialize<String>(e)).toList() as T;
+    final fn = _deserializers[t];
+    if (fn != null) {
+      return fn(data, this) as T;
     }
     try {
       return _i3.Protocol().deserialize<T>(data, t);

--- a/modules/serverpod_auth/serverpod_auth_bridge/serverpod_auth_bridge_server/lib/src/generated/protocol.dart
+++ b/modules/serverpod_auth/serverpod_auth_bridge/serverpod_auth_bridge_server/lib/src/generated/protocol.dart
@@ -41,6 +41,9 @@ class Protocol extends _i1.DatabaseSerializationManager {
 
   final Set<_i1.SerializationManager> _hostProtocols = {};
 
+  static final Map<Type, dynamic Function(dynamic, Protocol)> _deserializers =
+      _buildDeserializers();
+
   static List<_i2.TableDefinition> get targetTableDefinitions => [
     _i2.TableDefinition(
       name: 'serverpod_auth_bridge_email_password',
@@ -245,66 +248,9 @@ class Protocol extends _i1.DatabaseSerializationManager {
       }
     }
 
-    if (t == _i5.LegacyAuthenticationFailReason) {
-      return _i5.LegacyAuthenticationFailReason.fromJson(data) as T;
-    }
-    if (t == _i6.LegacyAuthenticationResponse) {
-      return _i6.LegacyAuthenticationResponse.fromJson(data) as T;
-    }
-    if (t == _i7.LegacyEmailPassword) {
-      return _i7.LegacyEmailPassword.fromJson(data) as T;
-    }
-    if (t == _i8.LegacyExternalUserIdentifier) {
-      return _i8.LegacyExternalUserIdentifier.fromJson(data) as T;
-    }
-    if (t == _i9.LegacySession) {
-      return _i9.LegacySession.fromJson(data) as T;
-    }
-    if (t == _i10.LegacyUserInfo) {
-      return _i10.LegacyUserInfo.fromJson(data) as T;
-    }
-    if (t == _i11.LegacyUserSettingsConfig) {
-      return _i11.LegacyUserSettingsConfig.fromJson(data) as T;
-    }
-    if (t == _i1.getType<_i5.LegacyAuthenticationFailReason?>()) {
-      return (data != null
-              ? _i5.LegacyAuthenticationFailReason.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i6.LegacyAuthenticationResponse?>()) {
-      return (data != null
-              ? _i6.LegacyAuthenticationResponse.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i7.LegacyEmailPassword?>()) {
-      return (data != null ? _i7.LegacyEmailPassword.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i8.LegacyExternalUserIdentifier?>()) {
-      return (data != null
-              ? _i8.LegacyExternalUserIdentifier.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i9.LegacySession?>()) {
-      return (data != null ? _i9.LegacySession.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i10.LegacyUserInfo?>()) {
-      return (data != null ? _i10.LegacyUserInfo.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i11.LegacyUserSettingsConfig?>()) {
-      return (data != null
-              ? _i11.LegacyUserSettingsConfig.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == Set<String>) {
-      return (data as List).map((e) => deserialize<String>(e)).toSet() as T;
-    }
-    if (t == List<String>) {
-      return (data as List).map((e) => deserialize<String>(e)).toList() as T;
+    final fn = _deserializers[t];
+    if (fn != null) {
+      return fn(data, this) as T;
     }
     try {
       return _i3.Protocol().deserialize<T>(data, t);
@@ -513,5 +459,45 @@ class Protocol extends _i1.DatabaseSerializationManager {
       return _i4.Protocol().mapRecordToJson(record);
     } catch (_) {}
     throw Exception('Unsupported record type ${record.runtimeType}');
+  }
+
+  static Map<Type, dynamic Function(dynamic, Protocol)> _buildDeserializers() {
+    final map = <Type, dynamic Function(dynamic, Protocol)>{};
+    map[_i5.LegacyAuthenticationFailReason] = (data, protocol) =>
+        _i5.LegacyAuthenticationFailReason.fromJson(data);
+    map[_i6.LegacyAuthenticationResponse] = (data, protocol) =>
+        _i6.LegacyAuthenticationResponse.fromJson(data);
+    map[_i7.LegacyEmailPassword] = (data, protocol) =>
+        _i7.LegacyEmailPassword.fromJson(data);
+    map[_i8.LegacyExternalUserIdentifier] = (data, protocol) =>
+        _i8.LegacyExternalUserIdentifier.fromJson(data);
+    map[_i9.LegacySession] = (data, protocol) =>
+        _i9.LegacySession.fromJson(data);
+    map[_i10.LegacyUserInfo] = (data, protocol) =>
+        _i10.LegacyUserInfo.fromJson(data);
+    map[_i11.LegacyUserSettingsConfig] = (data, protocol) =>
+        _i11.LegacyUserSettingsConfig.fromJson(data);
+    map[_i1
+        .getType<_i5.LegacyAuthenticationFailReason?>()] = (data, protocol) =>
+        (data != null
+        ? _i5.LegacyAuthenticationFailReason.fromJson(data)
+        : null);
+    map[_i1.getType<_i6.LegacyAuthenticationResponse?>()] = (data, protocol) =>
+        (data != null ? _i6.LegacyAuthenticationResponse.fromJson(data) : null);
+    map[_i1.getType<_i7.LegacyEmailPassword?>()] = (data, protocol) =>
+        (data != null ? _i7.LegacyEmailPassword.fromJson(data) : null);
+    map[_i1.getType<_i8.LegacyExternalUserIdentifier?>()] = (data, protocol) =>
+        (data != null ? _i8.LegacyExternalUserIdentifier.fromJson(data) : null);
+    map[_i1.getType<_i9.LegacySession?>()] = (data, protocol) =>
+        (data != null ? _i9.LegacySession.fromJson(data) : null);
+    map[_i1.getType<_i10.LegacyUserInfo?>()] = (data, protocol) =>
+        (data != null ? _i10.LegacyUserInfo.fromJson(data) : null);
+    map[_i1.getType<_i11.LegacyUserSettingsConfig?>()] = (data, protocol) =>
+        (data != null ? _i11.LegacyUserSettingsConfig.fromJson(data) : null);
+    map[Set<String>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<String>(e)).toSet();
+    map[List<String>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<String>(e)).toList();
+    return map;
   }
 }

--- a/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_client/lib/src/protocol/protocol.dart
+++ b/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_client/lib/src/protocol/protocol.dart
@@ -56,6 +56,86 @@ class Protocol extends _i1.SerializationManager {
 
   final Map<String, _i1.SerializationManager> _hostProtocols = {};
 
+  static final Map<Type, dynamic Function(dynamic, Protocol)> _deserializers =
+      _buildDeserializers();
+
+  static Map<Type, dynamic Function(dynamic, Protocol)> _buildDeserializers() {
+    final map = <Type, dynamic Function(dynamic, Protocol)>{};
+    map[_i2.AuthUser] = (data, protocol) => _i2.AuthUser.fromJson(data);
+    map[_i3.AuthUserBlockedException] = (data, protocol) =>
+        _i3.AuthUserBlockedException.fromJson(data);
+    map[_i4.AuthUserModel] = (data, protocol) =>
+        _i4.AuthUserModel.fromJson(data);
+    map[_i5.AuthUserNotFoundException] = (data, protocol) =>
+        _i5.AuthUserNotFoundException.fromJson(data);
+    map[_i6.AuthStrategy] = (data, protocol) => _i6.AuthStrategy.fromJson(data);
+    map[_i7.AuthSuccess] = (data, protocol) => _i7.AuthSuccess.fromJson(data);
+    map[_i8.JwtTokenInfo] = (data, protocol) => _i8.JwtTokenInfo.fromJson(data);
+    map[_i9.RefreshTokenExpiredException] = (data, protocol) =>
+        _i9.RefreshTokenExpiredException.fromJson(data);
+    map[_i10.RefreshTokenInvalidSecretException] = (data, protocol) =>
+        _i10.RefreshTokenInvalidSecretException.fromJson(data);
+    map[_i11.RefreshTokenMalformedException] = (data, protocol) =>
+        _i11.RefreshTokenMalformedException.fromJson(data);
+    map[_i12.RefreshTokenNotFoundException] = (data, protocol) =>
+        _i12.RefreshTokenNotFoundException.fromJson(data);
+    map[_i13.TokenPair] = (data, protocol) => _i13.TokenPair.fromJson(data);
+    map[_i14.UserProfile] = (data, protocol) => _i14.UserProfile.fromJson(data);
+    map[_i15.UserProfileData] = (data, protocol) =>
+        _i15.UserProfileData.fromJson(data);
+    map[_i16.UserProfileImage] = (data, protocol) =>
+        _i16.UserProfileImage.fromJson(data);
+    map[_i17.UserProfileModel] = (data, protocol) =>
+        _i17.UserProfileModel.fromJson(data);
+    map[_i18.ServerSideSessionInfo] = (data, protocol) =>
+        _i18.ServerSideSessionInfo.fromJson(data);
+    map[_i1.getType<_i2.AuthUser?>()] = (data, protocol) =>
+        (data != null ? _i2.AuthUser.fromJson(data) : null);
+    map[_i1.getType<_i3.AuthUserBlockedException?>()] = (data, protocol) =>
+        (data != null ? _i3.AuthUserBlockedException.fromJson(data) : null);
+    map[_i1.getType<_i4.AuthUserModel?>()] = (data, protocol) =>
+        (data != null ? _i4.AuthUserModel.fromJson(data) : null);
+    map[_i1.getType<_i5.AuthUserNotFoundException?>()] = (data, protocol) =>
+        (data != null ? _i5.AuthUserNotFoundException.fromJson(data) : null);
+    map[_i1.getType<_i6.AuthStrategy?>()] = (data, protocol) =>
+        (data != null ? _i6.AuthStrategy.fromJson(data) : null);
+    map[_i1.getType<_i7.AuthSuccess?>()] = (data, protocol) =>
+        (data != null ? _i7.AuthSuccess.fromJson(data) : null);
+    map[_i1.getType<_i8.JwtTokenInfo?>()] = (data, protocol) =>
+        (data != null ? _i8.JwtTokenInfo.fromJson(data) : null);
+    map[_i1.getType<_i9.RefreshTokenExpiredException?>()] = (data, protocol) =>
+        (data != null ? _i9.RefreshTokenExpiredException.fromJson(data) : null);
+    map[_i1.getType<_i10.RefreshTokenInvalidSecretException?>()] =
+        (data, protocol) => (data != null
+        ? _i10.RefreshTokenInvalidSecretException.fromJson(data)
+        : null);
+    map[_i1
+        .getType<_i11.RefreshTokenMalformedException?>()] = (data, protocol) =>
+        (data != null
+        ? _i11.RefreshTokenMalformedException.fromJson(data)
+        : null);
+    map[_i1
+        .getType<_i12.RefreshTokenNotFoundException?>()] = (data, protocol) =>
+        (data != null
+        ? _i12.RefreshTokenNotFoundException.fromJson(data)
+        : null);
+    map[_i1.getType<_i13.TokenPair?>()] = (data, protocol) =>
+        (data != null ? _i13.TokenPair.fromJson(data) : null);
+    map[_i1.getType<_i14.UserProfile?>()] = (data, protocol) =>
+        (data != null ? _i14.UserProfile.fromJson(data) : null);
+    map[_i1.getType<_i15.UserProfileData?>()] = (data, protocol) =>
+        (data != null ? _i15.UserProfileData.fromJson(data) : null);
+    map[_i1.getType<_i16.UserProfileImage?>()] = (data, protocol) =>
+        (data != null ? _i16.UserProfileImage.fromJson(data) : null);
+    map[_i1.getType<_i17.UserProfileModel?>()] = (data, protocol) =>
+        (data != null ? _i17.UserProfileModel.fromJson(data) : null);
+    map[_i1.getType<_i18.ServerSideSessionInfo?>()] = (data, protocol) =>
+        (data != null ? _i18.ServerSideSessionInfo.fromJson(data) : null);
+    map[Set<String>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<String>(e)).toSet();
+    return map;
+  }
+
   void registerHostProtocol(
     String projectName,
     _i1.SerializationManager protocol,
@@ -92,127 +172,9 @@ class Protocol extends _i1.SerializationManager {
       }
     }
 
-    if (t == _i2.AuthUser) {
-      return _i2.AuthUser.fromJson(data) as T;
-    }
-    if (t == _i3.AuthUserBlockedException) {
-      return _i3.AuthUserBlockedException.fromJson(data) as T;
-    }
-    if (t == _i4.AuthUserModel) {
-      return _i4.AuthUserModel.fromJson(data) as T;
-    }
-    if (t == _i5.AuthUserNotFoundException) {
-      return _i5.AuthUserNotFoundException.fromJson(data) as T;
-    }
-    if (t == _i6.AuthStrategy) {
-      return _i6.AuthStrategy.fromJson(data) as T;
-    }
-    if (t == _i7.AuthSuccess) {
-      return _i7.AuthSuccess.fromJson(data) as T;
-    }
-    if (t == _i8.JwtTokenInfo) {
-      return _i8.JwtTokenInfo.fromJson(data) as T;
-    }
-    if (t == _i9.RefreshTokenExpiredException) {
-      return _i9.RefreshTokenExpiredException.fromJson(data) as T;
-    }
-    if (t == _i10.RefreshTokenInvalidSecretException) {
-      return _i10.RefreshTokenInvalidSecretException.fromJson(data) as T;
-    }
-    if (t == _i11.RefreshTokenMalformedException) {
-      return _i11.RefreshTokenMalformedException.fromJson(data) as T;
-    }
-    if (t == _i12.RefreshTokenNotFoundException) {
-      return _i12.RefreshTokenNotFoundException.fromJson(data) as T;
-    }
-    if (t == _i13.TokenPair) {
-      return _i13.TokenPair.fromJson(data) as T;
-    }
-    if (t == _i14.UserProfile) {
-      return _i14.UserProfile.fromJson(data) as T;
-    }
-    if (t == _i15.UserProfileData) {
-      return _i15.UserProfileData.fromJson(data) as T;
-    }
-    if (t == _i16.UserProfileImage) {
-      return _i16.UserProfileImage.fromJson(data) as T;
-    }
-    if (t == _i17.UserProfileModel) {
-      return _i17.UserProfileModel.fromJson(data) as T;
-    }
-    if (t == _i18.ServerSideSessionInfo) {
-      return _i18.ServerSideSessionInfo.fromJson(data) as T;
-    }
-    if (t == _i1.getType<_i2.AuthUser?>()) {
-      return (data != null ? _i2.AuthUser.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i3.AuthUserBlockedException?>()) {
-      return (data != null ? _i3.AuthUserBlockedException.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i4.AuthUserModel?>()) {
-      return (data != null ? _i4.AuthUserModel.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i5.AuthUserNotFoundException?>()) {
-      return (data != null
-              ? _i5.AuthUserNotFoundException.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i6.AuthStrategy?>()) {
-      return (data != null ? _i6.AuthStrategy.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i7.AuthSuccess?>()) {
-      return (data != null ? _i7.AuthSuccess.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i8.JwtTokenInfo?>()) {
-      return (data != null ? _i8.JwtTokenInfo.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i9.RefreshTokenExpiredException?>()) {
-      return (data != null
-              ? _i9.RefreshTokenExpiredException.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i10.RefreshTokenInvalidSecretException?>()) {
-      return (data != null
-              ? _i10.RefreshTokenInvalidSecretException.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i11.RefreshTokenMalformedException?>()) {
-      return (data != null
-              ? _i11.RefreshTokenMalformedException.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i12.RefreshTokenNotFoundException?>()) {
-      return (data != null
-              ? _i12.RefreshTokenNotFoundException.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i13.TokenPair?>()) {
-      return (data != null ? _i13.TokenPair.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i14.UserProfile?>()) {
-      return (data != null ? _i14.UserProfile.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i15.UserProfileData?>()) {
-      return (data != null ? _i15.UserProfileData.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i16.UserProfileImage?>()) {
-      return (data != null ? _i16.UserProfileImage.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i17.UserProfileModel?>()) {
-      return (data != null ? _i17.UserProfileModel.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i18.ServerSideSessionInfo?>()) {
-      return (data != null ? _i18.ServerSideSessionInfo.fromJson(data) : null)
-          as T;
-    }
-    if (t == Set<String>) {
-      return (data as List).map((e) => deserialize<String>(e)).toSet() as T;
+    final fn = _deserializers[t];
+    if (fn != null) {
+      return fn(data, this) as T;
     }
     return super.deserialize<T>(data, t);
   }

--- a/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_client/lib/src/protocol/protocol.dart
+++ b/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_client/lib/src/protocol/protocol.dart
@@ -57,6 +57,9 @@ class Protocol extends _i1.SerializationManager {
 
   final Set<_i1.SerializationManager> _hostProtocols = {};
 
+  static final Map<Type, dynamic Function(dynamic, Protocol)> _deserializers =
+      _buildDeserializers();
+
   void registerHostProtocol(
     String projectName,
     _i1.SerializationManager protocol,
@@ -93,127 +96,9 @@ class Protocol extends _i1.SerializationManager {
       }
     }
 
-    if (t == _i2.AuthUser) {
-      return _i2.AuthUser.fromJson(data) as T;
-    }
-    if (t == _i3.AuthUserBlockedException) {
-      return _i3.AuthUserBlockedException.fromJson(data) as T;
-    }
-    if (t == _i4.AuthUserModel) {
-      return _i4.AuthUserModel.fromJson(data) as T;
-    }
-    if (t == _i5.AuthUserNotFoundException) {
-      return _i5.AuthUserNotFoundException.fromJson(data) as T;
-    }
-    if (t == _i6.AuthStrategy) {
-      return _i6.AuthStrategy.fromJson(data) as T;
-    }
-    if (t == _i7.AuthSuccess) {
-      return _i7.AuthSuccess.fromJson(data) as T;
-    }
-    if (t == _i8.JwtTokenInfo) {
-      return _i8.JwtTokenInfo.fromJson(data) as T;
-    }
-    if (t == _i9.RefreshTokenExpiredException) {
-      return _i9.RefreshTokenExpiredException.fromJson(data) as T;
-    }
-    if (t == _i10.RefreshTokenInvalidSecretException) {
-      return _i10.RefreshTokenInvalidSecretException.fromJson(data) as T;
-    }
-    if (t == _i11.RefreshTokenMalformedException) {
-      return _i11.RefreshTokenMalformedException.fromJson(data) as T;
-    }
-    if (t == _i12.RefreshTokenNotFoundException) {
-      return _i12.RefreshTokenNotFoundException.fromJson(data) as T;
-    }
-    if (t == _i13.TokenPair) {
-      return _i13.TokenPair.fromJson(data) as T;
-    }
-    if (t == _i14.UserProfile) {
-      return _i14.UserProfile.fromJson(data) as T;
-    }
-    if (t == _i15.UserProfileData) {
-      return _i15.UserProfileData.fromJson(data) as T;
-    }
-    if (t == _i16.UserProfileImage) {
-      return _i16.UserProfileImage.fromJson(data) as T;
-    }
-    if (t == _i17.UserProfileModel) {
-      return _i17.UserProfileModel.fromJson(data) as T;
-    }
-    if (t == _i18.ServerSideSessionInfo) {
-      return _i18.ServerSideSessionInfo.fromJson(data) as T;
-    }
-    if (t == _i1.getType<_i2.AuthUser?>()) {
-      return (data != null ? _i2.AuthUser.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i3.AuthUserBlockedException?>()) {
-      return (data != null ? _i3.AuthUserBlockedException.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i4.AuthUserModel?>()) {
-      return (data != null ? _i4.AuthUserModel.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i5.AuthUserNotFoundException?>()) {
-      return (data != null
-              ? _i5.AuthUserNotFoundException.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i6.AuthStrategy?>()) {
-      return (data != null ? _i6.AuthStrategy.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i7.AuthSuccess?>()) {
-      return (data != null ? _i7.AuthSuccess.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i8.JwtTokenInfo?>()) {
-      return (data != null ? _i8.JwtTokenInfo.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i9.RefreshTokenExpiredException?>()) {
-      return (data != null
-              ? _i9.RefreshTokenExpiredException.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i10.RefreshTokenInvalidSecretException?>()) {
-      return (data != null
-              ? _i10.RefreshTokenInvalidSecretException.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i11.RefreshTokenMalformedException?>()) {
-      return (data != null
-              ? _i11.RefreshTokenMalformedException.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i12.RefreshTokenNotFoundException?>()) {
-      return (data != null
-              ? _i12.RefreshTokenNotFoundException.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i13.TokenPair?>()) {
-      return (data != null ? _i13.TokenPair.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i14.UserProfile?>()) {
-      return (data != null ? _i14.UserProfile.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i15.UserProfileData?>()) {
-      return (data != null ? _i15.UserProfileData.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i16.UserProfileImage?>()) {
-      return (data != null ? _i16.UserProfileImage.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i17.UserProfileModel?>()) {
-      return (data != null ? _i17.UserProfileModel.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i18.ServerSideSessionInfo?>()) {
-      return (data != null ? _i18.ServerSideSessionInfo.fromJson(data) : null)
-          as T;
-    }
-    if (t == Set<String>) {
-      return (data as List).map((e) => deserialize<String>(e)).toSet() as T;
+    final fn = _deserializers[t];
+    if (fn != null) {
+      return fn(data, this) as T;
     }
     return super.deserialize<T>(data, t);
   }
@@ -425,5 +310,82 @@ class Protocol extends _i1.SerializationManager {
       return null;
     }
     throw Exception('Unsupported record type ${record.runtimeType}');
+  }
+
+  static Map<Type, dynamic Function(dynamic, Protocol)> _buildDeserializers() {
+    final map = <Type, dynamic Function(dynamic, Protocol)>{};
+    map[_i2.AuthUser] = (data, protocol) => _i2.AuthUser.fromJson(data);
+    map[_i3.AuthUserBlockedException] = (data, protocol) =>
+        _i3.AuthUserBlockedException.fromJson(data);
+    map[_i4.AuthUserModel] = (data, protocol) =>
+        _i4.AuthUserModel.fromJson(data);
+    map[_i5.AuthUserNotFoundException] = (data, protocol) =>
+        _i5.AuthUserNotFoundException.fromJson(data);
+    map[_i6.AuthStrategy] = (data, protocol) => _i6.AuthStrategy.fromJson(data);
+    map[_i7.AuthSuccess] = (data, protocol) => _i7.AuthSuccess.fromJson(data);
+    map[_i8.JwtTokenInfo] = (data, protocol) => _i8.JwtTokenInfo.fromJson(data);
+    map[_i9.RefreshTokenExpiredException] = (data, protocol) =>
+        _i9.RefreshTokenExpiredException.fromJson(data);
+    map[_i10.RefreshTokenInvalidSecretException] = (data, protocol) =>
+        _i10.RefreshTokenInvalidSecretException.fromJson(data);
+    map[_i11.RefreshTokenMalformedException] = (data, protocol) =>
+        _i11.RefreshTokenMalformedException.fromJson(data);
+    map[_i12.RefreshTokenNotFoundException] = (data, protocol) =>
+        _i12.RefreshTokenNotFoundException.fromJson(data);
+    map[_i13.TokenPair] = (data, protocol) => _i13.TokenPair.fromJson(data);
+    map[_i14.UserProfile] = (data, protocol) => _i14.UserProfile.fromJson(data);
+    map[_i15.UserProfileData] = (data, protocol) =>
+        _i15.UserProfileData.fromJson(data);
+    map[_i16.UserProfileImage] = (data, protocol) =>
+        _i16.UserProfileImage.fromJson(data);
+    map[_i17.UserProfileModel] = (data, protocol) =>
+        _i17.UserProfileModel.fromJson(data);
+    map[_i18.ServerSideSessionInfo] = (data, protocol) =>
+        _i18.ServerSideSessionInfo.fromJson(data);
+    map[_i1.getType<_i2.AuthUser?>()] = (data, protocol) =>
+        (data != null ? _i2.AuthUser.fromJson(data) : null);
+    map[_i1.getType<_i3.AuthUserBlockedException?>()] = (data, protocol) =>
+        (data != null ? _i3.AuthUserBlockedException.fromJson(data) : null);
+    map[_i1.getType<_i4.AuthUserModel?>()] = (data, protocol) =>
+        (data != null ? _i4.AuthUserModel.fromJson(data) : null);
+    map[_i1.getType<_i5.AuthUserNotFoundException?>()] = (data, protocol) =>
+        (data != null ? _i5.AuthUserNotFoundException.fromJson(data) : null);
+    map[_i1.getType<_i6.AuthStrategy?>()] = (data, protocol) =>
+        (data != null ? _i6.AuthStrategy.fromJson(data) : null);
+    map[_i1.getType<_i7.AuthSuccess?>()] = (data, protocol) =>
+        (data != null ? _i7.AuthSuccess.fromJson(data) : null);
+    map[_i1.getType<_i8.JwtTokenInfo?>()] = (data, protocol) =>
+        (data != null ? _i8.JwtTokenInfo.fromJson(data) : null);
+    map[_i1.getType<_i9.RefreshTokenExpiredException?>()] = (data, protocol) =>
+        (data != null ? _i9.RefreshTokenExpiredException.fromJson(data) : null);
+    map[_i1.getType<_i10.RefreshTokenInvalidSecretException?>()] =
+        (data, protocol) => (data != null
+        ? _i10.RefreshTokenInvalidSecretException.fromJson(data)
+        : null);
+    map[_i1
+        .getType<_i11.RefreshTokenMalformedException?>()] = (data, protocol) =>
+        (data != null
+        ? _i11.RefreshTokenMalformedException.fromJson(data)
+        : null);
+    map[_i1
+        .getType<_i12.RefreshTokenNotFoundException?>()] = (data, protocol) =>
+        (data != null
+        ? _i12.RefreshTokenNotFoundException.fromJson(data)
+        : null);
+    map[_i1.getType<_i13.TokenPair?>()] = (data, protocol) =>
+        (data != null ? _i13.TokenPair.fromJson(data) : null);
+    map[_i1.getType<_i14.UserProfile?>()] = (data, protocol) =>
+        (data != null ? _i14.UserProfile.fromJson(data) : null);
+    map[_i1.getType<_i15.UserProfileData?>()] = (data, protocol) =>
+        (data != null ? _i15.UserProfileData.fromJson(data) : null);
+    map[_i1.getType<_i16.UserProfileImage?>()] = (data, protocol) =>
+        (data != null ? _i16.UserProfileImage.fromJson(data) : null);
+    map[_i1.getType<_i17.UserProfileModel?>()] = (data, protocol) =>
+        (data != null ? _i17.UserProfileModel.fromJson(data) : null);
+    map[_i1.getType<_i18.ServerSideSessionInfo?>()] = (data, protocol) =>
+        (data != null ? _i18.ServerSideSessionInfo.fromJson(data) : null);
+    map[Set<String>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<String>(e)).toSet();
+    return map;
   }
 }

--- a/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_server/lib/src/generated/protocol.dart
+++ b/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_server/lib/src/generated/protocol.dart
@@ -427,6 +427,96 @@ class Protocol extends _i1.DatabaseSerializationManager {
 
   final Map<String, _i1.SerializationManager> _hostProtocols = {};
 
+  static final Map<Type, dynamic Function(dynamic, Protocol)> _deserializers =
+      _buildDeserializers();
+
+  static Map<Type, dynamic Function(dynamic, Protocol)> _buildDeserializers() {
+    final map = <Type, dynamic Function(dynamic, Protocol)>{};
+    map[_i3.AuthUser] = (data, protocol) => _i3.AuthUser.fromJson(data);
+    map[_i4.AuthUserBlockedException] = (data, protocol) =>
+        _i4.AuthUserBlockedException.fromJson(data);
+    map[_i5.AuthUserModel] = (data, protocol) =>
+        _i5.AuthUserModel.fromJson(data);
+    map[_i6.AuthUserNotFoundException] = (data, protocol) =>
+        _i6.AuthUserNotFoundException.fromJson(data);
+    map[_i7.AuthStrategy] = (data, protocol) => _i7.AuthStrategy.fromJson(data);
+    map[_i8.AuthSuccess] = (data, protocol) => _i8.AuthSuccess.fromJson(data);
+    map[_i9.JwtTokenInfo] = (data, protocol) => _i9.JwtTokenInfo.fromJson(data);
+    map[_i10.RefreshToken] = (data, protocol) =>
+        _i10.RefreshToken.fromJson(data);
+    map[_i11.RefreshTokenExpiredException] = (data, protocol) =>
+        _i11.RefreshTokenExpiredException.fromJson(data);
+    map[_i12.RefreshTokenInvalidSecretException] = (data, protocol) =>
+        _i12.RefreshTokenInvalidSecretException.fromJson(data);
+    map[_i13.RefreshTokenMalformedException] = (data, protocol) =>
+        _i13.RefreshTokenMalformedException.fromJson(data);
+    map[_i14.RefreshTokenNotFoundException] = (data, protocol) =>
+        _i14.RefreshTokenNotFoundException.fromJson(data);
+    map[_i15.TokenPair] = (data, protocol) => _i15.TokenPair.fromJson(data);
+    map[_i16.UserProfile] = (data, protocol) => _i16.UserProfile.fromJson(data);
+    map[_i17.UserProfileData] = (data, protocol) =>
+        _i17.UserProfileData.fromJson(data);
+    map[_i18.UserProfileImage] = (data, protocol) =>
+        _i18.UserProfileImage.fromJson(data);
+    map[_i19.UserProfileModel] = (data, protocol) =>
+        _i19.UserProfileModel.fromJson(data);
+    map[_i20.ServerSideSession] = (data, protocol) =>
+        _i20.ServerSideSession.fromJson(data);
+    map[_i21.ServerSideSessionInfo] = (data, protocol) =>
+        _i21.ServerSideSessionInfo.fromJson(data);
+    map[_i1.getType<_i3.AuthUser?>()] = (data, protocol) =>
+        (data != null ? _i3.AuthUser.fromJson(data) : null);
+    map[_i1.getType<_i4.AuthUserBlockedException?>()] = (data, protocol) =>
+        (data != null ? _i4.AuthUserBlockedException.fromJson(data) : null);
+    map[_i1.getType<_i5.AuthUserModel?>()] = (data, protocol) =>
+        (data != null ? _i5.AuthUserModel.fromJson(data) : null);
+    map[_i1.getType<_i6.AuthUserNotFoundException?>()] = (data, protocol) =>
+        (data != null ? _i6.AuthUserNotFoundException.fromJson(data) : null);
+    map[_i1.getType<_i7.AuthStrategy?>()] = (data, protocol) =>
+        (data != null ? _i7.AuthStrategy.fromJson(data) : null);
+    map[_i1.getType<_i8.AuthSuccess?>()] = (data, protocol) =>
+        (data != null ? _i8.AuthSuccess.fromJson(data) : null);
+    map[_i1.getType<_i9.JwtTokenInfo?>()] = (data, protocol) =>
+        (data != null ? _i9.JwtTokenInfo.fromJson(data) : null);
+    map[_i1.getType<_i10.RefreshToken?>()] = (data, protocol) =>
+        (data != null ? _i10.RefreshToken.fromJson(data) : null);
+    map[_i1.getType<_i11.RefreshTokenExpiredException?>()] = (data, protocol) =>
+        (data != null
+        ? _i11.RefreshTokenExpiredException.fromJson(data)
+        : null);
+    map[_i1.getType<_i12.RefreshTokenInvalidSecretException?>()] =
+        (data, protocol) => (data != null
+        ? _i12.RefreshTokenInvalidSecretException.fromJson(data)
+        : null);
+    map[_i1
+        .getType<_i13.RefreshTokenMalformedException?>()] = (data, protocol) =>
+        (data != null
+        ? _i13.RefreshTokenMalformedException.fromJson(data)
+        : null);
+    map[_i1
+        .getType<_i14.RefreshTokenNotFoundException?>()] = (data, protocol) =>
+        (data != null
+        ? _i14.RefreshTokenNotFoundException.fromJson(data)
+        : null);
+    map[_i1.getType<_i15.TokenPair?>()] = (data, protocol) =>
+        (data != null ? _i15.TokenPair.fromJson(data) : null);
+    map[_i1.getType<_i16.UserProfile?>()] = (data, protocol) =>
+        (data != null ? _i16.UserProfile.fromJson(data) : null);
+    map[_i1.getType<_i17.UserProfileData?>()] = (data, protocol) =>
+        (data != null ? _i17.UserProfileData.fromJson(data) : null);
+    map[_i1.getType<_i18.UserProfileImage?>()] = (data, protocol) =>
+        (data != null ? _i18.UserProfileImage.fromJson(data) : null);
+    map[_i1.getType<_i19.UserProfileModel?>()] = (data, protocol) =>
+        (data != null ? _i19.UserProfileModel.fromJson(data) : null);
+    map[_i1.getType<_i20.ServerSideSession?>()] = (data, protocol) =>
+        (data != null ? _i20.ServerSideSession.fromJson(data) : null);
+    map[_i1.getType<_i21.ServerSideSessionInfo?>()] = (data, protocol) =>
+        (data != null ? _i21.ServerSideSessionInfo.fromJson(data) : null);
+    map[Set<String>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<String>(e)).toSet();
+    return map;
+  }
+
   void registerHostProtocol(
     String projectName,
     _i1.SerializationManager protocol,
@@ -463,139 +553,9 @@ class Protocol extends _i1.DatabaseSerializationManager {
       }
     }
 
-    if (t == _i3.AuthUser) {
-      return _i3.AuthUser.fromJson(data) as T;
-    }
-    if (t == _i4.AuthUserBlockedException) {
-      return _i4.AuthUserBlockedException.fromJson(data) as T;
-    }
-    if (t == _i5.AuthUserModel) {
-      return _i5.AuthUserModel.fromJson(data) as T;
-    }
-    if (t == _i6.AuthUserNotFoundException) {
-      return _i6.AuthUserNotFoundException.fromJson(data) as T;
-    }
-    if (t == _i7.AuthStrategy) {
-      return _i7.AuthStrategy.fromJson(data) as T;
-    }
-    if (t == _i8.AuthSuccess) {
-      return _i8.AuthSuccess.fromJson(data) as T;
-    }
-    if (t == _i9.JwtTokenInfo) {
-      return _i9.JwtTokenInfo.fromJson(data) as T;
-    }
-    if (t == _i10.RefreshToken) {
-      return _i10.RefreshToken.fromJson(data) as T;
-    }
-    if (t == _i11.RefreshTokenExpiredException) {
-      return _i11.RefreshTokenExpiredException.fromJson(data) as T;
-    }
-    if (t == _i12.RefreshTokenInvalidSecretException) {
-      return _i12.RefreshTokenInvalidSecretException.fromJson(data) as T;
-    }
-    if (t == _i13.RefreshTokenMalformedException) {
-      return _i13.RefreshTokenMalformedException.fromJson(data) as T;
-    }
-    if (t == _i14.RefreshTokenNotFoundException) {
-      return _i14.RefreshTokenNotFoundException.fromJson(data) as T;
-    }
-    if (t == _i15.TokenPair) {
-      return _i15.TokenPair.fromJson(data) as T;
-    }
-    if (t == _i16.UserProfile) {
-      return _i16.UserProfile.fromJson(data) as T;
-    }
-    if (t == _i17.UserProfileData) {
-      return _i17.UserProfileData.fromJson(data) as T;
-    }
-    if (t == _i18.UserProfileImage) {
-      return _i18.UserProfileImage.fromJson(data) as T;
-    }
-    if (t == _i19.UserProfileModel) {
-      return _i19.UserProfileModel.fromJson(data) as T;
-    }
-    if (t == _i20.ServerSideSession) {
-      return _i20.ServerSideSession.fromJson(data) as T;
-    }
-    if (t == _i21.ServerSideSessionInfo) {
-      return _i21.ServerSideSessionInfo.fromJson(data) as T;
-    }
-    if (t == _i1.getType<_i3.AuthUser?>()) {
-      return (data != null ? _i3.AuthUser.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i4.AuthUserBlockedException?>()) {
-      return (data != null ? _i4.AuthUserBlockedException.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i5.AuthUserModel?>()) {
-      return (data != null ? _i5.AuthUserModel.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i6.AuthUserNotFoundException?>()) {
-      return (data != null
-              ? _i6.AuthUserNotFoundException.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i7.AuthStrategy?>()) {
-      return (data != null ? _i7.AuthStrategy.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i8.AuthSuccess?>()) {
-      return (data != null ? _i8.AuthSuccess.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i9.JwtTokenInfo?>()) {
-      return (data != null ? _i9.JwtTokenInfo.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i10.RefreshToken?>()) {
-      return (data != null ? _i10.RefreshToken.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i11.RefreshTokenExpiredException?>()) {
-      return (data != null
-              ? _i11.RefreshTokenExpiredException.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i12.RefreshTokenInvalidSecretException?>()) {
-      return (data != null
-              ? _i12.RefreshTokenInvalidSecretException.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i13.RefreshTokenMalformedException?>()) {
-      return (data != null
-              ? _i13.RefreshTokenMalformedException.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i14.RefreshTokenNotFoundException?>()) {
-      return (data != null
-              ? _i14.RefreshTokenNotFoundException.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i15.TokenPair?>()) {
-      return (data != null ? _i15.TokenPair.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i16.UserProfile?>()) {
-      return (data != null ? _i16.UserProfile.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i17.UserProfileData?>()) {
-      return (data != null ? _i17.UserProfileData.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i18.UserProfileImage?>()) {
-      return (data != null ? _i18.UserProfileImage.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i19.UserProfileModel?>()) {
-      return (data != null ? _i19.UserProfileModel.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i20.ServerSideSession?>()) {
-      return (data != null ? _i20.ServerSideSession.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i21.ServerSideSessionInfo?>()) {
-      return (data != null ? _i21.ServerSideSessionInfo.fromJson(data) : null)
-          as T;
-    }
-    if (t == Set<String>) {
-      return (data as List).map((e) => deserialize<String>(e)).toSet() as T;
+    final fn = _deserializers[t];
+    if (fn != null) {
+      return fn(data, this) as T;
     }
     try {
       return _i2.Protocol().deserialize<T>(data, t);

--- a/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_server/lib/src/generated/protocol.dart
+++ b/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_server/lib/src/generated/protocol.dart
@@ -61,6 +61,9 @@ class Protocol extends _i1.DatabaseSerializationManager {
 
   final Set<_i1.SerializationManager> _hostProtocols = {};
 
+  static final Map<Type, dynamic Function(dynamic, Protocol)> _deserializers =
+      _buildDeserializers();
+
   static List<_i2.TableDefinition> get targetTableDefinitions => [
     _i2.TableDefinition(
       name: 'serverpod_auth_core_jwt_refresh_token',
@@ -464,139 +467,9 @@ class Protocol extends _i1.DatabaseSerializationManager {
       }
     }
 
-    if (t == _i3.AuthUser) {
-      return _i3.AuthUser.fromJson(data) as T;
-    }
-    if (t == _i4.AuthUserBlockedException) {
-      return _i4.AuthUserBlockedException.fromJson(data) as T;
-    }
-    if (t == _i5.AuthUserModel) {
-      return _i5.AuthUserModel.fromJson(data) as T;
-    }
-    if (t == _i6.AuthUserNotFoundException) {
-      return _i6.AuthUserNotFoundException.fromJson(data) as T;
-    }
-    if (t == _i7.AuthStrategy) {
-      return _i7.AuthStrategy.fromJson(data) as T;
-    }
-    if (t == _i8.AuthSuccess) {
-      return _i8.AuthSuccess.fromJson(data) as T;
-    }
-    if (t == _i9.JwtTokenInfo) {
-      return _i9.JwtTokenInfo.fromJson(data) as T;
-    }
-    if (t == _i10.RefreshToken) {
-      return _i10.RefreshToken.fromJson(data) as T;
-    }
-    if (t == _i11.RefreshTokenExpiredException) {
-      return _i11.RefreshTokenExpiredException.fromJson(data) as T;
-    }
-    if (t == _i12.RefreshTokenInvalidSecretException) {
-      return _i12.RefreshTokenInvalidSecretException.fromJson(data) as T;
-    }
-    if (t == _i13.RefreshTokenMalformedException) {
-      return _i13.RefreshTokenMalformedException.fromJson(data) as T;
-    }
-    if (t == _i14.RefreshTokenNotFoundException) {
-      return _i14.RefreshTokenNotFoundException.fromJson(data) as T;
-    }
-    if (t == _i15.TokenPair) {
-      return _i15.TokenPair.fromJson(data) as T;
-    }
-    if (t == _i16.UserProfile) {
-      return _i16.UserProfile.fromJson(data) as T;
-    }
-    if (t == _i17.UserProfileData) {
-      return _i17.UserProfileData.fromJson(data) as T;
-    }
-    if (t == _i18.UserProfileImage) {
-      return _i18.UserProfileImage.fromJson(data) as T;
-    }
-    if (t == _i19.UserProfileModel) {
-      return _i19.UserProfileModel.fromJson(data) as T;
-    }
-    if (t == _i20.ServerSideSession) {
-      return _i20.ServerSideSession.fromJson(data) as T;
-    }
-    if (t == _i21.ServerSideSessionInfo) {
-      return _i21.ServerSideSessionInfo.fromJson(data) as T;
-    }
-    if (t == _i1.getType<_i3.AuthUser?>()) {
-      return (data != null ? _i3.AuthUser.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i4.AuthUserBlockedException?>()) {
-      return (data != null ? _i4.AuthUserBlockedException.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i5.AuthUserModel?>()) {
-      return (data != null ? _i5.AuthUserModel.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i6.AuthUserNotFoundException?>()) {
-      return (data != null
-              ? _i6.AuthUserNotFoundException.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i7.AuthStrategy?>()) {
-      return (data != null ? _i7.AuthStrategy.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i8.AuthSuccess?>()) {
-      return (data != null ? _i8.AuthSuccess.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i9.JwtTokenInfo?>()) {
-      return (data != null ? _i9.JwtTokenInfo.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i10.RefreshToken?>()) {
-      return (data != null ? _i10.RefreshToken.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i11.RefreshTokenExpiredException?>()) {
-      return (data != null
-              ? _i11.RefreshTokenExpiredException.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i12.RefreshTokenInvalidSecretException?>()) {
-      return (data != null
-              ? _i12.RefreshTokenInvalidSecretException.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i13.RefreshTokenMalformedException?>()) {
-      return (data != null
-              ? _i13.RefreshTokenMalformedException.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i14.RefreshTokenNotFoundException?>()) {
-      return (data != null
-              ? _i14.RefreshTokenNotFoundException.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i15.TokenPair?>()) {
-      return (data != null ? _i15.TokenPair.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i16.UserProfile?>()) {
-      return (data != null ? _i16.UserProfile.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i17.UserProfileData?>()) {
-      return (data != null ? _i17.UserProfileData.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i18.UserProfileImage?>()) {
-      return (data != null ? _i18.UserProfileImage.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i19.UserProfileModel?>()) {
-      return (data != null ? _i19.UserProfileModel.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i20.ServerSideSession?>()) {
-      return (data != null ? _i20.ServerSideSession.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i21.ServerSideSessionInfo?>()) {
-      return (data != null ? _i21.ServerSideSessionInfo.fromJson(data) : null)
-          as T;
-    }
-    if (t == Set<String>) {
-      return (data as List).map((e) => deserialize<String>(e)).toSet() as T;
+    final fn = _deserializers[t];
+    if (fn != null) {
+      return fn(data, this) as T;
     }
     try {
       return _i2.Protocol().deserialize<T>(data, t);
@@ -861,5 +734,92 @@ class Protocol extends _i1.DatabaseSerializationManager {
       return _i2.Protocol().mapRecordToJson(record);
     } catch (_) {}
     throw Exception('Unsupported record type ${record.runtimeType}');
+  }
+
+  static Map<Type, dynamic Function(dynamic, Protocol)> _buildDeserializers() {
+    final map = <Type, dynamic Function(dynamic, Protocol)>{};
+    map[_i3.AuthUser] = (data, protocol) => _i3.AuthUser.fromJson(data);
+    map[_i4.AuthUserBlockedException] = (data, protocol) =>
+        _i4.AuthUserBlockedException.fromJson(data);
+    map[_i5.AuthUserModel] = (data, protocol) =>
+        _i5.AuthUserModel.fromJson(data);
+    map[_i6.AuthUserNotFoundException] = (data, protocol) =>
+        _i6.AuthUserNotFoundException.fromJson(data);
+    map[_i7.AuthStrategy] = (data, protocol) => _i7.AuthStrategy.fromJson(data);
+    map[_i8.AuthSuccess] = (data, protocol) => _i8.AuthSuccess.fromJson(data);
+    map[_i9.JwtTokenInfo] = (data, protocol) => _i9.JwtTokenInfo.fromJson(data);
+    map[_i10.RefreshToken] = (data, protocol) =>
+        _i10.RefreshToken.fromJson(data);
+    map[_i11.RefreshTokenExpiredException] = (data, protocol) =>
+        _i11.RefreshTokenExpiredException.fromJson(data);
+    map[_i12.RefreshTokenInvalidSecretException] = (data, protocol) =>
+        _i12.RefreshTokenInvalidSecretException.fromJson(data);
+    map[_i13.RefreshTokenMalformedException] = (data, protocol) =>
+        _i13.RefreshTokenMalformedException.fromJson(data);
+    map[_i14.RefreshTokenNotFoundException] = (data, protocol) =>
+        _i14.RefreshTokenNotFoundException.fromJson(data);
+    map[_i15.TokenPair] = (data, protocol) => _i15.TokenPair.fromJson(data);
+    map[_i16.UserProfile] = (data, protocol) => _i16.UserProfile.fromJson(data);
+    map[_i17.UserProfileData] = (data, protocol) =>
+        _i17.UserProfileData.fromJson(data);
+    map[_i18.UserProfileImage] = (data, protocol) =>
+        _i18.UserProfileImage.fromJson(data);
+    map[_i19.UserProfileModel] = (data, protocol) =>
+        _i19.UserProfileModel.fromJson(data);
+    map[_i20.ServerSideSession] = (data, protocol) =>
+        _i20.ServerSideSession.fromJson(data);
+    map[_i21.ServerSideSessionInfo] = (data, protocol) =>
+        _i21.ServerSideSessionInfo.fromJson(data);
+    map[_i1.getType<_i3.AuthUser?>()] = (data, protocol) =>
+        (data != null ? _i3.AuthUser.fromJson(data) : null);
+    map[_i1.getType<_i4.AuthUserBlockedException?>()] = (data, protocol) =>
+        (data != null ? _i4.AuthUserBlockedException.fromJson(data) : null);
+    map[_i1.getType<_i5.AuthUserModel?>()] = (data, protocol) =>
+        (data != null ? _i5.AuthUserModel.fromJson(data) : null);
+    map[_i1.getType<_i6.AuthUserNotFoundException?>()] = (data, protocol) =>
+        (data != null ? _i6.AuthUserNotFoundException.fromJson(data) : null);
+    map[_i1.getType<_i7.AuthStrategy?>()] = (data, protocol) =>
+        (data != null ? _i7.AuthStrategy.fromJson(data) : null);
+    map[_i1.getType<_i8.AuthSuccess?>()] = (data, protocol) =>
+        (data != null ? _i8.AuthSuccess.fromJson(data) : null);
+    map[_i1.getType<_i9.JwtTokenInfo?>()] = (data, protocol) =>
+        (data != null ? _i9.JwtTokenInfo.fromJson(data) : null);
+    map[_i1.getType<_i10.RefreshToken?>()] = (data, protocol) =>
+        (data != null ? _i10.RefreshToken.fromJson(data) : null);
+    map[_i1.getType<_i11.RefreshTokenExpiredException?>()] = (data, protocol) =>
+        (data != null
+        ? _i11.RefreshTokenExpiredException.fromJson(data)
+        : null);
+    map[_i1.getType<_i12.RefreshTokenInvalidSecretException?>()] =
+        (data, protocol) => (data != null
+        ? _i12.RefreshTokenInvalidSecretException.fromJson(data)
+        : null);
+    map[_i1
+        .getType<_i13.RefreshTokenMalformedException?>()] = (data, protocol) =>
+        (data != null
+        ? _i13.RefreshTokenMalformedException.fromJson(data)
+        : null);
+    map[_i1
+        .getType<_i14.RefreshTokenNotFoundException?>()] = (data, protocol) =>
+        (data != null
+        ? _i14.RefreshTokenNotFoundException.fromJson(data)
+        : null);
+    map[_i1.getType<_i15.TokenPair?>()] = (data, protocol) =>
+        (data != null ? _i15.TokenPair.fromJson(data) : null);
+    map[_i1.getType<_i16.UserProfile?>()] = (data, protocol) =>
+        (data != null ? _i16.UserProfile.fromJson(data) : null);
+    map[_i1.getType<_i17.UserProfileData?>()] = (data, protocol) =>
+        (data != null ? _i17.UserProfileData.fromJson(data) : null);
+    map[_i1.getType<_i18.UserProfileImage?>()] = (data, protocol) =>
+        (data != null ? _i18.UserProfileImage.fromJson(data) : null);
+    map[_i1.getType<_i19.UserProfileModel?>()] = (data, protocol) =>
+        (data != null ? _i19.UserProfileModel.fromJson(data) : null);
+    map[_i1.getType<_i20.ServerSideSession?>()] = (data, protocol) =>
+        (data != null ? _i20.ServerSideSession.fromJson(data) : null);
+    map[_i1.getType<_i21.ServerSideSessionInfo?>()] = (data, protocol) =>
+        (data != null ? _i21.ServerSideSessionInfo.fromJson(data) : null);
+    map[Set<String>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<String>(e)).toSet();
+    return map;
   }
 }

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_client/lib/src/protocol/protocol.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_client/lib/src/protocol/protocol.dart
@@ -77,6 +77,123 @@ class Protocol extends _i1.SerializationManager {
 
   final Map<String, _i1.SerializationManager> _hostProtocols = {};
 
+  static final Map<Type, dynamic Function(dynamic, Protocol)> _deserializers =
+      _buildDeserializers();
+
+  static Map<Type, dynamic Function(dynamic, Protocol)> _buildDeserializers() {
+    final map = <Type, dynamic Function(dynamic, Protocol)>{};
+    map[_i2.AnonymousAccountBlockedException] = (data, protocol) =>
+        _i2.AnonymousAccountBlockedException.fromJson(data);
+    map[_i3.AnonymousAccountBlockedExceptionReason] = (data, protocol) =>
+        _i3.AnonymousAccountBlockedExceptionReason.fromJson(data);
+    map[_i4.EmailAccountLoginException] = (data, protocol) =>
+        _i4.EmailAccountLoginException.fromJson(data);
+    map[_i5.EmailAccountLoginExceptionReason] = (data, protocol) =>
+        _i5.EmailAccountLoginExceptionReason.fromJson(data);
+    map[_i6.EmailAccountPasswordResetException] = (data, protocol) =>
+        _i6.EmailAccountPasswordResetException.fromJson(data);
+    map[_i7.EmailAccountPasswordResetExceptionReason] = (data, protocol) =>
+        _i7.EmailAccountPasswordResetExceptionReason.fromJson(data);
+    map[_i8.EmailAccountRequestException] = (data, protocol) =>
+        _i8.EmailAccountRequestException.fromJson(data);
+    map[_i9.EmailAccountRequestExceptionReason] = (data, protocol) =>
+        _i9.EmailAccountRequestExceptionReason.fromJson(data);
+    map[_i10.FacebookAccessTokenVerificationException] = (data, protocol) =>
+        _i10.FacebookAccessTokenVerificationException.fromJson(data);
+    map[_i11.FirebaseIdTokenVerificationException] = (data, protocol) =>
+        _i11.FirebaseIdTokenVerificationException.fromJson(data);
+    map[_i12.GitHubAccessTokenVerificationException] = (data, protocol) =>
+        _i12.GitHubAccessTokenVerificationException.fromJson(data);
+    map[_i13.GoogleIdTokenVerificationException] = (data, protocol) =>
+        _i13.GoogleIdTokenVerificationException.fromJson(data);
+    map[_i14.MicrosoftAccessTokenVerificationException] = (data, protocol) =>
+        _i14.MicrosoftAccessTokenVerificationException.fromJson(data);
+    map[_i15.PasskeyChallengeExpiredException] = (data, protocol) =>
+        _i15.PasskeyChallengeExpiredException.fromJson(data);
+    map[_i16.PasskeyChallengeNotFoundException] = (data, protocol) =>
+        _i16.PasskeyChallengeNotFoundException.fromJson(data);
+    map[_i17.PasskeyLoginRequest] = (data, protocol) =>
+        _i17.PasskeyLoginRequest.fromJson(data);
+    map[_i18.PasskeyPublicKeyNotFoundException] = (data, protocol) =>
+        _i18.PasskeyPublicKeyNotFoundException.fromJson(data);
+    map[_i19.PasskeyRegistrationRequest] = (data, protocol) =>
+        _i19.PasskeyRegistrationRequest.fromJson(data);
+    map[_i1
+        .getType<_i2.AnonymousAccountBlockedException?>()] = (data, protocol) =>
+        (data != null
+        ? _i2.AnonymousAccountBlockedException.fromJson(data)
+        : null);
+    map[_i1.getType<_i3.AnonymousAccountBlockedExceptionReason?>()] =
+        (data, protocol) => (data != null
+        ? _i3.AnonymousAccountBlockedExceptionReason.fromJson(data)
+        : null);
+    map[_i1.getType<_i4.EmailAccountLoginException?>()] = (data, protocol) =>
+        (data != null ? _i4.EmailAccountLoginException.fromJson(data) : null);
+    map[_i1
+        .getType<_i5.EmailAccountLoginExceptionReason?>()] = (data, protocol) =>
+        (data != null
+        ? _i5.EmailAccountLoginExceptionReason.fromJson(data)
+        : null);
+    map[_i1.getType<_i6.EmailAccountPasswordResetException?>()] =
+        (data, protocol) => (data != null
+        ? _i6.EmailAccountPasswordResetException.fromJson(data)
+        : null);
+    map[_i1.getType<_i7.EmailAccountPasswordResetExceptionReason?>()] =
+        (data, protocol) => (data != null
+        ? _i7.EmailAccountPasswordResetExceptionReason.fromJson(data)
+        : null);
+    map[_i1.getType<_i8.EmailAccountRequestException?>()] = (data, protocol) =>
+        (data != null ? _i8.EmailAccountRequestException.fromJson(data) : null);
+    map[_i1.getType<_i9.EmailAccountRequestExceptionReason?>()] =
+        (data, protocol) => (data != null
+        ? _i9.EmailAccountRequestExceptionReason.fromJson(data)
+        : null);
+    map[_i1.getType<_i10.FacebookAccessTokenVerificationException?>()] =
+        (data, protocol) => (data != null
+        ? _i10.FacebookAccessTokenVerificationException.fromJson(data)
+        : null);
+    map[_i1.getType<_i11.FirebaseIdTokenVerificationException?>()] =
+        (data, protocol) => (data != null
+        ? _i11.FirebaseIdTokenVerificationException.fromJson(data)
+        : null);
+    map[_i1.getType<_i12.GitHubAccessTokenVerificationException?>()] =
+        (data, protocol) => (data != null
+        ? _i12.GitHubAccessTokenVerificationException.fromJson(data)
+        : null);
+    map[_i1.getType<_i13.GoogleIdTokenVerificationException?>()] =
+        (data, protocol) => (data != null
+        ? _i13.GoogleIdTokenVerificationException.fromJson(data)
+        : null);
+    map[_i1.getType<_i14.MicrosoftAccessTokenVerificationException?>()] =
+        (data, protocol) => (data != null
+        ? _i14.MicrosoftAccessTokenVerificationException.fromJson(data)
+        : null);
+    map[_i1.getType<_i15.PasskeyChallengeExpiredException?>()] =
+        (data, protocol) => (data != null
+        ? _i15.PasskeyChallengeExpiredException.fromJson(data)
+        : null);
+    map[_i1.getType<_i16.PasskeyChallengeNotFoundException?>()] =
+        (data, protocol) => (data != null
+        ? _i16.PasskeyChallengeNotFoundException.fromJson(data)
+        : null);
+    map[_i1.getType<_i17.PasskeyLoginRequest?>()] = (data, protocol) =>
+        (data != null ? _i17.PasskeyLoginRequest.fromJson(data) : null);
+    map[_i1.getType<_i18.PasskeyPublicKeyNotFoundException?>()] =
+        (data, protocol) => (data != null
+        ? _i18.PasskeyPublicKeyNotFoundException.fromJson(data)
+        : null);
+    map[_i1.getType<_i19.PasskeyRegistrationRequest?>()] = (data, protocol) =>
+        (data != null ? _i19.PasskeyRegistrationRequest.fromJson(data) : null);
+    map[_i1.getType<({_i20.ByteData challenge, _i1.UuidValue id})>()] =
+        (data, protocol) => (
+          challenge: protocol.deserialize<_i20.ByteData>(
+            ((data as Map)['n'] as Map)['challenge'],
+          ),
+          id: protocol.deserialize<_i1.UuidValue>(data['n']['id']),
+        );
+    return map;
+  }
+
   void registerHostProtocol(
     String projectName,
     _i1.SerializationManager protocol,
@@ -113,174 +230,9 @@ class Protocol extends _i1.SerializationManager {
       }
     }
 
-    if (t == _i2.AnonymousAccountBlockedException) {
-      return _i2.AnonymousAccountBlockedException.fromJson(data) as T;
-    }
-    if (t == _i3.AnonymousAccountBlockedExceptionReason) {
-      return _i3.AnonymousAccountBlockedExceptionReason.fromJson(data) as T;
-    }
-    if (t == _i4.EmailAccountLoginException) {
-      return _i4.EmailAccountLoginException.fromJson(data) as T;
-    }
-    if (t == _i5.EmailAccountLoginExceptionReason) {
-      return _i5.EmailAccountLoginExceptionReason.fromJson(data) as T;
-    }
-    if (t == _i6.EmailAccountPasswordResetException) {
-      return _i6.EmailAccountPasswordResetException.fromJson(data) as T;
-    }
-    if (t == _i7.EmailAccountPasswordResetExceptionReason) {
-      return _i7.EmailAccountPasswordResetExceptionReason.fromJson(data) as T;
-    }
-    if (t == _i8.EmailAccountRequestException) {
-      return _i8.EmailAccountRequestException.fromJson(data) as T;
-    }
-    if (t == _i9.EmailAccountRequestExceptionReason) {
-      return _i9.EmailAccountRequestExceptionReason.fromJson(data) as T;
-    }
-    if (t == _i10.FacebookAccessTokenVerificationException) {
-      return _i10.FacebookAccessTokenVerificationException.fromJson(data) as T;
-    }
-    if (t == _i11.FirebaseIdTokenVerificationException) {
-      return _i11.FirebaseIdTokenVerificationException.fromJson(data) as T;
-    }
-    if (t == _i12.GitHubAccessTokenVerificationException) {
-      return _i12.GitHubAccessTokenVerificationException.fromJson(data) as T;
-    }
-    if (t == _i13.GoogleIdTokenVerificationException) {
-      return _i13.GoogleIdTokenVerificationException.fromJson(data) as T;
-    }
-    if (t == _i14.MicrosoftAccessTokenVerificationException) {
-      return _i14.MicrosoftAccessTokenVerificationException.fromJson(data) as T;
-    }
-    if (t == _i15.PasskeyChallengeExpiredException) {
-      return _i15.PasskeyChallengeExpiredException.fromJson(data) as T;
-    }
-    if (t == _i16.PasskeyChallengeNotFoundException) {
-      return _i16.PasskeyChallengeNotFoundException.fromJson(data) as T;
-    }
-    if (t == _i17.PasskeyLoginRequest) {
-      return _i17.PasskeyLoginRequest.fromJson(data) as T;
-    }
-    if (t == _i18.PasskeyPublicKeyNotFoundException) {
-      return _i18.PasskeyPublicKeyNotFoundException.fromJson(data) as T;
-    }
-    if (t == _i19.PasskeyRegistrationRequest) {
-      return _i19.PasskeyRegistrationRequest.fromJson(data) as T;
-    }
-    if (t == _i1.getType<_i2.AnonymousAccountBlockedException?>()) {
-      return (data != null
-              ? _i2.AnonymousAccountBlockedException.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i3.AnonymousAccountBlockedExceptionReason?>()) {
-      return (data != null
-              ? _i3.AnonymousAccountBlockedExceptionReason.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i4.EmailAccountLoginException?>()) {
-      return (data != null
-              ? _i4.EmailAccountLoginException.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i5.EmailAccountLoginExceptionReason?>()) {
-      return (data != null
-              ? _i5.EmailAccountLoginExceptionReason.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i6.EmailAccountPasswordResetException?>()) {
-      return (data != null
-              ? _i6.EmailAccountPasswordResetException.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i7.EmailAccountPasswordResetExceptionReason?>()) {
-      return (data != null
-              ? _i7.EmailAccountPasswordResetExceptionReason.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i8.EmailAccountRequestException?>()) {
-      return (data != null
-              ? _i8.EmailAccountRequestException.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i9.EmailAccountRequestExceptionReason?>()) {
-      return (data != null
-              ? _i9.EmailAccountRequestExceptionReason.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i10.FacebookAccessTokenVerificationException?>()) {
-      return (data != null
-              ? _i10.FacebookAccessTokenVerificationException.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i11.FirebaseIdTokenVerificationException?>()) {
-      return (data != null
-              ? _i11.FirebaseIdTokenVerificationException.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i12.GitHubAccessTokenVerificationException?>()) {
-      return (data != null
-              ? _i12.GitHubAccessTokenVerificationException.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i13.GoogleIdTokenVerificationException?>()) {
-      return (data != null
-              ? _i13.GoogleIdTokenVerificationException.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i14.MicrosoftAccessTokenVerificationException?>()) {
-      return (data != null
-              ? _i14.MicrosoftAccessTokenVerificationException.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i15.PasskeyChallengeExpiredException?>()) {
-      return (data != null
-              ? _i15.PasskeyChallengeExpiredException.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i16.PasskeyChallengeNotFoundException?>()) {
-      return (data != null
-              ? _i16.PasskeyChallengeNotFoundException.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i17.PasskeyLoginRequest?>()) {
-      return (data != null ? _i17.PasskeyLoginRequest.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i18.PasskeyPublicKeyNotFoundException?>()) {
-      return (data != null
-              ? _i18.PasskeyPublicKeyNotFoundException.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i19.PasskeyRegistrationRequest?>()) {
-      return (data != null
-              ? _i19.PasskeyRegistrationRequest.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<({_i20.ByteData challenge, _i1.UuidValue id})>()) {
-      return (
-            challenge: deserialize<_i20.ByteData>(
-              ((data as Map)['n'] as Map)['challenge'],
-            ),
-            id: deserialize<_i1.UuidValue>(data['n']['id']),
-          )
-          as T;
+    final fn = _deserializers[t];
+    if (fn != null) {
+      return fn(data, this) as T;
     }
     try {
       return _i21.Protocol().deserialize<T>(data, t);

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_client/lib/src/protocol/protocol.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_client/lib/src/protocol/protocol.dart
@@ -12,45 +12,45 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
-import 'providers/anonymous/models/exceptions/anonymous_account_blocked_exception.dart'
-    as _i2;
-import 'providers/anonymous/models/exceptions/anonymous_account_blocked_exception_reason.dart'
-    as _i3;
-import 'providers/email/models/exceptions/email_account_login_exception.dart'
-    as _i4;
-import 'providers/email/models/exceptions/email_account_login_exception_reason.dart'
-    as _i5;
-import 'providers/email/models/exceptions/email_account_password_reset_exception.dart'
-    as _i6;
-import 'providers/email/models/exceptions/email_account_password_reset_exception_reason.dart'
-    as _i7;
-import 'providers/email/models/exceptions/email_account_request_exception.dart'
-    as _i8;
-import 'providers/email/models/exceptions/email_account_request_exception_reason.dart'
-    as _i9;
-import 'providers/facebook/models/facebook_access_token_verification_exception.dart'
-    as _i10;
-import 'providers/firebase/models/firebase_email_not_verified_exception.dart'
-    as _i11;
-import 'providers/firebase/models/firebase_id_token_verification_exception.dart'
-    as _i12;
-import 'providers/github/models/github_access_token_verification_exception.dart'
-    as _i13;
-import 'providers/google/models/google_id_token_verification_exception.dart'
-    as _i14;
-import 'providers/microsoft/models/microsoft_access_token_verification_exception.dart'
-    as _i15;
-import 'providers/passkey/models/passkey_challenge_expired_exception.dart'
-    as _i16;
-import 'providers/passkey/models/passkey_challenge_not_found_exception.dart'
-    as _i17;
-import 'providers/passkey/models/passkey_login_request.dart' as _i18;
-import 'providers/passkey/models/passkey_public_key_not_found_exception.dart'
-    as _i19;
-import 'providers/passkey/models/passkey_registration_request.dart' as _i20;
-import 'dart:typed_data' as _i21;
 import 'package:serverpod_auth_core_client/serverpod_auth_core_client.dart'
-    as _i22;
+    as _i2;
+import 'providers/anonymous/models/exceptions/anonymous_account_blocked_exception.dart'
+    as _i3;
+import 'providers/anonymous/models/exceptions/anonymous_account_blocked_exception_reason.dart'
+    as _i4;
+import 'providers/email/models/exceptions/email_account_login_exception.dart'
+    as _i5;
+import 'providers/email/models/exceptions/email_account_login_exception_reason.dart'
+    as _i6;
+import 'providers/email/models/exceptions/email_account_password_reset_exception.dart'
+    as _i7;
+import 'providers/email/models/exceptions/email_account_password_reset_exception_reason.dart'
+    as _i8;
+import 'providers/email/models/exceptions/email_account_request_exception.dart'
+    as _i9;
+import 'providers/email/models/exceptions/email_account_request_exception_reason.dart'
+    as _i10;
+import 'providers/facebook/models/facebook_access_token_verification_exception.dart'
+    as _i11;
+import 'providers/firebase/models/firebase_email_not_verified_exception.dart'
+    as _i12;
+import 'providers/firebase/models/firebase_id_token_verification_exception.dart'
+    as _i13;
+import 'providers/github/models/github_access_token_verification_exception.dart'
+    as _i14;
+import 'providers/google/models/google_id_token_verification_exception.dart'
+    as _i15;
+import 'providers/microsoft/models/microsoft_access_token_verification_exception.dart'
+    as _i16;
+import 'providers/passkey/models/passkey_challenge_expired_exception.dart'
+    as _i17;
+import 'providers/passkey/models/passkey_challenge_not_found_exception.dart'
+    as _i18;
+import 'providers/passkey/models/passkey_login_request.dart' as _i19;
+import 'providers/passkey/models/passkey_public_key_not_found_exception.dart'
+    as _i20;
+import 'providers/passkey/models/passkey_registration_request.dart' as _i21;
+import 'dart:typed_data' as _i22;
 export 'providers/anonymous/models/exceptions/anonymous_account_blocked_exception.dart';
 export 'providers/anonymous/models/exceptions/anonymous_account_blocked_exception_reason.dart';
 export 'providers/email/models/exceptions/email_account_login_exception.dart';
@@ -80,6 +80,9 @@ class Protocol extends _i1.SerializationManager {
   static final Protocol _instance = Protocol._();
 
   final Set<_i1.SerializationManager> _hostProtocols = {};
+
+  static final Map<Type, dynamic Function(dynamic, Protocol)> _deserializers =
+      _buildDeserializers();
 
   void registerHostProtocol(
     String projectName,
@@ -117,226 +120,52 @@ class Protocol extends _i1.SerializationManager {
       }
     }
 
-    if (t == _i2.AnonymousAccountBlockedException) {
-      return _i2.AnonymousAccountBlockedException.fromJson(data) as T;
-    }
-    if (t == _i3.AnonymousAccountBlockedExceptionReason) {
-      return _i3.AnonymousAccountBlockedExceptionReason.fromJson(data) as T;
-    }
-    if (t == _i4.EmailAccountLoginException) {
-      return _i4.EmailAccountLoginException.fromJson(data) as T;
-    }
-    if (t == _i5.EmailAccountLoginExceptionReason) {
-      return _i5.EmailAccountLoginExceptionReason.fromJson(data) as T;
-    }
-    if (t == _i6.EmailAccountPasswordResetException) {
-      return _i6.EmailAccountPasswordResetException.fromJson(data) as T;
-    }
-    if (t == _i7.EmailAccountPasswordResetExceptionReason) {
-      return _i7.EmailAccountPasswordResetExceptionReason.fromJson(data) as T;
-    }
-    if (t == _i8.EmailAccountRequestException) {
-      return _i8.EmailAccountRequestException.fromJson(data) as T;
-    }
-    if (t == _i9.EmailAccountRequestExceptionReason) {
-      return _i9.EmailAccountRequestExceptionReason.fromJson(data) as T;
-    }
-    if (t == _i10.FacebookAccessTokenVerificationException) {
-      return _i10.FacebookAccessTokenVerificationException.fromJson(data) as T;
-    }
-    if (t == _i11.FirebaseEmailNotVerifiedException) {
-      return _i11.FirebaseEmailNotVerifiedException.fromJson(data) as T;
-    }
-    if (t == _i12.FirebaseIdTokenVerificationException) {
-      return _i12.FirebaseIdTokenVerificationException.fromJson(data) as T;
-    }
-    if (t == _i13.GitHubAccessTokenVerificationException) {
-      return _i13.GitHubAccessTokenVerificationException.fromJson(data) as T;
-    }
-    if (t == _i14.GoogleIdTokenVerificationException) {
-      return _i14.GoogleIdTokenVerificationException.fromJson(data) as T;
-    }
-    if (t == _i15.MicrosoftAccessTokenVerificationException) {
-      return _i15.MicrosoftAccessTokenVerificationException.fromJson(data) as T;
-    }
-    if (t == _i16.PasskeyChallengeExpiredException) {
-      return _i16.PasskeyChallengeExpiredException.fromJson(data) as T;
-    }
-    if (t == _i17.PasskeyChallengeNotFoundException) {
-      return _i17.PasskeyChallengeNotFoundException.fromJson(data) as T;
-    }
-    if (t == _i18.PasskeyLoginRequest) {
-      return _i18.PasskeyLoginRequest.fromJson(data) as T;
-    }
-    if (t == _i19.PasskeyPublicKeyNotFoundException) {
-      return _i19.PasskeyPublicKeyNotFoundException.fromJson(data) as T;
-    }
-    if (t == _i20.PasskeyRegistrationRequest) {
-      return _i20.PasskeyRegistrationRequest.fromJson(data) as T;
-    }
-    if (t == _i1.getType<_i2.AnonymousAccountBlockedException?>()) {
-      return (data != null
-              ? _i2.AnonymousAccountBlockedException.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i3.AnonymousAccountBlockedExceptionReason?>()) {
-      return (data != null
-              ? _i3.AnonymousAccountBlockedExceptionReason.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i4.EmailAccountLoginException?>()) {
-      return (data != null
-              ? _i4.EmailAccountLoginException.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i5.EmailAccountLoginExceptionReason?>()) {
-      return (data != null
-              ? _i5.EmailAccountLoginExceptionReason.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i6.EmailAccountPasswordResetException?>()) {
-      return (data != null
-              ? _i6.EmailAccountPasswordResetException.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i7.EmailAccountPasswordResetExceptionReason?>()) {
-      return (data != null
-              ? _i7.EmailAccountPasswordResetExceptionReason.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i8.EmailAccountRequestException?>()) {
-      return (data != null
-              ? _i8.EmailAccountRequestException.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i9.EmailAccountRequestExceptionReason?>()) {
-      return (data != null
-              ? _i9.EmailAccountRequestExceptionReason.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i10.FacebookAccessTokenVerificationException?>()) {
-      return (data != null
-              ? _i10.FacebookAccessTokenVerificationException.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i11.FirebaseEmailNotVerifiedException?>()) {
-      return (data != null
-              ? _i11.FirebaseEmailNotVerifiedException.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i12.FirebaseIdTokenVerificationException?>()) {
-      return (data != null
-              ? _i12.FirebaseIdTokenVerificationException.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i13.GitHubAccessTokenVerificationException?>()) {
-      return (data != null
-              ? _i13.GitHubAccessTokenVerificationException.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i14.GoogleIdTokenVerificationException?>()) {
-      return (data != null
-              ? _i14.GoogleIdTokenVerificationException.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i15.MicrosoftAccessTokenVerificationException?>()) {
-      return (data != null
-              ? _i15.MicrosoftAccessTokenVerificationException.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i16.PasskeyChallengeExpiredException?>()) {
-      return (data != null
-              ? _i16.PasskeyChallengeExpiredException.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i17.PasskeyChallengeNotFoundException?>()) {
-      return (data != null
-              ? _i17.PasskeyChallengeNotFoundException.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i18.PasskeyLoginRequest?>()) {
-      return (data != null ? _i18.PasskeyLoginRequest.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i19.PasskeyPublicKeyNotFoundException?>()) {
-      return (data != null
-              ? _i19.PasskeyPublicKeyNotFoundException.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i20.PasskeyRegistrationRequest?>()) {
-      return (data != null
-              ? _i20.PasskeyRegistrationRequest.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<({_i21.ByteData challenge, _i1.UuidValue id})>()) {
-      return (
-            challenge: deserialize<_i21.ByteData>(
-              ((data as Map)['n'] as Map)['challenge'],
-            ),
-            id: deserialize<_i1.UuidValue>(data['n']['id']),
-          )
-          as T;
+    final fn = _deserializers[t];
+    if (fn != null) {
+      return fn(data, this) as T;
     }
     try {
-      return _i22.Protocol().deserialize<T>(data, t);
+      return _i2.Protocol().deserialize<T>(data, t);
     } on _i1.DeserializationTypeNotFoundException catch (_) {}
     return super.deserialize<T>(data, t);
   }
 
   static String? getClassNameForType(Type type) {
     return switch (type) {
-      _i2.AnonymousAccountBlockedException =>
+      _i3.AnonymousAccountBlockedException =>
         'AnonymousAccountBlockedException',
-      _i3.AnonymousAccountBlockedExceptionReason =>
+      _i4.AnonymousAccountBlockedExceptionReason =>
         'AnonymousAccountBlockedExceptionReason',
-      _i4.EmailAccountLoginException => 'EmailAccountLoginException',
-      _i5.EmailAccountLoginExceptionReason =>
+      _i5.EmailAccountLoginException => 'EmailAccountLoginException',
+      _i6.EmailAccountLoginExceptionReason =>
         'EmailAccountLoginExceptionReason',
-      _i6.EmailAccountPasswordResetException =>
+      _i7.EmailAccountPasswordResetException =>
         'EmailAccountPasswordResetException',
-      _i7.EmailAccountPasswordResetExceptionReason =>
+      _i8.EmailAccountPasswordResetExceptionReason =>
         'EmailAccountPasswordResetExceptionReason',
-      _i8.EmailAccountRequestException => 'EmailAccountRequestException',
-      _i9.EmailAccountRequestExceptionReason =>
+      _i9.EmailAccountRequestException => 'EmailAccountRequestException',
+      _i10.EmailAccountRequestExceptionReason =>
         'EmailAccountRequestExceptionReason',
-      _i10.FacebookAccessTokenVerificationException =>
+      _i11.FacebookAccessTokenVerificationException =>
         'FacebookAccessTokenVerificationException',
-      _i11.FirebaseEmailNotVerifiedException =>
+      _i12.FirebaseEmailNotVerifiedException =>
         'FirebaseEmailNotVerifiedException',
-      _i12.FirebaseIdTokenVerificationException =>
+      _i13.FirebaseIdTokenVerificationException =>
         'FirebaseIdTokenVerificationException',
-      _i13.GitHubAccessTokenVerificationException =>
+      _i14.GitHubAccessTokenVerificationException =>
         'GitHubAccessTokenVerificationException',
-      _i14.GoogleIdTokenVerificationException =>
+      _i15.GoogleIdTokenVerificationException =>
         'GoogleIdTokenVerificationException',
-      _i15.MicrosoftAccessTokenVerificationException =>
+      _i16.MicrosoftAccessTokenVerificationException =>
         'MicrosoftAccessTokenVerificationException',
-      _i16.PasskeyChallengeExpiredException =>
+      _i17.PasskeyChallengeExpiredException =>
         'PasskeyChallengeExpiredException',
-      _i17.PasskeyChallengeNotFoundException =>
+      _i18.PasskeyChallengeNotFoundException =>
         'PasskeyChallengeNotFoundException',
-      _i18.PasskeyLoginRequest => 'PasskeyLoginRequest',
-      _i19.PasskeyPublicKeyNotFoundException =>
+      _i19.PasskeyLoginRequest => 'PasskeyLoginRequest',
+      _i20.PasskeyPublicKeyNotFoundException =>
         'PasskeyPublicKeyNotFoundException',
-      _i20.PasskeyRegistrationRequest => 'PasskeyRegistrationRequest',
+      _i21.PasskeyRegistrationRequest => 'PasskeyRegistrationRequest',
       _ => null,
     };
   }
@@ -354,43 +183,43 @@ class Protocol extends _i1.SerializationManager {
     }
 
     switch (data) {
-      case _i2.AnonymousAccountBlockedException():
+      case _i3.AnonymousAccountBlockedException():
         return 'AnonymousAccountBlockedException';
-      case _i3.AnonymousAccountBlockedExceptionReason():
+      case _i4.AnonymousAccountBlockedExceptionReason():
         return 'AnonymousAccountBlockedExceptionReason';
-      case _i4.EmailAccountLoginException():
+      case _i5.EmailAccountLoginException():
         return 'EmailAccountLoginException';
-      case _i5.EmailAccountLoginExceptionReason():
+      case _i6.EmailAccountLoginExceptionReason():
         return 'EmailAccountLoginExceptionReason';
-      case _i6.EmailAccountPasswordResetException():
+      case _i7.EmailAccountPasswordResetException():
         return 'EmailAccountPasswordResetException';
-      case _i7.EmailAccountPasswordResetExceptionReason():
+      case _i8.EmailAccountPasswordResetExceptionReason():
         return 'EmailAccountPasswordResetExceptionReason';
-      case _i8.EmailAccountRequestException():
+      case _i9.EmailAccountRequestException():
         return 'EmailAccountRequestException';
-      case _i9.EmailAccountRequestExceptionReason():
+      case _i10.EmailAccountRequestExceptionReason():
         return 'EmailAccountRequestExceptionReason';
-      case _i10.FacebookAccessTokenVerificationException():
+      case _i11.FacebookAccessTokenVerificationException():
         return 'FacebookAccessTokenVerificationException';
-      case _i11.FirebaseEmailNotVerifiedException():
+      case _i12.FirebaseEmailNotVerifiedException():
         return 'FirebaseEmailNotVerifiedException';
-      case _i12.FirebaseIdTokenVerificationException():
+      case _i13.FirebaseIdTokenVerificationException():
         return 'FirebaseIdTokenVerificationException';
-      case _i13.GitHubAccessTokenVerificationException():
+      case _i14.GitHubAccessTokenVerificationException():
         return 'GitHubAccessTokenVerificationException';
-      case _i14.GoogleIdTokenVerificationException():
+      case _i15.GoogleIdTokenVerificationException():
         return 'GoogleIdTokenVerificationException';
-      case _i15.MicrosoftAccessTokenVerificationException():
+      case _i16.MicrosoftAccessTokenVerificationException():
         return 'MicrosoftAccessTokenVerificationException';
-      case _i16.PasskeyChallengeExpiredException():
+      case _i17.PasskeyChallengeExpiredException():
         return 'PasskeyChallengeExpiredException';
-      case _i17.PasskeyChallengeNotFoundException():
+      case _i18.PasskeyChallengeNotFoundException():
         return 'PasskeyChallengeNotFoundException';
-      case _i18.PasskeyLoginRequest():
+      case _i19.PasskeyLoginRequest():
         return 'PasskeyLoginRequest';
-      case _i19.PasskeyPublicKeyNotFoundException():
+      case _i20.PasskeyPublicKeyNotFoundException():
         return 'PasskeyPublicKeyNotFoundException';
-      case _i20.PasskeyRegistrationRequest():
+      case _i21.PasskeyRegistrationRequest():
         return 'PasskeyRegistrationRequest';
     }
     return null;
@@ -403,73 +232,73 @@ class Protocol extends _i1.SerializationManager {
       return super.deserializeByClassName(data);
     }
     if (dataClassName == 'AnonymousAccountBlockedException') {
-      return deserialize<_i2.AnonymousAccountBlockedException>(data['data']);
+      return deserialize<_i3.AnonymousAccountBlockedException>(data['data']);
     }
     if (dataClassName == 'AnonymousAccountBlockedExceptionReason') {
-      return deserialize<_i3.AnonymousAccountBlockedExceptionReason>(
+      return deserialize<_i4.AnonymousAccountBlockedExceptionReason>(
         data['data'],
       );
     }
     if (dataClassName == 'EmailAccountLoginException') {
-      return deserialize<_i4.EmailAccountLoginException>(data['data']);
+      return deserialize<_i5.EmailAccountLoginException>(data['data']);
     }
     if (dataClassName == 'EmailAccountLoginExceptionReason') {
-      return deserialize<_i5.EmailAccountLoginExceptionReason>(data['data']);
+      return deserialize<_i6.EmailAccountLoginExceptionReason>(data['data']);
     }
     if (dataClassName == 'EmailAccountPasswordResetException') {
-      return deserialize<_i6.EmailAccountPasswordResetException>(data['data']);
+      return deserialize<_i7.EmailAccountPasswordResetException>(data['data']);
     }
     if (dataClassName == 'EmailAccountPasswordResetExceptionReason') {
-      return deserialize<_i7.EmailAccountPasswordResetExceptionReason>(
+      return deserialize<_i8.EmailAccountPasswordResetExceptionReason>(
         data['data'],
       );
     }
     if (dataClassName == 'EmailAccountRequestException') {
-      return deserialize<_i8.EmailAccountRequestException>(data['data']);
+      return deserialize<_i9.EmailAccountRequestException>(data['data']);
     }
     if (dataClassName == 'EmailAccountRequestExceptionReason') {
-      return deserialize<_i9.EmailAccountRequestExceptionReason>(data['data']);
+      return deserialize<_i10.EmailAccountRequestExceptionReason>(data['data']);
     }
     if (dataClassName == 'FacebookAccessTokenVerificationException') {
-      return deserialize<_i10.FacebookAccessTokenVerificationException>(
+      return deserialize<_i11.FacebookAccessTokenVerificationException>(
         data['data'],
       );
     }
     if (dataClassName == 'FirebaseEmailNotVerifiedException') {
-      return deserialize<_i11.FirebaseEmailNotVerifiedException>(data['data']);
+      return deserialize<_i12.FirebaseEmailNotVerifiedException>(data['data']);
     }
     if (dataClassName == 'FirebaseIdTokenVerificationException') {
-      return deserialize<_i12.FirebaseIdTokenVerificationException>(
+      return deserialize<_i13.FirebaseIdTokenVerificationException>(
         data['data'],
       );
     }
     if (dataClassName == 'GitHubAccessTokenVerificationException') {
-      return deserialize<_i13.GitHubAccessTokenVerificationException>(
+      return deserialize<_i14.GitHubAccessTokenVerificationException>(
         data['data'],
       );
     }
     if (dataClassName == 'GoogleIdTokenVerificationException') {
-      return deserialize<_i14.GoogleIdTokenVerificationException>(data['data']);
+      return deserialize<_i15.GoogleIdTokenVerificationException>(data['data']);
     }
     if (dataClassName == 'MicrosoftAccessTokenVerificationException') {
-      return deserialize<_i15.MicrosoftAccessTokenVerificationException>(
+      return deserialize<_i16.MicrosoftAccessTokenVerificationException>(
         data['data'],
       );
     }
     if (dataClassName == 'PasskeyChallengeExpiredException') {
-      return deserialize<_i16.PasskeyChallengeExpiredException>(data['data']);
+      return deserialize<_i17.PasskeyChallengeExpiredException>(data['data']);
     }
     if (dataClassName == 'PasskeyChallengeNotFoundException') {
-      return deserialize<_i17.PasskeyChallengeNotFoundException>(data['data']);
+      return deserialize<_i18.PasskeyChallengeNotFoundException>(data['data']);
     }
     if (dataClassName == 'PasskeyLoginRequest') {
-      return deserialize<_i18.PasskeyLoginRequest>(data['data']);
+      return deserialize<_i19.PasskeyLoginRequest>(data['data']);
     }
     if (dataClassName == 'PasskeyPublicKeyNotFoundException') {
-      return deserialize<_i19.PasskeyPublicKeyNotFoundException>(data['data']);
+      return deserialize<_i20.PasskeyPublicKeyNotFoundException>(data['data']);
     }
     if (dataClassName == 'PasskeyRegistrationRequest') {
-      return deserialize<_i20.PasskeyRegistrationRequest>(data['data']);
+      return deserialize<_i21.PasskeyRegistrationRequest>(data['data']);
     }
     return super.deserializeByClassName(data);
   }
@@ -545,7 +374,7 @@ class Protocol extends _i1.SerializationManager {
     if (record == null) {
       return null;
     }
-    if (record is ({_i21.ByteData challenge, _i1.UuidValue id})) {
+    if (record is ({_i22.ByteData challenge, _i1.UuidValue id})) {
       return {
         "n": {
           "challenge": record.challenge.toJson(),
@@ -554,7 +383,7 @@ class Protocol extends _i1.SerializationManager {
       };
     }
     try {
-      return _i22.Protocol().mapRecordToJson(record);
+      return _i2.Protocol().mapRecordToJson(record);
     } catch (_) {}
     throw Exception('Unsupported record type ${record.runtimeType}');
   }
@@ -609,5 +438,125 @@ class Protocol extends _i1.SerializationManager {
     }
 
     return obj;
+  }
+
+  static Map<Type, dynamic Function(dynamic, Protocol)> _buildDeserializers() {
+    final map = <Type, dynamic Function(dynamic, Protocol)>{};
+    map[_i3.AnonymousAccountBlockedException] = (data, protocol) =>
+        _i3.AnonymousAccountBlockedException.fromJson(data);
+    map[_i4.AnonymousAccountBlockedExceptionReason] = (data, protocol) =>
+        _i4.AnonymousAccountBlockedExceptionReason.fromJson(data);
+    map[_i5.EmailAccountLoginException] = (data, protocol) =>
+        _i5.EmailAccountLoginException.fromJson(data);
+    map[_i6.EmailAccountLoginExceptionReason] = (data, protocol) =>
+        _i6.EmailAccountLoginExceptionReason.fromJson(data);
+    map[_i7.EmailAccountPasswordResetException] = (data, protocol) =>
+        _i7.EmailAccountPasswordResetException.fromJson(data);
+    map[_i8.EmailAccountPasswordResetExceptionReason] = (data, protocol) =>
+        _i8.EmailAccountPasswordResetExceptionReason.fromJson(data);
+    map[_i9.EmailAccountRequestException] = (data, protocol) =>
+        _i9.EmailAccountRequestException.fromJson(data);
+    map[_i10.EmailAccountRequestExceptionReason] = (data, protocol) =>
+        _i10.EmailAccountRequestExceptionReason.fromJson(data);
+    map[_i11.FacebookAccessTokenVerificationException] = (data, protocol) =>
+        _i11.FacebookAccessTokenVerificationException.fromJson(data);
+    map[_i12.FirebaseEmailNotVerifiedException] = (data, protocol) =>
+        _i12.FirebaseEmailNotVerifiedException.fromJson(data);
+    map[_i13.FirebaseIdTokenVerificationException] = (data, protocol) =>
+        _i13.FirebaseIdTokenVerificationException.fromJson(data);
+    map[_i14.GitHubAccessTokenVerificationException] = (data, protocol) =>
+        _i14.GitHubAccessTokenVerificationException.fromJson(data);
+    map[_i15.GoogleIdTokenVerificationException] = (data, protocol) =>
+        _i15.GoogleIdTokenVerificationException.fromJson(data);
+    map[_i16.MicrosoftAccessTokenVerificationException] = (data, protocol) =>
+        _i16.MicrosoftAccessTokenVerificationException.fromJson(data);
+    map[_i17.PasskeyChallengeExpiredException] = (data, protocol) =>
+        _i17.PasskeyChallengeExpiredException.fromJson(data);
+    map[_i18.PasskeyChallengeNotFoundException] = (data, protocol) =>
+        _i18.PasskeyChallengeNotFoundException.fromJson(data);
+    map[_i19.PasskeyLoginRequest] = (data, protocol) =>
+        _i19.PasskeyLoginRequest.fromJson(data);
+    map[_i20.PasskeyPublicKeyNotFoundException] = (data, protocol) =>
+        _i20.PasskeyPublicKeyNotFoundException.fromJson(data);
+    map[_i21.PasskeyRegistrationRequest] = (data, protocol) =>
+        _i21.PasskeyRegistrationRequest.fromJson(data);
+    map[_i1
+        .getType<_i3.AnonymousAccountBlockedException?>()] = (data, protocol) =>
+        (data != null
+        ? _i3.AnonymousAccountBlockedException.fromJson(data)
+        : null);
+    map[_i1.getType<_i4.AnonymousAccountBlockedExceptionReason?>()] =
+        (data, protocol) => (data != null
+        ? _i4.AnonymousAccountBlockedExceptionReason.fromJson(data)
+        : null);
+    map[_i1.getType<_i5.EmailAccountLoginException?>()] = (data, protocol) =>
+        (data != null ? _i5.EmailAccountLoginException.fromJson(data) : null);
+    map[_i1
+        .getType<_i6.EmailAccountLoginExceptionReason?>()] = (data, protocol) =>
+        (data != null
+        ? _i6.EmailAccountLoginExceptionReason.fromJson(data)
+        : null);
+    map[_i1.getType<_i7.EmailAccountPasswordResetException?>()] =
+        (data, protocol) => (data != null
+        ? _i7.EmailAccountPasswordResetException.fromJson(data)
+        : null);
+    map[_i1.getType<_i8.EmailAccountPasswordResetExceptionReason?>()] =
+        (data, protocol) => (data != null
+        ? _i8.EmailAccountPasswordResetExceptionReason.fromJson(data)
+        : null);
+    map[_i1.getType<_i9.EmailAccountRequestException?>()] = (data, protocol) =>
+        (data != null ? _i9.EmailAccountRequestException.fromJson(data) : null);
+    map[_i1.getType<_i10.EmailAccountRequestExceptionReason?>()] =
+        (data, protocol) => (data != null
+        ? _i10.EmailAccountRequestExceptionReason.fromJson(data)
+        : null);
+    map[_i1.getType<_i11.FacebookAccessTokenVerificationException?>()] =
+        (data, protocol) => (data != null
+        ? _i11.FacebookAccessTokenVerificationException.fromJson(data)
+        : null);
+    map[_i1.getType<_i12.FirebaseEmailNotVerifiedException?>()] =
+        (data, protocol) => (data != null
+        ? _i12.FirebaseEmailNotVerifiedException.fromJson(data)
+        : null);
+    map[_i1.getType<_i13.FirebaseIdTokenVerificationException?>()] =
+        (data, protocol) => (data != null
+        ? _i13.FirebaseIdTokenVerificationException.fromJson(data)
+        : null);
+    map[_i1.getType<_i14.GitHubAccessTokenVerificationException?>()] =
+        (data, protocol) => (data != null
+        ? _i14.GitHubAccessTokenVerificationException.fromJson(data)
+        : null);
+    map[_i1.getType<_i15.GoogleIdTokenVerificationException?>()] =
+        (data, protocol) => (data != null
+        ? _i15.GoogleIdTokenVerificationException.fromJson(data)
+        : null);
+    map[_i1.getType<_i16.MicrosoftAccessTokenVerificationException?>()] =
+        (data, protocol) => (data != null
+        ? _i16.MicrosoftAccessTokenVerificationException.fromJson(data)
+        : null);
+    map[_i1.getType<_i17.PasskeyChallengeExpiredException?>()] =
+        (data, protocol) => (data != null
+        ? _i17.PasskeyChallengeExpiredException.fromJson(data)
+        : null);
+    map[_i1.getType<_i18.PasskeyChallengeNotFoundException?>()] =
+        (data, protocol) => (data != null
+        ? _i18.PasskeyChallengeNotFoundException.fromJson(data)
+        : null);
+    map[_i1.getType<_i19.PasskeyLoginRequest?>()] = (data, protocol) =>
+        (data != null ? _i19.PasskeyLoginRequest.fromJson(data) : null);
+    map[_i1.getType<_i20.PasskeyPublicKeyNotFoundException?>()] =
+        (data, protocol) => (data != null
+        ? _i20.PasskeyPublicKeyNotFoundException.fromJson(data)
+        : null);
+    map[_i1.getType<_i21.PasskeyRegistrationRequest?>()] = (data, protocol) =>
+        (data != null ? _i21.PasskeyRegistrationRequest.fromJson(data) : null);
+    map[_i1.getType<({_i22.ByteData challenge, _i1.UuidValue id})>()] =
+        (data, protocol) => (
+          challenge: protocol.deserialize<_i22.ByteData>(
+            ((data as Map)['n'] as Map)['challenge'],
+          ),
+          id: protocol.deserialize<_i1.UuidValue>(data['n']['id']),
+        );
+    return map;
   }
 }

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/generated/protocol.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/generated/protocol.dart
@@ -1063,6 +1063,195 @@ class Protocol extends _i1.DatabaseSerializationManager {
 
   final Map<String, _i1.SerializationManager> _hostProtocols = {};
 
+  static final Map<Type, dynamic Function(dynamic, Protocol)> _deserializers =
+      _buildDeserializers();
+
+  static Map<Type, dynamic Function(dynamic, Protocol)> _buildDeserializers() {
+    final map = <Type, dynamic Function(dynamic, Protocol)>{};
+    map[_i4.RateLimitedRequestAttempt] = (data, protocol) =>
+        _i4.RateLimitedRequestAttempt.fromJson(data);
+    map[_i5.SecretChallenge] = (data, protocol) =>
+        _i5.SecretChallenge.fromJson(data);
+    map[_i6.AnonymousAccount] = (data, protocol) =>
+        _i6.AnonymousAccount.fromJson(data);
+    map[_i7.AnonymousAccountBlockedException] = (data, protocol) =>
+        _i7.AnonymousAccountBlockedException.fromJson(data);
+    map[_i8.AnonymousAccountBlockedExceptionReason] = (data, protocol) =>
+        _i8.AnonymousAccountBlockedExceptionReason.fromJson(data);
+    map[_i9.AppleAccount] = (data, protocol) => _i9.AppleAccount.fromJson(data);
+    map[_i10.EmailAccount] = (data, protocol) =>
+        _i10.EmailAccount.fromJson(data);
+    map[_i11.EmailAccountPasswordResetRequest] = (data, protocol) =>
+        _i11.EmailAccountPasswordResetRequest.fromJson(data);
+    map[_i12.EmailAccountRequest] = (data, protocol) =>
+        _i12.EmailAccountRequest.fromJson(data);
+    map[_i13.EmailAccountLoginException] = (data, protocol) =>
+        _i13.EmailAccountLoginException.fromJson(data);
+    map[_i14.EmailAccountLoginExceptionReason] = (data, protocol) =>
+        _i14.EmailAccountLoginExceptionReason.fromJson(data);
+    map[_i15.EmailAccountPasswordResetException] = (data, protocol) =>
+        _i15.EmailAccountPasswordResetException.fromJson(data);
+    map[_i16.EmailAccountPasswordResetExceptionReason] = (data, protocol) =>
+        _i16.EmailAccountPasswordResetExceptionReason.fromJson(data);
+    map[_i17.EmailAccountRequestException] = (data, protocol) =>
+        _i17.EmailAccountRequestException.fromJson(data);
+    map[_i18.EmailAccountRequestExceptionReason] = (data, protocol) =>
+        _i18.EmailAccountRequestExceptionReason.fromJson(data);
+    map[_i19.FacebookAccessTokenVerificationException] = (data, protocol) =>
+        _i19.FacebookAccessTokenVerificationException.fromJson(data);
+    map[_i20.FacebookAccount] = (data, protocol) =>
+        _i20.FacebookAccount.fromJson(data);
+    map[_i21.FirebaseAccount] = (data, protocol) =>
+        _i21.FirebaseAccount.fromJson(data);
+    map[_i22.FirebaseIdTokenVerificationException] = (data, protocol) =>
+        _i22.FirebaseIdTokenVerificationException.fromJson(data);
+    map[_i23.GitHubAccessTokenVerificationException] = (data, protocol) =>
+        _i23.GitHubAccessTokenVerificationException.fromJson(data);
+    map[_i24.GitHubAccount] = (data, protocol) =>
+        _i24.GitHubAccount.fromJson(data);
+    map[_i25.GoogleAccount] = (data, protocol) =>
+        _i25.GoogleAccount.fromJson(data);
+    map[_i26.GoogleIdTokenVerificationException] = (data, protocol) =>
+        _i26.GoogleIdTokenVerificationException.fromJson(data);
+    map[_i27.MicrosoftAccessTokenVerificationException] = (data, protocol) =>
+        _i27.MicrosoftAccessTokenVerificationException.fromJson(data);
+    map[_i28.MicrosoftAccount] = (data, protocol) =>
+        _i28.MicrosoftAccount.fromJson(data);
+    map[_i29.PasskeyAccount] = (data, protocol) =>
+        _i29.PasskeyAccount.fromJson(data);
+    map[_i30.PasskeyChallenge] = (data, protocol) =>
+        _i30.PasskeyChallenge.fromJson(data);
+    map[_i31.PasskeyChallengeExpiredException] = (data, protocol) =>
+        _i31.PasskeyChallengeExpiredException.fromJson(data);
+    map[_i32.PasskeyChallengeNotFoundException] = (data, protocol) =>
+        _i32.PasskeyChallengeNotFoundException.fromJson(data);
+    map[_i33.PasskeyLoginRequest] = (data, protocol) =>
+        _i33.PasskeyLoginRequest.fromJson(data);
+    map[_i34.PasskeyPublicKeyNotFoundException] = (data, protocol) =>
+        _i34.PasskeyPublicKeyNotFoundException.fromJson(data);
+    map[_i35.PasskeyRegistrationRequest] = (data, protocol) =>
+        _i35.PasskeyRegistrationRequest.fromJson(data);
+    map[_i1.getType<_i4.RateLimitedRequestAttempt?>()] = (data, protocol) =>
+        (data != null ? _i4.RateLimitedRequestAttempt.fromJson(data) : null);
+    map[_i1.getType<_i5.SecretChallenge?>()] = (data, protocol) =>
+        (data != null ? _i5.SecretChallenge.fromJson(data) : null);
+    map[_i1.getType<_i6.AnonymousAccount?>()] = (data, protocol) =>
+        (data != null ? _i6.AnonymousAccount.fromJson(data) : null);
+    map[_i1
+        .getType<_i7.AnonymousAccountBlockedException?>()] = (data, protocol) =>
+        (data != null
+        ? _i7.AnonymousAccountBlockedException.fromJson(data)
+        : null);
+    map[_i1.getType<_i8.AnonymousAccountBlockedExceptionReason?>()] =
+        (data, protocol) => (data != null
+        ? _i8.AnonymousAccountBlockedExceptionReason.fromJson(data)
+        : null);
+    map[_i1.getType<_i9.AppleAccount?>()] = (data, protocol) =>
+        (data != null ? _i9.AppleAccount.fromJson(data) : null);
+    map[_i1.getType<_i10.EmailAccount?>()] = (data, protocol) =>
+        (data != null ? _i10.EmailAccount.fromJson(data) : null);
+    map[_i1.getType<_i11.EmailAccountPasswordResetRequest?>()] =
+        (data, protocol) => (data != null
+        ? _i11.EmailAccountPasswordResetRequest.fromJson(data)
+        : null);
+    map[_i1.getType<_i12.EmailAccountRequest?>()] = (data, protocol) =>
+        (data != null ? _i12.EmailAccountRequest.fromJson(data) : null);
+    map[_i1.getType<_i13.EmailAccountLoginException?>()] = (data, protocol) =>
+        (data != null ? _i13.EmailAccountLoginException.fromJson(data) : null);
+    map[_i1.getType<_i14.EmailAccountLoginExceptionReason?>()] =
+        (data, protocol) => (data != null
+        ? _i14.EmailAccountLoginExceptionReason.fromJson(data)
+        : null);
+    map[_i1.getType<_i15.EmailAccountPasswordResetException?>()] =
+        (data, protocol) => (data != null
+        ? _i15.EmailAccountPasswordResetException.fromJson(data)
+        : null);
+    map[_i1.getType<_i16.EmailAccountPasswordResetExceptionReason?>()] =
+        (data, protocol) => (data != null
+        ? _i16.EmailAccountPasswordResetExceptionReason.fromJson(data)
+        : null);
+    map[_i1.getType<_i17.EmailAccountRequestException?>()] = (data, protocol) =>
+        (data != null
+        ? _i17.EmailAccountRequestException.fromJson(data)
+        : null);
+    map[_i1.getType<_i18.EmailAccountRequestExceptionReason?>()] =
+        (data, protocol) => (data != null
+        ? _i18.EmailAccountRequestExceptionReason.fromJson(data)
+        : null);
+    map[_i1.getType<_i19.FacebookAccessTokenVerificationException?>()] =
+        (data, protocol) => (data != null
+        ? _i19.FacebookAccessTokenVerificationException.fromJson(data)
+        : null);
+    map[_i1.getType<_i20.FacebookAccount?>()] = (data, protocol) =>
+        (data != null ? _i20.FacebookAccount.fromJson(data) : null);
+    map[_i1.getType<_i21.FirebaseAccount?>()] = (data, protocol) =>
+        (data != null ? _i21.FirebaseAccount.fromJson(data) : null);
+    map[_i1.getType<_i22.FirebaseIdTokenVerificationException?>()] =
+        (data, protocol) => (data != null
+        ? _i22.FirebaseIdTokenVerificationException.fromJson(data)
+        : null);
+    map[_i1.getType<_i23.GitHubAccessTokenVerificationException?>()] =
+        (data, protocol) => (data != null
+        ? _i23.GitHubAccessTokenVerificationException.fromJson(data)
+        : null);
+    map[_i1.getType<_i24.GitHubAccount?>()] = (data, protocol) =>
+        (data != null ? _i24.GitHubAccount.fromJson(data) : null);
+    map[_i1.getType<_i25.GoogleAccount?>()] = (data, protocol) =>
+        (data != null ? _i25.GoogleAccount.fromJson(data) : null);
+    map[_i1.getType<_i26.GoogleIdTokenVerificationException?>()] =
+        (data, protocol) => (data != null
+        ? _i26.GoogleIdTokenVerificationException.fromJson(data)
+        : null);
+    map[_i1.getType<_i27.MicrosoftAccessTokenVerificationException?>()] =
+        (data, protocol) => (data != null
+        ? _i27.MicrosoftAccessTokenVerificationException.fromJson(data)
+        : null);
+    map[_i1.getType<_i28.MicrosoftAccount?>()] = (data, protocol) =>
+        (data != null ? _i28.MicrosoftAccount.fromJson(data) : null);
+    map[_i1.getType<_i29.PasskeyAccount?>()] = (data, protocol) =>
+        (data != null ? _i29.PasskeyAccount.fromJson(data) : null);
+    map[_i1.getType<_i30.PasskeyChallenge?>()] = (data, protocol) =>
+        (data != null ? _i30.PasskeyChallenge.fromJson(data) : null);
+    map[_i1.getType<_i31.PasskeyChallengeExpiredException?>()] =
+        (data, protocol) => (data != null
+        ? _i31.PasskeyChallengeExpiredException.fromJson(data)
+        : null);
+    map[_i1.getType<_i32.PasskeyChallengeNotFoundException?>()] =
+        (data, protocol) => (data != null
+        ? _i32.PasskeyChallengeNotFoundException.fromJson(data)
+        : null);
+    map[_i1.getType<_i33.PasskeyLoginRequest?>()] = (data, protocol) =>
+        (data != null ? _i33.PasskeyLoginRequest.fromJson(data) : null);
+    map[_i1.getType<_i34.PasskeyPublicKeyNotFoundException?>()] =
+        (data, protocol) => (data != null
+        ? _i34.PasskeyPublicKeyNotFoundException.fromJson(data)
+        : null);
+    map[_i1.getType<_i35.PasskeyRegistrationRequest?>()] = (data, protocol) =>
+        (data != null ? _i35.PasskeyRegistrationRequest.fromJson(data) : null);
+    map[Map<String, String>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<String>(v),
+      ),
+    );
+    map[_i1.getType<Map<String, String>?>()] = (data, protocol) => (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<String>(v),
+            ),
+          )
+        : null);
+    map[_i1.getType<({_i36.ByteData challenge, _i1.UuidValue id})>()] =
+        (data, protocol) => (
+          challenge: protocol.deserialize<_i36.ByteData>(
+            ((data as Map)['n'] as Map)['challenge'],
+          ),
+          id: protocol.deserialize<_i1.UuidValue>(data['n']['id']),
+        );
+    return map;
+  }
+
   void registerHostProtocol(
     String projectName,
     _i1.SerializationManager protocol,
@@ -1099,280 +1288,9 @@ class Protocol extends _i1.DatabaseSerializationManager {
       }
     }
 
-    if (t == _i4.RateLimitedRequestAttempt) {
-      return _i4.RateLimitedRequestAttempt.fromJson(data) as T;
-    }
-    if (t == _i5.SecretChallenge) {
-      return _i5.SecretChallenge.fromJson(data) as T;
-    }
-    if (t == _i6.AnonymousAccount) {
-      return _i6.AnonymousAccount.fromJson(data) as T;
-    }
-    if (t == _i7.AnonymousAccountBlockedException) {
-      return _i7.AnonymousAccountBlockedException.fromJson(data) as T;
-    }
-    if (t == _i8.AnonymousAccountBlockedExceptionReason) {
-      return _i8.AnonymousAccountBlockedExceptionReason.fromJson(data) as T;
-    }
-    if (t == _i9.AppleAccount) {
-      return _i9.AppleAccount.fromJson(data) as T;
-    }
-    if (t == _i10.EmailAccount) {
-      return _i10.EmailAccount.fromJson(data) as T;
-    }
-    if (t == _i11.EmailAccountPasswordResetRequest) {
-      return _i11.EmailAccountPasswordResetRequest.fromJson(data) as T;
-    }
-    if (t == _i12.EmailAccountRequest) {
-      return _i12.EmailAccountRequest.fromJson(data) as T;
-    }
-    if (t == _i13.EmailAccountLoginException) {
-      return _i13.EmailAccountLoginException.fromJson(data) as T;
-    }
-    if (t == _i14.EmailAccountLoginExceptionReason) {
-      return _i14.EmailAccountLoginExceptionReason.fromJson(data) as T;
-    }
-    if (t == _i15.EmailAccountPasswordResetException) {
-      return _i15.EmailAccountPasswordResetException.fromJson(data) as T;
-    }
-    if (t == _i16.EmailAccountPasswordResetExceptionReason) {
-      return _i16.EmailAccountPasswordResetExceptionReason.fromJson(data) as T;
-    }
-    if (t == _i17.EmailAccountRequestException) {
-      return _i17.EmailAccountRequestException.fromJson(data) as T;
-    }
-    if (t == _i18.EmailAccountRequestExceptionReason) {
-      return _i18.EmailAccountRequestExceptionReason.fromJson(data) as T;
-    }
-    if (t == _i19.FacebookAccessTokenVerificationException) {
-      return _i19.FacebookAccessTokenVerificationException.fromJson(data) as T;
-    }
-    if (t == _i20.FacebookAccount) {
-      return _i20.FacebookAccount.fromJson(data) as T;
-    }
-    if (t == _i21.FirebaseAccount) {
-      return _i21.FirebaseAccount.fromJson(data) as T;
-    }
-    if (t == _i22.FirebaseIdTokenVerificationException) {
-      return _i22.FirebaseIdTokenVerificationException.fromJson(data) as T;
-    }
-    if (t == _i23.GitHubAccessTokenVerificationException) {
-      return _i23.GitHubAccessTokenVerificationException.fromJson(data) as T;
-    }
-    if (t == _i24.GitHubAccount) {
-      return _i24.GitHubAccount.fromJson(data) as T;
-    }
-    if (t == _i25.GoogleAccount) {
-      return _i25.GoogleAccount.fromJson(data) as T;
-    }
-    if (t == _i26.GoogleIdTokenVerificationException) {
-      return _i26.GoogleIdTokenVerificationException.fromJson(data) as T;
-    }
-    if (t == _i27.MicrosoftAccessTokenVerificationException) {
-      return _i27.MicrosoftAccessTokenVerificationException.fromJson(data) as T;
-    }
-    if (t == _i28.MicrosoftAccount) {
-      return _i28.MicrosoftAccount.fromJson(data) as T;
-    }
-    if (t == _i29.PasskeyAccount) {
-      return _i29.PasskeyAccount.fromJson(data) as T;
-    }
-    if (t == _i30.PasskeyChallenge) {
-      return _i30.PasskeyChallenge.fromJson(data) as T;
-    }
-    if (t == _i31.PasskeyChallengeExpiredException) {
-      return _i31.PasskeyChallengeExpiredException.fromJson(data) as T;
-    }
-    if (t == _i32.PasskeyChallengeNotFoundException) {
-      return _i32.PasskeyChallengeNotFoundException.fromJson(data) as T;
-    }
-    if (t == _i33.PasskeyLoginRequest) {
-      return _i33.PasskeyLoginRequest.fromJson(data) as T;
-    }
-    if (t == _i34.PasskeyPublicKeyNotFoundException) {
-      return _i34.PasskeyPublicKeyNotFoundException.fromJson(data) as T;
-    }
-    if (t == _i35.PasskeyRegistrationRequest) {
-      return _i35.PasskeyRegistrationRequest.fromJson(data) as T;
-    }
-    if (t == _i1.getType<_i4.RateLimitedRequestAttempt?>()) {
-      return (data != null
-              ? _i4.RateLimitedRequestAttempt.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i5.SecretChallenge?>()) {
-      return (data != null ? _i5.SecretChallenge.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i6.AnonymousAccount?>()) {
-      return (data != null ? _i6.AnonymousAccount.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i7.AnonymousAccountBlockedException?>()) {
-      return (data != null
-              ? _i7.AnonymousAccountBlockedException.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i8.AnonymousAccountBlockedExceptionReason?>()) {
-      return (data != null
-              ? _i8.AnonymousAccountBlockedExceptionReason.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i9.AppleAccount?>()) {
-      return (data != null ? _i9.AppleAccount.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i10.EmailAccount?>()) {
-      return (data != null ? _i10.EmailAccount.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i11.EmailAccountPasswordResetRequest?>()) {
-      return (data != null
-              ? _i11.EmailAccountPasswordResetRequest.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i12.EmailAccountRequest?>()) {
-      return (data != null ? _i12.EmailAccountRequest.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i13.EmailAccountLoginException?>()) {
-      return (data != null
-              ? _i13.EmailAccountLoginException.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i14.EmailAccountLoginExceptionReason?>()) {
-      return (data != null
-              ? _i14.EmailAccountLoginExceptionReason.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i15.EmailAccountPasswordResetException?>()) {
-      return (data != null
-              ? _i15.EmailAccountPasswordResetException.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i16.EmailAccountPasswordResetExceptionReason?>()) {
-      return (data != null
-              ? _i16.EmailAccountPasswordResetExceptionReason.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i17.EmailAccountRequestException?>()) {
-      return (data != null
-              ? _i17.EmailAccountRequestException.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i18.EmailAccountRequestExceptionReason?>()) {
-      return (data != null
-              ? _i18.EmailAccountRequestExceptionReason.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i19.FacebookAccessTokenVerificationException?>()) {
-      return (data != null
-              ? _i19.FacebookAccessTokenVerificationException.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i20.FacebookAccount?>()) {
-      return (data != null ? _i20.FacebookAccount.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i21.FirebaseAccount?>()) {
-      return (data != null ? _i21.FirebaseAccount.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i22.FirebaseIdTokenVerificationException?>()) {
-      return (data != null
-              ? _i22.FirebaseIdTokenVerificationException.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i23.GitHubAccessTokenVerificationException?>()) {
-      return (data != null
-              ? _i23.GitHubAccessTokenVerificationException.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i24.GitHubAccount?>()) {
-      return (data != null ? _i24.GitHubAccount.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i25.GoogleAccount?>()) {
-      return (data != null ? _i25.GoogleAccount.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i26.GoogleIdTokenVerificationException?>()) {
-      return (data != null
-              ? _i26.GoogleIdTokenVerificationException.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i27.MicrosoftAccessTokenVerificationException?>()) {
-      return (data != null
-              ? _i27.MicrosoftAccessTokenVerificationException.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i28.MicrosoftAccount?>()) {
-      return (data != null ? _i28.MicrosoftAccount.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i29.PasskeyAccount?>()) {
-      return (data != null ? _i29.PasskeyAccount.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i30.PasskeyChallenge?>()) {
-      return (data != null ? _i30.PasskeyChallenge.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i31.PasskeyChallengeExpiredException?>()) {
-      return (data != null
-              ? _i31.PasskeyChallengeExpiredException.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i32.PasskeyChallengeNotFoundException?>()) {
-      return (data != null
-              ? _i32.PasskeyChallengeNotFoundException.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i33.PasskeyLoginRequest?>()) {
-      return (data != null ? _i33.PasskeyLoginRequest.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i34.PasskeyPublicKeyNotFoundException?>()) {
-      return (data != null
-              ? _i34.PasskeyPublicKeyNotFoundException.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i35.PasskeyRegistrationRequest?>()) {
-      return (data != null
-              ? _i35.PasskeyRegistrationRequest.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == Map<String, String>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(deserialize<String>(k), deserialize<String>(v)),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<String, String>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) =>
-                      MapEntry(deserialize<String>(k), deserialize<String>(v)),
-                )
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<({_i36.ByteData challenge, _i1.UuidValue id})>()) {
-      return (
-            challenge: deserialize<_i36.ByteData>(
-              ((data as Map)['n'] as Map)['challenge'],
-            ),
-            id: deserialize<_i1.UuidValue>(data['n']['id']),
-          )
-          as T;
+    final fn = _deserializers[t];
+    if (fn != null) {
+      return fn(data, this) as T;
     }
     try {
       return _i3.Protocol().deserialize<T>(data, t);

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/generated/protocol.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/generated/protocol.dart
@@ -111,6 +111,9 @@ class Protocol extends _i1.DatabaseSerializationManager {
 
   final Set<_i1.SerializationManager> _hostProtocols = {};
 
+  static final Map<Type, dynamic Function(dynamic, Protocol)> _deserializers =
+      _buildDeserializers();
+
   static List<_i2.TableDefinition> get targetTableDefinitions => [
     _i2.TableDefinition(
       name: 'serverpod_auth_idp_anonymous_account',
@@ -1103,289 +1106,9 @@ class Protocol extends _i1.DatabaseSerializationManager {
       }
     }
 
-    if (t == _i4.RateLimitedRequestAttempt) {
-      return _i4.RateLimitedRequestAttempt.fromJson(data) as T;
-    }
-    if (t == _i5.SecretChallenge) {
-      return _i5.SecretChallenge.fromJson(data) as T;
-    }
-    if (t == _i6.AnonymousAccount) {
-      return _i6.AnonymousAccount.fromJson(data) as T;
-    }
-    if (t == _i7.AnonymousAccountBlockedException) {
-      return _i7.AnonymousAccountBlockedException.fromJson(data) as T;
-    }
-    if (t == _i8.AnonymousAccountBlockedExceptionReason) {
-      return _i8.AnonymousAccountBlockedExceptionReason.fromJson(data) as T;
-    }
-    if (t == _i9.AppleAccount) {
-      return _i9.AppleAccount.fromJson(data) as T;
-    }
-    if (t == _i10.EmailAccount) {
-      return _i10.EmailAccount.fromJson(data) as T;
-    }
-    if (t == _i11.EmailAccountPasswordResetRequest) {
-      return _i11.EmailAccountPasswordResetRequest.fromJson(data) as T;
-    }
-    if (t == _i12.EmailAccountRequest) {
-      return _i12.EmailAccountRequest.fromJson(data) as T;
-    }
-    if (t == _i13.EmailAccountLoginException) {
-      return _i13.EmailAccountLoginException.fromJson(data) as T;
-    }
-    if (t == _i14.EmailAccountLoginExceptionReason) {
-      return _i14.EmailAccountLoginExceptionReason.fromJson(data) as T;
-    }
-    if (t == _i15.EmailAccountPasswordResetException) {
-      return _i15.EmailAccountPasswordResetException.fromJson(data) as T;
-    }
-    if (t == _i16.EmailAccountPasswordResetExceptionReason) {
-      return _i16.EmailAccountPasswordResetExceptionReason.fromJson(data) as T;
-    }
-    if (t == _i17.EmailAccountRequestException) {
-      return _i17.EmailAccountRequestException.fromJson(data) as T;
-    }
-    if (t == _i18.EmailAccountRequestExceptionReason) {
-      return _i18.EmailAccountRequestExceptionReason.fromJson(data) as T;
-    }
-    if (t == _i19.FacebookAccessTokenVerificationException) {
-      return _i19.FacebookAccessTokenVerificationException.fromJson(data) as T;
-    }
-    if (t == _i20.FacebookAccount) {
-      return _i20.FacebookAccount.fromJson(data) as T;
-    }
-    if (t == _i21.FirebaseAccount) {
-      return _i21.FirebaseAccount.fromJson(data) as T;
-    }
-    if (t == _i22.FirebaseEmailNotVerifiedException) {
-      return _i22.FirebaseEmailNotVerifiedException.fromJson(data) as T;
-    }
-    if (t == _i23.FirebaseIdTokenVerificationException) {
-      return _i23.FirebaseIdTokenVerificationException.fromJson(data) as T;
-    }
-    if (t == _i24.GitHubAccessTokenVerificationException) {
-      return _i24.GitHubAccessTokenVerificationException.fromJson(data) as T;
-    }
-    if (t == _i25.GitHubAccount) {
-      return _i25.GitHubAccount.fromJson(data) as T;
-    }
-    if (t == _i26.GoogleAccount) {
-      return _i26.GoogleAccount.fromJson(data) as T;
-    }
-    if (t == _i27.GoogleIdTokenVerificationException) {
-      return _i27.GoogleIdTokenVerificationException.fromJson(data) as T;
-    }
-    if (t == _i28.MicrosoftAccessTokenVerificationException) {
-      return _i28.MicrosoftAccessTokenVerificationException.fromJson(data) as T;
-    }
-    if (t == _i29.MicrosoftAccount) {
-      return _i29.MicrosoftAccount.fromJson(data) as T;
-    }
-    if (t == _i30.PasskeyAccount) {
-      return _i30.PasskeyAccount.fromJson(data) as T;
-    }
-    if (t == _i31.PasskeyChallenge) {
-      return _i31.PasskeyChallenge.fromJson(data) as T;
-    }
-    if (t == _i32.PasskeyChallengeExpiredException) {
-      return _i32.PasskeyChallengeExpiredException.fromJson(data) as T;
-    }
-    if (t == _i33.PasskeyChallengeNotFoundException) {
-      return _i33.PasskeyChallengeNotFoundException.fromJson(data) as T;
-    }
-    if (t == _i34.PasskeyLoginRequest) {
-      return _i34.PasskeyLoginRequest.fromJson(data) as T;
-    }
-    if (t == _i35.PasskeyPublicKeyNotFoundException) {
-      return _i35.PasskeyPublicKeyNotFoundException.fromJson(data) as T;
-    }
-    if (t == _i36.PasskeyRegistrationRequest) {
-      return _i36.PasskeyRegistrationRequest.fromJson(data) as T;
-    }
-    if (t == _i1.getType<_i4.RateLimitedRequestAttempt?>()) {
-      return (data != null
-              ? _i4.RateLimitedRequestAttempt.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i5.SecretChallenge?>()) {
-      return (data != null ? _i5.SecretChallenge.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i6.AnonymousAccount?>()) {
-      return (data != null ? _i6.AnonymousAccount.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i7.AnonymousAccountBlockedException?>()) {
-      return (data != null
-              ? _i7.AnonymousAccountBlockedException.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i8.AnonymousAccountBlockedExceptionReason?>()) {
-      return (data != null
-              ? _i8.AnonymousAccountBlockedExceptionReason.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i9.AppleAccount?>()) {
-      return (data != null ? _i9.AppleAccount.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i10.EmailAccount?>()) {
-      return (data != null ? _i10.EmailAccount.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i11.EmailAccountPasswordResetRequest?>()) {
-      return (data != null
-              ? _i11.EmailAccountPasswordResetRequest.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i12.EmailAccountRequest?>()) {
-      return (data != null ? _i12.EmailAccountRequest.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i13.EmailAccountLoginException?>()) {
-      return (data != null
-              ? _i13.EmailAccountLoginException.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i14.EmailAccountLoginExceptionReason?>()) {
-      return (data != null
-              ? _i14.EmailAccountLoginExceptionReason.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i15.EmailAccountPasswordResetException?>()) {
-      return (data != null
-              ? _i15.EmailAccountPasswordResetException.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i16.EmailAccountPasswordResetExceptionReason?>()) {
-      return (data != null
-              ? _i16.EmailAccountPasswordResetExceptionReason.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i17.EmailAccountRequestException?>()) {
-      return (data != null
-              ? _i17.EmailAccountRequestException.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i18.EmailAccountRequestExceptionReason?>()) {
-      return (data != null
-              ? _i18.EmailAccountRequestExceptionReason.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i19.FacebookAccessTokenVerificationException?>()) {
-      return (data != null
-              ? _i19.FacebookAccessTokenVerificationException.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i20.FacebookAccount?>()) {
-      return (data != null ? _i20.FacebookAccount.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i21.FirebaseAccount?>()) {
-      return (data != null ? _i21.FirebaseAccount.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i22.FirebaseEmailNotVerifiedException?>()) {
-      return (data != null
-              ? _i22.FirebaseEmailNotVerifiedException.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i23.FirebaseIdTokenVerificationException?>()) {
-      return (data != null
-              ? _i23.FirebaseIdTokenVerificationException.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i24.GitHubAccessTokenVerificationException?>()) {
-      return (data != null
-              ? _i24.GitHubAccessTokenVerificationException.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i25.GitHubAccount?>()) {
-      return (data != null ? _i25.GitHubAccount.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i26.GoogleAccount?>()) {
-      return (data != null ? _i26.GoogleAccount.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i27.GoogleIdTokenVerificationException?>()) {
-      return (data != null
-              ? _i27.GoogleIdTokenVerificationException.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i28.MicrosoftAccessTokenVerificationException?>()) {
-      return (data != null
-              ? _i28.MicrosoftAccessTokenVerificationException.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i29.MicrosoftAccount?>()) {
-      return (data != null ? _i29.MicrosoftAccount.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i30.PasskeyAccount?>()) {
-      return (data != null ? _i30.PasskeyAccount.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i31.PasskeyChallenge?>()) {
-      return (data != null ? _i31.PasskeyChallenge.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i32.PasskeyChallengeExpiredException?>()) {
-      return (data != null
-              ? _i32.PasskeyChallengeExpiredException.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i33.PasskeyChallengeNotFoundException?>()) {
-      return (data != null
-              ? _i33.PasskeyChallengeNotFoundException.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i34.PasskeyLoginRequest?>()) {
-      return (data != null ? _i34.PasskeyLoginRequest.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i35.PasskeyPublicKeyNotFoundException?>()) {
-      return (data != null
-              ? _i35.PasskeyPublicKeyNotFoundException.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i36.PasskeyRegistrationRequest?>()) {
-      return (data != null
-              ? _i36.PasskeyRegistrationRequest.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == Map<String, String>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(deserialize<String>(k), deserialize<String>(v)),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<String, String>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) =>
-                      MapEntry(deserialize<String>(k), deserialize<String>(v)),
-                )
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<({_i37.ByteData challenge, _i1.UuidValue id})>()) {
-      return (
-            challenge: deserialize<_i37.ByteData>(
-              ((data as Map)['n'] as Map)['challenge'],
-            ),
-            id: deserialize<_i1.UuidValue>(data['n']['id']),
-          )
-          as T;
+    final fn = _deserializers[t];
+    if (fn != null) {
+      return fn(data, this) as T;
     }
     try {
       return _i3.Protocol().deserialize<T>(data, t);
@@ -1848,5 +1571,197 @@ class Protocol extends _i1.DatabaseSerializationManager {
     }
 
     return obj;
+  }
+
+  static Map<Type, dynamic Function(dynamic, Protocol)> _buildDeserializers() {
+    final map = <Type, dynamic Function(dynamic, Protocol)>{};
+    map[_i4.RateLimitedRequestAttempt] = (data, protocol) =>
+        _i4.RateLimitedRequestAttempt.fromJson(data);
+    map[_i5.SecretChallenge] = (data, protocol) =>
+        _i5.SecretChallenge.fromJson(data);
+    map[_i6.AnonymousAccount] = (data, protocol) =>
+        _i6.AnonymousAccount.fromJson(data);
+    map[_i7.AnonymousAccountBlockedException] = (data, protocol) =>
+        _i7.AnonymousAccountBlockedException.fromJson(data);
+    map[_i8.AnonymousAccountBlockedExceptionReason] = (data, protocol) =>
+        _i8.AnonymousAccountBlockedExceptionReason.fromJson(data);
+    map[_i9.AppleAccount] = (data, protocol) => _i9.AppleAccount.fromJson(data);
+    map[_i10.EmailAccount] = (data, protocol) =>
+        _i10.EmailAccount.fromJson(data);
+    map[_i11.EmailAccountPasswordResetRequest] = (data, protocol) =>
+        _i11.EmailAccountPasswordResetRequest.fromJson(data);
+    map[_i12.EmailAccountRequest] = (data, protocol) =>
+        _i12.EmailAccountRequest.fromJson(data);
+    map[_i13.EmailAccountLoginException] = (data, protocol) =>
+        _i13.EmailAccountLoginException.fromJson(data);
+    map[_i14.EmailAccountLoginExceptionReason] = (data, protocol) =>
+        _i14.EmailAccountLoginExceptionReason.fromJson(data);
+    map[_i15.EmailAccountPasswordResetException] = (data, protocol) =>
+        _i15.EmailAccountPasswordResetException.fromJson(data);
+    map[_i16.EmailAccountPasswordResetExceptionReason] = (data, protocol) =>
+        _i16.EmailAccountPasswordResetExceptionReason.fromJson(data);
+    map[_i17.EmailAccountRequestException] = (data, protocol) =>
+        _i17.EmailAccountRequestException.fromJson(data);
+    map[_i18.EmailAccountRequestExceptionReason] = (data, protocol) =>
+        _i18.EmailAccountRequestExceptionReason.fromJson(data);
+    map[_i19.FacebookAccessTokenVerificationException] = (data, protocol) =>
+        _i19.FacebookAccessTokenVerificationException.fromJson(data);
+    map[_i20.FacebookAccount] = (data, protocol) =>
+        _i20.FacebookAccount.fromJson(data);
+    map[_i21.FirebaseAccount] = (data, protocol) =>
+        _i21.FirebaseAccount.fromJson(data);
+    map[_i22.FirebaseEmailNotVerifiedException] = (data, protocol) =>
+        _i22.FirebaseEmailNotVerifiedException.fromJson(data);
+    map[_i23.FirebaseIdTokenVerificationException] = (data, protocol) =>
+        _i23.FirebaseIdTokenVerificationException.fromJson(data);
+    map[_i24.GitHubAccessTokenVerificationException] = (data, protocol) =>
+        _i24.GitHubAccessTokenVerificationException.fromJson(data);
+    map[_i25.GitHubAccount] = (data, protocol) =>
+        _i25.GitHubAccount.fromJson(data);
+    map[_i26.GoogleAccount] = (data, protocol) =>
+        _i26.GoogleAccount.fromJson(data);
+    map[_i27.GoogleIdTokenVerificationException] = (data, protocol) =>
+        _i27.GoogleIdTokenVerificationException.fromJson(data);
+    map[_i28.MicrosoftAccessTokenVerificationException] = (data, protocol) =>
+        _i28.MicrosoftAccessTokenVerificationException.fromJson(data);
+    map[_i29.MicrosoftAccount] = (data, protocol) =>
+        _i29.MicrosoftAccount.fromJson(data);
+    map[_i30.PasskeyAccount] = (data, protocol) =>
+        _i30.PasskeyAccount.fromJson(data);
+    map[_i31.PasskeyChallenge] = (data, protocol) =>
+        _i31.PasskeyChallenge.fromJson(data);
+    map[_i32.PasskeyChallengeExpiredException] = (data, protocol) =>
+        _i32.PasskeyChallengeExpiredException.fromJson(data);
+    map[_i33.PasskeyChallengeNotFoundException] = (data, protocol) =>
+        _i33.PasskeyChallengeNotFoundException.fromJson(data);
+    map[_i34.PasskeyLoginRequest] = (data, protocol) =>
+        _i34.PasskeyLoginRequest.fromJson(data);
+    map[_i35.PasskeyPublicKeyNotFoundException] = (data, protocol) =>
+        _i35.PasskeyPublicKeyNotFoundException.fromJson(data);
+    map[_i36.PasskeyRegistrationRequest] = (data, protocol) =>
+        _i36.PasskeyRegistrationRequest.fromJson(data);
+    map[_i1.getType<_i4.RateLimitedRequestAttempt?>()] = (data, protocol) =>
+        (data != null ? _i4.RateLimitedRequestAttempt.fromJson(data) : null);
+    map[_i1.getType<_i5.SecretChallenge?>()] = (data, protocol) =>
+        (data != null ? _i5.SecretChallenge.fromJson(data) : null);
+    map[_i1.getType<_i6.AnonymousAccount?>()] = (data, protocol) =>
+        (data != null ? _i6.AnonymousAccount.fromJson(data) : null);
+    map[_i1
+        .getType<_i7.AnonymousAccountBlockedException?>()] = (data, protocol) =>
+        (data != null
+        ? _i7.AnonymousAccountBlockedException.fromJson(data)
+        : null);
+    map[_i1.getType<_i8.AnonymousAccountBlockedExceptionReason?>()] =
+        (data, protocol) => (data != null
+        ? _i8.AnonymousAccountBlockedExceptionReason.fromJson(data)
+        : null);
+    map[_i1.getType<_i9.AppleAccount?>()] = (data, protocol) =>
+        (data != null ? _i9.AppleAccount.fromJson(data) : null);
+    map[_i1.getType<_i10.EmailAccount?>()] = (data, protocol) =>
+        (data != null ? _i10.EmailAccount.fromJson(data) : null);
+    map[_i1.getType<_i11.EmailAccountPasswordResetRequest?>()] =
+        (data, protocol) => (data != null
+        ? _i11.EmailAccountPasswordResetRequest.fromJson(data)
+        : null);
+    map[_i1.getType<_i12.EmailAccountRequest?>()] = (data, protocol) =>
+        (data != null ? _i12.EmailAccountRequest.fromJson(data) : null);
+    map[_i1.getType<_i13.EmailAccountLoginException?>()] = (data, protocol) =>
+        (data != null ? _i13.EmailAccountLoginException.fromJson(data) : null);
+    map[_i1.getType<_i14.EmailAccountLoginExceptionReason?>()] =
+        (data, protocol) => (data != null
+        ? _i14.EmailAccountLoginExceptionReason.fromJson(data)
+        : null);
+    map[_i1.getType<_i15.EmailAccountPasswordResetException?>()] =
+        (data, protocol) => (data != null
+        ? _i15.EmailAccountPasswordResetException.fromJson(data)
+        : null);
+    map[_i1.getType<_i16.EmailAccountPasswordResetExceptionReason?>()] =
+        (data, protocol) => (data != null
+        ? _i16.EmailAccountPasswordResetExceptionReason.fromJson(data)
+        : null);
+    map[_i1.getType<_i17.EmailAccountRequestException?>()] = (data, protocol) =>
+        (data != null
+        ? _i17.EmailAccountRequestException.fromJson(data)
+        : null);
+    map[_i1.getType<_i18.EmailAccountRequestExceptionReason?>()] =
+        (data, protocol) => (data != null
+        ? _i18.EmailAccountRequestExceptionReason.fromJson(data)
+        : null);
+    map[_i1.getType<_i19.FacebookAccessTokenVerificationException?>()] =
+        (data, protocol) => (data != null
+        ? _i19.FacebookAccessTokenVerificationException.fromJson(data)
+        : null);
+    map[_i1.getType<_i20.FacebookAccount?>()] = (data, protocol) =>
+        (data != null ? _i20.FacebookAccount.fromJson(data) : null);
+    map[_i1.getType<_i21.FirebaseAccount?>()] = (data, protocol) =>
+        (data != null ? _i21.FirebaseAccount.fromJson(data) : null);
+    map[_i1.getType<_i22.FirebaseEmailNotVerifiedException?>()] =
+        (data, protocol) => (data != null
+        ? _i22.FirebaseEmailNotVerifiedException.fromJson(data)
+        : null);
+    map[_i1.getType<_i23.FirebaseIdTokenVerificationException?>()] =
+        (data, protocol) => (data != null
+        ? _i23.FirebaseIdTokenVerificationException.fromJson(data)
+        : null);
+    map[_i1.getType<_i24.GitHubAccessTokenVerificationException?>()] =
+        (data, protocol) => (data != null
+        ? _i24.GitHubAccessTokenVerificationException.fromJson(data)
+        : null);
+    map[_i1.getType<_i25.GitHubAccount?>()] = (data, protocol) =>
+        (data != null ? _i25.GitHubAccount.fromJson(data) : null);
+    map[_i1.getType<_i26.GoogleAccount?>()] = (data, protocol) =>
+        (data != null ? _i26.GoogleAccount.fromJson(data) : null);
+    map[_i1.getType<_i27.GoogleIdTokenVerificationException?>()] =
+        (data, protocol) => (data != null
+        ? _i27.GoogleIdTokenVerificationException.fromJson(data)
+        : null);
+    map[_i1.getType<_i28.MicrosoftAccessTokenVerificationException?>()] =
+        (data, protocol) => (data != null
+        ? _i28.MicrosoftAccessTokenVerificationException.fromJson(data)
+        : null);
+    map[_i1.getType<_i29.MicrosoftAccount?>()] = (data, protocol) =>
+        (data != null ? _i29.MicrosoftAccount.fromJson(data) : null);
+    map[_i1.getType<_i30.PasskeyAccount?>()] = (data, protocol) =>
+        (data != null ? _i30.PasskeyAccount.fromJson(data) : null);
+    map[_i1.getType<_i31.PasskeyChallenge?>()] = (data, protocol) =>
+        (data != null ? _i31.PasskeyChallenge.fromJson(data) : null);
+    map[_i1.getType<_i32.PasskeyChallengeExpiredException?>()] =
+        (data, protocol) => (data != null
+        ? _i32.PasskeyChallengeExpiredException.fromJson(data)
+        : null);
+    map[_i1.getType<_i33.PasskeyChallengeNotFoundException?>()] =
+        (data, protocol) => (data != null
+        ? _i33.PasskeyChallengeNotFoundException.fromJson(data)
+        : null);
+    map[_i1.getType<_i34.PasskeyLoginRequest?>()] = (data, protocol) =>
+        (data != null ? _i34.PasskeyLoginRequest.fromJson(data) : null);
+    map[_i1.getType<_i35.PasskeyPublicKeyNotFoundException?>()] =
+        (data, protocol) => (data != null
+        ? _i35.PasskeyPublicKeyNotFoundException.fromJson(data)
+        : null);
+    map[_i1.getType<_i36.PasskeyRegistrationRequest?>()] = (data, protocol) =>
+        (data != null ? _i36.PasskeyRegistrationRequest.fromJson(data) : null);
+    map[Map<String, String>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<String>(v),
+      ),
+    );
+    map[_i1.getType<Map<String, String>?>()] = (data, protocol) => (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<String>(v),
+            ),
+          )
+        : null);
+    map[_i1.getType<({_i37.ByteData challenge, _i1.UuidValue id})>()] =
+        (data, protocol) => (
+          challenge: protocol.deserialize<_i37.ByteData>(
+            ((data as Map)['n'] as Map)['challenge'],
+          ),
+          id: protocol.deserialize<_i1.UuidValue>(data['n']['id']),
+        );
+    return map;
   }
 }

--- a/modules/serverpod_auth/serverpod_auth_migration/serverpod_auth_migration_client/lib/src/protocol/protocol.dart
+++ b/modules/serverpod_auth/serverpod_auth_migration/serverpod_auth_migration_client/lib/src/protocol/protocol.dart
@@ -29,6 +29,14 @@ class Protocol extends _i1.SerializationManager {
 
   final Map<String, _i1.SerializationManager> _hostProtocols = {};
 
+  static final Map<Type, dynamic Function(dynamic, Protocol)> _deserializers =
+      _buildDeserializers();
+
+  static Map<Type, dynamic Function(dynamic, Protocol)> _buildDeserializers() {
+    final map = <Type, dynamic Function(dynamic, Protocol)>{};
+    return map;
+  }
+
   void registerHostProtocol(
     String projectName,
     _i1.SerializationManager protocol,
@@ -65,6 +73,10 @@ class Protocol extends _i1.SerializationManager {
       }
     }
 
+    final fn = _deserializers[t];
+    if (fn != null) {
+      return fn(data, this) as T;
+    }
     try {
       return _i2.Protocol().deserialize<T>(data, t);
     } on _i1.DeserializationTypeNotFoundException catch (_) {}

--- a/modules/serverpod_auth/serverpod_auth_migration/serverpod_auth_migration_client/lib/src/protocol/protocol.dart
+++ b/modules/serverpod_auth/serverpod_auth_migration/serverpod_auth_migration_client/lib/src/protocol/protocol.dart
@@ -30,6 +30,9 @@ class Protocol extends _i1.SerializationManager {
 
   final Set<_i1.SerializationManager> _hostProtocols = {};
 
+  static final Map<Type, dynamic Function(dynamic, Protocol)> _deserializers =
+      _buildDeserializers();
+
   void registerHostProtocol(
     String projectName,
     _i1.SerializationManager protocol,
@@ -66,6 +69,10 @@ class Protocol extends _i1.SerializationManager {
       }
     }
 
+    final fn = _deserializers[t];
+    if (fn != null) {
+      return fn(data, this) as T;
+    }
     try {
       return _i2.Protocol().deserialize<T>(data, t);
     } on _i1.DeserializationTypeNotFoundException catch (_) {}
@@ -195,5 +202,10 @@ class Protocol extends _i1.SerializationManager {
       return _i5.Protocol().mapRecordToJson(record);
     } catch (_) {}
     throw Exception('Unsupported record type ${record.runtimeType}');
+  }
+
+  static Map<Type, dynamic Function(dynamic, Protocol)> _buildDeserializers() {
+    final map = <Type, dynamic Function(dynamic, Protocol)>{};
+    return map;
   }
 }

--- a/modules/serverpod_auth/serverpod_auth_migration/serverpod_auth_migration_server/lib/src/generated/protocol.dart
+++ b/modules/serverpod_auth/serverpod_auth_migration/serverpod_auth_migration_server/lib/src/generated/protocol.dart
@@ -116,6 +116,17 @@ class Protocol extends _i1.DatabaseSerializationManager {
 
   final Map<String, _i1.SerializationManager> _hostProtocols = {};
 
+  static final Map<Type, dynamic Function(dynamic, Protocol)> _deserializers =
+      _buildDeserializers();
+
+  static Map<Type, dynamic Function(dynamic, Protocol)> _buildDeserializers() {
+    final map = <Type, dynamic Function(dynamic, Protocol)>{};
+    map[_i7.MigratedUser] = (data, protocol) => _i7.MigratedUser.fromJson(data);
+    map[_i1.getType<_i7.MigratedUser?>()] = (data, protocol) =>
+        (data != null ? _i7.MigratedUser.fromJson(data) : null);
+    return map;
+  }
+
   void registerHostProtocol(
     String projectName,
     _i1.SerializationManager protocol,
@@ -152,11 +163,9 @@ class Protocol extends _i1.DatabaseSerializationManager {
       }
     }
 
-    if (t == _i7.MigratedUser) {
-      return _i7.MigratedUser.fromJson(data) as T;
-    }
-    if (t == _i1.getType<_i7.MigratedUser?>()) {
-      return (data != null ? _i7.MigratedUser.fromJson(data) : null) as T;
+    final fn = _deserializers[t];
+    if (fn != null) {
+      return fn(data, this) as T;
     }
     try {
       return _i3.Protocol().deserialize<T>(data, t);

--- a/modules/serverpod_auth/serverpod_auth_migration/serverpod_auth_migration_server/lib/src/generated/protocol.dart
+++ b/modules/serverpod_auth/serverpod_auth_migration/serverpod_auth_migration_server/lib/src/generated/protocol.dart
@@ -32,6 +32,9 @@ class Protocol extends _i1.DatabaseSerializationManager {
 
   final Set<_i1.SerializationManager> _hostProtocols = {};
 
+  static final Map<Type, dynamic Function(dynamic, Protocol)> _deserializers =
+      _buildDeserializers();
+
   static List<_i2.TableDefinition> get targetTableDefinitions => [
     _i2.TableDefinition(
       name: 'serverpod_auth_migration_migrated_user',
@@ -153,11 +156,9 @@ class Protocol extends _i1.DatabaseSerializationManager {
       }
     }
 
-    if (t == _i7.MigratedUser) {
-      return _i7.MigratedUser.fromJson(data) as T;
-    }
-    if (t == _i1.getType<_i7.MigratedUser?>()) {
-      return (data != null ? _i7.MigratedUser.fromJson(data) : null) as T;
+    final fn = _deserializers[t];
+    if (fn != null) {
+      return fn(data, this) as T;
     }
     try {
       return _i3.Protocol().deserialize<T>(data, t);
@@ -350,5 +351,13 @@ class Protocol extends _i1.DatabaseSerializationManager {
       return _i6.Protocol().mapRecordToJson(record);
     } catch (_) {}
     throw Exception('Unsupported record type ${record.runtimeType}');
+  }
+
+  static Map<Type, dynamic Function(dynamic, Protocol)> _buildDeserializers() {
+    final map = <Type, dynamic Function(dynamic, Protocol)>{};
+    map[_i7.MigratedUser] = (data, protocol) => _i7.MigratedUser.fromJson(data);
+    map[_i1.getType<_i7.MigratedUser?>()] = (data, protocol) =>
+        (data != null ? _i7.MigratedUser.fromJson(data) : null);
+    return map;
   }
 }

--- a/packages/serverpod/lib/src/generated/protocol.dart
+++ b/packages/serverpod/lib/src/generated/protocol.dart
@@ -1183,6 +1183,215 @@ class Protocol extends _i1.DatabaseSerializationManager {
     ),
   ];
 
+  static final Map<Type, dynamic Function(dynamic, Protocol)> _deserializers =
+      _buildDeserializers();
+
+  static Map<Type, dynamic Function(dynamic, Protocol)> _buildDeserializers() {
+    final map = <Type, dynamic Function(dynamic, Protocol)>{};
+    map[_i3.RevokedAuthenticationAuthId] = (data, protocol) =>
+        _i3.RevokedAuthenticationAuthId.fromJson(data);
+    map[_i4.RevokedAuthenticationScope] = (data, protocol) =>
+        _i4.RevokedAuthenticationScope.fromJson(data);
+    map[_i5.RevokedAuthenticationUser] = (data, protocol) =>
+        _i5.RevokedAuthenticationUser.fromJson(data);
+    map[_i6.CacheInfo] = (data, protocol) => _i6.CacheInfo.fromJson(data);
+    map[_i7.CachesInfo] = (data, protocol) => _i7.CachesInfo.fromJson(data);
+    map[_i8.CloudStorageEntry] = (data, protocol) =>
+        _i8.CloudStorageEntry.fromJson(data);
+    map[_i9.CloudStorageDirectUploadEntry] = (data, protocol) =>
+        _i9.CloudStorageDirectUploadEntry.fromJson(data);
+    map[_i10.ClusterInfo] = (data, protocol) => _i10.ClusterInfo.fromJson(data);
+    map[_i11.ClusterServerInfo] = (data, protocol) =>
+        _i11.ClusterServerInfo.fromJson(data);
+    map[_i12.CronFutureCallScheduling] = (data, protocol) =>
+        _i12.CronFutureCallScheduling.fromJson(data);
+    map[_i13.DatabaseMigrationVersion] = (data, protocol) =>
+        _i13.DatabaseMigrationVersion.fromJson(data);
+    map[_i14.DistributedCacheEntry] = (data, protocol) =>
+        _i14.DistributedCacheEntry.fromJson(data);
+    map[_i15.AccessDeniedException] = (data, protocol) =>
+        _i15.AccessDeniedException.fromJson(data);
+    map[_i16.FileNotFoundException] = (data, protocol) =>
+        _i16.FileNotFoundException.fromJson(data);
+    map[_i17.FutureCallClaimEntry] = (data, protocol) =>
+        _i17.FutureCallClaimEntry.fromJson(data);
+    map[_i18.FutureCallEntry] = (data, protocol) =>
+        _i18.FutureCallEntry.fromJson(data);
+    map[_i12.IntervalFutureCallScheduling] = (data, protocol) =>
+        _i12.IntervalFutureCallScheduling.fromJson(data);
+    map[_i19.LogEntry] = (data, protocol) => _i19.LogEntry.fromJson(data);
+    map[_i20.LogLevel] = (data, protocol) => _i20.LogLevel.fromJson(data);
+    map[_i21.LogResult] = (data, protocol) => _i21.LogResult.fromJson(data);
+    map[_i22.LogSettings] = (data, protocol) => _i22.LogSettings.fromJson(data);
+    map[_i23.LogSettingsOverride] = (data, protocol) =>
+        _i23.LogSettingsOverride.fromJson(data);
+    map[_i24.MessageLogEntry] = (data, protocol) =>
+        _i24.MessageLogEntry.fromJson(data);
+    map[_i25.MethodInfo] = (data, protocol) => _i25.MethodInfo.fromJson(data);
+    map[_i26.QueryLogEntry] = (data, protocol) =>
+        _i26.QueryLogEntry.fromJson(data);
+    map[_i27.ReadWriteTestEntry] = (data, protocol) =>
+        _i27.ReadWriteTestEntry.fromJson(data);
+    map[_i28.RuntimeSettings] = (data, protocol) =>
+        _i28.RuntimeSettings.fromJson(data);
+    map[_i29.ServerHealthConnectionInfo] = (data, protocol) =>
+        _i29.ServerHealthConnectionInfo.fromJson(data);
+    map[_i30.ServerHealthMetric] = (data, protocol) =>
+        _i30.ServerHealthMetric.fromJson(data);
+    map[_i31.ServerHealthResult] = (data, protocol) =>
+        _i31.ServerHealthResult.fromJson(data);
+    map[_i32.ServerpodSqlException] = (data, protocol) =>
+        _i32.ServerpodSqlException.fromJson(data);
+    map[_i33.SessionLogEntry] = (data, protocol) =>
+        _i33.SessionLogEntry.fromJson(data);
+    map[_i34.SessionLogFilter] = (data, protocol) =>
+        _i34.SessionLogFilter.fromJson(data);
+    map[_i35.SessionLogInfo] = (data, protocol) =>
+        _i35.SessionLogInfo.fromJson(data);
+    map[_i36.SessionLogResult] = (data, protocol) =>
+        _i36.SessionLogResult.fromJson(data);
+    map[_i1.getType<_i3.RevokedAuthenticationAuthId?>()] = (data, protocol) =>
+        (data != null ? _i3.RevokedAuthenticationAuthId.fromJson(data) : null);
+    map[_i1.getType<_i4.RevokedAuthenticationScope?>()] = (data, protocol) =>
+        (data != null ? _i4.RevokedAuthenticationScope.fromJson(data) : null);
+    map[_i1.getType<_i5.RevokedAuthenticationUser?>()] = (data, protocol) =>
+        (data != null ? _i5.RevokedAuthenticationUser.fromJson(data) : null);
+    map[_i1.getType<_i6.CacheInfo?>()] = (data, protocol) =>
+        (data != null ? _i6.CacheInfo.fromJson(data) : null);
+    map[_i1.getType<_i7.CachesInfo?>()] = (data, protocol) =>
+        (data != null ? _i7.CachesInfo.fromJson(data) : null);
+    map[_i1.getType<_i8.CloudStorageEntry?>()] = (data, protocol) =>
+        (data != null ? _i8.CloudStorageEntry.fromJson(data) : null);
+    map[_i1.getType<_i9.CloudStorageDirectUploadEntry?>()] = (data, protocol) =>
+        (data != null
+        ? _i9.CloudStorageDirectUploadEntry.fromJson(data)
+        : null);
+    map[_i1.getType<_i10.ClusterInfo?>()] = (data, protocol) =>
+        (data != null ? _i10.ClusterInfo.fromJson(data) : null);
+    map[_i1.getType<_i11.ClusterServerInfo?>()] = (data, protocol) =>
+        (data != null ? _i11.ClusterServerInfo.fromJson(data) : null);
+    map[_i1.getType<_i12.CronFutureCallScheduling?>()] = (data, protocol) =>
+        (data != null ? _i12.CronFutureCallScheduling.fromJson(data) : null);
+    map[_i1.getType<_i13.DatabaseMigrationVersion?>()] = (data, protocol) =>
+        (data != null ? _i13.DatabaseMigrationVersion.fromJson(data) : null);
+    map[_i1.getType<_i14.DistributedCacheEntry?>()] = (data, protocol) =>
+        (data != null ? _i14.DistributedCacheEntry.fromJson(data) : null);
+    map[_i1.getType<_i15.AccessDeniedException?>()] = (data, protocol) =>
+        (data != null ? _i15.AccessDeniedException.fromJson(data) : null);
+    map[_i1.getType<_i16.FileNotFoundException?>()] = (data, protocol) =>
+        (data != null ? _i16.FileNotFoundException.fromJson(data) : null);
+    map[_i1.getType<_i17.FutureCallClaimEntry?>()] = (data, protocol) =>
+        (data != null ? _i17.FutureCallClaimEntry.fromJson(data) : null);
+    map[_i1.getType<_i18.FutureCallEntry?>()] = (data, protocol) =>
+        (data != null ? _i18.FutureCallEntry.fromJson(data) : null);
+    map[_i1.getType<_i12.IntervalFutureCallScheduling?>()] = (data, protocol) =>
+        (data != null
+        ? _i12.IntervalFutureCallScheduling.fromJson(data)
+        : null);
+    map[_i1.getType<_i19.LogEntry?>()] = (data, protocol) =>
+        (data != null ? _i19.LogEntry.fromJson(data) : null);
+    map[_i1.getType<_i20.LogLevel?>()] = (data, protocol) =>
+        (data != null ? _i20.LogLevel.fromJson(data) : null);
+    map[_i1.getType<_i21.LogResult?>()] = (data, protocol) =>
+        (data != null ? _i21.LogResult.fromJson(data) : null);
+    map[_i1.getType<_i22.LogSettings?>()] = (data, protocol) =>
+        (data != null ? _i22.LogSettings.fromJson(data) : null);
+    map[_i1.getType<_i23.LogSettingsOverride?>()] = (data, protocol) =>
+        (data != null ? _i23.LogSettingsOverride.fromJson(data) : null);
+    map[_i1.getType<_i24.MessageLogEntry?>()] = (data, protocol) =>
+        (data != null ? _i24.MessageLogEntry.fromJson(data) : null);
+    map[_i1.getType<_i25.MethodInfo?>()] = (data, protocol) =>
+        (data != null ? _i25.MethodInfo.fromJson(data) : null);
+    map[_i1.getType<_i26.QueryLogEntry?>()] = (data, protocol) =>
+        (data != null ? _i26.QueryLogEntry.fromJson(data) : null);
+    map[_i1.getType<_i27.ReadWriteTestEntry?>()] = (data, protocol) =>
+        (data != null ? _i27.ReadWriteTestEntry.fromJson(data) : null);
+    map[_i1.getType<_i28.RuntimeSettings?>()] = (data, protocol) =>
+        (data != null ? _i28.RuntimeSettings.fromJson(data) : null);
+    map[_i1.getType<_i29.ServerHealthConnectionInfo?>()] = (data, protocol) =>
+        (data != null ? _i29.ServerHealthConnectionInfo.fromJson(data) : null);
+    map[_i1.getType<_i30.ServerHealthMetric?>()] = (data, protocol) =>
+        (data != null ? _i30.ServerHealthMetric.fromJson(data) : null);
+    map[_i1.getType<_i31.ServerHealthResult?>()] = (data, protocol) =>
+        (data != null ? _i31.ServerHealthResult.fromJson(data) : null);
+    map[_i1.getType<_i32.ServerpodSqlException?>()] = (data, protocol) =>
+        (data != null ? _i32.ServerpodSqlException.fromJson(data) : null);
+    map[_i1.getType<_i33.SessionLogEntry?>()] = (data, protocol) =>
+        (data != null ? _i33.SessionLogEntry.fromJson(data) : null);
+    map[_i1.getType<_i34.SessionLogFilter?>()] = (data, protocol) =>
+        (data != null ? _i34.SessionLogFilter.fromJson(data) : null);
+    map[_i1.getType<_i35.SessionLogInfo?>()] = (data, protocol) =>
+        (data != null ? _i35.SessionLogInfo.fromJson(data) : null);
+    map[_i1.getType<_i36.SessionLogResult?>()] = (data, protocol) =>
+        (data != null ? _i36.SessionLogResult.fromJson(data) : null);
+    map[List<String>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<String>(e)).toList();
+    map[List<String>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<String>(e)).toList();
+    map[_i1.getType<List<String>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<String>(e)).toList()
+        : null);
+    map[List<_i11.ClusterServerInfo>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i11.ClusterServerInfo>(e))
+        .toList();
+    map[List<_i19.LogEntry>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i19.LogEntry>(e))
+        .toList();
+    map[List<_i23.LogSettingsOverride>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i23.LogSettingsOverride>(e))
+        .toList();
+    map[List<_i30.ServerHealthMetric>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i30.ServerHealthMetric>(e))
+        .toList();
+    map[List<_i29.ServerHealthConnectionInfo>] = (data, protocol) =>
+        (data as List)
+            .map(
+              (e) => protocol.deserialize<_i29.ServerHealthConnectionInfo>(e),
+            )
+            .toList();
+    map[List<_i19.LogEntry>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i19.LogEntry>(e))
+        .toList();
+    map[_i1.getType<List<_i19.LogEntry>?>()] = (data, protocol) => (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i19.LogEntry>(e))
+              .toList()
+        : null);
+    map[List<_i26.QueryLogEntry>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i26.QueryLogEntry>(e))
+        .toList();
+    map[_i1.getType<List<_i26.QueryLogEntry>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i26.QueryLogEntry>(e))
+              .toList()
+        : null);
+    map[List<_i24.MessageLogEntry>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i24.MessageLogEntry>(e))
+        .toList();
+    map[_i1.getType<List<_i24.MessageLogEntry>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i24.MessageLogEntry>(e))
+              .toList()
+        : null);
+    map[List<_i26.QueryLogEntry>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i26.QueryLogEntry>(e))
+        .toList();
+    map[List<_i24.MessageLogEntry>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i24.MessageLogEntry>(e))
+        .toList();
+    map[List<_i35.SessionLogInfo>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i35.SessionLogInfo>(e))
+        .toList();
+    map[List<_i37.TableDefinition>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i37.TableDefinition>(e))
+        .toList();
+    map[List<String>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<String>(e)).toList();
+    return map;
+  }
+
   static String? getClassNameFromObjectJson(dynamic data) {
     if (data is! Map) return null;
     final className = data['__className__'] as String?;
@@ -1212,336 +1421,9 @@ class Protocol extends _i1.DatabaseSerializationManager {
       }
     }
 
-    if (t == _i3.RevokedAuthenticationAuthId) {
-      return _i3.RevokedAuthenticationAuthId.fromJson(data) as T;
-    }
-    if (t == _i4.RevokedAuthenticationScope) {
-      return _i4.RevokedAuthenticationScope.fromJson(data) as T;
-    }
-    if (t == _i5.RevokedAuthenticationUser) {
-      return _i5.RevokedAuthenticationUser.fromJson(data) as T;
-    }
-    if (t == _i6.CacheInfo) {
-      return _i6.CacheInfo.fromJson(data) as T;
-    }
-    if (t == _i7.CachesInfo) {
-      return _i7.CachesInfo.fromJson(data) as T;
-    }
-    if (t == _i8.CloudStorageEntry) {
-      return _i8.CloudStorageEntry.fromJson(data) as T;
-    }
-    if (t == _i9.CloudStorageDirectUploadEntry) {
-      return _i9.CloudStorageDirectUploadEntry.fromJson(data) as T;
-    }
-    if (t == _i10.ClusterInfo) {
-      return _i10.ClusterInfo.fromJson(data) as T;
-    }
-    if (t == _i11.ClusterServerInfo) {
-      return _i11.ClusterServerInfo.fromJson(data) as T;
-    }
-    if (t == _i12.CronFutureCallScheduling) {
-      return _i12.CronFutureCallScheduling.fromJson(data) as T;
-    }
-    if (t == _i13.DatabaseMigrationVersion) {
-      return _i13.DatabaseMigrationVersion.fromJson(data) as T;
-    }
-    if (t == _i14.DistributedCacheEntry) {
-      return _i14.DistributedCacheEntry.fromJson(data) as T;
-    }
-    if (t == _i15.AccessDeniedException) {
-      return _i15.AccessDeniedException.fromJson(data) as T;
-    }
-    if (t == _i16.FileNotFoundException) {
-      return _i16.FileNotFoundException.fromJson(data) as T;
-    }
-    if (t == _i17.FutureCallClaimEntry) {
-      return _i17.FutureCallClaimEntry.fromJson(data) as T;
-    }
-    if (t == _i18.FutureCallEntry) {
-      return _i18.FutureCallEntry.fromJson(data) as T;
-    }
-    if (t == _i12.IntervalFutureCallScheduling) {
-      return _i12.IntervalFutureCallScheduling.fromJson(data) as T;
-    }
-    if (t == _i19.LogEntry) {
-      return _i19.LogEntry.fromJson(data) as T;
-    }
-    if (t == _i20.LogLevel) {
-      return _i20.LogLevel.fromJson(data) as T;
-    }
-    if (t == _i21.LogResult) {
-      return _i21.LogResult.fromJson(data) as T;
-    }
-    if (t == _i22.LogSettings) {
-      return _i22.LogSettings.fromJson(data) as T;
-    }
-    if (t == _i23.LogSettingsOverride) {
-      return _i23.LogSettingsOverride.fromJson(data) as T;
-    }
-    if (t == _i24.MessageLogEntry) {
-      return _i24.MessageLogEntry.fromJson(data) as T;
-    }
-    if (t == _i25.MethodInfo) {
-      return _i25.MethodInfo.fromJson(data) as T;
-    }
-    if (t == _i26.QueryLogEntry) {
-      return _i26.QueryLogEntry.fromJson(data) as T;
-    }
-    if (t == _i27.ReadWriteTestEntry) {
-      return _i27.ReadWriteTestEntry.fromJson(data) as T;
-    }
-    if (t == _i28.RuntimeSettings) {
-      return _i28.RuntimeSettings.fromJson(data) as T;
-    }
-    if (t == _i29.ServerHealthConnectionInfo) {
-      return _i29.ServerHealthConnectionInfo.fromJson(data) as T;
-    }
-    if (t == _i30.ServerHealthMetric) {
-      return _i30.ServerHealthMetric.fromJson(data) as T;
-    }
-    if (t == _i31.ServerHealthResult) {
-      return _i31.ServerHealthResult.fromJson(data) as T;
-    }
-    if (t == _i32.ServerpodSqlException) {
-      return _i32.ServerpodSqlException.fromJson(data) as T;
-    }
-    if (t == _i33.SessionLogEntry) {
-      return _i33.SessionLogEntry.fromJson(data) as T;
-    }
-    if (t == _i34.SessionLogFilter) {
-      return _i34.SessionLogFilter.fromJson(data) as T;
-    }
-    if (t == _i35.SessionLogInfo) {
-      return _i35.SessionLogInfo.fromJson(data) as T;
-    }
-    if (t == _i36.SessionLogResult) {
-      return _i36.SessionLogResult.fromJson(data) as T;
-    }
-    if (t == _i1.getType<_i3.RevokedAuthenticationAuthId?>()) {
-      return (data != null
-              ? _i3.RevokedAuthenticationAuthId.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i4.RevokedAuthenticationScope?>()) {
-      return (data != null
-              ? _i4.RevokedAuthenticationScope.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i5.RevokedAuthenticationUser?>()) {
-      return (data != null
-              ? _i5.RevokedAuthenticationUser.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i6.CacheInfo?>()) {
-      return (data != null ? _i6.CacheInfo.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i7.CachesInfo?>()) {
-      return (data != null ? _i7.CachesInfo.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i8.CloudStorageEntry?>()) {
-      return (data != null ? _i8.CloudStorageEntry.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i9.CloudStorageDirectUploadEntry?>()) {
-      return (data != null
-              ? _i9.CloudStorageDirectUploadEntry.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i10.ClusterInfo?>()) {
-      return (data != null ? _i10.ClusterInfo.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i11.ClusterServerInfo?>()) {
-      return (data != null ? _i11.ClusterServerInfo.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i12.CronFutureCallScheduling?>()) {
-      return (data != null
-              ? _i12.CronFutureCallScheduling.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i13.DatabaseMigrationVersion?>()) {
-      return (data != null
-              ? _i13.DatabaseMigrationVersion.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i14.DistributedCacheEntry?>()) {
-      return (data != null ? _i14.DistributedCacheEntry.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i15.AccessDeniedException?>()) {
-      return (data != null ? _i15.AccessDeniedException.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i16.FileNotFoundException?>()) {
-      return (data != null ? _i16.FileNotFoundException.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i17.FutureCallClaimEntry?>()) {
-      return (data != null ? _i17.FutureCallClaimEntry.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i18.FutureCallEntry?>()) {
-      return (data != null ? _i18.FutureCallEntry.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i12.IntervalFutureCallScheduling?>()) {
-      return (data != null
-              ? _i12.IntervalFutureCallScheduling.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i19.LogEntry?>()) {
-      return (data != null ? _i19.LogEntry.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i20.LogLevel?>()) {
-      return (data != null ? _i20.LogLevel.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i21.LogResult?>()) {
-      return (data != null ? _i21.LogResult.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i22.LogSettings?>()) {
-      return (data != null ? _i22.LogSettings.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i23.LogSettingsOverride?>()) {
-      return (data != null ? _i23.LogSettingsOverride.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i24.MessageLogEntry?>()) {
-      return (data != null ? _i24.MessageLogEntry.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i25.MethodInfo?>()) {
-      return (data != null ? _i25.MethodInfo.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i26.QueryLogEntry?>()) {
-      return (data != null ? _i26.QueryLogEntry.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i27.ReadWriteTestEntry?>()) {
-      return (data != null ? _i27.ReadWriteTestEntry.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i28.RuntimeSettings?>()) {
-      return (data != null ? _i28.RuntimeSettings.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i29.ServerHealthConnectionInfo?>()) {
-      return (data != null
-              ? _i29.ServerHealthConnectionInfo.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i30.ServerHealthMetric?>()) {
-      return (data != null ? _i30.ServerHealthMetric.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i31.ServerHealthResult?>()) {
-      return (data != null ? _i31.ServerHealthResult.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i32.ServerpodSqlException?>()) {
-      return (data != null ? _i32.ServerpodSqlException.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i33.SessionLogEntry?>()) {
-      return (data != null ? _i33.SessionLogEntry.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i34.SessionLogFilter?>()) {
-      return (data != null ? _i34.SessionLogFilter.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i35.SessionLogInfo?>()) {
-      return (data != null ? _i35.SessionLogInfo.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i36.SessionLogResult?>()) {
-      return (data != null ? _i36.SessionLogResult.fromJson(data) : null) as T;
-    }
-    if (t == List<String>) {
-      return (data as List).map((e) => deserialize<String>(e)).toList() as T;
-    }
-    if (t == _i1.getType<List<String>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<String>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i11.ClusterServerInfo>) {
-      return (data as List)
-              .map((e) => deserialize<_i11.ClusterServerInfo>(e))
-              .toList()
-          as T;
-    }
-    if (t == List<_i19.LogEntry>) {
-      return (data as List).map((e) => deserialize<_i19.LogEntry>(e)).toList()
-          as T;
-    }
-    if (t == List<_i23.LogSettingsOverride>) {
-      return (data as List)
-              .map((e) => deserialize<_i23.LogSettingsOverride>(e))
-              .toList()
-          as T;
-    }
-    if (t == List<_i30.ServerHealthMetric>) {
-      return (data as List)
-              .map((e) => deserialize<_i30.ServerHealthMetric>(e))
-              .toList()
-          as T;
-    }
-    if (t == List<_i29.ServerHealthConnectionInfo>) {
-      return (data as List)
-              .map((e) => deserialize<_i29.ServerHealthConnectionInfo>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i19.LogEntry>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i19.LogEntry>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i26.QueryLogEntry>) {
-      return (data as List)
-              .map((e) => deserialize<_i26.QueryLogEntry>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i26.QueryLogEntry>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i26.QueryLogEntry>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i24.MessageLogEntry>) {
-      return (data as List)
-              .map((e) => deserialize<_i24.MessageLogEntry>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i24.MessageLogEntry>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i24.MessageLogEntry>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i35.SessionLogInfo>) {
-      return (data as List)
-              .map((e) => deserialize<_i35.SessionLogInfo>(e))
-              .toList()
-          as T;
-    }
-    if (t == List<_i37.TableDefinition>) {
-      return (data as List)
-              .map((e) => deserialize<_i37.TableDefinition>(e))
-              .toList()
-          as T;
-    }
-    if (t == List<String>) {
-      return (data as List).map((e) => deserialize<String>(e)).toList() as T;
+    final fn = _deserializers[t];
+    if (fn != null) {
+      return fn(data, this) as T;
     }
     try {
       return _i38.Protocol().deserialize<T>(data, t);

--- a/packages/serverpod/lib/src/generated/protocol.dart
+++ b/packages/serverpod/lib/src/generated/protocol.dart
@@ -90,6 +90,9 @@ class Protocol extends _i1.DatabaseSerializationManager {
 
   static final Protocol _instance = Protocol._().._registerHostProtocols();
 
+  static final Map<Type, dynamic Function(dynamic, Protocol)> _deserializers =
+      _buildDeserializers();
+
   static List<_i2.TableDefinition> get targetTableDefinitions => [
     _i2.TableDefinition(
       name: 'serverpod_cloud_storage',
@@ -1216,336 +1219,9 @@ class Protocol extends _i1.DatabaseSerializationManager {
       }
     }
 
-    if (t == _i4.RevokedAuthenticationAuthId) {
-      return _i4.RevokedAuthenticationAuthId.fromJson(data) as T;
-    }
-    if (t == _i5.RevokedAuthenticationScope) {
-      return _i5.RevokedAuthenticationScope.fromJson(data) as T;
-    }
-    if (t == _i6.RevokedAuthenticationUser) {
-      return _i6.RevokedAuthenticationUser.fromJson(data) as T;
-    }
-    if (t == _i7.CacheInfo) {
-      return _i7.CacheInfo.fromJson(data) as T;
-    }
-    if (t == _i8.CachesInfo) {
-      return _i8.CachesInfo.fromJson(data) as T;
-    }
-    if (t == _i9.CloudStorageEntry) {
-      return _i9.CloudStorageEntry.fromJson(data) as T;
-    }
-    if (t == _i10.CloudStorageDirectUploadEntry) {
-      return _i10.CloudStorageDirectUploadEntry.fromJson(data) as T;
-    }
-    if (t == _i11.ClusterInfo) {
-      return _i11.ClusterInfo.fromJson(data) as T;
-    }
-    if (t == _i12.ClusterServerInfo) {
-      return _i12.ClusterServerInfo.fromJson(data) as T;
-    }
-    if (t == _i13.CronFutureCallScheduling) {
-      return _i13.CronFutureCallScheduling.fromJson(data) as T;
-    }
-    if (t == _i14.DatabaseMigrationVersion) {
-      return _i14.DatabaseMigrationVersion.fromJson(data) as T;
-    }
-    if (t == _i15.DistributedCacheEntry) {
-      return _i15.DistributedCacheEntry.fromJson(data) as T;
-    }
-    if (t == _i16.AccessDeniedException) {
-      return _i16.AccessDeniedException.fromJson(data) as T;
-    }
-    if (t == _i17.FileNotFoundException) {
-      return _i17.FileNotFoundException.fromJson(data) as T;
-    }
-    if (t == _i18.FutureCallClaimEntry) {
-      return _i18.FutureCallClaimEntry.fromJson(data) as T;
-    }
-    if (t == _i19.FutureCallEntry) {
-      return _i19.FutureCallEntry.fromJson(data) as T;
-    }
-    if (t == _i13.IntervalFutureCallScheduling) {
-      return _i13.IntervalFutureCallScheduling.fromJson(data) as T;
-    }
-    if (t == _i20.LogEntry) {
-      return _i20.LogEntry.fromJson(data) as T;
-    }
-    if (t == _i21.LogLevel) {
-      return _i21.LogLevel.fromJson(data) as T;
-    }
-    if (t == _i22.LogResult) {
-      return _i22.LogResult.fromJson(data) as T;
-    }
-    if (t == _i23.LogSettings) {
-      return _i23.LogSettings.fromJson(data) as T;
-    }
-    if (t == _i24.LogSettingsOverride) {
-      return _i24.LogSettingsOverride.fromJson(data) as T;
-    }
-    if (t == _i25.MessageLogEntry) {
-      return _i25.MessageLogEntry.fromJson(data) as T;
-    }
-    if (t == _i26.MethodInfo) {
-      return _i26.MethodInfo.fromJson(data) as T;
-    }
-    if (t == _i27.QueryLogEntry) {
-      return _i27.QueryLogEntry.fromJson(data) as T;
-    }
-    if (t == _i28.ReadWriteTestEntry) {
-      return _i28.ReadWriteTestEntry.fromJson(data) as T;
-    }
-    if (t == _i29.RuntimeSettings) {
-      return _i29.RuntimeSettings.fromJson(data) as T;
-    }
-    if (t == _i30.ServerHealthConnectionInfo) {
-      return _i30.ServerHealthConnectionInfo.fromJson(data) as T;
-    }
-    if (t == _i31.ServerHealthMetric) {
-      return _i31.ServerHealthMetric.fromJson(data) as T;
-    }
-    if (t == _i32.ServerHealthResult) {
-      return _i32.ServerHealthResult.fromJson(data) as T;
-    }
-    if (t == _i33.ServerpodSqlException) {
-      return _i33.ServerpodSqlException.fromJson(data) as T;
-    }
-    if (t == _i34.SessionLogEntry) {
-      return _i34.SessionLogEntry.fromJson(data) as T;
-    }
-    if (t == _i35.SessionLogFilter) {
-      return _i35.SessionLogFilter.fromJson(data) as T;
-    }
-    if (t == _i36.SessionLogInfo) {
-      return _i36.SessionLogInfo.fromJson(data) as T;
-    }
-    if (t == _i37.SessionLogResult) {
-      return _i37.SessionLogResult.fromJson(data) as T;
-    }
-    if (t == _i1.getType<_i4.RevokedAuthenticationAuthId?>()) {
-      return (data != null
-              ? _i4.RevokedAuthenticationAuthId.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i5.RevokedAuthenticationScope?>()) {
-      return (data != null
-              ? _i5.RevokedAuthenticationScope.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i6.RevokedAuthenticationUser?>()) {
-      return (data != null
-              ? _i6.RevokedAuthenticationUser.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i7.CacheInfo?>()) {
-      return (data != null ? _i7.CacheInfo.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i8.CachesInfo?>()) {
-      return (data != null ? _i8.CachesInfo.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i9.CloudStorageEntry?>()) {
-      return (data != null ? _i9.CloudStorageEntry.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i10.CloudStorageDirectUploadEntry?>()) {
-      return (data != null
-              ? _i10.CloudStorageDirectUploadEntry.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i11.ClusterInfo?>()) {
-      return (data != null ? _i11.ClusterInfo.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i12.ClusterServerInfo?>()) {
-      return (data != null ? _i12.ClusterServerInfo.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i13.CronFutureCallScheduling?>()) {
-      return (data != null
-              ? _i13.CronFutureCallScheduling.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i14.DatabaseMigrationVersion?>()) {
-      return (data != null
-              ? _i14.DatabaseMigrationVersion.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i15.DistributedCacheEntry?>()) {
-      return (data != null ? _i15.DistributedCacheEntry.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i16.AccessDeniedException?>()) {
-      return (data != null ? _i16.AccessDeniedException.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i17.FileNotFoundException?>()) {
-      return (data != null ? _i17.FileNotFoundException.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i18.FutureCallClaimEntry?>()) {
-      return (data != null ? _i18.FutureCallClaimEntry.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i19.FutureCallEntry?>()) {
-      return (data != null ? _i19.FutureCallEntry.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i13.IntervalFutureCallScheduling?>()) {
-      return (data != null
-              ? _i13.IntervalFutureCallScheduling.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i20.LogEntry?>()) {
-      return (data != null ? _i20.LogEntry.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i21.LogLevel?>()) {
-      return (data != null ? _i21.LogLevel.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i22.LogResult?>()) {
-      return (data != null ? _i22.LogResult.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i23.LogSettings?>()) {
-      return (data != null ? _i23.LogSettings.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i24.LogSettingsOverride?>()) {
-      return (data != null ? _i24.LogSettingsOverride.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i25.MessageLogEntry?>()) {
-      return (data != null ? _i25.MessageLogEntry.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i26.MethodInfo?>()) {
-      return (data != null ? _i26.MethodInfo.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i27.QueryLogEntry?>()) {
-      return (data != null ? _i27.QueryLogEntry.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i28.ReadWriteTestEntry?>()) {
-      return (data != null ? _i28.ReadWriteTestEntry.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i29.RuntimeSettings?>()) {
-      return (data != null ? _i29.RuntimeSettings.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i30.ServerHealthConnectionInfo?>()) {
-      return (data != null
-              ? _i30.ServerHealthConnectionInfo.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i31.ServerHealthMetric?>()) {
-      return (data != null ? _i31.ServerHealthMetric.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i32.ServerHealthResult?>()) {
-      return (data != null ? _i32.ServerHealthResult.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i33.ServerpodSqlException?>()) {
-      return (data != null ? _i33.ServerpodSqlException.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i34.SessionLogEntry?>()) {
-      return (data != null ? _i34.SessionLogEntry.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i35.SessionLogFilter?>()) {
-      return (data != null ? _i35.SessionLogFilter.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i36.SessionLogInfo?>()) {
-      return (data != null ? _i36.SessionLogInfo.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i37.SessionLogResult?>()) {
-      return (data != null ? _i37.SessionLogResult.fromJson(data) : null) as T;
-    }
-    if (t == List<String>) {
-      return (data as List).map((e) => deserialize<String>(e)).toList() as T;
-    }
-    if (t == _i1.getType<List<String>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<String>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i12.ClusterServerInfo>) {
-      return (data as List)
-              .map((e) => deserialize<_i12.ClusterServerInfo>(e))
-              .toList()
-          as T;
-    }
-    if (t == List<_i20.LogEntry>) {
-      return (data as List).map((e) => deserialize<_i20.LogEntry>(e)).toList()
-          as T;
-    }
-    if (t == List<_i24.LogSettingsOverride>) {
-      return (data as List)
-              .map((e) => deserialize<_i24.LogSettingsOverride>(e))
-              .toList()
-          as T;
-    }
-    if (t == List<_i31.ServerHealthMetric>) {
-      return (data as List)
-              .map((e) => deserialize<_i31.ServerHealthMetric>(e))
-              .toList()
-          as T;
-    }
-    if (t == List<_i30.ServerHealthConnectionInfo>) {
-      return (data as List)
-              .map((e) => deserialize<_i30.ServerHealthConnectionInfo>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i20.LogEntry>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i20.LogEntry>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i27.QueryLogEntry>) {
-      return (data as List)
-              .map((e) => deserialize<_i27.QueryLogEntry>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i27.QueryLogEntry>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i27.QueryLogEntry>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i25.MessageLogEntry>) {
-      return (data as List)
-              .map((e) => deserialize<_i25.MessageLogEntry>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i25.MessageLogEntry>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i25.MessageLogEntry>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i36.SessionLogInfo>) {
-      return (data as List)
-              .map((e) => deserialize<_i36.SessionLogInfo>(e))
-              .toList()
-          as T;
-    }
-    if (t == List<_i3.TableDefinition>) {
-      return (data as List)
-              .map((e) => deserialize<_i3.TableDefinition>(e))
-              .toList()
-          as T;
-    }
-    if (t == List<String>) {
-      return (data as List).map((e) => deserialize<String>(e)).toList() as T;
+    final fn = _deserializers[t];
+    if (fn != null) {
+      return fn(data, this) as T;
     }
     try {
       return _i3.Protocol().deserialize<T>(data, t);
@@ -1867,5 +1543,212 @@ class Protocol extends _i1.DatabaseSerializationManager {
       return null;
     }
     throw Exception('Unsupported record type ${record.runtimeType}');
+  }
+
+  static Map<Type, dynamic Function(dynamic, Protocol)> _buildDeserializers() {
+    final map = <Type, dynamic Function(dynamic, Protocol)>{};
+    map[_i4.RevokedAuthenticationAuthId] = (data, protocol) =>
+        _i4.RevokedAuthenticationAuthId.fromJson(data);
+    map[_i5.RevokedAuthenticationScope] = (data, protocol) =>
+        _i5.RevokedAuthenticationScope.fromJson(data);
+    map[_i6.RevokedAuthenticationUser] = (data, protocol) =>
+        _i6.RevokedAuthenticationUser.fromJson(data);
+    map[_i7.CacheInfo] = (data, protocol) => _i7.CacheInfo.fromJson(data);
+    map[_i8.CachesInfo] = (data, protocol) => _i8.CachesInfo.fromJson(data);
+    map[_i9.CloudStorageEntry] = (data, protocol) =>
+        _i9.CloudStorageEntry.fromJson(data);
+    map[_i10.CloudStorageDirectUploadEntry] = (data, protocol) =>
+        _i10.CloudStorageDirectUploadEntry.fromJson(data);
+    map[_i11.ClusterInfo] = (data, protocol) => _i11.ClusterInfo.fromJson(data);
+    map[_i12.ClusterServerInfo] = (data, protocol) =>
+        _i12.ClusterServerInfo.fromJson(data);
+    map[_i13.CronFutureCallScheduling] = (data, protocol) =>
+        _i13.CronFutureCallScheduling.fromJson(data);
+    map[_i14.DatabaseMigrationVersion] = (data, protocol) =>
+        _i14.DatabaseMigrationVersion.fromJson(data);
+    map[_i15.DistributedCacheEntry] = (data, protocol) =>
+        _i15.DistributedCacheEntry.fromJson(data);
+    map[_i16.AccessDeniedException] = (data, protocol) =>
+        _i16.AccessDeniedException.fromJson(data);
+    map[_i17.FileNotFoundException] = (data, protocol) =>
+        _i17.FileNotFoundException.fromJson(data);
+    map[_i18.FutureCallClaimEntry] = (data, protocol) =>
+        _i18.FutureCallClaimEntry.fromJson(data);
+    map[_i19.FutureCallEntry] = (data, protocol) =>
+        _i19.FutureCallEntry.fromJson(data);
+    map[_i13.IntervalFutureCallScheduling] = (data, protocol) =>
+        _i13.IntervalFutureCallScheduling.fromJson(data);
+    map[_i20.LogEntry] = (data, protocol) => _i20.LogEntry.fromJson(data);
+    map[_i21.LogLevel] = (data, protocol) => _i21.LogLevel.fromJson(data);
+    map[_i22.LogResult] = (data, protocol) => _i22.LogResult.fromJson(data);
+    map[_i23.LogSettings] = (data, protocol) => _i23.LogSettings.fromJson(data);
+    map[_i24.LogSettingsOverride] = (data, protocol) =>
+        _i24.LogSettingsOverride.fromJson(data);
+    map[_i25.MessageLogEntry] = (data, protocol) =>
+        _i25.MessageLogEntry.fromJson(data);
+    map[_i26.MethodInfo] = (data, protocol) => _i26.MethodInfo.fromJson(data);
+    map[_i27.QueryLogEntry] = (data, protocol) =>
+        _i27.QueryLogEntry.fromJson(data);
+    map[_i28.ReadWriteTestEntry] = (data, protocol) =>
+        _i28.ReadWriteTestEntry.fromJson(data);
+    map[_i29.RuntimeSettings] = (data, protocol) =>
+        _i29.RuntimeSettings.fromJson(data);
+    map[_i30.ServerHealthConnectionInfo] = (data, protocol) =>
+        _i30.ServerHealthConnectionInfo.fromJson(data);
+    map[_i31.ServerHealthMetric] = (data, protocol) =>
+        _i31.ServerHealthMetric.fromJson(data);
+    map[_i32.ServerHealthResult] = (data, protocol) =>
+        _i32.ServerHealthResult.fromJson(data);
+    map[_i33.ServerpodSqlException] = (data, protocol) =>
+        _i33.ServerpodSqlException.fromJson(data);
+    map[_i34.SessionLogEntry] = (data, protocol) =>
+        _i34.SessionLogEntry.fromJson(data);
+    map[_i35.SessionLogFilter] = (data, protocol) =>
+        _i35.SessionLogFilter.fromJson(data);
+    map[_i36.SessionLogInfo] = (data, protocol) =>
+        _i36.SessionLogInfo.fromJson(data);
+    map[_i37.SessionLogResult] = (data, protocol) =>
+        _i37.SessionLogResult.fromJson(data);
+    map[_i1.getType<_i4.RevokedAuthenticationAuthId?>()] = (data, protocol) =>
+        (data != null ? _i4.RevokedAuthenticationAuthId.fromJson(data) : null);
+    map[_i1.getType<_i5.RevokedAuthenticationScope?>()] = (data, protocol) =>
+        (data != null ? _i5.RevokedAuthenticationScope.fromJson(data) : null);
+    map[_i1.getType<_i6.RevokedAuthenticationUser?>()] = (data, protocol) =>
+        (data != null ? _i6.RevokedAuthenticationUser.fromJson(data) : null);
+    map[_i1.getType<_i7.CacheInfo?>()] = (data, protocol) =>
+        (data != null ? _i7.CacheInfo.fromJson(data) : null);
+    map[_i1.getType<_i8.CachesInfo?>()] = (data, protocol) =>
+        (data != null ? _i8.CachesInfo.fromJson(data) : null);
+    map[_i1.getType<_i9.CloudStorageEntry?>()] = (data, protocol) =>
+        (data != null ? _i9.CloudStorageEntry.fromJson(data) : null);
+    map[_i1
+        .getType<_i10.CloudStorageDirectUploadEntry?>()] = (data, protocol) =>
+        (data != null
+        ? _i10.CloudStorageDirectUploadEntry.fromJson(data)
+        : null);
+    map[_i1.getType<_i11.ClusterInfo?>()] = (data, protocol) =>
+        (data != null ? _i11.ClusterInfo.fromJson(data) : null);
+    map[_i1.getType<_i12.ClusterServerInfo?>()] = (data, protocol) =>
+        (data != null ? _i12.ClusterServerInfo.fromJson(data) : null);
+    map[_i1.getType<_i13.CronFutureCallScheduling?>()] = (data, protocol) =>
+        (data != null ? _i13.CronFutureCallScheduling.fromJson(data) : null);
+    map[_i1.getType<_i14.DatabaseMigrationVersion?>()] = (data, protocol) =>
+        (data != null ? _i14.DatabaseMigrationVersion.fromJson(data) : null);
+    map[_i1.getType<_i15.DistributedCacheEntry?>()] = (data, protocol) =>
+        (data != null ? _i15.DistributedCacheEntry.fromJson(data) : null);
+    map[_i1.getType<_i16.AccessDeniedException?>()] = (data, protocol) =>
+        (data != null ? _i16.AccessDeniedException.fromJson(data) : null);
+    map[_i1.getType<_i17.FileNotFoundException?>()] = (data, protocol) =>
+        (data != null ? _i17.FileNotFoundException.fromJson(data) : null);
+    map[_i1.getType<_i18.FutureCallClaimEntry?>()] = (data, protocol) =>
+        (data != null ? _i18.FutureCallClaimEntry.fromJson(data) : null);
+    map[_i1.getType<_i19.FutureCallEntry?>()] = (data, protocol) =>
+        (data != null ? _i19.FutureCallEntry.fromJson(data) : null);
+    map[_i1.getType<_i13.IntervalFutureCallScheduling?>()] = (data, protocol) =>
+        (data != null
+        ? _i13.IntervalFutureCallScheduling.fromJson(data)
+        : null);
+    map[_i1.getType<_i20.LogEntry?>()] = (data, protocol) =>
+        (data != null ? _i20.LogEntry.fromJson(data) : null);
+    map[_i1.getType<_i21.LogLevel?>()] = (data, protocol) =>
+        (data != null ? _i21.LogLevel.fromJson(data) : null);
+    map[_i1.getType<_i22.LogResult?>()] = (data, protocol) =>
+        (data != null ? _i22.LogResult.fromJson(data) : null);
+    map[_i1.getType<_i23.LogSettings?>()] = (data, protocol) =>
+        (data != null ? _i23.LogSettings.fromJson(data) : null);
+    map[_i1.getType<_i24.LogSettingsOverride?>()] = (data, protocol) =>
+        (data != null ? _i24.LogSettingsOverride.fromJson(data) : null);
+    map[_i1.getType<_i25.MessageLogEntry?>()] = (data, protocol) =>
+        (data != null ? _i25.MessageLogEntry.fromJson(data) : null);
+    map[_i1.getType<_i26.MethodInfo?>()] = (data, protocol) =>
+        (data != null ? _i26.MethodInfo.fromJson(data) : null);
+    map[_i1.getType<_i27.QueryLogEntry?>()] = (data, protocol) =>
+        (data != null ? _i27.QueryLogEntry.fromJson(data) : null);
+    map[_i1.getType<_i28.ReadWriteTestEntry?>()] = (data, protocol) =>
+        (data != null ? _i28.ReadWriteTestEntry.fromJson(data) : null);
+    map[_i1.getType<_i29.RuntimeSettings?>()] = (data, protocol) =>
+        (data != null ? _i29.RuntimeSettings.fromJson(data) : null);
+    map[_i1.getType<_i30.ServerHealthConnectionInfo?>()] = (data, protocol) =>
+        (data != null ? _i30.ServerHealthConnectionInfo.fromJson(data) : null);
+    map[_i1.getType<_i31.ServerHealthMetric?>()] = (data, protocol) =>
+        (data != null ? _i31.ServerHealthMetric.fromJson(data) : null);
+    map[_i1.getType<_i32.ServerHealthResult?>()] = (data, protocol) =>
+        (data != null ? _i32.ServerHealthResult.fromJson(data) : null);
+    map[_i1.getType<_i33.ServerpodSqlException?>()] = (data, protocol) =>
+        (data != null ? _i33.ServerpodSqlException.fromJson(data) : null);
+    map[_i1.getType<_i34.SessionLogEntry?>()] = (data, protocol) =>
+        (data != null ? _i34.SessionLogEntry.fromJson(data) : null);
+    map[_i1.getType<_i35.SessionLogFilter?>()] = (data, protocol) =>
+        (data != null ? _i35.SessionLogFilter.fromJson(data) : null);
+    map[_i1.getType<_i36.SessionLogInfo?>()] = (data, protocol) =>
+        (data != null ? _i36.SessionLogInfo.fromJson(data) : null);
+    map[_i1.getType<_i37.SessionLogResult?>()] = (data, protocol) =>
+        (data != null ? _i37.SessionLogResult.fromJson(data) : null);
+    map[List<String>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<String>(e)).toList();
+    map[List<String>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<String>(e)).toList();
+    map[_i1.getType<List<String>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<String>(e)).toList()
+        : null);
+    map[List<_i12.ClusterServerInfo>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i12.ClusterServerInfo>(e))
+        .toList();
+    map[List<_i20.LogEntry>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i20.LogEntry>(e))
+        .toList();
+    map[List<_i24.LogSettingsOverride>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i24.LogSettingsOverride>(e))
+        .toList();
+    map[List<_i31.ServerHealthMetric>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i31.ServerHealthMetric>(e))
+        .toList();
+    map[List<_i30.ServerHealthConnectionInfo>] = (data, protocol) =>
+        (data as List)
+            .map(
+              (e) => protocol.deserialize<_i30.ServerHealthConnectionInfo>(e),
+            )
+            .toList();
+    map[List<_i20.LogEntry>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i20.LogEntry>(e))
+        .toList();
+    map[_i1.getType<List<_i20.LogEntry>?>()] = (data, protocol) => (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i20.LogEntry>(e))
+              .toList()
+        : null);
+    map[List<_i27.QueryLogEntry>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i27.QueryLogEntry>(e))
+        .toList();
+    map[_i1.getType<List<_i27.QueryLogEntry>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i27.QueryLogEntry>(e))
+              .toList()
+        : null);
+    map[List<_i25.MessageLogEntry>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i25.MessageLogEntry>(e))
+        .toList();
+    map[_i1.getType<List<_i25.MessageLogEntry>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i25.MessageLogEntry>(e))
+              .toList()
+        : null);
+    map[List<_i27.QueryLogEntry>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i27.QueryLogEntry>(e))
+        .toList();
+    map[List<_i25.MessageLogEntry>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i25.MessageLogEntry>(e))
+        .toList();
+    map[List<_i36.SessionLogInfo>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i36.SessionLogInfo>(e))
+        .toList();
+    map[List<_i3.TableDefinition>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i3.TableDefinition>(e))
+        .toList();
+    map[List<String>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<String>(e)).toList();
+    return map;
   }
 }

--- a/packages/serverpod_database/lib/src/generated/protocol.dart
+++ b/packages/serverpod_database/lib/src/generated/protocol.dart
@@ -82,6 +82,198 @@ class Protocol extends _i1.SerializationManager {
 
   final Map<String, _i1.SerializationManager> _hostProtocols = {};
 
+  static final Map<Type, dynamic Function(dynamic, Protocol)> _deserializers =
+      _buildDeserializers();
+
+  static Map<Type, dynamic Function(dynamic, Protocol)> _buildDeserializers() {
+    final map = <Type, dynamic Function(dynamic, Protocol)>{};
+    map[_i2.BulkData] = (data, protocol) => _i2.BulkData.fromJson(data);
+    map[_i3.BulkDataException] = (data, protocol) =>
+        _i3.BulkDataException.fromJson(data);
+    map[_i4.BulkQueryColumnDescription] = (data, protocol) =>
+        _i4.BulkQueryColumnDescription.fromJson(data);
+    map[_i5.BulkQueryResult] = (data, protocol) =>
+        _i5.BulkQueryResult.fromJson(data);
+    map[_i6.ColumnDefinition] = (data, protocol) =>
+        _i6.ColumnDefinition.fromJson(data);
+    map[_i7.ColumnMigration] = (data, protocol) =>
+        _i7.ColumnMigration.fromJson(data);
+    map[_i8.ColumnType] = (data, protocol) => _i8.ColumnType.fromJson(data);
+    map[_i9.DatabaseDefinition] = (data, protocol) =>
+        _i9.DatabaseDefinition.fromJson(data);
+    map[_i10.DatabaseDefinitions] = (data, protocol) =>
+        _i10.DatabaseDefinitions.fromJson(data);
+    map[_i11.DatabaseMigration] = (data, protocol) =>
+        _i11.DatabaseMigration.fromJson(data);
+    map[_i12.DatabaseMigrationAction] = (data, protocol) =>
+        _i12.DatabaseMigrationAction.fromJson(data);
+    map[_i13.DatabaseMigrationActionType] = (data, protocol) =>
+        _i13.DatabaseMigrationActionType.fromJson(data);
+    map[_i14.DatabaseMigrationVersionModel] = (data, protocol) =>
+        _i14.DatabaseMigrationVersionModel.fromJson(data);
+    map[_i15.DatabaseMigrationWarning] = (data, protocol) =>
+        _i15.DatabaseMigrationWarning.fromJson(data);
+    map[_i16.DatabaseMigrationWarningType] = (data, protocol) =>
+        _i16.DatabaseMigrationWarningType.fromJson(data);
+    map[_i17.EnumSerialization] = (data, protocol) =>
+        _i17.EnumSerialization.fromJson(data);
+    map[_i18.Filter] = (data, protocol) => _i18.Filter.fromJson(data);
+    map[_i19.FilterConstraint] = (data, protocol) =>
+        _i19.FilterConstraint.fromJson(data);
+    map[_i20.FilterConstraintType] = (data, protocol) =>
+        _i20.FilterConstraintType.fromJson(data);
+    map[_i21.ForeignKeyAction] = (data, protocol) =>
+        _i21.ForeignKeyAction.fromJson(data);
+    map[_i22.ForeignKeyDefinition] = (data, protocol) =>
+        _i22.ForeignKeyDefinition.fromJson(data);
+    map[_i23.ForeignKeyMatchType] = (data, protocol) =>
+        _i23.ForeignKeyMatchType.fromJson(data);
+    map[_i24.GinOperatorClass] = (data, protocol) =>
+        _i24.GinOperatorClass.fromJson(data);
+    map[_i25.IndexDefinition] = (data, protocol) =>
+        _i25.IndexDefinition.fromJson(data);
+    map[_i26.IndexElementDefinition] = (data, protocol) =>
+        _i26.IndexElementDefinition.fromJson(data);
+    map[_i27.IndexElementDefinitionType] = (data, protocol) =>
+        _i27.IndexElementDefinitionType.fromJson(data);
+    map[_i28.MigrationsApplyResult] = (data, protocol) =>
+        _i28.MigrationsApplyResult.fromJson(data);
+    map[_i29.TableDefinition] = (data, protocol) =>
+        _i29.TableDefinition.fromJson(data);
+    map[_i30.TableMigration] = (data, protocol) =>
+        _i30.TableMigration.fromJson(data);
+    map[_i31.VectorDistanceFunction] = (data, protocol) =>
+        _i31.VectorDistanceFunction.fromJson(data);
+    map[_i1.getType<_i2.BulkData?>()] = (data, protocol) =>
+        (data != null ? _i2.BulkData.fromJson(data) : null);
+    map[_i1.getType<_i3.BulkDataException?>()] = (data, protocol) =>
+        (data != null ? _i3.BulkDataException.fromJson(data) : null);
+    map[_i1.getType<_i4.BulkQueryColumnDescription?>()] = (data, protocol) =>
+        (data != null ? _i4.BulkQueryColumnDescription.fromJson(data) : null);
+    map[_i1.getType<_i5.BulkQueryResult?>()] = (data, protocol) =>
+        (data != null ? _i5.BulkQueryResult.fromJson(data) : null);
+    map[_i1.getType<_i6.ColumnDefinition?>()] = (data, protocol) =>
+        (data != null ? _i6.ColumnDefinition.fromJson(data) : null);
+    map[_i1.getType<_i7.ColumnMigration?>()] = (data, protocol) =>
+        (data != null ? _i7.ColumnMigration.fromJson(data) : null);
+    map[_i1.getType<_i8.ColumnType?>()] = (data, protocol) =>
+        (data != null ? _i8.ColumnType.fromJson(data) : null);
+    map[_i1.getType<_i9.DatabaseDefinition?>()] = (data, protocol) =>
+        (data != null ? _i9.DatabaseDefinition.fromJson(data) : null);
+    map[_i1.getType<_i10.DatabaseDefinitions?>()] = (data, protocol) =>
+        (data != null ? _i10.DatabaseDefinitions.fromJson(data) : null);
+    map[_i1.getType<_i11.DatabaseMigration?>()] = (data, protocol) =>
+        (data != null ? _i11.DatabaseMigration.fromJson(data) : null);
+    map[_i1.getType<_i12.DatabaseMigrationAction?>()] = (data, protocol) =>
+        (data != null ? _i12.DatabaseMigrationAction.fromJson(data) : null);
+    map[_i1.getType<_i13.DatabaseMigrationActionType?>()] = (data, protocol) =>
+        (data != null ? _i13.DatabaseMigrationActionType.fromJson(data) : null);
+    map[_i1
+        .getType<_i14.DatabaseMigrationVersionModel?>()] = (data, protocol) =>
+        (data != null
+        ? _i14.DatabaseMigrationVersionModel.fromJson(data)
+        : null);
+    map[_i1.getType<_i15.DatabaseMigrationWarning?>()] = (data, protocol) =>
+        (data != null ? _i15.DatabaseMigrationWarning.fromJson(data) : null);
+    map[_i1.getType<_i16.DatabaseMigrationWarningType?>()] = (data, protocol) =>
+        (data != null
+        ? _i16.DatabaseMigrationWarningType.fromJson(data)
+        : null);
+    map[_i1.getType<_i17.EnumSerialization?>()] = (data, protocol) =>
+        (data != null ? _i17.EnumSerialization.fromJson(data) : null);
+    map[_i1.getType<_i18.Filter?>()] = (data, protocol) =>
+        (data != null ? _i18.Filter.fromJson(data) : null);
+    map[_i1.getType<_i19.FilterConstraint?>()] = (data, protocol) =>
+        (data != null ? _i19.FilterConstraint.fromJson(data) : null);
+    map[_i1.getType<_i20.FilterConstraintType?>()] = (data, protocol) =>
+        (data != null ? _i20.FilterConstraintType.fromJson(data) : null);
+    map[_i1.getType<_i21.ForeignKeyAction?>()] = (data, protocol) =>
+        (data != null ? _i21.ForeignKeyAction.fromJson(data) : null);
+    map[_i1.getType<_i22.ForeignKeyDefinition?>()] = (data, protocol) =>
+        (data != null ? _i22.ForeignKeyDefinition.fromJson(data) : null);
+    map[_i1.getType<_i23.ForeignKeyMatchType?>()] = (data, protocol) =>
+        (data != null ? _i23.ForeignKeyMatchType.fromJson(data) : null);
+    map[_i1.getType<_i24.GinOperatorClass?>()] = (data, protocol) =>
+        (data != null ? _i24.GinOperatorClass.fromJson(data) : null);
+    map[_i1.getType<_i25.IndexDefinition?>()] = (data, protocol) =>
+        (data != null ? _i25.IndexDefinition.fromJson(data) : null);
+    map[_i1.getType<_i26.IndexElementDefinition?>()] = (data, protocol) =>
+        (data != null ? _i26.IndexElementDefinition.fromJson(data) : null);
+    map[_i1.getType<_i27.IndexElementDefinitionType?>()] = (data, protocol) =>
+        (data != null ? _i27.IndexElementDefinitionType.fromJson(data) : null);
+    map[_i1.getType<_i28.MigrationsApplyResult?>()] = (data, protocol) =>
+        (data != null ? _i28.MigrationsApplyResult.fromJson(data) : null);
+    map[_i1.getType<_i29.TableDefinition?>()] = (data, protocol) =>
+        (data != null ? _i29.TableDefinition.fromJson(data) : null);
+    map[_i1.getType<_i30.TableMigration?>()] = (data, protocol) =>
+        (data != null ? _i30.TableMigration.fromJson(data) : null);
+    map[_i1.getType<_i31.VectorDistanceFunction?>()] = (data, protocol) =>
+        (data != null ? _i31.VectorDistanceFunction.fromJson(data) : null);
+    map[List<_i32.BulkQueryColumnDescription>] = (data, protocol) =>
+        (data as List)
+            .map(
+              (e) => protocol.deserialize<_i32.BulkQueryColumnDescription>(e),
+            )
+            .toList();
+    map[List<_i32.TableDefinition>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i32.TableDefinition>(e))
+        .toList();
+    map[List<_i32.DatabaseMigrationVersionModel>] = (data, protocol) =>
+        (data as List)
+            .map(
+              (e) =>
+                  protocol.deserialize<_i32.DatabaseMigrationVersionModel>(e),
+            )
+            .toList();
+    map[List<_i32.DatabaseMigrationAction>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i32.DatabaseMigrationAction>(e))
+        .toList();
+    map[List<_i32.DatabaseMigrationWarning>] = (data, protocol) =>
+        (data as List)
+            .map((e) => protocol.deserialize<_i32.DatabaseMigrationWarning>(e))
+            .toList();
+    map[List<String>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<String>(e)).toList();
+    map[List<_i32.FilterConstraint>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i32.FilterConstraint>(e))
+        .toList();
+    map[List<_i32.IndexElementDefinition>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i32.IndexElementDefinition>(e))
+        .toList();
+    map[Map<String, String>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<String>(v),
+      ),
+    );
+    map[_i1.getType<Map<String, String>?>()] = (data, protocol) => (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<String>(v),
+            ),
+          )
+        : null);
+    map[List<String>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<String>(e)).toList();
+    map[_i1.getType<List<String>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<String>(e)).toList()
+        : null);
+    map[List<_i32.ColumnDefinition>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i32.ColumnDefinition>(e))
+        .toList();
+    map[List<_i32.ForeignKeyDefinition>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i32.ForeignKeyDefinition>(e))
+        .toList();
+    map[List<_i32.IndexDefinition>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i32.IndexDefinition>(e))
+        .toList();
+    map[List<_i32.ColumnMigration>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i32.ColumnMigration>(e))
+        .toList();
+    return map;
+  }
+
   void registerHostProtocol(
     String projectName,
     _i1.SerializationManager protocol,
@@ -118,301 +310,9 @@ class Protocol extends _i1.SerializationManager {
       }
     }
 
-    if (t == _i2.BulkData) {
-      return _i2.BulkData.fromJson(data) as T;
-    }
-    if (t == _i3.BulkDataException) {
-      return _i3.BulkDataException.fromJson(data) as T;
-    }
-    if (t == _i4.BulkQueryColumnDescription) {
-      return _i4.BulkQueryColumnDescription.fromJson(data) as T;
-    }
-    if (t == _i5.BulkQueryResult) {
-      return _i5.BulkQueryResult.fromJson(data) as T;
-    }
-    if (t == _i6.ColumnDefinition) {
-      return _i6.ColumnDefinition.fromJson(data) as T;
-    }
-    if (t == _i7.ColumnMigration) {
-      return _i7.ColumnMigration.fromJson(data) as T;
-    }
-    if (t == _i8.ColumnType) {
-      return _i8.ColumnType.fromJson(data) as T;
-    }
-    if (t == _i9.DatabaseDefinition) {
-      return _i9.DatabaseDefinition.fromJson(data) as T;
-    }
-    if (t == _i10.DatabaseDefinitions) {
-      return _i10.DatabaseDefinitions.fromJson(data) as T;
-    }
-    if (t == _i11.DatabaseMigration) {
-      return _i11.DatabaseMigration.fromJson(data) as T;
-    }
-    if (t == _i12.DatabaseMigrationAction) {
-      return _i12.DatabaseMigrationAction.fromJson(data) as T;
-    }
-    if (t == _i13.DatabaseMigrationActionType) {
-      return _i13.DatabaseMigrationActionType.fromJson(data) as T;
-    }
-    if (t == _i14.DatabaseMigrationVersionModel) {
-      return _i14.DatabaseMigrationVersionModel.fromJson(data) as T;
-    }
-    if (t == _i15.DatabaseMigrationWarning) {
-      return _i15.DatabaseMigrationWarning.fromJson(data) as T;
-    }
-    if (t == _i16.DatabaseMigrationWarningType) {
-      return _i16.DatabaseMigrationWarningType.fromJson(data) as T;
-    }
-    if (t == _i17.EnumSerialization) {
-      return _i17.EnumSerialization.fromJson(data) as T;
-    }
-    if (t == _i18.Filter) {
-      return _i18.Filter.fromJson(data) as T;
-    }
-    if (t == _i19.FilterConstraint) {
-      return _i19.FilterConstraint.fromJson(data) as T;
-    }
-    if (t == _i20.FilterConstraintType) {
-      return _i20.FilterConstraintType.fromJson(data) as T;
-    }
-    if (t == _i21.ForeignKeyAction) {
-      return _i21.ForeignKeyAction.fromJson(data) as T;
-    }
-    if (t == _i22.ForeignKeyDefinition) {
-      return _i22.ForeignKeyDefinition.fromJson(data) as T;
-    }
-    if (t == _i23.ForeignKeyMatchType) {
-      return _i23.ForeignKeyMatchType.fromJson(data) as T;
-    }
-    if (t == _i24.GinOperatorClass) {
-      return _i24.GinOperatorClass.fromJson(data) as T;
-    }
-    if (t == _i25.IndexDefinition) {
-      return _i25.IndexDefinition.fromJson(data) as T;
-    }
-    if (t == _i26.IndexElementDefinition) {
-      return _i26.IndexElementDefinition.fromJson(data) as T;
-    }
-    if (t == _i27.IndexElementDefinitionType) {
-      return _i27.IndexElementDefinitionType.fromJson(data) as T;
-    }
-    if (t == _i28.MigrationsApplyResult) {
-      return _i28.MigrationsApplyResult.fromJson(data) as T;
-    }
-    if (t == _i29.TableDefinition) {
-      return _i29.TableDefinition.fromJson(data) as T;
-    }
-    if (t == _i30.TableMigration) {
-      return _i30.TableMigration.fromJson(data) as T;
-    }
-    if (t == _i31.VectorDistanceFunction) {
-      return _i31.VectorDistanceFunction.fromJson(data) as T;
-    }
-    if (t == _i1.getType<_i2.BulkData?>()) {
-      return (data != null ? _i2.BulkData.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i3.BulkDataException?>()) {
-      return (data != null ? _i3.BulkDataException.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i4.BulkQueryColumnDescription?>()) {
-      return (data != null
-              ? _i4.BulkQueryColumnDescription.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i5.BulkQueryResult?>()) {
-      return (data != null ? _i5.BulkQueryResult.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i6.ColumnDefinition?>()) {
-      return (data != null ? _i6.ColumnDefinition.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i7.ColumnMigration?>()) {
-      return (data != null ? _i7.ColumnMigration.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i8.ColumnType?>()) {
-      return (data != null ? _i8.ColumnType.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i9.DatabaseDefinition?>()) {
-      return (data != null ? _i9.DatabaseDefinition.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i10.DatabaseDefinitions?>()) {
-      return (data != null ? _i10.DatabaseDefinitions.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i11.DatabaseMigration?>()) {
-      return (data != null ? _i11.DatabaseMigration.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i12.DatabaseMigrationAction?>()) {
-      return (data != null ? _i12.DatabaseMigrationAction.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i13.DatabaseMigrationActionType?>()) {
-      return (data != null
-              ? _i13.DatabaseMigrationActionType.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i14.DatabaseMigrationVersionModel?>()) {
-      return (data != null
-              ? _i14.DatabaseMigrationVersionModel.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i15.DatabaseMigrationWarning?>()) {
-      return (data != null
-              ? _i15.DatabaseMigrationWarning.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i16.DatabaseMigrationWarningType?>()) {
-      return (data != null
-              ? _i16.DatabaseMigrationWarningType.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i17.EnumSerialization?>()) {
-      return (data != null ? _i17.EnumSerialization.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i18.Filter?>()) {
-      return (data != null ? _i18.Filter.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i19.FilterConstraint?>()) {
-      return (data != null ? _i19.FilterConstraint.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i20.FilterConstraintType?>()) {
-      return (data != null ? _i20.FilterConstraintType.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i21.ForeignKeyAction?>()) {
-      return (data != null ? _i21.ForeignKeyAction.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i22.ForeignKeyDefinition?>()) {
-      return (data != null ? _i22.ForeignKeyDefinition.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i23.ForeignKeyMatchType?>()) {
-      return (data != null ? _i23.ForeignKeyMatchType.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i24.GinOperatorClass?>()) {
-      return (data != null ? _i24.GinOperatorClass.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i25.IndexDefinition?>()) {
-      return (data != null ? _i25.IndexDefinition.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i26.IndexElementDefinition?>()) {
-      return (data != null ? _i26.IndexElementDefinition.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i27.IndexElementDefinitionType?>()) {
-      return (data != null
-              ? _i27.IndexElementDefinitionType.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i28.MigrationsApplyResult?>()) {
-      return (data != null ? _i28.MigrationsApplyResult.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i29.TableDefinition?>()) {
-      return (data != null ? _i29.TableDefinition.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i30.TableMigration?>()) {
-      return (data != null ? _i30.TableMigration.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i31.VectorDistanceFunction?>()) {
-      return (data != null ? _i31.VectorDistanceFunction.fromJson(data) : null)
-          as T;
-    }
-    if (t == List<_i32.BulkQueryColumnDescription>) {
-      return (data as List)
-              .map((e) => deserialize<_i32.BulkQueryColumnDescription>(e))
-              .toList()
-          as T;
-    }
-    if (t == List<_i32.TableDefinition>) {
-      return (data as List)
-              .map((e) => deserialize<_i32.TableDefinition>(e))
-              .toList()
-          as T;
-    }
-    if (t == List<_i32.DatabaseMigrationVersionModel>) {
-      return (data as List)
-              .map((e) => deserialize<_i32.DatabaseMigrationVersionModel>(e))
-              .toList()
-          as T;
-    }
-    if (t == List<_i32.DatabaseMigrationAction>) {
-      return (data as List)
-              .map((e) => deserialize<_i32.DatabaseMigrationAction>(e))
-              .toList()
-          as T;
-    }
-    if (t == List<_i32.DatabaseMigrationWarning>) {
-      return (data as List)
-              .map((e) => deserialize<_i32.DatabaseMigrationWarning>(e))
-              .toList()
-          as T;
-    }
-    if (t == List<String>) {
-      return (data as List).map((e) => deserialize<String>(e)).toList() as T;
-    }
-    if (t == List<_i32.FilterConstraint>) {
-      return (data as List)
-              .map((e) => deserialize<_i32.FilterConstraint>(e))
-              .toList()
-          as T;
-    }
-    if (t == List<_i32.IndexElementDefinition>) {
-      return (data as List)
-              .map((e) => deserialize<_i32.IndexElementDefinition>(e))
-              .toList()
-          as T;
-    }
-    if (t == Map<String, String>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(deserialize<String>(k), deserialize<String>(v)),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<String, String>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) =>
-                      MapEntry(deserialize<String>(k), deserialize<String>(v)),
-                )
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<List<String>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<String>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i32.ColumnDefinition>) {
-      return (data as List)
-              .map((e) => deserialize<_i32.ColumnDefinition>(e))
-              .toList()
-          as T;
-    }
-    if (t == List<_i32.ForeignKeyDefinition>) {
-      return (data as List)
-              .map((e) => deserialize<_i32.ForeignKeyDefinition>(e))
-              .toList()
-          as T;
-    }
-    if (t == List<_i32.IndexDefinition>) {
-      return (data as List)
-              .map((e) => deserialize<_i32.IndexDefinition>(e))
-              .toList()
-          as T;
-    }
-    if (t == List<_i32.ColumnMigration>) {
-      return (data as List)
-              .map((e) => deserialize<_i32.ColumnMigration>(e))
-              .toList()
-          as T;
+    final fn = _deserializers[t];
+    if (fn != null) {
+      return fn(data, this) as T;
     }
     return super.deserialize<T>(data, t);
   }

--- a/packages/serverpod_database/lib/src/generated/protocol.dart
+++ b/packages/serverpod_database/lib/src/generated/protocol.dart
@@ -83,6 +83,9 @@ class Protocol extends _i1.SerializationManager {
 
   final Set<_i1.SerializationManager> _hostProtocols = {};
 
+  static final Map<Type, dynamic Function(dynamic, Protocol)> _deserializers =
+      _buildDeserializers();
+
   void registerHostProtocol(
     String projectName,
     _i1.SerializationManager protocol,
@@ -119,301 +122,9 @@ class Protocol extends _i1.SerializationManager {
       }
     }
 
-    if (t == _i2.BulkData) {
-      return _i2.BulkData.fromJson(data) as T;
-    }
-    if (t == _i3.BulkDataException) {
-      return _i3.BulkDataException.fromJson(data) as T;
-    }
-    if (t == _i4.BulkQueryColumnDescription) {
-      return _i4.BulkQueryColumnDescription.fromJson(data) as T;
-    }
-    if (t == _i5.BulkQueryResult) {
-      return _i5.BulkQueryResult.fromJson(data) as T;
-    }
-    if (t == _i6.ColumnDefinition) {
-      return _i6.ColumnDefinition.fromJson(data) as T;
-    }
-    if (t == _i7.ColumnMigration) {
-      return _i7.ColumnMigration.fromJson(data) as T;
-    }
-    if (t == _i8.ColumnType) {
-      return _i8.ColumnType.fromJson(data) as T;
-    }
-    if (t == _i9.DatabaseDefinition) {
-      return _i9.DatabaseDefinition.fromJson(data) as T;
-    }
-    if (t == _i10.DatabaseDefinitions) {
-      return _i10.DatabaseDefinitions.fromJson(data) as T;
-    }
-    if (t == _i11.DatabaseMigration) {
-      return _i11.DatabaseMigration.fromJson(data) as T;
-    }
-    if (t == _i12.DatabaseMigrationAction) {
-      return _i12.DatabaseMigrationAction.fromJson(data) as T;
-    }
-    if (t == _i13.DatabaseMigrationActionType) {
-      return _i13.DatabaseMigrationActionType.fromJson(data) as T;
-    }
-    if (t == _i14.DatabaseMigrationVersionModel) {
-      return _i14.DatabaseMigrationVersionModel.fromJson(data) as T;
-    }
-    if (t == _i15.DatabaseMigrationWarning) {
-      return _i15.DatabaseMigrationWarning.fromJson(data) as T;
-    }
-    if (t == _i16.DatabaseMigrationWarningType) {
-      return _i16.DatabaseMigrationWarningType.fromJson(data) as T;
-    }
-    if (t == _i17.EnumSerialization) {
-      return _i17.EnumSerialization.fromJson(data) as T;
-    }
-    if (t == _i18.Filter) {
-      return _i18.Filter.fromJson(data) as T;
-    }
-    if (t == _i19.FilterConstraint) {
-      return _i19.FilterConstraint.fromJson(data) as T;
-    }
-    if (t == _i20.FilterConstraintType) {
-      return _i20.FilterConstraintType.fromJson(data) as T;
-    }
-    if (t == _i21.ForeignKeyAction) {
-      return _i21.ForeignKeyAction.fromJson(data) as T;
-    }
-    if (t == _i22.ForeignKeyDefinition) {
-      return _i22.ForeignKeyDefinition.fromJson(data) as T;
-    }
-    if (t == _i23.ForeignKeyMatchType) {
-      return _i23.ForeignKeyMatchType.fromJson(data) as T;
-    }
-    if (t == _i24.GinOperatorClass) {
-      return _i24.GinOperatorClass.fromJson(data) as T;
-    }
-    if (t == _i25.IndexDefinition) {
-      return _i25.IndexDefinition.fromJson(data) as T;
-    }
-    if (t == _i26.IndexElementDefinition) {
-      return _i26.IndexElementDefinition.fromJson(data) as T;
-    }
-    if (t == _i27.IndexElementDefinitionType) {
-      return _i27.IndexElementDefinitionType.fromJson(data) as T;
-    }
-    if (t == _i28.MigrationsApplyResult) {
-      return _i28.MigrationsApplyResult.fromJson(data) as T;
-    }
-    if (t == _i29.TableDefinition) {
-      return _i29.TableDefinition.fromJson(data) as T;
-    }
-    if (t == _i30.TableMigration) {
-      return _i30.TableMigration.fromJson(data) as T;
-    }
-    if (t == _i31.VectorDistanceFunction) {
-      return _i31.VectorDistanceFunction.fromJson(data) as T;
-    }
-    if (t == _i1.getType<_i2.BulkData?>()) {
-      return (data != null ? _i2.BulkData.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i3.BulkDataException?>()) {
-      return (data != null ? _i3.BulkDataException.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i4.BulkQueryColumnDescription?>()) {
-      return (data != null
-              ? _i4.BulkQueryColumnDescription.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i5.BulkQueryResult?>()) {
-      return (data != null ? _i5.BulkQueryResult.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i6.ColumnDefinition?>()) {
-      return (data != null ? _i6.ColumnDefinition.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i7.ColumnMigration?>()) {
-      return (data != null ? _i7.ColumnMigration.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i8.ColumnType?>()) {
-      return (data != null ? _i8.ColumnType.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i9.DatabaseDefinition?>()) {
-      return (data != null ? _i9.DatabaseDefinition.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i10.DatabaseDefinitions?>()) {
-      return (data != null ? _i10.DatabaseDefinitions.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i11.DatabaseMigration?>()) {
-      return (data != null ? _i11.DatabaseMigration.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i12.DatabaseMigrationAction?>()) {
-      return (data != null ? _i12.DatabaseMigrationAction.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i13.DatabaseMigrationActionType?>()) {
-      return (data != null
-              ? _i13.DatabaseMigrationActionType.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i14.DatabaseMigrationVersionModel?>()) {
-      return (data != null
-              ? _i14.DatabaseMigrationVersionModel.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i15.DatabaseMigrationWarning?>()) {
-      return (data != null
-              ? _i15.DatabaseMigrationWarning.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i16.DatabaseMigrationWarningType?>()) {
-      return (data != null
-              ? _i16.DatabaseMigrationWarningType.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i17.EnumSerialization?>()) {
-      return (data != null ? _i17.EnumSerialization.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i18.Filter?>()) {
-      return (data != null ? _i18.Filter.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i19.FilterConstraint?>()) {
-      return (data != null ? _i19.FilterConstraint.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i20.FilterConstraintType?>()) {
-      return (data != null ? _i20.FilterConstraintType.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i21.ForeignKeyAction?>()) {
-      return (data != null ? _i21.ForeignKeyAction.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i22.ForeignKeyDefinition?>()) {
-      return (data != null ? _i22.ForeignKeyDefinition.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i23.ForeignKeyMatchType?>()) {
-      return (data != null ? _i23.ForeignKeyMatchType.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i24.GinOperatorClass?>()) {
-      return (data != null ? _i24.GinOperatorClass.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i25.IndexDefinition?>()) {
-      return (data != null ? _i25.IndexDefinition.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i26.IndexElementDefinition?>()) {
-      return (data != null ? _i26.IndexElementDefinition.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i27.IndexElementDefinitionType?>()) {
-      return (data != null
-              ? _i27.IndexElementDefinitionType.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i28.MigrationsApplyResult?>()) {
-      return (data != null ? _i28.MigrationsApplyResult.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i29.TableDefinition?>()) {
-      return (data != null ? _i29.TableDefinition.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i30.TableMigration?>()) {
-      return (data != null ? _i30.TableMigration.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i31.VectorDistanceFunction?>()) {
-      return (data != null ? _i31.VectorDistanceFunction.fromJson(data) : null)
-          as T;
-    }
-    if (t == List<_i32.BulkQueryColumnDescription>) {
-      return (data as List)
-              .map((e) => deserialize<_i32.BulkQueryColumnDescription>(e))
-              .toList()
-          as T;
-    }
-    if (t == List<_i32.TableDefinition>) {
-      return (data as List)
-              .map((e) => deserialize<_i32.TableDefinition>(e))
-              .toList()
-          as T;
-    }
-    if (t == List<_i32.DatabaseMigrationVersionModel>) {
-      return (data as List)
-              .map((e) => deserialize<_i32.DatabaseMigrationVersionModel>(e))
-              .toList()
-          as T;
-    }
-    if (t == List<_i32.DatabaseMigrationAction>) {
-      return (data as List)
-              .map((e) => deserialize<_i32.DatabaseMigrationAction>(e))
-              .toList()
-          as T;
-    }
-    if (t == List<_i32.DatabaseMigrationWarning>) {
-      return (data as List)
-              .map((e) => deserialize<_i32.DatabaseMigrationWarning>(e))
-              .toList()
-          as T;
-    }
-    if (t == List<String>) {
-      return (data as List).map((e) => deserialize<String>(e)).toList() as T;
-    }
-    if (t == List<_i32.FilterConstraint>) {
-      return (data as List)
-              .map((e) => deserialize<_i32.FilterConstraint>(e))
-              .toList()
-          as T;
-    }
-    if (t == List<_i32.IndexElementDefinition>) {
-      return (data as List)
-              .map((e) => deserialize<_i32.IndexElementDefinition>(e))
-              .toList()
-          as T;
-    }
-    if (t == Map<String, String>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(deserialize<String>(k), deserialize<String>(v)),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<String, String>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) =>
-                      MapEntry(deserialize<String>(k), deserialize<String>(v)),
-                )
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<List<String>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<String>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i32.ColumnDefinition>) {
-      return (data as List)
-              .map((e) => deserialize<_i32.ColumnDefinition>(e))
-              .toList()
-          as T;
-    }
-    if (t == List<_i32.ForeignKeyDefinition>) {
-      return (data as List)
-              .map((e) => deserialize<_i32.ForeignKeyDefinition>(e))
-              .toList()
-          as T;
-    }
-    if (t == List<_i32.IndexDefinition>) {
-      return (data as List)
-              .map((e) => deserialize<_i32.IndexDefinition>(e))
-              .toList()
-          as T;
-    }
-    if (t == List<_i32.ColumnMigration>) {
-      return (data as List)
-              .map((e) => deserialize<_i32.ColumnMigration>(e))
-              .toList()
-          as T;
+    final fn = _deserializers[t];
+    if (fn != null) {
+      return fn(data, this) as T;
     }
     return super.deserialize<T>(data, t);
   }
@@ -699,5 +410,194 @@ class Protocol extends _i1.SerializationManager {
       return null;
     }
     throw Exception('Unsupported record type ${record.runtimeType}');
+  }
+
+  static Map<Type, dynamic Function(dynamic, Protocol)> _buildDeserializers() {
+    final map = <Type, dynamic Function(dynamic, Protocol)>{};
+    map[_i2.BulkData] = (data, protocol) => _i2.BulkData.fromJson(data);
+    map[_i3.BulkDataException] = (data, protocol) =>
+        _i3.BulkDataException.fromJson(data);
+    map[_i4.BulkQueryColumnDescription] = (data, protocol) =>
+        _i4.BulkQueryColumnDescription.fromJson(data);
+    map[_i5.BulkQueryResult] = (data, protocol) =>
+        _i5.BulkQueryResult.fromJson(data);
+    map[_i6.ColumnDefinition] = (data, protocol) =>
+        _i6.ColumnDefinition.fromJson(data);
+    map[_i7.ColumnMigration] = (data, protocol) =>
+        _i7.ColumnMigration.fromJson(data);
+    map[_i8.ColumnType] = (data, protocol) => _i8.ColumnType.fromJson(data);
+    map[_i9.DatabaseDefinition] = (data, protocol) =>
+        _i9.DatabaseDefinition.fromJson(data);
+    map[_i10.DatabaseDefinitions] = (data, protocol) =>
+        _i10.DatabaseDefinitions.fromJson(data);
+    map[_i11.DatabaseMigration] = (data, protocol) =>
+        _i11.DatabaseMigration.fromJson(data);
+    map[_i12.DatabaseMigrationAction] = (data, protocol) =>
+        _i12.DatabaseMigrationAction.fromJson(data);
+    map[_i13.DatabaseMigrationActionType] = (data, protocol) =>
+        _i13.DatabaseMigrationActionType.fromJson(data);
+    map[_i14.DatabaseMigrationVersionModel] = (data, protocol) =>
+        _i14.DatabaseMigrationVersionModel.fromJson(data);
+    map[_i15.DatabaseMigrationWarning] = (data, protocol) =>
+        _i15.DatabaseMigrationWarning.fromJson(data);
+    map[_i16.DatabaseMigrationWarningType] = (data, protocol) =>
+        _i16.DatabaseMigrationWarningType.fromJson(data);
+    map[_i17.EnumSerialization] = (data, protocol) =>
+        _i17.EnumSerialization.fromJson(data);
+    map[_i18.Filter] = (data, protocol) => _i18.Filter.fromJson(data);
+    map[_i19.FilterConstraint] = (data, protocol) =>
+        _i19.FilterConstraint.fromJson(data);
+    map[_i20.FilterConstraintType] = (data, protocol) =>
+        _i20.FilterConstraintType.fromJson(data);
+    map[_i21.ForeignKeyAction] = (data, protocol) =>
+        _i21.ForeignKeyAction.fromJson(data);
+    map[_i22.ForeignKeyDefinition] = (data, protocol) =>
+        _i22.ForeignKeyDefinition.fromJson(data);
+    map[_i23.ForeignKeyMatchType] = (data, protocol) =>
+        _i23.ForeignKeyMatchType.fromJson(data);
+    map[_i24.GinOperatorClass] = (data, protocol) =>
+        _i24.GinOperatorClass.fromJson(data);
+    map[_i25.IndexDefinition] = (data, protocol) =>
+        _i25.IndexDefinition.fromJson(data);
+    map[_i26.IndexElementDefinition] = (data, protocol) =>
+        _i26.IndexElementDefinition.fromJson(data);
+    map[_i27.IndexElementDefinitionType] = (data, protocol) =>
+        _i27.IndexElementDefinitionType.fromJson(data);
+    map[_i28.MigrationsApplyResult] = (data, protocol) =>
+        _i28.MigrationsApplyResult.fromJson(data);
+    map[_i29.TableDefinition] = (data, protocol) =>
+        _i29.TableDefinition.fromJson(data);
+    map[_i30.TableMigration] = (data, protocol) =>
+        _i30.TableMigration.fromJson(data);
+    map[_i31.VectorDistanceFunction] = (data, protocol) =>
+        _i31.VectorDistanceFunction.fromJson(data);
+    map[_i1.getType<_i2.BulkData?>()] = (data, protocol) =>
+        (data != null ? _i2.BulkData.fromJson(data) : null);
+    map[_i1.getType<_i3.BulkDataException?>()] = (data, protocol) =>
+        (data != null ? _i3.BulkDataException.fromJson(data) : null);
+    map[_i1.getType<_i4.BulkQueryColumnDescription?>()] = (data, protocol) =>
+        (data != null ? _i4.BulkQueryColumnDescription.fromJson(data) : null);
+    map[_i1.getType<_i5.BulkQueryResult?>()] = (data, protocol) =>
+        (data != null ? _i5.BulkQueryResult.fromJson(data) : null);
+    map[_i1.getType<_i6.ColumnDefinition?>()] = (data, protocol) =>
+        (data != null ? _i6.ColumnDefinition.fromJson(data) : null);
+    map[_i1.getType<_i7.ColumnMigration?>()] = (data, protocol) =>
+        (data != null ? _i7.ColumnMigration.fromJson(data) : null);
+    map[_i1.getType<_i8.ColumnType?>()] = (data, protocol) =>
+        (data != null ? _i8.ColumnType.fromJson(data) : null);
+    map[_i1.getType<_i9.DatabaseDefinition?>()] = (data, protocol) =>
+        (data != null ? _i9.DatabaseDefinition.fromJson(data) : null);
+    map[_i1.getType<_i10.DatabaseDefinitions?>()] = (data, protocol) =>
+        (data != null ? _i10.DatabaseDefinitions.fromJson(data) : null);
+    map[_i1.getType<_i11.DatabaseMigration?>()] = (data, protocol) =>
+        (data != null ? _i11.DatabaseMigration.fromJson(data) : null);
+    map[_i1.getType<_i12.DatabaseMigrationAction?>()] = (data, protocol) =>
+        (data != null ? _i12.DatabaseMigrationAction.fromJson(data) : null);
+    map[_i1.getType<_i13.DatabaseMigrationActionType?>()] = (data, protocol) =>
+        (data != null ? _i13.DatabaseMigrationActionType.fromJson(data) : null);
+    map[_i1
+        .getType<_i14.DatabaseMigrationVersionModel?>()] = (data, protocol) =>
+        (data != null
+        ? _i14.DatabaseMigrationVersionModel.fromJson(data)
+        : null);
+    map[_i1.getType<_i15.DatabaseMigrationWarning?>()] = (data, protocol) =>
+        (data != null ? _i15.DatabaseMigrationWarning.fromJson(data) : null);
+    map[_i1.getType<_i16.DatabaseMigrationWarningType?>()] = (data, protocol) =>
+        (data != null
+        ? _i16.DatabaseMigrationWarningType.fromJson(data)
+        : null);
+    map[_i1.getType<_i17.EnumSerialization?>()] = (data, protocol) =>
+        (data != null ? _i17.EnumSerialization.fromJson(data) : null);
+    map[_i1.getType<_i18.Filter?>()] = (data, protocol) =>
+        (data != null ? _i18.Filter.fromJson(data) : null);
+    map[_i1.getType<_i19.FilterConstraint?>()] = (data, protocol) =>
+        (data != null ? _i19.FilterConstraint.fromJson(data) : null);
+    map[_i1.getType<_i20.FilterConstraintType?>()] = (data, protocol) =>
+        (data != null ? _i20.FilterConstraintType.fromJson(data) : null);
+    map[_i1.getType<_i21.ForeignKeyAction?>()] = (data, protocol) =>
+        (data != null ? _i21.ForeignKeyAction.fromJson(data) : null);
+    map[_i1.getType<_i22.ForeignKeyDefinition?>()] = (data, protocol) =>
+        (data != null ? _i22.ForeignKeyDefinition.fromJson(data) : null);
+    map[_i1.getType<_i23.ForeignKeyMatchType?>()] = (data, protocol) =>
+        (data != null ? _i23.ForeignKeyMatchType.fromJson(data) : null);
+    map[_i1.getType<_i24.GinOperatorClass?>()] = (data, protocol) =>
+        (data != null ? _i24.GinOperatorClass.fromJson(data) : null);
+    map[_i1.getType<_i25.IndexDefinition?>()] = (data, protocol) =>
+        (data != null ? _i25.IndexDefinition.fromJson(data) : null);
+    map[_i1.getType<_i26.IndexElementDefinition?>()] = (data, protocol) =>
+        (data != null ? _i26.IndexElementDefinition.fromJson(data) : null);
+    map[_i1.getType<_i27.IndexElementDefinitionType?>()] = (data, protocol) =>
+        (data != null ? _i27.IndexElementDefinitionType.fromJson(data) : null);
+    map[_i1.getType<_i28.MigrationsApplyResult?>()] = (data, protocol) =>
+        (data != null ? _i28.MigrationsApplyResult.fromJson(data) : null);
+    map[_i1.getType<_i29.TableDefinition?>()] = (data, protocol) =>
+        (data != null ? _i29.TableDefinition.fromJson(data) : null);
+    map[_i1.getType<_i30.TableMigration?>()] = (data, protocol) =>
+        (data != null ? _i30.TableMigration.fromJson(data) : null);
+    map[_i1.getType<_i31.VectorDistanceFunction?>()] = (data, protocol) =>
+        (data != null ? _i31.VectorDistanceFunction.fromJson(data) : null);
+    map[List<_i32.BulkQueryColumnDescription>] = (data, protocol) =>
+        (data as List)
+            .map(
+              (e) => protocol.deserialize<_i32.BulkQueryColumnDescription>(e),
+            )
+            .toList();
+    map[List<_i32.TableDefinition>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i32.TableDefinition>(e))
+        .toList();
+    map[List<_i32.DatabaseMigrationVersionModel>] = (data, protocol) =>
+        (data as List)
+            .map(
+              (e) =>
+                  protocol.deserialize<_i32.DatabaseMigrationVersionModel>(e),
+            )
+            .toList();
+    map[List<_i32.DatabaseMigrationAction>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i32.DatabaseMigrationAction>(e))
+        .toList();
+    map[List<_i32.DatabaseMigrationWarning>] = (data, protocol) =>
+        (data as List)
+            .map((e) => protocol.deserialize<_i32.DatabaseMigrationWarning>(e))
+            .toList();
+    map[List<String>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<String>(e)).toList();
+    map[List<_i32.FilterConstraint>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i32.FilterConstraint>(e))
+        .toList();
+    map[List<_i32.IndexElementDefinition>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i32.IndexElementDefinition>(e))
+        .toList();
+    map[Map<String, String>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<String>(v),
+      ),
+    );
+    map[_i1.getType<Map<String, String>?>()] = (data, protocol) => (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<String>(v),
+            ),
+          )
+        : null);
+    map[List<String>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<String>(e)).toList();
+    map[_i1.getType<List<String>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<String>(e)).toList()
+        : null);
+    map[List<_i32.ColumnDefinition>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i32.ColumnDefinition>(e))
+        .toList();
+    map[List<_i32.ForeignKeyDefinition>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i32.ForeignKeyDefinition>(e))
+        .toList();
+    map[List<_i32.IndexDefinition>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i32.IndexDefinition>(e))
+        .toList();
+    map[List<_i32.ColumnMigration>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i32.ColumnMigration>(e))
+        .toList();
+    return map;
   }
 }

--- a/packages/serverpod_service_client/lib/src/protocol/protocol.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/protocol.dart
@@ -84,6 +84,199 @@ class Protocol extends _i1.SerializationManager {
 
   static final Protocol _instance = Protocol._().._registerHostProtocols();
 
+  static final Map<Type, dynamic Function(dynamic, Protocol)> _deserializers =
+      _buildDeserializers();
+
+  static Map<Type, dynamic Function(dynamic, Protocol)> _buildDeserializers() {
+    final map = <Type, dynamic Function(dynamic, Protocol)>{};
+    map[_i2.CacheInfo] = (data, protocol) => _i2.CacheInfo.fromJson(data);
+    map[_i3.CachesInfo] = (data, protocol) => _i3.CachesInfo.fromJson(data);
+    map[_i4.CloudStorageEntry] = (data, protocol) =>
+        _i4.CloudStorageEntry.fromJson(data);
+    map[_i5.CloudStorageDirectUploadEntry] = (data, protocol) =>
+        _i5.CloudStorageDirectUploadEntry.fromJson(data);
+    map[_i6.ClusterInfo] = (data, protocol) => _i6.ClusterInfo.fromJson(data);
+    map[_i7.ClusterServerInfo] = (data, protocol) =>
+        _i7.ClusterServerInfo.fromJson(data);
+    map[_i8.CronFutureCallScheduling] = (data, protocol) =>
+        _i8.CronFutureCallScheduling.fromJson(data);
+    map[_i9.DatabaseMigrationVersion] = (data, protocol) =>
+        _i9.DatabaseMigrationVersion.fromJson(data);
+    map[_i10.DistributedCacheEntry] = (data, protocol) =>
+        _i10.DistributedCacheEntry.fromJson(data);
+    map[_i11.AccessDeniedException] = (data, protocol) =>
+        _i11.AccessDeniedException.fromJson(data);
+    map[_i12.FileNotFoundException] = (data, protocol) =>
+        _i12.FileNotFoundException.fromJson(data);
+    map[_i13.FutureCallClaimEntry] = (data, protocol) =>
+        _i13.FutureCallClaimEntry.fromJson(data);
+    map[_i14.FutureCallEntry] = (data, protocol) =>
+        _i14.FutureCallEntry.fromJson(data);
+    map[_i8.IntervalFutureCallScheduling] = (data, protocol) =>
+        _i8.IntervalFutureCallScheduling.fromJson(data);
+    map[_i15.LogEntry] = (data, protocol) => _i15.LogEntry.fromJson(data);
+    map[_i16.LogLevel] = (data, protocol) => _i16.LogLevel.fromJson(data);
+    map[_i17.LogResult] = (data, protocol) => _i17.LogResult.fromJson(data);
+    map[_i18.LogSettings] = (data, protocol) => _i18.LogSettings.fromJson(data);
+    map[_i19.LogSettingsOverride] = (data, protocol) =>
+        _i19.LogSettingsOverride.fromJson(data);
+    map[_i20.MessageLogEntry] = (data, protocol) =>
+        _i20.MessageLogEntry.fromJson(data);
+    map[_i21.MethodInfo] = (data, protocol) => _i21.MethodInfo.fromJson(data);
+    map[_i22.QueryLogEntry] = (data, protocol) =>
+        _i22.QueryLogEntry.fromJson(data);
+    map[_i23.ReadWriteTestEntry] = (data, protocol) =>
+        _i23.ReadWriteTestEntry.fromJson(data);
+    map[_i24.RuntimeSettings] = (data, protocol) =>
+        _i24.RuntimeSettings.fromJson(data);
+    map[_i25.ServerHealthConnectionInfo] = (data, protocol) =>
+        _i25.ServerHealthConnectionInfo.fromJson(data);
+    map[_i26.ServerHealthMetric] = (data, protocol) =>
+        _i26.ServerHealthMetric.fromJson(data);
+    map[_i27.ServerHealthResult] = (data, protocol) =>
+        _i27.ServerHealthResult.fromJson(data);
+    map[_i28.ServerpodSqlException] = (data, protocol) =>
+        _i28.ServerpodSqlException.fromJson(data);
+    map[_i29.SessionLogEntry] = (data, protocol) =>
+        _i29.SessionLogEntry.fromJson(data);
+    map[_i30.SessionLogFilter] = (data, protocol) =>
+        _i30.SessionLogFilter.fromJson(data);
+    map[_i31.SessionLogInfo] = (data, protocol) =>
+        _i31.SessionLogInfo.fromJson(data);
+    map[_i32.SessionLogResult] = (data, protocol) =>
+        _i32.SessionLogResult.fromJson(data);
+    map[_i1.getType<_i2.CacheInfo?>()] = (data, protocol) =>
+        (data != null ? _i2.CacheInfo.fromJson(data) : null);
+    map[_i1.getType<_i3.CachesInfo?>()] = (data, protocol) =>
+        (data != null ? _i3.CachesInfo.fromJson(data) : null);
+    map[_i1.getType<_i4.CloudStorageEntry?>()] = (data, protocol) =>
+        (data != null ? _i4.CloudStorageEntry.fromJson(data) : null);
+    map[_i1.getType<_i5.CloudStorageDirectUploadEntry?>()] = (data, protocol) =>
+        (data != null
+        ? _i5.CloudStorageDirectUploadEntry.fromJson(data)
+        : null);
+    map[_i1.getType<_i6.ClusterInfo?>()] = (data, protocol) =>
+        (data != null ? _i6.ClusterInfo.fromJson(data) : null);
+    map[_i1.getType<_i7.ClusterServerInfo?>()] = (data, protocol) =>
+        (data != null ? _i7.ClusterServerInfo.fromJson(data) : null);
+    map[_i1.getType<_i8.CronFutureCallScheduling?>()] = (data, protocol) =>
+        (data != null ? _i8.CronFutureCallScheduling.fromJson(data) : null);
+    map[_i1.getType<_i9.DatabaseMigrationVersion?>()] = (data, protocol) =>
+        (data != null ? _i9.DatabaseMigrationVersion.fromJson(data) : null);
+    map[_i1.getType<_i10.DistributedCacheEntry?>()] = (data, protocol) =>
+        (data != null ? _i10.DistributedCacheEntry.fromJson(data) : null);
+    map[_i1.getType<_i11.AccessDeniedException?>()] = (data, protocol) =>
+        (data != null ? _i11.AccessDeniedException.fromJson(data) : null);
+    map[_i1.getType<_i12.FileNotFoundException?>()] = (data, protocol) =>
+        (data != null ? _i12.FileNotFoundException.fromJson(data) : null);
+    map[_i1.getType<_i13.FutureCallClaimEntry?>()] = (data, protocol) =>
+        (data != null ? _i13.FutureCallClaimEntry.fromJson(data) : null);
+    map[_i1.getType<_i14.FutureCallEntry?>()] = (data, protocol) =>
+        (data != null ? _i14.FutureCallEntry.fromJson(data) : null);
+    map[_i1.getType<_i8.IntervalFutureCallScheduling?>()] = (data, protocol) =>
+        (data != null ? _i8.IntervalFutureCallScheduling.fromJson(data) : null);
+    map[_i1.getType<_i15.LogEntry?>()] = (data, protocol) =>
+        (data != null ? _i15.LogEntry.fromJson(data) : null);
+    map[_i1.getType<_i16.LogLevel?>()] = (data, protocol) =>
+        (data != null ? _i16.LogLevel.fromJson(data) : null);
+    map[_i1.getType<_i17.LogResult?>()] = (data, protocol) =>
+        (data != null ? _i17.LogResult.fromJson(data) : null);
+    map[_i1.getType<_i18.LogSettings?>()] = (data, protocol) =>
+        (data != null ? _i18.LogSettings.fromJson(data) : null);
+    map[_i1.getType<_i19.LogSettingsOverride?>()] = (data, protocol) =>
+        (data != null ? _i19.LogSettingsOverride.fromJson(data) : null);
+    map[_i1.getType<_i20.MessageLogEntry?>()] = (data, protocol) =>
+        (data != null ? _i20.MessageLogEntry.fromJson(data) : null);
+    map[_i1.getType<_i21.MethodInfo?>()] = (data, protocol) =>
+        (data != null ? _i21.MethodInfo.fromJson(data) : null);
+    map[_i1.getType<_i22.QueryLogEntry?>()] = (data, protocol) =>
+        (data != null ? _i22.QueryLogEntry.fromJson(data) : null);
+    map[_i1.getType<_i23.ReadWriteTestEntry?>()] = (data, protocol) =>
+        (data != null ? _i23.ReadWriteTestEntry.fromJson(data) : null);
+    map[_i1.getType<_i24.RuntimeSettings?>()] = (data, protocol) =>
+        (data != null ? _i24.RuntimeSettings.fromJson(data) : null);
+    map[_i1.getType<_i25.ServerHealthConnectionInfo?>()] = (data, protocol) =>
+        (data != null ? _i25.ServerHealthConnectionInfo.fromJson(data) : null);
+    map[_i1.getType<_i26.ServerHealthMetric?>()] = (data, protocol) =>
+        (data != null ? _i26.ServerHealthMetric.fromJson(data) : null);
+    map[_i1.getType<_i27.ServerHealthResult?>()] = (data, protocol) =>
+        (data != null ? _i27.ServerHealthResult.fromJson(data) : null);
+    map[_i1.getType<_i28.ServerpodSqlException?>()] = (data, protocol) =>
+        (data != null ? _i28.ServerpodSqlException.fromJson(data) : null);
+    map[_i1.getType<_i29.SessionLogEntry?>()] = (data, protocol) =>
+        (data != null ? _i29.SessionLogEntry.fromJson(data) : null);
+    map[_i1.getType<_i30.SessionLogFilter?>()] = (data, protocol) =>
+        (data != null ? _i30.SessionLogFilter.fromJson(data) : null);
+    map[_i1.getType<_i31.SessionLogInfo?>()] = (data, protocol) =>
+        (data != null ? _i31.SessionLogInfo.fromJson(data) : null);
+    map[_i1.getType<_i32.SessionLogResult?>()] = (data, protocol) =>
+        (data != null ? _i32.SessionLogResult.fromJson(data) : null);
+    map[List<String>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<String>(e)).toList();
+    map[_i1.getType<List<String>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<String>(e)).toList()
+        : null);
+    map[List<_i7.ClusterServerInfo>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i7.ClusterServerInfo>(e))
+        .toList();
+    map[List<_i15.LogEntry>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i15.LogEntry>(e))
+        .toList();
+    map[List<_i19.LogSettingsOverride>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i19.LogSettingsOverride>(e))
+        .toList();
+    map[List<_i26.ServerHealthMetric>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i26.ServerHealthMetric>(e))
+        .toList();
+    map[List<_i25.ServerHealthConnectionInfo>] = (data, protocol) =>
+        (data as List)
+            .map(
+              (e) => protocol.deserialize<_i25.ServerHealthConnectionInfo>(e),
+            )
+            .toList();
+    map[List<_i15.LogEntry>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i15.LogEntry>(e))
+        .toList();
+    map[_i1.getType<List<_i15.LogEntry>?>()] = (data, protocol) => (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i15.LogEntry>(e))
+              .toList()
+        : null);
+    map[List<_i22.QueryLogEntry>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i22.QueryLogEntry>(e))
+        .toList();
+    map[_i1.getType<List<_i22.QueryLogEntry>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i22.QueryLogEntry>(e))
+              .toList()
+        : null);
+    map[List<_i20.MessageLogEntry>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i20.MessageLogEntry>(e))
+        .toList();
+    map[_i1.getType<List<_i20.MessageLogEntry>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i20.MessageLogEntry>(e))
+              .toList()
+        : null);
+    map[List<_i22.QueryLogEntry>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i22.QueryLogEntry>(e))
+        .toList();
+    map[List<_i20.MessageLogEntry>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i20.MessageLogEntry>(e))
+        .toList();
+    map[List<_i31.SessionLogInfo>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i31.SessionLogInfo>(e))
+        .toList();
+    map[List<_i33.TableDefinition>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i33.TableDefinition>(e))
+        .toList();
+    map[List<String>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<String>(e)).toList();
+    return map;
+  }
+
   static String? getClassNameFromObjectJson(dynamic data) {
     if (data is! Map) return null;
     final className = data['__className__'] as String?;
@@ -113,305 +306,9 @@ class Protocol extends _i1.SerializationManager {
       }
     }
 
-    if (t == _i2.CacheInfo) {
-      return _i2.CacheInfo.fromJson(data) as T;
-    }
-    if (t == _i3.CachesInfo) {
-      return _i3.CachesInfo.fromJson(data) as T;
-    }
-    if (t == _i4.CloudStorageEntry) {
-      return _i4.CloudStorageEntry.fromJson(data) as T;
-    }
-    if (t == _i5.CloudStorageDirectUploadEntry) {
-      return _i5.CloudStorageDirectUploadEntry.fromJson(data) as T;
-    }
-    if (t == _i6.ClusterInfo) {
-      return _i6.ClusterInfo.fromJson(data) as T;
-    }
-    if (t == _i7.ClusterServerInfo) {
-      return _i7.ClusterServerInfo.fromJson(data) as T;
-    }
-    if (t == _i8.CronFutureCallScheduling) {
-      return _i8.CronFutureCallScheduling.fromJson(data) as T;
-    }
-    if (t == _i9.DatabaseMigrationVersion) {
-      return _i9.DatabaseMigrationVersion.fromJson(data) as T;
-    }
-    if (t == _i10.DistributedCacheEntry) {
-      return _i10.DistributedCacheEntry.fromJson(data) as T;
-    }
-    if (t == _i11.AccessDeniedException) {
-      return _i11.AccessDeniedException.fromJson(data) as T;
-    }
-    if (t == _i12.FileNotFoundException) {
-      return _i12.FileNotFoundException.fromJson(data) as T;
-    }
-    if (t == _i13.FutureCallClaimEntry) {
-      return _i13.FutureCallClaimEntry.fromJson(data) as T;
-    }
-    if (t == _i14.FutureCallEntry) {
-      return _i14.FutureCallEntry.fromJson(data) as T;
-    }
-    if (t == _i8.IntervalFutureCallScheduling) {
-      return _i8.IntervalFutureCallScheduling.fromJson(data) as T;
-    }
-    if (t == _i15.LogEntry) {
-      return _i15.LogEntry.fromJson(data) as T;
-    }
-    if (t == _i16.LogLevel) {
-      return _i16.LogLevel.fromJson(data) as T;
-    }
-    if (t == _i17.LogResult) {
-      return _i17.LogResult.fromJson(data) as T;
-    }
-    if (t == _i18.LogSettings) {
-      return _i18.LogSettings.fromJson(data) as T;
-    }
-    if (t == _i19.LogSettingsOverride) {
-      return _i19.LogSettingsOverride.fromJson(data) as T;
-    }
-    if (t == _i20.MessageLogEntry) {
-      return _i20.MessageLogEntry.fromJson(data) as T;
-    }
-    if (t == _i21.MethodInfo) {
-      return _i21.MethodInfo.fromJson(data) as T;
-    }
-    if (t == _i22.QueryLogEntry) {
-      return _i22.QueryLogEntry.fromJson(data) as T;
-    }
-    if (t == _i23.ReadWriteTestEntry) {
-      return _i23.ReadWriteTestEntry.fromJson(data) as T;
-    }
-    if (t == _i24.RuntimeSettings) {
-      return _i24.RuntimeSettings.fromJson(data) as T;
-    }
-    if (t == _i25.ServerHealthConnectionInfo) {
-      return _i25.ServerHealthConnectionInfo.fromJson(data) as T;
-    }
-    if (t == _i26.ServerHealthMetric) {
-      return _i26.ServerHealthMetric.fromJson(data) as T;
-    }
-    if (t == _i27.ServerHealthResult) {
-      return _i27.ServerHealthResult.fromJson(data) as T;
-    }
-    if (t == _i28.ServerpodSqlException) {
-      return _i28.ServerpodSqlException.fromJson(data) as T;
-    }
-    if (t == _i29.SessionLogEntry) {
-      return _i29.SessionLogEntry.fromJson(data) as T;
-    }
-    if (t == _i30.SessionLogFilter) {
-      return _i30.SessionLogFilter.fromJson(data) as T;
-    }
-    if (t == _i31.SessionLogInfo) {
-      return _i31.SessionLogInfo.fromJson(data) as T;
-    }
-    if (t == _i32.SessionLogResult) {
-      return _i32.SessionLogResult.fromJson(data) as T;
-    }
-    if (t == _i1.getType<_i2.CacheInfo?>()) {
-      return (data != null ? _i2.CacheInfo.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i3.CachesInfo?>()) {
-      return (data != null ? _i3.CachesInfo.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i4.CloudStorageEntry?>()) {
-      return (data != null ? _i4.CloudStorageEntry.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i5.CloudStorageDirectUploadEntry?>()) {
-      return (data != null
-              ? _i5.CloudStorageDirectUploadEntry.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i6.ClusterInfo?>()) {
-      return (data != null ? _i6.ClusterInfo.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i7.ClusterServerInfo?>()) {
-      return (data != null ? _i7.ClusterServerInfo.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i8.CronFutureCallScheduling?>()) {
-      return (data != null ? _i8.CronFutureCallScheduling.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i9.DatabaseMigrationVersion?>()) {
-      return (data != null ? _i9.DatabaseMigrationVersion.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i10.DistributedCacheEntry?>()) {
-      return (data != null ? _i10.DistributedCacheEntry.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i11.AccessDeniedException?>()) {
-      return (data != null ? _i11.AccessDeniedException.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i12.FileNotFoundException?>()) {
-      return (data != null ? _i12.FileNotFoundException.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i13.FutureCallClaimEntry?>()) {
-      return (data != null ? _i13.FutureCallClaimEntry.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i14.FutureCallEntry?>()) {
-      return (data != null ? _i14.FutureCallEntry.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i8.IntervalFutureCallScheduling?>()) {
-      return (data != null
-              ? _i8.IntervalFutureCallScheduling.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i15.LogEntry?>()) {
-      return (data != null ? _i15.LogEntry.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i16.LogLevel?>()) {
-      return (data != null ? _i16.LogLevel.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i17.LogResult?>()) {
-      return (data != null ? _i17.LogResult.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i18.LogSettings?>()) {
-      return (data != null ? _i18.LogSettings.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i19.LogSettingsOverride?>()) {
-      return (data != null ? _i19.LogSettingsOverride.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i20.MessageLogEntry?>()) {
-      return (data != null ? _i20.MessageLogEntry.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i21.MethodInfo?>()) {
-      return (data != null ? _i21.MethodInfo.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i22.QueryLogEntry?>()) {
-      return (data != null ? _i22.QueryLogEntry.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i23.ReadWriteTestEntry?>()) {
-      return (data != null ? _i23.ReadWriteTestEntry.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i24.RuntimeSettings?>()) {
-      return (data != null ? _i24.RuntimeSettings.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i25.ServerHealthConnectionInfo?>()) {
-      return (data != null
-              ? _i25.ServerHealthConnectionInfo.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i26.ServerHealthMetric?>()) {
-      return (data != null ? _i26.ServerHealthMetric.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i27.ServerHealthResult?>()) {
-      return (data != null ? _i27.ServerHealthResult.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i28.ServerpodSqlException?>()) {
-      return (data != null ? _i28.ServerpodSqlException.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i29.SessionLogEntry?>()) {
-      return (data != null ? _i29.SessionLogEntry.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i30.SessionLogFilter?>()) {
-      return (data != null ? _i30.SessionLogFilter.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i31.SessionLogInfo?>()) {
-      return (data != null ? _i31.SessionLogInfo.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i32.SessionLogResult?>()) {
-      return (data != null ? _i32.SessionLogResult.fromJson(data) : null) as T;
-    }
-    if (t == List<String>) {
-      return (data as List).map((e) => deserialize<String>(e)).toList() as T;
-    }
-    if (t == _i1.getType<List<String>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<String>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i7.ClusterServerInfo>) {
-      return (data as List)
-              .map((e) => deserialize<_i7.ClusterServerInfo>(e))
-              .toList()
-          as T;
-    }
-    if (t == List<_i15.LogEntry>) {
-      return (data as List).map((e) => deserialize<_i15.LogEntry>(e)).toList()
-          as T;
-    }
-    if (t == List<_i19.LogSettingsOverride>) {
-      return (data as List)
-              .map((e) => deserialize<_i19.LogSettingsOverride>(e))
-              .toList()
-          as T;
-    }
-    if (t == List<_i26.ServerHealthMetric>) {
-      return (data as List)
-              .map((e) => deserialize<_i26.ServerHealthMetric>(e))
-              .toList()
-          as T;
-    }
-    if (t == List<_i25.ServerHealthConnectionInfo>) {
-      return (data as List)
-              .map((e) => deserialize<_i25.ServerHealthConnectionInfo>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i15.LogEntry>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i15.LogEntry>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i22.QueryLogEntry>) {
-      return (data as List)
-              .map((e) => deserialize<_i22.QueryLogEntry>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i22.QueryLogEntry>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i22.QueryLogEntry>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i20.MessageLogEntry>) {
-      return (data as List)
-              .map((e) => deserialize<_i20.MessageLogEntry>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i20.MessageLogEntry>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i20.MessageLogEntry>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i31.SessionLogInfo>) {
-      return (data as List)
-              .map((e) => deserialize<_i31.SessionLogInfo>(e))
-              .toList()
-          as T;
-    }
-    if (t == List<_i33.TableDefinition>) {
-      return (data as List)
-              .map((e) => deserialize<_i33.TableDefinition>(e))
-              .toList()
-          as T;
-    }
-    if (t == List<String>) {
-      return (data as List).map((e) => deserialize<String>(e)).toList() as T;
+    final fn = _deserializers[t];
+    if (fn != null) {
+      return fn(data, this) as T;
     }
     try {
       return _i34.Protocol().deserialize<T>(data, t);

--- a/packages/serverpod_service_client/lib/src/protocol/protocol.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/protocol.dart
@@ -12,38 +12,38 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
-import 'cache_info.dart' as _i2;
-import 'caches_info.dart' as _i3;
-import 'cloud_storage.dart' as _i4;
-import 'cloud_storage_direct_upload.dart' as _i5;
-import 'cluster_info.dart' as _i6;
-import 'cluster_server_info.dart' as _i7;
-import 'future_call_scheduling.dart' as _i8;
-import 'database_migration_version.dart' as _i9;
-import 'distributed_cache_entry.dart' as _i10;
-import 'exceptions/access_denied.dart' as _i11;
-import 'exceptions/file_not_found.dart' as _i12;
-import 'future_call_claim_entry.dart' as _i13;
-import 'future_call_entry.dart' as _i14;
-import 'log_entry.dart' as _i15;
-import 'log_level.dart' as _i16;
-import 'log_result.dart' as _i17;
-import 'log_settings.dart' as _i18;
-import 'log_settings_override.dart' as _i19;
-import 'message_log_entry.dart' as _i20;
-import 'method_info.dart' as _i21;
-import 'query_log_entry.dart' as _i22;
-import 'readwrite_test.dart' as _i23;
-import 'runtime_settings.dart' as _i24;
-import 'server_health_connection_info.dart' as _i25;
-import 'server_health_metric.dart' as _i26;
-import 'server_health_result.dart' as _i27;
-import 'serverpod_sql_exception.dart' as _i28;
-import 'session_log_entry.dart' as _i29;
-import 'session_log_filter.dart' as _i30;
-import 'session_log_info.dart' as _i31;
-import 'session_log_result.dart' as _i32;
-import 'package:serverpod_database/serverpod_database.dart' as _i33;
+import 'package:serverpod_database/serverpod_database.dart' as _i2;
+import 'cache_info.dart' as _i3;
+import 'caches_info.dart' as _i4;
+import 'cloud_storage.dart' as _i5;
+import 'cloud_storage_direct_upload.dart' as _i6;
+import 'cluster_info.dart' as _i7;
+import 'cluster_server_info.dart' as _i8;
+import 'future_call_scheduling.dart' as _i9;
+import 'database_migration_version.dart' as _i10;
+import 'distributed_cache_entry.dart' as _i11;
+import 'exceptions/access_denied.dart' as _i12;
+import 'exceptions/file_not_found.dart' as _i13;
+import 'future_call_claim_entry.dart' as _i14;
+import 'future_call_entry.dart' as _i15;
+import 'log_entry.dart' as _i16;
+import 'log_level.dart' as _i17;
+import 'log_result.dart' as _i18;
+import 'log_settings.dart' as _i19;
+import 'log_settings_override.dart' as _i20;
+import 'message_log_entry.dart' as _i21;
+import 'method_info.dart' as _i22;
+import 'query_log_entry.dart' as _i23;
+import 'readwrite_test.dart' as _i24;
+import 'runtime_settings.dart' as _i25;
+import 'server_health_connection_info.dart' as _i26;
+import 'server_health_metric.dart' as _i27;
+import 'server_health_result.dart' as _i28;
+import 'serverpod_sql_exception.dart' as _i29;
+import 'session_log_entry.dart' as _i30;
+import 'session_log_filter.dart' as _i31;
+import 'session_log_info.dart' as _i32;
+import 'session_log_result.dart' as _i33;
 export 'cache_info.dart';
 export 'caches_info.dart';
 export 'cloud_storage.dart';
@@ -84,6 +84,9 @@ class Protocol extends _i1.SerializationManager {
 
   static final Protocol _instance = Protocol._().._registerHostProtocols();
 
+  static final Map<Type, dynamic Function(dynamic, Protocol)> _deserializers =
+      _buildDeserializers();
+
   static String? getClassNameFromObjectJson(dynamic data) {
     if (data is! Map) return null;
     final className = data['__className__'] as String?;
@@ -113,346 +116,50 @@ class Protocol extends _i1.SerializationManager {
       }
     }
 
-    if (t == _i2.CacheInfo) {
-      return _i2.CacheInfo.fromJson(data) as T;
-    }
-    if (t == _i3.CachesInfo) {
-      return _i3.CachesInfo.fromJson(data) as T;
-    }
-    if (t == _i4.CloudStorageEntry) {
-      return _i4.CloudStorageEntry.fromJson(data) as T;
-    }
-    if (t == _i5.CloudStorageDirectUploadEntry) {
-      return _i5.CloudStorageDirectUploadEntry.fromJson(data) as T;
-    }
-    if (t == _i6.ClusterInfo) {
-      return _i6.ClusterInfo.fromJson(data) as T;
-    }
-    if (t == _i7.ClusterServerInfo) {
-      return _i7.ClusterServerInfo.fromJson(data) as T;
-    }
-    if (t == _i8.CronFutureCallScheduling) {
-      return _i8.CronFutureCallScheduling.fromJson(data) as T;
-    }
-    if (t == _i9.DatabaseMigrationVersion) {
-      return _i9.DatabaseMigrationVersion.fromJson(data) as T;
-    }
-    if (t == _i10.DistributedCacheEntry) {
-      return _i10.DistributedCacheEntry.fromJson(data) as T;
-    }
-    if (t == _i11.AccessDeniedException) {
-      return _i11.AccessDeniedException.fromJson(data) as T;
-    }
-    if (t == _i12.FileNotFoundException) {
-      return _i12.FileNotFoundException.fromJson(data) as T;
-    }
-    if (t == _i13.FutureCallClaimEntry) {
-      return _i13.FutureCallClaimEntry.fromJson(data) as T;
-    }
-    if (t == _i14.FutureCallEntry) {
-      return _i14.FutureCallEntry.fromJson(data) as T;
-    }
-    if (t == _i8.IntervalFutureCallScheduling) {
-      return _i8.IntervalFutureCallScheduling.fromJson(data) as T;
-    }
-    if (t == _i15.LogEntry) {
-      return _i15.LogEntry.fromJson(data) as T;
-    }
-    if (t == _i16.LogLevel) {
-      return _i16.LogLevel.fromJson(data) as T;
-    }
-    if (t == _i17.LogResult) {
-      return _i17.LogResult.fromJson(data) as T;
-    }
-    if (t == _i18.LogSettings) {
-      return _i18.LogSettings.fromJson(data) as T;
-    }
-    if (t == _i19.LogSettingsOverride) {
-      return _i19.LogSettingsOverride.fromJson(data) as T;
-    }
-    if (t == _i20.MessageLogEntry) {
-      return _i20.MessageLogEntry.fromJson(data) as T;
-    }
-    if (t == _i21.MethodInfo) {
-      return _i21.MethodInfo.fromJson(data) as T;
-    }
-    if (t == _i22.QueryLogEntry) {
-      return _i22.QueryLogEntry.fromJson(data) as T;
-    }
-    if (t == _i23.ReadWriteTestEntry) {
-      return _i23.ReadWriteTestEntry.fromJson(data) as T;
-    }
-    if (t == _i24.RuntimeSettings) {
-      return _i24.RuntimeSettings.fromJson(data) as T;
-    }
-    if (t == _i25.ServerHealthConnectionInfo) {
-      return _i25.ServerHealthConnectionInfo.fromJson(data) as T;
-    }
-    if (t == _i26.ServerHealthMetric) {
-      return _i26.ServerHealthMetric.fromJson(data) as T;
-    }
-    if (t == _i27.ServerHealthResult) {
-      return _i27.ServerHealthResult.fromJson(data) as T;
-    }
-    if (t == _i28.ServerpodSqlException) {
-      return _i28.ServerpodSqlException.fromJson(data) as T;
-    }
-    if (t == _i29.SessionLogEntry) {
-      return _i29.SessionLogEntry.fromJson(data) as T;
-    }
-    if (t == _i30.SessionLogFilter) {
-      return _i30.SessionLogFilter.fromJson(data) as T;
-    }
-    if (t == _i31.SessionLogInfo) {
-      return _i31.SessionLogInfo.fromJson(data) as T;
-    }
-    if (t == _i32.SessionLogResult) {
-      return _i32.SessionLogResult.fromJson(data) as T;
-    }
-    if (t == _i1.getType<_i2.CacheInfo?>()) {
-      return (data != null ? _i2.CacheInfo.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i3.CachesInfo?>()) {
-      return (data != null ? _i3.CachesInfo.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i4.CloudStorageEntry?>()) {
-      return (data != null ? _i4.CloudStorageEntry.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i5.CloudStorageDirectUploadEntry?>()) {
-      return (data != null
-              ? _i5.CloudStorageDirectUploadEntry.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i6.ClusterInfo?>()) {
-      return (data != null ? _i6.ClusterInfo.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i7.ClusterServerInfo?>()) {
-      return (data != null ? _i7.ClusterServerInfo.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i8.CronFutureCallScheduling?>()) {
-      return (data != null ? _i8.CronFutureCallScheduling.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i9.DatabaseMigrationVersion?>()) {
-      return (data != null ? _i9.DatabaseMigrationVersion.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i10.DistributedCacheEntry?>()) {
-      return (data != null ? _i10.DistributedCacheEntry.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i11.AccessDeniedException?>()) {
-      return (data != null ? _i11.AccessDeniedException.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i12.FileNotFoundException?>()) {
-      return (data != null ? _i12.FileNotFoundException.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i13.FutureCallClaimEntry?>()) {
-      return (data != null ? _i13.FutureCallClaimEntry.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i14.FutureCallEntry?>()) {
-      return (data != null ? _i14.FutureCallEntry.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i8.IntervalFutureCallScheduling?>()) {
-      return (data != null
-              ? _i8.IntervalFutureCallScheduling.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i15.LogEntry?>()) {
-      return (data != null ? _i15.LogEntry.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i16.LogLevel?>()) {
-      return (data != null ? _i16.LogLevel.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i17.LogResult?>()) {
-      return (data != null ? _i17.LogResult.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i18.LogSettings?>()) {
-      return (data != null ? _i18.LogSettings.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i19.LogSettingsOverride?>()) {
-      return (data != null ? _i19.LogSettingsOverride.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i20.MessageLogEntry?>()) {
-      return (data != null ? _i20.MessageLogEntry.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i21.MethodInfo?>()) {
-      return (data != null ? _i21.MethodInfo.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i22.QueryLogEntry?>()) {
-      return (data != null ? _i22.QueryLogEntry.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i23.ReadWriteTestEntry?>()) {
-      return (data != null ? _i23.ReadWriteTestEntry.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i24.RuntimeSettings?>()) {
-      return (data != null ? _i24.RuntimeSettings.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i25.ServerHealthConnectionInfo?>()) {
-      return (data != null
-              ? _i25.ServerHealthConnectionInfo.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i26.ServerHealthMetric?>()) {
-      return (data != null ? _i26.ServerHealthMetric.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i27.ServerHealthResult?>()) {
-      return (data != null ? _i27.ServerHealthResult.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i28.ServerpodSqlException?>()) {
-      return (data != null ? _i28.ServerpodSqlException.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i29.SessionLogEntry?>()) {
-      return (data != null ? _i29.SessionLogEntry.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i30.SessionLogFilter?>()) {
-      return (data != null ? _i30.SessionLogFilter.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i31.SessionLogInfo?>()) {
-      return (data != null ? _i31.SessionLogInfo.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i32.SessionLogResult?>()) {
-      return (data != null ? _i32.SessionLogResult.fromJson(data) : null) as T;
-    }
-    if (t == List<String>) {
-      return (data as List).map((e) => deserialize<String>(e)).toList() as T;
-    }
-    if (t == _i1.getType<List<String>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<String>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i7.ClusterServerInfo>) {
-      return (data as List)
-              .map((e) => deserialize<_i7.ClusterServerInfo>(e))
-              .toList()
-          as T;
-    }
-    if (t == List<_i15.LogEntry>) {
-      return (data as List).map((e) => deserialize<_i15.LogEntry>(e)).toList()
-          as T;
-    }
-    if (t == List<_i19.LogSettingsOverride>) {
-      return (data as List)
-              .map((e) => deserialize<_i19.LogSettingsOverride>(e))
-              .toList()
-          as T;
-    }
-    if (t == List<_i26.ServerHealthMetric>) {
-      return (data as List)
-              .map((e) => deserialize<_i26.ServerHealthMetric>(e))
-              .toList()
-          as T;
-    }
-    if (t == List<_i25.ServerHealthConnectionInfo>) {
-      return (data as List)
-              .map((e) => deserialize<_i25.ServerHealthConnectionInfo>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i15.LogEntry>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i15.LogEntry>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i22.QueryLogEntry>) {
-      return (data as List)
-              .map((e) => deserialize<_i22.QueryLogEntry>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i22.QueryLogEntry>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i22.QueryLogEntry>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i20.MessageLogEntry>) {
-      return (data as List)
-              .map((e) => deserialize<_i20.MessageLogEntry>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i20.MessageLogEntry>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i20.MessageLogEntry>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i31.SessionLogInfo>) {
-      return (data as List)
-              .map((e) => deserialize<_i31.SessionLogInfo>(e))
-              .toList()
-          as T;
-    }
-    if (t == List<_i33.TableDefinition>) {
-      return (data as List)
-              .map((e) => deserialize<_i33.TableDefinition>(e))
-              .toList()
-          as T;
-    }
-    if (t == List<String>) {
-      return (data as List).map((e) => deserialize<String>(e)).toList() as T;
+    final fn = _deserializers[t];
+    if (fn != null) {
+      return fn(data, this) as T;
     }
     try {
-      return _i33.Protocol().deserialize<T>(data, t);
+      return _i2.Protocol().deserialize<T>(data, t);
     } on _i1.DeserializationTypeNotFoundException catch (_) {}
     return super.deserialize<T>(data, t);
   }
 
   static String? getClassNameForType(Type type) {
     return switch (type) {
-      _i2.CacheInfo => 'CacheInfo',
-      _i3.CachesInfo => 'CachesInfo',
-      _i4.CloudStorageEntry => 'CloudStorageEntry',
-      _i5.CloudStorageDirectUploadEntry => 'CloudStorageDirectUploadEntry',
-      _i6.ClusterInfo => 'ClusterInfo',
-      _i7.ClusterServerInfo => 'ClusterServerInfo',
-      _i8.CronFutureCallScheduling => 'CronFutureCallScheduling',
-      _i9.DatabaseMigrationVersion => 'DatabaseMigrationVersion',
-      _i10.DistributedCacheEntry => 'DistributedCacheEntry',
-      _i11.AccessDeniedException => 'AccessDeniedException',
-      _i12.FileNotFoundException => 'FileNotFoundException',
-      _i13.FutureCallClaimEntry => 'FutureCallClaimEntry',
-      _i14.FutureCallEntry => 'FutureCallEntry',
-      _i8.IntervalFutureCallScheduling => 'IntervalFutureCallScheduling',
-      _i15.LogEntry => 'LogEntry',
-      _i16.LogLevel => 'LogLevel',
-      _i17.LogResult => 'LogResult',
-      _i18.LogSettings => 'LogSettings',
-      _i19.LogSettingsOverride => 'LogSettingsOverride',
-      _i20.MessageLogEntry => 'MessageLogEntry',
-      _i21.MethodInfo => 'MethodInfo',
-      _i22.QueryLogEntry => 'QueryLogEntry',
-      _i23.ReadWriteTestEntry => 'ReadWriteTestEntry',
-      _i24.RuntimeSettings => 'RuntimeSettings',
-      _i25.ServerHealthConnectionInfo => 'ServerHealthConnectionInfo',
-      _i26.ServerHealthMetric => 'ServerHealthMetric',
-      _i27.ServerHealthResult => 'ServerHealthResult',
-      _i28.ServerpodSqlException => 'ServerpodSqlException',
-      _i29.SessionLogEntry => 'SessionLogEntry',
-      _i30.SessionLogFilter => 'SessionLogFilter',
-      _i31.SessionLogInfo => 'SessionLogInfo',
-      _i32.SessionLogResult => 'SessionLogResult',
+      _i3.CacheInfo => 'CacheInfo',
+      _i4.CachesInfo => 'CachesInfo',
+      _i5.CloudStorageEntry => 'CloudStorageEntry',
+      _i6.CloudStorageDirectUploadEntry => 'CloudStorageDirectUploadEntry',
+      _i7.ClusterInfo => 'ClusterInfo',
+      _i8.ClusterServerInfo => 'ClusterServerInfo',
+      _i9.CronFutureCallScheduling => 'CronFutureCallScheduling',
+      _i10.DatabaseMigrationVersion => 'DatabaseMigrationVersion',
+      _i11.DistributedCacheEntry => 'DistributedCacheEntry',
+      _i12.AccessDeniedException => 'AccessDeniedException',
+      _i13.FileNotFoundException => 'FileNotFoundException',
+      _i14.FutureCallClaimEntry => 'FutureCallClaimEntry',
+      _i15.FutureCallEntry => 'FutureCallEntry',
+      _i9.IntervalFutureCallScheduling => 'IntervalFutureCallScheduling',
+      _i16.LogEntry => 'LogEntry',
+      _i17.LogLevel => 'LogLevel',
+      _i18.LogResult => 'LogResult',
+      _i19.LogSettings => 'LogSettings',
+      _i20.LogSettingsOverride => 'LogSettingsOverride',
+      _i21.MessageLogEntry => 'MessageLogEntry',
+      _i22.MethodInfo => 'MethodInfo',
+      _i23.QueryLogEntry => 'QueryLogEntry',
+      _i24.ReadWriteTestEntry => 'ReadWriteTestEntry',
+      _i25.RuntimeSettings => 'RuntimeSettings',
+      _i26.ServerHealthConnectionInfo => 'ServerHealthConnectionInfo',
+      _i27.ServerHealthMetric => 'ServerHealthMetric',
+      _i28.ServerHealthResult => 'ServerHealthResult',
+      _i29.ServerpodSqlException => 'ServerpodSqlException',
+      _i30.SessionLogEntry => 'SessionLogEntry',
+      _i31.SessionLogFilter => 'SessionLogFilter',
+      _i32.SessionLogInfo => 'SessionLogInfo',
+      _i33.SessionLogResult => 'SessionLogResult',
       _ => null,
     };
   }
@@ -467,72 +174,72 @@ class Protocol extends _i1.SerializationManager {
     }
 
     switch (data) {
-      case _i2.CacheInfo():
+      case _i3.CacheInfo():
         return 'CacheInfo';
-      case _i3.CachesInfo():
+      case _i4.CachesInfo():
         return 'CachesInfo';
-      case _i4.CloudStorageEntry():
+      case _i5.CloudStorageEntry():
         return 'CloudStorageEntry';
-      case _i5.CloudStorageDirectUploadEntry():
+      case _i6.CloudStorageDirectUploadEntry():
         return 'CloudStorageDirectUploadEntry';
-      case _i6.ClusterInfo():
+      case _i7.ClusterInfo():
         return 'ClusterInfo';
-      case _i7.ClusterServerInfo():
+      case _i8.ClusterServerInfo():
         return 'ClusterServerInfo';
-      case _i8.CronFutureCallScheduling():
+      case _i9.CronFutureCallScheduling():
         return 'CronFutureCallScheduling';
-      case _i9.DatabaseMigrationVersion():
+      case _i10.DatabaseMigrationVersion():
         return 'DatabaseMigrationVersion';
-      case _i10.DistributedCacheEntry():
+      case _i11.DistributedCacheEntry():
         return 'DistributedCacheEntry';
-      case _i11.AccessDeniedException():
+      case _i12.AccessDeniedException():
         return 'AccessDeniedException';
-      case _i12.FileNotFoundException():
+      case _i13.FileNotFoundException():
         return 'FileNotFoundException';
-      case _i13.FutureCallClaimEntry():
+      case _i14.FutureCallClaimEntry():
         return 'FutureCallClaimEntry';
-      case _i14.FutureCallEntry():
+      case _i15.FutureCallEntry():
         return 'FutureCallEntry';
-      case _i8.IntervalFutureCallScheduling():
+      case _i9.IntervalFutureCallScheduling():
         return 'IntervalFutureCallScheduling';
-      case _i15.LogEntry():
+      case _i16.LogEntry():
         return 'LogEntry';
-      case _i16.LogLevel():
+      case _i17.LogLevel():
         return 'LogLevel';
-      case _i17.LogResult():
+      case _i18.LogResult():
         return 'LogResult';
-      case _i18.LogSettings():
+      case _i19.LogSettings():
         return 'LogSettings';
-      case _i19.LogSettingsOverride():
+      case _i20.LogSettingsOverride():
         return 'LogSettingsOverride';
-      case _i20.MessageLogEntry():
+      case _i21.MessageLogEntry():
         return 'MessageLogEntry';
-      case _i21.MethodInfo():
+      case _i22.MethodInfo():
         return 'MethodInfo';
-      case _i22.QueryLogEntry():
+      case _i23.QueryLogEntry():
         return 'QueryLogEntry';
-      case _i23.ReadWriteTestEntry():
+      case _i24.ReadWriteTestEntry():
         return 'ReadWriteTestEntry';
-      case _i24.RuntimeSettings():
+      case _i25.RuntimeSettings():
         return 'RuntimeSettings';
-      case _i25.ServerHealthConnectionInfo():
+      case _i26.ServerHealthConnectionInfo():
         return 'ServerHealthConnectionInfo';
-      case _i26.ServerHealthMetric():
+      case _i27.ServerHealthMetric():
         return 'ServerHealthMetric';
-      case _i27.ServerHealthResult():
+      case _i28.ServerHealthResult():
         return 'ServerHealthResult';
-      case _i28.ServerpodSqlException():
+      case _i29.ServerpodSqlException():
         return 'ServerpodSqlException';
-      case _i29.SessionLogEntry():
+      case _i30.SessionLogEntry():
         return 'SessionLogEntry';
-      case _i30.SessionLogFilter():
+      case _i31.SessionLogFilter():
         return 'SessionLogFilter';
-      case _i31.SessionLogInfo():
+      case _i32.SessionLogInfo():
         return 'SessionLogInfo';
-      case _i32.SessionLogResult():
+      case _i33.SessionLogResult():
         return 'SessionLogResult';
     }
-    className = _i33.Protocol().getClassNameForObject(data);
+    className = _i2.Protocol().getClassNameForObject(data);
     if (className != null) {
       return className.contains('.')
           ? className
@@ -548,110 +255,110 @@ class Protocol extends _i1.SerializationManager {
       return super.deserializeByClassName(data);
     }
     if (dataClassName == 'CacheInfo') {
-      return deserialize<_i2.CacheInfo>(data['data']);
+      return deserialize<_i3.CacheInfo>(data['data']);
     }
     if (dataClassName == 'CachesInfo') {
-      return deserialize<_i3.CachesInfo>(data['data']);
+      return deserialize<_i4.CachesInfo>(data['data']);
     }
     if (dataClassName == 'CloudStorageEntry') {
-      return deserialize<_i4.CloudStorageEntry>(data['data']);
+      return deserialize<_i5.CloudStorageEntry>(data['data']);
     }
     if (dataClassName == 'CloudStorageDirectUploadEntry') {
-      return deserialize<_i5.CloudStorageDirectUploadEntry>(data['data']);
+      return deserialize<_i6.CloudStorageDirectUploadEntry>(data['data']);
     }
     if (dataClassName == 'ClusterInfo') {
-      return deserialize<_i6.ClusterInfo>(data['data']);
+      return deserialize<_i7.ClusterInfo>(data['data']);
     }
     if (dataClassName == 'ClusterServerInfo') {
-      return deserialize<_i7.ClusterServerInfo>(data['data']);
+      return deserialize<_i8.ClusterServerInfo>(data['data']);
     }
     if (dataClassName == 'CronFutureCallScheduling') {
-      return deserialize<_i8.CronFutureCallScheduling>(data['data']);
+      return deserialize<_i9.CronFutureCallScheduling>(data['data']);
     }
     if (dataClassName == 'DatabaseMigrationVersion') {
-      return deserialize<_i9.DatabaseMigrationVersion>(data['data']);
+      return deserialize<_i10.DatabaseMigrationVersion>(data['data']);
     }
     if (dataClassName == 'DistributedCacheEntry') {
-      return deserialize<_i10.DistributedCacheEntry>(data['data']);
+      return deserialize<_i11.DistributedCacheEntry>(data['data']);
     }
     if (dataClassName == 'AccessDeniedException') {
-      return deserialize<_i11.AccessDeniedException>(data['data']);
+      return deserialize<_i12.AccessDeniedException>(data['data']);
     }
     if (dataClassName == 'FileNotFoundException') {
-      return deserialize<_i12.FileNotFoundException>(data['data']);
+      return deserialize<_i13.FileNotFoundException>(data['data']);
     }
     if (dataClassName == 'FutureCallClaimEntry') {
-      return deserialize<_i13.FutureCallClaimEntry>(data['data']);
+      return deserialize<_i14.FutureCallClaimEntry>(data['data']);
     }
     if (dataClassName == 'FutureCallEntry') {
-      return deserialize<_i14.FutureCallEntry>(data['data']);
+      return deserialize<_i15.FutureCallEntry>(data['data']);
     }
     if (dataClassName == 'IntervalFutureCallScheduling') {
-      return deserialize<_i8.IntervalFutureCallScheduling>(data['data']);
+      return deserialize<_i9.IntervalFutureCallScheduling>(data['data']);
     }
     if (dataClassName == 'LogEntry') {
-      return deserialize<_i15.LogEntry>(data['data']);
+      return deserialize<_i16.LogEntry>(data['data']);
     }
     if (dataClassName == 'LogLevel') {
-      return deserialize<_i16.LogLevel>(data['data']);
+      return deserialize<_i17.LogLevel>(data['data']);
     }
     if (dataClassName == 'LogResult') {
-      return deserialize<_i17.LogResult>(data['data']);
+      return deserialize<_i18.LogResult>(data['data']);
     }
     if (dataClassName == 'LogSettings') {
-      return deserialize<_i18.LogSettings>(data['data']);
+      return deserialize<_i19.LogSettings>(data['data']);
     }
     if (dataClassName == 'LogSettingsOverride') {
-      return deserialize<_i19.LogSettingsOverride>(data['data']);
+      return deserialize<_i20.LogSettingsOverride>(data['data']);
     }
     if (dataClassName == 'MessageLogEntry') {
-      return deserialize<_i20.MessageLogEntry>(data['data']);
+      return deserialize<_i21.MessageLogEntry>(data['data']);
     }
     if (dataClassName == 'MethodInfo') {
-      return deserialize<_i21.MethodInfo>(data['data']);
+      return deserialize<_i22.MethodInfo>(data['data']);
     }
     if (dataClassName == 'QueryLogEntry') {
-      return deserialize<_i22.QueryLogEntry>(data['data']);
+      return deserialize<_i23.QueryLogEntry>(data['data']);
     }
     if (dataClassName == 'ReadWriteTestEntry') {
-      return deserialize<_i23.ReadWriteTestEntry>(data['data']);
+      return deserialize<_i24.ReadWriteTestEntry>(data['data']);
     }
     if (dataClassName == 'RuntimeSettings') {
-      return deserialize<_i24.RuntimeSettings>(data['data']);
+      return deserialize<_i25.RuntimeSettings>(data['data']);
     }
     if (dataClassName == 'ServerHealthConnectionInfo') {
-      return deserialize<_i25.ServerHealthConnectionInfo>(data['data']);
+      return deserialize<_i26.ServerHealthConnectionInfo>(data['data']);
     }
     if (dataClassName == 'ServerHealthMetric') {
-      return deserialize<_i26.ServerHealthMetric>(data['data']);
+      return deserialize<_i27.ServerHealthMetric>(data['data']);
     }
     if (dataClassName == 'ServerHealthResult') {
-      return deserialize<_i27.ServerHealthResult>(data['data']);
+      return deserialize<_i28.ServerHealthResult>(data['data']);
     }
     if (dataClassName == 'ServerpodSqlException') {
-      return deserialize<_i28.ServerpodSqlException>(data['data']);
+      return deserialize<_i29.ServerpodSqlException>(data['data']);
     }
     if (dataClassName == 'SessionLogEntry') {
-      return deserialize<_i29.SessionLogEntry>(data['data']);
+      return deserialize<_i30.SessionLogEntry>(data['data']);
     }
     if (dataClassName == 'SessionLogFilter') {
-      return deserialize<_i30.SessionLogFilter>(data['data']);
+      return deserialize<_i31.SessionLogFilter>(data['data']);
     }
     if (dataClassName == 'SessionLogInfo') {
-      return deserialize<_i31.SessionLogInfo>(data['data']);
+      return deserialize<_i32.SessionLogInfo>(data['data']);
     }
     if (dataClassName == 'SessionLogResult') {
-      return deserialize<_i32.SessionLogResult>(data['data']);
+      return deserialize<_i33.SessionLogResult>(data['data']);
     }
     if (dataClassName.startsWith('serverpod_database.')) {
       data['className'] = dataClassName.substring(19);
-      return _i33.Protocol().deserializeByClassName(data);
+      return _i2.Protocol().deserializeByClassName(data);
     }
     return super.deserializeByClassName(data);
   }
 
   void _registerHostProtocols() {
-    _i33.Protocol().registerHostProtocol('serverpod', this);
+    _i2.Protocol().registerHostProtocol('serverpod', this);
   }
 
   @override
@@ -667,5 +374,195 @@ class Protocol extends _i1.SerializationManager {
       return null;
     }
     throw Exception('Unsupported record type ${record.runtimeType}');
+  }
+
+  static Map<Type, dynamic Function(dynamic, Protocol)> _buildDeserializers() {
+    final map = <Type, dynamic Function(dynamic, Protocol)>{};
+    map[_i3.CacheInfo] = (data, protocol) => _i3.CacheInfo.fromJson(data);
+    map[_i4.CachesInfo] = (data, protocol) => _i4.CachesInfo.fromJson(data);
+    map[_i5.CloudStorageEntry] = (data, protocol) =>
+        _i5.CloudStorageEntry.fromJson(data);
+    map[_i6.CloudStorageDirectUploadEntry] = (data, protocol) =>
+        _i6.CloudStorageDirectUploadEntry.fromJson(data);
+    map[_i7.ClusterInfo] = (data, protocol) => _i7.ClusterInfo.fromJson(data);
+    map[_i8.ClusterServerInfo] = (data, protocol) =>
+        _i8.ClusterServerInfo.fromJson(data);
+    map[_i9.CronFutureCallScheduling] = (data, protocol) =>
+        _i9.CronFutureCallScheduling.fromJson(data);
+    map[_i10.DatabaseMigrationVersion] = (data, protocol) =>
+        _i10.DatabaseMigrationVersion.fromJson(data);
+    map[_i11.DistributedCacheEntry] = (data, protocol) =>
+        _i11.DistributedCacheEntry.fromJson(data);
+    map[_i12.AccessDeniedException] = (data, protocol) =>
+        _i12.AccessDeniedException.fromJson(data);
+    map[_i13.FileNotFoundException] = (data, protocol) =>
+        _i13.FileNotFoundException.fromJson(data);
+    map[_i14.FutureCallClaimEntry] = (data, protocol) =>
+        _i14.FutureCallClaimEntry.fromJson(data);
+    map[_i15.FutureCallEntry] = (data, protocol) =>
+        _i15.FutureCallEntry.fromJson(data);
+    map[_i9.IntervalFutureCallScheduling] = (data, protocol) =>
+        _i9.IntervalFutureCallScheduling.fromJson(data);
+    map[_i16.LogEntry] = (data, protocol) => _i16.LogEntry.fromJson(data);
+    map[_i17.LogLevel] = (data, protocol) => _i17.LogLevel.fromJson(data);
+    map[_i18.LogResult] = (data, protocol) => _i18.LogResult.fromJson(data);
+    map[_i19.LogSettings] = (data, protocol) => _i19.LogSettings.fromJson(data);
+    map[_i20.LogSettingsOverride] = (data, protocol) =>
+        _i20.LogSettingsOverride.fromJson(data);
+    map[_i21.MessageLogEntry] = (data, protocol) =>
+        _i21.MessageLogEntry.fromJson(data);
+    map[_i22.MethodInfo] = (data, protocol) => _i22.MethodInfo.fromJson(data);
+    map[_i23.QueryLogEntry] = (data, protocol) =>
+        _i23.QueryLogEntry.fromJson(data);
+    map[_i24.ReadWriteTestEntry] = (data, protocol) =>
+        _i24.ReadWriteTestEntry.fromJson(data);
+    map[_i25.RuntimeSettings] = (data, protocol) =>
+        _i25.RuntimeSettings.fromJson(data);
+    map[_i26.ServerHealthConnectionInfo] = (data, protocol) =>
+        _i26.ServerHealthConnectionInfo.fromJson(data);
+    map[_i27.ServerHealthMetric] = (data, protocol) =>
+        _i27.ServerHealthMetric.fromJson(data);
+    map[_i28.ServerHealthResult] = (data, protocol) =>
+        _i28.ServerHealthResult.fromJson(data);
+    map[_i29.ServerpodSqlException] = (data, protocol) =>
+        _i29.ServerpodSqlException.fromJson(data);
+    map[_i30.SessionLogEntry] = (data, protocol) =>
+        _i30.SessionLogEntry.fromJson(data);
+    map[_i31.SessionLogFilter] = (data, protocol) =>
+        _i31.SessionLogFilter.fromJson(data);
+    map[_i32.SessionLogInfo] = (data, protocol) =>
+        _i32.SessionLogInfo.fromJson(data);
+    map[_i33.SessionLogResult] = (data, protocol) =>
+        _i33.SessionLogResult.fromJson(data);
+    map[_i1.getType<_i3.CacheInfo?>()] = (data, protocol) =>
+        (data != null ? _i3.CacheInfo.fromJson(data) : null);
+    map[_i1.getType<_i4.CachesInfo?>()] = (data, protocol) =>
+        (data != null ? _i4.CachesInfo.fromJson(data) : null);
+    map[_i1.getType<_i5.CloudStorageEntry?>()] = (data, protocol) =>
+        (data != null ? _i5.CloudStorageEntry.fromJson(data) : null);
+    map[_i1.getType<_i6.CloudStorageDirectUploadEntry?>()] = (data, protocol) =>
+        (data != null
+        ? _i6.CloudStorageDirectUploadEntry.fromJson(data)
+        : null);
+    map[_i1.getType<_i7.ClusterInfo?>()] = (data, protocol) =>
+        (data != null ? _i7.ClusterInfo.fromJson(data) : null);
+    map[_i1.getType<_i8.ClusterServerInfo?>()] = (data, protocol) =>
+        (data != null ? _i8.ClusterServerInfo.fromJson(data) : null);
+    map[_i1.getType<_i9.CronFutureCallScheduling?>()] = (data, protocol) =>
+        (data != null ? _i9.CronFutureCallScheduling.fromJson(data) : null);
+    map[_i1.getType<_i10.DatabaseMigrationVersion?>()] = (data, protocol) =>
+        (data != null ? _i10.DatabaseMigrationVersion.fromJson(data) : null);
+    map[_i1.getType<_i11.DistributedCacheEntry?>()] = (data, protocol) =>
+        (data != null ? _i11.DistributedCacheEntry.fromJson(data) : null);
+    map[_i1.getType<_i12.AccessDeniedException?>()] = (data, protocol) =>
+        (data != null ? _i12.AccessDeniedException.fromJson(data) : null);
+    map[_i1.getType<_i13.FileNotFoundException?>()] = (data, protocol) =>
+        (data != null ? _i13.FileNotFoundException.fromJson(data) : null);
+    map[_i1.getType<_i14.FutureCallClaimEntry?>()] = (data, protocol) =>
+        (data != null ? _i14.FutureCallClaimEntry.fromJson(data) : null);
+    map[_i1.getType<_i15.FutureCallEntry?>()] = (data, protocol) =>
+        (data != null ? _i15.FutureCallEntry.fromJson(data) : null);
+    map[_i1.getType<_i9.IntervalFutureCallScheduling?>()] = (data, protocol) =>
+        (data != null ? _i9.IntervalFutureCallScheduling.fromJson(data) : null);
+    map[_i1.getType<_i16.LogEntry?>()] = (data, protocol) =>
+        (data != null ? _i16.LogEntry.fromJson(data) : null);
+    map[_i1.getType<_i17.LogLevel?>()] = (data, protocol) =>
+        (data != null ? _i17.LogLevel.fromJson(data) : null);
+    map[_i1.getType<_i18.LogResult?>()] = (data, protocol) =>
+        (data != null ? _i18.LogResult.fromJson(data) : null);
+    map[_i1.getType<_i19.LogSettings?>()] = (data, protocol) =>
+        (data != null ? _i19.LogSettings.fromJson(data) : null);
+    map[_i1.getType<_i20.LogSettingsOverride?>()] = (data, protocol) =>
+        (data != null ? _i20.LogSettingsOverride.fromJson(data) : null);
+    map[_i1.getType<_i21.MessageLogEntry?>()] = (data, protocol) =>
+        (data != null ? _i21.MessageLogEntry.fromJson(data) : null);
+    map[_i1.getType<_i22.MethodInfo?>()] = (data, protocol) =>
+        (data != null ? _i22.MethodInfo.fromJson(data) : null);
+    map[_i1.getType<_i23.QueryLogEntry?>()] = (data, protocol) =>
+        (data != null ? _i23.QueryLogEntry.fromJson(data) : null);
+    map[_i1.getType<_i24.ReadWriteTestEntry?>()] = (data, protocol) =>
+        (data != null ? _i24.ReadWriteTestEntry.fromJson(data) : null);
+    map[_i1.getType<_i25.RuntimeSettings?>()] = (data, protocol) =>
+        (data != null ? _i25.RuntimeSettings.fromJson(data) : null);
+    map[_i1.getType<_i26.ServerHealthConnectionInfo?>()] = (data, protocol) =>
+        (data != null ? _i26.ServerHealthConnectionInfo.fromJson(data) : null);
+    map[_i1.getType<_i27.ServerHealthMetric?>()] = (data, protocol) =>
+        (data != null ? _i27.ServerHealthMetric.fromJson(data) : null);
+    map[_i1.getType<_i28.ServerHealthResult?>()] = (data, protocol) =>
+        (data != null ? _i28.ServerHealthResult.fromJson(data) : null);
+    map[_i1.getType<_i29.ServerpodSqlException?>()] = (data, protocol) =>
+        (data != null ? _i29.ServerpodSqlException.fromJson(data) : null);
+    map[_i1.getType<_i30.SessionLogEntry?>()] = (data, protocol) =>
+        (data != null ? _i30.SessionLogEntry.fromJson(data) : null);
+    map[_i1.getType<_i31.SessionLogFilter?>()] = (data, protocol) =>
+        (data != null ? _i31.SessionLogFilter.fromJson(data) : null);
+    map[_i1.getType<_i32.SessionLogInfo?>()] = (data, protocol) =>
+        (data != null ? _i32.SessionLogInfo.fromJson(data) : null);
+    map[_i1.getType<_i33.SessionLogResult?>()] = (data, protocol) =>
+        (data != null ? _i33.SessionLogResult.fromJson(data) : null);
+    map[List<String>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<String>(e)).toList();
+    map[_i1.getType<List<String>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<String>(e)).toList()
+        : null);
+    map[List<_i8.ClusterServerInfo>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i8.ClusterServerInfo>(e))
+        .toList();
+    map[List<_i16.LogEntry>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i16.LogEntry>(e))
+        .toList();
+    map[List<_i20.LogSettingsOverride>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i20.LogSettingsOverride>(e))
+        .toList();
+    map[List<_i27.ServerHealthMetric>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i27.ServerHealthMetric>(e))
+        .toList();
+    map[List<_i26.ServerHealthConnectionInfo>] = (data, protocol) =>
+        (data as List)
+            .map(
+              (e) => protocol.deserialize<_i26.ServerHealthConnectionInfo>(e),
+            )
+            .toList();
+    map[List<_i16.LogEntry>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i16.LogEntry>(e))
+        .toList();
+    map[_i1.getType<List<_i16.LogEntry>?>()] = (data, protocol) => (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i16.LogEntry>(e))
+              .toList()
+        : null);
+    map[List<_i23.QueryLogEntry>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i23.QueryLogEntry>(e))
+        .toList();
+    map[_i1.getType<List<_i23.QueryLogEntry>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i23.QueryLogEntry>(e))
+              .toList()
+        : null);
+    map[List<_i21.MessageLogEntry>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i21.MessageLogEntry>(e))
+        .toList();
+    map[_i1.getType<List<_i21.MessageLogEntry>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i21.MessageLogEntry>(e))
+              .toList()
+        : null);
+    map[List<_i23.QueryLogEntry>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i23.QueryLogEntry>(e))
+        .toList();
+    map[List<_i21.MessageLogEntry>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i21.MessageLogEntry>(e))
+        .toList();
+    map[List<_i32.SessionLogInfo>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i32.SessionLogInfo>(e))
+        .toList();
+    map[List<_i2.TableDefinition>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i2.TableDefinition>(e))
+        .toList();
+    map[List<String>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<String>(e)).toList();
+    return map;
   }
 }

--- a/tests/serverpod_auth_test/serverpod_auth_test_client/lib/src/protocol/protocol.dart
+++ b/tests/serverpod_auth_test/serverpod_auth_test_client/lib/src/protocol/protocol.dart
@@ -32,6 +32,26 @@ class Protocol extends _i1.SerializationManager {
 
   static final Protocol _instance = Protocol._().._registerHostProtocols();
 
+  static final Map<Type, dynamic Function(dynamic, Protocol)> _deserializers =
+      _buildDeserializers();
+
+  static Map<Type, dynamic Function(dynamic, Protocol)> _buildDeserializers() {
+    final map = <Type, dynamic Function(dynamic, Protocol)>{};
+    map[_i2.UserData] = (data, protocol) => _i2.UserData.fromJson(data);
+    map[_i1.getType<_i2.UserData?>()] = (data, protocol) =>
+        (data != null ? _i2.UserData.fromJson(data) : null);
+    map[Set<String>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<String>(e)).toSet();
+    map[_i1.getType<({_i3.ByteData challenge, _i1.UuidValue id})>()] =
+        (data, protocol) => (
+          challenge: protocol.deserialize<_i3.ByteData>(
+            ((data as Map)['n'] as Map)['challenge'],
+          ),
+          id: protocol.deserialize<_i1.UuidValue>(data['n']['id']),
+        );
+    return map;
+  }
+
   static String? getClassNameFromObjectJson(dynamic data) {
     if (data is! Map) return null;
     final className = data['__className__'] as String?;
@@ -59,23 +79,9 @@ class Protocol extends _i1.SerializationManager {
       }
     }
 
-    if (t == _i2.UserData) {
-      return _i2.UserData.fromJson(data) as T;
-    }
-    if (t == _i1.getType<_i2.UserData?>()) {
-      return (data != null ? _i2.UserData.fromJson(data) : null) as T;
-    }
-    if (t == Set<String>) {
-      return (data as List).map((e) => deserialize<String>(e)).toSet() as T;
-    }
-    if (t == _i1.getType<({_i3.ByteData challenge, _i1.UuidValue id})>()) {
-      return (
-            challenge: deserialize<_i3.ByteData>(
-              ((data as Map)['n'] as Map)['challenge'],
-            ),
-            id: deserialize<_i1.UuidValue>(data['n']['id']),
-          )
-          as T;
+    final fn = _deserializers[t];
+    if (fn != null) {
+      return fn(data, this) as T;
     }
     try {
       return _i4.Protocol().deserialize<T>(data, t);

--- a/tests/serverpod_auth_test/serverpod_auth_test_client/lib/src/protocol/protocol.dart
+++ b/tests/serverpod_auth_test/serverpod_auth_test_client/lib/src/protocol/protocol.dart
@@ -12,17 +12,17 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
-import 'user_data.dart' as _i2;
-import 'dart:typed_data' as _i3;
 import 'package:serverpod_auth_bridge_client/serverpod_auth_bridge_client.dart'
-    as _i4;
+    as _i2;
 import 'package:serverpod_auth_core_client/serverpod_auth_core_client.dart'
-    as _i5;
+    as _i3;
 import 'package:serverpod_auth_idp_client/serverpod_auth_idp_client.dart'
-    as _i6;
+    as _i4;
 import 'package:serverpod_auth_migration_client/serverpod_auth_migration_client.dart'
-    as _i7;
-import 'package:serverpod_auth_client/serverpod_auth_client.dart' as _i8;
+    as _i5;
+import 'package:serverpod_auth_client/serverpod_auth_client.dart' as _i6;
+import 'user_data.dart' as _i7;
+import 'dart:typed_data' as _i8;
 export 'user_data.dart';
 export 'client.dart';
 
@@ -32,6 +32,9 @@ class Protocol extends _i1.SerializationManager {
   factory Protocol() => _instance;
 
   static final Protocol _instance = Protocol._().._registerHostProtocols();
+
+  static final Map<Type, dynamic Function(dynamic, Protocol)> _deserializers =
+      _buildDeserializers();
 
   static String? getClassNameFromObjectJson(dynamic data) {
     if (data is! Map) return null;
@@ -60,24 +63,16 @@ class Protocol extends _i1.SerializationManager {
       }
     }
 
-    if (t == _i2.UserData) {
-      return _i2.UserData.fromJson(data) as T;
+    final fn = _deserializers[t];
+    if (fn != null) {
+      return fn(data, this) as T;
     }
-    if (t == _i1.getType<_i2.UserData?>()) {
-      return (data != null ? _i2.UserData.fromJson(data) : null) as T;
-    }
-    if (t == Set<String>) {
-      return (data as List).map((e) => deserialize<String>(e)).toSet() as T;
-    }
-    if (t == _i1.getType<({_i3.ByteData challenge, _i1.UuidValue id})>()) {
-      return (
-            challenge: deserialize<_i3.ByteData>(
-              ((data as Map)['n'] as Map)['challenge'],
-            ),
-            id: deserialize<_i1.UuidValue>(data['n']['id']),
-          )
-          as T;
-    }
+    try {
+      return _i2.Protocol().deserialize<T>(data, t);
+    } on _i1.DeserializationTypeNotFoundException catch (_) {}
+    try {
+      return _i3.Protocol().deserialize<T>(data, t);
+    } on _i1.DeserializationTypeNotFoundException catch (_) {}
     try {
       return _i4.Protocol().deserialize<T>(data, t);
     } on _i1.DeserializationTypeNotFoundException catch (_) {}
@@ -87,18 +82,12 @@ class Protocol extends _i1.SerializationManager {
     try {
       return _i6.Protocol().deserialize<T>(data, t);
     } on _i1.DeserializationTypeNotFoundException catch (_) {}
-    try {
-      return _i7.Protocol().deserialize<T>(data, t);
-    } on _i1.DeserializationTypeNotFoundException catch (_) {}
-    try {
-      return _i8.Protocol().deserialize<T>(data, t);
-    } on _i1.DeserializationTypeNotFoundException catch (_) {}
     return super.deserialize<T>(data, t);
   }
 
   static String? getClassNameForType(Type type) {
     return switch (type) {
-      _i2.UserData => 'UserData',
+      _i7.UserData => 'UserData',
       _ => null,
     };
   }
@@ -116,34 +105,34 @@ class Protocol extends _i1.SerializationManager {
     }
 
     switch (data) {
-      case _i2.UserData():
+      case _i7.UserData():
         return 'UserData';
     }
-    className = _i4.Protocol().getClassNameForObject(data);
+    className = _i2.Protocol().getClassNameForObject(data);
     if (className != null) {
       return className.contains('.')
           ? className
           : 'serverpod_auth_bridge.$className';
     }
-    className = _i5.Protocol().getClassNameForObject(data);
+    className = _i3.Protocol().getClassNameForObject(data);
     if (className != null) {
       return className.contains('.')
           ? className
           : 'serverpod_auth_core.$className';
     }
-    className = _i6.Protocol().getClassNameForObject(data);
+    className = _i4.Protocol().getClassNameForObject(data);
     if (className != null) {
       return className.contains('.')
           ? className
           : 'serverpod_auth_idp.$className';
     }
-    className = _i7.Protocol().getClassNameForObject(data);
+    className = _i5.Protocol().getClassNameForObject(data);
     if (className != null) {
       return className.contains('.')
           ? className
           : 'serverpod_auth_migration.$className';
     }
-    className = _i8.Protocol().getClassNameForObject(data);
+    className = _i6.Protocol().getClassNameForObject(data);
     if (className != null) {
       return className.contains('.') ? className : 'serverpod_auth.$className';
     }
@@ -157,37 +146,37 @@ class Protocol extends _i1.SerializationManager {
       return super.deserializeByClassName(data);
     }
     if (dataClassName == 'UserData') {
-      return deserialize<_i2.UserData>(data['data']);
+      return deserialize<_i7.UserData>(data['data']);
     }
     if (dataClassName.startsWith('serverpod_auth_bridge.')) {
       data['className'] = dataClassName.substring(22);
-      return _i4.Protocol().deserializeByClassName(data);
+      return _i2.Protocol().deserializeByClassName(data);
     }
     if (dataClassName.startsWith('serverpod_auth_core.')) {
       data['className'] = dataClassName.substring(20);
-      return _i5.Protocol().deserializeByClassName(data);
+      return _i3.Protocol().deserializeByClassName(data);
     }
     if (dataClassName.startsWith('serverpod_auth_idp.')) {
       data['className'] = dataClassName.substring(19);
-      return _i6.Protocol().deserializeByClassName(data);
+      return _i4.Protocol().deserializeByClassName(data);
     }
     if (dataClassName.startsWith('serverpod_auth_migration.')) {
       data['className'] = dataClassName.substring(25);
-      return _i7.Protocol().deserializeByClassName(data);
+      return _i5.Protocol().deserializeByClassName(data);
     }
     if (dataClassName.startsWith('serverpod_auth.')) {
       data['className'] = dataClassName.substring(15);
-      return _i8.Protocol().deserializeByClassName(data);
+      return _i6.Protocol().deserializeByClassName(data);
     }
     return super.deserializeByClassName(data);
   }
 
   void _registerHostProtocols() {
+    _i2.Protocol().registerHostProtocol('serverpod_auth_test', this);
+    _i3.Protocol().registerHostProtocol('serverpod_auth_test', this);
     _i4.Protocol().registerHostProtocol('serverpod_auth_test', this);
     _i5.Protocol().registerHostProtocol('serverpod_auth_test', this);
     _i6.Protocol().registerHostProtocol('serverpod_auth_test', this);
-    _i7.Protocol().registerHostProtocol('serverpod_auth_test', this);
-    _i8.Protocol().registerHostProtocol('serverpod_auth_test', this);
   }
 
   @override
@@ -202,7 +191,7 @@ class Protocol extends _i1.SerializationManager {
     if (record == null) {
       return null;
     }
-    if (record is ({_i3.ByteData challenge, _i1.UuidValue id})) {
+    if (record is ({_i8.ByteData challenge, _i1.UuidValue id})) {
       return {
         "n": {
           "challenge": record.challenge.toJson(),
@@ -211,6 +200,12 @@ class Protocol extends _i1.SerializationManager {
       };
     }
     try {
+      return _i2.Protocol().mapRecordToJson(record);
+    } catch (_) {}
+    try {
+      return _i3.Protocol().mapRecordToJson(record);
+    } catch (_) {}
+    try {
       return _i4.Protocol().mapRecordToJson(record);
     } catch (_) {}
     try {
@@ -218,12 +213,6 @@ class Protocol extends _i1.SerializationManager {
     } catch (_) {}
     try {
       return _i6.Protocol().mapRecordToJson(record);
-    } catch (_) {}
-    try {
-      return _i7.Protocol().mapRecordToJson(record);
-    } catch (_) {}
-    try {
-      return _i8.Protocol().mapRecordToJson(record);
     } catch (_) {}
     throw Exception('Unsupported record type ${record.runtimeType}');
   }
@@ -278,5 +267,22 @@ class Protocol extends _i1.SerializationManager {
     }
 
     return obj;
+  }
+
+  static Map<Type, dynamic Function(dynamic, Protocol)> _buildDeserializers() {
+    final map = <Type, dynamic Function(dynamic, Protocol)>{};
+    map[_i7.UserData] = (data, protocol) => _i7.UserData.fromJson(data);
+    map[_i1.getType<_i7.UserData?>()] = (data, protocol) =>
+        (data != null ? _i7.UserData.fromJson(data) : null);
+    map[Set<String>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<String>(e)).toSet();
+    map[_i1.getType<({_i8.ByteData challenge, _i1.UuidValue id})>()] =
+        (data, protocol) => (
+          challenge: protocol.deserialize<_i8.ByteData>(
+            ((data as Map)['n'] as Map)['challenge'],
+          ),
+          id: protocol.deserialize<_i1.UuidValue>(data['n']['id']),
+        );
+    return map;
   }
 }

--- a/tests/serverpod_auth_test/serverpod_auth_test_server/lib/src/generated/protocol.dart
+++ b/tests/serverpod_auth_test/serverpod_auth_test_server/lib/src/generated/protocol.dart
@@ -315,6 +315,38 @@ class Protocol extends _i1.DatabaseSerializationManager {
     ..._i2.Protocol.targetTableDefinitions,
   ];
 
+  static final Map<Type, dynamic Function(dynamic, Protocol)> _deserializers =
+      _buildDeserializers();
+
+  static Map<Type, dynamic Function(dynamic, Protocol)> _buildDeserializers() {
+    final map = <Type, dynamic Function(dynamic, Protocol)>{};
+    map[_i8.ChallengeTracker] = (data, protocol) =>
+        _i8.ChallengeTracker.fromJson(data);
+    map[_i9.SessionMetadata] = (data, protocol) =>
+        _i9.SessionMetadata.fromJson(data);
+    map[_i10.TokenMetadata] = (data, protocol) =>
+        _i10.TokenMetadata.fromJson(data);
+    map[_i11.UserData] = (data, protocol) => _i11.UserData.fromJson(data);
+    map[_i1.getType<_i8.ChallengeTracker?>()] = (data, protocol) =>
+        (data != null ? _i8.ChallengeTracker.fromJson(data) : null);
+    map[_i1.getType<_i9.SessionMetadata?>()] = (data, protocol) =>
+        (data != null ? _i9.SessionMetadata.fromJson(data) : null);
+    map[_i1.getType<_i10.TokenMetadata?>()] = (data, protocol) =>
+        (data != null ? _i10.TokenMetadata.fromJson(data) : null);
+    map[_i1.getType<_i11.UserData?>()] = (data, protocol) =>
+        (data != null ? _i11.UserData.fromJson(data) : null);
+    map[Set<String>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<String>(e)).toSet();
+    map[_i1.getType<({_i12.ByteData challenge, _i1.UuidValue id})>()] =
+        (data, protocol) => (
+          challenge: protocol.deserialize<_i12.ByteData>(
+            ((data as Map)['n'] as Map)['challenge'],
+          ),
+          id: protocol.deserialize<_i1.UuidValue>(data['n']['id']),
+        );
+    return map;
+  }
+
   static String? getClassNameFromObjectJson(dynamic data) {
     if (data is! Map) return null;
     final className = data['__className__'] as String?;
@@ -342,41 +374,9 @@ class Protocol extends _i1.DatabaseSerializationManager {
       }
     }
 
-    if (t == _i8.ChallengeTracker) {
-      return _i8.ChallengeTracker.fromJson(data) as T;
-    }
-    if (t == _i9.SessionMetadata) {
-      return _i9.SessionMetadata.fromJson(data) as T;
-    }
-    if (t == _i10.TokenMetadata) {
-      return _i10.TokenMetadata.fromJson(data) as T;
-    }
-    if (t == _i11.UserData) {
-      return _i11.UserData.fromJson(data) as T;
-    }
-    if (t == _i1.getType<_i8.ChallengeTracker?>()) {
-      return (data != null ? _i8.ChallengeTracker.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i9.SessionMetadata?>()) {
-      return (data != null ? _i9.SessionMetadata.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i10.TokenMetadata?>()) {
-      return (data != null ? _i10.TokenMetadata.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i11.UserData?>()) {
-      return (data != null ? _i11.UserData.fromJson(data) : null) as T;
-    }
-    if (t == Set<String>) {
-      return (data as List).map((e) => deserialize<String>(e)).toSet() as T;
-    }
-    if (t == _i1.getType<({_i12.ByteData challenge, _i1.UuidValue id})>()) {
-      return (
-            challenge: deserialize<_i12.ByteData>(
-              ((data as Map)['n'] as Map)['challenge'],
-            ),
-            id: deserialize<_i1.UuidValue>(data['n']['id']),
-          )
-          as T;
+    final fn = _deserializers[t];
+    if (fn != null) {
+      return fn(data, this) as T;
     }
     try {
       return _i3.Protocol().deserialize<T>(data, t);

--- a/tests/serverpod_auth_test/serverpod_auth_test_server/lib/src/generated/protocol.dart
+++ b/tests/serverpod_auth_test/serverpod_auth_test_server/lib/src/generated/protocol.dart
@@ -39,6 +39,9 @@ class Protocol extends _i1.DatabaseSerializationManager {
 
   static final Protocol _instance = Protocol._().._registerHostProtocols();
 
+  static final Map<Type, dynamic Function(dynamic, Protocol)> _deserializers =
+      _buildDeserializers();
+
   static List<_i2.TableDefinition> get targetTableDefinitions => [
     _i2.TableDefinition(
       name: 'challenge_tracker',
@@ -343,41 +346,9 @@ class Protocol extends _i1.DatabaseSerializationManager {
       }
     }
 
-    if (t == _i8.ChallengeTracker) {
-      return _i8.ChallengeTracker.fromJson(data) as T;
-    }
-    if (t == _i9.SessionMetadata) {
-      return _i9.SessionMetadata.fromJson(data) as T;
-    }
-    if (t == _i10.TokenMetadata) {
-      return _i10.TokenMetadata.fromJson(data) as T;
-    }
-    if (t == _i11.UserData) {
-      return _i11.UserData.fromJson(data) as T;
-    }
-    if (t == _i1.getType<_i8.ChallengeTracker?>()) {
-      return (data != null ? _i8.ChallengeTracker.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i9.SessionMetadata?>()) {
-      return (data != null ? _i9.SessionMetadata.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i10.TokenMetadata?>()) {
-      return (data != null ? _i10.TokenMetadata.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i11.UserData?>()) {
-      return (data != null ? _i11.UserData.fromJson(data) : null) as T;
-    }
-    if (t == Set<String>) {
-      return (data as List).map((e) => deserialize<String>(e)).toSet() as T;
-    }
-    if (t == _i1.getType<({_i12.ByteData challenge, _i1.UuidValue id})>()) {
-      return (
-            challenge: deserialize<_i12.ByteData>(
-              ((data as Map)['n'] as Map)['challenge'],
-            ),
-            id: deserialize<_i1.UuidValue>(data['n']['id']),
-          )
-          as T;
+    final fn = _deserializers[t];
+    if (fn != null) {
+      return fn(data, this) as T;
     }
     try {
       return _i3.Protocol().deserialize<T>(data, t);
@@ -663,5 +634,34 @@ class Protocol extends _i1.DatabaseSerializationManager {
     }
 
     return obj;
+  }
+
+  static Map<Type, dynamic Function(dynamic, Protocol)> _buildDeserializers() {
+    final map = <Type, dynamic Function(dynamic, Protocol)>{};
+    map[_i8.ChallengeTracker] = (data, protocol) =>
+        _i8.ChallengeTracker.fromJson(data);
+    map[_i9.SessionMetadata] = (data, protocol) =>
+        _i9.SessionMetadata.fromJson(data);
+    map[_i10.TokenMetadata] = (data, protocol) =>
+        _i10.TokenMetadata.fromJson(data);
+    map[_i11.UserData] = (data, protocol) => _i11.UserData.fromJson(data);
+    map[_i1.getType<_i8.ChallengeTracker?>()] = (data, protocol) =>
+        (data != null ? _i8.ChallengeTracker.fromJson(data) : null);
+    map[_i1.getType<_i9.SessionMetadata?>()] = (data, protocol) =>
+        (data != null ? _i9.SessionMetadata.fromJson(data) : null);
+    map[_i1.getType<_i10.TokenMetadata?>()] = (data, protocol) =>
+        (data != null ? _i10.TokenMetadata.fromJson(data) : null);
+    map[_i1.getType<_i11.UserData?>()] = (data, protocol) =>
+        (data != null ? _i11.UserData.fromJson(data) : null);
+    map[Set<String>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<String>(e)).toSet();
+    map[_i1.getType<({_i12.ByteData challenge, _i1.UuidValue id})>()] =
+        (data, protocol) => (
+          challenge: protocol.deserialize<_i12.ByteData>(
+            ((data as Map)['n'] as Map)['challenge'],
+          ),
+          id: protocol.deserialize<_i1.UuidValue>(data['n']['id']),
+        );
+    return map;
   }
 }

--- a/tests/serverpod_test_client/lib/src/protocol/protocol.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/protocol.dart
@@ -448,6 +448,4151 @@ class Protocol extends _i1.SerializationManager {
 
   static final Protocol _instance = Protocol._().._registerHostProtocols();
 
+  static final Map<Type, dynamic Function(dynamic, Protocol)> _deserializers =
+      _buildDeserializers();
+
+  static Map<Type, dynamic Function(dynamic, Protocol)> _buildDeserializers() {
+    final map = <Type, dynamic Function(dynamic, Protocol)>{};
+    map[_i2.ByIndexEnumWithNameValue] = (data, protocol) =>
+        _i2.ByIndexEnumWithNameValue.fromJson(data);
+    map[_i3.ByNameEnumWithNameValue] = (data, protocol) =>
+        _i3.ByNameEnumWithNameValue.fromJson(data);
+    map[_i4.CourseUuid] = (data, protocol) => _i4.CourseUuid.fromJson(data);
+    map[_i5.EnrollmentInt] = (data, protocol) =>
+        _i5.EnrollmentInt.fromJson(data);
+    map[_i6.StudentUuid] = (data, protocol) => _i6.StudentUuid.fromJson(data);
+    map[_i7.ArenaUuid] = (data, protocol) => _i7.ArenaUuid.fromJson(data);
+    map[_i8.PlayerUuid] = (data, protocol) => _i8.PlayerUuid.fromJson(data);
+    map[_i9.TeamInt] = (data, protocol) => _i9.TeamInt.fromJson(data);
+    map[_i10.CommentInt] = (data, protocol) => _i10.CommentInt.fromJson(data);
+    map[_i11.CustomerInt] = (data, protocol) => _i11.CustomerInt.fromJson(data);
+    map[_i12.OrderUuid] = (data, protocol) => _i12.OrderUuid.fromJson(data);
+    map[_i13.AddressUuid] = (data, protocol) => _i13.AddressUuid.fromJson(data);
+    map[_i14.CitizenInt] = (data, protocol) => _i14.CitizenInt.fromJson(data);
+    map[_i15.CompanyUuid] = (data, protocol) => _i15.CompanyUuid.fromJson(data);
+    map[_i16.TownInt] = (data, protocol) => _i16.TownInt.fromJson(data);
+    map[_i17.ChangedIdTypeSelf] = (data, protocol) =>
+        _i17.ChangedIdTypeSelf.fromJson(data);
+    map[_i18.BigIntDefault] = (data, protocol) =>
+        _i18.BigIntDefault.fromJson(data);
+    map[_i19.BigIntDefaultMix] = (data, protocol) =>
+        _i19.BigIntDefaultMix.fromJson(data);
+    map[_i20.BigIntDefaultModel] = (data, protocol) =>
+        _i20.BigIntDefaultModel.fromJson(data);
+    map[_i21.BigIntDefaultPersist] = (data, protocol) =>
+        _i21.BigIntDefaultPersist.fromJson(data);
+    map[_i22.BoolDefault] = (data, protocol) => _i22.BoolDefault.fromJson(data);
+    map[_i23.BoolDefaultMix] = (data, protocol) =>
+        _i23.BoolDefaultMix.fromJson(data);
+    map[_i24.BoolDefaultModel] = (data, protocol) =>
+        _i24.BoolDefaultModel.fromJson(data);
+    map[_i25.BoolDefaultPersist] = (data, protocol) =>
+        _i25.BoolDefaultPersist.fromJson(data);
+    map[_i26.DateTimeDefault] = (data, protocol) =>
+        _i26.DateTimeDefault.fromJson(data);
+    map[_i27.DateTimeDefaultMix] = (data, protocol) =>
+        _i27.DateTimeDefaultMix.fromJson(data);
+    map[_i28.DateTimeDefaultModel] = (data, protocol) =>
+        _i28.DateTimeDefaultModel.fromJson(data);
+    map[_i29.DateTimeDefaultPersist] = (data, protocol) =>
+        _i29.DateTimeDefaultPersist.fromJson(data);
+    map[_i30.DoubleDefault] = (data, protocol) =>
+        _i30.DoubleDefault.fromJson(data);
+    map[_i31.DoubleDefaultMix] = (data, protocol) =>
+        _i31.DoubleDefaultMix.fromJson(data);
+    map[_i32.DoubleDefaultModel] = (data, protocol) =>
+        _i32.DoubleDefaultModel.fromJson(data);
+    map[_i33.DoubleDefaultPersist] = (data, protocol) =>
+        _i33.DoubleDefaultPersist.fromJson(data);
+    map[_i34.DurationDefault] = (data, protocol) =>
+        _i34.DurationDefault.fromJson(data);
+    map[_i35.DurationDefaultMix] = (data, protocol) =>
+        _i35.DurationDefaultMix.fromJson(data);
+    map[_i36.DurationDefaultModel] = (data, protocol) =>
+        _i36.DurationDefaultModel.fromJson(data);
+    map[_i37.DurationDefaultPersist] = (data, protocol) =>
+        _i37.DurationDefaultPersist.fromJson(data);
+    map[_i38.EnumDefault] = (data, protocol) => _i38.EnumDefault.fromJson(data);
+    map[_i39.EnumDefaultMix] = (data, protocol) =>
+        _i39.EnumDefaultMix.fromJson(data);
+    map[_i40.EnumDefaultModel] = (data, protocol) =>
+        _i40.EnumDefaultModel.fromJson(data);
+    map[_i41.EnumDefaultPersist] = (data, protocol) =>
+        _i41.EnumDefaultPersist.fromJson(data);
+    map[_i42.ByIndexEnum] = (data, protocol) => _i42.ByIndexEnum.fromJson(data);
+    map[_i43.ByNameEnum] = (data, protocol) => _i43.ByNameEnum.fromJson(data);
+    map[_i44.DefaultValueEnum] = (data, protocol) =>
+        _i44.DefaultValueEnum.fromJson(data);
+    map[_i45.DefaultException] = (data, protocol) =>
+        _i45.DefaultException.fromJson(data);
+    map[_i46.IntDefault] = (data, protocol) => _i46.IntDefault.fromJson(data);
+    map[_i47.IntDefaultMix] = (data, protocol) =>
+        _i47.IntDefaultMix.fromJson(data);
+    map[_i48.IntDefaultModel] = (data, protocol) =>
+        _i48.IntDefaultModel.fromJson(data);
+    map[_i49.IntDefaultPersist] = (data, protocol) =>
+        _i49.IntDefaultPersist.fromJson(data);
+    map[_i50.StringDefault] = (data, protocol) =>
+        _i50.StringDefault.fromJson(data);
+    map[_i51.StringDefaultMix] = (data, protocol) =>
+        _i51.StringDefaultMix.fromJson(data);
+    map[_i52.StringDefaultModel] = (data, protocol) =>
+        _i52.StringDefaultModel.fromJson(data);
+    map[_i53.StringDefaultPersist] = (data, protocol) =>
+        _i53.StringDefaultPersist.fromJson(data);
+    map[_i54.UriDefault] = (data, protocol) => _i54.UriDefault.fromJson(data);
+    map[_i55.UriDefaultMix] = (data, protocol) =>
+        _i55.UriDefaultMix.fromJson(data);
+    map[_i56.UriDefaultModel] = (data, protocol) =>
+        _i56.UriDefaultModel.fromJson(data);
+    map[_i57.UriDefaultPersist] = (data, protocol) =>
+        _i57.UriDefaultPersist.fromJson(data);
+    map[_i58.UuidDefault] = (data, protocol) => _i58.UuidDefault.fromJson(data);
+    map[_i59.UuidDefaultMix] = (data, protocol) =>
+        _i59.UuidDefaultMix.fromJson(data);
+    map[_i60.UuidDefaultModel] = (data, protocol) =>
+        _i60.UuidDefaultModel.fromJson(data);
+    map[_i61.UuidDefaultPersist] = (data, protocol) =>
+        _i61.UuidDefaultPersist.fromJson(data);
+    map[_i62.EmptyModel] = (data, protocol) => _i62.EmptyModel.fromJson(data);
+    map[_i63.EmptyModelRelationItem] = (data, protocol) =>
+        _i63.EmptyModelRelationItem.fromJson(data);
+    map[_i64.EmptyModelWithTable] = (data, protocol) =>
+        _i64.EmptyModelWithTable.fromJson(data);
+    map[_i65.RelationEmptyModel] = (data, protocol) =>
+        _i65.RelationEmptyModel.fromJson(data);
+    map[_i66.ExceptionWithData] = (data, protocol) =>
+        _i66.ExceptionWithData.fromJson(data);
+    map[_i67.ChildClassExplicitColumn] = (data, protocol) =>
+        _i67.ChildClassExplicitColumn.fromJson(data);
+    map[_i68.NonTableParentClass] = (data, protocol) =>
+        _i68.NonTableParentClass.fromJson(data);
+    map[_i69.ModifiedColumnName] = (data, protocol) =>
+        _i69.ModifiedColumnName.fromJson(data);
+    map[_i70.Department] = (data, protocol) => _i70.Department.fromJson(data);
+    map[_i71.Employee] = (data, protocol) => _i71.Employee.fromJson(data);
+    map[_i72.Contractor] = (data, protocol) => _i72.Contractor.fromJson(data);
+    map[_i73.Service] = (data, protocol) => _i73.Service.fromJson(data);
+    map[_i74.TableWithExplicitColumnName] = (data, protocol) =>
+        _i74.TableWithExplicitColumnName.fromJson(data);
+    map[_i75.ImmutableChildObject] = (data, protocol) =>
+        _i75.ImmutableChildObject.fromJson(data);
+    map[_i76.ImmutableChildObjectWithNoAdditionalFields] = (data, protocol) =>
+        _i76.ImmutableChildObjectWithNoAdditionalFields.fromJson(data);
+    map[_i77.ImmutableObject] = (data, protocol) =>
+        _i77.ImmutableObject.fromJson(data);
+    map[_i78.ImmutableObjectWithImmutableObject] = (data, protocol) =>
+        _i78.ImmutableObjectWithImmutableObject.fromJson(data);
+    map[_i79.ImmutableObjectWithList] = (data, protocol) =>
+        _i79.ImmutableObjectWithList.fromJson(data);
+    map[_i80.ImmutableObjectWithMap] = (data, protocol) =>
+        _i80.ImmutableObjectWithMap.fromJson(data);
+    map[_i81.ImmutableObjectWithMultipleFields] = (data, protocol) =>
+        _i81.ImmutableObjectWithMultipleFields.fromJson(data);
+    map[_i82.ImmutableObjectWithNoFields] = (data, protocol) =>
+        _i82.ImmutableObjectWithNoFields.fromJson(data);
+    map[_i83.ImmutableObjectWithRecord] = (data, protocol) =>
+        _i83.ImmutableObjectWithRecord.fromJson(data);
+    map[_i84.ImmutableObjectWithTable] = (data, protocol) =>
+        _i84.ImmutableObjectWithTable.fromJson(data);
+    map[_i85.ImmutableObjectWithTwentyFields] = (data, protocol) =>
+        _i85.ImmutableObjectWithTwentyFields.fromJson(data);
+    map[_i86.ChildClass] = (data, protocol) => _i86.ChildClass.fromJson(data);
+    map[_i87.ChildWithDefault] = (data, protocol) =>
+        _i87.ChildWithDefault.fromJson(data);
+    map[_i88.ChildClassWithoutId] = (data, protocol) =>
+        _i88.ChildClassWithoutId.fromJson(data);
+    map[_i89.ParentClass] = (data, protocol) => _i89.ParentClass.fromJson(data);
+    map[_i90.GrandparentClass] = (data, protocol) =>
+        _i90.GrandparentClass.fromJson(data);
+    map[_i91.ParentClassWithoutId] = (data, protocol) =>
+        _i91.ParentClassWithoutId.fromJson(data);
+    map[_i92.GrandparentClassWithId] = (data, protocol) =>
+        _i92.GrandparentClassWithId.fromJson(data);
+    map[_i93.ChildEntity] = (data, protocol) => _i93.ChildEntity.fromJson(data);
+    map[_i94.BaseEntity] = (data, protocol) => _i94.BaseEntity.fromJson(data);
+    map[_i95.ParentEntity] = (data, protocol) =>
+        _i95.ParentEntity.fromJson(data);
+    map[_i96.NonServerOnlyParentClass] = (data, protocol) =>
+        _i96.NonServerOnlyParentClass.fromJson(data);
+    map[_i97.ParentWithDefault] = (data, protocol) =>
+        _i97.ParentWithDefault.fromJson(data);
+    map[_i98.PolymorphicGrandChild] = (data, protocol) =>
+        _i98.PolymorphicGrandChild.fromJson(data);
+    map[_i99.PolymorphicChild] = (data, protocol) =>
+        _i99.PolymorphicChild.fromJson(data);
+    map[_i100.PolymorphicChildContainer] = (data, protocol) =>
+        _i100.PolymorphicChildContainer.fromJson(data);
+    map[_i101.ModulePolymorphicChildContainer] = (data, protocol) =>
+        _i101.ModulePolymorphicChildContainer.fromJson(data);
+    map[_i102.SimilarButNotParent] = (data, protocol) =>
+        _i102.SimilarButNotParent.fromJson(data);
+    map[_i103.PolymorphicParent] = (data, protocol) =>
+        _i103.PolymorphicParent.fromJson(data);
+    map[_i104.UnrelatedToPolymorphism] = (data, protocol) =>
+        _i104.UnrelatedToPolymorphism.fromJson(data);
+    map[_i105.SealedGrandChild] = (data, protocol) =>
+        _i105.SealedGrandChild.fromJson(data);
+    map[_i105.SealedChild] = (data, protocol) =>
+        _i105.SealedChild.fromJson(data);
+    map[_i106.SealedChildOnlyRequired] = (data, protocol) =>
+        _i106.SealedChildOnlyRequired.fromJson(data);
+    map[_i105.SealedOtherChild] = (data, protocol) =>
+        _i105.SealedOtherChild.fromJson(data);
+    map[_i107.CityWithLongTableName] = (data, protocol) =>
+        _i107.CityWithLongTableName.fromJson(data);
+    map[_i108.OrganizationWithLongTableName] = (data, protocol) =>
+        _i108.OrganizationWithLongTableName.fromJson(data);
+    map[_i109.PersonWithLongTableName] = (data, protocol) =>
+        _i109.PersonWithLongTableName.fromJson(data);
+    map[_i110.MaxFieldName] = (data, protocol) =>
+        _i110.MaxFieldName.fromJson(data);
+    map[_i111.LongImplicitIdField] = (data, protocol) =>
+        _i111.LongImplicitIdField.fromJson(data);
+    map[_i112.LongImplicitIdFieldCollection] = (data, protocol) =>
+        _i112.LongImplicitIdFieldCollection.fromJson(data);
+    map[_i113.RelationToMultipleMaxFieldName] = (data, protocol) =>
+        _i113.RelationToMultipleMaxFieldName.fromJson(data);
+    map[_i114.UserNote] = (data, protocol) => _i114.UserNote.fromJson(data);
+    map[_i115.UserNoteCollection] = (data, protocol) =>
+        _i115.UserNoteCollection.fromJson(data);
+    map[_i116.UserNoteCollectionWithALongName] = (data, protocol) =>
+        _i116.UserNoteCollectionWithALongName.fromJson(data);
+    map[_i117.UserNoteWithALongName] = (data, protocol) =>
+        _i117.UserNoteWithALongName.fromJson(data);
+    map[_i118.MultipleMaxFieldName] = (data, protocol) =>
+        _i118.MultipleMaxFieldName.fromJson(data);
+    map[_i119.City] = (data, protocol) => _i119.City.fromJson(data);
+    map[_i120.Organization] = (data, protocol) =>
+        _i120.Organization.fromJson(data);
+    map[_i121.Person] = (data, protocol) => _i121.Person.fromJson(data);
+    map[_i122.Course] = (data, protocol) => _i122.Course.fromJson(data);
+    map[_i123.Enrollment] = (data, protocol) => _i123.Enrollment.fromJson(data);
+    map[_i124.Student] = (data, protocol) => _i124.Student.fromJson(data);
+    map[_i125.ObjectUser] = (data, protocol) => _i125.ObjectUser.fromJson(data);
+    map[_i126.ParentUser] = (data, protocol) => _i126.ParentUser.fromJson(data);
+    map[_i127.Arena] = (data, protocol) => _i127.Arena.fromJson(data);
+    map[_i128.Player] = (data, protocol) => _i128.Player.fromJson(data);
+    map[_i129.Team] = (data, protocol) => _i129.Team.fromJson(data);
+    map[_i130.Comment] = (data, protocol) => _i130.Comment.fromJson(data);
+    map[_i131.Customer] = (data, protocol) => _i131.Customer.fromJson(data);
+    map[_i132.Book] = (data, protocol) => _i132.Book.fromJson(data);
+    map[_i133.Chapter] = (data, protocol) => _i133.Chapter.fromJson(data);
+    map[_i134.Order] = (data, protocol) => _i134.Order.fromJson(data);
+    map[_i135.Address] = (data, protocol) => _i135.Address.fromJson(data);
+    map[_i136.Citizen] = (data, protocol) => _i136.Citizen.fromJson(data);
+    map[_i137.Company] = (data, protocol) => _i137.Company.fromJson(data);
+    map[_i138.Town] = (data, protocol) => _i138.Town.fromJson(data);
+    map[_i139.Blocking] = (data, protocol) => _i139.Blocking.fromJson(data);
+    map[_i140.Member] = (data, protocol) => _i140.Member.fromJson(data);
+    map[_i141.Cat] = (data, protocol) => _i141.Cat.fromJson(data);
+    map[_i142.Post] = (data, protocol) => _i142.Post.fromJson(data);
+    map[_i143.ModuleDatatype] = (data, protocol) =>
+        _i143.ModuleDatatype.fromJson(data);
+    map[_i144.MyFeatureModel] = (data, protocol) =>
+        _i144.MyFeatureModel.fromJson(data);
+    map[_i145.MyTriggerType] = (data, protocol) =>
+        _i145.MyTriggerType.fromJson(data);
+    map[_i146.Nullability] = (data, protocol) =>
+        _i146.Nullability.fromJson(data);
+    map[_i147.ObjectFieldPersist] = (data, protocol) =>
+        _i147.ObjectFieldPersist.fromJson(data);
+    map[_i148.ObjectFieldScopes] = (data, protocol) =>
+        _i148.ObjectFieldScopes.fromJson(data);
+    map[_i149.ObjectWithBit] = (data, protocol) =>
+        _i149.ObjectWithBit.fromJson(data);
+    map[_i150.ObjectWithByteData] = (data, protocol) =>
+        _i150.ObjectWithByteData.fromJson(data);
+    map[_i151.ObjectWithCustomClass] = (data, protocol) =>
+        _i151.ObjectWithCustomClass.fromJson(data);
+    map[_i152.ObjectWithDuration] = (data, protocol) =>
+        _i152.ObjectWithDuration.fromJson(data);
+    map[_i153.ObjectWithDynamic] = (data, protocol) =>
+        _i153.ObjectWithDynamic.fromJson(data);
+    map[_i154.ObjectWithEnum] = (data, protocol) =>
+        _i154.ObjectWithEnum.fromJson(data);
+    map[_i155.ObjectWithEnumEnhanced] = (data, protocol) =>
+        _i155.ObjectWithEnumEnhanced.fromJson(data);
+    map[_i156.ObjectWithHalfVector] = (data, protocol) =>
+        _i156.ObjectWithHalfVector.fromJson(data);
+    map[_i157.ObjectWithIndex] = (data, protocol) =>
+        _i157.ObjectWithIndex.fromJson(data);
+    map[_i158.ObjectWithJsonb] = (data, protocol) =>
+        _i158.ObjectWithJsonb.fromJson(data);
+    map[_i159.ObjectWithJsonbClassLevel] = (data, protocol) =>
+        _i159.ObjectWithJsonbClassLevel.fromJson(data);
+    map[_i160.ObjectWithMaps] = (data, protocol) =>
+        _i160.ObjectWithMaps.fromJson(data);
+    map[_i161.ObjectWithNullableCustomClass] = (data, protocol) =>
+        _i161.ObjectWithNullableCustomClass.fromJson(data);
+    map[_i162.ObjectWithObject] = (data, protocol) =>
+        _i162.ObjectWithObject.fromJson(data);
+    map[_i163.ObjectWithParent] = (data, protocol) =>
+        _i163.ObjectWithParent.fromJson(data);
+    map[_i164.ObjectWithSealedClass] = (data, protocol) =>
+        _i164.ObjectWithSealedClass.fromJson(data);
+    map[_i165.ObjectWithSelfParent] = (data, protocol) =>
+        _i165.ObjectWithSelfParent.fromJson(data);
+    map[_i166.ObjectWithSparseVector] = (data, protocol) =>
+        _i166.ObjectWithSparseVector.fromJson(data);
+    map[_i167.ObjectWithUuid] = (data, protocol) =>
+        _i167.ObjectWithUuid.fromJson(data);
+    map[_i168.ObjectWithVector] = (data, protocol) =>
+        _i168.ObjectWithVector.fromJson(data);
+    map[_i169.Record] = (data, protocol) => _i169.Record.fromJson(data);
+    map[_i170.RelatedUniqueData] = (data, protocol) =>
+        _i170.RelatedUniqueData.fromJson(data);
+    map[_i171.ExceptionWithRequiredField] = (data, protocol) =>
+        _i171.ExceptionWithRequiredField.fromJson(data);
+    map[_i172.ModelWithRequiredField] = (data, protocol) =>
+        _i172.ModelWithRequiredField.fromJson(data);
+    map[_i173.ScopeNoneFields] = (data, protocol) =>
+        _i173.ScopeNoneFields.fromJson(data);
+    map[_i174.ScopeServerOnlyFieldChild] = (data, protocol) =>
+        _i174.ScopeServerOnlyFieldChild.fromJson(data);
+    map[_i175.ScopeServerOnlyField] = (data, protocol) =>
+        _i175.ScopeServerOnlyField.fromJson(data);
+    map[_i176.DefaultServerOnlyClass] = (data, protocol) =>
+        _i176.DefaultServerOnlyClass.fromJson(data);
+    map[_i177.DefaultServerOnlyEnum] = (data, protocol) =>
+        _i177.DefaultServerOnlyEnum.fromJson(data);
+    map[_i178.NotServerOnlyClass] = (data, protocol) =>
+        _i178.NotServerOnlyClass.fromJson(data);
+    map[_i179.NotServerOnlyEnum] = (data, protocol) =>
+        _i179.NotServerOnlyEnum.fromJson(data);
+    map[_i180.ServerOnlyClassField] = (data, protocol) =>
+        _i180.ServerOnlyClassField.fromJson(data);
+    map[_i181.ServerOnlyDefault] = (data, protocol) =>
+        _i181.ServerOnlyDefault.fromJson(data);
+    map[_i182.SessionAuthInfo] = (data, protocol) =>
+        _i182.SessionAuthInfo.fromJson(data);
+    map[_i183.SharedModelContainer] = (data, protocol) =>
+        _i183.SharedModelContainer.fromJson(data);
+    map[_i184.SharedModelSubclass] = (data, protocol) =>
+        _i184.SharedModelSubclass.fromJson(data);
+    map[_i185.SimpleData] = (data, protocol) => _i185.SimpleData.fromJson(data);
+    map[_i186.SimpleDataList] = (data, protocol) =>
+        _i186.SimpleDataList.fromJson(data);
+    map[_i187.SimpleDataMap] = (data, protocol) =>
+        _i187.SimpleDataMap.fromJson(data);
+    map[_i188.SimpleDataObject] = (data, protocol) =>
+        _i188.SimpleDataObject.fromJson(data);
+    map[_i189.SimpleDateTime] = (data, protocol) =>
+        _i189.SimpleDateTime.fromJson(data);
+    map[_i190.ModelInSubfolder] = (data, protocol) =>
+        _i190.ModelInSubfolder.fromJson(data);
+    map[_i191.TestEnum] = (data, protocol) => _i191.TestEnum.fromJson(data);
+    map[_i192.TestEnumDefaultSerialization] = (data, protocol) =>
+        _i192.TestEnumDefaultSerialization.fromJson(data);
+    map[_i193.TestEnumEnhanced] = (data, protocol) =>
+        _i193.TestEnumEnhanced.fromJson(data);
+    map[_i194.TestEnumEnhancedByName] = (data, protocol) =>
+        _i194.TestEnumEnhancedByName.fromJson(data);
+    map[_i195.TestEnumStringified] = (data, protocol) =>
+        _i195.TestEnumStringified.fromJson(data);
+    map[_i196.Types] = (data, protocol) => _i196.Types.fromJson(data);
+    map[_i197.TypesList] = (data, protocol) => _i197.TypesList.fromJson(data);
+    map[_i198.TypesMap] = (data, protocol) => _i198.TypesMap.fromJson(data);
+    map[_i199.TypesRecord] = (data, protocol) =>
+        _i199.TypesRecord.fromJson(data);
+    map[_i200.TypesSet] = (data, protocol) => _i200.TypesSet.fromJson(data);
+    map[_i201.TypesSetRequired] = (data, protocol) =>
+        _i201.TypesSetRequired.fromJson(data);
+    map[_i202.UniqueData] = (data, protocol) => _i202.UniqueData.fromJson(data);
+    map[_i203.UniqueDataWithNonPersist] = (data, protocol) =>
+        _i203.UniqueDataWithNonPersist.fromJson(data);
+    map[_i204.UpsertTestModel] = (data, protocol) =>
+        _i204.UpsertTestModel.fromJson(data);
+    map[_i1.getType<_i2.ByIndexEnumWithNameValue?>()] = (data, protocol) =>
+        (data != null ? _i2.ByIndexEnumWithNameValue.fromJson(data) : null);
+    map[_i1.getType<_i3.ByNameEnumWithNameValue?>()] = (data, protocol) =>
+        (data != null ? _i3.ByNameEnumWithNameValue.fromJson(data) : null);
+    map[_i1.getType<_i4.CourseUuid?>()] = (data, protocol) =>
+        (data != null ? _i4.CourseUuid.fromJson(data) : null);
+    map[_i1.getType<_i5.EnrollmentInt?>()] = (data, protocol) =>
+        (data != null ? _i5.EnrollmentInt.fromJson(data) : null);
+    map[_i1.getType<_i6.StudentUuid?>()] = (data, protocol) =>
+        (data != null ? _i6.StudentUuid.fromJson(data) : null);
+    map[_i1.getType<_i7.ArenaUuid?>()] = (data, protocol) =>
+        (data != null ? _i7.ArenaUuid.fromJson(data) : null);
+    map[_i1.getType<_i8.PlayerUuid?>()] = (data, protocol) =>
+        (data != null ? _i8.PlayerUuid.fromJson(data) : null);
+    map[_i1.getType<_i9.TeamInt?>()] = (data, protocol) =>
+        (data != null ? _i9.TeamInt.fromJson(data) : null);
+    map[_i1.getType<_i10.CommentInt?>()] = (data, protocol) =>
+        (data != null ? _i10.CommentInt.fromJson(data) : null);
+    map[_i1.getType<_i11.CustomerInt?>()] = (data, protocol) =>
+        (data != null ? _i11.CustomerInt.fromJson(data) : null);
+    map[_i1.getType<_i12.OrderUuid?>()] = (data, protocol) =>
+        (data != null ? _i12.OrderUuid.fromJson(data) : null);
+    map[_i1.getType<_i13.AddressUuid?>()] = (data, protocol) =>
+        (data != null ? _i13.AddressUuid.fromJson(data) : null);
+    map[_i1.getType<_i14.CitizenInt?>()] = (data, protocol) =>
+        (data != null ? _i14.CitizenInt.fromJson(data) : null);
+    map[_i1.getType<_i15.CompanyUuid?>()] = (data, protocol) =>
+        (data != null ? _i15.CompanyUuid.fromJson(data) : null);
+    map[_i1.getType<_i16.TownInt?>()] = (data, protocol) =>
+        (data != null ? _i16.TownInt.fromJson(data) : null);
+    map[_i1.getType<_i17.ChangedIdTypeSelf?>()] = (data, protocol) =>
+        (data != null ? _i17.ChangedIdTypeSelf.fromJson(data) : null);
+    map[_i1.getType<_i18.BigIntDefault?>()] = (data, protocol) =>
+        (data != null ? _i18.BigIntDefault.fromJson(data) : null);
+    map[_i1.getType<_i19.BigIntDefaultMix?>()] = (data, protocol) =>
+        (data != null ? _i19.BigIntDefaultMix.fromJson(data) : null);
+    map[_i1.getType<_i20.BigIntDefaultModel?>()] = (data, protocol) =>
+        (data != null ? _i20.BigIntDefaultModel.fromJson(data) : null);
+    map[_i1.getType<_i21.BigIntDefaultPersist?>()] = (data, protocol) =>
+        (data != null ? _i21.BigIntDefaultPersist.fromJson(data) : null);
+    map[_i1.getType<_i22.BoolDefault?>()] = (data, protocol) =>
+        (data != null ? _i22.BoolDefault.fromJson(data) : null);
+    map[_i1.getType<_i23.BoolDefaultMix?>()] = (data, protocol) =>
+        (data != null ? _i23.BoolDefaultMix.fromJson(data) : null);
+    map[_i1.getType<_i24.BoolDefaultModel?>()] = (data, protocol) =>
+        (data != null ? _i24.BoolDefaultModel.fromJson(data) : null);
+    map[_i1.getType<_i25.BoolDefaultPersist?>()] = (data, protocol) =>
+        (data != null ? _i25.BoolDefaultPersist.fromJson(data) : null);
+    map[_i1.getType<_i26.DateTimeDefault?>()] = (data, protocol) =>
+        (data != null ? _i26.DateTimeDefault.fromJson(data) : null);
+    map[_i1.getType<_i27.DateTimeDefaultMix?>()] = (data, protocol) =>
+        (data != null ? _i27.DateTimeDefaultMix.fromJson(data) : null);
+    map[_i1.getType<_i28.DateTimeDefaultModel?>()] = (data, protocol) =>
+        (data != null ? _i28.DateTimeDefaultModel.fromJson(data) : null);
+    map[_i1.getType<_i29.DateTimeDefaultPersist?>()] = (data, protocol) =>
+        (data != null ? _i29.DateTimeDefaultPersist.fromJson(data) : null);
+    map[_i1.getType<_i30.DoubleDefault?>()] = (data, protocol) =>
+        (data != null ? _i30.DoubleDefault.fromJson(data) : null);
+    map[_i1.getType<_i31.DoubleDefaultMix?>()] = (data, protocol) =>
+        (data != null ? _i31.DoubleDefaultMix.fromJson(data) : null);
+    map[_i1.getType<_i32.DoubleDefaultModel?>()] = (data, protocol) =>
+        (data != null ? _i32.DoubleDefaultModel.fromJson(data) : null);
+    map[_i1.getType<_i33.DoubleDefaultPersist?>()] = (data, protocol) =>
+        (data != null ? _i33.DoubleDefaultPersist.fromJson(data) : null);
+    map[_i1.getType<_i34.DurationDefault?>()] = (data, protocol) =>
+        (data != null ? _i34.DurationDefault.fromJson(data) : null);
+    map[_i1.getType<_i35.DurationDefaultMix?>()] = (data, protocol) =>
+        (data != null ? _i35.DurationDefaultMix.fromJson(data) : null);
+    map[_i1.getType<_i36.DurationDefaultModel?>()] = (data, protocol) =>
+        (data != null ? _i36.DurationDefaultModel.fromJson(data) : null);
+    map[_i1.getType<_i37.DurationDefaultPersist?>()] = (data, protocol) =>
+        (data != null ? _i37.DurationDefaultPersist.fromJson(data) : null);
+    map[_i1.getType<_i38.EnumDefault?>()] = (data, protocol) =>
+        (data != null ? _i38.EnumDefault.fromJson(data) : null);
+    map[_i1.getType<_i39.EnumDefaultMix?>()] = (data, protocol) =>
+        (data != null ? _i39.EnumDefaultMix.fromJson(data) : null);
+    map[_i1.getType<_i40.EnumDefaultModel?>()] = (data, protocol) =>
+        (data != null ? _i40.EnumDefaultModel.fromJson(data) : null);
+    map[_i1.getType<_i41.EnumDefaultPersist?>()] = (data, protocol) =>
+        (data != null ? _i41.EnumDefaultPersist.fromJson(data) : null);
+    map[_i1.getType<_i42.ByIndexEnum?>()] = (data, protocol) =>
+        (data != null ? _i42.ByIndexEnum.fromJson(data) : null);
+    map[_i1.getType<_i43.ByNameEnum?>()] = (data, protocol) =>
+        (data != null ? _i43.ByNameEnum.fromJson(data) : null);
+    map[_i1.getType<_i44.DefaultValueEnum?>()] = (data, protocol) =>
+        (data != null ? _i44.DefaultValueEnum.fromJson(data) : null);
+    map[_i1.getType<_i45.DefaultException?>()] = (data, protocol) =>
+        (data != null ? _i45.DefaultException.fromJson(data) : null);
+    map[_i1.getType<_i46.IntDefault?>()] = (data, protocol) =>
+        (data != null ? _i46.IntDefault.fromJson(data) : null);
+    map[_i1.getType<_i47.IntDefaultMix?>()] = (data, protocol) =>
+        (data != null ? _i47.IntDefaultMix.fromJson(data) : null);
+    map[_i1.getType<_i48.IntDefaultModel?>()] = (data, protocol) =>
+        (data != null ? _i48.IntDefaultModel.fromJson(data) : null);
+    map[_i1.getType<_i49.IntDefaultPersist?>()] = (data, protocol) =>
+        (data != null ? _i49.IntDefaultPersist.fromJson(data) : null);
+    map[_i1.getType<_i50.StringDefault?>()] = (data, protocol) =>
+        (data != null ? _i50.StringDefault.fromJson(data) : null);
+    map[_i1.getType<_i51.StringDefaultMix?>()] = (data, protocol) =>
+        (data != null ? _i51.StringDefaultMix.fromJson(data) : null);
+    map[_i1.getType<_i52.StringDefaultModel?>()] = (data, protocol) =>
+        (data != null ? _i52.StringDefaultModel.fromJson(data) : null);
+    map[_i1.getType<_i53.StringDefaultPersist?>()] = (data, protocol) =>
+        (data != null ? _i53.StringDefaultPersist.fromJson(data) : null);
+    map[_i1.getType<_i54.UriDefault?>()] = (data, protocol) =>
+        (data != null ? _i54.UriDefault.fromJson(data) : null);
+    map[_i1.getType<_i55.UriDefaultMix?>()] = (data, protocol) =>
+        (data != null ? _i55.UriDefaultMix.fromJson(data) : null);
+    map[_i1.getType<_i56.UriDefaultModel?>()] = (data, protocol) =>
+        (data != null ? _i56.UriDefaultModel.fromJson(data) : null);
+    map[_i1.getType<_i57.UriDefaultPersist?>()] = (data, protocol) =>
+        (data != null ? _i57.UriDefaultPersist.fromJson(data) : null);
+    map[_i1.getType<_i58.UuidDefault?>()] = (data, protocol) =>
+        (data != null ? _i58.UuidDefault.fromJson(data) : null);
+    map[_i1.getType<_i59.UuidDefaultMix?>()] = (data, protocol) =>
+        (data != null ? _i59.UuidDefaultMix.fromJson(data) : null);
+    map[_i1.getType<_i60.UuidDefaultModel?>()] = (data, protocol) =>
+        (data != null ? _i60.UuidDefaultModel.fromJson(data) : null);
+    map[_i1.getType<_i61.UuidDefaultPersist?>()] = (data, protocol) =>
+        (data != null ? _i61.UuidDefaultPersist.fromJson(data) : null);
+    map[_i1.getType<_i62.EmptyModel?>()] = (data, protocol) =>
+        (data != null ? _i62.EmptyModel.fromJson(data) : null);
+    map[_i1.getType<_i63.EmptyModelRelationItem?>()] = (data, protocol) =>
+        (data != null ? _i63.EmptyModelRelationItem.fromJson(data) : null);
+    map[_i1.getType<_i64.EmptyModelWithTable?>()] = (data, protocol) =>
+        (data != null ? _i64.EmptyModelWithTable.fromJson(data) : null);
+    map[_i1.getType<_i65.RelationEmptyModel?>()] = (data, protocol) =>
+        (data != null ? _i65.RelationEmptyModel.fromJson(data) : null);
+    map[_i1.getType<_i66.ExceptionWithData?>()] = (data, protocol) =>
+        (data != null ? _i66.ExceptionWithData.fromJson(data) : null);
+    map[_i1.getType<_i67.ChildClassExplicitColumn?>()] = (data, protocol) =>
+        (data != null ? _i67.ChildClassExplicitColumn.fromJson(data) : null);
+    map[_i1.getType<_i68.NonTableParentClass?>()] = (data, protocol) =>
+        (data != null ? _i68.NonTableParentClass.fromJson(data) : null);
+    map[_i1.getType<_i69.ModifiedColumnName?>()] = (data, protocol) =>
+        (data != null ? _i69.ModifiedColumnName.fromJson(data) : null);
+    map[_i1.getType<_i70.Department?>()] = (data, protocol) =>
+        (data != null ? _i70.Department.fromJson(data) : null);
+    map[_i1.getType<_i71.Employee?>()] = (data, protocol) =>
+        (data != null ? _i71.Employee.fromJson(data) : null);
+    map[_i1.getType<_i72.Contractor?>()] = (data, protocol) =>
+        (data != null ? _i72.Contractor.fromJson(data) : null);
+    map[_i1.getType<_i73.Service?>()] = (data, protocol) =>
+        (data != null ? _i73.Service.fromJson(data) : null);
+    map[_i1.getType<_i74.TableWithExplicitColumnName?>()] = (data, protocol) =>
+        (data != null ? _i74.TableWithExplicitColumnName.fromJson(data) : null);
+    map[_i1.getType<_i75.ImmutableChildObject?>()] = (data, protocol) =>
+        (data != null ? _i75.ImmutableChildObject.fromJson(data) : null);
+    map[_i1.getType<_i76.ImmutableChildObjectWithNoAdditionalFields?>()] =
+        (data, protocol) => (data != null
+        ? _i76.ImmutableChildObjectWithNoAdditionalFields.fromJson(data)
+        : null);
+    map[_i1.getType<_i77.ImmutableObject?>()] = (data, protocol) =>
+        (data != null ? _i77.ImmutableObject.fromJson(data) : null);
+    map[_i1.getType<_i78.ImmutableObjectWithImmutableObject?>()] =
+        (data, protocol) => (data != null
+        ? _i78.ImmutableObjectWithImmutableObject.fromJson(data)
+        : null);
+    map[_i1.getType<_i79.ImmutableObjectWithList?>()] = (data, protocol) =>
+        (data != null ? _i79.ImmutableObjectWithList.fromJson(data) : null);
+    map[_i1.getType<_i80.ImmutableObjectWithMap?>()] = (data, protocol) =>
+        (data != null ? _i80.ImmutableObjectWithMap.fromJson(data) : null);
+    map[_i1.getType<_i81.ImmutableObjectWithMultipleFields?>()] =
+        (data, protocol) => (data != null
+        ? _i81.ImmutableObjectWithMultipleFields.fromJson(data)
+        : null);
+    map[_i1.getType<_i82.ImmutableObjectWithNoFields?>()] = (data, protocol) =>
+        (data != null ? _i82.ImmutableObjectWithNoFields.fromJson(data) : null);
+    map[_i1.getType<_i83.ImmutableObjectWithRecord?>()] = (data, protocol) =>
+        (data != null ? _i83.ImmutableObjectWithRecord.fromJson(data) : null);
+    map[_i1.getType<_i84.ImmutableObjectWithTable?>()] = (data, protocol) =>
+        (data != null ? _i84.ImmutableObjectWithTable.fromJson(data) : null);
+    map[_i1
+        .getType<_i85.ImmutableObjectWithTwentyFields?>()] = (data, protocol) =>
+        (data != null
+        ? _i85.ImmutableObjectWithTwentyFields.fromJson(data)
+        : null);
+    map[_i1.getType<_i86.ChildClass?>()] = (data, protocol) =>
+        (data != null ? _i86.ChildClass.fromJson(data) : null);
+    map[_i1.getType<_i87.ChildWithDefault?>()] = (data, protocol) =>
+        (data != null ? _i87.ChildWithDefault.fromJson(data) : null);
+    map[_i1.getType<_i88.ChildClassWithoutId?>()] = (data, protocol) =>
+        (data != null ? _i88.ChildClassWithoutId.fromJson(data) : null);
+    map[_i1.getType<_i89.ParentClass?>()] = (data, protocol) =>
+        (data != null ? _i89.ParentClass.fromJson(data) : null);
+    map[_i1.getType<_i90.GrandparentClass?>()] = (data, protocol) =>
+        (data != null ? _i90.GrandparentClass.fromJson(data) : null);
+    map[_i1.getType<_i91.ParentClassWithoutId?>()] = (data, protocol) =>
+        (data != null ? _i91.ParentClassWithoutId.fromJson(data) : null);
+    map[_i1.getType<_i92.GrandparentClassWithId?>()] = (data, protocol) =>
+        (data != null ? _i92.GrandparentClassWithId.fromJson(data) : null);
+    map[_i1.getType<_i93.ChildEntity?>()] = (data, protocol) =>
+        (data != null ? _i93.ChildEntity.fromJson(data) : null);
+    map[_i1.getType<_i94.BaseEntity?>()] = (data, protocol) =>
+        (data != null ? _i94.BaseEntity.fromJson(data) : null);
+    map[_i1.getType<_i95.ParentEntity?>()] = (data, protocol) =>
+        (data != null ? _i95.ParentEntity.fromJson(data) : null);
+    map[_i1.getType<_i96.NonServerOnlyParentClass?>()] = (data, protocol) =>
+        (data != null ? _i96.NonServerOnlyParentClass.fromJson(data) : null);
+    map[_i1.getType<_i97.ParentWithDefault?>()] = (data, protocol) =>
+        (data != null ? _i97.ParentWithDefault.fromJson(data) : null);
+    map[_i1.getType<_i98.PolymorphicGrandChild?>()] = (data, protocol) =>
+        (data != null ? _i98.PolymorphicGrandChild.fromJson(data) : null);
+    map[_i1.getType<_i99.PolymorphicChild?>()] = (data, protocol) =>
+        (data != null ? _i99.PolymorphicChild.fromJson(data) : null);
+    map[_i1.getType<_i100.PolymorphicChildContainer?>()] = (data, protocol) =>
+        (data != null ? _i100.PolymorphicChildContainer.fromJson(data) : null);
+    map[_i1.getType<_i101.ModulePolymorphicChildContainer?>()] =
+        (data, protocol) => (data != null
+        ? _i101.ModulePolymorphicChildContainer.fromJson(data)
+        : null);
+    map[_i1.getType<_i102.SimilarButNotParent?>()] = (data, protocol) =>
+        (data != null ? _i102.SimilarButNotParent.fromJson(data) : null);
+    map[_i1.getType<_i103.PolymorphicParent?>()] = (data, protocol) =>
+        (data != null ? _i103.PolymorphicParent.fromJson(data) : null);
+    map[_i1.getType<_i104.UnrelatedToPolymorphism?>()] = (data, protocol) =>
+        (data != null ? _i104.UnrelatedToPolymorphism.fromJson(data) : null);
+    map[_i1.getType<_i105.SealedGrandChild?>()] = (data, protocol) =>
+        (data != null ? _i105.SealedGrandChild.fromJson(data) : null);
+    map[_i1.getType<_i105.SealedChild?>()] = (data, protocol) =>
+        (data != null ? _i105.SealedChild.fromJson(data) : null);
+    map[_i1.getType<_i106.SealedChildOnlyRequired?>()] = (data, protocol) =>
+        (data != null ? _i106.SealedChildOnlyRequired.fromJson(data) : null);
+    map[_i1.getType<_i105.SealedOtherChild?>()] = (data, protocol) =>
+        (data != null ? _i105.SealedOtherChild.fromJson(data) : null);
+    map[_i1.getType<_i107.CityWithLongTableName?>()] = (data, protocol) =>
+        (data != null ? _i107.CityWithLongTableName.fromJson(data) : null);
+    map[_i1
+        .getType<_i108.OrganizationWithLongTableName?>()] = (data, protocol) =>
+        (data != null
+        ? _i108.OrganizationWithLongTableName.fromJson(data)
+        : null);
+    map[_i1.getType<_i109.PersonWithLongTableName?>()] = (data, protocol) =>
+        (data != null ? _i109.PersonWithLongTableName.fromJson(data) : null);
+    map[_i1.getType<_i110.MaxFieldName?>()] = (data, protocol) =>
+        (data != null ? _i110.MaxFieldName.fromJson(data) : null);
+    map[_i1.getType<_i111.LongImplicitIdField?>()] = (data, protocol) =>
+        (data != null ? _i111.LongImplicitIdField.fromJson(data) : null);
+    map[_i1
+        .getType<_i112.LongImplicitIdFieldCollection?>()] = (data, protocol) =>
+        (data != null
+        ? _i112.LongImplicitIdFieldCollection.fromJson(data)
+        : null);
+    map[_i1
+        .getType<_i113.RelationToMultipleMaxFieldName?>()] = (data, protocol) =>
+        (data != null
+        ? _i113.RelationToMultipleMaxFieldName.fromJson(data)
+        : null);
+    map[_i1.getType<_i114.UserNote?>()] = (data, protocol) =>
+        (data != null ? _i114.UserNote.fromJson(data) : null);
+    map[_i1.getType<_i115.UserNoteCollection?>()] = (data, protocol) =>
+        (data != null ? _i115.UserNoteCollection.fromJson(data) : null);
+    map[_i1.getType<_i116.UserNoteCollectionWithALongName?>()] =
+        (data, protocol) => (data != null
+        ? _i116.UserNoteCollectionWithALongName.fromJson(data)
+        : null);
+    map[_i1.getType<_i117.UserNoteWithALongName?>()] = (data, protocol) =>
+        (data != null ? _i117.UserNoteWithALongName.fromJson(data) : null);
+    map[_i1.getType<_i118.MultipleMaxFieldName?>()] = (data, protocol) =>
+        (data != null ? _i118.MultipleMaxFieldName.fromJson(data) : null);
+    map[_i1.getType<_i119.City?>()] = (data, protocol) =>
+        (data != null ? _i119.City.fromJson(data) : null);
+    map[_i1.getType<_i120.Organization?>()] = (data, protocol) =>
+        (data != null ? _i120.Organization.fromJson(data) : null);
+    map[_i1.getType<_i121.Person?>()] = (data, protocol) =>
+        (data != null ? _i121.Person.fromJson(data) : null);
+    map[_i1.getType<_i122.Course?>()] = (data, protocol) =>
+        (data != null ? _i122.Course.fromJson(data) : null);
+    map[_i1.getType<_i123.Enrollment?>()] = (data, protocol) =>
+        (data != null ? _i123.Enrollment.fromJson(data) : null);
+    map[_i1.getType<_i124.Student?>()] = (data, protocol) =>
+        (data != null ? _i124.Student.fromJson(data) : null);
+    map[_i1.getType<_i125.ObjectUser?>()] = (data, protocol) =>
+        (data != null ? _i125.ObjectUser.fromJson(data) : null);
+    map[_i1.getType<_i126.ParentUser?>()] = (data, protocol) =>
+        (data != null ? _i126.ParentUser.fromJson(data) : null);
+    map[_i1.getType<_i127.Arena?>()] = (data, protocol) =>
+        (data != null ? _i127.Arena.fromJson(data) : null);
+    map[_i1.getType<_i128.Player?>()] = (data, protocol) =>
+        (data != null ? _i128.Player.fromJson(data) : null);
+    map[_i1.getType<_i129.Team?>()] = (data, protocol) =>
+        (data != null ? _i129.Team.fromJson(data) : null);
+    map[_i1.getType<_i130.Comment?>()] = (data, protocol) =>
+        (data != null ? _i130.Comment.fromJson(data) : null);
+    map[_i1.getType<_i131.Customer?>()] = (data, protocol) =>
+        (data != null ? _i131.Customer.fromJson(data) : null);
+    map[_i1.getType<_i132.Book?>()] = (data, protocol) =>
+        (data != null ? _i132.Book.fromJson(data) : null);
+    map[_i1.getType<_i133.Chapter?>()] = (data, protocol) =>
+        (data != null ? _i133.Chapter.fromJson(data) : null);
+    map[_i1.getType<_i134.Order?>()] = (data, protocol) =>
+        (data != null ? _i134.Order.fromJson(data) : null);
+    map[_i1.getType<_i135.Address?>()] = (data, protocol) =>
+        (data != null ? _i135.Address.fromJson(data) : null);
+    map[_i1.getType<_i136.Citizen?>()] = (data, protocol) =>
+        (data != null ? _i136.Citizen.fromJson(data) : null);
+    map[_i1.getType<_i137.Company?>()] = (data, protocol) =>
+        (data != null ? _i137.Company.fromJson(data) : null);
+    map[_i1.getType<_i138.Town?>()] = (data, protocol) =>
+        (data != null ? _i138.Town.fromJson(data) : null);
+    map[_i1.getType<_i139.Blocking?>()] = (data, protocol) =>
+        (data != null ? _i139.Blocking.fromJson(data) : null);
+    map[_i1.getType<_i140.Member?>()] = (data, protocol) =>
+        (data != null ? _i140.Member.fromJson(data) : null);
+    map[_i1.getType<_i141.Cat?>()] = (data, protocol) =>
+        (data != null ? _i141.Cat.fromJson(data) : null);
+    map[_i1.getType<_i142.Post?>()] = (data, protocol) =>
+        (data != null ? _i142.Post.fromJson(data) : null);
+    map[_i1.getType<_i143.ModuleDatatype?>()] = (data, protocol) =>
+        (data != null ? _i143.ModuleDatatype.fromJson(data) : null);
+    map[_i1.getType<_i144.MyFeatureModel?>()] = (data, protocol) =>
+        (data != null ? _i144.MyFeatureModel.fromJson(data) : null);
+    map[_i1.getType<_i145.MyTriggerType?>()] = (data, protocol) =>
+        (data != null ? _i145.MyTriggerType.fromJson(data) : null);
+    map[_i1.getType<_i146.Nullability?>()] = (data, protocol) =>
+        (data != null ? _i146.Nullability.fromJson(data) : null);
+    map[_i1.getType<_i147.ObjectFieldPersist?>()] = (data, protocol) =>
+        (data != null ? _i147.ObjectFieldPersist.fromJson(data) : null);
+    map[_i1.getType<_i148.ObjectFieldScopes?>()] = (data, protocol) =>
+        (data != null ? _i148.ObjectFieldScopes.fromJson(data) : null);
+    map[_i1.getType<_i149.ObjectWithBit?>()] = (data, protocol) =>
+        (data != null ? _i149.ObjectWithBit.fromJson(data) : null);
+    map[_i1.getType<_i150.ObjectWithByteData?>()] = (data, protocol) =>
+        (data != null ? _i150.ObjectWithByteData.fromJson(data) : null);
+    map[_i1.getType<_i151.ObjectWithCustomClass?>()] = (data, protocol) =>
+        (data != null ? _i151.ObjectWithCustomClass.fromJson(data) : null);
+    map[_i1.getType<_i152.ObjectWithDuration?>()] = (data, protocol) =>
+        (data != null ? _i152.ObjectWithDuration.fromJson(data) : null);
+    map[_i1.getType<_i153.ObjectWithDynamic?>()] = (data, protocol) =>
+        (data != null ? _i153.ObjectWithDynamic.fromJson(data) : null);
+    map[_i1.getType<_i154.ObjectWithEnum?>()] = (data, protocol) =>
+        (data != null ? _i154.ObjectWithEnum.fromJson(data) : null);
+    map[_i1.getType<_i155.ObjectWithEnumEnhanced?>()] = (data, protocol) =>
+        (data != null ? _i155.ObjectWithEnumEnhanced.fromJson(data) : null);
+    map[_i1.getType<_i156.ObjectWithHalfVector?>()] = (data, protocol) =>
+        (data != null ? _i156.ObjectWithHalfVector.fromJson(data) : null);
+    map[_i1.getType<_i157.ObjectWithIndex?>()] = (data, protocol) =>
+        (data != null ? _i157.ObjectWithIndex.fromJson(data) : null);
+    map[_i1.getType<_i158.ObjectWithJsonb?>()] = (data, protocol) =>
+        (data != null ? _i158.ObjectWithJsonb.fromJson(data) : null);
+    map[_i1.getType<_i159.ObjectWithJsonbClassLevel?>()] = (data, protocol) =>
+        (data != null ? _i159.ObjectWithJsonbClassLevel.fromJson(data) : null);
+    map[_i1.getType<_i160.ObjectWithMaps?>()] = (data, protocol) =>
+        (data != null ? _i160.ObjectWithMaps.fromJson(data) : null);
+    map[_i1
+        .getType<_i161.ObjectWithNullableCustomClass?>()] = (data, protocol) =>
+        (data != null
+        ? _i161.ObjectWithNullableCustomClass.fromJson(data)
+        : null);
+    map[_i1.getType<_i162.ObjectWithObject?>()] = (data, protocol) =>
+        (data != null ? _i162.ObjectWithObject.fromJson(data) : null);
+    map[_i1.getType<_i163.ObjectWithParent?>()] = (data, protocol) =>
+        (data != null ? _i163.ObjectWithParent.fromJson(data) : null);
+    map[_i1.getType<_i164.ObjectWithSealedClass?>()] = (data, protocol) =>
+        (data != null ? _i164.ObjectWithSealedClass.fromJson(data) : null);
+    map[_i1.getType<_i165.ObjectWithSelfParent?>()] = (data, protocol) =>
+        (data != null ? _i165.ObjectWithSelfParent.fromJson(data) : null);
+    map[_i1.getType<_i166.ObjectWithSparseVector?>()] = (data, protocol) =>
+        (data != null ? _i166.ObjectWithSparseVector.fromJson(data) : null);
+    map[_i1.getType<_i167.ObjectWithUuid?>()] = (data, protocol) =>
+        (data != null ? _i167.ObjectWithUuid.fromJson(data) : null);
+    map[_i1.getType<_i168.ObjectWithVector?>()] = (data, protocol) =>
+        (data != null ? _i168.ObjectWithVector.fromJson(data) : null);
+    map[_i1.getType<_i169.Record?>()] = (data, protocol) =>
+        (data != null ? _i169.Record.fromJson(data) : null);
+    map[_i1.getType<_i170.RelatedUniqueData?>()] = (data, protocol) =>
+        (data != null ? _i170.RelatedUniqueData.fromJson(data) : null);
+    map[_i1.getType<_i171.ExceptionWithRequiredField?>()] = (data, protocol) =>
+        (data != null ? _i171.ExceptionWithRequiredField.fromJson(data) : null);
+    map[_i1.getType<_i172.ModelWithRequiredField?>()] = (data, protocol) =>
+        (data != null ? _i172.ModelWithRequiredField.fromJson(data) : null);
+    map[_i1.getType<_i173.ScopeNoneFields?>()] = (data, protocol) =>
+        (data != null ? _i173.ScopeNoneFields.fromJson(data) : null);
+    map[_i1.getType<_i174.ScopeServerOnlyFieldChild?>()] = (data, protocol) =>
+        (data != null ? _i174.ScopeServerOnlyFieldChild.fromJson(data) : null);
+    map[_i1.getType<_i175.ScopeServerOnlyField?>()] = (data, protocol) =>
+        (data != null ? _i175.ScopeServerOnlyField.fromJson(data) : null);
+    map[_i1.getType<_i176.DefaultServerOnlyClass?>()] = (data, protocol) =>
+        (data != null ? _i176.DefaultServerOnlyClass.fromJson(data) : null);
+    map[_i1.getType<_i177.DefaultServerOnlyEnum?>()] = (data, protocol) =>
+        (data != null ? _i177.DefaultServerOnlyEnum.fromJson(data) : null);
+    map[_i1.getType<_i178.NotServerOnlyClass?>()] = (data, protocol) =>
+        (data != null ? _i178.NotServerOnlyClass.fromJson(data) : null);
+    map[_i1.getType<_i179.NotServerOnlyEnum?>()] = (data, protocol) =>
+        (data != null ? _i179.NotServerOnlyEnum.fromJson(data) : null);
+    map[_i1.getType<_i180.ServerOnlyClassField?>()] = (data, protocol) =>
+        (data != null ? _i180.ServerOnlyClassField.fromJson(data) : null);
+    map[_i1.getType<_i181.ServerOnlyDefault?>()] = (data, protocol) =>
+        (data != null ? _i181.ServerOnlyDefault.fromJson(data) : null);
+    map[_i1.getType<_i182.SessionAuthInfo?>()] = (data, protocol) =>
+        (data != null ? _i182.SessionAuthInfo.fromJson(data) : null);
+    map[_i1.getType<_i183.SharedModelContainer?>()] = (data, protocol) =>
+        (data != null ? _i183.SharedModelContainer.fromJson(data) : null);
+    map[_i1.getType<_i184.SharedModelSubclass?>()] = (data, protocol) =>
+        (data != null ? _i184.SharedModelSubclass.fromJson(data) : null);
+    map[_i1.getType<_i185.SimpleData?>()] = (data, protocol) =>
+        (data != null ? _i185.SimpleData.fromJson(data) : null);
+    map[_i1.getType<_i186.SimpleDataList?>()] = (data, protocol) =>
+        (data != null ? _i186.SimpleDataList.fromJson(data) : null);
+    map[_i1.getType<_i187.SimpleDataMap?>()] = (data, protocol) =>
+        (data != null ? _i187.SimpleDataMap.fromJson(data) : null);
+    map[_i1.getType<_i188.SimpleDataObject?>()] = (data, protocol) =>
+        (data != null ? _i188.SimpleDataObject.fromJson(data) : null);
+    map[_i1.getType<_i189.SimpleDateTime?>()] = (data, protocol) =>
+        (data != null ? _i189.SimpleDateTime.fromJson(data) : null);
+    map[_i1.getType<_i190.ModelInSubfolder?>()] = (data, protocol) =>
+        (data != null ? _i190.ModelInSubfolder.fromJson(data) : null);
+    map[_i1.getType<_i191.TestEnum?>()] = (data, protocol) =>
+        (data != null ? _i191.TestEnum.fromJson(data) : null);
+    map[_i1
+        .getType<_i192.TestEnumDefaultSerialization?>()] = (data, protocol) =>
+        (data != null
+        ? _i192.TestEnumDefaultSerialization.fromJson(data)
+        : null);
+    map[_i1.getType<_i193.TestEnumEnhanced?>()] = (data, protocol) =>
+        (data != null ? _i193.TestEnumEnhanced.fromJson(data) : null);
+    map[_i1.getType<_i194.TestEnumEnhancedByName?>()] = (data, protocol) =>
+        (data != null ? _i194.TestEnumEnhancedByName.fromJson(data) : null);
+    map[_i1.getType<_i195.TestEnumStringified?>()] = (data, protocol) =>
+        (data != null ? _i195.TestEnumStringified.fromJson(data) : null);
+    map[_i1.getType<_i196.Types?>()] = (data, protocol) =>
+        (data != null ? _i196.Types.fromJson(data) : null);
+    map[_i1.getType<_i197.TypesList?>()] = (data, protocol) =>
+        (data != null ? _i197.TypesList.fromJson(data) : null);
+    map[_i1.getType<_i198.TypesMap?>()] = (data, protocol) =>
+        (data != null ? _i198.TypesMap.fromJson(data) : null);
+    map[_i1.getType<_i199.TypesRecord?>()] = (data, protocol) =>
+        (data != null ? _i199.TypesRecord.fromJson(data) : null);
+    map[_i1.getType<_i200.TypesSet?>()] = (data, protocol) =>
+        (data != null ? _i200.TypesSet.fromJson(data) : null);
+    map[_i1.getType<_i201.TypesSetRequired?>()] = (data, protocol) =>
+        (data != null ? _i201.TypesSetRequired.fromJson(data) : null);
+    map[_i1.getType<_i202.UniqueData?>()] = (data, protocol) =>
+        (data != null ? _i202.UniqueData.fromJson(data) : null);
+    map[_i1.getType<_i203.UniqueDataWithNonPersist?>()] = (data, protocol) =>
+        (data != null ? _i203.UniqueDataWithNonPersist.fromJson(data) : null);
+    map[_i1.getType<_i204.UpsertTestModel?>()] = (data, protocol) =>
+        (data != null ? _i204.UpsertTestModel.fromJson(data) : null);
+    map[List<_i5.EnrollmentInt>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i5.EnrollmentInt>(e))
+        .toList();
+    map[_i1.getType<List<_i5.EnrollmentInt>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i5.EnrollmentInt>(e))
+              .toList()
+        : null);
+    map[List<_i8.PlayerUuid>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i8.PlayerUuid>(e))
+        .toList();
+    map[_i1.getType<List<_i8.PlayerUuid>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i8.PlayerUuid>(e))
+              .toList()
+        : null);
+    map[List<_i12.OrderUuid>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i12.OrderUuid>(e))
+        .toList();
+    map[_i1.getType<List<_i12.OrderUuid>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i12.OrderUuid>(e))
+              .toList()
+        : null);
+    map[List<_i10.CommentInt>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i10.CommentInt>(e))
+        .toList();
+    map[_i1.getType<List<_i10.CommentInt>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i10.CommentInt>(e))
+              .toList()
+        : null);
+    map[List<_i17.ChangedIdTypeSelf>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i17.ChangedIdTypeSelf>(e))
+        .toList();
+    map[_i1.getType<List<_i17.ChangedIdTypeSelf>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i17.ChangedIdTypeSelf>(e))
+              .toList()
+        : null);
+    map[List<_i63.EmptyModelRelationItem>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i63.EmptyModelRelationItem>(e))
+        .toList();
+    map[_i1.getType<List<_i63.EmptyModelRelationItem>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i63.EmptyModelRelationItem>(e))
+              .toList()
+        : null);
+    map[List<_i71.Employee>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i71.Employee>(e))
+        .toList();
+    map[_i1.getType<List<_i71.Employee>?>()] = (data, protocol) => (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i71.Employee>(e))
+              .toList()
+        : null);
+    map[List<String>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<String>(e)).toList();
+    map[Map<String, String>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<String>(v),
+      ),
+    );
+    map[_i1.getType<(int, String)>()] = (data, protocol) => (
+      protocol.deserialize<int>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<String>(data['p'][1]),
+    );
+    map[List<_i93.ChildEntity>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i93.ChildEntity>(e))
+        .toList();
+    map[_i1.getType<List<_i93.ChildEntity>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i93.ChildEntity>(e))
+              .toList()
+        : null);
+    map[List<_i99.PolymorphicChild>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i99.PolymorphicChild>(e))
+        .toList();
+    map[List<_i99.PolymorphicChild?>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i99.PolymorphicChild?>(e))
+        .toList();
+    map[Map<String, _i99.PolymorphicChild>] = (data, protocol) =>
+        (data as Map).map(
+          (k, v) => MapEntry(
+            protocol.deserialize<String>(k),
+            protocol.deserialize<_i99.PolymorphicChild>(v),
+          ),
+        );
+    map[Map<String, _i99.PolymorphicChild?>] = (data, protocol) =>
+        (data as Map).map(
+          (k, v) => MapEntry(
+            protocol.deserialize<String>(k),
+            protocol.deserialize<_i99.PolymorphicChild?>(v),
+          ),
+        );
+    map[List<_i205.ModulePolymorphicChild>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i205.ModulePolymorphicChild>(e))
+        .toList();
+    map[Map<String, _i205.ModulePolymorphicChild>] = (data, protocol) =>
+        (data as Map).map(
+          (k, v) => MapEntry(
+            protocol.deserialize<String>(k),
+            protocol.deserialize<_i205.ModulePolymorphicChild>(v),
+          ),
+        );
+    map[List<_i109.PersonWithLongTableName>] = (data, protocol) =>
+        (data as List)
+            .map((e) => protocol.deserialize<_i109.PersonWithLongTableName>(e))
+            .toList();
+    map[_i1.getType<List<_i109.PersonWithLongTableName>?>()] =
+        (data, protocol) => (data != null
+        ? (data as List)
+              .map(
+                (e) => protocol.deserialize<_i109.PersonWithLongTableName>(e),
+              )
+              .toList()
+        : null);
+    map[List<_i108.OrganizationWithLongTableName>] = (data, protocol) =>
+        (data as List)
+            .map(
+              (e) =>
+                  protocol.deserialize<_i108.OrganizationWithLongTableName>(e),
+            )
+            .toList();
+    map[_i1.getType<List<_i108.OrganizationWithLongTableName>?>()] =
+        (data, protocol) => (data != null
+        ? (data as List)
+              .map(
+                (e) => protocol
+                    .deserialize<_i108.OrganizationWithLongTableName>(e),
+              )
+              .toList()
+        : null);
+    map[List<_i111.LongImplicitIdField>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i111.LongImplicitIdField>(e))
+        .toList();
+    map[_i1.getType<List<_i111.LongImplicitIdField>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i111.LongImplicitIdField>(e))
+              .toList()
+        : null);
+    map[List<_i118.MultipleMaxFieldName>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i118.MultipleMaxFieldName>(e))
+        .toList();
+    map[_i1.getType<List<_i118.MultipleMaxFieldName>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i118.MultipleMaxFieldName>(e))
+              .toList()
+        : null);
+    map[List<_i114.UserNote>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i114.UserNote>(e))
+        .toList();
+    map[_i1.getType<List<_i114.UserNote>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i114.UserNote>(e))
+              .toList()
+        : null);
+    map[List<_i117.UserNoteWithALongName>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i117.UserNoteWithALongName>(e))
+        .toList();
+    map[_i1.getType<List<_i117.UserNoteWithALongName>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i117.UserNoteWithALongName>(e))
+              .toList()
+        : null);
+    map[List<_i121.Person>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i121.Person>(e))
+        .toList();
+    map[_i1.getType<List<_i121.Person>?>()] = (data, protocol) => (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i121.Person>(e))
+              .toList()
+        : null);
+    map[List<_i120.Organization>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i120.Organization>(e))
+        .toList();
+    map[_i1.getType<List<_i120.Organization>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i120.Organization>(e))
+              .toList()
+        : null);
+    map[List<_i123.Enrollment>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i123.Enrollment>(e))
+        .toList();
+    map[_i1.getType<List<_i123.Enrollment>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i123.Enrollment>(e))
+              .toList()
+        : null);
+    map[List<_i128.Player>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i128.Player>(e))
+        .toList();
+    map[_i1.getType<List<_i128.Player>?>()] = (data, protocol) => (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i128.Player>(e))
+              .toList()
+        : null);
+    map[List<_i134.Order>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i134.Order>(e))
+        .toList();
+    map[_i1.getType<List<_i134.Order>?>()] = (data, protocol) => (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i134.Order>(e))
+              .toList()
+        : null);
+    map[List<_i133.Chapter>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i133.Chapter>(e))
+        .toList();
+    map[_i1.getType<List<_i133.Chapter>?>()] = (data, protocol) => (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i133.Chapter>(e))
+              .toList()
+        : null);
+    map[List<_i130.Comment>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i130.Comment>(e))
+        .toList();
+    map[_i1.getType<List<_i130.Comment>?>()] = (data, protocol) => (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i130.Comment>(e))
+              .toList()
+        : null);
+    map[List<_i139.Blocking>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i139.Blocking>(e))
+        .toList();
+    map[_i1.getType<List<_i139.Blocking>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i139.Blocking>(e))
+              .toList()
+        : null);
+    map[List<_i141.Cat>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<_i141.Cat>(e)).toList();
+    map[_i1.getType<List<_i141.Cat>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<_i141.Cat>(e)).toList()
+        : null);
+    map[List<_i205.ModuleClass>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i205.ModuleClass>(e))
+        .toList();
+    map[Map<String, _i205.ModuleClass>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i205.ModuleClass>(v),
+      ),
+    );
+    map[_i1.getType<(_i205.ModuleClass,)?>()] = (data, protocol) =>
+        (data == null)
+        ? null
+        : (
+            protocol.deserialize<_i205.ModuleClass>(
+              ((data as Map)['p'] as List)[0],
+            ),
+          );
+    map[List<int>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int>(e)).toList();
+    map[List<int>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int>(e)).toList();
+    map[_i1.getType<List<int>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<int>(e)).toList()
+        : null);
+    map[List<int?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int?>(e)).toList();
+    map[List<int?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int?>(e)).toList();
+    map[_i1.getType<List<int?>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<int?>(e)).toList()
+        : null);
+    map[List<_i185.SimpleData>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i185.SimpleData>(e))
+        .toList();
+    map[List<_i185.SimpleData>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i185.SimpleData>(e))
+        .toList();
+    map[_i1.getType<List<_i185.SimpleData>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i185.SimpleData>(e))
+              .toList()
+        : null);
+    map[List<_i185.SimpleData?>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i185.SimpleData?>(e))
+        .toList();
+    map[List<_i185.SimpleData?>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i185.SimpleData?>(e))
+        .toList();
+    map[_i1.getType<List<_i185.SimpleData?>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i185.SimpleData?>(e))
+              .toList()
+        : null);
+    map[List<DateTime>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<DateTime>(e)).toList();
+    map[List<DateTime>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<DateTime>(e)).toList();
+    map[_i1.getType<List<DateTime>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<DateTime>(e)).toList()
+        : null);
+    map[List<DateTime?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<DateTime?>(e)).toList();
+    map[List<DateTime?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<DateTime?>(e)).toList();
+    map[_i1.getType<List<DateTime?>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<DateTime?>(e)).toList()
+        : null);
+    map[List<_i206.ByteData>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i206.ByteData>(e))
+        .toList();
+    map[List<_i206.ByteData>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i206.ByteData>(e))
+        .toList();
+    map[_i1.getType<List<_i206.ByteData>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i206.ByteData>(e))
+              .toList()
+        : null);
+    map[List<_i206.ByteData?>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i206.ByteData?>(e))
+        .toList();
+    map[List<_i206.ByteData?>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i206.ByteData?>(e))
+        .toList();
+    map[_i1.getType<List<_i206.ByteData?>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i206.ByteData?>(e))
+              .toList()
+        : null);
+    map[List<Duration>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<Duration>(e)).toList();
+    map[List<Duration>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<Duration>(e)).toList();
+    map[_i1.getType<List<Duration>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<Duration>(e)).toList()
+        : null);
+    map[List<Duration?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<Duration?>(e)).toList();
+    map[List<Duration?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<Duration?>(e)).toList();
+    map[_i1.getType<List<Duration?>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<Duration?>(e)).toList()
+        : null);
+    map[List<_i1.UuidValue>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i1.UuidValue>(e))
+        .toList();
+    map[List<_i1.UuidValue>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i1.UuidValue>(e))
+        .toList();
+    map[_i1.getType<List<_i1.UuidValue>?>()] = (data, protocol) => (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i1.UuidValue>(e))
+              .toList()
+        : null);
+    map[List<_i1.UuidValue?>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i1.UuidValue?>(e))
+        .toList();
+    map[List<_i1.UuidValue?>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i1.UuidValue?>(e))
+        .toList();
+    map[_i1.getType<List<_i1.UuidValue?>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i1.UuidValue?>(e))
+              .toList()
+        : null);
+    map[Map<String, int>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<int>(v),
+      ),
+    );
+    map[Map<String, int>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<int>(v),
+      ),
+    );
+    map[_i1.getType<Map<String, int>?>()] = (data, protocol) => (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<int>(v),
+            ),
+          )
+        : null);
+    map[Map<String, int?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<int?>(v),
+      ),
+    );
+    map[Map<String, int?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<int?>(v),
+      ),
+    );
+    map[_i1.getType<Map<String, int?>?>()] = (data, protocol) => (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<int?>(v),
+            ),
+          )
+        : null);
+    map[_i207.CustomClassWithoutProtocolSerialization] = (data, protocol) =>
+        _i207.CustomClassWithoutProtocolSerialization.fromJson(data);
+    map[_i207.CustomClassWithProtocolSerialization] = (data, protocol) =>
+        _i207.CustomClassWithProtocolSerialization.fromJson(data);
+    map[_i207.CustomClassWithProtocolSerializationMethod] = (data, protocol) =>
+        _i207.CustomClassWithProtocolSerializationMethod.fromJson(data);
+    map[dynamic] = (data, protocol) => deserializeDynamicFieldValue(data) as T;
+    map[List<dynamic>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<dynamic>(e)).toList();
+    map[dynamic] = (data, protocol) => deserializeDynamicFieldValue(data) as T;
+    map[Map<String, dynamic>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<dynamic>(v),
+      ),
+    );
+    map[dynamic] = (data, protocol) => deserializeDynamicFieldValue(data) as T;
+    map[Set<dynamic>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<dynamic>(e)).toSet();
+    map[dynamic] = (data, protocol) => deserializeDynamicFieldValue(data) as T;
+    map[Map<dynamic, dynamic>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<dynamic>(e['k']),
+          protocol.deserialize<dynamic>(e['v']),
+        ),
+      ),
+    );
+    map[dynamic] = (data, protocol) => deserializeDynamicFieldValue(data) as T;
+    map[dynamic] = (data, protocol) => deserializeDynamicFieldValue(data) as T;
+    map[List<_i191.TestEnum>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i191.TestEnum>(e))
+        .toList();
+    map[List<_i191.TestEnum?>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i191.TestEnum?>(e))
+        .toList();
+    map[List<List<_i191.TestEnum>>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<List<_i191.TestEnum>>(e))
+        .toList();
+    map[List<_i191.TestEnum>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i191.TestEnum>(e))
+        .toList();
+    map[List<_i193.TestEnumEnhanced>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i193.TestEnumEnhanced>(e))
+        .toList();
+    map[List<_i194.TestEnumEnhancedByName>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i194.TestEnumEnhancedByName>(e))
+        .toList();
+    map[List<String>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<String>(e)).toList();
+    map[_i1.getType<List<String>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<String>(e)).toList()
+        : null);
+    map[Map<String, _i185.SimpleData>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i185.SimpleData>(v),
+      ),
+    );
+    map[Map<String, DateTime>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<DateTime>(v),
+      ),
+    );
+    map[Map<String, _i206.ByteData>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i206.ByteData>(v),
+      ),
+    );
+    map[Map<String, Duration>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<Duration>(v),
+      ),
+    );
+    map[Map<String, _i1.UuidValue>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i1.UuidValue>(v),
+      ),
+    );
+    map[Map<String, _i185.SimpleData?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i185.SimpleData?>(v),
+      ),
+    );
+    map[Map<String, String?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<String?>(v),
+      ),
+    );
+    map[Map<String, DateTime?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<DateTime?>(v),
+      ),
+    );
+    map[Map<String, _i206.ByteData?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i206.ByteData?>(v),
+      ),
+    );
+    map[Map<String, Duration?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<Duration?>(v),
+      ),
+    );
+    map[Map<String, _i1.UuidValue?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i1.UuidValue?>(v),
+      ),
+    );
+    map[Map<int, int>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<int>(e['k']),
+          protocol.deserialize<int>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<_i207.CustomClassWithoutProtocolSerialization?>()] =
+        (data, protocol) => (data != null
+        ? _i207.CustomClassWithoutProtocolSerialization.fromJson(data)
+        : null);
+    map[_i1.getType<_i207.CustomClassWithProtocolSerialization?>()] =
+        (data, protocol) => (data != null
+        ? _i207.CustomClassWithProtocolSerialization.fromJson(data)
+        : null);
+    map[_i1.getType<_i207.CustomClassWithProtocolSerializationMethod?>()] =
+        (data, protocol) => (data != null
+        ? _i207.CustomClassWithProtocolSerializationMethod.fromJson(data)
+        : null);
+    map[List<List<_i185.SimpleData>>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<List<_i185.SimpleData>>(e))
+        .toList();
+    map[List<_i185.SimpleData>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i185.SimpleData>(e))
+        .toList();
+    map[_i1.getType<List<List<_i185.SimpleData>>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<List<_i185.SimpleData>>(e))
+              .toList()
+        : null);
+    map[List<_i185.SimpleData>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i185.SimpleData>(e))
+        .toList();
+    map[Map<String, List<List<Map<int, _i185.SimpleData>>?>>] =
+        (data, protocol) => (data as Map).map(
+          (k, v) => MapEntry(
+            protocol.deserialize<String>(k),
+            protocol.deserialize<List<List<Map<int, _i185.SimpleData>>?>>(v),
+          ),
+        );
+    map[List<List<Map<int, _i185.SimpleData>>?>] = (data, protocol) =>
+        (data as List)
+            .map(
+              (e) => protocol.deserialize<List<Map<int, _i185.SimpleData>>?>(e),
+            )
+            .toList();
+    map[List<Map<int, _i185.SimpleData>>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<Map<int, _i185.SimpleData>>(e))
+        .toList();
+    map[Map<int, _i185.SimpleData>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<int>(e['k']),
+          protocol.deserialize<_i185.SimpleData>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<List<Map<int, _i185.SimpleData>>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<Map<int, _i185.SimpleData>>(e))
+              .toList()
+        : null);
+    map[Map<int, _i185.SimpleData>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<int>(e['k']),
+          protocol.deserialize<_i185.SimpleData>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<Map<String, List<List<Map<int, _i185.SimpleData>>?>>?>()] =
+        (data, protocol) => (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<List<List<Map<int, _i185.SimpleData>>?>>(v),
+            ),
+          )
+        : null);
+    map[List<List<Map<int, _i185.SimpleData>>?>] = (data, protocol) =>
+        (data as List)
+            .map(
+              (e) => protocol.deserialize<List<Map<int, _i185.SimpleData>>?>(e),
+            )
+            .toList();
+    map[List<Map<int, _i185.SimpleData>>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<Map<int, _i185.SimpleData>>(e))
+        .toList();
+    map[Map<int, _i185.SimpleData>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<int>(e['k']),
+          protocol.deserialize<_i185.SimpleData>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<List<Map<int, _i185.SimpleData>>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<Map<int, _i185.SimpleData>>(e))
+              .toList()
+        : null);
+    map[Map<int, _i185.SimpleData>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<int>(e['k']),
+          protocol.deserialize<_i185.SimpleData>(e['v']),
+        ),
+      ),
+    );
+    map[Map<String, Map<int, _i185.SimpleData>>] = (data, protocol) =>
+        (data as Map).map(
+          (k, v) => MapEntry(
+            protocol.deserialize<String>(k),
+            protocol.deserialize<Map<int, _i185.SimpleData>>(v),
+          ),
+        );
+    map[Map<int, _i185.SimpleData>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<int>(e['k']),
+          protocol.deserialize<_i185.SimpleData>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<Map<String, Map<int, _i185.SimpleData>>?>()] =
+        (data, protocol) => (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<Map<int, _i185.SimpleData>>(v),
+            ),
+          )
+        : null);
+    map[Map<int, _i185.SimpleData>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<int>(e['k']),
+          protocol.deserialize<_i185.SimpleData>(e['v']),
+        ),
+      ),
+    );
+    map[List<_i105.SealedParent>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i105.SealedParent>(e))
+        .toList();
+    map[_i1.getType<(bool,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<bool>(((data as Map)['p'] as List)[0]),);
+    map[List<_i207.SharedModel>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i207.SharedModel>(e))
+        .toList();
+    map[List<_i207.SharedModel?>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i207.SharedModel?>(e))
+        .toList();
+    map[List<_i207.SharedModel>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i207.SharedModel>(e))
+        .toList();
+    map[_i1.getType<List<_i207.SharedModel>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i207.SharedModel>(e))
+              .toList()
+        : null);
+    map[Map<String, _i207.SharedModel>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i207.SharedModel>(v),
+      ),
+    );
+    map[Map<String, _i207.SharedModel>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i207.SharedModel>(v),
+      ),
+    );
+    map[_i1.getType<Map<String, _i207.SharedModel>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<_i207.SharedModel>(v),
+            ),
+          )
+        : null);
+    map[Map<String, _i207.SharedSubclass>] = (data, protocol) =>
+        (data as Map).map(
+          (k, v) => MapEntry(
+            protocol.deserialize<String>(k),
+            protocol.deserialize<_i207.SharedSubclass>(v),
+          ),
+        );
+    map[Set<_i207.SharedModel>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i207.SharedModel>(e))
+        .toSet();
+    map[Set<_i207.SharedModel>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i207.SharedModel>(e))
+        .toSet();
+    map[_i1.getType<Set<_i207.SharedModel>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i207.SharedModel>(e))
+              .toSet()
+        : null);
+    map[List<_i195.TestEnumStringified>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i195.TestEnumStringified>(e))
+        .toList();
+    map[_i1.getType<List<_i195.TestEnumStringified>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i195.TestEnumStringified>(e))
+              .toList()
+        : null);
+    map[_i1.getType<(_i195.TestEnumStringified,)?>()] = (data, protocol) =>
+        (data == null)
+        ? null
+        : (
+            protocol.deserialize<_i195.TestEnumStringified>(
+              ((data as Map)['p'] as List)[0],
+            ),
+          );
+    map[List<(_i195.TestEnumStringified,)>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<(_i195.TestEnumStringified,)>(e))
+        .toList();
+    map[_i1.getType<(_i195.TestEnumStringified,)>()] = (data, protocol) => (
+      protocol.deserialize<_i195.TestEnumStringified>(
+        ((data as Map)['p'] as List)[0],
+      ),
+    );
+    map[_i1.getType<List<(_i195.TestEnumStringified,)>?>()] =
+        (data, protocol) => (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<(_i195.TestEnumStringified,)>(e))
+              .toList()
+        : null);
+    map[_i1.getType<(_i195.TestEnumStringified,)>()] = (data, protocol) => (
+      protocol.deserialize<_i195.TestEnumStringified>(
+        ((data as Map)['p'] as List)[0],
+      ),
+    );
+    map[_i1.getType<(_i146.Nullability,)?>()] = (data, protocol) =>
+        (data == null)
+        ? null
+        : (
+            protocol.deserialize<_i146.Nullability>(
+              ((data as Map)['p'] as List)[0],
+            ),
+          );
+    map[_i1.getType<({_i195.TestEnumStringified value})?>()] =
+        (data, protocol) => (data == null)
+        ? null
+        : (
+            value: protocol.deserialize<_i195.TestEnumStringified>(
+              ((data as Map)['n'] as Map)['value'],
+            ),
+          );
+    map[List<({_i195.TestEnumStringified value})>] = (data, protocol) =>
+        (data as List)
+            .map(
+              (e) =>
+                  protocol.deserialize<({_i195.TestEnumStringified value})>(e),
+            )
+            .toList();
+    map[_i1
+        .getType<({_i195.TestEnumStringified value})>()] = (data, protocol) => (
+      value: protocol.deserialize<_i195.TestEnumStringified>(
+        ((data as Map)['n'] as Map)['value'],
+      ),
+    );
+    map[_i1.getType<List<({_i195.TestEnumStringified value})>?>()] =
+        (data, protocol) => (data != null
+        ? (data as List)
+              .map(
+                (e) => protocol
+                    .deserialize<({_i195.TestEnumStringified value})>(e),
+              )
+              .toList()
+        : null);
+    map[_i1
+        .getType<({_i195.TestEnumStringified value})>()] = (data, protocol) => (
+      value: protocol.deserialize<_i195.TestEnumStringified>(
+        ((data as Map)['n'] as Map)['value'],
+      ),
+    );
+    map[_i1.getType<({_i205.ModuleClass value})?>()] = (data, protocol) =>
+        (data == null)
+        ? null
+        : (
+            value: protocol.deserialize<_i205.ModuleClass>(
+              ((data as Map)['n'] as Map)['value'],
+            ),
+          );
+    map[_i1.getType<({_i146.Nullability value})?>()] = (data, protocol) =>
+        (data == null)
+        ? null
+        : (
+            value: protocol.deserialize<_i146.Nullability>(
+              ((data as Map)['n'] as Map)['value'],
+            ),
+          );
+    map[Map<int, int>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<int>(e['k']),
+          protocol.deserialize<int>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<Map<int, int>?>()] = (data, protocol) => (data != null
+        ? Map.fromEntries(
+            (data as List).map(
+              (e) => MapEntry(
+                protocol.deserialize<int>(e['k']),
+                protocol.deserialize<int>(e['v']),
+              ),
+            ),
+          )
+        : null);
+    map[Set<int>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int>(e)).toSet();
+    map[_i1.getType<Set<int>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<int>(e)).toSet()
+        : null);
+    map[_i1.getType<(String, {Uri? optionalUri})?>()] = (data, protocol) =>
+        (data == null)
+        ? null
+        : (
+            protocol.deserialize<String>(((data as Map)['p'] as List)[0]),
+            optionalUri: ((data)['n'] as Map)['optionalUri'] == null
+                ? null
+                : protocol.deserialize<Uri>(data['n']['optionalUri']),
+          );
+    map[List<bool>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<bool>(e)).toList();
+    map[_i1.getType<List<bool>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<bool>(e)).toList()
+        : null);
+    map[List<double>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<double>(e)).toList();
+    map[_i1.getType<List<double>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<double>(e)).toList()
+        : null);
+    map[List<Uri>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<Uri>(e)).toList();
+    map[_i1.getType<List<Uri>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<Uri>(e)).toList()
+        : null);
+    map[List<BigInt>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<BigInt>(e)).toList();
+    map[_i1.getType<List<BigInt>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<BigInt>(e)).toList()
+        : null);
+    map[List<_i191.TestEnum>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i191.TestEnum>(e))
+        .toList();
+    map[_i1.getType<List<_i191.TestEnum>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i191.TestEnum>(e))
+              .toList()
+        : null);
+    map[List<_i196.Types>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i196.Types>(e))
+        .toList();
+    map[_i1.getType<List<_i196.Types>?>()] = (data, protocol) => (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i196.Types>(e))
+              .toList()
+        : null);
+    map[List<Map<String, _i196.Types>>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<Map<String, _i196.Types>>(e))
+        .toList();
+    map[Map<String, _i196.Types>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i196.Types>(v),
+      ),
+    );
+    map[_i1.getType<List<Map<String, _i196.Types>>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<Map<String, _i196.Types>>(e))
+              .toList()
+        : null);
+    map[Map<String, _i196.Types>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i196.Types>(v),
+      ),
+    );
+    map[List<List<_i196.Types>>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<List<_i196.Types>>(e))
+        .toList();
+    map[List<_i196.Types>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i196.Types>(e))
+        .toList();
+    map[_i1.getType<List<List<_i196.Types>>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<List<_i196.Types>>(e))
+              .toList()
+        : null);
+    map[List<_i196.Types>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i196.Types>(e))
+        .toList();
+    map[List<(int,)>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<(int,)>(e)).toList();
+    map[_i1.getType<(int,)>()] = (data, protocol) =>
+        (protocol.deserialize<int>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<List<(int,)>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<(int,)>(e)).toList()
+        : null);
+    map[_i1.getType<(int,)>()] = (data, protocol) =>
+        (protocol.deserialize<int>(((data as Map)['p'] as List)[0]),);
+    map[List<(int,)?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<(int,)?>(e)).toList();
+    map[_i1.getType<(int,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<int>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<List<(int,)?>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<(int,)?>(e)).toList()
+        : null);
+    map[_i1.getType<(int,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<int>(((data as Map)['p'] as List)[0]),);
+    map[List<(_i191.TestEnum,)>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<(_i191.TestEnum,)>(e))
+        .toList();
+    map[_i1.getType<(_i191.TestEnum,)>()] = (data, protocol) => (
+      protocol.deserialize<_i191.TestEnum>(((data as Map)['p'] as List)[0]),
+    );
+    map[_i1.getType<List<(_i191.TestEnum,)>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<(_i191.TestEnum,)>(e))
+              .toList()
+        : null);
+    map[_i1.getType<(_i191.TestEnum,)>()] = (data, protocol) => (
+      protocol.deserialize<_i191.TestEnum>(((data as Map)['p'] as List)[0]),
+    );
+    map[Map<int, String>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<int>(e['k']),
+          protocol.deserialize<String>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<Map<int, String>?>()] = (data, protocol) => (data != null
+        ? Map.fromEntries(
+            (data as List).map(
+              (e) => MapEntry(
+                protocol.deserialize<int>(e['k']),
+                protocol.deserialize<String>(e['v']),
+              ),
+            ),
+          )
+        : null);
+    map[Map<bool, String>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<bool>(e['k']),
+          protocol.deserialize<String>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<Map<bool, String>?>()] = (data, protocol) => (data != null
+        ? Map.fromEntries(
+            (data as List).map(
+              (e) => MapEntry(
+                protocol.deserialize<bool>(e['k']),
+                protocol.deserialize<String>(e['v']),
+              ),
+            ),
+          )
+        : null);
+    map[Map<double, String>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<double>(e['k']),
+          protocol.deserialize<String>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<Map<double, String>?>()] = (data, protocol) => (data != null
+        ? Map.fromEntries(
+            (data as List).map(
+              (e) => MapEntry(
+                protocol.deserialize<double>(e['k']),
+                protocol.deserialize<String>(e['v']),
+              ),
+            ),
+          )
+        : null);
+    map[Map<DateTime, String>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<DateTime>(e['k']),
+          protocol.deserialize<String>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<Map<DateTime, String>?>()] = (data, protocol) =>
+        (data != null
+        ? Map.fromEntries(
+            (data as List).map(
+              (e) => MapEntry(
+                protocol.deserialize<DateTime>(e['k']),
+                protocol.deserialize<String>(e['v']),
+              ),
+            ),
+          )
+        : null);
+    map[Map<String, String>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<String>(v),
+      ),
+    );
+    map[_i1.getType<Map<String, String>?>()] = (data, protocol) => (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<String>(v),
+            ),
+          )
+        : null);
+    map[Map<_i206.ByteData, String>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<_i206.ByteData>(e['k']),
+          protocol.deserialize<String>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<Map<_i206.ByteData, String>?>()] = (data, protocol) =>
+        (data != null
+        ? Map.fromEntries(
+            (data as List).map(
+              (e) => MapEntry(
+                protocol.deserialize<_i206.ByteData>(e['k']),
+                protocol.deserialize<String>(e['v']),
+              ),
+            ),
+          )
+        : null);
+    map[Map<Duration, String>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<Duration>(e['k']),
+          protocol.deserialize<String>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<Map<Duration, String>?>()] = (data, protocol) =>
+        (data != null
+        ? Map.fromEntries(
+            (data as List).map(
+              (e) => MapEntry(
+                protocol.deserialize<Duration>(e['k']),
+                protocol.deserialize<String>(e['v']),
+              ),
+            ),
+          )
+        : null);
+    map[Map<_i1.UuidValue, String>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<_i1.UuidValue>(e['k']),
+          protocol.deserialize<String>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<Map<_i1.UuidValue, String>?>()] = (data, protocol) =>
+        (data != null
+        ? Map.fromEntries(
+            (data as List).map(
+              (e) => MapEntry(
+                protocol.deserialize<_i1.UuidValue>(e['k']),
+                protocol.deserialize<String>(e['v']),
+              ),
+            ),
+          )
+        : null);
+    map[Map<Uri, String>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<Uri>(e['k']),
+          protocol.deserialize<String>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<Map<Uri, String>?>()] = (data, protocol) => (data != null
+        ? Map.fromEntries(
+            (data as List).map(
+              (e) => MapEntry(
+                protocol.deserialize<Uri>(e['k']),
+                protocol.deserialize<String>(e['v']),
+              ),
+            ),
+          )
+        : null);
+    map[Map<BigInt, String>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<BigInt>(e['k']),
+          protocol.deserialize<String>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<Map<BigInt, String>?>()] = (data, protocol) => (data != null
+        ? Map.fromEntries(
+            (data as List).map(
+              (e) => MapEntry(
+                protocol.deserialize<BigInt>(e['k']),
+                protocol.deserialize<String>(e['v']),
+              ),
+            ),
+          )
+        : null);
+    map[Map<_i191.TestEnum, String>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<_i191.TestEnum>(e['k']),
+          protocol.deserialize<String>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<Map<_i191.TestEnum, String>?>()] = (data, protocol) =>
+        (data != null
+        ? Map.fromEntries(
+            (data as List).map(
+              (e) => MapEntry(
+                protocol.deserialize<_i191.TestEnum>(e['k']),
+                protocol.deserialize<String>(e['v']),
+              ),
+            ),
+          )
+        : null);
+    map[Map<_i195.TestEnumStringified, String>] = (data, protocol) =>
+        Map.fromEntries(
+          (data as List).map(
+            (e) => MapEntry(
+              protocol.deserialize<_i195.TestEnumStringified>(e['k']),
+              protocol.deserialize<String>(e['v']),
+            ),
+          ),
+        );
+    map[_i1.getType<Map<_i195.TestEnumStringified, String>?>()] =
+        (data, protocol) => (data != null
+        ? Map.fromEntries(
+            (data as List).map(
+              (e) => MapEntry(
+                protocol.deserialize<_i195.TestEnumStringified>(e['k']),
+                protocol.deserialize<String>(e['v']),
+              ),
+            ),
+          )
+        : null);
+    map[Map<_i196.Types, String>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<_i196.Types>(e['k']),
+          protocol.deserialize<String>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<Map<_i196.Types, String>?>()] = (data, protocol) =>
+        (data != null
+        ? Map.fromEntries(
+            (data as List).map(
+              (e) => MapEntry(
+                protocol.deserialize<_i196.Types>(e['k']),
+                protocol.deserialize<String>(e['v']),
+              ),
+            ),
+          )
+        : null);
+    map[Map<Map<_i196.Types, String>, String>] = (data, protocol) =>
+        Map.fromEntries(
+          (data as List).map(
+            (e) => MapEntry(
+              protocol.deserialize<Map<_i196.Types, String>>(e['k']),
+              protocol.deserialize<String>(e['v']),
+            ),
+          ),
+        );
+    map[Map<_i196.Types, String>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<_i196.Types>(e['k']),
+          protocol.deserialize<String>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<Map<Map<_i196.Types, String>, String>?>()] =
+        (data, protocol) => (data != null
+        ? Map.fromEntries(
+            (data as List).map(
+              (e) => MapEntry(
+                protocol.deserialize<Map<_i196.Types, String>>(e['k']),
+                protocol.deserialize<String>(e['v']),
+              ),
+            ),
+          )
+        : null);
+    map[Map<_i196.Types, String>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<_i196.Types>(e['k']),
+          protocol.deserialize<String>(e['v']),
+        ),
+      ),
+    );
+    map[Map<List<_i196.Types>, String>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<List<_i196.Types>>(e['k']),
+          protocol.deserialize<String>(e['v']),
+        ),
+      ),
+    );
+    map[List<_i196.Types>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i196.Types>(e))
+        .toList();
+    map[_i1.getType<Map<List<_i196.Types>, String>?>()] = (data, protocol) =>
+        (data != null
+        ? Map.fromEntries(
+            (data as List).map(
+              (e) => MapEntry(
+                protocol.deserialize<List<_i196.Types>>(e['k']),
+                protocol.deserialize<String>(e['v']),
+              ),
+            ),
+          )
+        : null);
+    map[List<_i196.Types>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i196.Types>(e))
+        .toList();
+    map[Map<(String,), String>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<(String,)>(e['k']),
+          protocol.deserialize<String>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<(String,)>()] = (data, protocol) =>
+        (protocol.deserialize<String>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<Map<(String,), String>?>()] = (data, protocol) =>
+        (data != null
+        ? Map.fromEntries(
+            (data as List).map(
+              (e) => MapEntry(
+                protocol.deserialize<(String,)>(e['k']),
+                protocol.deserialize<String>(e['v']),
+              ),
+            ),
+          )
+        : null);
+    map[_i1.getType<(String,)>()] = (data, protocol) =>
+        (protocol.deserialize<String>(((data as Map)['p'] as List)[0]),);
+    map[Map<String, bool>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<bool>(v),
+      ),
+    );
+    map[_i1.getType<Map<String, bool>?>()] = (data, protocol) => (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<bool>(v),
+            ),
+          )
+        : null);
+    map[Map<String, double>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<double>(v),
+      ),
+    );
+    map[_i1.getType<Map<String, double>?>()] = (data, protocol) => (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<double>(v),
+            ),
+          )
+        : null);
+    map[Map<String, DateTime>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<DateTime>(v),
+      ),
+    );
+    map[_i1.getType<Map<String, DateTime>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<DateTime>(v),
+            ),
+          )
+        : null);
+    map[Map<String, _i206.ByteData>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i206.ByteData>(v),
+      ),
+    );
+    map[_i1.getType<Map<String, _i206.ByteData>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<_i206.ByteData>(v),
+            ),
+          )
+        : null);
+    map[Map<String, Duration>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<Duration>(v),
+      ),
+    );
+    map[_i1.getType<Map<String, Duration>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<Duration>(v),
+            ),
+          )
+        : null);
+    map[Map<String, _i1.UuidValue>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i1.UuidValue>(v),
+      ),
+    );
+    map[_i1.getType<Map<String, _i1.UuidValue>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<_i1.UuidValue>(v),
+            ),
+          )
+        : null);
+    map[Map<String, Uri>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<Uri>(v),
+      ),
+    );
+    map[_i1.getType<Map<String, Uri>?>()] = (data, protocol) => (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<Uri>(v),
+            ),
+          )
+        : null);
+    map[Map<String, BigInt>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<BigInt>(v),
+      ),
+    );
+    map[_i1.getType<Map<String, BigInt>?>()] = (data, protocol) => (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<BigInt>(v),
+            ),
+          )
+        : null);
+    map[Map<String, _i191.TestEnum>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i191.TestEnum>(v),
+      ),
+    );
+    map[_i1.getType<Map<String, _i191.TestEnum>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<_i191.TestEnum>(v),
+            ),
+          )
+        : null);
+    map[Map<String, _i195.TestEnumStringified>] = (data, protocol) =>
+        (data as Map).map(
+          (k, v) => MapEntry(
+            protocol.deserialize<String>(k),
+            protocol.deserialize<_i195.TestEnumStringified>(v),
+          ),
+        );
+    map[_i1.getType<Map<String, _i195.TestEnumStringified>?>()] =
+        (data, protocol) => (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<_i195.TestEnumStringified>(v),
+            ),
+          )
+        : null);
+    map[Map<String, _i196.Types>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i196.Types>(v),
+      ),
+    );
+    map[_i1.getType<Map<String, _i196.Types>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<_i196.Types>(v),
+            ),
+          )
+        : null);
+    map[Map<String, Map<String, _i196.Types>>] = (data, protocol) =>
+        (data as Map).map(
+          (k, v) => MapEntry(
+            protocol.deserialize<String>(k),
+            protocol.deserialize<Map<String, _i196.Types>>(v),
+          ),
+        );
+    map[Map<String, _i196.Types>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i196.Types>(v),
+      ),
+    );
+    map[_i1.getType<Map<String, Map<String, _i196.Types>>?>()] =
+        (data, protocol) => (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<Map<String, _i196.Types>>(v),
+            ),
+          )
+        : null);
+    map[Map<String, _i196.Types>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i196.Types>(v),
+      ),
+    );
+    map[Map<String, List<_i196.Types>>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<List<_i196.Types>>(v),
+      ),
+    );
+    map[List<_i196.Types>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i196.Types>(e))
+        .toList();
+    map[_i1.getType<Map<String, List<_i196.Types>>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<List<_i196.Types>>(v),
+            ),
+          )
+        : null);
+    map[List<_i196.Types>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i196.Types>(e))
+        .toList();
+    map[Map<String, (String,)>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<(String,)>(v),
+      ),
+    );
+    map[_i1.getType<(String,)>()] = (data, protocol) =>
+        (protocol.deserialize<String>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<Map<String, (String,)>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<(String,)>(v),
+            ),
+          )
+        : null);
+    map[_i1.getType<(String,)>()] = (data, protocol) =>
+        (protocol.deserialize<String>(((data as Map)['p'] as List)[0]),);
+    map[Map<String, (String,)?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<(String,)?>(v),
+      ),
+    );
+    map[_i1.getType<(String,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<String>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<Map<String, (String,)?>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<(String,)?>(v),
+            ),
+          )
+        : null);
+    map[_i1.getType<(String,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<String>(((data as Map)['p'] as List)[0]),);
+    map[Map<(String,)?, String>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<(String,)?>(e['k']),
+          protocol.deserialize<String>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<(String,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<String>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<Map<(String,)?, String>?>()] = (data, protocol) =>
+        (data != null
+        ? Map.fromEntries(
+            (data as List).map(
+              (e) => MapEntry(
+                protocol.deserialize<(String,)?>(e['k']),
+                protocol.deserialize<String>(e['v']),
+              ),
+            ),
+          )
+        : null);
+    map[_i1.getType<(String,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<String>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(int,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<int>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(double,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<double>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(DateTime,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<DateTime>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(String,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<String>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(_i206.ByteData,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (
+            protocol.deserialize<_i206.ByteData>(
+              ((data as Map)['p'] as List)[0],
+            ),
+          );
+    map[_i1.getType<(Duration,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<Duration>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(_i1.UuidValue,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (
+            protocol.deserialize<_i1.UuidValue>(
+              ((data as Map)['p'] as List)[0],
+            ),
+          );
+    map[_i1.getType<(Uri,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<Uri>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(BigInt,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<BigInt>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(_i191.TestEnum,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (
+            protocol.deserialize<_i191.TestEnum>(
+              ((data as Map)['p'] as List)[0],
+            ),
+          );
+    map[_i1.getType<(List<int>,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<List<int>>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(Map<int, int>,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (
+            protocol.deserialize<Map<int, int>>(
+              ((data as Map)['p'] as List)[0],
+            ),
+          );
+    map[_i1.getType<(Set<int>,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<Set<int>>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(_i185.SimpleData,)?>()] = (data, protocol) =>
+        (data == null)
+        ? null
+        : (
+            protocol.deserialize<_i185.SimpleData>(
+              ((data as Map)['p'] as List)[0],
+            ),
+          );
+    map[_i1.getType<({_i185.SimpleData namedModel})?>()] = (data, protocol) =>
+        (data == null)
+        ? null
+        : (
+            namedModel: protocol.deserialize<_i185.SimpleData>(
+              ((data as Map)['n'] as Map)['namedModel'],
+            ),
+          );
+    map[_i1.getType<(_i185.SimpleData, {_i185.SimpleData namedModel})?>()] =
+        (data, protocol) => (data == null)
+        ? null
+        : (
+            protocol.deserialize<_i185.SimpleData>(
+              ((data as Map)['p'] as List)[0],
+            ),
+            namedModel: protocol.deserialize<_i185.SimpleData>(
+              data['n']['namedModel'],
+            ),
+          );
+    map[_i1.getType<((int, String), {(int, String) namedNestedRecord})?>()] =
+        (data, protocol) => (data == null)
+        ? null
+        : (
+            protocol.deserialize<(int, String)>(
+              ((data as Map)['p'] as List)[0],
+            ),
+            namedNestedRecord: protocol.deserialize<(int, String)>(
+              data['n']['namedNestedRecord'],
+            ),
+          );
+    map[_i1
+        .getType<
+          (
+            (List<(_i185.SimpleData,)>,), {
+            (_i185.SimpleData, Map<String, _i185.SimpleData>) namedNestedRecord,
+          })?
+        >()] = (data, protocol) => (data == null)
+        ? null
+        : (
+            protocol.deserialize<(List<(_i185.SimpleData,)>,)>(
+              ((data as Map)['p'] as List)[0],
+            ),
+            namedNestedRecord: protocol
+                .deserialize<(_i185.SimpleData, Map<String, _i185.SimpleData>)>(
+                  data['n']['namedNestedRecord'],
+                ),
+          );
+    map[Set<bool>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<bool>(e)).toSet();
+    map[_i1.getType<Set<bool>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<bool>(e)).toSet()
+        : null);
+    map[Set<double>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<double>(e)).toSet();
+    map[_i1.getType<Set<double>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<double>(e)).toSet()
+        : null);
+    map[Set<DateTime>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<DateTime>(e)).toSet();
+    map[_i1.getType<Set<DateTime>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<DateTime>(e)).toSet()
+        : null);
+    map[Set<String>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<String>(e)).toSet();
+    map[_i1.getType<Set<String>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<String>(e)).toSet()
+        : null);
+    map[Set<_i206.ByteData>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i206.ByteData>(e))
+        .toSet();
+    map[_i1.getType<Set<_i206.ByteData>?>()] = (data, protocol) => (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i206.ByteData>(e))
+              .toSet()
+        : null);
+    map[Set<Duration>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<Duration>(e)).toSet();
+    map[_i1.getType<Set<Duration>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<Duration>(e)).toSet()
+        : null);
+    map[Set<_i1.UuidValue>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i1.UuidValue>(e))
+        .toSet();
+    map[_i1.getType<Set<_i1.UuidValue>?>()] = (data, protocol) => (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i1.UuidValue>(e))
+              .toSet()
+        : null);
+    map[Set<BigInt>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<BigInt>(e)).toSet();
+    map[_i1.getType<Set<BigInt>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<BigInt>(e)).toSet()
+        : null);
+    map[Set<_i191.TestEnum>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i191.TestEnum>(e))
+        .toSet();
+    map[_i1.getType<Set<_i191.TestEnum>?>()] = (data, protocol) => (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i191.TestEnum>(e))
+              .toSet()
+        : null);
+    map[Set<_i195.TestEnumStringified>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i195.TestEnumStringified>(e))
+        .toSet();
+    map[_i1.getType<Set<_i195.TestEnumStringified>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i195.TestEnumStringified>(e))
+              .toSet()
+        : null);
+    map[Set<_i196.Types>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<_i196.Types>(e)).toSet();
+    map[_i1.getType<Set<_i196.Types>?>()] = (data, protocol) => (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i196.Types>(e))
+              .toSet()
+        : null);
+    map[Set<Map<String, _i196.Types>>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<Map<String, _i196.Types>>(e))
+        .toSet();
+    map[Map<String, _i196.Types>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i196.Types>(v),
+      ),
+    );
+    map[_i1.getType<Set<Map<String, _i196.Types>>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<Map<String, _i196.Types>>(e))
+              .toSet()
+        : null);
+    map[Map<String, _i196.Types>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i196.Types>(v),
+      ),
+    );
+    map[Set<List<_i196.Types>>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<List<_i196.Types>>(e))
+        .toSet();
+    map[List<_i196.Types>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i196.Types>(e))
+        .toList();
+    map[_i1.getType<Set<List<_i196.Types>>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<List<_i196.Types>>(e))
+              .toSet()
+        : null);
+    map[List<_i196.Types>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i196.Types>(e))
+        .toList();
+    map[Set<(int,)>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<(int,)>(e)).toSet();
+    map[_i1.getType<(int,)>()] = (data, protocol) =>
+        (protocol.deserialize<int>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<Set<(int,)>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<(int,)>(e)).toSet()
+        : null);
+    map[_i1.getType<(int,)>()] = (data, protocol) =>
+        (protocol.deserialize<int>(((data as Map)['p'] as List)[0]),);
+    map[Set<(int,)?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<(int,)?>(e)).toSet();
+    map[_i1.getType<(int,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<int>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<Set<(int,)?>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<(int,)?>(e)).toSet()
+        : null);
+    map[_i1.getType<(int,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<int>(((data as Map)['p'] as List)[0]),);
+    map[Set<int>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int>(e)).toSet();
+    map[List<String>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<String>(e)).toList();
+    map[_i1.getType<List<String>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<String>(e)).toList()
+        : null);
+    map[List<String>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<String>(e)).toList();
+    map[List<_i208.SimpleData>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i208.SimpleData>(e))
+        .toList();
+    map[List<int>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int>(e)).toList();
+    map[List<List<int>>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<List<int>>(e)).toList();
+    map[List<int>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int>(e)).toList();
+    map[List<int>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int>(e)).toList();
+    map[_i1.getType<List<int>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<int>(e)).toList()
+        : null);
+    map[List<List<int>?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<List<int>?>(e)).toList();
+    map[List<int>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int>(e)).toList();
+    map[_i1.getType<List<int>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<int>(e)).toList()
+        : null);
+    map[List<List<int>>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<List<int>>(e)).toList();
+    map[List<int>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int>(e)).toList();
+    map[_i1.getType<List<List<int>>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<List<int>>(e)).toList()
+        : null);
+    map[List<int>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int>(e)).toList();
+    map[List<int?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int?>(e)).toList();
+    map[List<int?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int?>(e)).toList();
+    map[_i1.getType<List<int?>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<int?>(e)).toList()
+        : null);
+    map[List<double>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<double>(e)).toList();
+    map[List<double?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<double?>(e)).toList();
+    map[List<bool>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<bool>(e)).toList();
+    map[List<bool?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<bool?>(e)).toList();
+    map[List<String?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<String?>(e)).toList();
+    map[List<DateTime>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<DateTime>(e)).toList();
+    map[List<DateTime?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<DateTime?>(e)).toList();
+    map[List<_i206.ByteData>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i206.ByteData>(e))
+        .toList();
+    map[List<_i206.ByteData?>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i206.ByteData?>(e))
+        .toList();
+    map[List<_i208.SimpleData?>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i208.SimpleData?>(e))
+        .toList();
+    map[List<_i208.SimpleData>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i208.SimpleData>(e))
+        .toList();
+    map[_i1.getType<List<_i208.SimpleData>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i208.SimpleData>(e))
+              .toList()
+        : null);
+    map[List<_i208.SimpleData?>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i208.SimpleData?>(e))
+        .toList();
+    map[_i1.getType<List<_i208.SimpleData?>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i208.SimpleData?>(e))
+              .toList()
+        : null);
+    map[List<Duration>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<Duration>(e)).toList();
+    map[List<Duration?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<Duration?>(e)).toList();
+    map[Map<String, int>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<int>(v),
+      ),
+    );
+    map[Map<String, int>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<int>(v),
+      ),
+    );
+    map[_i1.getType<Map<String, int>?>()] = (data, protocol) => (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<int>(v),
+            ),
+          )
+        : null);
+    map[Map<String, Map<String, int>>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<Map<String, int>>(v),
+      ),
+    );
+    map[Map<String, int>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<int>(v),
+      ),
+    );
+    map[Map<String, int?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<int?>(v),
+      ),
+    );
+    map[Map<String, int?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<int?>(v),
+      ),
+    );
+    map[_i1.getType<Map<String, int?>?>()] = (data, protocol) => (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<int?>(v),
+            ),
+          )
+        : null);
+    map[Map<int, int>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<int>(e['k']),
+          protocol.deserialize<int>(e['v']),
+        ),
+      ),
+    );
+    map[Map<String, Map<int, int>>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<Map<int, int>>(v),
+      ),
+    );
+    map[Map<int, int>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<int>(e['k']),
+          protocol.deserialize<int>(e['v']),
+        ),
+      ),
+    );
+    map[Map<_i209.TestEnum, int>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<_i209.TestEnum>(e['k']),
+          protocol.deserialize<int>(e['v']),
+        ),
+      ),
+    );
+    map[Map<String, _i209.TestEnum>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i209.TestEnum>(v),
+      ),
+    );
+    map[Map<String, double>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<double>(v),
+      ),
+    );
+    map[Map<String, double?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<double?>(v),
+      ),
+    );
+    map[Map<String, bool>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<bool>(v),
+      ),
+    );
+    map[Map<String, bool?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<bool?>(v),
+      ),
+    );
+    map[Map<String, String>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<String>(v),
+      ),
+    );
+    map[Map<String, String?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<String?>(v),
+      ),
+    );
+    map[Map<String, DateTime>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<DateTime>(v),
+      ),
+    );
+    map[Map<String, DateTime?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<DateTime?>(v),
+      ),
+    );
+    map[Map<String, _i206.ByteData>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i206.ByteData>(v),
+      ),
+    );
+    map[Map<String, _i206.ByteData?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i206.ByteData?>(v),
+      ),
+    );
+    map[Map<String, _i208.SimpleData>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i208.SimpleData>(v),
+      ),
+    );
+    map[Map<String, _i208.SimpleData?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i208.SimpleData?>(v),
+      ),
+    );
+    map[Map<String, _i208.SimpleData>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i208.SimpleData>(v),
+      ),
+    );
+    map[_i1.getType<Map<String, _i208.SimpleData>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<_i208.SimpleData>(v),
+            ),
+          )
+        : null);
+    map[Map<String, _i208.SimpleData?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i208.SimpleData?>(v),
+      ),
+    );
+    map[_i1.getType<Map<String, _i208.SimpleData?>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<_i208.SimpleData?>(v),
+            ),
+          )
+        : null);
+    map[Map<String, Duration>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<Duration>(v),
+      ),
+    );
+    map[Map<String, Duration?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<Duration?>(v),
+      ),
+    );
+    map[Map<(Map<int, String>, String), String>] = (data, protocol) =>
+        Map.fromEntries(
+          (data as List).map(
+            (e) => MapEntry(
+              protocol.deserialize<(Map<int, String>, String)>(e['k']),
+              protocol.deserialize<String>(e['v']),
+            ),
+          ),
+        );
+    map[_i1.getType<(Map<int, String>, String)>()] = (data, protocol) => (
+      protocol.deserialize<Map<int, String>>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<String>(data['p'][1]),
+    );
+    map[_i1.getType<(Map<int, String>, String)>()] = (data, protocol) => (
+      protocol.deserialize<Map<int, String>>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<String>(data['p'][1]),
+    );
+    map[Map<int, String>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<int>(e['k']),
+          protocol.deserialize<String>(e['v']),
+        ),
+      ),
+    );
+    map[Map<String, (Map<int, int>,)>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<(Map<int, int>,)>(v),
+      ),
+    );
+    map[_i1.getType<(Map<int, int>,)>()] = (data, protocol) =>
+        (protocol.deserialize<Map<int, int>>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(Map<int, int>,)>()] = (data, protocol) =>
+        (protocol.deserialize<Map<int, int>>(((data as Map)['p'] as List)[0]),);
+    map[Map<DateTime, bool>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<DateTime>(e['k']),
+          protocol.deserialize<bool>(e['v']),
+        ),
+      ),
+    );
+    map[Map<DateTime, bool>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<DateTime>(e['k']),
+          protocol.deserialize<bool>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<Map<DateTime, bool>?>()] = (data, protocol) => (data != null
+        ? Map.fromEntries(
+            (data as List).map(
+              (e) => MapEntry(
+                protocol.deserialize<DateTime>(e['k']),
+                protocol.deserialize<bool>(e['v']),
+              ),
+            ),
+          )
+        : null);
+    map[Map<int, String>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<int>(e['k']),
+          protocol.deserialize<String>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<Map<int, String>?>()] = (data, protocol) => (data != null
+        ? Map.fromEntries(
+            (data as List).map(
+              (e) => MapEntry(
+                protocol.deserialize<int>(e['k']),
+                protocol.deserialize<String>(e['v']),
+              ),
+            ),
+          )
+        : null);
+    map[dynamic] = (data, protocol) => deserializeDynamicFieldValue(data) as T;
+    map[List<_i210.UserInfo>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i210.UserInfo>(e))
+        .toList();
+    map[Set<int>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int>(e)).toSet();
+    map[Set<_i208.SimpleData>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i208.SimpleData>(e))
+        .toSet();
+    map[List<Set<_i208.SimpleData>>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<Set<_i208.SimpleData>>(e))
+        .toList();
+    map[Set<_i208.SimpleData>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i208.SimpleData>(e))
+        .toSet();
+    map[_i1.getType<(int, BigInt)>()] = (data, protocol) => (
+      protocol.deserialize<int>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<BigInt>(data['p'][1]),
+    );
+    map[_i1.getType<(String, _i211.PolymorphicParent)>()] = (data, protocol) =>
+        (
+          protocol.deserialize<String>(((data as Map)['p'] as List)[0]),
+          protocol.deserialize<_i211.PolymorphicParent>(data['p'][1]),
+        );
+    map[_i1.getType<(int,)>()] = (data, protocol) =>
+        (protocol.deserialize<int>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(int,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<int>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(int?,)>()] = (data, protocol) => (
+      ((data as Map)['p'] as List)[0] == null
+          ? null
+          : protocol.deserialize<int>(data['p'][0]),
+    );
+    map[_i1.getType<(int?,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (
+            ((data as Map)['p'] as List)[0] == null
+                ? null
+                : protocol.deserialize<int>(data['p'][0]),
+          );
+    map[_i1.getType<(int, String)>()] = (data, protocol) => (
+      protocol.deserialize<int>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<String>(data['p'][1]),
+    );
+    map[_i1.getType<(int, String)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (
+            protocol.deserialize<int>(((data as Map)['p'] as List)[0]),
+            protocol.deserialize<String>(data['p'][1]),
+          );
+    map[_i1.getType<(int, _i208.SimpleData)>()] = (data, protocol) => (
+      protocol.deserialize<int>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<_i208.SimpleData>(data['p'][1]),
+    );
+    map[_i1.getType<(int, _i208.SimpleData)?>()] = (data, protocol) =>
+        (data == null)
+        ? null
+        : (
+            protocol.deserialize<int>(((data as Map)['p'] as List)[0]),
+            protocol.deserialize<_i208.SimpleData>(data['p'][1]),
+          );
+    map[_i1.getType<(Map<String, int>,)>()] = (data, protocol) => (
+      protocol.deserialize<Map<String, int>>(((data as Map)['p'] as List)[0]),
+    );
+    map[_i1.getType<(Set<(int,)>,)>()] = (data, protocol) =>
+        (protocol.deserialize<Set<(int,)>>(((data as Map)['p'] as List)[0]),);
+    map[Set<(int,)>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<(int,)>(e)).toSet();
+    map[_i1.getType<(int,)>()] = (data, protocol) =>
+        (protocol.deserialize<int>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<({int number, String text})>()] = (data, protocol) => (
+      number: protocol.deserialize<int>(((data as Map)['n'] as Map)['number']),
+      text: protocol.deserialize<String>(data['n']['text']),
+    );
+    map[_i1.getType<({int number, String text})?>()] = (data, protocol) =>
+        (data == null)
+        ? null
+        : (
+            number: protocol.deserialize<int>(
+              ((data as Map)['n'] as Map)['number'],
+            ),
+            text: protocol.deserialize<String>(data['n']['text']),
+          );
+    map[_i1.getType<({_i208.SimpleData data, int number})>()] =
+        (data, protocol) => (
+          data: protocol.deserialize<_i208.SimpleData>(
+            ((data as Map)['n'] as Map)['data'],
+          ),
+          number: protocol.deserialize<int>(data['n']['number']),
+        );
+    map[_i1.getType<({_i208.SimpleData data, int number})?>()] =
+        (data, protocol) => (data == null)
+        ? null
+        : (
+            data: protocol.deserialize<_i208.SimpleData>(
+              ((data as Map)['n'] as Map)['data'],
+            ),
+            number: protocol.deserialize<int>(data['n']['number']),
+          );
+    map[_i1.getType<({_i208.SimpleData? data, int? number})>()] =
+        (data, protocol) => (
+          data: ((data as Map)['n'] as Map)['data'] == null
+              ? null
+              : protocol.deserialize<_i208.SimpleData>(data['n']['data']),
+          number: ((data)['n'] as Map)['number'] == null
+              ? null
+              : protocol.deserialize<int>(data['n']['number']),
+        );
+    map[_i1.getType<({Map<int, int> intIntMap})>()] = (data, protocol) => (
+      intIntMap: protocol.deserialize<Map<int, int>>(
+        ((data as Map)['n'] as Map)['intIntMap'],
+      ),
+    );
+    map[_i1.getType<({Set<(bool,)> boolSet})>()] = (data, protocol) => (
+      boolSet: protocol.deserialize<Set<(bool,)>>(
+        ((data as Map)['n'] as Map)['boolSet'],
+      ),
+    );
+    map[Set<(bool,)>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<(bool,)>(e)).toSet();
+    map[_i1.getType<(bool,)>()] = (data, protocol) =>
+        (protocol.deserialize<bool>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(bool,)>()] = (data, protocol) =>
+        (protocol.deserialize<bool>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(Map<(Map<int, String>, String), String>,)>()] =
+        (data, protocol) => (
+          protocol.deserialize<Map<(Map<int, String>, String), String>>(
+            ((data as Map)['p'] as List)[0],
+          ),
+        );
+    map[_i1.getType<(int, {_i208.SimpleData data})>()] = (data, protocol) => (
+      protocol.deserialize<int>(((data as Map)['p'] as List)[0]),
+      data: protocol.deserialize<_i208.SimpleData>(data['n']['data']),
+    );
+    map[_i1.getType<(int, {_i208.SimpleData data})?>()] = (data, protocol) =>
+        (data == null)
+        ? null
+        : (
+            protocol.deserialize<int>(((data as Map)['p'] as List)[0]),
+            data: protocol.deserialize<_i208.SimpleData>(data['n']['data']),
+          );
+    map[List<(int, _i208.SimpleData)>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<(int, _i208.SimpleData)>(e))
+        .toList();
+    map[_i1.getType<(int, _i208.SimpleData)>()] = (data, protocol) => (
+      protocol.deserialize<int>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<_i208.SimpleData>(data['p'][1]),
+    );
+    map[List<(int, _i208.SimpleData)?>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<(int, _i208.SimpleData)?>(e))
+        .toList();
+    map[_i1.getType<(int, _i208.SimpleData)?>()] = (data, protocol) =>
+        (data == null)
+        ? null
+        : (
+            protocol.deserialize<int>(((data as Map)['p'] as List)[0]),
+            protocol.deserialize<_i208.SimpleData>(data['p'][1]),
+          );
+    map[Set<(int, _i208.SimpleData)>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<(int, _i208.SimpleData)>(e))
+        .toSet();
+    map[_i1.getType<(int, _i208.SimpleData)>()] = (data, protocol) => (
+      protocol.deserialize<int>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<_i208.SimpleData>(data['p'][1]),
+    );
+    map[Set<(int, _i208.SimpleData)?>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<(int, _i208.SimpleData)?>(e))
+        .toSet();
+    map[_i1.getType<(int, _i208.SimpleData)?>()] = (data, protocol) =>
+        (data == null)
+        ? null
+        : (
+            protocol.deserialize<int>(((data as Map)['p'] as List)[0]),
+            protocol.deserialize<_i208.SimpleData>(data['p'][1]),
+          );
+    map[Set<(int, _i208.SimpleData)>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<(int, _i208.SimpleData)>(e))
+        .toSet();
+    map[_i1.getType<(int, _i208.SimpleData)>()] = (data, protocol) => (
+      protocol.deserialize<int>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<_i208.SimpleData>(data['p'][1]),
+    );
+    map[_i1.getType<Set<(int, _i208.SimpleData)>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<(int, _i208.SimpleData)>(e))
+              .toSet()
+        : null);
+    map[_i1.getType<(int, _i208.SimpleData)>()] = (data, protocol) => (
+      protocol.deserialize<int>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<_i208.SimpleData>(data['p'][1]),
+    );
+    map[Map<String, (int, _i208.SimpleData)>] = (data, protocol) =>
+        (data as Map).map(
+          (k, v) => MapEntry(
+            protocol.deserialize<String>(k),
+            protocol.deserialize<(int, _i208.SimpleData)>(v),
+          ),
+        );
+    map[_i1.getType<(int, _i208.SimpleData)>()] = (data, protocol) => (
+      protocol.deserialize<int>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<_i208.SimpleData>(data['p'][1]),
+    );
+    map[Map<String, (int, _i208.SimpleData)?>] = (data, protocol) =>
+        (data as Map).map(
+          (k, v) => MapEntry(
+            protocol.deserialize<String>(k),
+            protocol.deserialize<(int, _i208.SimpleData)?>(v),
+          ),
+        );
+    map[_i1.getType<(int, _i208.SimpleData)?>()] = (data, protocol) =>
+        (data == null)
+        ? null
+        : (
+            protocol.deserialize<int>(((data as Map)['p'] as List)[0]),
+            protocol.deserialize<_i208.SimpleData>(data['p'][1]),
+          );
+    map[Map<(String, int), (int, _i208.SimpleData)>] = (data, protocol) =>
+        Map.fromEntries(
+          (data as List).map(
+            (e) => MapEntry(
+              protocol.deserialize<(String, int)>(e['k']),
+              protocol.deserialize<(int, _i208.SimpleData)>(e['v']),
+            ),
+          ),
+        );
+    map[_i1.getType<(String, int)>()] = (data, protocol) => (
+      protocol.deserialize<String>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<int>(data['p'][1]),
+    );
+    map[_i1.getType<(int, _i208.SimpleData)>()] = (data, protocol) => (
+      protocol.deserialize<int>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<_i208.SimpleData>(data['p'][1]),
+    );
+    map[_i1.getType<(String, int)>()] = (data, protocol) => (
+      protocol.deserialize<String>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<int>(data['p'][1]),
+    );
+    map[Map<String, List<Set<(int,)>>>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<List<Set<(int,)>>>(v),
+      ),
+    );
+    map[List<Set<(int,)>>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<Set<(int,)>>(e))
+        .toList();
+    map[Set<(int,)>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<(int,)>(e)).toSet();
+    map[_i1.getType<(int,)>()] = (data, protocol) =>
+        (protocol.deserialize<int>(((data as Map)['p'] as List)[0]),);
+    map[List<Set<(int,)>>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<Set<(int,)>>(e))
+        .toList();
+    map[Set<(int,)>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<(int,)>(e)).toSet();
+    map[_i1.getType<(int,)>()] = (data, protocol) =>
+        (protocol.deserialize<int>(((data as Map)['p'] as List)[0]),);
+    map[Set<List<Map<String, (int,)>>>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<List<Map<String, (int,)>>>(e))
+        .toSet();
+    map[List<Map<String, (int,)>>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<Map<String, (int,)>>(e))
+        .toList();
+    map[Map<String, (int,)>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<(int,)>(v),
+      ),
+    );
+    map[_i1.getType<(int,)>()] = (data, protocol) =>
+        (protocol.deserialize<int>(((data as Map)['p'] as List)[0]),);
+    map[List<Map<String, (int,)>>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<Map<String, (int,)>>(e))
+        .toList();
+    map[Map<String, (int,)>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<(int,)>(v),
+      ),
+    );
+    map[_i1.getType<(int,)>()] = (data, protocol) =>
+        (protocol.deserialize<int>(((data as Map)['p'] as List)[0]),);
+    map[Map<String, (int,)>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<(int,)>(v),
+      ),
+    );
+    map[_i1.getType<(int,)>()] = (data, protocol) =>
+        (protocol.deserialize<int>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<({(_i208.SimpleData, double) namedSubRecord})>()] =
+        (data, protocol) => (
+          namedSubRecord: protocol.deserialize<(_i208.SimpleData, double)>(
+            ((data as Map)['n'] as Map)['namedSubRecord'],
+          ),
+        );
+    map[_i1.getType<(_i208.SimpleData, double)>()] = (data, protocol) => (
+      protocol.deserialize<_i208.SimpleData>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<double>(data['p'][1]),
+    );
+    map[_i1.getType<({(_i208.SimpleData, double)? namedSubRecord})>()] =
+        (data, protocol) => (
+          namedSubRecord: ((data as Map)['n'] as Map)['namedSubRecord'] == null
+              ? null
+              : protocol.deserialize<(_i208.SimpleData, double)>(
+                  data['n']['namedSubRecord'],
+                ),
+        );
+    map[_i1.getType<(_i208.SimpleData, double)?>()] = (data, protocol) =>
+        (data == null)
+        ? null
+        : (
+            protocol.deserialize<_i208.SimpleData>(
+              ((data as Map)['p'] as List)[0],
+            ),
+            protocol.deserialize<double>(data['p'][1]),
+          );
+    map[_i1
+        .getType<
+          ((int, String), {(_i208.SimpleData, double) namedSubRecord})
+        >()] = (data, protocol) => (
+      protocol.deserialize<(int, String)>(((data as Map)['p'] as List)[0]),
+      namedSubRecord: protocol.deserialize<(_i208.SimpleData, double)>(
+        data['n']['namedSubRecord'],
+      ),
+    );
+    map[List<((int, String), {(_i208.SimpleData, double) namedSubRecord})>] =
+        (data, protocol) => (data as List)
+            .map(
+              (e) =>
+                  protocol.deserialize<
+                    ((int, String), {(_i208.SimpleData, double) namedSubRecord})
+                  >(e),
+            )
+            .toList();
+    map[_i1
+        .getType<
+          ((int, String), {(_i208.SimpleData, double) namedSubRecord})
+        >()] = (data, protocol) => (
+      protocol.deserialize<(int, String)>(((data as Map)['p'] as List)[0]),
+      namedSubRecord: protocol.deserialize<(_i208.SimpleData, double)>(
+        data['n']['namedSubRecord'],
+      ),
+    );
+    map[List<((int, String), {(_i208.SimpleData, double) namedSubRecord})?>] =
+        (data, protocol) => (data as List)
+            .map(
+              (e) =>
+                  protocol.deserialize<
+                    (
+                      (int, String), {
+                      (_i208.SimpleData, double) namedSubRecord,
+                    })?
+                  >(e),
+            )
+            .toList();
+    map[_i1
+        .getType<
+          ((int, String), {(_i208.SimpleData, double) namedSubRecord})?
+        >()] = (data, protocol) => (data == null)
+        ? null
+        : (
+            protocol.deserialize<(int, String)>(
+              ((data as Map)['p'] as List)[0],
+            ),
+            namedSubRecord: protocol.deserialize<(_i208.SimpleData, double)>(
+              data['n']['namedSubRecord'],
+            ),
+          );
+    map[_i1
+        .getType<
+          List<((int, String), {(_i208.SimpleData, double) namedSubRecord})?>?
+        >()] = (data, protocol) => (data != null
+        ? (data as List)
+              .map(
+                (e) =>
+                    protocol.deserialize<
+                      (
+                        (int, String), {
+                        (_i208.SimpleData, double) namedSubRecord,
+                      })?
+                    >(e),
+              )
+              .toList()
+        : null);
+    map[_i1
+        .getType<
+          ((int, String), {(_i208.SimpleData, double) namedSubRecord})?
+        >()] = (data, protocol) => (data == null)
+        ? null
+        : (
+            protocol.deserialize<(int, String)>(
+              ((data as Map)['p'] as List)[0],
+            ),
+            namedSubRecord: protocol.deserialize<(_i208.SimpleData, double)>(
+              data['n']['namedSubRecord'],
+            ),
+          );
+    map[_i1
+        .getType<
+          ((int, String), {(_i208.SimpleData, double) namedSubRecord})?
+        >()] = (data, protocol) => (data == null)
+        ? null
+        : (
+            protocol.deserialize<(int, String)>(
+              ((data as Map)['p'] as List)[0],
+            ),
+            namedSubRecord: protocol.deserialize<(_i208.SimpleData, double)>(
+              data['n']['namedSubRecord'],
+            ),
+          );
+    map[_i1.getType<(int?, _i205.ProjectStreamingClass?)>()] =
+        (data, protocol) => (
+          ((data as Map)['p'] as List)[0] == null
+              ? null
+              : protocol.deserialize<int>(data['p'][0]),
+          ((data)['p'] as List)[1] == null
+              ? null
+              : protocol.deserialize<_i205.ProjectStreamingClass>(data['p'][1]),
+        );
+    map[Set<Set<int>>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<Set<int>>(e)).toSet();
+    map[Set<int>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int>(e)).toSet();
+    map[Set<List<int>>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<List<int>>(e)).toSet();
+    map[List<int>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int>(e)).toList();
+    map[Set<int>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int>(e)).toSet();
+    map[_i1.getType<Set<int>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<int>(e)).toSet()
+        : null);
+    map[Set<Set<int>?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<Set<int>?>(e)).toSet();
+    map[Set<int>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int>(e)).toSet();
+    map[_i1.getType<Set<int>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<int>(e)).toSet()
+        : null);
+    map[Set<Set<int>>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<Set<int>>(e)).toSet();
+    map[Set<int>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int>(e)).toSet();
+    map[_i1.getType<Set<Set<int>>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<Set<int>>(e)).toSet()
+        : null);
+    map[Set<int>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int>(e)).toSet();
+    map[Set<int?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int?>(e)).toSet();
+    map[Set<int?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int?>(e)).toSet();
+    map[_i1.getType<Set<int?>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<int?>(e)).toSet()
+        : null);
+    map[Set<double>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<double>(e)).toSet();
+    map[Set<double?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<double?>(e)).toSet();
+    map[Set<bool>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<bool>(e)).toSet();
+    map[Set<bool?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<bool?>(e)).toSet();
+    map[Set<String>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<String>(e)).toSet();
+    map[Set<String?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<String?>(e)).toSet();
+    map[Set<DateTime>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<DateTime>(e)).toSet();
+    map[Set<DateTime?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<DateTime?>(e)).toSet();
+    map[Set<_i206.ByteData>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i206.ByteData>(e))
+        .toSet();
+    map[Set<_i206.ByteData?>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i206.ByteData?>(e))
+        .toSet();
+    map[Set<_i208.SimpleData?>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i208.SimpleData?>(e))
+        .toSet();
+    map[Set<Duration>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<Duration>(e)).toSet();
+    map[Set<Duration?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<Duration?>(e)).toSet();
+    map[List<_i212.Types>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i212.Types>(e))
+        .toList();
+    map[_i1.getType<(String, (int, bool))>()] = (data, protocol) => (
+      protocol.deserialize<String>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<(int, bool)>(data['p'][1]),
+    );
+    map[_i1.getType<(int, bool)>()] = (data, protocol) => (
+      protocol.deserialize<int>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<bool>(data['p'][1]),
+    );
+    map[List<(String, (int, bool))>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<(String, (int, bool))>(e))
+        .toList();
+    map[_i1.getType<(String, (int, bool))>()] = (data, protocol) => (
+      protocol.deserialize<String>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<(int, bool)>(data['p'][1]),
+    );
+    map[_i1
+        .getType<
+          (String, (Map<String, int>, {bool flag, _i208.SimpleData simpleData}))
+        >()] = (data, protocol) => (
+      protocol.deserialize<String>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<
+        (Map<String, int>, {bool flag, _i208.SimpleData simpleData})
+      >(data['p'][1]),
+    );
+    map[_i1
+        .getType<
+          (Map<String, int>, {bool flag, _i208.SimpleData simpleData})
+        >()] = (data, protocol) => (
+      protocol.deserialize<Map<String, int>>(((data as Map)['p'] as List)[0]),
+      flag: protocol.deserialize<bool>(data['n']['flag']),
+      simpleData: protocol.deserialize<_i208.SimpleData>(
+        data['n']['simpleData'],
+      ),
+    );
+    map[List<(String, int)>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<(String, int)>(e))
+        .toList();
+    map[_i1.getType<(String, int)>()] = (data, protocol) => (
+      protocol.deserialize<String>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<int>(data['p'][1]),
+    );
+    map[_i1
+        .getType<
+          (
+            String,
+            (Map<String, int>, {bool flag, _i208.SimpleData simpleData}),
+          )?
+        >()] = (data, protocol) => (data == null)
+        ? null
+        : (
+            protocol.deserialize<String>(((data as Map)['p'] as List)[0]),
+            protocol.deserialize<
+              (Map<String, int>, {bool flag, _i208.SimpleData simpleData})
+            >(data['p'][1]),
+          );
+    map[List<(String, int)>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<(String, int)>(e))
+        .toList();
+    map[_i1.getType<(String, int)>()] = (data, protocol) => (
+      protocol.deserialize<String>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<int>(data['p'][1]),
+    );
+    map[_i1.getType<List<(String, int)>?>()] = (data, protocol) => (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<(String, int)>(e))
+              .toList()
+        : null);
+    map[_i1.getType<(String, int)>()] = (data, protocol) => (
+      protocol.deserialize<String>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<int>(data['p'][1]),
+    );
+    map[_i1.getType<(int, String)>()] = (data, protocol) => (
+      protocol.deserialize<int>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<String>(data['p'][1]),
+    );
+    map[_i1.getType<(_i205.ModuleClass,)?>()] = (data, protocol) =>
+        (data == null)
+        ? null
+        : (
+            protocol.deserialize<_i205.ModuleClass>(
+              ((data as Map)['p'] as List)[0],
+            ),
+          );
+    map[_i1.getType<(bool,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<bool>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(_i195.TestEnumStringified,)?>()] = (data, protocol) =>
+        (data == null)
+        ? null
+        : (
+            protocol.deserialize<_i195.TestEnumStringified>(
+              ((data as Map)['p'] as List)[0],
+            ),
+          );
+    map[List<(_i195.TestEnumStringified,)>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<(_i195.TestEnumStringified,)>(e))
+        .toList();
+    map[_i1.getType<(_i195.TestEnumStringified,)>()] = (data, protocol) => (
+      protocol.deserialize<_i195.TestEnumStringified>(
+        ((data as Map)['p'] as List)[0],
+      ),
+    );
+    map[_i1.getType<List<(_i195.TestEnumStringified,)>?>()] =
+        (data, protocol) => (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<(_i195.TestEnumStringified,)>(e))
+              .toList()
+        : null);
+    map[_i1.getType<(_i195.TestEnumStringified,)>()] = (data, protocol) => (
+      protocol.deserialize<_i195.TestEnumStringified>(
+        ((data as Map)['p'] as List)[0],
+      ),
+    );
+    map[_i1.getType<(_i195.TestEnumStringified,)>()] = (data, protocol) => (
+      protocol.deserialize<_i195.TestEnumStringified>(
+        ((data as Map)['p'] as List)[0],
+      ),
+    );
+    map[_i1.getType<(_i146.Nullability,)?>()] = (data, protocol) =>
+        (data == null)
+        ? null
+        : (
+            protocol.deserialize<_i146.Nullability>(
+              ((data as Map)['p'] as List)[0],
+            ),
+          );
+    map[_i1.getType<({_i195.TestEnumStringified value})?>()] =
+        (data, protocol) => (data == null)
+        ? null
+        : (
+            value: protocol.deserialize<_i195.TestEnumStringified>(
+              ((data as Map)['n'] as Map)['value'],
+            ),
+          );
+    map[List<({_i195.TestEnumStringified value})>] = (data, protocol) =>
+        (data as List)
+            .map(
+              (e) =>
+                  protocol.deserialize<({_i195.TestEnumStringified value})>(e),
+            )
+            .toList();
+    map[_i1
+        .getType<({_i195.TestEnumStringified value})>()] = (data, protocol) => (
+      value: protocol.deserialize<_i195.TestEnumStringified>(
+        ((data as Map)['n'] as Map)['value'],
+      ),
+    );
+    map[_i1.getType<List<({_i195.TestEnumStringified value})>?>()] =
+        (data, protocol) => (data != null
+        ? (data as List)
+              .map(
+                (e) => protocol
+                    .deserialize<({_i195.TestEnumStringified value})>(e),
+              )
+              .toList()
+        : null);
+    map[_i1
+        .getType<({_i195.TestEnumStringified value})>()] = (data, protocol) => (
+      value: protocol.deserialize<_i195.TestEnumStringified>(
+        ((data as Map)['n'] as Map)['value'],
+      ),
+    );
+    map[_i1
+        .getType<({_i195.TestEnumStringified value})>()] = (data, protocol) => (
+      value: protocol.deserialize<_i195.TestEnumStringified>(
+        ((data as Map)['n'] as Map)['value'],
+      ),
+    );
+    map[_i1.getType<({_i205.ModuleClass value})?>()] = (data, protocol) =>
+        (data == null)
+        ? null
+        : (
+            value: protocol.deserialize<_i205.ModuleClass>(
+              ((data as Map)['n'] as Map)['value'],
+            ),
+          );
+    map[_i1.getType<({_i146.Nullability value})?>()] = (data, protocol) =>
+        (data == null)
+        ? null
+        : (
+            value: protocol.deserialize<_i146.Nullability>(
+              ((data as Map)['n'] as Map)['value'],
+            ),
+          );
+    map[_i1.getType<(String, {Uri? optionalUri})?>()] = (data, protocol) =>
+        (data == null)
+        ? null
+        : (
+            protocol.deserialize<String>(((data as Map)['p'] as List)[0]),
+            optionalUri: ((data)['n'] as Map)['optionalUri'] == null
+                ? null
+                : protocol.deserialize<Uri>(data['n']['optionalUri']),
+          );
+    map[List<(int,)>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<(int,)>(e)).toList();
+    map[_i1.getType<(int,)>()] = (data, protocol) =>
+        (protocol.deserialize<int>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<List<(int,)>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<(int,)>(e)).toList()
+        : null);
+    map[_i1.getType<(int,)>()] = (data, protocol) =>
+        (protocol.deserialize<int>(((data as Map)['p'] as List)[0]),);
+    map[List<(int,)?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<(int,)?>(e)).toList();
+    map[_i1.getType<(int,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<int>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<List<(int,)?>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<(int,)?>(e)).toList()
+        : null);
+    map[_i1.getType<(int,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<int>(((data as Map)['p'] as List)[0]),);
+    map[List<(_i191.TestEnum,)>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<(_i191.TestEnum,)>(e))
+        .toList();
+    map[_i1.getType<(_i191.TestEnum,)>()] = (data, protocol) => (
+      protocol.deserialize<_i191.TestEnum>(((data as Map)['p'] as List)[0]),
+    );
+    map[_i1.getType<List<(_i191.TestEnum,)>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<(_i191.TestEnum,)>(e))
+              .toList()
+        : null);
+    map[_i1.getType<(_i191.TestEnum,)>()] = (data, protocol) => (
+      protocol.deserialize<_i191.TestEnum>(((data as Map)['p'] as List)[0]),
+    );
+    map[_i1.getType<(_i191.TestEnum,)>()] = (data, protocol) => (
+      protocol.deserialize<_i191.TestEnum>(((data as Map)['p'] as List)[0]),
+    );
+    map[Map<(String,), String>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<(String,)>(e['k']),
+          protocol.deserialize<String>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<(String,)>()] = (data, protocol) =>
+        (protocol.deserialize<String>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<Map<(String,), String>?>()] = (data, protocol) =>
+        (data != null
+        ? Map.fromEntries(
+            (data as List).map(
+              (e) => MapEntry(
+                protocol.deserialize<(String,)>(e['k']),
+                protocol.deserialize<String>(e['v']),
+              ),
+            ),
+          )
+        : null);
+    map[_i1.getType<(String,)>()] = (data, protocol) =>
+        (protocol.deserialize<String>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(String,)>()] = (data, protocol) =>
+        (protocol.deserialize<String>(((data as Map)['p'] as List)[0]),);
+    map[Map<String, (String,)>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<(String,)>(v),
+      ),
+    );
+    map[_i1.getType<(String,)>()] = (data, protocol) =>
+        (protocol.deserialize<String>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<Map<String, (String,)>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<(String,)>(v),
+            ),
+          )
+        : null);
+    map[_i1.getType<(String,)>()] = (data, protocol) =>
+        (protocol.deserialize<String>(((data as Map)['p'] as List)[0]),);
+    map[Map<String, (String,)?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<(String,)?>(v),
+      ),
+    );
+    map[_i1.getType<(String,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<String>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<Map<String, (String,)?>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<(String,)?>(v),
+            ),
+          )
+        : null);
+    map[_i1.getType<(String,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<String>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(String,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<String>(((data as Map)['p'] as List)[0]),);
+    map[Map<(String,)?, String>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<(String,)?>(e['k']),
+          protocol.deserialize<String>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<(String,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<String>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<Map<(String,)?, String>?>()] = (data, protocol) =>
+        (data != null
+        ? Map.fromEntries(
+            (data as List).map(
+              (e) => MapEntry(
+                protocol.deserialize<(String,)?>(e['k']),
+                protocol.deserialize<String>(e['v']),
+              ),
+            ),
+          )
+        : null);
+    map[_i1.getType<(String,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<String>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(double,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<double>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(DateTime,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<DateTime>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(_i206.ByteData,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (
+            protocol.deserialize<_i206.ByteData>(
+              ((data as Map)['p'] as List)[0],
+            ),
+          );
+    map[_i1.getType<(Duration,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<Duration>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(_i1.UuidValue,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (
+            protocol.deserialize<_i1.UuidValue>(
+              ((data as Map)['p'] as List)[0],
+            ),
+          );
+    map[_i1.getType<(Uri,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<Uri>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(BigInt,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<BigInt>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(_i191.TestEnum,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (
+            protocol.deserialize<_i191.TestEnum>(
+              ((data as Map)['p'] as List)[0],
+            ),
+          );
+    map[_i1.getType<(List<int>,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<List<int>>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(Map<int, int>,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (
+            protocol.deserialize<Map<int, int>>(
+              ((data as Map)['p'] as List)[0],
+            ),
+          );
+    map[Map<int, int>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<int>(e['k']),
+          protocol.deserialize<int>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<(Set<int>,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<Set<int>>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(_i185.SimpleData,)?>()] = (data, protocol) =>
+        (data == null)
+        ? null
+        : (
+            protocol.deserialize<_i185.SimpleData>(
+              ((data as Map)['p'] as List)[0],
+            ),
+          );
+    map[_i1.getType<({_i185.SimpleData namedModel})?>()] = (data, protocol) =>
+        (data == null)
+        ? null
+        : (
+            namedModel: protocol.deserialize<_i185.SimpleData>(
+              ((data as Map)['n'] as Map)['namedModel'],
+            ),
+          );
+    map[_i1.getType<(_i185.SimpleData, {_i185.SimpleData namedModel})?>()] =
+        (data, protocol) => (data == null)
+        ? null
+        : (
+            protocol.deserialize<_i185.SimpleData>(
+              ((data as Map)['p'] as List)[0],
+            ),
+            namedModel: protocol.deserialize<_i185.SimpleData>(
+              data['n']['namedModel'],
+            ),
+          );
+    map[_i1.getType<((int, String), {(int, String) namedNestedRecord})?>()] =
+        (data, protocol) => (data == null)
+        ? null
+        : (
+            protocol.deserialize<(int, String)>(
+              ((data as Map)['p'] as List)[0],
+            ),
+            namedNestedRecord: protocol.deserialize<(int, String)>(
+              data['n']['namedNestedRecord'],
+            ),
+          );
+    map[_i1
+        .getType<
+          (
+            (List<(_i185.SimpleData,)>,), {
+            (_i185.SimpleData, Map<String, _i185.SimpleData>) namedNestedRecord,
+          })?
+        >()] = (data, protocol) => (data == null)
+        ? null
+        : (
+            protocol.deserialize<(List<(_i185.SimpleData,)>,)>(
+              ((data as Map)['p'] as List)[0],
+            ),
+            namedNestedRecord: protocol
+                .deserialize<(_i185.SimpleData, Map<String, _i185.SimpleData>)>(
+                  data['n']['namedNestedRecord'],
+                ),
+          );
+    map[_i1.getType<(List<(_i185.SimpleData,)>,)>()] = (data, protocol) => (
+      protocol.deserialize<List<(_i185.SimpleData,)>>(
+        ((data as Map)['p'] as List)[0],
+      ),
+    );
+    map[List<(_i185.SimpleData,)>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<(_i185.SimpleData,)>(e))
+        .toList();
+    map[_i1.getType<(_i185.SimpleData,)>()] = (data, protocol) => (
+      protocol.deserialize<_i185.SimpleData>(((data as Map)['p'] as List)[0]),
+    );
+    map[_i1.getType<(_i185.SimpleData,)>()] = (data, protocol) => (
+      protocol.deserialize<_i185.SimpleData>(((data as Map)['p'] as List)[0]),
+    );
+    map[_i1.getType<(_i185.SimpleData, Map<String, _i185.SimpleData>)>()] =
+        (data, protocol) => (
+          protocol.deserialize<_i185.SimpleData>(
+            ((data as Map)['p'] as List)[0],
+          ),
+          protocol.deserialize<Map<String, _i185.SimpleData>>(data['p'][1]),
+        );
+    map[Map<String, _i185.SimpleData>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i185.SimpleData>(v),
+      ),
+    );
+    map[Set<(int,)>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<(int,)>(e)).toSet();
+    map[_i1.getType<(int,)>()] = (data, protocol) =>
+        (protocol.deserialize<int>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<Set<(int,)>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<(int,)>(e)).toSet()
+        : null);
+    map[_i1.getType<(int,)>()] = (data, protocol) =>
+        (protocol.deserialize<int>(((data as Map)['p'] as List)[0]),);
+    map[Set<(int,)?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<(int,)?>(e)).toSet();
+    map[_i1.getType<(int,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<int>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<Set<(int,)?>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<(int,)?>(e)).toSet()
+        : null);
+    map[_i1.getType<(int,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<int>(((data as Map)['p'] as List)[0]),);
+    map[_i207.CustomClass] = (data, protocol) =>
+        _i207.CustomClass.fromJson(data);
+    map[_i207.CustomClass2] = (data, protocol) =>
+        _i207.CustomClass2.fromJson(data);
+    map[_i207.CustomClassWithoutProtocolSerialization] = (data, protocol) =>
+        _i207.CustomClassWithoutProtocolSerialization.fromJson(data);
+    map[_i207.CustomClassWithProtocolSerialization] = (data, protocol) =>
+        _i207.CustomClassWithProtocolSerialization.fromJson(data);
+    map[_i207.CustomClassWithProtocolSerializationMethod] = (data, protocol) =>
+        _i207.CustomClassWithProtocolSerializationMethod.fromJson(data);
+    map[_i207.ProtocolCustomClass] = (data, protocol) =>
+        _i207.ProtocolCustomClass.fromJson(data);
+    map[_i207.ExternalCustomClass] = (data, protocol) =>
+        _i207.ExternalCustomClass.fromJson(data);
+    map[_i207.FreezedCustomClass] = (data, protocol) =>
+        _i207.FreezedCustomClass.fromJson(data);
+    map[_i1.getType<_i207.CustomClass?>()] = (data, protocol) =>
+        (data != null ? _i207.CustomClass.fromJson(data) : null);
+    map[_i1.getType<_i207.CustomClass2?>()] = (data, protocol) =>
+        (data != null ? _i207.CustomClass2.fromJson(data) : null);
+    map[_i1.getType<_i207.CustomClassWithoutProtocolSerialization?>()] =
+        (data, protocol) => (data != null
+        ? _i207.CustomClassWithoutProtocolSerialization.fromJson(data)
+        : null);
+    map[_i1.getType<_i207.CustomClassWithProtocolSerialization?>()] =
+        (data, protocol) => (data != null
+        ? _i207.CustomClassWithProtocolSerialization.fromJson(data)
+        : null);
+    map[_i1.getType<_i207.CustomClassWithProtocolSerializationMethod?>()] =
+        (data, protocol) => (data != null
+        ? _i207.CustomClassWithProtocolSerializationMethod.fromJson(data)
+        : null);
+    map[_i1.getType<_i207.ProtocolCustomClass?>()] = (data, protocol) =>
+        (data != null ? _i207.ProtocolCustomClass.fromJson(data) : null);
+    map[_i1.getType<_i207.ExternalCustomClass?>()] = (data, protocol) =>
+        (data != null ? _i207.ExternalCustomClass.fromJson(data) : null);
+    map[_i1.getType<_i207.FreezedCustomClass?>()] = (data, protocol) =>
+        (data != null ? _i207.FreezedCustomClass.fromJson(data) : null);
+    map[List<int>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int>(e)).toList();
+    map[List<_i208.SimpleData>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i208.SimpleData>(e))
+        .toList();
+    map[List<_i210.UserInfo>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i210.UserInfo>(e))
+        .toList();
+    map[List<_i208.SimpleData>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i208.SimpleData>(e))
+        .toList();
+    map[_i1.getType<List<_i208.SimpleData>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i208.SimpleData>(e))
+              .toList()
+        : null);
+    map[List<_i208.SimpleData?>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i208.SimpleData?>(e))
+        .toList();
+    map[Set<int>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int>(e)).toSet();
+    map[Set<_i208.SimpleData>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i208.SimpleData>(e))
+        .toSet();
+    map[List<Set<_i208.SimpleData>>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<Set<_i208.SimpleData>>(e))
+        .toList();
+    map[Set<_i208.SimpleData>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i208.SimpleData>(e))
+        .toSet();
+    map[_i1.getType<(String, _i211.PolymorphicParent)>()] = (data, protocol) =>
+        (
+          protocol.deserialize<String>(((data as Map)['p'] as List)[0]),
+          protocol.deserialize<_i211.PolymorphicParent>(data['p'][1]),
+        );
+    map[_i1.getType<(int?,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (
+            ((data as Map)['p'] as List)[0] == null
+                ? null
+                : protocol.deserialize<int>(data['p'][0]),
+          );
+    map[List<((int, String), {(_i208.SimpleData, double) namedSubRecord})?>] =
+        (data, protocol) => (data as List)
+            .map(
+              (e) =>
+                  protocol.deserialize<
+                    (
+                      (int, String), {
+                      (_i208.SimpleData, double) namedSubRecord,
+                    })?
+                  >(e),
+            )
+            .toList();
+    map[_i1
+        .getType<
+          ((int, String), {(_i208.SimpleData, double) namedSubRecord})?
+        >()] = (data, protocol) => (data == null)
+        ? null
+        : (
+            protocol.deserialize<(int, String)>(
+              ((data as Map)['p'] as List)[0],
+            ),
+            namedSubRecord: protocol.deserialize<(_i208.SimpleData, double)>(
+              data['n']['namedSubRecord'],
+            ),
+          );
+    map[_i1
+        .getType<
+          List<((int, String), {(_i208.SimpleData, double) namedSubRecord})?>?
+        >()] = (data, protocol) => (data != null
+        ? (data as List)
+              .map(
+                (e) =>
+                    protocol.deserialize<
+                      (
+                        (int, String), {
+                        (_i208.SimpleData, double) namedSubRecord,
+                      })?
+                    >(e),
+              )
+              .toList()
+        : null);
+    map[_i1
+        .getType<
+          ((int, String), {(_i208.SimpleData, double) namedSubRecord})?
+        >()] = (data, protocol) => (data == null)
+        ? null
+        : (
+            protocol.deserialize<(int, String)>(
+              ((data as Map)['p'] as List)[0],
+            ),
+            namedSubRecord: protocol.deserialize<(_i208.SimpleData, double)>(
+              data['n']['namedSubRecord'],
+            ),
+          );
+    map[_i1.getType<(int?, _i205.ProjectStreamingClass?)>()] =
+        (data, protocol) => (
+          ((data as Map)['p'] as List)[0] == null
+              ? null
+              : protocol.deserialize<int>(data['p'][0]),
+          ((data)['p'] as List)[1] == null
+              ? null
+              : protocol.deserialize<_i205.ProjectStreamingClass>(data['p'][1]),
+        );
+    map[_i1
+        .getType<
+          (String, (Map<String, int>, {bool flag, _i208.SimpleData simpleData}))
+        >()] = (data, protocol) => (
+      protocol.deserialize<String>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<
+        (Map<String, int>, {bool flag, _i208.SimpleData simpleData})
+      >(data['p'][1]),
+    );
+    map[List<(String, int)>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<(String, int)>(e))
+        .toList();
+    map[_i1.getType<(String, int)>()] = (data, protocol) => (
+      protocol.deserialize<String>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<int>(data['p'][1]),
+    );
+    map[_i1
+        .getType<
+          (
+            String,
+            (Map<String, int>, {bool flag, _i208.SimpleData simpleData}),
+          )?
+        >()] = (data, protocol) => (data == null)
+        ? null
+        : (
+            protocol.deserialize<String>(((data as Map)['p'] as List)[0]),
+            protocol.deserialize<
+              (Map<String, int>, {bool flag, _i208.SimpleData simpleData})
+            >(data['p'][1]),
+          );
+    map[List<(String, int)>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<(String, int)>(e))
+        .toList();
+    map[_i1.getType<(String, int)>()] = (data, protocol) => (
+      protocol.deserialize<String>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<int>(data['p'][1]),
+    );
+    map[_i1.getType<List<(String, int)>?>()] = (data, protocol) => (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<(String, int)>(e))
+              .toList()
+        : null);
+    map[_i1.getType<(String, int)>()] = (data, protocol) => (
+      protocol.deserialize<String>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<int>(data['p'][1]),
+    );
+    return map;
+  }
+
   static String? getClassNameFromObjectJson(dynamic data) {
     if (data is! Map) return null;
     final className = data['__className__'] as String?;
@@ -475,5321 +4620,9 @@ class Protocol extends _i1.SerializationManager {
       }
     }
 
-    if (t == _i2.ByIndexEnumWithNameValue) {
-      return _i2.ByIndexEnumWithNameValue.fromJson(data) as T;
-    }
-    if (t == _i3.ByNameEnumWithNameValue) {
-      return _i3.ByNameEnumWithNameValue.fromJson(data) as T;
-    }
-    if (t == _i4.CourseUuid) {
-      return _i4.CourseUuid.fromJson(data) as T;
-    }
-    if (t == _i5.EnrollmentInt) {
-      return _i5.EnrollmentInt.fromJson(data) as T;
-    }
-    if (t == _i6.StudentUuid) {
-      return _i6.StudentUuid.fromJson(data) as T;
-    }
-    if (t == _i7.ArenaUuid) {
-      return _i7.ArenaUuid.fromJson(data) as T;
-    }
-    if (t == _i8.PlayerUuid) {
-      return _i8.PlayerUuid.fromJson(data) as T;
-    }
-    if (t == _i9.TeamInt) {
-      return _i9.TeamInt.fromJson(data) as T;
-    }
-    if (t == _i10.CommentInt) {
-      return _i10.CommentInt.fromJson(data) as T;
-    }
-    if (t == _i11.CustomerInt) {
-      return _i11.CustomerInt.fromJson(data) as T;
-    }
-    if (t == _i12.OrderUuid) {
-      return _i12.OrderUuid.fromJson(data) as T;
-    }
-    if (t == _i13.AddressUuid) {
-      return _i13.AddressUuid.fromJson(data) as T;
-    }
-    if (t == _i14.CitizenInt) {
-      return _i14.CitizenInt.fromJson(data) as T;
-    }
-    if (t == _i15.CompanyUuid) {
-      return _i15.CompanyUuid.fromJson(data) as T;
-    }
-    if (t == _i16.TownInt) {
-      return _i16.TownInt.fromJson(data) as T;
-    }
-    if (t == _i17.ChangedIdTypeSelf) {
-      return _i17.ChangedIdTypeSelf.fromJson(data) as T;
-    }
-    if (t == _i18.BigIntDefault) {
-      return _i18.BigIntDefault.fromJson(data) as T;
-    }
-    if (t == _i19.BigIntDefaultMix) {
-      return _i19.BigIntDefaultMix.fromJson(data) as T;
-    }
-    if (t == _i20.BigIntDefaultModel) {
-      return _i20.BigIntDefaultModel.fromJson(data) as T;
-    }
-    if (t == _i21.BigIntDefaultPersist) {
-      return _i21.BigIntDefaultPersist.fromJson(data) as T;
-    }
-    if (t == _i22.BoolDefault) {
-      return _i22.BoolDefault.fromJson(data) as T;
-    }
-    if (t == _i23.BoolDefaultMix) {
-      return _i23.BoolDefaultMix.fromJson(data) as T;
-    }
-    if (t == _i24.BoolDefaultModel) {
-      return _i24.BoolDefaultModel.fromJson(data) as T;
-    }
-    if (t == _i25.BoolDefaultPersist) {
-      return _i25.BoolDefaultPersist.fromJson(data) as T;
-    }
-    if (t == _i26.DateTimeDefault) {
-      return _i26.DateTimeDefault.fromJson(data) as T;
-    }
-    if (t == _i27.DateTimeDefaultMix) {
-      return _i27.DateTimeDefaultMix.fromJson(data) as T;
-    }
-    if (t == _i28.DateTimeDefaultModel) {
-      return _i28.DateTimeDefaultModel.fromJson(data) as T;
-    }
-    if (t == _i29.DateTimeDefaultPersist) {
-      return _i29.DateTimeDefaultPersist.fromJson(data) as T;
-    }
-    if (t == _i30.DoubleDefault) {
-      return _i30.DoubleDefault.fromJson(data) as T;
-    }
-    if (t == _i31.DoubleDefaultMix) {
-      return _i31.DoubleDefaultMix.fromJson(data) as T;
-    }
-    if (t == _i32.DoubleDefaultModel) {
-      return _i32.DoubleDefaultModel.fromJson(data) as T;
-    }
-    if (t == _i33.DoubleDefaultPersist) {
-      return _i33.DoubleDefaultPersist.fromJson(data) as T;
-    }
-    if (t == _i34.DurationDefault) {
-      return _i34.DurationDefault.fromJson(data) as T;
-    }
-    if (t == _i35.DurationDefaultMix) {
-      return _i35.DurationDefaultMix.fromJson(data) as T;
-    }
-    if (t == _i36.DurationDefaultModel) {
-      return _i36.DurationDefaultModel.fromJson(data) as T;
-    }
-    if (t == _i37.DurationDefaultPersist) {
-      return _i37.DurationDefaultPersist.fromJson(data) as T;
-    }
-    if (t == _i38.EnumDefault) {
-      return _i38.EnumDefault.fromJson(data) as T;
-    }
-    if (t == _i39.EnumDefaultMix) {
-      return _i39.EnumDefaultMix.fromJson(data) as T;
-    }
-    if (t == _i40.EnumDefaultModel) {
-      return _i40.EnumDefaultModel.fromJson(data) as T;
-    }
-    if (t == _i41.EnumDefaultPersist) {
-      return _i41.EnumDefaultPersist.fromJson(data) as T;
-    }
-    if (t == _i42.ByIndexEnum) {
-      return _i42.ByIndexEnum.fromJson(data) as T;
-    }
-    if (t == _i43.ByNameEnum) {
-      return _i43.ByNameEnum.fromJson(data) as T;
-    }
-    if (t == _i44.DefaultValueEnum) {
-      return _i44.DefaultValueEnum.fromJson(data) as T;
-    }
-    if (t == _i45.DefaultException) {
-      return _i45.DefaultException.fromJson(data) as T;
-    }
-    if (t == _i46.IntDefault) {
-      return _i46.IntDefault.fromJson(data) as T;
-    }
-    if (t == _i47.IntDefaultMix) {
-      return _i47.IntDefaultMix.fromJson(data) as T;
-    }
-    if (t == _i48.IntDefaultModel) {
-      return _i48.IntDefaultModel.fromJson(data) as T;
-    }
-    if (t == _i49.IntDefaultPersist) {
-      return _i49.IntDefaultPersist.fromJson(data) as T;
-    }
-    if (t == _i50.StringDefault) {
-      return _i50.StringDefault.fromJson(data) as T;
-    }
-    if (t == _i51.StringDefaultMix) {
-      return _i51.StringDefaultMix.fromJson(data) as T;
-    }
-    if (t == _i52.StringDefaultModel) {
-      return _i52.StringDefaultModel.fromJson(data) as T;
-    }
-    if (t == _i53.StringDefaultPersist) {
-      return _i53.StringDefaultPersist.fromJson(data) as T;
-    }
-    if (t == _i54.UriDefault) {
-      return _i54.UriDefault.fromJson(data) as T;
-    }
-    if (t == _i55.UriDefaultMix) {
-      return _i55.UriDefaultMix.fromJson(data) as T;
-    }
-    if (t == _i56.UriDefaultModel) {
-      return _i56.UriDefaultModel.fromJson(data) as T;
-    }
-    if (t == _i57.UriDefaultPersist) {
-      return _i57.UriDefaultPersist.fromJson(data) as T;
-    }
-    if (t == _i58.UuidDefault) {
-      return _i58.UuidDefault.fromJson(data) as T;
-    }
-    if (t == _i59.UuidDefaultMix) {
-      return _i59.UuidDefaultMix.fromJson(data) as T;
-    }
-    if (t == _i60.UuidDefaultModel) {
-      return _i60.UuidDefaultModel.fromJson(data) as T;
-    }
-    if (t == _i61.UuidDefaultPersist) {
-      return _i61.UuidDefaultPersist.fromJson(data) as T;
-    }
-    if (t == _i62.EmptyModel) {
-      return _i62.EmptyModel.fromJson(data) as T;
-    }
-    if (t == _i63.EmptyModelRelationItem) {
-      return _i63.EmptyModelRelationItem.fromJson(data) as T;
-    }
-    if (t == _i64.EmptyModelWithTable) {
-      return _i64.EmptyModelWithTable.fromJson(data) as T;
-    }
-    if (t == _i65.RelationEmptyModel) {
-      return _i65.RelationEmptyModel.fromJson(data) as T;
-    }
-    if (t == _i66.ExceptionWithData) {
-      return _i66.ExceptionWithData.fromJson(data) as T;
-    }
-    if (t == _i67.ChildClassExplicitColumn) {
-      return _i67.ChildClassExplicitColumn.fromJson(data) as T;
-    }
-    if (t == _i68.NonTableParentClass) {
-      return _i68.NonTableParentClass.fromJson(data) as T;
-    }
-    if (t == _i69.ModifiedColumnName) {
-      return _i69.ModifiedColumnName.fromJson(data) as T;
-    }
-    if (t == _i70.Department) {
-      return _i70.Department.fromJson(data) as T;
-    }
-    if (t == _i71.Employee) {
-      return _i71.Employee.fromJson(data) as T;
-    }
-    if (t == _i72.Contractor) {
-      return _i72.Contractor.fromJson(data) as T;
-    }
-    if (t == _i73.Service) {
-      return _i73.Service.fromJson(data) as T;
-    }
-    if (t == _i74.TableWithExplicitColumnName) {
-      return _i74.TableWithExplicitColumnName.fromJson(data) as T;
-    }
-    if (t == _i75.ImmutableChildObject) {
-      return _i75.ImmutableChildObject.fromJson(data) as T;
-    }
-    if (t == _i76.ImmutableChildObjectWithNoAdditionalFields) {
-      return _i76.ImmutableChildObjectWithNoAdditionalFields.fromJson(data)
-          as T;
-    }
-    if (t == _i77.ImmutableObject) {
-      return _i77.ImmutableObject.fromJson(data) as T;
-    }
-    if (t == _i78.ImmutableObjectWithImmutableObject) {
-      return _i78.ImmutableObjectWithImmutableObject.fromJson(data) as T;
-    }
-    if (t == _i79.ImmutableObjectWithList) {
-      return _i79.ImmutableObjectWithList.fromJson(data) as T;
-    }
-    if (t == _i80.ImmutableObjectWithMap) {
-      return _i80.ImmutableObjectWithMap.fromJson(data) as T;
-    }
-    if (t == _i81.ImmutableObjectWithMultipleFields) {
-      return _i81.ImmutableObjectWithMultipleFields.fromJson(data) as T;
-    }
-    if (t == _i82.ImmutableObjectWithNoFields) {
-      return _i82.ImmutableObjectWithNoFields.fromJson(data) as T;
-    }
-    if (t == _i83.ImmutableObjectWithRecord) {
-      return _i83.ImmutableObjectWithRecord.fromJson(data) as T;
-    }
-    if (t == _i84.ImmutableObjectWithTable) {
-      return _i84.ImmutableObjectWithTable.fromJson(data) as T;
-    }
-    if (t == _i85.ImmutableObjectWithTwentyFields) {
-      return _i85.ImmutableObjectWithTwentyFields.fromJson(data) as T;
-    }
-    if (t == _i86.ChildClass) {
-      return _i86.ChildClass.fromJson(data) as T;
-    }
-    if (t == _i87.ChildWithDefault) {
-      return _i87.ChildWithDefault.fromJson(data) as T;
-    }
-    if (t == _i88.ChildClassWithoutId) {
-      return _i88.ChildClassWithoutId.fromJson(data) as T;
-    }
-    if (t == _i89.ParentClass) {
-      return _i89.ParentClass.fromJson(data) as T;
-    }
-    if (t == _i90.GrandparentClass) {
-      return _i90.GrandparentClass.fromJson(data) as T;
-    }
-    if (t == _i91.ParentClassWithoutId) {
-      return _i91.ParentClassWithoutId.fromJson(data) as T;
-    }
-    if (t == _i92.GrandparentClassWithId) {
-      return _i92.GrandparentClassWithId.fromJson(data) as T;
-    }
-    if (t == _i93.ChildEntity) {
-      return _i93.ChildEntity.fromJson(data) as T;
-    }
-    if (t == _i94.BaseEntity) {
-      return _i94.BaseEntity.fromJson(data) as T;
-    }
-    if (t == _i95.ParentEntity) {
-      return _i95.ParentEntity.fromJson(data) as T;
-    }
-    if (t == _i96.NonServerOnlyParentClass) {
-      return _i96.NonServerOnlyParentClass.fromJson(data) as T;
-    }
-    if (t == _i97.ParentWithDefault) {
-      return _i97.ParentWithDefault.fromJson(data) as T;
-    }
-    if (t == _i98.PolymorphicGrandChild) {
-      return _i98.PolymorphicGrandChild.fromJson(data) as T;
-    }
-    if (t == _i99.PolymorphicChild) {
-      return _i99.PolymorphicChild.fromJson(data) as T;
-    }
-    if (t == _i100.PolymorphicChildContainer) {
-      return _i100.PolymorphicChildContainer.fromJson(data) as T;
-    }
-    if (t == _i101.ModulePolymorphicChildContainer) {
-      return _i101.ModulePolymorphicChildContainer.fromJson(data) as T;
-    }
-    if (t == _i102.SimilarButNotParent) {
-      return _i102.SimilarButNotParent.fromJson(data) as T;
-    }
-    if (t == _i103.PolymorphicParent) {
-      return _i103.PolymorphicParent.fromJson(data) as T;
-    }
-    if (t == _i104.UnrelatedToPolymorphism) {
-      return _i104.UnrelatedToPolymorphism.fromJson(data) as T;
-    }
-    if (t == _i105.SealedGrandChild) {
-      return _i105.SealedGrandChild.fromJson(data) as T;
-    }
-    if (t == _i105.SealedChild) {
-      return _i105.SealedChild.fromJson(data) as T;
-    }
-    if (t == _i106.SealedChildOnlyRequired) {
-      return _i106.SealedChildOnlyRequired.fromJson(data) as T;
-    }
-    if (t == _i105.SealedOtherChild) {
-      return _i105.SealedOtherChild.fromJson(data) as T;
-    }
-    if (t == _i107.CityWithLongTableName) {
-      return _i107.CityWithLongTableName.fromJson(data) as T;
-    }
-    if (t == _i108.OrganizationWithLongTableName) {
-      return _i108.OrganizationWithLongTableName.fromJson(data) as T;
-    }
-    if (t == _i109.PersonWithLongTableName) {
-      return _i109.PersonWithLongTableName.fromJson(data) as T;
-    }
-    if (t == _i110.MaxFieldName) {
-      return _i110.MaxFieldName.fromJson(data) as T;
-    }
-    if (t == _i111.LongImplicitIdField) {
-      return _i111.LongImplicitIdField.fromJson(data) as T;
-    }
-    if (t == _i112.LongImplicitIdFieldCollection) {
-      return _i112.LongImplicitIdFieldCollection.fromJson(data) as T;
-    }
-    if (t == _i113.RelationToMultipleMaxFieldName) {
-      return _i113.RelationToMultipleMaxFieldName.fromJson(data) as T;
-    }
-    if (t == _i114.UserNote) {
-      return _i114.UserNote.fromJson(data) as T;
-    }
-    if (t == _i115.UserNoteCollection) {
-      return _i115.UserNoteCollection.fromJson(data) as T;
-    }
-    if (t == _i116.UserNoteCollectionWithALongName) {
-      return _i116.UserNoteCollectionWithALongName.fromJson(data) as T;
-    }
-    if (t == _i117.UserNoteWithALongName) {
-      return _i117.UserNoteWithALongName.fromJson(data) as T;
-    }
-    if (t == _i118.MultipleMaxFieldName) {
-      return _i118.MultipleMaxFieldName.fromJson(data) as T;
-    }
-    if (t == _i119.City) {
-      return _i119.City.fromJson(data) as T;
-    }
-    if (t == _i120.Organization) {
-      return _i120.Organization.fromJson(data) as T;
-    }
-    if (t == _i121.Person) {
-      return _i121.Person.fromJson(data) as T;
-    }
-    if (t == _i122.Course) {
-      return _i122.Course.fromJson(data) as T;
-    }
-    if (t == _i123.Enrollment) {
-      return _i123.Enrollment.fromJson(data) as T;
-    }
-    if (t == _i124.Student) {
-      return _i124.Student.fromJson(data) as T;
-    }
-    if (t == _i125.ObjectUser) {
-      return _i125.ObjectUser.fromJson(data) as T;
-    }
-    if (t == _i126.ParentUser) {
-      return _i126.ParentUser.fromJson(data) as T;
-    }
-    if (t == _i127.Arena) {
-      return _i127.Arena.fromJson(data) as T;
-    }
-    if (t == _i128.Player) {
-      return _i128.Player.fromJson(data) as T;
-    }
-    if (t == _i129.Team) {
-      return _i129.Team.fromJson(data) as T;
-    }
-    if (t == _i130.Comment) {
-      return _i130.Comment.fromJson(data) as T;
-    }
-    if (t == _i131.Customer) {
-      return _i131.Customer.fromJson(data) as T;
-    }
-    if (t == _i132.Book) {
-      return _i132.Book.fromJson(data) as T;
-    }
-    if (t == _i133.Chapter) {
-      return _i133.Chapter.fromJson(data) as T;
-    }
-    if (t == _i134.Order) {
-      return _i134.Order.fromJson(data) as T;
-    }
-    if (t == _i135.Address) {
-      return _i135.Address.fromJson(data) as T;
-    }
-    if (t == _i136.Citizen) {
-      return _i136.Citizen.fromJson(data) as T;
-    }
-    if (t == _i137.Company) {
-      return _i137.Company.fromJson(data) as T;
-    }
-    if (t == _i138.Town) {
-      return _i138.Town.fromJson(data) as T;
-    }
-    if (t == _i139.Blocking) {
-      return _i139.Blocking.fromJson(data) as T;
-    }
-    if (t == _i140.Member) {
-      return _i140.Member.fromJson(data) as T;
-    }
-    if (t == _i141.Cat) {
-      return _i141.Cat.fromJson(data) as T;
-    }
-    if (t == _i142.Post) {
-      return _i142.Post.fromJson(data) as T;
-    }
-    if (t == _i143.ModuleDatatype) {
-      return _i143.ModuleDatatype.fromJson(data) as T;
-    }
-    if (t == _i144.MyFeatureModel) {
-      return _i144.MyFeatureModel.fromJson(data) as T;
-    }
-    if (t == _i145.MyTriggerType) {
-      return _i145.MyTriggerType.fromJson(data) as T;
-    }
-    if (t == _i146.Nullability) {
-      return _i146.Nullability.fromJson(data) as T;
-    }
-    if (t == _i147.ObjectFieldPersist) {
-      return _i147.ObjectFieldPersist.fromJson(data) as T;
-    }
-    if (t == _i148.ObjectFieldScopes) {
-      return _i148.ObjectFieldScopes.fromJson(data) as T;
-    }
-    if (t == _i149.ObjectWithBit) {
-      return _i149.ObjectWithBit.fromJson(data) as T;
-    }
-    if (t == _i150.ObjectWithByteData) {
-      return _i150.ObjectWithByteData.fromJson(data) as T;
-    }
-    if (t == _i151.ObjectWithCustomClass) {
-      return _i151.ObjectWithCustomClass.fromJson(data) as T;
-    }
-    if (t == _i152.ObjectWithDuration) {
-      return _i152.ObjectWithDuration.fromJson(data) as T;
-    }
-    if (t == _i153.ObjectWithDynamic) {
-      return _i153.ObjectWithDynamic.fromJson(data) as T;
-    }
-    if (t == _i154.ObjectWithEnum) {
-      return _i154.ObjectWithEnum.fromJson(data) as T;
-    }
-    if (t == _i155.ObjectWithEnumEnhanced) {
-      return _i155.ObjectWithEnumEnhanced.fromJson(data) as T;
-    }
-    if (t == _i156.ObjectWithHalfVector) {
-      return _i156.ObjectWithHalfVector.fromJson(data) as T;
-    }
-    if (t == _i157.ObjectWithIndex) {
-      return _i157.ObjectWithIndex.fromJson(data) as T;
-    }
-    if (t == _i158.ObjectWithJsonb) {
-      return _i158.ObjectWithJsonb.fromJson(data) as T;
-    }
-    if (t == _i159.ObjectWithJsonbClassLevel) {
-      return _i159.ObjectWithJsonbClassLevel.fromJson(data) as T;
-    }
-    if (t == _i160.ObjectWithMaps) {
-      return _i160.ObjectWithMaps.fromJson(data) as T;
-    }
-    if (t == _i161.ObjectWithNullableCustomClass) {
-      return _i161.ObjectWithNullableCustomClass.fromJson(data) as T;
-    }
-    if (t == _i162.ObjectWithObject) {
-      return _i162.ObjectWithObject.fromJson(data) as T;
-    }
-    if (t == _i163.ObjectWithParent) {
-      return _i163.ObjectWithParent.fromJson(data) as T;
-    }
-    if (t == _i164.ObjectWithSealedClass) {
-      return _i164.ObjectWithSealedClass.fromJson(data) as T;
-    }
-    if (t == _i165.ObjectWithSelfParent) {
-      return _i165.ObjectWithSelfParent.fromJson(data) as T;
-    }
-    if (t == _i166.ObjectWithSparseVector) {
-      return _i166.ObjectWithSparseVector.fromJson(data) as T;
-    }
-    if (t == _i167.ObjectWithUuid) {
-      return _i167.ObjectWithUuid.fromJson(data) as T;
-    }
-    if (t == _i168.ObjectWithVector) {
-      return _i168.ObjectWithVector.fromJson(data) as T;
-    }
-    if (t == _i169.Record) {
-      return _i169.Record.fromJson(data) as T;
-    }
-    if (t == _i170.RelatedUniqueData) {
-      return _i170.RelatedUniqueData.fromJson(data) as T;
-    }
-    if (t == _i171.ExceptionWithRequiredField) {
-      return _i171.ExceptionWithRequiredField.fromJson(data) as T;
-    }
-    if (t == _i172.ModelWithRequiredField) {
-      return _i172.ModelWithRequiredField.fromJson(data) as T;
-    }
-    if (t == _i173.ScopeNoneFields) {
-      return _i173.ScopeNoneFields.fromJson(data) as T;
-    }
-    if (t == _i174.ScopeServerOnlyFieldChild) {
-      return _i174.ScopeServerOnlyFieldChild.fromJson(data) as T;
-    }
-    if (t == _i175.ScopeServerOnlyField) {
-      return _i175.ScopeServerOnlyField.fromJson(data) as T;
-    }
-    if (t == _i176.DefaultServerOnlyClass) {
-      return _i176.DefaultServerOnlyClass.fromJson(data) as T;
-    }
-    if (t == _i177.DefaultServerOnlyEnum) {
-      return _i177.DefaultServerOnlyEnum.fromJson(data) as T;
-    }
-    if (t == _i178.NotServerOnlyClass) {
-      return _i178.NotServerOnlyClass.fromJson(data) as T;
-    }
-    if (t == _i179.NotServerOnlyEnum) {
-      return _i179.NotServerOnlyEnum.fromJson(data) as T;
-    }
-    if (t == _i180.ServerOnlyClassField) {
-      return _i180.ServerOnlyClassField.fromJson(data) as T;
-    }
-    if (t == _i181.ServerOnlyDefault) {
-      return _i181.ServerOnlyDefault.fromJson(data) as T;
-    }
-    if (t == _i182.SessionAuthInfo) {
-      return _i182.SessionAuthInfo.fromJson(data) as T;
-    }
-    if (t == _i183.SharedModelContainer) {
-      return _i183.SharedModelContainer.fromJson(data) as T;
-    }
-    if (t == _i184.SharedModelSubclass) {
-      return _i184.SharedModelSubclass.fromJson(data) as T;
-    }
-    if (t == _i185.SimpleData) {
-      return _i185.SimpleData.fromJson(data) as T;
-    }
-    if (t == _i186.SimpleDataList) {
-      return _i186.SimpleDataList.fromJson(data) as T;
-    }
-    if (t == _i187.SimpleDataMap) {
-      return _i187.SimpleDataMap.fromJson(data) as T;
-    }
-    if (t == _i188.SimpleDataObject) {
-      return _i188.SimpleDataObject.fromJson(data) as T;
-    }
-    if (t == _i189.SimpleDateTime) {
-      return _i189.SimpleDateTime.fromJson(data) as T;
-    }
-    if (t == _i190.ModelInSubfolder) {
-      return _i190.ModelInSubfolder.fromJson(data) as T;
-    }
-    if (t == _i191.TestEnum) {
-      return _i191.TestEnum.fromJson(data) as T;
-    }
-    if (t == _i192.TestEnumDefaultSerialization) {
-      return _i192.TestEnumDefaultSerialization.fromJson(data) as T;
-    }
-    if (t == _i193.TestEnumEnhanced) {
-      return _i193.TestEnumEnhanced.fromJson(data) as T;
-    }
-    if (t == _i194.TestEnumEnhancedByName) {
-      return _i194.TestEnumEnhancedByName.fromJson(data) as T;
-    }
-    if (t == _i195.TestEnumStringified) {
-      return _i195.TestEnumStringified.fromJson(data) as T;
-    }
-    if (t == _i196.Types) {
-      return _i196.Types.fromJson(data) as T;
-    }
-    if (t == _i197.TypesList) {
-      return _i197.TypesList.fromJson(data) as T;
-    }
-    if (t == _i198.TypesMap) {
-      return _i198.TypesMap.fromJson(data) as T;
-    }
-    if (t == _i199.TypesRecord) {
-      return _i199.TypesRecord.fromJson(data) as T;
-    }
-    if (t == _i200.TypesSet) {
-      return _i200.TypesSet.fromJson(data) as T;
-    }
-    if (t == _i201.TypesSetRequired) {
-      return _i201.TypesSetRequired.fromJson(data) as T;
-    }
-    if (t == _i202.UniqueData) {
-      return _i202.UniqueData.fromJson(data) as T;
-    }
-    if (t == _i203.UniqueDataWithNonPersist) {
-      return _i203.UniqueDataWithNonPersist.fromJson(data) as T;
-    }
-    if (t == _i204.UpsertTestModel) {
-      return _i204.UpsertTestModel.fromJson(data) as T;
-    }
-    if (t == _i1.getType<_i2.ByIndexEnumWithNameValue?>()) {
-      return (data != null ? _i2.ByIndexEnumWithNameValue.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i3.ByNameEnumWithNameValue?>()) {
-      return (data != null ? _i3.ByNameEnumWithNameValue.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i4.CourseUuid?>()) {
-      return (data != null ? _i4.CourseUuid.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i5.EnrollmentInt?>()) {
-      return (data != null ? _i5.EnrollmentInt.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i6.StudentUuid?>()) {
-      return (data != null ? _i6.StudentUuid.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i7.ArenaUuid?>()) {
-      return (data != null ? _i7.ArenaUuid.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i8.PlayerUuid?>()) {
-      return (data != null ? _i8.PlayerUuid.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i9.TeamInt?>()) {
-      return (data != null ? _i9.TeamInt.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i10.CommentInt?>()) {
-      return (data != null ? _i10.CommentInt.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i11.CustomerInt?>()) {
-      return (data != null ? _i11.CustomerInt.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i12.OrderUuid?>()) {
-      return (data != null ? _i12.OrderUuid.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i13.AddressUuid?>()) {
-      return (data != null ? _i13.AddressUuid.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i14.CitizenInt?>()) {
-      return (data != null ? _i14.CitizenInt.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i15.CompanyUuid?>()) {
-      return (data != null ? _i15.CompanyUuid.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i16.TownInt?>()) {
-      return (data != null ? _i16.TownInt.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i17.ChangedIdTypeSelf?>()) {
-      return (data != null ? _i17.ChangedIdTypeSelf.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i18.BigIntDefault?>()) {
-      return (data != null ? _i18.BigIntDefault.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i19.BigIntDefaultMix?>()) {
-      return (data != null ? _i19.BigIntDefaultMix.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i20.BigIntDefaultModel?>()) {
-      return (data != null ? _i20.BigIntDefaultModel.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i21.BigIntDefaultPersist?>()) {
-      return (data != null ? _i21.BigIntDefaultPersist.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i22.BoolDefault?>()) {
-      return (data != null ? _i22.BoolDefault.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i23.BoolDefaultMix?>()) {
-      return (data != null ? _i23.BoolDefaultMix.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i24.BoolDefaultModel?>()) {
-      return (data != null ? _i24.BoolDefaultModel.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i25.BoolDefaultPersist?>()) {
-      return (data != null ? _i25.BoolDefaultPersist.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i26.DateTimeDefault?>()) {
-      return (data != null ? _i26.DateTimeDefault.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i27.DateTimeDefaultMix?>()) {
-      return (data != null ? _i27.DateTimeDefaultMix.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i28.DateTimeDefaultModel?>()) {
-      return (data != null ? _i28.DateTimeDefaultModel.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i29.DateTimeDefaultPersist?>()) {
-      return (data != null ? _i29.DateTimeDefaultPersist.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i30.DoubleDefault?>()) {
-      return (data != null ? _i30.DoubleDefault.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i31.DoubleDefaultMix?>()) {
-      return (data != null ? _i31.DoubleDefaultMix.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i32.DoubleDefaultModel?>()) {
-      return (data != null ? _i32.DoubleDefaultModel.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i33.DoubleDefaultPersist?>()) {
-      return (data != null ? _i33.DoubleDefaultPersist.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i34.DurationDefault?>()) {
-      return (data != null ? _i34.DurationDefault.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i35.DurationDefaultMix?>()) {
-      return (data != null ? _i35.DurationDefaultMix.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i36.DurationDefaultModel?>()) {
-      return (data != null ? _i36.DurationDefaultModel.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i37.DurationDefaultPersist?>()) {
-      return (data != null ? _i37.DurationDefaultPersist.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i38.EnumDefault?>()) {
-      return (data != null ? _i38.EnumDefault.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i39.EnumDefaultMix?>()) {
-      return (data != null ? _i39.EnumDefaultMix.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i40.EnumDefaultModel?>()) {
-      return (data != null ? _i40.EnumDefaultModel.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i41.EnumDefaultPersist?>()) {
-      return (data != null ? _i41.EnumDefaultPersist.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i42.ByIndexEnum?>()) {
-      return (data != null ? _i42.ByIndexEnum.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i43.ByNameEnum?>()) {
-      return (data != null ? _i43.ByNameEnum.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i44.DefaultValueEnum?>()) {
-      return (data != null ? _i44.DefaultValueEnum.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i45.DefaultException?>()) {
-      return (data != null ? _i45.DefaultException.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i46.IntDefault?>()) {
-      return (data != null ? _i46.IntDefault.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i47.IntDefaultMix?>()) {
-      return (data != null ? _i47.IntDefaultMix.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i48.IntDefaultModel?>()) {
-      return (data != null ? _i48.IntDefaultModel.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i49.IntDefaultPersist?>()) {
-      return (data != null ? _i49.IntDefaultPersist.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i50.StringDefault?>()) {
-      return (data != null ? _i50.StringDefault.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i51.StringDefaultMix?>()) {
-      return (data != null ? _i51.StringDefaultMix.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i52.StringDefaultModel?>()) {
-      return (data != null ? _i52.StringDefaultModel.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i53.StringDefaultPersist?>()) {
-      return (data != null ? _i53.StringDefaultPersist.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i54.UriDefault?>()) {
-      return (data != null ? _i54.UriDefault.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i55.UriDefaultMix?>()) {
-      return (data != null ? _i55.UriDefaultMix.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i56.UriDefaultModel?>()) {
-      return (data != null ? _i56.UriDefaultModel.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i57.UriDefaultPersist?>()) {
-      return (data != null ? _i57.UriDefaultPersist.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i58.UuidDefault?>()) {
-      return (data != null ? _i58.UuidDefault.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i59.UuidDefaultMix?>()) {
-      return (data != null ? _i59.UuidDefaultMix.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i60.UuidDefaultModel?>()) {
-      return (data != null ? _i60.UuidDefaultModel.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i61.UuidDefaultPersist?>()) {
-      return (data != null ? _i61.UuidDefaultPersist.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i62.EmptyModel?>()) {
-      return (data != null ? _i62.EmptyModel.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i63.EmptyModelRelationItem?>()) {
-      return (data != null ? _i63.EmptyModelRelationItem.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i64.EmptyModelWithTable?>()) {
-      return (data != null ? _i64.EmptyModelWithTable.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i65.RelationEmptyModel?>()) {
-      return (data != null ? _i65.RelationEmptyModel.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i66.ExceptionWithData?>()) {
-      return (data != null ? _i66.ExceptionWithData.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i67.ChildClassExplicitColumn?>()) {
-      return (data != null
-              ? _i67.ChildClassExplicitColumn.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i68.NonTableParentClass?>()) {
-      return (data != null ? _i68.NonTableParentClass.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i69.ModifiedColumnName?>()) {
-      return (data != null ? _i69.ModifiedColumnName.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i70.Department?>()) {
-      return (data != null ? _i70.Department.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i71.Employee?>()) {
-      return (data != null ? _i71.Employee.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i72.Contractor?>()) {
-      return (data != null ? _i72.Contractor.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i73.Service?>()) {
-      return (data != null ? _i73.Service.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i74.TableWithExplicitColumnName?>()) {
-      return (data != null
-              ? _i74.TableWithExplicitColumnName.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i75.ImmutableChildObject?>()) {
-      return (data != null ? _i75.ImmutableChildObject.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i76.ImmutableChildObjectWithNoAdditionalFields?>()) {
-      return (data != null
-              ? _i76.ImmutableChildObjectWithNoAdditionalFields.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i77.ImmutableObject?>()) {
-      return (data != null ? _i77.ImmutableObject.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i78.ImmutableObjectWithImmutableObject?>()) {
-      return (data != null
-              ? _i78.ImmutableObjectWithImmutableObject.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i79.ImmutableObjectWithList?>()) {
-      return (data != null ? _i79.ImmutableObjectWithList.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i80.ImmutableObjectWithMap?>()) {
-      return (data != null ? _i80.ImmutableObjectWithMap.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i81.ImmutableObjectWithMultipleFields?>()) {
-      return (data != null
-              ? _i81.ImmutableObjectWithMultipleFields.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i82.ImmutableObjectWithNoFields?>()) {
-      return (data != null
-              ? _i82.ImmutableObjectWithNoFields.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i83.ImmutableObjectWithRecord?>()) {
-      return (data != null
-              ? _i83.ImmutableObjectWithRecord.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i84.ImmutableObjectWithTable?>()) {
-      return (data != null
-              ? _i84.ImmutableObjectWithTable.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i85.ImmutableObjectWithTwentyFields?>()) {
-      return (data != null
-              ? _i85.ImmutableObjectWithTwentyFields.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i86.ChildClass?>()) {
-      return (data != null ? _i86.ChildClass.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i87.ChildWithDefault?>()) {
-      return (data != null ? _i87.ChildWithDefault.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i88.ChildClassWithoutId?>()) {
-      return (data != null ? _i88.ChildClassWithoutId.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i89.ParentClass?>()) {
-      return (data != null ? _i89.ParentClass.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i90.GrandparentClass?>()) {
-      return (data != null ? _i90.GrandparentClass.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i91.ParentClassWithoutId?>()) {
-      return (data != null ? _i91.ParentClassWithoutId.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i92.GrandparentClassWithId?>()) {
-      return (data != null ? _i92.GrandparentClassWithId.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i93.ChildEntity?>()) {
-      return (data != null ? _i93.ChildEntity.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i94.BaseEntity?>()) {
-      return (data != null ? _i94.BaseEntity.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i95.ParentEntity?>()) {
-      return (data != null ? _i95.ParentEntity.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i96.NonServerOnlyParentClass?>()) {
-      return (data != null
-              ? _i96.NonServerOnlyParentClass.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i97.ParentWithDefault?>()) {
-      return (data != null ? _i97.ParentWithDefault.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i98.PolymorphicGrandChild?>()) {
-      return (data != null ? _i98.PolymorphicGrandChild.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i99.PolymorphicChild?>()) {
-      return (data != null ? _i99.PolymorphicChild.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i100.PolymorphicChildContainer?>()) {
-      return (data != null
-              ? _i100.PolymorphicChildContainer.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i101.ModulePolymorphicChildContainer?>()) {
-      return (data != null
-              ? _i101.ModulePolymorphicChildContainer.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i102.SimilarButNotParent?>()) {
-      return (data != null ? _i102.SimilarButNotParent.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i103.PolymorphicParent?>()) {
-      return (data != null ? _i103.PolymorphicParent.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i104.UnrelatedToPolymorphism?>()) {
-      return (data != null
-              ? _i104.UnrelatedToPolymorphism.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i105.SealedGrandChild?>()) {
-      return (data != null ? _i105.SealedGrandChild.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i105.SealedChild?>()) {
-      return (data != null ? _i105.SealedChild.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i106.SealedChildOnlyRequired?>()) {
-      return (data != null
-              ? _i106.SealedChildOnlyRequired.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i105.SealedOtherChild?>()) {
-      return (data != null ? _i105.SealedOtherChild.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i107.CityWithLongTableName?>()) {
-      return (data != null ? _i107.CityWithLongTableName.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i108.OrganizationWithLongTableName?>()) {
-      return (data != null
-              ? _i108.OrganizationWithLongTableName.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i109.PersonWithLongTableName?>()) {
-      return (data != null
-              ? _i109.PersonWithLongTableName.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i110.MaxFieldName?>()) {
-      return (data != null ? _i110.MaxFieldName.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i111.LongImplicitIdField?>()) {
-      return (data != null ? _i111.LongImplicitIdField.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i112.LongImplicitIdFieldCollection?>()) {
-      return (data != null
-              ? _i112.LongImplicitIdFieldCollection.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i113.RelationToMultipleMaxFieldName?>()) {
-      return (data != null
-              ? _i113.RelationToMultipleMaxFieldName.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i114.UserNote?>()) {
-      return (data != null ? _i114.UserNote.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i115.UserNoteCollection?>()) {
-      return (data != null ? _i115.UserNoteCollection.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i116.UserNoteCollectionWithALongName?>()) {
-      return (data != null
-              ? _i116.UserNoteCollectionWithALongName.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i117.UserNoteWithALongName?>()) {
-      return (data != null ? _i117.UserNoteWithALongName.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i118.MultipleMaxFieldName?>()) {
-      return (data != null ? _i118.MultipleMaxFieldName.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i119.City?>()) {
-      return (data != null ? _i119.City.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i120.Organization?>()) {
-      return (data != null ? _i120.Organization.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i121.Person?>()) {
-      return (data != null ? _i121.Person.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i122.Course?>()) {
-      return (data != null ? _i122.Course.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i123.Enrollment?>()) {
-      return (data != null ? _i123.Enrollment.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i124.Student?>()) {
-      return (data != null ? _i124.Student.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i125.ObjectUser?>()) {
-      return (data != null ? _i125.ObjectUser.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i126.ParentUser?>()) {
-      return (data != null ? _i126.ParentUser.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i127.Arena?>()) {
-      return (data != null ? _i127.Arena.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i128.Player?>()) {
-      return (data != null ? _i128.Player.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i129.Team?>()) {
-      return (data != null ? _i129.Team.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i130.Comment?>()) {
-      return (data != null ? _i130.Comment.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i131.Customer?>()) {
-      return (data != null ? _i131.Customer.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i132.Book?>()) {
-      return (data != null ? _i132.Book.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i133.Chapter?>()) {
-      return (data != null ? _i133.Chapter.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i134.Order?>()) {
-      return (data != null ? _i134.Order.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i135.Address?>()) {
-      return (data != null ? _i135.Address.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i136.Citizen?>()) {
-      return (data != null ? _i136.Citizen.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i137.Company?>()) {
-      return (data != null ? _i137.Company.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i138.Town?>()) {
-      return (data != null ? _i138.Town.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i139.Blocking?>()) {
-      return (data != null ? _i139.Blocking.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i140.Member?>()) {
-      return (data != null ? _i140.Member.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i141.Cat?>()) {
-      return (data != null ? _i141.Cat.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i142.Post?>()) {
-      return (data != null ? _i142.Post.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i143.ModuleDatatype?>()) {
-      return (data != null ? _i143.ModuleDatatype.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i144.MyFeatureModel?>()) {
-      return (data != null ? _i144.MyFeatureModel.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i145.MyTriggerType?>()) {
-      return (data != null ? _i145.MyTriggerType.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i146.Nullability?>()) {
-      return (data != null ? _i146.Nullability.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i147.ObjectFieldPersist?>()) {
-      return (data != null ? _i147.ObjectFieldPersist.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i148.ObjectFieldScopes?>()) {
-      return (data != null ? _i148.ObjectFieldScopes.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i149.ObjectWithBit?>()) {
-      return (data != null ? _i149.ObjectWithBit.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i150.ObjectWithByteData?>()) {
-      return (data != null ? _i150.ObjectWithByteData.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i151.ObjectWithCustomClass?>()) {
-      return (data != null ? _i151.ObjectWithCustomClass.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i152.ObjectWithDuration?>()) {
-      return (data != null ? _i152.ObjectWithDuration.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i153.ObjectWithDynamic?>()) {
-      return (data != null ? _i153.ObjectWithDynamic.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i154.ObjectWithEnum?>()) {
-      return (data != null ? _i154.ObjectWithEnum.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i155.ObjectWithEnumEnhanced?>()) {
-      return (data != null ? _i155.ObjectWithEnumEnhanced.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i156.ObjectWithHalfVector?>()) {
-      return (data != null ? _i156.ObjectWithHalfVector.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i157.ObjectWithIndex?>()) {
-      return (data != null ? _i157.ObjectWithIndex.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i158.ObjectWithJsonb?>()) {
-      return (data != null ? _i158.ObjectWithJsonb.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i159.ObjectWithJsonbClassLevel?>()) {
-      return (data != null
-              ? _i159.ObjectWithJsonbClassLevel.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i160.ObjectWithMaps?>()) {
-      return (data != null ? _i160.ObjectWithMaps.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i161.ObjectWithNullableCustomClass?>()) {
-      return (data != null
-              ? _i161.ObjectWithNullableCustomClass.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i162.ObjectWithObject?>()) {
-      return (data != null ? _i162.ObjectWithObject.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i163.ObjectWithParent?>()) {
-      return (data != null ? _i163.ObjectWithParent.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i164.ObjectWithSealedClass?>()) {
-      return (data != null ? _i164.ObjectWithSealedClass.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i165.ObjectWithSelfParent?>()) {
-      return (data != null ? _i165.ObjectWithSelfParent.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i166.ObjectWithSparseVector?>()) {
-      return (data != null ? _i166.ObjectWithSparseVector.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i167.ObjectWithUuid?>()) {
-      return (data != null ? _i167.ObjectWithUuid.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i168.ObjectWithVector?>()) {
-      return (data != null ? _i168.ObjectWithVector.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i169.Record?>()) {
-      return (data != null ? _i169.Record.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i170.RelatedUniqueData?>()) {
-      return (data != null ? _i170.RelatedUniqueData.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i171.ExceptionWithRequiredField?>()) {
-      return (data != null
-              ? _i171.ExceptionWithRequiredField.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i172.ModelWithRequiredField?>()) {
-      return (data != null ? _i172.ModelWithRequiredField.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i173.ScopeNoneFields?>()) {
-      return (data != null ? _i173.ScopeNoneFields.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i174.ScopeServerOnlyFieldChild?>()) {
-      return (data != null
-              ? _i174.ScopeServerOnlyFieldChild.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i175.ScopeServerOnlyField?>()) {
-      return (data != null ? _i175.ScopeServerOnlyField.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i176.DefaultServerOnlyClass?>()) {
-      return (data != null ? _i176.DefaultServerOnlyClass.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i177.DefaultServerOnlyEnum?>()) {
-      return (data != null ? _i177.DefaultServerOnlyEnum.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i178.NotServerOnlyClass?>()) {
-      return (data != null ? _i178.NotServerOnlyClass.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i179.NotServerOnlyEnum?>()) {
-      return (data != null ? _i179.NotServerOnlyEnum.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i180.ServerOnlyClassField?>()) {
-      return (data != null ? _i180.ServerOnlyClassField.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i181.ServerOnlyDefault?>()) {
-      return (data != null ? _i181.ServerOnlyDefault.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i182.SessionAuthInfo?>()) {
-      return (data != null ? _i182.SessionAuthInfo.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i183.SharedModelContainer?>()) {
-      return (data != null ? _i183.SharedModelContainer.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i184.SharedModelSubclass?>()) {
-      return (data != null ? _i184.SharedModelSubclass.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i185.SimpleData?>()) {
-      return (data != null ? _i185.SimpleData.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i186.SimpleDataList?>()) {
-      return (data != null ? _i186.SimpleDataList.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i187.SimpleDataMap?>()) {
-      return (data != null ? _i187.SimpleDataMap.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i188.SimpleDataObject?>()) {
-      return (data != null ? _i188.SimpleDataObject.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i189.SimpleDateTime?>()) {
-      return (data != null ? _i189.SimpleDateTime.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i190.ModelInSubfolder?>()) {
-      return (data != null ? _i190.ModelInSubfolder.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i191.TestEnum?>()) {
-      return (data != null ? _i191.TestEnum.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i192.TestEnumDefaultSerialization?>()) {
-      return (data != null
-              ? _i192.TestEnumDefaultSerialization.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i193.TestEnumEnhanced?>()) {
-      return (data != null ? _i193.TestEnumEnhanced.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i194.TestEnumEnhancedByName?>()) {
-      return (data != null ? _i194.TestEnumEnhancedByName.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i195.TestEnumStringified?>()) {
-      return (data != null ? _i195.TestEnumStringified.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i196.Types?>()) {
-      return (data != null ? _i196.Types.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i197.TypesList?>()) {
-      return (data != null ? _i197.TypesList.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i198.TypesMap?>()) {
-      return (data != null ? _i198.TypesMap.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i199.TypesRecord?>()) {
-      return (data != null ? _i199.TypesRecord.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i200.TypesSet?>()) {
-      return (data != null ? _i200.TypesSet.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i201.TypesSetRequired?>()) {
-      return (data != null ? _i201.TypesSetRequired.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i202.UniqueData?>()) {
-      return (data != null ? _i202.UniqueData.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i203.UniqueDataWithNonPersist?>()) {
-      return (data != null
-              ? _i203.UniqueDataWithNonPersist.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i204.UpsertTestModel?>()) {
-      return (data != null ? _i204.UpsertTestModel.fromJson(data) : null) as T;
-    }
-    if (t == List<_i5.EnrollmentInt>) {
-      return (data as List)
-              .map((e) => deserialize<_i5.EnrollmentInt>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i5.EnrollmentInt>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i5.EnrollmentInt>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i8.PlayerUuid>) {
-      return (data as List).map((e) => deserialize<_i8.PlayerUuid>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i8.PlayerUuid>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i8.PlayerUuid>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i12.OrderUuid>) {
-      return (data as List).map((e) => deserialize<_i12.OrderUuid>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i12.OrderUuid>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i12.OrderUuid>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i10.CommentInt>) {
-      return (data as List).map((e) => deserialize<_i10.CommentInt>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i10.CommentInt>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i10.CommentInt>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i17.ChangedIdTypeSelf>) {
-      return (data as List)
-              .map((e) => deserialize<_i17.ChangedIdTypeSelf>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i17.ChangedIdTypeSelf>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i17.ChangedIdTypeSelf>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i63.EmptyModelRelationItem>) {
-      return (data as List)
-              .map((e) => deserialize<_i63.EmptyModelRelationItem>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i63.EmptyModelRelationItem>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i63.EmptyModelRelationItem>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i71.Employee>) {
-      return (data as List).map((e) => deserialize<_i71.Employee>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i71.Employee>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i71.Employee>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<String>) {
-      return (data as List).map((e) => deserialize<String>(e)).toList() as T;
-    }
-    if (t == Map<String, String>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(deserialize<String>(k), deserialize<String>(v)),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(int, String)>()) {
-      return (
-            deserialize<int>(((data as Map)['p'] as List)[0]),
-            deserialize<String>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == List<_i93.ChildEntity>) {
-      return (data as List)
-              .map((e) => deserialize<_i93.ChildEntity>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i93.ChildEntity>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i93.ChildEntity>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i99.PolymorphicChild>) {
-      return (data as List)
-              .map((e) => deserialize<_i99.PolymorphicChild>(e))
-              .toList()
-          as T;
-    }
-    if (t == List<_i99.PolymorphicChild?>) {
-      return (data as List)
-              .map((e) => deserialize<_i99.PolymorphicChild?>(e))
-              .toList()
-          as T;
-    }
-    if (t == Map<String, _i99.PolymorphicChild>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<_i99.PolymorphicChild>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == Map<String, _i99.PolymorphicChild?>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<_i99.PolymorphicChild?>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == List<_i205.ModulePolymorphicChild>) {
-      return (data as List)
-              .map((e) => deserialize<_i205.ModulePolymorphicChild>(e))
-              .toList()
-          as T;
-    }
-    if (t == Map<String, _i205.ModulePolymorphicChild>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<_i205.ModulePolymorphicChild>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == List<_i109.PersonWithLongTableName>) {
-      return (data as List)
-              .map((e) => deserialize<_i109.PersonWithLongTableName>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i109.PersonWithLongTableName>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i109.PersonWithLongTableName>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i108.OrganizationWithLongTableName>) {
-      return (data as List)
-              .map((e) => deserialize<_i108.OrganizationWithLongTableName>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i108.OrganizationWithLongTableName>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map(
-                      (e) =>
-                          deserialize<_i108.OrganizationWithLongTableName>(e),
-                    )
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i111.LongImplicitIdField>) {
-      return (data as List)
-              .map((e) => deserialize<_i111.LongImplicitIdField>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i111.LongImplicitIdField>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i111.LongImplicitIdField>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i118.MultipleMaxFieldName>) {
-      return (data as List)
-              .map((e) => deserialize<_i118.MultipleMaxFieldName>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i118.MultipleMaxFieldName>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i118.MultipleMaxFieldName>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i114.UserNote>) {
-      return (data as List).map((e) => deserialize<_i114.UserNote>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i114.UserNote>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i114.UserNote>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i117.UserNoteWithALongName>) {
-      return (data as List)
-              .map((e) => deserialize<_i117.UserNoteWithALongName>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i117.UserNoteWithALongName>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i117.UserNoteWithALongName>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i121.Person>) {
-      return (data as List).map((e) => deserialize<_i121.Person>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i121.Person>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<_i121.Person>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i120.Organization>) {
-      return (data as List)
-              .map((e) => deserialize<_i120.Organization>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i120.Organization>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i120.Organization>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i123.Enrollment>) {
-      return (data as List)
-              .map((e) => deserialize<_i123.Enrollment>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i123.Enrollment>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i123.Enrollment>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i128.Player>) {
-      return (data as List).map((e) => deserialize<_i128.Player>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i128.Player>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<_i128.Player>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i134.Order>) {
-      return (data as List).map((e) => deserialize<_i134.Order>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i134.Order>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<_i134.Order>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i133.Chapter>) {
-      return (data as List).map((e) => deserialize<_i133.Chapter>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i133.Chapter>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i133.Chapter>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i130.Comment>) {
-      return (data as List).map((e) => deserialize<_i130.Comment>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i130.Comment>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i130.Comment>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i139.Blocking>) {
-      return (data as List).map((e) => deserialize<_i139.Blocking>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i139.Blocking>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i139.Blocking>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i141.Cat>) {
-      return (data as List).map((e) => deserialize<_i141.Cat>(e)).toList() as T;
-    }
-    if (t == _i1.getType<List<_i141.Cat>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<_i141.Cat>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i205.ModuleClass>) {
-      return (data as List)
-              .map((e) => deserialize<_i205.ModuleClass>(e))
-              .toList()
-          as T;
-    }
-    if (t == Map<String, _i205.ModuleClass>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<_i205.ModuleClass>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(_i205.ModuleClass,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<_i205.ModuleClass>(((data as Map)['p'] as List)[0]),)
-                as T;
-    }
-    if (t == List<int>) {
-      return (data as List).map((e) => deserialize<int>(e)).toList() as T;
-    }
-    if (t == _i1.getType<List<int>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<int>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == List<int?>) {
-      return (data as List).map((e) => deserialize<int?>(e)).toList() as T;
-    }
-    if (t == _i1.getType<List<int?>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<int?>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i185.SimpleData>) {
-      return (data as List)
-              .map((e) => deserialize<_i185.SimpleData>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i185.SimpleData>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i185.SimpleData>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i185.SimpleData?>) {
-      return (data as List)
-              .map((e) => deserialize<_i185.SimpleData?>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i185.SimpleData?>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i185.SimpleData?>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<DateTime>) {
-      return (data as List).map((e) => deserialize<DateTime>(e)).toList() as T;
-    }
-    if (t == _i1.getType<List<DateTime>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<DateTime>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == List<DateTime?>) {
-      return (data as List).map((e) => deserialize<DateTime?>(e)).toList() as T;
-    }
-    if (t == _i1.getType<List<DateTime?>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<DateTime?>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i206.ByteData>) {
-      return (data as List).map((e) => deserialize<_i206.ByteData>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i206.ByteData>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i206.ByteData>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i206.ByteData?>) {
-      return (data as List).map((e) => deserialize<_i206.ByteData?>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i206.ByteData?>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i206.ByteData?>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<Duration>) {
-      return (data as List).map((e) => deserialize<Duration>(e)).toList() as T;
-    }
-    if (t == _i1.getType<List<Duration>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<Duration>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == List<Duration?>) {
-      return (data as List).map((e) => deserialize<Duration?>(e)).toList() as T;
-    }
-    if (t == _i1.getType<List<Duration?>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<Duration?>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i1.UuidValue>) {
-      return (data as List).map((e) => deserialize<_i1.UuidValue>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i1.UuidValue>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i1.UuidValue>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i1.UuidValue?>) {
-      return (data as List).map((e) => deserialize<_i1.UuidValue?>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i1.UuidValue?>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i1.UuidValue?>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == Map<String, int>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(deserialize<String>(k), deserialize<int>(v)),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<String, int>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) =>
-                      MapEntry(deserialize<String>(k), deserialize<int>(v)),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<String, int?>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(deserialize<String>(k), deserialize<int?>(v)),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<String, int?>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) =>
-                      MapEntry(deserialize<String>(k), deserialize<int?>(v)),
-                )
-              : null)
-          as T;
-    }
-    if (t == _i207.CustomClassWithoutProtocolSerialization) {
-      return _i207.CustomClassWithoutProtocolSerialization.fromJson(data) as T;
-    }
-    if (t == _i207.CustomClassWithProtocolSerialization) {
-      return _i207.CustomClassWithProtocolSerialization.fromJson(data) as T;
-    }
-    if (t == _i207.CustomClassWithProtocolSerializationMethod) {
-      return _i207.CustomClassWithProtocolSerializationMethod.fromJson(data)
-          as T;
-    }
-    if (t == dynamic) {
-      return deserializeDynamicFieldValue(data) as T;
-    }
-    if (t == List<dynamic>) {
-      return (data as List).map((e) => deserialize<dynamic>(e)).toList() as T;
-    }
-    if (t == Map<String, dynamic>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(deserialize<String>(k), deserialize<dynamic>(v)),
-          )
-          as T;
-    }
-    if (t == Set<dynamic>) {
-      return (data as List).map((e) => deserialize<dynamic>(e)).toSet() as T;
-    }
-    if (t == Map<dynamic, dynamic>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) => MapEntry(
-                deserialize<dynamic>(e['k']),
-                deserialize<dynamic>(e['v']),
-              ),
-            ),
-          )
-          as T;
-    }
-    if (t == List<_i191.TestEnum>) {
-      return (data as List).map((e) => deserialize<_i191.TestEnum>(e)).toList()
-          as T;
-    }
-    if (t == List<_i191.TestEnum?>) {
-      return (data as List).map((e) => deserialize<_i191.TestEnum?>(e)).toList()
-          as T;
-    }
-    if (t == List<List<_i191.TestEnum>>) {
-      return (data as List)
-              .map((e) => deserialize<List<_i191.TestEnum>>(e))
-              .toList()
-          as T;
-    }
-    if (t == List<_i193.TestEnumEnhanced>) {
-      return (data as List)
-              .map((e) => deserialize<_i193.TestEnumEnhanced>(e))
-              .toList()
-          as T;
-    }
-    if (t == List<_i194.TestEnumEnhancedByName>) {
-      return (data as List)
-              .map((e) => deserialize<_i194.TestEnumEnhancedByName>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<String>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<String>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == Map<String, _i185.SimpleData>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<_i185.SimpleData>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == Map<String, DateTime>) {
-      return (data as Map).map(
-            (k, v) =>
-                MapEntry(deserialize<String>(k), deserialize<DateTime>(v)),
-          )
-          as T;
-    }
-    if (t == Map<String, _i206.ByteData>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<_i206.ByteData>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == Map<String, Duration>) {
-      return (data as Map).map(
-            (k, v) =>
-                MapEntry(deserialize<String>(k), deserialize<Duration>(v)),
-          )
-          as T;
-    }
-    if (t == Map<String, _i1.UuidValue>) {
-      return (data as Map).map(
-            (k, v) =>
-                MapEntry(deserialize<String>(k), deserialize<_i1.UuidValue>(v)),
-          )
-          as T;
-    }
-    if (t == Map<String, _i185.SimpleData?>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<_i185.SimpleData?>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == Map<String, String?>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(deserialize<String>(k), deserialize<String?>(v)),
-          )
-          as T;
-    }
-    if (t == Map<String, DateTime?>) {
-      return (data as Map).map(
-            (k, v) =>
-                MapEntry(deserialize<String>(k), deserialize<DateTime?>(v)),
-          )
-          as T;
-    }
-    if (t == Map<String, _i206.ByteData?>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<_i206.ByteData?>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == Map<String, Duration?>) {
-      return (data as Map).map(
-            (k, v) =>
-                MapEntry(deserialize<String>(k), deserialize<Duration?>(v)),
-          )
-          as T;
-    }
-    if (t == Map<String, _i1.UuidValue?>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<_i1.UuidValue?>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == Map<int, int>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) =>
-                  MapEntry(deserialize<int>(e['k']), deserialize<int>(e['v'])),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<_i207.CustomClassWithoutProtocolSerialization?>()) {
-      return (data != null
-              ? _i207.CustomClassWithoutProtocolSerialization.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i207.CustomClassWithProtocolSerialization?>()) {
-      return (data != null
-              ? _i207.CustomClassWithProtocolSerialization.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i207.CustomClassWithProtocolSerializationMethod?>()) {
-      return (data != null
-              ? _i207.CustomClassWithProtocolSerializationMethod.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == List<List<_i185.SimpleData>>) {
-      return (data as List)
-              .map((e) => deserialize<List<_i185.SimpleData>>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<List<_i185.SimpleData>>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<List<_i185.SimpleData>>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == Map<String, List<List<Map<int, _i185.SimpleData>>?>>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<List<List<Map<int, _i185.SimpleData>>?>>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == List<List<Map<int, _i185.SimpleData>>?>) {
-      return (data as List)
-              .map((e) => deserialize<List<Map<int, _i185.SimpleData>>?>(e))
-              .toList()
-          as T;
-    }
-    if (t == List<Map<int, _i185.SimpleData>>) {
-      return (data as List)
-              .map((e) => deserialize<Map<int, _i185.SimpleData>>(e))
-              .toList()
-          as T;
-    }
-    if (t == Map<int, _i185.SimpleData>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) => MapEntry(
-                deserialize<int>(e['k']),
-                deserialize<_i185.SimpleData>(e['v']),
-              ),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<List<Map<int, _i185.SimpleData>>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<Map<int, _i185.SimpleData>>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t ==
-        _i1.getType<Map<String, List<List<Map<int, _i185.SimpleData>>?>>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) => MapEntry(
-                    deserialize<String>(k),
-                    deserialize<List<List<Map<int, _i185.SimpleData>>?>>(v),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<List<Map<int, _i185.SimpleData>>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<Map<int, _i185.SimpleData>>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == Map<String, Map<int, _i185.SimpleData>>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<Map<int, _i185.SimpleData>>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<String, Map<int, _i185.SimpleData>>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) => MapEntry(
-                    deserialize<String>(k),
-                    deserialize<Map<int, _i185.SimpleData>>(v),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == List<_i105.SealedParent>) {
-      return (data as List)
-              .map((e) => deserialize<_i105.SealedParent>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<(bool,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<bool>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == List<_i207.SharedModel>) {
-      return (data as List)
-              .map((e) => deserialize<_i207.SharedModel>(e))
-              .toList()
-          as T;
-    }
-    if (t == List<_i207.SharedModel?>) {
-      return (data as List)
-              .map((e) => deserialize<_i207.SharedModel?>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i207.SharedModel>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i207.SharedModel>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == Map<String, _i207.SharedModel>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<_i207.SharedModel>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<String, _i207.SharedModel>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) => MapEntry(
-                    deserialize<String>(k),
-                    deserialize<_i207.SharedModel>(v),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<String, _i207.SharedSubclass>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<_i207.SharedSubclass>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == Set<_i207.SharedModel>) {
-      return (data as List)
-              .map((e) => deserialize<_i207.SharedModel>(e))
-              .toSet()
-          as T;
-    }
-    if (t == _i1.getType<Set<_i207.SharedModel>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i207.SharedModel>(e))
-                    .toSet()
-              : null)
-          as T;
-    }
-    if (t == List<_i195.TestEnumStringified>) {
-      return (data as List)
-              .map((e) => deserialize<_i195.TestEnumStringified>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i195.TestEnumStringified>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i195.TestEnumStringified>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(_i195.TestEnumStringified,)?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<_i195.TestEnumStringified>(
-                    ((data as Map)['p'] as List)[0],
-                  ),
-                )
-                as T;
-    }
-    if (t == List<(_i195.TestEnumStringified,)>) {
-      return (data as List)
-              .map((e) => deserialize<(_i195.TestEnumStringified,)>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<(_i195.TestEnumStringified,)>()) {
-      return (
-            deserialize<_i195.TestEnumStringified>(
-              ((data as Map)['p'] as List)[0],
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<List<(_i195.TestEnumStringified,)>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<(_i195.TestEnumStringified,)>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(_i195.TestEnumStringified,)>()) {
-      return (
-            deserialize<_i195.TestEnumStringified>(
-              ((data as Map)['p'] as List)[0],
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(_i146.Nullability,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<_i146.Nullability>(((data as Map)['p'] as List)[0]),)
-                as T;
-    }
-    if (t == _i1.getType<({_i195.TestEnumStringified value})?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  value: deserialize<_i195.TestEnumStringified>(
-                    ((data as Map)['n'] as Map)['value'],
-                  ),
-                )
-                as T;
-    }
-    if (t == List<({_i195.TestEnumStringified value})>) {
-      return (data as List)
-              .map((e) => deserialize<({_i195.TestEnumStringified value})>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<({_i195.TestEnumStringified value})>()) {
-      return (
-            value: deserialize<_i195.TestEnumStringified>(
-              ((data as Map)['n'] as Map)['value'],
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<List<({_i195.TestEnumStringified value})>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map(
-                      (e) =>
-                          deserialize<({_i195.TestEnumStringified value})>(e),
-                    )
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<({_i195.TestEnumStringified value})>()) {
-      return (
-            value: deserialize<_i195.TestEnumStringified>(
-              ((data as Map)['n'] as Map)['value'],
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<({_i205.ModuleClass value})?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  value: deserialize<_i205.ModuleClass>(
-                    ((data as Map)['n'] as Map)['value'],
-                  ),
-                )
-                as T;
-    }
-    if (t == _i1.getType<({_i146.Nullability value})?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  value: deserialize<_i146.Nullability>(
-                    ((data as Map)['n'] as Map)['value'],
-                  ),
-                )
-                as T;
-    }
-    if (t == _i1.getType<Map<int, int>?>()) {
-      return (data != null
-              ? Map.fromEntries(
-                  (data as List).map(
-                    (e) => MapEntry(
-                      deserialize<int>(e['k']),
-                      deserialize<int>(e['v']),
-                    ),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == Set<int>) {
-      return (data as List).map((e) => deserialize<int>(e)).toSet() as T;
-    }
-    if (t == _i1.getType<Set<int>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<int>(e)).toSet()
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(String, {Uri? optionalUri})?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<String>(((data as Map)['p'] as List)[0]),
-                  optionalUri: ((data)['n'] as Map)['optionalUri'] == null
-                      ? null
-                      : deserialize<Uri>(data['n']['optionalUri']),
-                )
-                as T;
-    }
-    if (t == List<bool>) {
-      return (data as List).map((e) => deserialize<bool>(e)).toList() as T;
-    }
-    if (t == _i1.getType<List<bool>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<bool>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == List<double>) {
-      return (data as List).map((e) => deserialize<double>(e)).toList() as T;
-    }
-    if (t == _i1.getType<List<double>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<double>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == List<Uri>) {
-      return (data as List).map((e) => deserialize<Uri>(e)).toList() as T;
-    }
-    if (t == _i1.getType<List<Uri>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<Uri>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == List<BigInt>) {
-      return (data as List).map((e) => deserialize<BigInt>(e)).toList() as T;
-    }
-    if (t == _i1.getType<List<BigInt>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<BigInt>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<List<_i191.TestEnum>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i191.TestEnum>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i196.Types>) {
-      return (data as List).map((e) => deserialize<_i196.Types>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i196.Types>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<_i196.Types>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == List<Map<String, _i196.Types>>) {
-      return (data as List)
-              .map((e) => deserialize<Map<String, _i196.Types>>(e))
-              .toList()
-          as T;
-    }
-    if (t == Map<String, _i196.Types>) {
-      return (data as Map).map(
-            (k, v) =>
-                MapEntry(deserialize<String>(k), deserialize<_i196.Types>(v)),
-          )
-          as T;
-    }
-    if (t == _i1.getType<List<Map<String, _i196.Types>>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<Map<String, _i196.Types>>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<List<_i196.Types>>) {
-      return (data as List)
-              .map((e) => deserialize<List<_i196.Types>>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<List<_i196.Types>>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<List<_i196.Types>>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<(int,)>) {
-      return (data as List).map((e) => deserialize<(int,)>(e)).toList() as T;
-    }
-    if (t == _i1.getType<(int,)>()) {
-      return (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<List<(int,)>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<(int,)>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(int,)>()) {
-      return (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == List<(int,)?>) {
-      return (data as List).map((e) => deserialize<(int,)?>(e)).toList() as T;
-    }
-    if (t == _i1.getType<(int,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<List<(int,)?>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<(int,)?>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(int,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == List<(_i191.TestEnum,)>) {
-      return (data as List)
-              .map((e) => deserialize<(_i191.TestEnum,)>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<(_i191.TestEnum,)>()) {
-      return (deserialize<_i191.TestEnum>(((data as Map)['p'] as List)[0]),)
-          as T;
-    }
-    if (t == _i1.getType<List<(_i191.TestEnum,)>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<(_i191.TestEnum,)>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(_i191.TestEnum,)>()) {
-      return (deserialize<_i191.TestEnum>(((data as Map)['p'] as List)[0]),)
-          as T;
-    }
-    if (t == Map<int, String>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) => MapEntry(
-                deserialize<int>(e['k']),
-                deserialize<String>(e['v']),
-              ),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<int, String>?>()) {
-      return (data != null
-              ? Map.fromEntries(
-                  (data as List).map(
-                    (e) => MapEntry(
-                      deserialize<int>(e['k']),
-                      deserialize<String>(e['v']),
-                    ),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<bool, String>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) => MapEntry(
-                deserialize<bool>(e['k']),
-                deserialize<String>(e['v']),
-              ),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<bool, String>?>()) {
-      return (data != null
-              ? Map.fromEntries(
-                  (data as List).map(
-                    (e) => MapEntry(
-                      deserialize<bool>(e['k']),
-                      deserialize<String>(e['v']),
-                    ),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<double, String>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) => MapEntry(
-                deserialize<double>(e['k']),
-                deserialize<String>(e['v']),
-              ),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<double, String>?>()) {
-      return (data != null
-              ? Map.fromEntries(
-                  (data as List).map(
-                    (e) => MapEntry(
-                      deserialize<double>(e['k']),
-                      deserialize<String>(e['v']),
-                    ),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<DateTime, String>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) => MapEntry(
-                deserialize<DateTime>(e['k']),
-                deserialize<String>(e['v']),
-              ),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<DateTime, String>?>()) {
-      return (data != null
-              ? Map.fromEntries(
-                  (data as List).map(
-                    (e) => MapEntry(
-                      deserialize<DateTime>(e['k']),
-                      deserialize<String>(e['v']),
-                    ),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<Map<String, String>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) =>
-                      MapEntry(deserialize<String>(k), deserialize<String>(v)),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<_i206.ByteData, String>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) => MapEntry(
-                deserialize<_i206.ByteData>(e['k']),
-                deserialize<String>(e['v']),
-              ),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<_i206.ByteData, String>?>()) {
-      return (data != null
-              ? Map.fromEntries(
-                  (data as List).map(
-                    (e) => MapEntry(
-                      deserialize<_i206.ByteData>(e['k']),
-                      deserialize<String>(e['v']),
-                    ),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<Duration, String>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) => MapEntry(
-                deserialize<Duration>(e['k']),
-                deserialize<String>(e['v']),
-              ),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<Duration, String>?>()) {
-      return (data != null
-              ? Map.fromEntries(
-                  (data as List).map(
-                    (e) => MapEntry(
-                      deserialize<Duration>(e['k']),
-                      deserialize<String>(e['v']),
-                    ),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<_i1.UuidValue, String>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) => MapEntry(
-                deserialize<_i1.UuidValue>(e['k']),
-                deserialize<String>(e['v']),
-              ),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<_i1.UuidValue, String>?>()) {
-      return (data != null
-              ? Map.fromEntries(
-                  (data as List).map(
-                    (e) => MapEntry(
-                      deserialize<_i1.UuidValue>(e['k']),
-                      deserialize<String>(e['v']),
-                    ),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<Uri, String>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) => MapEntry(
-                deserialize<Uri>(e['k']),
-                deserialize<String>(e['v']),
-              ),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<Uri, String>?>()) {
-      return (data != null
-              ? Map.fromEntries(
-                  (data as List).map(
-                    (e) => MapEntry(
-                      deserialize<Uri>(e['k']),
-                      deserialize<String>(e['v']),
-                    ),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<BigInt, String>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) => MapEntry(
-                deserialize<BigInt>(e['k']),
-                deserialize<String>(e['v']),
-              ),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<BigInt, String>?>()) {
-      return (data != null
-              ? Map.fromEntries(
-                  (data as List).map(
-                    (e) => MapEntry(
-                      deserialize<BigInt>(e['k']),
-                      deserialize<String>(e['v']),
-                    ),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<_i191.TestEnum, String>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) => MapEntry(
-                deserialize<_i191.TestEnum>(e['k']),
-                deserialize<String>(e['v']),
-              ),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<_i191.TestEnum, String>?>()) {
-      return (data != null
-              ? Map.fromEntries(
-                  (data as List).map(
-                    (e) => MapEntry(
-                      deserialize<_i191.TestEnum>(e['k']),
-                      deserialize<String>(e['v']),
-                    ),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<_i195.TestEnumStringified, String>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) => MapEntry(
-                deserialize<_i195.TestEnumStringified>(e['k']),
-                deserialize<String>(e['v']),
-              ),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<_i195.TestEnumStringified, String>?>()) {
-      return (data != null
-              ? Map.fromEntries(
-                  (data as List).map(
-                    (e) => MapEntry(
-                      deserialize<_i195.TestEnumStringified>(e['k']),
-                      deserialize<String>(e['v']),
-                    ),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<_i196.Types, String>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) => MapEntry(
-                deserialize<_i196.Types>(e['k']),
-                deserialize<String>(e['v']),
-              ),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<_i196.Types, String>?>()) {
-      return (data != null
-              ? Map.fromEntries(
-                  (data as List).map(
-                    (e) => MapEntry(
-                      deserialize<_i196.Types>(e['k']),
-                      deserialize<String>(e['v']),
-                    ),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<Map<_i196.Types, String>, String>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) => MapEntry(
-                deserialize<Map<_i196.Types, String>>(e['k']),
-                deserialize<String>(e['v']),
-              ),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<Map<_i196.Types, String>, String>?>()) {
-      return (data != null
-              ? Map.fromEntries(
-                  (data as List).map(
-                    (e) => MapEntry(
-                      deserialize<Map<_i196.Types, String>>(e['k']),
-                      deserialize<String>(e['v']),
-                    ),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<List<_i196.Types>, String>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) => MapEntry(
-                deserialize<List<_i196.Types>>(e['k']),
-                deserialize<String>(e['v']),
-              ),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<List<_i196.Types>, String>?>()) {
-      return (data != null
-              ? Map.fromEntries(
-                  (data as List).map(
-                    (e) => MapEntry(
-                      deserialize<List<_i196.Types>>(e['k']),
-                      deserialize<String>(e['v']),
-                    ),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<(String,), String>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) => MapEntry(
-                deserialize<(String,)>(e['k']),
-                deserialize<String>(e['v']),
-              ),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(String,)>()) {
-      return (deserialize<String>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<Map<(String,), String>?>()) {
-      return (data != null
-              ? Map.fromEntries(
-                  (data as List).map(
-                    (e) => MapEntry(
-                      deserialize<(String,)>(e['k']),
-                      deserialize<String>(e['v']),
-                    ),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(String,)>()) {
-      return (deserialize<String>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == Map<String, bool>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(deserialize<String>(k), deserialize<bool>(v)),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<String, bool>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) =>
-                      MapEntry(deserialize<String>(k), deserialize<bool>(v)),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<String, double>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(deserialize<String>(k), deserialize<double>(v)),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<String, double>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) =>
-                      MapEntry(deserialize<String>(k), deserialize<double>(v)),
-                )
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<Map<String, DateTime>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) => MapEntry(
-                    deserialize<String>(k),
-                    deserialize<DateTime>(v),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<Map<String, _i206.ByteData>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) => MapEntry(
-                    deserialize<String>(k),
-                    deserialize<_i206.ByteData>(v),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<Map<String, Duration>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) => MapEntry(
-                    deserialize<String>(k),
-                    deserialize<Duration>(v),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<Map<String, _i1.UuidValue>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) => MapEntry(
-                    deserialize<String>(k),
-                    deserialize<_i1.UuidValue>(v),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<String, Uri>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(deserialize<String>(k), deserialize<Uri>(v)),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<String, Uri>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) =>
-                      MapEntry(deserialize<String>(k), deserialize<Uri>(v)),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<String, BigInt>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(deserialize<String>(k), deserialize<BigInt>(v)),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<String, BigInt>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) =>
-                      MapEntry(deserialize<String>(k), deserialize<BigInt>(v)),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<String, _i191.TestEnum>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<_i191.TestEnum>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<String, _i191.TestEnum>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) => MapEntry(
-                    deserialize<String>(k),
-                    deserialize<_i191.TestEnum>(v),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<String, _i195.TestEnumStringified>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<_i195.TestEnumStringified>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<String, _i195.TestEnumStringified>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) => MapEntry(
-                    deserialize<String>(k),
-                    deserialize<_i195.TestEnumStringified>(v),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<Map<String, _i196.Types>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) => MapEntry(
-                    deserialize<String>(k),
-                    deserialize<_i196.Types>(v),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<String, Map<String, _i196.Types>>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<Map<String, _i196.Types>>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<String, Map<String, _i196.Types>>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) => MapEntry(
-                    deserialize<String>(k),
-                    deserialize<Map<String, _i196.Types>>(v),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<String, List<_i196.Types>>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<List<_i196.Types>>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<String, List<_i196.Types>>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) => MapEntry(
-                    deserialize<String>(k),
-                    deserialize<List<_i196.Types>>(v),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<String, (String,)>) {
-      return (data as Map).map(
-            (k, v) =>
-                MapEntry(deserialize<String>(k), deserialize<(String,)>(v)),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(String,)>()) {
-      return (deserialize<String>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<Map<String, (String,)>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) => MapEntry(
-                    deserialize<String>(k),
-                    deserialize<(String,)>(v),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(String,)>()) {
-      return (deserialize<String>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == Map<String, (String,)?>) {
-      return (data as Map).map(
-            (k, v) =>
-                MapEntry(deserialize<String>(k), deserialize<(String,)?>(v)),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(String,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<String>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<Map<String, (String,)?>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) => MapEntry(
-                    deserialize<String>(k),
-                    deserialize<(String,)?>(v),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(String,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<String>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == Map<(String,)?, String>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) => MapEntry(
-                deserialize<(String,)?>(e['k']),
-                deserialize<String>(e['v']),
-              ),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(String,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<String>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<Map<(String,)?, String>?>()) {
-      return (data != null
-              ? Map.fromEntries(
-                  (data as List).map(
-                    (e) => MapEntry(
-                      deserialize<(String,)?>(e['k']),
-                      deserialize<String>(e['v']),
-                    ),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(String,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<String>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(int,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(double,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<double>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(DateTime,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<DateTime>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(String,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<String>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(_i206.ByteData,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<_i206.ByteData>(((data as Map)['p'] as List)[0]),)
-                as T;
-    }
-    if (t == _i1.getType<(Duration,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<Duration>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(_i1.UuidValue,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<_i1.UuidValue>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(Uri,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<Uri>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(BigInt,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<BigInt>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(_i191.TestEnum,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<_i191.TestEnum>(((data as Map)['p'] as List)[0]),)
-                as T;
-    }
-    if (t == _i1.getType<(List<int>,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<List<int>>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(Map<int, int>,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<Map<int, int>>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(Set<int>,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<Set<int>>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(_i185.SimpleData,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<_i185.SimpleData>(((data as Map)['p'] as List)[0]),)
-                as T;
-    }
-    if (t == _i1.getType<({_i185.SimpleData namedModel})?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  namedModel: deserialize<_i185.SimpleData>(
-                    ((data as Map)['n'] as Map)['namedModel'],
-                  ),
-                )
-                as T;
-    }
-    if (t ==
-        _i1.getType<(_i185.SimpleData, {_i185.SimpleData namedModel})?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<_i185.SimpleData>(
-                    ((data as Map)['p'] as List)[0],
-                  ),
-                  namedModel: deserialize<_i185.SimpleData>(
-                    data['n']['namedModel'],
-                  ),
-                )
-                as T;
-    }
-    if (t ==
-        _i1.getType<((int, String), {(int, String) namedNestedRecord})?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<(int, String)>(((data as Map)['p'] as List)[0]),
-                  namedNestedRecord: deserialize<(int, String)>(
-                    data['n']['namedNestedRecord'],
-                  ),
-                )
-                as T;
-    }
-    if (t ==
-        _i1
-            .getType<
-              (
-                (List<(_i185.SimpleData,)>,), {
-                (_i185.SimpleData, Map<String, _i185.SimpleData>)
-                namedNestedRecord,
-              })?
-            >()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<(List<(_i185.SimpleData,)>,)>(
-                    ((data as Map)['p'] as List)[0],
-                  ),
-                  namedNestedRecord:
-                      deserialize<
-                        (_i185.SimpleData, Map<String, _i185.SimpleData>)
-                      >(data['n']['namedNestedRecord']),
-                )
-                as T;
-    }
-    if (t == Set<bool>) {
-      return (data as List).map((e) => deserialize<bool>(e)).toSet() as T;
-    }
-    if (t == _i1.getType<Set<bool>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<bool>(e)).toSet()
-              : null)
-          as T;
-    }
-    if (t == Set<double>) {
-      return (data as List).map((e) => deserialize<double>(e)).toSet() as T;
-    }
-    if (t == _i1.getType<Set<double>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<double>(e)).toSet()
-              : null)
-          as T;
-    }
-    if (t == Set<DateTime>) {
-      return (data as List).map((e) => deserialize<DateTime>(e)).toSet() as T;
-    }
-    if (t == _i1.getType<Set<DateTime>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<DateTime>(e)).toSet()
-              : null)
-          as T;
-    }
-    if (t == Set<String>) {
-      return (data as List).map((e) => deserialize<String>(e)).toSet() as T;
-    }
-    if (t == _i1.getType<Set<String>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<String>(e)).toSet()
-              : null)
-          as T;
-    }
-    if (t == Set<_i206.ByteData>) {
-      return (data as List).map((e) => deserialize<_i206.ByteData>(e)).toSet()
-          as T;
-    }
-    if (t == _i1.getType<Set<_i206.ByteData>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i206.ByteData>(e))
-                    .toSet()
-              : null)
-          as T;
-    }
-    if (t == Set<Duration>) {
-      return (data as List).map((e) => deserialize<Duration>(e)).toSet() as T;
-    }
-    if (t == _i1.getType<Set<Duration>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<Duration>(e)).toSet()
-              : null)
-          as T;
-    }
-    if (t == Set<_i1.UuidValue>) {
-      return (data as List).map((e) => deserialize<_i1.UuidValue>(e)).toSet()
-          as T;
-    }
-    if (t == _i1.getType<Set<_i1.UuidValue>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<_i1.UuidValue>(e)).toSet()
-              : null)
-          as T;
-    }
-    if (t == Set<BigInt>) {
-      return (data as List).map((e) => deserialize<BigInt>(e)).toSet() as T;
-    }
-    if (t == _i1.getType<Set<BigInt>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<BigInt>(e)).toSet()
-              : null)
-          as T;
-    }
-    if (t == Set<_i191.TestEnum>) {
-      return (data as List).map((e) => deserialize<_i191.TestEnum>(e)).toSet()
-          as T;
-    }
-    if (t == _i1.getType<Set<_i191.TestEnum>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i191.TestEnum>(e))
-                    .toSet()
-              : null)
-          as T;
-    }
-    if (t == Set<_i195.TestEnumStringified>) {
-      return (data as List)
-              .map((e) => deserialize<_i195.TestEnumStringified>(e))
-              .toSet()
-          as T;
-    }
-    if (t == _i1.getType<Set<_i195.TestEnumStringified>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i195.TestEnumStringified>(e))
-                    .toSet()
-              : null)
-          as T;
-    }
-    if (t == Set<_i196.Types>) {
-      return (data as List).map((e) => deserialize<_i196.Types>(e)).toSet()
-          as T;
-    }
-    if (t == _i1.getType<Set<_i196.Types>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<_i196.Types>(e)).toSet()
-              : null)
-          as T;
-    }
-    if (t == Set<Map<String, _i196.Types>>) {
-      return (data as List)
-              .map((e) => deserialize<Map<String, _i196.Types>>(e))
-              .toSet()
-          as T;
-    }
-    if (t == _i1.getType<Set<Map<String, _i196.Types>>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<Map<String, _i196.Types>>(e))
-                    .toSet()
-              : null)
-          as T;
-    }
-    if (t == Set<List<_i196.Types>>) {
-      return (data as List)
-              .map((e) => deserialize<List<_i196.Types>>(e))
-              .toSet()
-          as T;
-    }
-    if (t == _i1.getType<Set<List<_i196.Types>>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<List<_i196.Types>>(e))
-                    .toSet()
-              : null)
-          as T;
-    }
-    if (t == Set<(int,)>) {
-      return (data as List).map((e) => deserialize<(int,)>(e)).toSet() as T;
-    }
-    if (t == _i1.getType<(int,)>()) {
-      return (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<Set<(int,)>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<(int,)>(e)).toSet()
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(int,)>()) {
-      return (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == Set<(int,)?>) {
-      return (data as List).map((e) => deserialize<(int,)?>(e)).toSet() as T;
-    }
-    if (t == _i1.getType<(int,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<Set<(int,)?>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<(int,)?>(e)).toSet()
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(int,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == List<String>) {
-      return (data as List).map((e) => deserialize<String>(e)).toList() as T;
-    }
-    if (t == _i1.getType<List<String>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<String>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i208.SimpleData>) {
-      return (data as List)
-              .map((e) => deserialize<_i208.SimpleData>(e))
-              .toList()
-          as T;
-    }
-    if (t == List<int>) {
-      return (data as List).map((e) => deserialize<int>(e)).toList() as T;
-    }
-    if (t == List<List<int>>) {
-      return (data as List).map((e) => deserialize<List<int>>(e)).toList() as T;
-    }
-    if (t == _i1.getType<List<int>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<int>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == List<List<int>?>) {
-      return (data as List).map((e) => deserialize<List<int>?>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<List<int>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<int>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<List<List<int>>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<List<int>>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == List<int?>) {
-      return (data as List).map((e) => deserialize<int?>(e)).toList() as T;
-    }
-    if (t == _i1.getType<List<int?>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<int?>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == List<double>) {
-      return (data as List).map((e) => deserialize<double>(e)).toList() as T;
-    }
-    if (t == List<double?>) {
-      return (data as List).map((e) => deserialize<double?>(e)).toList() as T;
-    }
-    if (t == List<bool>) {
-      return (data as List).map((e) => deserialize<bool>(e)).toList() as T;
-    }
-    if (t == List<bool?>) {
-      return (data as List).map((e) => deserialize<bool?>(e)).toList() as T;
-    }
-    if (t == List<String?>) {
-      return (data as List).map((e) => deserialize<String?>(e)).toList() as T;
-    }
-    if (t == List<DateTime>) {
-      return (data as List).map((e) => deserialize<DateTime>(e)).toList() as T;
-    }
-    if (t == List<DateTime?>) {
-      return (data as List).map((e) => deserialize<DateTime?>(e)).toList() as T;
-    }
-    if (t == List<_i206.ByteData>) {
-      return (data as List).map((e) => deserialize<_i206.ByteData>(e)).toList()
-          as T;
-    }
-    if (t == List<_i206.ByteData?>) {
-      return (data as List).map((e) => deserialize<_i206.ByteData?>(e)).toList()
-          as T;
-    }
-    if (t == List<_i208.SimpleData?>) {
-      return (data as List)
-              .map((e) => deserialize<_i208.SimpleData?>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i208.SimpleData>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i208.SimpleData>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<List<_i208.SimpleData?>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i208.SimpleData?>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<Duration>) {
-      return (data as List).map((e) => deserialize<Duration>(e)).toList() as T;
-    }
-    if (t == List<Duration?>) {
-      return (data as List).map((e) => deserialize<Duration?>(e)).toList() as T;
-    }
-    if (t == Map<String, int>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(deserialize<String>(k), deserialize<int>(v)),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<String, int>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) =>
-                      MapEntry(deserialize<String>(k), deserialize<int>(v)),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<String, Map<String, int>>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<Map<String, int>>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == Map<String, int?>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(deserialize<String>(k), deserialize<int?>(v)),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<String, int?>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) =>
-                      MapEntry(deserialize<String>(k), deserialize<int?>(v)),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<int, int>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) =>
-                  MapEntry(deserialize<int>(e['k']), deserialize<int>(e['v'])),
-            ),
-          )
-          as T;
-    }
-    if (t == Map<String, Map<int, int>>) {
-      return (data as Map).map(
-            (k, v) =>
-                MapEntry(deserialize<String>(k), deserialize<Map<int, int>>(v)),
-          )
-          as T;
-    }
-    if (t == Map<_i209.TestEnum, int>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) => MapEntry(
-                deserialize<_i209.TestEnum>(e['k']),
-                deserialize<int>(e['v']),
-              ),
-            ),
-          )
-          as T;
-    }
-    if (t == Map<String, _i209.TestEnum>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<_i209.TestEnum>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == Map<String, double>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(deserialize<String>(k), deserialize<double>(v)),
-          )
-          as T;
-    }
-    if (t == Map<String, double?>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(deserialize<String>(k), deserialize<double?>(v)),
-          )
-          as T;
-    }
-    if (t == Map<String, bool>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(deserialize<String>(k), deserialize<bool>(v)),
-          )
-          as T;
-    }
-    if (t == Map<String, bool?>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(deserialize<String>(k), deserialize<bool?>(v)),
-          )
-          as T;
-    }
-    if (t == Map<String, String>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(deserialize<String>(k), deserialize<String>(v)),
-          )
-          as T;
-    }
-    if (t == Map<String, String?>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(deserialize<String>(k), deserialize<String?>(v)),
-          )
-          as T;
-    }
-    if (t == Map<String, DateTime>) {
-      return (data as Map).map(
-            (k, v) =>
-                MapEntry(deserialize<String>(k), deserialize<DateTime>(v)),
-          )
-          as T;
-    }
-    if (t == Map<String, DateTime?>) {
-      return (data as Map).map(
-            (k, v) =>
-                MapEntry(deserialize<String>(k), deserialize<DateTime?>(v)),
-          )
-          as T;
-    }
-    if (t == Map<String, _i206.ByteData>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<_i206.ByteData>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == Map<String, _i206.ByteData?>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<_i206.ByteData?>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == Map<String, _i208.SimpleData>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<_i208.SimpleData>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == Map<String, _i208.SimpleData?>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<_i208.SimpleData?>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<String, _i208.SimpleData>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) => MapEntry(
-                    deserialize<String>(k),
-                    deserialize<_i208.SimpleData>(v),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<Map<String, _i208.SimpleData?>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) => MapEntry(
-                    deserialize<String>(k),
-                    deserialize<_i208.SimpleData?>(v),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<String, Duration>) {
-      return (data as Map).map(
-            (k, v) =>
-                MapEntry(deserialize<String>(k), deserialize<Duration>(v)),
-          )
-          as T;
-    }
-    if (t == Map<String, Duration?>) {
-      return (data as Map).map(
-            (k, v) =>
-                MapEntry(deserialize<String>(k), deserialize<Duration?>(v)),
-          )
-          as T;
-    }
-    if (t == Map<(Map<int, String>, String), String>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) => MapEntry(
-                deserialize<(Map<int, String>, String)>(e['k']),
-                deserialize<String>(e['v']),
-              ),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(Map<int, String>, String)>()) {
-      return (
-            deserialize<Map<int, String>>(((data as Map)['p'] as List)[0]),
-            deserialize<String>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(Map<int, String>, String)>()) {
-      return (
-            deserialize<Map<int, String>>(((data as Map)['p'] as List)[0]),
-            deserialize<String>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == Map<int, String>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) => MapEntry(
-                deserialize<int>(e['k']),
-                deserialize<String>(e['v']),
-              ),
-            ),
-          )
-          as T;
-    }
-    if (t == Map<String, (Map<int, int>,)>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<(Map<int, int>,)>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(Map<int, int>,)>()) {
-      return (deserialize<Map<int, int>>(((data as Map)['p'] as List)[0]),)
-          as T;
-    }
-    if (t == _i1.getType<(Map<int, int>,)>()) {
-      return (deserialize<Map<int, int>>(((data as Map)['p'] as List)[0]),)
-          as T;
-    }
-    if (t == Map<DateTime, bool>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) => MapEntry(
-                deserialize<DateTime>(e['k']),
-                deserialize<bool>(e['v']),
-              ),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<DateTime, bool>?>()) {
-      return (data != null
-              ? Map.fromEntries(
-                  (data as List).map(
-                    (e) => MapEntry(
-                      deserialize<DateTime>(e['k']),
-                      deserialize<bool>(e['v']),
-                    ),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<Map<int, String>?>()) {
-      return (data != null
-              ? Map.fromEntries(
-                  (data as List).map(
-                    (e) => MapEntry(
-                      deserialize<int>(e['k']),
-                      deserialize<String>(e['v']),
-                    ),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == List<_i210.UserInfo>) {
-      return (data as List).map((e) => deserialize<_i210.UserInfo>(e)).toList()
-          as T;
-    }
-    if (t == Set<int>) {
-      return (data as List).map((e) => deserialize<int>(e)).toSet() as T;
-    }
-    if (t == Set<_i208.SimpleData>) {
-      return (data as List).map((e) => deserialize<_i208.SimpleData>(e)).toSet()
-          as T;
-    }
-    if (t == List<Set<_i208.SimpleData>>) {
-      return (data as List)
-              .map((e) => deserialize<Set<_i208.SimpleData>>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<(int, BigInt)>()) {
-      return (
-            deserialize<int>(((data as Map)['p'] as List)[0]),
-            deserialize<BigInt>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(String, _i211.PolymorphicParent)>()) {
-      return (
-            deserialize<String>(((data as Map)['p'] as List)[0]),
-            deserialize<_i211.PolymorphicParent>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(int,)>()) {
-      return (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(int,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(int?,)>()) {
-      return (
-            ((data as Map)['p'] as List)[0] == null
-                ? null
-                : deserialize<int>(data['p'][0]),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(int?,)?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  ((data as Map)['p'] as List)[0] == null
-                      ? null
-                      : deserialize<int>(data['p'][0]),
-                )
-                as T;
-    }
-    if (t == _i1.getType<(int, String)>()) {
-      return (
-            deserialize<int>(((data as Map)['p'] as List)[0]),
-            deserialize<String>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(int, String)?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<int>(((data as Map)['p'] as List)[0]),
-                  deserialize<String>(data['p'][1]),
-                )
-                as T;
-    }
-    if (t == _i1.getType<(int, _i208.SimpleData)>()) {
-      return (
-            deserialize<int>(((data as Map)['p'] as List)[0]),
-            deserialize<_i208.SimpleData>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(int, _i208.SimpleData)?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<int>(((data as Map)['p'] as List)[0]),
-                  deserialize<_i208.SimpleData>(data['p'][1]),
-                )
-                as T;
-    }
-    if (t == _i1.getType<(Map<String, int>,)>()) {
-      return (deserialize<Map<String, int>>(((data as Map)['p'] as List)[0]),)
-          as T;
-    }
-    if (t == _i1.getType<(Set<(int,)>,)>()) {
-      return (deserialize<Set<(int,)>>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == Set<(int,)>) {
-      return (data as List).map((e) => deserialize<(int,)>(e)).toSet() as T;
-    }
-    if (t == _i1.getType<(int,)>()) {
-      return (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<({int number, String text})>()) {
-      return (
-            number: deserialize<int>(((data as Map)['n'] as Map)['number']),
-            text: deserialize<String>(data['n']['text']),
-          )
-          as T;
-    }
-    if (t == _i1.getType<({int number, String text})?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  number: deserialize<int>(
-                    ((data as Map)['n'] as Map)['number'],
-                  ),
-                  text: deserialize<String>(data['n']['text']),
-                )
-                as T;
-    }
-    if (t == _i1.getType<({_i208.SimpleData data, int number})>()) {
-      return (
-            data: deserialize<_i208.SimpleData>(
-              ((data as Map)['n'] as Map)['data'],
-            ),
-            number: deserialize<int>(data['n']['number']),
-          )
-          as T;
-    }
-    if (t == _i1.getType<({_i208.SimpleData data, int number})?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  data: deserialize<_i208.SimpleData>(
-                    ((data as Map)['n'] as Map)['data'],
-                  ),
-                  number: deserialize<int>(data['n']['number']),
-                )
-                as T;
-    }
-    if (t == _i1.getType<({_i208.SimpleData? data, int? number})>()) {
-      return (
-            data: ((data as Map)['n'] as Map)['data'] == null
-                ? null
-                : deserialize<_i208.SimpleData>(data['n']['data']),
-            number: ((data)['n'] as Map)['number'] == null
-                ? null
-                : deserialize<int>(data['n']['number']),
-          )
-          as T;
-    }
-    if (t == _i1.getType<({Map<int, int> intIntMap})>()) {
-      return (
-            intIntMap: deserialize<Map<int, int>>(
-              ((data as Map)['n'] as Map)['intIntMap'],
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<({Set<(bool,)> boolSet})>()) {
-      return (
-            boolSet: deserialize<Set<(bool,)>>(
-              ((data as Map)['n'] as Map)['boolSet'],
-            ),
-          )
-          as T;
-    }
-    if (t == Set<(bool,)>) {
-      return (data as List).map((e) => deserialize<(bool,)>(e)).toSet() as T;
-    }
-    if (t == _i1.getType<(bool,)>()) {
-      return (deserialize<bool>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(bool,)>()) {
-      return (deserialize<bool>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(Map<(Map<int, String>, String), String>,)>()) {
-      return (
-            deserialize<Map<(Map<int, String>, String), String>>(
-              ((data as Map)['p'] as List)[0],
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(int, {_i208.SimpleData data})>()) {
-      return (
-            deserialize<int>(((data as Map)['p'] as List)[0]),
-            data: deserialize<_i208.SimpleData>(data['n']['data']),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(int, {_i208.SimpleData data})?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<int>(((data as Map)['p'] as List)[0]),
-                  data: deserialize<_i208.SimpleData>(data['n']['data']),
-                )
-                as T;
-    }
-    if (t == List<(int, _i208.SimpleData)>) {
-      return (data as List)
-              .map((e) => deserialize<(int, _i208.SimpleData)>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<(int, _i208.SimpleData)>()) {
-      return (
-            deserialize<int>(((data as Map)['p'] as List)[0]),
-            deserialize<_i208.SimpleData>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == List<(int, _i208.SimpleData)?>) {
-      return (data as List)
-              .map((e) => deserialize<(int, _i208.SimpleData)?>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<(int, _i208.SimpleData)?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<int>(((data as Map)['p'] as List)[0]),
-                  deserialize<_i208.SimpleData>(data['p'][1]),
-                )
-                as T;
-    }
-    if (t == Set<(int, _i208.SimpleData)>) {
-      return (data as List)
-              .map((e) => deserialize<(int, _i208.SimpleData)>(e))
-              .toSet()
-          as T;
-    }
-    if (t == _i1.getType<(int, _i208.SimpleData)>()) {
-      return (
-            deserialize<int>(((data as Map)['p'] as List)[0]),
-            deserialize<_i208.SimpleData>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == Set<(int, _i208.SimpleData)?>) {
-      return (data as List)
-              .map((e) => deserialize<(int, _i208.SimpleData)?>(e))
-              .toSet()
-          as T;
-    }
-    if (t == _i1.getType<(int, _i208.SimpleData)?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<int>(((data as Map)['p'] as List)[0]),
-                  deserialize<_i208.SimpleData>(data['p'][1]),
-                )
-                as T;
-    }
-    if (t == _i1.getType<(int, _i208.SimpleData)>()) {
-      return (
-            deserialize<int>(((data as Map)['p'] as List)[0]),
-            deserialize<_i208.SimpleData>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Set<(int, _i208.SimpleData)>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<(int, _i208.SimpleData)>(e))
-                    .toSet()
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(int, _i208.SimpleData)>()) {
-      return (
-            deserialize<int>(((data as Map)['p'] as List)[0]),
-            deserialize<_i208.SimpleData>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == Map<String, (int, _i208.SimpleData)>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<(int, _i208.SimpleData)>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(int, _i208.SimpleData)>()) {
-      return (
-            deserialize<int>(((data as Map)['p'] as List)[0]),
-            deserialize<_i208.SimpleData>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == Map<String, (int, _i208.SimpleData)?>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<(int, _i208.SimpleData)?>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(int, _i208.SimpleData)?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<int>(((data as Map)['p'] as List)[0]),
-                  deserialize<_i208.SimpleData>(data['p'][1]),
-                )
-                as T;
-    }
-    if (t == Map<(String, int), (int, _i208.SimpleData)>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) => MapEntry(
-                deserialize<(String, int)>(e['k']),
-                deserialize<(int, _i208.SimpleData)>(e['v']),
-              ),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(String, int)>()) {
-      return (
-            deserialize<String>(((data as Map)['p'] as List)[0]),
-            deserialize<int>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(int, _i208.SimpleData)>()) {
-      return (
-            deserialize<int>(((data as Map)['p'] as List)[0]),
-            deserialize<_i208.SimpleData>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(String, int)>()) {
-      return (
-            deserialize<String>(((data as Map)['p'] as List)[0]),
-            deserialize<int>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == Map<String, List<Set<(int,)>>>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<List<Set<(int,)>>>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == List<Set<(int,)>>) {
-      return (data as List).map((e) => deserialize<Set<(int,)>>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<(int,)>()) {
-      return (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(int,)>()) {
-      return (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == Set<List<Map<String, (int,)>>>) {
-      return (data as List)
-              .map((e) => deserialize<List<Map<String, (int,)>>>(e))
-              .toSet()
-          as T;
-    }
-    if (t == List<Map<String, (int,)>>) {
-      return (data as List)
-              .map((e) => deserialize<Map<String, (int,)>>(e))
-              .toList()
-          as T;
-    }
-    if (t == Map<String, (int,)>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(deserialize<String>(k), deserialize<(int,)>(v)),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(int,)>()) {
-      return (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(int,)>()) {
-      return (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(int,)>()) {
-      return (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<({(_i208.SimpleData, double) namedSubRecord})>()) {
-      return (
-            namedSubRecord: deserialize<(_i208.SimpleData, double)>(
-              ((data as Map)['n'] as Map)['namedSubRecord'],
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(_i208.SimpleData, double)>()) {
-      return (
-            deserialize<_i208.SimpleData>(((data as Map)['p'] as List)[0]),
-            deserialize<double>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == _i1.getType<({(_i208.SimpleData, double)? namedSubRecord})>()) {
-      return (
-            namedSubRecord:
-                ((data as Map)['n'] as Map)['namedSubRecord'] == null
-                ? null
-                : deserialize<(_i208.SimpleData, double)>(
-                    data['n']['namedSubRecord'],
-                  ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(_i208.SimpleData, double)?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<_i208.SimpleData>(
-                    ((data as Map)['p'] as List)[0],
-                  ),
-                  deserialize<double>(data['p'][1]),
-                )
-                as T;
-    }
-    if (t ==
-        _i1
-            .getType<
-              ((int, String), {(_i208.SimpleData, double) namedSubRecord})
-            >()) {
-      return (
-            deserialize<(int, String)>(((data as Map)['p'] as List)[0]),
-            namedSubRecord: deserialize<(_i208.SimpleData, double)>(
-              data['n']['namedSubRecord'],
-            ),
-          )
-          as T;
-    }
-    if (t ==
-        List<((int, String), {(_i208.SimpleData, double) namedSubRecord})>) {
-      return (data as List)
-              .map(
-                (e) =>
-                    deserialize<
-                      (
-                        (int, String), {
-                        (_i208.SimpleData, double) namedSubRecord,
-                      })
-                    >(e),
-              )
-              .toList()
-          as T;
-    }
-    if (t ==
-        _i1
-            .getType<
-              ((int, String), {(_i208.SimpleData, double) namedSubRecord})
-            >()) {
-      return (
-            deserialize<(int, String)>(((data as Map)['p'] as List)[0]),
-            namedSubRecord: deserialize<(_i208.SimpleData, double)>(
-              data['n']['namedSubRecord'],
-            ),
-          )
-          as T;
-    }
-    if (t ==
-        List<((int, String), {(_i208.SimpleData, double) namedSubRecord})?>) {
-      return (data as List)
-              .map(
-                (e) =>
-                    deserialize<
-                      (
-                        (int, String), {
-                        (_i208.SimpleData, double) namedSubRecord,
-                      })?
-                    >(e),
-              )
-              .toList()
-          as T;
-    }
-    if (t ==
-        _i1
-            .getType<
-              ((int, String), {(_i208.SimpleData, double) namedSubRecord})?
-            >()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<(int, String)>(((data as Map)['p'] as List)[0]),
-                  namedSubRecord: deserialize<(_i208.SimpleData, double)>(
-                    data['n']['namedSubRecord'],
-                  ),
-                )
-                as T;
-    }
-    if (t ==
-        _i1
-            .getType<
-              List<
-                ((int, String), {(_i208.SimpleData, double) namedSubRecord})?
-              >?
-            >()) {
-      return (data != null
-              ? (data as List)
-                    .map(
-                      (e) =>
-                          deserialize<
-                            (
-                              (int, String), {
-                              (_i208.SimpleData, double) namedSubRecord,
-                            })?
-                          >(e),
-                    )
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t ==
-        _i1
-            .getType<
-              ((int, String), {(_i208.SimpleData, double) namedSubRecord})?
-            >()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<(int, String)>(((data as Map)['p'] as List)[0]),
-                  namedSubRecord: deserialize<(_i208.SimpleData, double)>(
-                    data['n']['namedSubRecord'],
-                  ),
-                )
-                as T;
-    }
-    if (t ==
-        _i1
-            .getType<
-              ((int, String), {(_i208.SimpleData, double) namedSubRecord})?
-            >()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<(int, String)>(((data as Map)['p'] as List)[0]),
-                  namedSubRecord: deserialize<(_i208.SimpleData, double)>(
-                    data['n']['namedSubRecord'],
-                  ),
-                )
-                as T;
-    }
-    if (t == _i1.getType<(int?, _i205.ProjectStreamingClass?)>()) {
-      return (
-            ((data as Map)['p'] as List)[0] == null
-                ? null
-                : deserialize<int>(data['p'][0]),
-            ((data)['p'] as List)[1] == null
-                ? null
-                : deserialize<_i205.ProjectStreamingClass>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == Set<Set<int>>) {
-      return (data as List).map((e) => deserialize<Set<int>>(e)).toSet() as T;
-    }
-    if (t == Set<List<int>>) {
-      return (data as List).map((e) => deserialize<List<int>>(e)).toSet() as T;
-    }
-    if (t == _i1.getType<Set<int>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<int>(e)).toSet()
-              : null)
-          as T;
-    }
-    if (t == Set<Set<int>?>) {
-      return (data as List).map((e) => deserialize<Set<int>?>(e)).toSet() as T;
-    }
-    if (t == _i1.getType<Set<int>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<int>(e)).toSet()
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<Set<Set<int>>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<Set<int>>(e)).toSet()
-              : null)
-          as T;
-    }
-    if (t == Set<int?>) {
-      return (data as List).map((e) => deserialize<int?>(e)).toSet() as T;
-    }
-    if (t == _i1.getType<Set<int?>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<int?>(e)).toSet()
-              : null)
-          as T;
-    }
-    if (t == Set<double>) {
-      return (data as List).map((e) => deserialize<double>(e)).toSet() as T;
-    }
-    if (t == Set<double?>) {
-      return (data as List).map((e) => deserialize<double?>(e)).toSet() as T;
-    }
-    if (t == Set<bool>) {
-      return (data as List).map((e) => deserialize<bool>(e)).toSet() as T;
-    }
-    if (t == Set<bool?>) {
-      return (data as List).map((e) => deserialize<bool?>(e)).toSet() as T;
-    }
-    if (t == Set<String>) {
-      return (data as List).map((e) => deserialize<String>(e)).toSet() as T;
-    }
-    if (t == Set<String?>) {
-      return (data as List).map((e) => deserialize<String?>(e)).toSet() as T;
-    }
-    if (t == Set<DateTime>) {
-      return (data as List).map((e) => deserialize<DateTime>(e)).toSet() as T;
-    }
-    if (t == Set<DateTime?>) {
-      return (data as List).map((e) => deserialize<DateTime?>(e)).toSet() as T;
-    }
-    if (t == Set<_i206.ByteData>) {
-      return (data as List).map((e) => deserialize<_i206.ByteData>(e)).toSet()
-          as T;
-    }
-    if (t == Set<_i206.ByteData?>) {
-      return (data as List).map((e) => deserialize<_i206.ByteData?>(e)).toSet()
-          as T;
-    }
-    if (t == Set<_i208.SimpleData?>) {
-      return (data as List)
-              .map((e) => deserialize<_i208.SimpleData?>(e))
-              .toSet()
-          as T;
-    }
-    if (t == Set<Duration>) {
-      return (data as List).map((e) => deserialize<Duration>(e)).toSet() as T;
-    }
-    if (t == Set<Duration?>) {
-      return (data as List).map((e) => deserialize<Duration?>(e)).toSet() as T;
-    }
-    if (t == List<_i212.Types>) {
-      return (data as List).map((e) => deserialize<_i212.Types>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<(String, (int, bool))>()) {
-      return (
-            deserialize<String>(((data as Map)['p'] as List)[0]),
-            deserialize<(int, bool)>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(int, bool)>()) {
-      return (
-            deserialize<int>(((data as Map)['p'] as List)[0]),
-            deserialize<bool>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == List<(String, (int, bool))>) {
-      return (data as List)
-              .map((e) => deserialize<(String, (int, bool))>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<(String, (int, bool))>()) {
-      return (
-            deserialize<String>(((data as Map)['p'] as List)[0]),
-            deserialize<(int, bool)>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t ==
-        _i1
-            .getType<
-              (
-                String,
-                (Map<String, int>, {bool flag, _i208.SimpleData simpleData}),
-              )
-            >()) {
-      return (
-            deserialize<String>(((data as Map)['p'] as List)[0]),
-            deserialize<
-              (Map<String, int>, {bool flag, _i208.SimpleData simpleData})
-            >(data['p'][1]),
-          )
-          as T;
-    }
-    if (t ==
-        _i1
-            .getType<
-              (Map<String, int>, {bool flag, _i208.SimpleData simpleData})
-            >()) {
-      return (
-            deserialize<Map<String, int>>(((data as Map)['p'] as List)[0]),
-            flag: deserialize<bool>(data['n']['flag']),
-            simpleData: deserialize<_i208.SimpleData>(data['n']['simpleData']),
-          )
-          as T;
-    }
-    if (t == List<(String, int)>) {
-      return (data as List).map((e) => deserialize<(String, int)>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<(String, int)>()) {
-      return (
-            deserialize<String>(((data as Map)['p'] as List)[0]),
-            deserialize<int>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t ==
-        _i1
-            .getType<
-              (
-                String,
-                (Map<String, int>, {bool flag, _i208.SimpleData simpleData}),
-              )?
-            >()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<String>(((data as Map)['p'] as List)[0]),
-                  deserialize<
-                    (Map<String, int>, {bool flag, _i208.SimpleData simpleData})
-                  >(data['p'][1]),
-                )
-                as T;
-    }
-    if (t == _i1.getType<(String, int)>()) {
-      return (
-            deserialize<String>(((data as Map)['p'] as List)[0]),
-            deserialize<int>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == _i1.getType<List<(String, int)>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<(String, int)>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(String, int)>()) {
-      return (
-            deserialize<String>(((data as Map)['p'] as List)[0]),
-            deserialize<int>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(int, String)>()) {
-      return (
-            deserialize<int>(((data as Map)['p'] as List)[0]),
-            deserialize<String>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(_i205.ModuleClass,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<_i205.ModuleClass>(((data as Map)['p'] as List)[0]),)
-                as T;
-    }
-    if (t == _i1.getType<(bool,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<bool>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(_i195.TestEnumStringified,)?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<_i195.TestEnumStringified>(
-                    ((data as Map)['p'] as List)[0],
-                  ),
-                )
-                as T;
-    }
-    if (t == _i1.getType<(_i195.TestEnumStringified,)>()) {
-      return (
-            deserialize<_i195.TestEnumStringified>(
-              ((data as Map)['p'] as List)[0],
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<List<(_i195.TestEnumStringified,)>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<(_i195.TestEnumStringified,)>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(_i195.TestEnumStringified,)>()) {
-      return (
-            deserialize<_i195.TestEnumStringified>(
-              ((data as Map)['p'] as List)[0],
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(_i195.TestEnumStringified,)>()) {
-      return (
-            deserialize<_i195.TestEnumStringified>(
-              ((data as Map)['p'] as List)[0],
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(_i146.Nullability,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<_i146.Nullability>(((data as Map)['p'] as List)[0]),)
-                as T;
-    }
-    if (t == _i1.getType<({_i195.TestEnumStringified value})?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  value: deserialize<_i195.TestEnumStringified>(
-                    ((data as Map)['n'] as Map)['value'],
-                  ),
-                )
-                as T;
-    }
-    if (t == _i1.getType<({_i195.TestEnumStringified value})>()) {
-      return (
-            value: deserialize<_i195.TestEnumStringified>(
-              ((data as Map)['n'] as Map)['value'],
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<List<({_i195.TestEnumStringified value})>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map(
-                      (e) =>
-                          deserialize<({_i195.TestEnumStringified value})>(e),
-                    )
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<({_i195.TestEnumStringified value})>()) {
-      return (
-            value: deserialize<_i195.TestEnumStringified>(
-              ((data as Map)['n'] as Map)['value'],
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<({_i195.TestEnumStringified value})>()) {
-      return (
-            value: deserialize<_i195.TestEnumStringified>(
-              ((data as Map)['n'] as Map)['value'],
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<({_i205.ModuleClass value})?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  value: deserialize<_i205.ModuleClass>(
-                    ((data as Map)['n'] as Map)['value'],
-                  ),
-                )
-                as T;
-    }
-    if (t == _i1.getType<({_i146.Nullability value})?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  value: deserialize<_i146.Nullability>(
-                    ((data as Map)['n'] as Map)['value'],
-                  ),
-                )
-                as T;
-    }
-    if (t == _i1.getType<(String, {Uri? optionalUri})?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<String>(((data as Map)['p'] as List)[0]),
-                  optionalUri: ((data)['n'] as Map)['optionalUri'] == null
-                      ? null
-                      : deserialize<Uri>(data['n']['optionalUri']),
-                )
-                as T;
-    }
-    if (t == _i1.getType<(int,)>()) {
-      return (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<List<(int,)>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<(int,)>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(int,)>()) {
-      return (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(int,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<List<(int,)?>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<(int,)?>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(int,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(_i191.TestEnum,)>()) {
-      return (deserialize<_i191.TestEnum>(((data as Map)['p'] as List)[0]),)
-          as T;
-    }
-    if (t == _i1.getType<List<(_i191.TestEnum,)>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<(_i191.TestEnum,)>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(_i191.TestEnum,)>()) {
-      return (deserialize<_i191.TestEnum>(((data as Map)['p'] as List)[0]),)
-          as T;
-    }
-    if (t == _i1.getType<(_i191.TestEnum,)>()) {
-      return (deserialize<_i191.TestEnum>(((data as Map)['p'] as List)[0]),)
-          as T;
-    }
-    if (t == _i1.getType<(String,)>()) {
-      return (deserialize<String>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<Map<(String,), String>?>()) {
-      return (data != null
-              ? Map.fromEntries(
-                  (data as List).map(
-                    (e) => MapEntry(
-                      deserialize<(String,)>(e['k']),
-                      deserialize<String>(e['v']),
-                    ),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(String,)>()) {
-      return (deserialize<String>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(String,)>()) {
-      return (deserialize<String>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(String,)>()) {
-      return (deserialize<String>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<Map<String, (String,)>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) => MapEntry(
-                    deserialize<String>(k),
-                    deserialize<(String,)>(v),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(String,)>()) {
-      return (deserialize<String>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(String,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<String>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<Map<String, (String,)?>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) => MapEntry(
-                    deserialize<String>(k),
-                    deserialize<(String,)?>(v),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(String,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<String>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(String,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<String>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(String,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<String>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<Map<(String,)?, String>?>()) {
-      return (data != null
-              ? Map.fromEntries(
-                  (data as List).map(
-                    (e) => MapEntry(
-                      deserialize<(String,)?>(e['k']),
-                      deserialize<String>(e['v']),
-                    ),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(String,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<String>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(double,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<double>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(DateTime,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<DateTime>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(_i206.ByteData,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<_i206.ByteData>(((data as Map)['p'] as List)[0]),)
-                as T;
-    }
-    if (t == _i1.getType<(Duration,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<Duration>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(_i1.UuidValue,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<_i1.UuidValue>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(Uri,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<Uri>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(BigInt,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<BigInt>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(_i191.TestEnum,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<_i191.TestEnum>(((data as Map)['p'] as List)[0]),)
-                as T;
-    }
-    if (t == _i1.getType<(List<int>,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<List<int>>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(Map<int, int>,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<Map<int, int>>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(Set<int>,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<Set<int>>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(_i185.SimpleData,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<_i185.SimpleData>(((data as Map)['p'] as List)[0]),)
-                as T;
-    }
-    if (t == _i1.getType<({_i185.SimpleData namedModel})?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  namedModel: deserialize<_i185.SimpleData>(
-                    ((data as Map)['n'] as Map)['namedModel'],
-                  ),
-                )
-                as T;
-    }
-    if (t ==
-        _i1.getType<(_i185.SimpleData, {_i185.SimpleData namedModel})?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<_i185.SimpleData>(
-                    ((data as Map)['p'] as List)[0],
-                  ),
-                  namedModel: deserialize<_i185.SimpleData>(
-                    data['n']['namedModel'],
-                  ),
-                )
-                as T;
-    }
-    if (t ==
-        _i1.getType<((int, String), {(int, String) namedNestedRecord})?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<(int, String)>(((data as Map)['p'] as List)[0]),
-                  namedNestedRecord: deserialize<(int, String)>(
-                    data['n']['namedNestedRecord'],
-                  ),
-                )
-                as T;
-    }
-    if (t ==
-        _i1
-            .getType<
-              (
-                (List<(_i185.SimpleData,)>,), {
-                (_i185.SimpleData, Map<String, _i185.SimpleData>)
-                namedNestedRecord,
-              })?
-            >()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<(List<(_i185.SimpleData,)>,)>(
-                    ((data as Map)['p'] as List)[0],
-                  ),
-                  namedNestedRecord:
-                      deserialize<
-                        (_i185.SimpleData, Map<String, _i185.SimpleData>)
-                      >(data['n']['namedNestedRecord']),
-                )
-                as T;
-    }
-    if (t == _i1.getType<(List<(_i185.SimpleData,)>,)>()) {
-      return (
-            deserialize<List<(_i185.SimpleData,)>>(
-              ((data as Map)['p'] as List)[0],
-            ),
-          )
-          as T;
-    }
-    if (t == List<(_i185.SimpleData,)>) {
-      return (data as List)
-              .map((e) => deserialize<(_i185.SimpleData,)>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<(_i185.SimpleData,)>()) {
-      return (deserialize<_i185.SimpleData>(((data as Map)['p'] as List)[0]),)
-          as T;
-    }
-    if (t == _i1.getType<(_i185.SimpleData,)>()) {
-      return (deserialize<_i185.SimpleData>(((data as Map)['p'] as List)[0]),)
-          as T;
-    }
-    if (t == _i1.getType<(_i185.SimpleData, Map<String, _i185.SimpleData>)>()) {
-      return (
-            deserialize<_i185.SimpleData>(((data as Map)['p'] as List)[0]),
-            deserialize<Map<String, _i185.SimpleData>>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(int,)>()) {
-      return (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<Set<(int,)>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<(int,)>(e)).toSet()
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(int,)>()) {
-      return (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(int,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<Set<(int,)?>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<(int,)?>(e)).toSet()
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(int,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i207.CustomClass) {
-      return _i207.CustomClass.fromJson(data) as T;
-    }
-    if (t == _i207.CustomClass2) {
-      return _i207.CustomClass2.fromJson(data) as T;
-    }
-    if (t == _i207.ProtocolCustomClass) {
-      return _i207.ProtocolCustomClass.fromJson(data) as T;
-    }
-    if (t == _i207.ExternalCustomClass) {
-      return _i207.ExternalCustomClass.fromJson(data) as T;
-    }
-    if (t == _i207.FreezedCustomClass) {
-      return _i207.FreezedCustomClass.fromJson(data) as T;
-    }
-    if (t == _i1.getType<_i207.CustomClass?>()) {
-      return (data != null ? _i207.CustomClass.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i207.CustomClass2?>()) {
-      return (data != null ? _i207.CustomClass2.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i207.CustomClassWithoutProtocolSerialization?>()) {
-      return (data != null
-              ? _i207.CustomClassWithoutProtocolSerialization.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i207.CustomClassWithProtocolSerialization?>()) {
-      return (data != null
-              ? _i207.CustomClassWithProtocolSerialization.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i207.CustomClassWithProtocolSerializationMethod?>()) {
-      return (data != null
-              ? _i207.CustomClassWithProtocolSerializationMethod.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i207.ProtocolCustomClass?>()) {
-      return (data != null ? _i207.ProtocolCustomClass.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i207.ExternalCustomClass?>()) {
-      return (data != null ? _i207.ExternalCustomClass.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i207.FreezedCustomClass?>()) {
-      return (data != null ? _i207.FreezedCustomClass.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<List<_i208.SimpleData>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i208.SimpleData>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(String, _i211.PolymorphicParent)>()) {
-      return (
-            deserialize<String>(((data as Map)['p'] as List)[0]),
-            deserialize<_i211.PolymorphicParent>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(int?,)?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  ((data as Map)['p'] as List)[0] == null
-                      ? null
-                      : deserialize<int>(data['p'][0]),
-                )
-                as T;
-    }
-    if (t ==
-        _i1
-            .getType<
-              ((int, String), {(_i208.SimpleData, double) namedSubRecord})?
-            >()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<(int, String)>(((data as Map)['p'] as List)[0]),
-                  namedSubRecord: deserialize<(_i208.SimpleData, double)>(
-                    data['n']['namedSubRecord'],
-                  ),
-                )
-                as T;
-    }
-    if (t ==
-        _i1
-            .getType<
-              List<
-                ((int, String), {(_i208.SimpleData, double) namedSubRecord})?
-              >?
-            >()) {
-      return (data != null
-              ? (data as List)
-                    .map(
-                      (e) =>
-                          deserialize<
-                            (
-                              (int, String), {
-                              (_i208.SimpleData, double) namedSubRecord,
-                            })?
-                          >(e),
-                    )
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t ==
-        _i1
-            .getType<
-              ((int, String), {(_i208.SimpleData, double) namedSubRecord})?
-            >()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<(int, String)>(((data as Map)['p'] as List)[0]),
-                  namedSubRecord: deserialize<(_i208.SimpleData, double)>(
-                    data['n']['namedSubRecord'],
-                  ),
-                )
-                as T;
-    }
-    if (t == _i1.getType<(int?, _i205.ProjectStreamingClass?)>()) {
-      return (
-            ((data as Map)['p'] as List)[0] == null
-                ? null
-                : deserialize<int>(data['p'][0]),
-            ((data)['p'] as List)[1] == null
-                ? null
-                : deserialize<_i205.ProjectStreamingClass>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t ==
-        _i1
-            .getType<
-              (
-                String,
-                (Map<String, int>, {bool flag, _i208.SimpleData simpleData}),
-              )
-            >()) {
-      return (
-            deserialize<String>(((data as Map)['p'] as List)[0]),
-            deserialize<
-              (Map<String, int>, {bool flag, _i208.SimpleData simpleData})
-            >(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(String, int)>()) {
-      return (
-            deserialize<String>(((data as Map)['p'] as List)[0]),
-            deserialize<int>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t ==
-        _i1
-            .getType<
-              (
-                String,
-                (Map<String, int>, {bool flag, _i208.SimpleData simpleData}),
-              )?
-            >()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<String>(((data as Map)['p'] as List)[0]),
-                  deserialize<
-                    (Map<String, int>, {bool flag, _i208.SimpleData simpleData})
-                  >(data['p'][1]),
-                )
-                as T;
-    }
-    if (t == _i1.getType<(String, int)>()) {
-      return (
-            deserialize<String>(((data as Map)['p'] as List)[0]),
-            deserialize<int>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == _i1.getType<List<(String, int)>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<(String, int)>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(String, int)>()) {
-      return (
-            deserialize<String>(((data as Map)['p'] as List)[0]),
-            deserialize<int>(data['p'][1]),
-          )
-          as T;
+    final fn = _deserializers[t];
+    if (fn != null) {
+      return fn(data, this) as T;
     }
     try {
       return _i210.Protocol().deserialize<T>(data, t);

--- a/tests/serverpod_test_client/lib/src/protocol/protocol.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/protocol.dart
@@ -12,243 +12,243 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
-import 'by_index_enum_with_name_value.dart' as _i2;
-import 'by_name_enum_with_name_value.dart' as _i3;
-import 'changed_id_type/many_to_many/course.dart' as _i4;
-import 'changed_id_type/many_to_many/enrollment.dart' as _i5;
-import 'changed_id_type/many_to_many/student.dart' as _i6;
-import 'changed_id_type/nested_one_to_many/arena.dart' as _i7;
-import 'changed_id_type/nested_one_to_many/player.dart' as _i8;
-import 'changed_id_type/nested_one_to_many/team.dart' as _i9;
-import 'changed_id_type/one_to_many/comment.dart' as _i10;
-import 'changed_id_type/one_to_many/customer.dart' as _i11;
-import 'changed_id_type/one_to_many/order.dart' as _i12;
-import 'changed_id_type/one_to_one/address.dart' as _i13;
-import 'changed_id_type/one_to_one/citizen.dart' as _i14;
-import 'changed_id_type/one_to_one/company.dart' as _i15;
-import 'changed_id_type/one_to_one/town.dart' as _i16;
-import 'changed_id_type/self.dart' as _i17;
-import 'defaults/bigint/bigint_default.dart' as _i18;
-import 'defaults/bigint/bigint_default_mix.dart' as _i19;
-import 'defaults/bigint/bigint_default_model.dart' as _i20;
-import 'defaults/bigint/bigint_default_persist.dart' as _i21;
-import 'defaults/boolean/bool_default.dart' as _i22;
-import 'defaults/boolean/bool_default_mix.dart' as _i23;
-import 'defaults/boolean/bool_default_model.dart' as _i24;
-import 'defaults/boolean/bool_default_persist.dart' as _i25;
-import 'defaults/datetime/datetime_default.dart' as _i26;
-import 'defaults/datetime/datetime_default_mix.dart' as _i27;
-import 'defaults/datetime/datetime_default_model.dart' as _i28;
-import 'defaults/datetime/datetime_default_persist.dart' as _i29;
-import 'defaults/double/double_default.dart' as _i30;
-import 'defaults/double/double_default_mix.dart' as _i31;
-import 'defaults/double/double_default_model.dart' as _i32;
-import 'defaults/double/double_default_persist.dart' as _i33;
-import 'defaults/duration/duration_default.dart' as _i34;
-import 'defaults/duration/duration_default_mix.dart' as _i35;
-import 'defaults/duration/duration_default_model.dart' as _i36;
-import 'defaults/duration/duration_default_persist.dart' as _i37;
-import 'defaults/enum/enum_default.dart' as _i38;
-import 'defaults/enum/enum_default_mix.dart' as _i39;
-import 'defaults/enum/enum_default_model.dart' as _i40;
-import 'defaults/enum/enum_default_persist.dart' as _i41;
-import 'defaults/enum/enums/by_index_enum.dart' as _i42;
-import 'defaults/enum/enums/by_name_enum.dart' as _i43;
-import 'defaults/enum/enums/default_value_enum.dart' as _i44;
-import 'defaults/exception/default_exception.dart' as _i45;
-import 'defaults/integer/int_default.dart' as _i46;
-import 'defaults/integer/int_default_mix.dart' as _i47;
-import 'defaults/integer/int_default_model.dart' as _i48;
-import 'defaults/integer/int_default_persist.dart' as _i49;
-import 'defaults/string/string_default.dart' as _i50;
-import 'defaults/string/string_default_mix.dart' as _i51;
-import 'defaults/string/string_default_model.dart' as _i52;
-import 'defaults/string/string_default_persist.dart' as _i53;
-import 'defaults/uri/uri_default.dart' as _i54;
-import 'defaults/uri/uri_default_mix.dart' as _i55;
-import 'defaults/uri/uri_default_model.dart' as _i56;
-import 'defaults/uri/uri_default_persist.dart' as _i57;
-import 'defaults/uuid/uuid_default.dart' as _i58;
-import 'defaults/uuid/uuid_default_mix.dart' as _i59;
-import 'defaults/uuid/uuid_default_model.dart' as _i60;
-import 'defaults/uuid/uuid_default_persist.dart' as _i61;
-import 'empty_model/empty_model.dart' as _i62;
-import 'empty_model/empty_model_relation_item.dart' as _i63;
-import 'empty_model/empty_model_with_table.dart' as _i64;
-import 'empty_model/relation_empy_model.dart' as _i65;
-import 'exception_with_data.dart' as _i66;
-import 'explicit_column_name/inheritance/child_class_explicit_column.dart'
-    as _i67;
-import 'explicit_column_name/inheritance/non_table_parent_class.dart' as _i68;
-import 'explicit_column_name/modified_column_name.dart' as _i69;
-import 'explicit_column_name/relations/one_to_many/department.dart' as _i70;
-import 'explicit_column_name/relations/one_to_many/employee.dart' as _i71;
-import 'explicit_column_name/relations/one_to_one/contractor.dart' as _i72;
-import 'explicit_column_name/relations/one_to_one/service.dart' as _i73;
-import 'explicit_column_name/table_with_explicit_column_names.dart' as _i74;
-import 'immutable/immutable_child_object.dart' as _i75;
-import 'immutable/immutable_child_object_with_no_additional_fields.dart'
-    as _i76;
-import 'immutable/immutable_object.dart' as _i77;
-import 'immutable/immutable_object_with_immutable_object.dart' as _i78;
-import 'immutable/immutable_object_with_list.dart' as _i79;
-import 'immutable/immutable_object_with_map.dart' as _i80;
-import 'immutable/immutable_object_with_multiple_fields.dart' as _i81;
-import 'immutable/immutable_object_with_no_fields.dart' as _i82;
-import 'immutable/immutable_object_with_record.dart' as _i83;
-import 'immutable/immutable_object_with_table.dart' as _i84;
-import 'immutable/immutable_object_with_twenty_fields.dart' as _i85;
-import 'inheritance/child_class.dart' as _i86;
-import 'inheritance/child_with_default.dart' as _i87;
-import 'inheritance/child_without_id.dart' as _i88;
-import 'inheritance/exception/extended_app_exception.dart' as _i89;
-import 'inheritance/exception/base_app_exception.dart' as _i90;
-import 'inheritance/exception/sealed_app_exception.dart' as _i91;
-import 'inheritance/parent_class.dart' as _i92;
-import 'inheritance/grandparent_class.dart' as _i93;
-import 'inheritance/parent_without_id.dart' as _i94;
-import 'inheritance/grandparent_with_id.dart' as _i95;
-import 'inheritance/list_relation_of_child/child_entity.dart' as _i96;
-import 'inheritance/list_relation_of_child/base_entity.dart' as _i97;
-import 'inheritance/list_relation_of_child/parent_entity.dart' as _i98;
-import 'inheritance/parent_non_server_only.dart' as _i99;
-import 'inheritance/parent_with_default.dart' as _i100;
-import 'inheritance/polymorphism/grandchild.dart' as _i101;
-import 'inheritance/polymorphism/child.dart' as _i102;
-import 'inheritance/polymorphism/container.dart' as _i103;
-import 'inheritance/polymorphism/container_module.dart' as _i104;
-import 'inheritance/polymorphism/other.dart' as _i105;
-import 'inheritance/polymorphism/parent.dart' as _i106;
-import 'inheritance/polymorphism/unrelated.dart' as _i107;
-import 'inheritance/sealed_parent.dart' as _i108;
-import 'inheritance/sealed_parent_nullable_field.dart' as _i109;
-import 'long_identifiers/deep_includes/city_with_long_table_name.dart' as _i110;
-import 'long_identifiers/deep_includes/organization_with_long_table_name.dart'
-    as _i111;
-import 'long_identifiers/deep_includes/person_with_long_table_name.dart'
-    as _i112;
-import 'long_identifiers/max_field_name.dart' as _i113;
-import 'long_identifiers/models_with_relations/long_implicit_id_field.dart'
-    as _i114;
-import 'long_identifiers/models_with_relations/long_implicit_id_field_collection.dart'
-    as _i115;
-import 'long_identifiers/models_with_relations/relation_to_mutiple_max_field_name.dart'
-    as _i116;
-import 'long_identifiers/models_with_relations/user_note.dart' as _i117;
-import 'long_identifiers/models_with_relations/user_note_collection.dart'
-    as _i118;
-import 'long_identifiers/models_with_relations/user_note_collection_with_a_long_name.dart'
-    as _i119;
-import 'long_identifiers/models_with_relations/user_note_with_a_long_name.dart'
-    as _i120;
-import 'long_identifiers/multiple_max_field_name.dart' as _i121;
-import 'models_with_list_relations/city.dart' as _i122;
-import 'models_with_list_relations/organization.dart' as _i123;
-import 'models_with_list_relations/person.dart' as _i124;
-import 'models_with_relations/column_alias_collision/bleed_child.dart' as _i125;
-import 'models_with_relations/column_alias_collision/bleed_root.dart' as _i126;
-import 'models_with_relations/many_to_many/course.dart' as _i127;
-import 'models_with_relations/many_to_many/enrollment.dart' as _i128;
-import 'models_with_relations/many_to_many/student.dart' as _i129;
-import 'models_with_relations/module/object_user.dart' as _i130;
-import 'models_with_relations/module/parent_user.dart' as _i131;
-import 'models_with_relations/nested_one_to_many/arena.dart' as _i132;
-import 'models_with_relations/nested_one_to_many/player.dart' as _i133;
-import 'models_with_relations/nested_one_to_many/team.dart' as _i134;
-import 'models_with_relations/one_to_many/comment.dart' as _i135;
-import 'models_with_relations/one_to_many/customer.dart' as _i136;
-import 'models_with_relations/one_to_many/implicit/book.dart' as _i137;
-import 'models_with_relations/one_to_many/implicit/chapter.dart' as _i138;
-import 'models_with_relations/one_to_many/order.dart' as _i139;
-import 'models_with_relations/one_to_one/address.dart' as _i140;
-import 'models_with_relations/one_to_one/citizen.dart' as _i141;
-import 'models_with_relations/one_to_one/company.dart' as _i142;
-import 'models_with_relations/one_to_one/town.dart' as _i143;
-import 'models_with_relations/self_relation/many_to_many/blocking.dart'
-    as _i144;
-import 'models_with_relations/self_relation/many_to_many/member.dart' as _i145;
-import 'models_with_relations/self_relation/one_to_many/cat.dart' as _i146;
-import 'models_with_relations/self_relation/one_to_one/post.dart' as _i147;
-import 'module_datatype.dart' as _i148;
-import 'my_feature/models/my_feature_model.dart' as _i149;
-import 'my_trigger_type.dart' as _i150;
-import 'nullability.dart' as _i151;
-import 'nulls_distinct_data.dart' as _i152;
-import 'object_field_persist.dart' as _i153;
-import 'object_field_scopes.dart' as _i154;
-import 'object_with_bit.dart' as _i155;
-import 'object_with_bytedata.dart' as _i156;
-import 'object_with_custom_class.dart' as _i157;
-import 'object_with_duration.dart' as _i158;
-import 'object_with_dynamic.dart' as _i159;
-import 'object_with_enum.dart' as _i160;
-import 'object_with_enum_enhanced.dart' as _i161;
-import 'object_with_geography_geometry_collection.dart' as _i162;
-import 'object_with_geography_line_string.dart' as _i163;
-import 'object_with_geography_point.dart' as _i164;
-import 'object_with_geography_polygon.dart' as _i165;
-import 'object_with_half_vector.dart' as _i166;
-import 'object_with_index.dart' as _i167;
-import 'object_with_jsonb.dart' as _i168;
-import 'object_with_jsonb_class_level.dart' as _i169;
-import 'object_with_maps.dart' as _i170;
-import 'object_with_nullable_custom_class.dart' as _i171;
-import 'object_with_object.dart' as _i172;
-import 'object_with_parent.dart' as _i173;
-import 'object_with_sealed_class.dart' as _i174;
-import 'object_with_sealed_exception.dart' as _i175;
-import 'object_with_self_parent.dart' as _i176;
-import 'object_with_sparse_vector.dart' as _i177;
-import 'object_with_uuid.dart' as _i178;
-import 'object_with_vector.dart' as _i179;
-import 'record.dart' as _i180;
-import 'related_unique_data.dart' as _i181;
-import 'required/exception_with_required_field.dart' as _i182;
-import 'required/model_with_required_field.dart' as _i183;
-import 'scopes/scope_none_fields.dart' as _i184;
-import 'scopes/scope_server_only_field_child.dart' as _i185;
-import 'scopes/scope_server_only_field.dart' as _i186;
-import 'scopes/serverOnly/default_server_only_class.dart' as _i187;
-import 'scopes/serverOnly/default_server_only_enum.dart' as _i188;
-import 'scopes/serverOnly/not_server_only_class.dart' as _i189;
-import 'scopes/serverOnly/not_server_only_enum.dart' as _i190;
-import 'scopes/server_only_class_field.dart' as _i191;
-import 'server_only_default.dart' as _i192;
-import 'session_auth_info.dart' as _i193;
-import 'shared_model_container.dart' as _i194;
-import 'shared_model_subclass.dart' as _i195;
-import 'simple_data.dart' as _i196;
-import 'simple_data_list.dart' as _i197;
-import 'simple_data_map.dart' as _i198;
-import 'simple_data_object.dart' as _i199;
-import 'simple_date_time.dart' as _i200;
-import 'subfolder/model_in_subfolder.dart' as _i201;
-import 'test_enum.dart' as _i202;
-import 'test_enum_default_serialization.dart' as _i203;
-import 'test_enum_enhanced.dart' as _i204;
-import 'test_enum_enhanced_by_name.dart' as _i205;
-import 'test_enum_stringified.dart' as _i206;
-import 'types.dart' as _i207;
-import 'types_list.dart' as _i208;
-import 'types_map.dart' as _i209;
-import 'types_record.dart' as _i210;
-import 'types_set.dart' as _i211;
-import 'types_set_required.dart' as _i212;
-import 'unique_data.dart' as _i213;
-import 'unique_data_with_non_persist.dart' as _i214;
-import 'upsert_test_model.dart' as _i215;
+import 'package:serverpod_auth_client/serverpod_auth_client.dart' as _i2;
 import 'package:serverpod_test_module_client/serverpod_test_module_client.dart'
-    as _i216;
-import 'dart:typed_data' as _i217;
-import 'package:serverpod_test_shared/serverpod_test_shared.dart' as _i218;
-import 'package:serverpod_test_client/src/protocol/simple_data.dart' as _i219;
-import 'package:serverpod_test_client/src/protocol/test_enum.dart' as _i220;
-import 'package:serverpod_auth_client/serverpod_auth_client.dart' as _i221;
-import 'package:serverpod_test_client/src/protocol/inheritance/polymorphism/parent.dart'
-    as _i222;
-import 'package:serverpod_test_client/src/protocol/types.dart' as _i223;
+    as _i3;
 import 'package:serverpod_test_shared_module_client/serverpod_test_shared_module_client.dart'
-    as _i224;
+    as _i4;
+import 'package:serverpod_test_shared/serverpod_test_shared.dart' as _i5;
+import 'by_index_enum_with_name_value.dart' as _i6;
+import 'by_name_enum_with_name_value.dart' as _i7;
+import 'changed_id_type/many_to_many/course.dart' as _i8;
+import 'changed_id_type/many_to_many/enrollment.dart' as _i9;
+import 'changed_id_type/many_to_many/student.dart' as _i10;
+import 'changed_id_type/nested_one_to_many/arena.dart' as _i11;
+import 'changed_id_type/nested_one_to_many/player.dart' as _i12;
+import 'changed_id_type/nested_one_to_many/team.dart' as _i13;
+import 'changed_id_type/one_to_many/comment.dart' as _i14;
+import 'changed_id_type/one_to_many/customer.dart' as _i15;
+import 'changed_id_type/one_to_many/order.dart' as _i16;
+import 'changed_id_type/one_to_one/address.dart' as _i17;
+import 'changed_id_type/one_to_one/citizen.dart' as _i18;
+import 'changed_id_type/one_to_one/company.dart' as _i19;
+import 'changed_id_type/one_to_one/town.dart' as _i20;
+import 'changed_id_type/self.dart' as _i21;
+import 'defaults/bigint/bigint_default.dart' as _i22;
+import 'defaults/bigint/bigint_default_mix.dart' as _i23;
+import 'defaults/bigint/bigint_default_model.dart' as _i24;
+import 'defaults/bigint/bigint_default_persist.dart' as _i25;
+import 'defaults/boolean/bool_default.dart' as _i26;
+import 'defaults/boolean/bool_default_mix.dart' as _i27;
+import 'defaults/boolean/bool_default_model.dart' as _i28;
+import 'defaults/boolean/bool_default_persist.dart' as _i29;
+import 'defaults/datetime/datetime_default.dart' as _i30;
+import 'defaults/datetime/datetime_default_mix.dart' as _i31;
+import 'defaults/datetime/datetime_default_model.dart' as _i32;
+import 'defaults/datetime/datetime_default_persist.dart' as _i33;
+import 'defaults/double/double_default.dart' as _i34;
+import 'defaults/double/double_default_mix.dart' as _i35;
+import 'defaults/double/double_default_model.dart' as _i36;
+import 'defaults/double/double_default_persist.dart' as _i37;
+import 'defaults/duration/duration_default.dart' as _i38;
+import 'defaults/duration/duration_default_mix.dart' as _i39;
+import 'defaults/duration/duration_default_model.dart' as _i40;
+import 'defaults/duration/duration_default_persist.dart' as _i41;
+import 'defaults/enum/enum_default.dart' as _i42;
+import 'defaults/enum/enum_default_mix.dart' as _i43;
+import 'defaults/enum/enum_default_model.dart' as _i44;
+import 'defaults/enum/enum_default_persist.dart' as _i45;
+import 'defaults/enum/enums/by_index_enum.dart' as _i46;
+import 'defaults/enum/enums/by_name_enum.dart' as _i47;
+import 'defaults/enum/enums/default_value_enum.dart' as _i48;
+import 'defaults/exception/default_exception.dart' as _i49;
+import 'defaults/integer/int_default.dart' as _i50;
+import 'defaults/integer/int_default_mix.dart' as _i51;
+import 'defaults/integer/int_default_model.dart' as _i52;
+import 'defaults/integer/int_default_persist.dart' as _i53;
+import 'defaults/string/string_default.dart' as _i54;
+import 'defaults/string/string_default_mix.dart' as _i55;
+import 'defaults/string/string_default_model.dart' as _i56;
+import 'defaults/string/string_default_persist.dart' as _i57;
+import 'defaults/uri/uri_default.dart' as _i58;
+import 'defaults/uri/uri_default_mix.dart' as _i59;
+import 'defaults/uri/uri_default_model.dart' as _i60;
+import 'defaults/uri/uri_default_persist.dart' as _i61;
+import 'defaults/uuid/uuid_default.dart' as _i62;
+import 'defaults/uuid/uuid_default_mix.dart' as _i63;
+import 'defaults/uuid/uuid_default_model.dart' as _i64;
+import 'defaults/uuid/uuid_default_persist.dart' as _i65;
+import 'empty_model/empty_model.dart' as _i66;
+import 'empty_model/empty_model_relation_item.dart' as _i67;
+import 'empty_model/empty_model_with_table.dart' as _i68;
+import 'empty_model/relation_empy_model.dart' as _i69;
+import 'exception_with_data.dart' as _i70;
+import 'explicit_column_name/inheritance/child_class_explicit_column.dart'
+    as _i71;
+import 'explicit_column_name/inheritance/non_table_parent_class.dart' as _i72;
+import 'explicit_column_name/modified_column_name.dart' as _i73;
+import 'explicit_column_name/relations/one_to_many/department.dart' as _i74;
+import 'explicit_column_name/relations/one_to_many/employee.dart' as _i75;
+import 'explicit_column_name/relations/one_to_one/contractor.dart' as _i76;
+import 'explicit_column_name/relations/one_to_one/service.dart' as _i77;
+import 'explicit_column_name/table_with_explicit_column_names.dart' as _i78;
+import 'immutable/immutable_child_object.dart' as _i79;
+import 'immutable/immutable_child_object_with_no_additional_fields.dart'
+    as _i80;
+import 'immutable/immutable_object.dart' as _i81;
+import 'immutable/immutable_object_with_immutable_object.dart' as _i82;
+import 'immutable/immutable_object_with_list.dart' as _i83;
+import 'immutable/immutable_object_with_map.dart' as _i84;
+import 'immutable/immutable_object_with_multiple_fields.dart' as _i85;
+import 'immutable/immutable_object_with_no_fields.dart' as _i86;
+import 'immutable/immutable_object_with_record.dart' as _i87;
+import 'immutable/immutable_object_with_table.dart' as _i88;
+import 'immutable/immutable_object_with_twenty_fields.dart' as _i89;
+import 'inheritance/child_class.dart' as _i90;
+import 'inheritance/child_with_default.dart' as _i91;
+import 'inheritance/child_without_id.dart' as _i92;
+import 'inheritance/exception/extended_app_exception.dart' as _i93;
+import 'inheritance/exception/base_app_exception.dart' as _i94;
+import 'inheritance/exception/sealed_app_exception.dart' as _i95;
+import 'inheritance/parent_class.dart' as _i96;
+import 'inheritance/grandparent_class.dart' as _i97;
+import 'inheritance/parent_without_id.dart' as _i98;
+import 'inheritance/grandparent_with_id.dart' as _i99;
+import 'inheritance/list_relation_of_child/child_entity.dart' as _i100;
+import 'inheritance/list_relation_of_child/base_entity.dart' as _i101;
+import 'inheritance/list_relation_of_child/parent_entity.dart' as _i102;
+import 'inheritance/parent_non_server_only.dart' as _i103;
+import 'inheritance/parent_with_default.dart' as _i104;
+import 'inheritance/polymorphism/grandchild.dart' as _i105;
+import 'inheritance/polymorphism/child.dart' as _i106;
+import 'inheritance/polymorphism/container.dart' as _i107;
+import 'inheritance/polymorphism/container_module.dart' as _i108;
+import 'inheritance/polymorphism/other.dart' as _i109;
+import 'inheritance/polymorphism/parent.dart' as _i110;
+import 'inheritance/polymorphism/unrelated.dart' as _i111;
+import 'inheritance/sealed_parent.dart' as _i112;
+import 'inheritance/sealed_parent_nullable_field.dart' as _i113;
+import 'long_identifiers/deep_includes/city_with_long_table_name.dart' as _i114;
+import 'long_identifiers/deep_includes/organization_with_long_table_name.dart'
+    as _i115;
+import 'long_identifiers/deep_includes/person_with_long_table_name.dart'
+    as _i116;
+import 'long_identifiers/max_field_name.dart' as _i117;
+import 'long_identifiers/models_with_relations/long_implicit_id_field.dart'
+    as _i118;
+import 'long_identifiers/models_with_relations/long_implicit_id_field_collection.dart'
+    as _i119;
+import 'long_identifiers/models_with_relations/relation_to_mutiple_max_field_name.dart'
+    as _i120;
+import 'long_identifiers/models_with_relations/user_note.dart' as _i121;
+import 'long_identifiers/models_with_relations/user_note_collection.dart'
+    as _i122;
+import 'long_identifiers/models_with_relations/user_note_collection_with_a_long_name.dart'
+    as _i123;
+import 'long_identifiers/models_with_relations/user_note_with_a_long_name.dart'
+    as _i124;
+import 'long_identifiers/multiple_max_field_name.dart' as _i125;
+import 'models_with_list_relations/city.dart' as _i126;
+import 'models_with_list_relations/organization.dart' as _i127;
+import 'models_with_list_relations/person.dart' as _i128;
+import 'models_with_relations/column_alias_collision/bleed_child.dart' as _i129;
+import 'models_with_relations/column_alias_collision/bleed_root.dart' as _i130;
+import 'models_with_relations/many_to_many/course.dart' as _i131;
+import 'models_with_relations/many_to_many/enrollment.dart' as _i132;
+import 'models_with_relations/many_to_many/student.dart' as _i133;
+import 'models_with_relations/module/object_user.dart' as _i134;
+import 'models_with_relations/module/parent_user.dart' as _i135;
+import 'models_with_relations/nested_one_to_many/arena.dart' as _i136;
+import 'models_with_relations/nested_one_to_many/player.dart' as _i137;
+import 'models_with_relations/nested_one_to_many/team.dart' as _i138;
+import 'models_with_relations/one_to_many/comment.dart' as _i139;
+import 'models_with_relations/one_to_many/customer.dart' as _i140;
+import 'models_with_relations/one_to_many/implicit/book.dart' as _i141;
+import 'models_with_relations/one_to_many/implicit/chapter.dart' as _i142;
+import 'models_with_relations/one_to_many/order.dart' as _i143;
+import 'models_with_relations/one_to_one/address.dart' as _i144;
+import 'models_with_relations/one_to_one/citizen.dart' as _i145;
+import 'models_with_relations/one_to_one/company.dart' as _i146;
+import 'models_with_relations/one_to_one/town.dart' as _i147;
+import 'models_with_relations/self_relation/many_to_many/blocking.dart'
+    as _i148;
+import 'models_with_relations/self_relation/many_to_many/member.dart' as _i149;
+import 'models_with_relations/self_relation/one_to_many/cat.dart' as _i150;
+import 'models_with_relations/self_relation/one_to_one/post.dart' as _i151;
+import 'module_datatype.dart' as _i152;
+import 'my_feature/models/my_feature_model.dart' as _i153;
+import 'my_trigger_type.dart' as _i154;
+import 'nullability.dart' as _i155;
+import 'nulls_distinct_data.dart' as _i156;
+import 'object_field_persist.dart' as _i157;
+import 'object_field_scopes.dart' as _i158;
+import 'object_with_bit.dart' as _i159;
+import 'object_with_bytedata.dart' as _i160;
+import 'object_with_custom_class.dart' as _i161;
+import 'object_with_duration.dart' as _i162;
+import 'object_with_dynamic.dart' as _i163;
+import 'object_with_enum.dart' as _i164;
+import 'object_with_enum_enhanced.dart' as _i165;
+import 'object_with_geography_geometry_collection.dart' as _i166;
+import 'object_with_geography_line_string.dart' as _i167;
+import 'object_with_geography_point.dart' as _i168;
+import 'object_with_geography_polygon.dart' as _i169;
+import 'object_with_half_vector.dart' as _i170;
+import 'object_with_index.dart' as _i171;
+import 'object_with_jsonb.dart' as _i172;
+import 'object_with_jsonb_class_level.dart' as _i173;
+import 'object_with_maps.dart' as _i174;
+import 'object_with_nullable_custom_class.dart' as _i175;
+import 'object_with_object.dart' as _i176;
+import 'object_with_parent.dart' as _i177;
+import 'object_with_sealed_class.dart' as _i178;
+import 'object_with_sealed_exception.dart' as _i179;
+import 'object_with_self_parent.dart' as _i180;
+import 'object_with_sparse_vector.dart' as _i181;
+import 'object_with_uuid.dart' as _i182;
+import 'object_with_vector.dart' as _i183;
+import 'record.dart' as _i184;
+import 'related_unique_data.dart' as _i185;
+import 'required/exception_with_required_field.dart' as _i186;
+import 'required/model_with_required_field.dart' as _i187;
+import 'scopes/scope_none_fields.dart' as _i188;
+import 'scopes/scope_server_only_field_child.dart' as _i189;
+import 'scopes/scope_server_only_field.dart' as _i190;
+import 'scopes/serverOnly/default_server_only_class.dart' as _i191;
+import 'scopes/serverOnly/default_server_only_enum.dart' as _i192;
+import 'scopes/serverOnly/not_server_only_class.dart' as _i193;
+import 'scopes/serverOnly/not_server_only_enum.dart' as _i194;
+import 'scopes/server_only_class_field.dart' as _i195;
+import 'server_only_default.dart' as _i196;
+import 'session_auth_info.dart' as _i197;
+import 'shared_model_container.dart' as _i198;
+import 'shared_model_subclass.dart' as _i199;
+import 'simple_data.dart' as _i200;
+import 'simple_data_list.dart' as _i201;
+import 'simple_data_map.dart' as _i202;
+import 'simple_data_object.dart' as _i203;
+import 'simple_date_time.dart' as _i204;
+import 'subfolder/model_in_subfolder.dart' as _i205;
+import 'test_enum.dart' as _i206;
+import 'test_enum_default_serialization.dart' as _i207;
+import 'test_enum_enhanced.dart' as _i208;
+import 'test_enum_enhanced_by_name.dart' as _i209;
+import 'test_enum_stringified.dart' as _i210;
+import 'types.dart' as _i211;
+import 'types_list.dart' as _i212;
+import 'types_map.dart' as _i213;
+import 'types_record.dart' as _i214;
+import 'types_set.dart' as _i215;
+import 'types_set_required.dart' as _i216;
+import 'unique_data.dart' as _i217;
+import 'unique_data_with_non_persist.dart' as _i218;
+import 'upsert_test_model.dart' as _i219;
+import 'package:serverpod_test_client/src/protocol/simple_data.dart' as _i220;
+import 'package:serverpod_test_client/src/protocol/inheritance/polymorphism/parent.dart'
+    as _i221;
+import 'dart:typed_data' as _i222;
+import 'package:serverpod_test_client/src/protocol/test_enum.dart' as _i223;
+import 'package:serverpod_test_client/src/protocol/types.dart' as _i224;
 export 'by_index_enum_with_name_value.dart';
 export 'by_name_enum_with_name_value.dart';
 export 'changed_id_type/many_to_many/course.dart';
@@ -473,6 +473,9 @@ class Protocol extends _i1.SerializationManager {
 
   static final Protocol _instance = Protocol._().._registerHostProtocols();
 
+  static final Map<Type, dynamic Function(dynamic, Protocol)> _deserializers =
+      _buildDeserializers();
+
   static String? getClassNameFromObjectJson(dynamic data) {
     if (data is! Map) return null;
     final className = data['__className__'] as String?;
@@ -500,5670 +503,261 @@ class Protocol extends _i1.SerializationManager {
       }
     }
 
-    if (t == _i2.ByIndexEnumWithNameValue) {
-      return _i2.ByIndexEnumWithNameValue.fromJson(data) as T;
-    }
-    if (t == _i3.ByNameEnumWithNameValue) {
-      return _i3.ByNameEnumWithNameValue.fromJson(data) as T;
-    }
-    if (t == _i4.CourseUuid) {
-      return _i4.CourseUuid.fromJson(data) as T;
-    }
-    if (t == _i5.EnrollmentInt) {
-      return _i5.EnrollmentInt.fromJson(data) as T;
-    }
-    if (t == _i6.StudentUuid) {
-      return _i6.StudentUuid.fromJson(data) as T;
-    }
-    if (t == _i7.ArenaUuid) {
-      return _i7.ArenaUuid.fromJson(data) as T;
-    }
-    if (t == _i8.PlayerUuid) {
-      return _i8.PlayerUuid.fromJson(data) as T;
-    }
-    if (t == _i9.TeamInt) {
-      return _i9.TeamInt.fromJson(data) as T;
-    }
-    if (t == _i10.CommentInt) {
-      return _i10.CommentInt.fromJson(data) as T;
-    }
-    if (t == _i11.CustomerInt) {
-      return _i11.CustomerInt.fromJson(data) as T;
-    }
-    if (t == _i12.OrderUuid) {
-      return _i12.OrderUuid.fromJson(data) as T;
-    }
-    if (t == _i13.AddressUuid) {
-      return _i13.AddressUuid.fromJson(data) as T;
-    }
-    if (t == _i14.CitizenInt) {
-      return _i14.CitizenInt.fromJson(data) as T;
-    }
-    if (t == _i15.CompanyUuid) {
-      return _i15.CompanyUuid.fromJson(data) as T;
-    }
-    if (t == _i16.TownInt) {
-      return _i16.TownInt.fromJson(data) as T;
-    }
-    if (t == _i17.ChangedIdTypeSelf) {
-      return _i17.ChangedIdTypeSelf.fromJson(data) as T;
-    }
-    if (t == _i18.BigIntDefault) {
-      return _i18.BigIntDefault.fromJson(data) as T;
-    }
-    if (t == _i19.BigIntDefaultMix) {
-      return _i19.BigIntDefaultMix.fromJson(data) as T;
-    }
-    if (t == _i20.BigIntDefaultModel) {
-      return _i20.BigIntDefaultModel.fromJson(data) as T;
-    }
-    if (t == _i21.BigIntDefaultPersist) {
-      return _i21.BigIntDefaultPersist.fromJson(data) as T;
-    }
-    if (t == _i22.BoolDefault) {
-      return _i22.BoolDefault.fromJson(data) as T;
-    }
-    if (t == _i23.BoolDefaultMix) {
-      return _i23.BoolDefaultMix.fromJson(data) as T;
-    }
-    if (t == _i24.BoolDefaultModel) {
-      return _i24.BoolDefaultModel.fromJson(data) as T;
-    }
-    if (t == _i25.BoolDefaultPersist) {
-      return _i25.BoolDefaultPersist.fromJson(data) as T;
-    }
-    if (t == _i26.DateTimeDefault) {
-      return _i26.DateTimeDefault.fromJson(data) as T;
-    }
-    if (t == _i27.DateTimeDefaultMix) {
-      return _i27.DateTimeDefaultMix.fromJson(data) as T;
-    }
-    if (t == _i28.DateTimeDefaultModel) {
-      return _i28.DateTimeDefaultModel.fromJson(data) as T;
-    }
-    if (t == _i29.DateTimeDefaultPersist) {
-      return _i29.DateTimeDefaultPersist.fromJson(data) as T;
-    }
-    if (t == _i30.DoubleDefault) {
-      return _i30.DoubleDefault.fromJson(data) as T;
-    }
-    if (t == _i31.DoubleDefaultMix) {
-      return _i31.DoubleDefaultMix.fromJson(data) as T;
-    }
-    if (t == _i32.DoubleDefaultModel) {
-      return _i32.DoubleDefaultModel.fromJson(data) as T;
-    }
-    if (t == _i33.DoubleDefaultPersist) {
-      return _i33.DoubleDefaultPersist.fromJson(data) as T;
-    }
-    if (t == _i34.DurationDefault) {
-      return _i34.DurationDefault.fromJson(data) as T;
-    }
-    if (t == _i35.DurationDefaultMix) {
-      return _i35.DurationDefaultMix.fromJson(data) as T;
-    }
-    if (t == _i36.DurationDefaultModel) {
-      return _i36.DurationDefaultModel.fromJson(data) as T;
-    }
-    if (t == _i37.DurationDefaultPersist) {
-      return _i37.DurationDefaultPersist.fromJson(data) as T;
-    }
-    if (t == _i38.EnumDefault) {
-      return _i38.EnumDefault.fromJson(data) as T;
-    }
-    if (t == _i39.EnumDefaultMix) {
-      return _i39.EnumDefaultMix.fromJson(data) as T;
-    }
-    if (t == _i40.EnumDefaultModel) {
-      return _i40.EnumDefaultModel.fromJson(data) as T;
-    }
-    if (t == _i41.EnumDefaultPersist) {
-      return _i41.EnumDefaultPersist.fromJson(data) as T;
-    }
-    if (t == _i42.ByIndexEnum) {
-      return _i42.ByIndexEnum.fromJson(data) as T;
-    }
-    if (t == _i43.ByNameEnum) {
-      return _i43.ByNameEnum.fromJson(data) as T;
-    }
-    if (t == _i44.DefaultValueEnum) {
-      return _i44.DefaultValueEnum.fromJson(data) as T;
-    }
-    if (t == _i45.DefaultException) {
-      return _i45.DefaultException.fromJson(data) as T;
-    }
-    if (t == _i46.IntDefault) {
-      return _i46.IntDefault.fromJson(data) as T;
-    }
-    if (t == _i47.IntDefaultMix) {
-      return _i47.IntDefaultMix.fromJson(data) as T;
-    }
-    if (t == _i48.IntDefaultModel) {
-      return _i48.IntDefaultModel.fromJson(data) as T;
-    }
-    if (t == _i49.IntDefaultPersist) {
-      return _i49.IntDefaultPersist.fromJson(data) as T;
-    }
-    if (t == _i50.StringDefault) {
-      return _i50.StringDefault.fromJson(data) as T;
-    }
-    if (t == _i51.StringDefaultMix) {
-      return _i51.StringDefaultMix.fromJson(data) as T;
-    }
-    if (t == _i52.StringDefaultModel) {
-      return _i52.StringDefaultModel.fromJson(data) as T;
-    }
-    if (t == _i53.StringDefaultPersist) {
-      return _i53.StringDefaultPersist.fromJson(data) as T;
-    }
-    if (t == _i54.UriDefault) {
-      return _i54.UriDefault.fromJson(data) as T;
-    }
-    if (t == _i55.UriDefaultMix) {
-      return _i55.UriDefaultMix.fromJson(data) as T;
-    }
-    if (t == _i56.UriDefaultModel) {
-      return _i56.UriDefaultModel.fromJson(data) as T;
-    }
-    if (t == _i57.UriDefaultPersist) {
-      return _i57.UriDefaultPersist.fromJson(data) as T;
-    }
-    if (t == _i58.UuidDefault) {
-      return _i58.UuidDefault.fromJson(data) as T;
-    }
-    if (t == _i59.UuidDefaultMix) {
-      return _i59.UuidDefaultMix.fromJson(data) as T;
-    }
-    if (t == _i60.UuidDefaultModel) {
-      return _i60.UuidDefaultModel.fromJson(data) as T;
-    }
-    if (t == _i61.UuidDefaultPersist) {
-      return _i61.UuidDefaultPersist.fromJson(data) as T;
-    }
-    if (t == _i62.EmptyModel) {
-      return _i62.EmptyModel.fromJson(data) as T;
-    }
-    if (t == _i63.EmptyModelRelationItem) {
-      return _i63.EmptyModelRelationItem.fromJson(data) as T;
-    }
-    if (t == _i64.EmptyModelWithTable) {
-      return _i64.EmptyModelWithTable.fromJson(data) as T;
-    }
-    if (t == _i65.RelationEmptyModel) {
-      return _i65.RelationEmptyModel.fromJson(data) as T;
-    }
-    if (t == _i66.ExceptionWithData) {
-      return _i66.ExceptionWithData.fromJson(data) as T;
-    }
-    if (t == _i67.ChildClassExplicitColumn) {
-      return _i67.ChildClassExplicitColumn.fromJson(data) as T;
-    }
-    if (t == _i68.NonTableParentClass) {
-      return _i68.NonTableParentClass.fromJson(data) as T;
-    }
-    if (t == _i69.ModifiedColumnName) {
-      return _i69.ModifiedColumnName.fromJson(data) as T;
-    }
-    if (t == _i70.Department) {
-      return _i70.Department.fromJson(data) as T;
-    }
-    if (t == _i71.Employee) {
-      return _i71.Employee.fromJson(data) as T;
-    }
-    if (t == _i72.Contractor) {
-      return _i72.Contractor.fromJson(data) as T;
-    }
-    if (t == _i73.Service) {
-      return _i73.Service.fromJson(data) as T;
-    }
-    if (t == _i74.TableWithExplicitColumnName) {
-      return _i74.TableWithExplicitColumnName.fromJson(data) as T;
-    }
-    if (t == _i75.ImmutableChildObject) {
-      return _i75.ImmutableChildObject.fromJson(data) as T;
-    }
-    if (t == _i76.ImmutableChildObjectWithNoAdditionalFields) {
-      return _i76.ImmutableChildObjectWithNoAdditionalFields.fromJson(data)
-          as T;
-    }
-    if (t == _i77.ImmutableObject) {
-      return _i77.ImmutableObject.fromJson(data) as T;
-    }
-    if (t == _i78.ImmutableObjectWithImmutableObject) {
-      return _i78.ImmutableObjectWithImmutableObject.fromJson(data) as T;
-    }
-    if (t == _i79.ImmutableObjectWithList) {
-      return _i79.ImmutableObjectWithList.fromJson(data) as T;
-    }
-    if (t == _i80.ImmutableObjectWithMap) {
-      return _i80.ImmutableObjectWithMap.fromJson(data) as T;
-    }
-    if (t == _i81.ImmutableObjectWithMultipleFields) {
-      return _i81.ImmutableObjectWithMultipleFields.fromJson(data) as T;
-    }
-    if (t == _i82.ImmutableObjectWithNoFields) {
-      return _i82.ImmutableObjectWithNoFields.fromJson(data) as T;
-    }
-    if (t == _i83.ImmutableObjectWithRecord) {
-      return _i83.ImmutableObjectWithRecord.fromJson(data) as T;
-    }
-    if (t == _i84.ImmutableObjectWithTable) {
-      return _i84.ImmutableObjectWithTable.fromJson(data) as T;
-    }
-    if (t == _i85.ImmutableObjectWithTwentyFields) {
-      return _i85.ImmutableObjectWithTwentyFields.fromJson(data) as T;
-    }
-    if (t == _i86.ChildClass) {
-      return _i86.ChildClass.fromJson(data) as T;
-    }
-    if (t == _i87.ChildWithDefault) {
-      return _i87.ChildWithDefault.fromJson(data) as T;
-    }
-    if (t == _i88.ChildClassWithoutId) {
-      return _i88.ChildClassWithoutId.fromJson(data) as T;
-    }
-    if (t == _i89.ExtendedAppException) {
-      return _i89.ExtendedAppException.fromJson(data) as T;
-    }
-    if (t == _i90.BaseAppException) {
-      return _i90.BaseAppException.fromJson(data) as T;
-    }
-    if (t == _i91.NotFoundException) {
-      return _i91.NotFoundException.fromJson(data) as T;
-    }
-    if (t == _i91.ValidationException) {
-      return _i91.ValidationException.fromJson(data) as T;
-    }
-    if (t == _i92.ParentClass) {
-      return _i92.ParentClass.fromJson(data) as T;
-    }
-    if (t == _i93.GrandparentClass) {
-      return _i93.GrandparentClass.fromJson(data) as T;
-    }
-    if (t == _i94.ParentClassWithoutId) {
-      return _i94.ParentClassWithoutId.fromJson(data) as T;
-    }
-    if (t == _i95.GrandparentClassWithId) {
-      return _i95.GrandparentClassWithId.fromJson(data) as T;
-    }
-    if (t == _i96.ChildEntity) {
-      return _i96.ChildEntity.fromJson(data) as T;
-    }
-    if (t == _i97.BaseEntity) {
-      return _i97.BaseEntity.fromJson(data) as T;
-    }
-    if (t == _i98.ParentEntity) {
-      return _i98.ParentEntity.fromJson(data) as T;
-    }
-    if (t == _i99.NonServerOnlyParentClass) {
-      return _i99.NonServerOnlyParentClass.fromJson(data) as T;
-    }
-    if (t == _i100.ParentWithDefault) {
-      return _i100.ParentWithDefault.fromJson(data) as T;
-    }
-    if (t == _i101.PolymorphicGrandChild) {
-      return _i101.PolymorphicGrandChild.fromJson(data) as T;
-    }
-    if (t == _i102.PolymorphicChild) {
-      return _i102.PolymorphicChild.fromJson(data) as T;
-    }
-    if (t == _i103.PolymorphicChildContainer) {
-      return _i103.PolymorphicChildContainer.fromJson(data) as T;
-    }
-    if (t == _i104.ModulePolymorphicChildContainer) {
-      return _i104.ModulePolymorphicChildContainer.fromJson(data) as T;
-    }
-    if (t == _i105.SimilarButNotParent) {
-      return _i105.SimilarButNotParent.fromJson(data) as T;
-    }
-    if (t == _i106.PolymorphicParent) {
-      return _i106.PolymorphicParent.fromJson(data) as T;
-    }
-    if (t == _i107.UnrelatedToPolymorphism) {
-      return _i107.UnrelatedToPolymorphism.fromJson(data) as T;
-    }
-    if (t == _i108.SealedGrandChild) {
-      return _i108.SealedGrandChild.fromJson(data) as T;
-    }
-    if (t == _i108.SealedChild) {
-      return _i108.SealedChild.fromJson(data) as T;
-    }
-    if (t == _i109.SealedChildOnlyRequired) {
-      return _i109.SealedChildOnlyRequired.fromJson(data) as T;
-    }
-    if (t == _i108.SealedOtherChild) {
-      return _i108.SealedOtherChild.fromJson(data) as T;
-    }
-    if (t == _i110.CityWithLongTableName) {
-      return _i110.CityWithLongTableName.fromJson(data) as T;
-    }
-    if (t == _i111.OrganizationWithLongTableName) {
-      return _i111.OrganizationWithLongTableName.fromJson(data) as T;
-    }
-    if (t == _i112.PersonWithLongTableName) {
-      return _i112.PersonWithLongTableName.fromJson(data) as T;
-    }
-    if (t == _i113.MaxFieldName) {
-      return _i113.MaxFieldName.fromJson(data) as T;
-    }
-    if (t == _i114.LongImplicitIdField) {
-      return _i114.LongImplicitIdField.fromJson(data) as T;
-    }
-    if (t == _i115.LongImplicitIdFieldCollection) {
-      return _i115.LongImplicitIdFieldCollection.fromJson(data) as T;
-    }
-    if (t == _i116.RelationToMultipleMaxFieldName) {
-      return _i116.RelationToMultipleMaxFieldName.fromJson(data) as T;
-    }
-    if (t == _i117.UserNote) {
-      return _i117.UserNote.fromJson(data) as T;
-    }
-    if (t == _i118.UserNoteCollection) {
-      return _i118.UserNoteCollection.fromJson(data) as T;
-    }
-    if (t == _i119.UserNoteCollectionWithALongName) {
-      return _i119.UserNoteCollectionWithALongName.fromJson(data) as T;
-    }
-    if (t == _i120.UserNoteWithALongName) {
-      return _i120.UserNoteWithALongName.fromJson(data) as T;
-    }
-    if (t == _i121.MultipleMaxFieldName) {
-      return _i121.MultipleMaxFieldName.fromJson(data) as T;
-    }
-    if (t == _i122.City) {
-      return _i122.City.fromJson(data) as T;
-    }
-    if (t == _i123.Organization) {
-      return _i123.Organization.fromJson(data) as T;
-    }
-    if (t == _i124.Person) {
-      return _i124.Person.fromJson(data) as T;
-    }
-    if (t == _i125.BleedChild) {
-      return _i125.BleedChild.fromJson(data) as T;
-    }
-    if (t == _i126.BleedRoot) {
-      return _i126.BleedRoot.fromJson(data) as T;
-    }
-    if (t == _i127.Course) {
-      return _i127.Course.fromJson(data) as T;
-    }
-    if (t == _i128.Enrollment) {
-      return _i128.Enrollment.fromJson(data) as T;
-    }
-    if (t == _i129.Student) {
-      return _i129.Student.fromJson(data) as T;
-    }
-    if (t == _i130.ObjectUser) {
-      return _i130.ObjectUser.fromJson(data) as T;
-    }
-    if (t == _i131.ParentUser) {
-      return _i131.ParentUser.fromJson(data) as T;
-    }
-    if (t == _i132.Arena) {
-      return _i132.Arena.fromJson(data) as T;
-    }
-    if (t == _i133.Player) {
-      return _i133.Player.fromJson(data) as T;
-    }
-    if (t == _i134.Team) {
-      return _i134.Team.fromJson(data) as T;
-    }
-    if (t == _i135.Comment) {
-      return _i135.Comment.fromJson(data) as T;
-    }
-    if (t == _i136.Customer) {
-      return _i136.Customer.fromJson(data) as T;
-    }
-    if (t == _i137.Book) {
-      return _i137.Book.fromJson(data) as T;
-    }
-    if (t == _i138.Chapter) {
-      return _i138.Chapter.fromJson(data) as T;
-    }
-    if (t == _i139.Order) {
-      return _i139.Order.fromJson(data) as T;
-    }
-    if (t == _i140.Address) {
-      return _i140.Address.fromJson(data) as T;
-    }
-    if (t == _i141.Citizen) {
-      return _i141.Citizen.fromJson(data) as T;
-    }
-    if (t == _i142.Company) {
-      return _i142.Company.fromJson(data) as T;
-    }
-    if (t == _i143.Town) {
-      return _i143.Town.fromJson(data) as T;
-    }
-    if (t == _i144.Blocking) {
-      return _i144.Blocking.fromJson(data) as T;
-    }
-    if (t == _i145.Member) {
-      return _i145.Member.fromJson(data) as T;
-    }
-    if (t == _i146.Cat) {
-      return _i146.Cat.fromJson(data) as T;
-    }
-    if (t == _i147.Post) {
-      return _i147.Post.fromJson(data) as T;
-    }
-    if (t == _i148.ModuleDatatype) {
-      return _i148.ModuleDatatype.fromJson(data) as T;
-    }
-    if (t == _i149.MyFeatureModel) {
-      return _i149.MyFeatureModel.fromJson(data) as T;
-    }
-    if (t == _i150.MyTriggerType) {
-      return _i150.MyTriggerType.fromJson(data) as T;
-    }
-    if (t == _i151.Nullability) {
-      return _i151.Nullability.fromJson(data) as T;
-    }
-    if (t == _i152.NullsDistinctData) {
-      return _i152.NullsDistinctData.fromJson(data) as T;
-    }
-    if (t == _i153.ObjectFieldPersist) {
-      return _i153.ObjectFieldPersist.fromJson(data) as T;
-    }
-    if (t == _i154.ObjectFieldScopes) {
-      return _i154.ObjectFieldScopes.fromJson(data) as T;
-    }
-    if (t == _i155.ObjectWithBit) {
-      return _i155.ObjectWithBit.fromJson(data) as T;
-    }
-    if (t == _i156.ObjectWithByteData) {
-      return _i156.ObjectWithByteData.fromJson(data) as T;
-    }
-    if (t == _i157.ObjectWithCustomClass) {
-      return _i157.ObjectWithCustomClass.fromJson(data) as T;
-    }
-    if (t == _i158.ObjectWithDuration) {
-      return _i158.ObjectWithDuration.fromJson(data) as T;
-    }
-    if (t == _i159.ObjectWithDynamic) {
-      return _i159.ObjectWithDynamic.fromJson(data) as T;
-    }
-    if (t == _i160.ObjectWithEnum) {
-      return _i160.ObjectWithEnum.fromJson(data) as T;
-    }
-    if (t == _i161.ObjectWithEnumEnhanced) {
-      return _i161.ObjectWithEnumEnhanced.fromJson(data) as T;
-    }
-    if (t == _i162.ObjectWithGeographyGeometryCollection) {
-      return _i162.ObjectWithGeographyGeometryCollection.fromJson(data) as T;
-    }
-    if (t == _i163.ObjectWithGeographyLineString) {
-      return _i163.ObjectWithGeographyLineString.fromJson(data) as T;
-    }
-    if (t == _i164.ObjectWithGeographyPoint) {
-      return _i164.ObjectWithGeographyPoint.fromJson(data) as T;
-    }
-    if (t == _i165.ObjectWithGeographyPolygon) {
-      return _i165.ObjectWithGeographyPolygon.fromJson(data) as T;
-    }
-    if (t == _i166.ObjectWithHalfVector) {
-      return _i166.ObjectWithHalfVector.fromJson(data) as T;
-    }
-    if (t == _i167.ObjectWithIndex) {
-      return _i167.ObjectWithIndex.fromJson(data) as T;
-    }
-    if (t == _i168.ObjectWithJsonb) {
-      return _i168.ObjectWithJsonb.fromJson(data) as T;
-    }
-    if (t == _i169.ObjectWithJsonbClassLevel) {
-      return _i169.ObjectWithJsonbClassLevel.fromJson(data) as T;
-    }
-    if (t == _i170.ObjectWithMaps) {
-      return _i170.ObjectWithMaps.fromJson(data) as T;
-    }
-    if (t == _i171.ObjectWithNullableCustomClass) {
-      return _i171.ObjectWithNullableCustomClass.fromJson(data) as T;
-    }
-    if (t == _i172.ObjectWithObject) {
-      return _i172.ObjectWithObject.fromJson(data) as T;
-    }
-    if (t == _i173.ObjectWithParent) {
-      return _i173.ObjectWithParent.fromJson(data) as T;
-    }
-    if (t == _i174.ObjectWithSealedClass) {
-      return _i174.ObjectWithSealedClass.fromJson(data) as T;
-    }
-    if (t == _i175.ObjectWithSealedException) {
-      return _i175.ObjectWithSealedException.fromJson(data) as T;
-    }
-    if (t == _i176.ObjectWithSelfParent) {
-      return _i176.ObjectWithSelfParent.fromJson(data) as T;
-    }
-    if (t == _i177.ObjectWithSparseVector) {
-      return _i177.ObjectWithSparseVector.fromJson(data) as T;
-    }
-    if (t == _i178.ObjectWithUuid) {
-      return _i178.ObjectWithUuid.fromJson(data) as T;
-    }
-    if (t == _i179.ObjectWithVector) {
-      return _i179.ObjectWithVector.fromJson(data) as T;
-    }
-    if (t == _i180.Record) {
-      return _i180.Record.fromJson(data) as T;
-    }
-    if (t == _i181.RelatedUniqueData) {
-      return _i181.RelatedUniqueData.fromJson(data) as T;
-    }
-    if (t == _i182.ExceptionWithRequiredField) {
-      return _i182.ExceptionWithRequiredField.fromJson(data) as T;
-    }
-    if (t == _i183.ModelWithRequiredField) {
-      return _i183.ModelWithRequiredField.fromJson(data) as T;
-    }
-    if (t == _i184.ScopeNoneFields) {
-      return _i184.ScopeNoneFields.fromJson(data) as T;
-    }
-    if (t == _i185.ScopeServerOnlyFieldChild) {
-      return _i185.ScopeServerOnlyFieldChild.fromJson(data) as T;
-    }
-    if (t == _i186.ScopeServerOnlyField) {
-      return _i186.ScopeServerOnlyField.fromJson(data) as T;
-    }
-    if (t == _i187.DefaultServerOnlyClass) {
-      return _i187.DefaultServerOnlyClass.fromJson(data) as T;
-    }
-    if (t == _i188.DefaultServerOnlyEnum) {
-      return _i188.DefaultServerOnlyEnum.fromJson(data) as T;
-    }
-    if (t == _i189.NotServerOnlyClass) {
-      return _i189.NotServerOnlyClass.fromJson(data) as T;
-    }
-    if (t == _i190.NotServerOnlyEnum) {
-      return _i190.NotServerOnlyEnum.fromJson(data) as T;
-    }
-    if (t == _i191.ServerOnlyClassField) {
-      return _i191.ServerOnlyClassField.fromJson(data) as T;
-    }
-    if (t == _i192.ServerOnlyDefault) {
-      return _i192.ServerOnlyDefault.fromJson(data) as T;
-    }
-    if (t == _i193.SessionAuthInfo) {
-      return _i193.SessionAuthInfo.fromJson(data) as T;
-    }
-    if (t == _i194.SharedModelContainer) {
-      return _i194.SharedModelContainer.fromJson(data) as T;
-    }
-    if (t == _i195.SharedModelSubclass) {
-      return _i195.SharedModelSubclass.fromJson(data) as T;
-    }
-    if (t == _i196.SimpleData) {
-      return _i196.SimpleData.fromJson(data) as T;
-    }
-    if (t == _i197.SimpleDataList) {
-      return _i197.SimpleDataList.fromJson(data) as T;
-    }
-    if (t == _i198.SimpleDataMap) {
-      return _i198.SimpleDataMap.fromJson(data) as T;
-    }
-    if (t == _i199.SimpleDataObject) {
-      return _i199.SimpleDataObject.fromJson(data) as T;
-    }
-    if (t == _i200.SimpleDateTime) {
-      return _i200.SimpleDateTime.fromJson(data) as T;
-    }
-    if (t == _i201.ModelInSubfolder) {
-      return _i201.ModelInSubfolder.fromJson(data) as T;
-    }
-    if (t == _i202.TestEnum) {
-      return _i202.TestEnum.fromJson(data) as T;
-    }
-    if (t == _i203.TestEnumDefaultSerialization) {
-      return _i203.TestEnumDefaultSerialization.fromJson(data) as T;
-    }
-    if (t == _i204.TestEnumEnhanced) {
-      return _i204.TestEnumEnhanced.fromJson(data) as T;
-    }
-    if (t == _i205.TestEnumEnhancedByName) {
-      return _i205.TestEnumEnhancedByName.fromJson(data) as T;
-    }
-    if (t == _i206.TestEnumStringified) {
-      return _i206.TestEnumStringified.fromJson(data) as T;
-    }
-    if (t == _i207.Types) {
-      return _i207.Types.fromJson(data) as T;
-    }
-    if (t == _i208.TypesList) {
-      return _i208.TypesList.fromJson(data) as T;
-    }
-    if (t == _i209.TypesMap) {
-      return _i209.TypesMap.fromJson(data) as T;
-    }
-    if (t == _i210.TypesRecord) {
-      return _i210.TypesRecord.fromJson(data) as T;
-    }
-    if (t == _i211.TypesSet) {
-      return _i211.TypesSet.fromJson(data) as T;
-    }
-    if (t == _i212.TypesSetRequired) {
-      return _i212.TypesSetRequired.fromJson(data) as T;
-    }
-    if (t == _i213.UniqueData) {
-      return _i213.UniqueData.fromJson(data) as T;
-    }
-    if (t == _i214.UniqueDataWithNonPersist) {
-      return _i214.UniqueDataWithNonPersist.fromJson(data) as T;
-    }
-    if (t == _i215.UpsertTestModel) {
-      return _i215.UpsertTestModel.fromJson(data) as T;
-    }
-    if (t == _i1.getType<_i2.ByIndexEnumWithNameValue?>()) {
-      return (data != null ? _i2.ByIndexEnumWithNameValue.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i3.ByNameEnumWithNameValue?>()) {
-      return (data != null ? _i3.ByNameEnumWithNameValue.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i4.CourseUuid?>()) {
-      return (data != null ? _i4.CourseUuid.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i5.EnrollmentInt?>()) {
-      return (data != null ? _i5.EnrollmentInt.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i6.StudentUuid?>()) {
-      return (data != null ? _i6.StudentUuid.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i7.ArenaUuid?>()) {
-      return (data != null ? _i7.ArenaUuid.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i8.PlayerUuid?>()) {
-      return (data != null ? _i8.PlayerUuid.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i9.TeamInt?>()) {
-      return (data != null ? _i9.TeamInt.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i10.CommentInt?>()) {
-      return (data != null ? _i10.CommentInt.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i11.CustomerInt?>()) {
-      return (data != null ? _i11.CustomerInt.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i12.OrderUuid?>()) {
-      return (data != null ? _i12.OrderUuid.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i13.AddressUuid?>()) {
-      return (data != null ? _i13.AddressUuid.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i14.CitizenInt?>()) {
-      return (data != null ? _i14.CitizenInt.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i15.CompanyUuid?>()) {
-      return (data != null ? _i15.CompanyUuid.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i16.TownInt?>()) {
-      return (data != null ? _i16.TownInt.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i17.ChangedIdTypeSelf?>()) {
-      return (data != null ? _i17.ChangedIdTypeSelf.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i18.BigIntDefault?>()) {
-      return (data != null ? _i18.BigIntDefault.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i19.BigIntDefaultMix?>()) {
-      return (data != null ? _i19.BigIntDefaultMix.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i20.BigIntDefaultModel?>()) {
-      return (data != null ? _i20.BigIntDefaultModel.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i21.BigIntDefaultPersist?>()) {
-      return (data != null ? _i21.BigIntDefaultPersist.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i22.BoolDefault?>()) {
-      return (data != null ? _i22.BoolDefault.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i23.BoolDefaultMix?>()) {
-      return (data != null ? _i23.BoolDefaultMix.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i24.BoolDefaultModel?>()) {
-      return (data != null ? _i24.BoolDefaultModel.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i25.BoolDefaultPersist?>()) {
-      return (data != null ? _i25.BoolDefaultPersist.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i26.DateTimeDefault?>()) {
-      return (data != null ? _i26.DateTimeDefault.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i27.DateTimeDefaultMix?>()) {
-      return (data != null ? _i27.DateTimeDefaultMix.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i28.DateTimeDefaultModel?>()) {
-      return (data != null ? _i28.DateTimeDefaultModel.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i29.DateTimeDefaultPersist?>()) {
-      return (data != null ? _i29.DateTimeDefaultPersist.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i30.DoubleDefault?>()) {
-      return (data != null ? _i30.DoubleDefault.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i31.DoubleDefaultMix?>()) {
-      return (data != null ? _i31.DoubleDefaultMix.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i32.DoubleDefaultModel?>()) {
-      return (data != null ? _i32.DoubleDefaultModel.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i33.DoubleDefaultPersist?>()) {
-      return (data != null ? _i33.DoubleDefaultPersist.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i34.DurationDefault?>()) {
-      return (data != null ? _i34.DurationDefault.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i35.DurationDefaultMix?>()) {
-      return (data != null ? _i35.DurationDefaultMix.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i36.DurationDefaultModel?>()) {
-      return (data != null ? _i36.DurationDefaultModel.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i37.DurationDefaultPersist?>()) {
-      return (data != null ? _i37.DurationDefaultPersist.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i38.EnumDefault?>()) {
-      return (data != null ? _i38.EnumDefault.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i39.EnumDefaultMix?>()) {
-      return (data != null ? _i39.EnumDefaultMix.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i40.EnumDefaultModel?>()) {
-      return (data != null ? _i40.EnumDefaultModel.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i41.EnumDefaultPersist?>()) {
-      return (data != null ? _i41.EnumDefaultPersist.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i42.ByIndexEnum?>()) {
-      return (data != null ? _i42.ByIndexEnum.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i43.ByNameEnum?>()) {
-      return (data != null ? _i43.ByNameEnum.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i44.DefaultValueEnum?>()) {
-      return (data != null ? _i44.DefaultValueEnum.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i45.DefaultException?>()) {
-      return (data != null ? _i45.DefaultException.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i46.IntDefault?>()) {
-      return (data != null ? _i46.IntDefault.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i47.IntDefaultMix?>()) {
-      return (data != null ? _i47.IntDefaultMix.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i48.IntDefaultModel?>()) {
-      return (data != null ? _i48.IntDefaultModel.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i49.IntDefaultPersist?>()) {
-      return (data != null ? _i49.IntDefaultPersist.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i50.StringDefault?>()) {
-      return (data != null ? _i50.StringDefault.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i51.StringDefaultMix?>()) {
-      return (data != null ? _i51.StringDefaultMix.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i52.StringDefaultModel?>()) {
-      return (data != null ? _i52.StringDefaultModel.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i53.StringDefaultPersist?>()) {
-      return (data != null ? _i53.StringDefaultPersist.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i54.UriDefault?>()) {
-      return (data != null ? _i54.UriDefault.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i55.UriDefaultMix?>()) {
-      return (data != null ? _i55.UriDefaultMix.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i56.UriDefaultModel?>()) {
-      return (data != null ? _i56.UriDefaultModel.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i57.UriDefaultPersist?>()) {
-      return (data != null ? _i57.UriDefaultPersist.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i58.UuidDefault?>()) {
-      return (data != null ? _i58.UuidDefault.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i59.UuidDefaultMix?>()) {
-      return (data != null ? _i59.UuidDefaultMix.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i60.UuidDefaultModel?>()) {
-      return (data != null ? _i60.UuidDefaultModel.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i61.UuidDefaultPersist?>()) {
-      return (data != null ? _i61.UuidDefaultPersist.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i62.EmptyModel?>()) {
-      return (data != null ? _i62.EmptyModel.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i63.EmptyModelRelationItem?>()) {
-      return (data != null ? _i63.EmptyModelRelationItem.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i64.EmptyModelWithTable?>()) {
-      return (data != null ? _i64.EmptyModelWithTable.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i65.RelationEmptyModel?>()) {
-      return (data != null ? _i65.RelationEmptyModel.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i66.ExceptionWithData?>()) {
-      return (data != null ? _i66.ExceptionWithData.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i67.ChildClassExplicitColumn?>()) {
-      return (data != null
-              ? _i67.ChildClassExplicitColumn.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i68.NonTableParentClass?>()) {
-      return (data != null ? _i68.NonTableParentClass.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i69.ModifiedColumnName?>()) {
-      return (data != null ? _i69.ModifiedColumnName.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i70.Department?>()) {
-      return (data != null ? _i70.Department.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i71.Employee?>()) {
-      return (data != null ? _i71.Employee.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i72.Contractor?>()) {
-      return (data != null ? _i72.Contractor.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i73.Service?>()) {
-      return (data != null ? _i73.Service.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i74.TableWithExplicitColumnName?>()) {
-      return (data != null
-              ? _i74.TableWithExplicitColumnName.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i75.ImmutableChildObject?>()) {
-      return (data != null ? _i75.ImmutableChildObject.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i76.ImmutableChildObjectWithNoAdditionalFields?>()) {
-      return (data != null
-              ? _i76.ImmutableChildObjectWithNoAdditionalFields.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i77.ImmutableObject?>()) {
-      return (data != null ? _i77.ImmutableObject.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i78.ImmutableObjectWithImmutableObject?>()) {
-      return (data != null
-              ? _i78.ImmutableObjectWithImmutableObject.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i79.ImmutableObjectWithList?>()) {
-      return (data != null ? _i79.ImmutableObjectWithList.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i80.ImmutableObjectWithMap?>()) {
-      return (data != null ? _i80.ImmutableObjectWithMap.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i81.ImmutableObjectWithMultipleFields?>()) {
-      return (data != null
-              ? _i81.ImmutableObjectWithMultipleFields.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i82.ImmutableObjectWithNoFields?>()) {
-      return (data != null
-              ? _i82.ImmutableObjectWithNoFields.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i83.ImmutableObjectWithRecord?>()) {
-      return (data != null
-              ? _i83.ImmutableObjectWithRecord.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i84.ImmutableObjectWithTable?>()) {
-      return (data != null
-              ? _i84.ImmutableObjectWithTable.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i85.ImmutableObjectWithTwentyFields?>()) {
-      return (data != null
-              ? _i85.ImmutableObjectWithTwentyFields.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i86.ChildClass?>()) {
-      return (data != null ? _i86.ChildClass.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i87.ChildWithDefault?>()) {
-      return (data != null ? _i87.ChildWithDefault.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i88.ChildClassWithoutId?>()) {
-      return (data != null ? _i88.ChildClassWithoutId.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i89.ExtendedAppException?>()) {
-      return (data != null ? _i89.ExtendedAppException.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i90.BaseAppException?>()) {
-      return (data != null ? _i90.BaseAppException.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i91.NotFoundException?>()) {
-      return (data != null ? _i91.NotFoundException.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i91.ValidationException?>()) {
-      return (data != null ? _i91.ValidationException.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i92.ParentClass?>()) {
-      return (data != null ? _i92.ParentClass.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i93.GrandparentClass?>()) {
-      return (data != null ? _i93.GrandparentClass.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i94.ParentClassWithoutId?>()) {
-      return (data != null ? _i94.ParentClassWithoutId.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i95.GrandparentClassWithId?>()) {
-      return (data != null ? _i95.GrandparentClassWithId.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i96.ChildEntity?>()) {
-      return (data != null ? _i96.ChildEntity.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i97.BaseEntity?>()) {
-      return (data != null ? _i97.BaseEntity.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i98.ParentEntity?>()) {
-      return (data != null ? _i98.ParentEntity.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i99.NonServerOnlyParentClass?>()) {
-      return (data != null
-              ? _i99.NonServerOnlyParentClass.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i100.ParentWithDefault?>()) {
-      return (data != null ? _i100.ParentWithDefault.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i101.PolymorphicGrandChild?>()) {
-      return (data != null ? _i101.PolymorphicGrandChild.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i102.PolymorphicChild?>()) {
-      return (data != null ? _i102.PolymorphicChild.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i103.PolymorphicChildContainer?>()) {
-      return (data != null
-              ? _i103.PolymorphicChildContainer.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i104.ModulePolymorphicChildContainer?>()) {
-      return (data != null
-              ? _i104.ModulePolymorphicChildContainer.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i105.SimilarButNotParent?>()) {
-      return (data != null ? _i105.SimilarButNotParent.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i106.PolymorphicParent?>()) {
-      return (data != null ? _i106.PolymorphicParent.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i107.UnrelatedToPolymorphism?>()) {
-      return (data != null
-              ? _i107.UnrelatedToPolymorphism.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i108.SealedGrandChild?>()) {
-      return (data != null ? _i108.SealedGrandChild.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i108.SealedChild?>()) {
-      return (data != null ? _i108.SealedChild.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i109.SealedChildOnlyRequired?>()) {
-      return (data != null
-              ? _i109.SealedChildOnlyRequired.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i108.SealedOtherChild?>()) {
-      return (data != null ? _i108.SealedOtherChild.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i110.CityWithLongTableName?>()) {
-      return (data != null ? _i110.CityWithLongTableName.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i111.OrganizationWithLongTableName?>()) {
-      return (data != null
-              ? _i111.OrganizationWithLongTableName.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i112.PersonWithLongTableName?>()) {
-      return (data != null
-              ? _i112.PersonWithLongTableName.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i113.MaxFieldName?>()) {
-      return (data != null ? _i113.MaxFieldName.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i114.LongImplicitIdField?>()) {
-      return (data != null ? _i114.LongImplicitIdField.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i115.LongImplicitIdFieldCollection?>()) {
-      return (data != null
-              ? _i115.LongImplicitIdFieldCollection.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i116.RelationToMultipleMaxFieldName?>()) {
-      return (data != null
-              ? _i116.RelationToMultipleMaxFieldName.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i117.UserNote?>()) {
-      return (data != null ? _i117.UserNote.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i118.UserNoteCollection?>()) {
-      return (data != null ? _i118.UserNoteCollection.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i119.UserNoteCollectionWithALongName?>()) {
-      return (data != null
-              ? _i119.UserNoteCollectionWithALongName.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i120.UserNoteWithALongName?>()) {
-      return (data != null ? _i120.UserNoteWithALongName.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i121.MultipleMaxFieldName?>()) {
-      return (data != null ? _i121.MultipleMaxFieldName.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i122.City?>()) {
-      return (data != null ? _i122.City.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i123.Organization?>()) {
-      return (data != null ? _i123.Organization.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i124.Person?>()) {
-      return (data != null ? _i124.Person.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i125.BleedChild?>()) {
-      return (data != null ? _i125.BleedChild.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i126.BleedRoot?>()) {
-      return (data != null ? _i126.BleedRoot.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i127.Course?>()) {
-      return (data != null ? _i127.Course.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i128.Enrollment?>()) {
-      return (data != null ? _i128.Enrollment.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i129.Student?>()) {
-      return (data != null ? _i129.Student.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i130.ObjectUser?>()) {
-      return (data != null ? _i130.ObjectUser.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i131.ParentUser?>()) {
-      return (data != null ? _i131.ParentUser.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i132.Arena?>()) {
-      return (data != null ? _i132.Arena.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i133.Player?>()) {
-      return (data != null ? _i133.Player.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i134.Team?>()) {
-      return (data != null ? _i134.Team.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i135.Comment?>()) {
-      return (data != null ? _i135.Comment.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i136.Customer?>()) {
-      return (data != null ? _i136.Customer.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i137.Book?>()) {
-      return (data != null ? _i137.Book.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i138.Chapter?>()) {
-      return (data != null ? _i138.Chapter.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i139.Order?>()) {
-      return (data != null ? _i139.Order.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i140.Address?>()) {
-      return (data != null ? _i140.Address.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i141.Citizen?>()) {
-      return (data != null ? _i141.Citizen.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i142.Company?>()) {
-      return (data != null ? _i142.Company.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i143.Town?>()) {
-      return (data != null ? _i143.Town.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i144.Blocking?>()) {
-      return (data != null ? _i144.Blocking.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i145.Member?>()) {
-      return (data != null ? _i145.Member.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i146.Cat?>()) {
-      return (data != null ? _i146.Cat.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i147.Post?>()) {
-      return (data != null ? _i147.Post.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i148.ModuleDatatype?>()) {
-      return (data != null ? _i148.ModuleDatatype.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i149.MyFeatureModel?>()) {
-      return (data != null ? _i149.MyFeatureModel.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i150.MyTriggerType?>()) {
-      return (data != null ? _i150.MyTriggerType.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i151.Nullability?>()) {
-      return (data != null ? _i151.Nullability.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i152.NullsDistinctData?>()) {
-      return (data != null ? _i152.NullsDistinctData.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i153.ObjectFieldPersist?>()) {
-      return (data != null ? _i153.ObjectFieldPersist.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i154.ObjectFieldScopes?>()) {
-      return (data != null ? _i154.ObjectFieldScopes.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i155.ObjectWithBit?>()) {
-      return (data != null ? _i155.ObjectWithBit.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i156.ObjectWithByteData?>()) {
-      return (data != null ? _i156.ObjectWithByteData.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i157.ObjectWithCustomClass?>()) {
-      return (data != null ? _i157.ObjectWithCustomClass.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i158.ObjectWithDuration?>()) {
-      return (data != null ? _i158.ObjectWithDuration.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i159.ObjectWithDynamic?>()) {
-      return (data != null ? _i159.ObjectWithDynamic.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i160.ObjectWithEnum?>()) {
-      return (data != null ? _i160.ObjectWithEnum.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i161.ObjectWithEnumEnhanced?>()) {
-      return (data != null ? _i161.ObjectWithEnumEnhanced.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i162.ObjectWithGeographyGeometryCollection?>()) {
-      return (data != null
-              ? _i162.ObjectWithGeographyGeometryCollection.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i163.ObjectWithGeographyLineString?>()) {
-      return (data != null
-              ? _i163.ObjectWithGeographyLineString.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i164.ObjectWithGeographyPoint?>()) {
-      return (data != null
-              ? _i164.ObjectWithGeographyPoint.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i165.ObjectWithGeographyPolygon?>()) {
-      return (data != null
-              ? _i165.ObjectWithGeographyPolygon.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i166.ObjectWithHalfVector?>()) {
-      return (data != null ? _i166.ObjectWithHalfVector.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i167.ObjectWithIndex?>()) {
-      return (data != null ? _i167.ObjectWithIndex.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i168.ObjectWithJsonb?>()) {
-      return (data != null ? _i168.ObjectWithJsonb.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i169.ObjectWithJsonbClassLevel?>()) {
-      return (data != null
-              ? _i169.ObjectWithJsonbClassLevel.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i170.ObjectWithMaps?>()) {
-      return (data != null ? _i170.ObjectWithMaps.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i171.ObjectWithNullableCustomClass?>()) {
-      return (data != null
-              ? _i171.ObjectWithNullableCustomClass.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i172.ObjectWithObject?>()) {
-      return (data != null ? _i172.ObjectWithObject.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i173.ObjectWithParent?>()) {
-      return (data != null ? _i173.ObjectWithParent.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i174.ObjectWithSealedClass?>()) {
-      return (data != null ? _i174.ObjectWithSealedClass.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i175.ObjectWithSealedException?>()) {
-      return (data != null
-              ? _i175.ObjectWithSealedException.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i176.ObjectWithSelfParent?>()) {
-      return (data != null ? _i176.ObjectWithSelfParent.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i177.ObjectWithSparseVector?>()) {
-      return (data != null ? _i177.ObjectWithSparseVector.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i178.ObjectWithUuid?>()) {
-      return (data != null ? _i178.ObjectWithUuid.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i179.ObjectWithVector?>()) {
-      return (data != null ? _i179.ObjectWithVector.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i180.Record?>()) {
-      return (data != null ? _i180.Record.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i181.RelatedUniqueData?>()) {
-      return (data != null ? _i181.RelatedUniqueData.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i182.ExceptionWithRequiredField?>()) {
-      return (data != null
-              ? _i182.ExceptionWithRequiredField.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i183.ModelWithRequiredField?>()) {
-      return (data != null ? _i183.ModelWithRequiredField.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i184.ScopeNoneFields?>()) {
-      return (data != null ? _i184.ScopeNoneFields.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i185.ScopeServerOnlyFieldChild?>()) {
-      return (data != null
-              ? _i185.ScopeServerOnlyFieldChild.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i186.ScopeServerOnlyField?>()) {
-      return (data != null ? _i186.ScopeServerOnlyField.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i187.DefaultServerOnlyClass?>()) {
-      return (data != null ? _i187.DefaultServerOnlyClass.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i188.DefaultServerOnlyEnum?>()) {
-      return (data != null ? _i188.DefaultServerOnlyEnum.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i189.NotServerOnlyClass?>()) {
-      return (data != null ? _i189.NotServerOnlyClass.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i190.NotServerOnlyEnum?>()) {
-      return (data != null ? _i190.NotServerOnlyEnum.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i191.ServerOnlyClassField?>()) {
-      return (data != null ? _i191.ServerOnlyClassField.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i192.ServerOnlyDefault?>()) {
-      return (data != null ? _i192.ServerOnlyDefault.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i193.SessionAuthInfo?>()) {
-      return (data != null ? _i193.SessionAuthInfo.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i194.SharedModelContainer?>()) {
-      return (data != null ? _i194.SharedModelContainer.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i195.SharedModelSubclass?>()) {
-      return (data != null ? _i195.SharedModelSubclass.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i196.SimpleData?>()) {
-      return (data != null ? _i196.SimpleData.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i197.SimpleDataList?>()) {
-      return (data != null ? _i197.SimpleDataList.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i198.SimpleDataMap?>()) {
-      return (data != null ? _i198.SimpleDataMap.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i199.SimpleDataObject?>()) {
-      return (data != null ? _i199.SimpleDataObject.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i200.SimpleDateTime?>()) {
-      return (data != null ? _i200.SimpleDateTime.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i201.ModelInSubfolder?>()) {
-      return (data != null ? _i201.ModelInSubfolder.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i202.TestEnum?>()) {
-      return (data != null ? _i202.TestEnum.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i203.TestEnumDefaultSerialization?>()) {
-      return (data != null
-              ? _i203.TestEnumDefaultSerialization.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i204.TestEnumEnhanced?>()) {
-      return (data != null ? _i204.TestEnumEnhanced.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i205.TestEnumEnhancedByName?>()) {
-      return (data != null ? _i205.TestEnumEnhancedByName.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i206.TestEnumStringified?>()) {
-      return (data != null ? _i206.TestEnumStringified.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i207.Types?>()) {
-      return (data != null ? _i207.Types.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i208.TypesList?>()) {
-      return (data != null ? _i208.TypesList.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i209.TypesMap?>()) {
-      return (data != null ? _i209.TypesMap.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i210.TypesRecord?>()) {
-      return (data != null ? _i210.TypesRecord.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i211.TypesSet?>()) {
-      return (data != null ? _i211.TypesSet.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i212.TypesSetRequired?>()) {
-      return (data != null ? _i212.TypesSetRequired.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i213.UniqueData?>()) {
-      return (data != null ? _i213.UniqueData.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i214.UniqueDataWithNonPersist?>()) {
-      return (data != null
-              ? _i214.UniqueDataWithNonPersist.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i215.UpsertTestModel?>()) {
-      return (data != null ? _i215.UpsertTestModel.fromJson(data) : null) as T;
-    }
-    if (t == List<_i5.EnrollmentInt>) {
-      return (data as List)
-              .map((e) => deserialize<_i5.EnrollmentInt>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i5.EnrollmentInt>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i5.EnrollmentInt>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i8.PlayerUuid>) {
-      return (data as List).map((e) => deserialize<_i8.PlayerUuid>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i8.PlayerUuid>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i8.PlayerUuid>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i12.OrderUuid>) {
-      return (data as List).map((e) => deserialize<_i12.OrderUuid>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i12.OrderUuid>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i12.OrderUuid>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i10.CommentInt>) {
-      return (data as List).map((e) => deserialize<_i10.CommentInt>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i10.CommentInt>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i10.CommentInt>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i17.ChangedIdTypeSelf>) {
-      return (data as List)
-              .map((e) => deserialize<_i17.ChangedIdTypeSelf>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i17.ChangedIdTypeSelf>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i17.ChangedIdTypeSelf>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i63.EmptyModelRelationItem>) {
-      return (data as List)
-              .map((e) => deserialize<_i63.EmptyModelRelationItem>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i63.EmptyModelRelationItem>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i63.EmptyModelRelationItem>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i71.Employee>) {
-      return (data as List).map((e) => deserialize<_i71.Employee>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i71.Employee>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i71.Employee>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<String>) {
-      return (data as List).map((e) => deserialize<String>(e)).toList() as T;
-    }
-    if (t == Map<String, String>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(deserialize<String>(k), deserialize<String>(v)),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(int, String)>()) {
-      return (
-            deserialize<int>(((data as Map)['p'] as List)[0]),
-            deserialize<String>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == List<_i96.ChildEntity>) {
-      return (data as List)
-              .map((e) => deserialize<_i96.ChildEntity>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i96.ChildEntity>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i96.ChildEntity>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i102.PolymorphicChild>) {
-      return (data as List)
-              .map((e) => deserialize<_i102.PolymorphicChild>(e))
-              .toList()
-          as T;
-    }
-    if (t == List<_i102.PolymorphicChild?>) {
-      return (data as List)
-              .map((e) => deserialize<_i102.PolymorphicChild?>(e))
-              .toList()
-          as T;
-    }
-    if (t == Map<String, _i102.PolymorphicChild>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<_i102.PolymorphicChild>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == Map<String, _i102.PolymorphicChild?>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<_i102.PolymorphicChild?>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == List<_i216.ModulePolymorphicChild>) {
-      return (data as List)
-              .map((e) => deserialize<_i216.ModulePolymorphicChild>(e))
-              .toList()
-          as T;
-    }
-    if (t == Map<String, _i216.ModulePolymorphicChild>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<_i216.ModulePolymorphicChild>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == List<_i112.PersonWithLongTableName>) {
-      return (data as List)
-              .map((e) => deserialize<_i112.PersonWithLongTableName>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i112.PersonWithLongTableName>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i112.PersonWithLongTableName>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i111.OrganizationWithLongTableName>) {
-      return (data as List)
-              .map((e) => deserialize<_i111.OrganizationWithLongTableName>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i111.OrganizationWithLongTableName>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map(
-                      (e) =>
-                          deserialize<_i111.OrganizationWithLongTableName>(e),
-                    )
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i114.LongImplicitIdField>) {
-      return (data as List)
-              .map((e) => deserialize<_i114.LongImplicitIdField>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i114.LongImplicitIdField>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i114.LongImplicitIdField>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i121.MultipleMaxFieldName>) {
-      return (data as List)
-              .map((e) => deserialize<_i121.MultipleMaxFieldName>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i121.MultipleMaxFieldName>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i121.MultipleMaxFieldName>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i117.UserNote>) {
-      return (data as List).map((e) => deserialize<_i117.UserNote>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i117.UserNote>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i117.UserNote>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i120.UserNoteWithALongName>) {
-      return (data as List)
-              .map((e) => deserialize<_i120.UserNoteWithALongName>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i120.UserNoteWithALongName>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i120.UserNoteWithALongName>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i124.Person>) {
-      return (data as List).map((e) => deserialize<_i124.Person>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i124.Person>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<_i124.Person>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i123.Organization>) {
-      return (data as List)
-              .map((e) => deserialize<_i123.Organization>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i123.Organization>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i123.Organization>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i128.Enrollment>) {
-      return (data as List)
-              .map((e) => deserialize<_i128.Enrollment>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i128.Enrollment>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i128.Enrollment>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i133.Player>) {
-      return (data as List).map((e) => deserialize<_i133.Player>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i133.Player>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<_i133.Player>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i139.Order>) {
-      return (data as List).map((e) => deserialize<_i139.Order>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i139.Order>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<_i139.Order>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i138.Chapter>) {
-      return (data as List).map((e) => deserialize<_i138.Chapter>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i138.Chapter>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i138.Chapter>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i135.Comment>) {
-      return (data as List).map((e) => deserialize<_i135.Comment>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i135.Comment>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i135.Comment>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i144.Blocking>) {
-      return (data as List).map((e) => deserialize<_i144.Blocking>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i144.Blocking>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i144.Blocking>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i146.Cat>) {
-      return (data as List).map((e) => deserialize<_i146.Cat>(e)).toList() as T;
-    }
-    if (t == _i1.getType<List<_i146.Cat>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<_i146.Cat>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i216.ModuleClass>) {
-      return (data as List)
-              .map((e) => deserialize<_i216.ModuleClass>(e))
-              .toList()
-          as T;
-    }
-    if (t == Map<String, _i216.ModuleClass>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<_i216.ModuleClass>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(_i216.ModuleClass,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<_i216.ModuleClass>(((data as Map)['p'] as List)[0]),)
-                as T;
-    }
-    if (t == List<int>) {
-      return (data as List).map((e) => deserialize<int>(e)).toList() as T;
-    }
-    if (t == _i1.getType<List<int>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<int>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == List<int?>) {
-      return (data as List).map((e) => deserialize<int?>(e)).toList() as T;
-    }
-    if (t == _i1.getType<List<int?>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<int?>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i196.SimpleData>) {
-      return (data as List)
-              .map((e) => deserialize<_i196.SimpleData>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i196.SimpleData>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i196.SimpleData>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i196.SimpleData?>) {
-      return (data as List)
-              .map((e) => deserialize<_i196.SimpleData?>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i196.SimpleData?>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i196.SimpleData?>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<DateTime>) {
-      return (data as List).map((e) => deserialize<DateTime>(e)).toList() as T;
-    }
-    if (t == _i1.getType<List<DateTime>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<DateTime>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == List<DateTime?>) {
-      return (data as List).map((e) => deserialize<DateTime?>(e)).toList() as T;
-    }
-    if (t == _i1.getType<List<DateTime?>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<DateTime?>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i217.ByteData>) {
-      return (data as List).map((e) => deserialize<_i217.ByteData>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i217.ByteData>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i217.ByteData>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i217.ByteData?>) {
-      return (data as List).map((e) => deserialize<_i217.ByteData?>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i217.ByteData?>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i217.ByteData?>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<Duration>) {
-      return (data as List).map((e) => deserialize<Duration>(e)).toList() as T;
-    }
-    if (t == _i1.getType<List<Duration>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<Duration>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == List<Duration?>) {
-      return (data as List).map((e) => deserialize<Duration?>(e)).toList() as T;
-    }
-    if (t == _i1.getType<List<Duration?>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<Duration?>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i1.UuidValue>) {
-      return (data as List).map((e) => deserialize<_i1.UuidValue>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i1.UuidValue>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i1.UuidValue>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i1.UuidValue?>) {
-      return (data as List).map((e) => deserialize<_i1.UuidValue?>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i1.UuidValue?>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i1.UuidValue?>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == Map<String, int>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(deserialize<String>(k), deserialize<int>(v)),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<String, int>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) =>
-                      MapEntry(deserialize<String>(k), deserialize<int>(v)),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<String, int?>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(deserialize<String>(k), deserialize<int?>(v)),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<String, int?>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) =>
-                      MapEntry(deserialize<String>(k), deserialize<int?>(v)),
-                )
-              : null)
-          as T;
-    }
-    if (t == _i218.CustomClassWithoutProtocolSerialization) {
-      return _i218.CustomClassWithoutProtocolSerialization.fromJson(data) as T;
-    }
-    if (t == _i218.CustomClassWithProtocolSerialization) {
-      return _i218.CustomClassWithProtocolSerialization.fromJson(data) as T;
-    }
-    if (t == _i218.CustomClassWithProtocolSerializationMethod) {
-      return _i218.CustomClassWithProtocolSerializationMethod.fromJson(data)
-          as T;
-    }
-    if (t == dynamic) {
-      return deserializeDynamicFieldValue(data) as T;
-    }
-    if (t == List<dynamic>) {
-      return (data as List).map((e) => deserialize<dynamic>(e)).toList() as T;
-    }
-    if (t == Map<String, dynamic>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(deserialize<String>(k), deserialize<dynamic>(v)),
-          )
-          as T;
-    }
-    if (t == Set<dynamic>) {
-      return (data as List).map((e) => deserialize<dynamic>(e)).toSet() as T;
-    }
-    if (t == Map<dynamic, dynamic>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) => MapEntry(
-                deserialize<dynamic>(e['k']),
-                deserialize<dynamic>(e['v']),
-              ),
-            ),
-          )
-          as T;
-    }
-    if (t == List<_i202.TestEnum>) {
-      return (data as List).map((e) => deserialize<_i202.TestEnum>(e)).toList()
-          as T;
-    }
-    if (t == List<_i202.TestEnum?>) {
-      return (data as List).map((e) => deserialize<_i202.TestEnum?>(e)).toList()
-          as T;
-    }
-    if (t == List<List<_i202.TestEnum>>) {
-      return (data as List)
-              .map((e) => deserialize<List<_i202.TestEnum>>(e))
-              .toList()
-          as T;
-    }
-    if (t == List<_i204.TestEnumEnhanced>) {
-      return (data as List)
-              .map((e) => deserialize<_i204.TestEnumEnhanced>(e))
-              .toList()
-          as T;
-    }
-    if (t == List<_i205.TestEnumEnhancedByName>) {
-      return (data as List)
-              .map((e) => deserialize<_i205.TestEnumEnhancedByName>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<String>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<String>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == Map<String, _i196.SimpleData>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<_i196.SimpleData>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == Map<String, DateTime>) {
-      return (data as Map).map(
-            (k, v) =>
-                MapEntry(deserialize<String>(k), deserialize<DateTime>(v)),
-          )
-          as T;
-    }
-    if (t == Map<String, _i217.ByteData>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<_i217.ByteData>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == Map<String, Duration>) {
-      return (data as Map).map(
-            (k, v) =>
-                MapEntry(deserialize<String>(k), deserialize<Duration>(v)),
-          )
-          as T;
-    }
-    if (t == Map<String, _i1.UuidValue>) {
-      return (data as Map).map(
-            (k, v) =>
-                MapEntry(deserialize<String>(k), deserialize<_i1.UuidValue>(v)),
-          )
-          as T;
-    }
-    if (t == Map<String, _i196.SimpleData?>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<_i196.SimpleData?>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == Map<String, String?>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(deserialize<String>(k), deserialize<String?>(v)),
-          )
-          as T;
-    }
-    if (t == Map<String, DateTime?>) {
-      return (data as Map).map(
-            (k, v) =>
-                MapEntry(deserialize<String>(k), deserialize<DateTime?>(v)),
-          )
-          as T;
-    }
-    if (t == Map<String, _i217.ByteData?>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<_i217.ByteData?>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == Map<String, Duration?>) {
-      return (data as Map).map(
-            (k, v) =>
-                MapEntry(deserialize<String>(k), deserialize<Duration?>(v)),
-          )
-          as T;
-    }
-    if (t == Map<String, _i1.UuidValue?>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<_i1.UuidValue?>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == Map<int, int>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) =>
-                  MapEntry(deserialize<int>(e['k']), deserialize<int>(e['v'])),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<_i218.CustomClassWithoutProtocolSerialization?>()) {
-      return (data != null
-              ? _i218.CustomClassWithoutProtocolSerialization.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i218.CustomClassWithProtocolSerialization?>()) {
-      return (data != null
-              ? _i218.CustomClassWithProtocolSerialization.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i218.CustomClassWithProtocolSerializationMethod?>()) {
-      return (data != null
-              ? _i218.CustomClassWithProtocolSerializationMethod.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == List<List<_i196.SimpleData>>) {
-      return (data as List)
-              .map((e) => deserialize<List<_i196.SimpleData>>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<List<_i196.SimpleData>>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<List<_i196.SimpleData>>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == Map<String, List<List<Map<int, _i196.SimpleData>>?>>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<List<List<Map<int, _i196.SimpleData>>?>>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == List<List<Map<int, _i196.SimpleData>>?>) {
-      return (data as List)
-              .map((e) => deserialize<List<Map<int, _i196.SimpleData>>?>(e))
-              .toList()
-          as T;
-    }
-    if (t == List<Map<int, _i196.SimpleData>>) {
-      return (data as List)
-              .map((e) => deserialize<Map<int, _i196.SimpleData>>(e))
-              .toList()
-          as T;
-    }
-    if (t == Map<int, _i196.SimpleData>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) => MapEntry(
-                deserialize<int>(e['k']),
-                deserialize<_i196.SimpleData>(e['v']),
-              ),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<List<Map<int, _i196.SimpleData>>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<Map<int, _i196.SimpleData>>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t ==
-        _i1.getType<Map<String, List<List<Map<int, _i196.SimpleData>>?>>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) => MapEntry(
-                    deserialize<String>(k),
-                    deserialize<List<List<Map<int, _i196.SimpleData>>?>>(v),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<List<Map<int, _i196.SimpleData>>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<Map<int, _i196.SimpleData>>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == Map<String, Map<int, _i196.SimpleData>>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<Map<int, _i196.SimpleData>>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<String, Map<int, _i196.SimpleData>>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) => MapEntry(
-                    deserialize<String>(k),
-                    deserialize<Map<int, _i196.SimpleData>>(v),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == List<_i108.SealedParent>) {
-      return (data as List)
-              .map((e) => deserialize<_i108.SealedParent>(e))
-              .toList()
-          as T;
-    }
-    if (t == List<_i91.SealedAppException>) {
-      return (data as List)
-              .map((e) => deserialize<_i91.SealedAppException>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<(bool,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<bool>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == List<_i218.SharedModel>) {
-      return (data as List)
-              .map((e) => deserialize<_i218.SharedModel>(e))
-              .toList()
-          as T;
-    }
-    if (t == List<_i218.SharedModel?>) {
-      return (data as List)
-              .map((e) => deserialize<_i218.SharedModel?>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i218.SharedModel>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i218.SharedModel>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == Map<String, _i218.SharedModel>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<_i218.SharedModel>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<String, _i218.SharedModel>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) => MapEntry(
-                    deserialize<String>(k),
-                    deserialize<_i218.SharedModel>(v),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<String, _i218.SharedSubclass>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<_i218.SharedSubclass>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == Set<_i218.SharedModel>) {
-      return (data as List)
-              .map((e) => deserialize<_i218.SharedModel>(e))
-              .toSet()
-          as T;
-    }
-    if (t == _i1.getType<Set<_i218.SharedModel>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i218.SharedModel>(e))
-                    .toSet()
-              : null)
-          as T;
-    }
-    if (t == List<_i206.TestEnumStringified>) {
-      return (data as List)
-              .map((e) => deserialize<_i206.TestEnumStringified>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i206.TestEnumStringified>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i206.TestEnumStringified>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(_i206.TestEnumStringified,)?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<_i206.TestEnumStringified>(
-                    ((data as Map)['p'] as List)[0],
-                  ),
-                )
-                as T;
-    }
-    if (t == List<(_i206.TestEnumStringified,)>) {
-      return (data as List)
-              .map((e) => deserialize<(_i206.TestEnumStringified,)>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<(_i206.TestEnumStringified,)>()) {
-      return (
-            deserialize<_i206.TestEnumStringified>(
-              ((data as Map)['p'] as List)[0],
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<List<(_i206.TestEnumStringified,)>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<(_i206.TestEnumStringified,)>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(_i206.TestEnumStringified,)>()) {
-      return (
-            deserialize<_i206.TestEnumStringified>(
-              ((data as Map)['p'] as List)[0],
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(_i151.Nullability,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<_i151.Nullability>(((data as Map)['p'] as List)[0]),)
-                as T;
-    }
-    if (t == _i1.getType<({_i206.TestEnumStringified value})?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  value: deserialize<_i206.TestEnumStringified>(
-                    ((data as Map)['n'] as Map)['value'],
-                  ),
-                )
-                as T;
-    }
-    if (t == List<({_i206.TestEnumStringified value})>) {
-      return (data as List)
-              .map((e) => deserialize<({_i206.TestEnumStringified value})>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<({_i206.TestEnumStringified value})>()) {
-      return (
-            value: deserialize<_i206.TestEnumStringified>(
-              ((data as Map)['n'] as Map)['value'],
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<List<({_i206.TestEnumStringified value})>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map(
-                      (e) =>
-                          deserialize<({_i206.TestEnumStringified value})>(e),
-                    )
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<({_i206.TestEnumStringified value})>()) {
-      return (
-            value: deserialize<_i206.TestEnumStringified>(
-              ((data as Map)['n'] as Map)['value'],
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<({_i216.ModuleClass value})?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  value: deserialize<_i216.ModuleClass>(
-                    ((data as Map)['n'] as Map)['value'],
-                  ),
-                )
-                as T;
-    }
-    if (t == _i1.getType<({_i151.Nullability value})?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  value: deserialize<_i151.Nullability>(
-                    ((data as Map)['n'] as Map)['value'],
-                  ),
-                )
-                as T;
-    }
-    if (t == _i1.getType<Map<int, int>?>()) {
-      return (data != null
-              ? Map.fromEntries(
-                  (data as List).map(
-                    (e) => MapEntry(
-                      deserialize<int>(e['k']),
-                      deserialize<int>(e['v']),
-                    ),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == Set<int>) {
-      return (data as List).map((e) => deserialize<int>(e)).toSet() as T;
-    }
-    if (t == _i1.getType<Set<int>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<int>(e)).toSet()
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(String, {Uri? optionalUri})?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<String>(((data as Map)['p'] as List)[0]),
-                  optionalUri: ((data)['n'] as Map)['optionalUri'] == null
-                      ? null
-                      : deserialize<Uri>(data['n']['optionalUri']),
-                )
-                as T;
-    }
-    if (t == List<bool>) {
-      return (data as List).map((e) => deserialize<bool>(e)).toList() as T;
-    }
-    if (t == _i1.getType<List<bool>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<bool>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == List<double>) {
-      return (data as List).map((e) => deserialize<double>(e)).toList() as T;
-    }
-    if (t == _i1.getType<List<double>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<double>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == List<Uri>) {
-      return (data as List).map((e) => deserialize<Uri>(e)).toList() as T;
-    }
-    if (t == _i1.getType<List<Uri>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<Uri>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == List<BigInt>) {
-      return (data as List).map((e) => deserialize<BigInt>(e)).toList() as T;
-    }
-    if (t == _i1.getType<List<BigInt>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<BigInt>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<List<_i202.TestEnum>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i202.TestEnum>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i207.Types>) {
-      return (data as List).map((e) => deserialize<_i207.Types>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i207.Types>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<_i207.Types>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == List<Map<String, _i207.Types>>) {
-      return (data as List)
-              .map((e) => deserialize<Map<String, _i207.Types>>(e))
-              .toList()
-          as T;
-    }
-    if (t == Map<String, _i207.Types>) {
-      return (data as Map).map(
-            (k, v) =>
-                MapEntry(deserialize<String>(k), deserialize<_i207.Types>(v)),
-          )
-          as T;
-    }
-    if (t == _i1.getType<List<Map<String, _i207.Types>>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<Map<String, _i207.Types>>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<List<_i207.Types>>) {
-      return (data as List)
-              .map((e) => deserialize<List<_i207.Types>>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<List<_i207.Types>>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<List<_i207.Types>>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<(int,)>) {
-      return (data as List).map((e) => deserialize<(int,)>(e)).toList() as T;
-    }
-    if (t == _i1.getType<(int,)>()) {
-      return (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<List<(int,)>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<(int,)>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(int,)>()) {
-      return (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == List<(int,)?>) {
-      return (data as List).map((e) => deserialize<(int,)?>(e)).toList() as T;
-    }
-    if (t == _i1.getType<(int,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<List<(int,)?>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<(int,)?>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(int,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == List<(_i202.TestEnum,)>) {
-      return (data as List)
-              .map((e) => deserialize<(_i202.TestEnum,)>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<(_i202.TestEnum,)>()) {
-      return (deserialize<_i202.TestEnum>(((data as Map)['p'] as List)[0]),)
-          as T;
-    }
-    if (t == _i1.getType<List<(_i202.TestEnum,)>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<(_i202.TestEnum,)>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(_i202.TestEnum,)>()) {
-      return (deserialize<_i202.TestEnum>(((data as Map)['p'] as List)[0]),)
-          as T;
-    }
-    if (t == Map<int, String>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) => MapEntry(
-                deserialize<int>(e['k']),
-                deserialize<String>(e['v']),
-              ),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<int, String>?>()) {
-      return (data != null
-              ? Map.fromEntries(
-                  (data as List).map(
-                    (e) => MapEntry(
-                      deserialize<int>(e['k']),
-                      deserialize<String>(e['v']),
-                    ),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<bool, String>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) => MapEntry(
-                deserialize<bool>(e['k']),
-                deserialize<String>(e['v']),
-              ),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<bool, String>?>()) {
-      return (data != null
-              ? Map.fromEntries(
-                  (data as List).map(
-                    (e) => MapEntry(
-                      deserialize<bool>(e['k']),
-                      deserialize<String>(e['v']),
-                    ),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<double, String>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) => MapEntry(
-                deserialize<double>(e['k']),
-                deserialize<String>(e['v']),
-              ),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<double, String>?>()) {
-      return (data != null
-              ? Map.fromEntries(
-                  (data as List).map(
-                    (e) => MapEntry(
-                      deserialize<double>(e['k']),
-                      deserialize<String>(e['v']),
-                    ),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<DateTime, String>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) => MapEntry(
-                deserialize<DateTime>(e['k']),
-                deserialize<String>(e['v']),
-              ),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<DateTime, String>?>()) {
-      return (data != null
-              ? Map.fromEntries(
-                  (data as List).map(
-                    (e) => MapEntry(
-                      deserialize<DateTime>(e['k']),
-                      deserialize<String>(e['v']),
-                    ),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<Map<String, String>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) =>
-                      MapEntry(deserialize<String>(k), deserialize<String>(v)),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<_i217.ByteData, String>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) => MapEntry(
-                deserialize<_i217.ByteData>(e['k']),
-                deserialize<String>(e['v']),
-              ),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<_i217.ByteData, String>?>()) {
-      return (data != null
-              ? Map.fromEntries(
-                  (data as List).map(
-                    (e) => MapEntry(
-                      deserialize<_i217.ByteData>(e['k']),
-                      deserialize<String>(e['v']),
-                    ),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<Duration, String>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) => MapEntry(
-                deserialize<Duration>(e['k']),
-                deserialize<String>(e['v']),
-              ),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<Duration, String>?>()) {
-      return (data != null
-              ? Map.fromEntries(
-                  (data as List).map(
-                    (e) => MapEntry(
-                      deserialize<Duration>(e['k']),
-                      deserialize<String>(e['v']),
-                    ),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<_i1.UuidValue, String>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) => MapEntry(
-                deserialize<_i1.UuidValue>(e['k']),
-                deserialize<String>(e['v']),
-              ),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<_i1.UuidValue, String>?>()) {
-      return (data != null
-              ? Map.fromEntries(
-                  (data as List).map(
-                    (e) => MapEntry(
-                      deserialize<_i1.UuidValue>(e['k']),
-                      deserialize<String>(e['v']),
-                    ),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<Uri, String>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) => MapEntry(
-                deserialize<Uri>(e['k']),
-                deserialize<String>(e['v']),
-              ),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<Uri, String>?>()) {
-      return (data != null
-              ? Map.fromEntries(
-                  (data as List).map(
-                    (e) => MapEntry(
-                      deserialize<Uri>(e['k']),
-                      deserialize<String>(e['v']),
-                    ),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<BigInt, String>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) => MapEntry(
-                deserialize<BigInt>(e['k']),
-                deserialize<String>(e['v']),
-              ),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<BigInt, String>?>()) {
-      return (data != null
-              ? Map.fromEntries(
-                  (data as List).map(
-                    (e) => MapEntry(
-                      deserialize<BigInt>(e['k']),
-                      deserialize<String>(e['v']),
-                    ),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<_i202.TestEnum, String>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) => MapEntry(
-                deserialize<_i202.TestEnum>(e['k']),
-                deserialize<String>(e['v']),
-              ),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<_i202.TestEnum, String>?>()) {
-      return (data != null
-              ? Map.fromEntries(
-                  (data as List).map(
-                    (e) => MapEntry(
-                      deserialize<_i202.TestEnum>(e['k']),
-                      deserialize<String>(e['v']),
-                    ),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<_i206.TestEnumStringified, String>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) => MapEntry(
-                deserialize<_i206.TestEnumStringified>(e['k']),
-                deserialize<String>(e['v']),
-              ),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<_i206.TestEnumStringified, String>?>()) {
-      return (data != null
-              ? Map.fromEntries(
-                  (data as List).map(
-                    (e) => MapEntry(
-                      deserialize<_i206.TestEnumStringified>(e['k']),
-                      deserialize<String>(e['v']),
-                    ),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<_i207.Types, String>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) => MapEntry(
-                deserialize<_i207.Types>(e['k']),
-                deserialize<String>(e['v']),
-              ),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<_i207.Types, String>?>()) {
-      return (data != null
-              ? Map.fromEntries(
-                  (data as List).map(
-                    (e) => MapEntry(
-                      deserialize<_i207.Types>(e['k']),
-                      deserialize<String>(e['v']),
-                    ),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<Map<_i207.Types, String>, String>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) => MapEntry(
-                deserialize<Map<_i207.Types, String>>(e['k']),
-                deserialize<String>(e['v']),
-              ),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<Map<_i207.Types, String>, String>?>()) {
-      return (data != null
-              ? Map.fromEntries(
-                  (data as List).map(
-                    (e) => MapEntry(
-                      deserialize<Map<_i207.Types, String>>(e['k']),
-                      deserialize<String>(e['v']),
-                    ),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<List<_i207.Types>, String>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) => MapEntry(
-                deserialize<List<_i207.Types>>(e['k']),
-                deserialize<String>(e['v']),
-              ),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<List<_i207.Types>, String>?>()) {
-      return (data != null
-              ? Map.fromEntries(
-                  (data as List).map(
-                    (e) => MapEntry(
-                      deserialize<List<_i207.Types>>(e['k']),
-                      deserialize<String>(e['v']),
-                    ),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<(String,), String>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) => MapEntry(
-                deserialize<(String,)>(e['k']),
-                deserialize<String>(e['v']),
-              ),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(String,)>()) {
-      return (deserialize<String>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<Map<(String,), String>?>()) {
-      return (data != null
-              ? Map.fromEntries(
-                  (data as List).map(
-                    (e) => MapEntry(
-                      deserialize<(String,)>(e['k']),
-                      deserialize<String>(e['v']),
-                    ),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(String,)>()) {
-      return (deserialize<String>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == Map<String, bool>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(deserialize<String>(k), deserialize<bool>(v)),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<String, bool>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) =>
-                      MapEntry(deserialize<String>(k), deserialize<bool>(v)),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<String, double>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(deserialize<String>(k), deserialize<double>(v)),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<String, double>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) =>
-                      MapEntry(deserialize<String>(k), deserialize<double>(v)),
-                )
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<Map<String, DateTime>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) => MapEntry(
-                    deserialize<String>(k),
-                    deserialize<DateTime>(v),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<Map<String, _i217.ByteData>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) => MapEntry(
-                    deserialize<String>(k),
-                    deserialize<_i217.ByteData>(v),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<Map<String, Duration>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) => MapEntry(
-                    deserialize<String>(k),
-                    deserialize<Duration>(v),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<Map<String, _i1.UuidValue>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) => MapEntry(
-                    deserialize<String>(k),
-                    deserialize<_i1.UuidValue>(v),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<String, Uri>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(deserialize<String>(k), deserialize<Uri>(v)),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<String, Uri>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) =>
-                      MapEntry(deserialize<String>(k), deserialize<Uri>(v)),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<String, BigInt>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(deserialize<String>(k), deserialize<BigInt>(v)),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<String, BigInt>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) =>
-                      MapEntry(deserialize<String>(k), deserialize<BigInt>(v)),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<String, _i202.TestEnum>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<_i202.TestEnum>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<String, _i202.TestEnum>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) => MapEntry(
-                    deserialize<String>(k),
-                    deserialize<_i202.TestEnum>(v),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<String, _i206.TestEnumStringified>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<_i206.TestEnumStringified>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<String, _i206.TestEnumStringified>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) => MapEntry(
-                    deserialize<String>(k),
-                    deserialize<_i206.TestEnumStringified>(v),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<Map<String, _i207.Types>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) => MapEntry(
-                    deserialize<String>(k),
-                    deserialize<_i207.Types>(v),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<String, Map<String, _i207.Types>>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<Map<String, _i207.Types>>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<String, Map<String, _i207.Types>>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) => MapEntry(
-                    deserialize<String>(k),
-                    deserialize<Map<String, _i207.Types>>(v),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<String, List<_i207.Types>>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<List<_i207.Types>>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<String, List<_i207.Types>>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) => MapEntry(
-                    deserialize<String>(k),
-                    deserialize<List<_i207.Types>>(v),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<String, (String,)>) {
-      return (data as Map).map(
-            (k, v) =>
-                MapEntry(deserialize<String>(k), deserialize<(String,)>(v)),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(String,)>()) {
-      return (deserialize<String>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<Map<String, (String,)>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) => MapEntry(
-                    deserialize<String>(k),
-                    deserialize<(String,)>(v),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(String,)>()) {
-      return (deserialize<String>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == Map<String, (String,)?>) {
-      return (data as Map).map(
-            (k, v) =>
-                MapEntry(deserialize<String>(k), deserialize<(String,)?>(v)),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(String,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<String>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<Map<String, (String,)?>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) => MapEntry(
-                    deserialize<String>(k),
-                    deserialize<(String,)?>(v),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(String,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<String>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == Map<(String,)?, String>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) => MapEntry(
-                deserialize<(String,)?>(e['k']),
-                deserialize<String>(e['v']),
-              ),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(String,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<String>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<Map<(String,)?, String>?>()) {
-      return (data != null
-              ? Map.fromEntries(
-                  (data as List).map(
-                    (e) => MapEntry(
-                      deserialize<(String,)?>(e['k']),
-                      deserialize<String>(e['v']),
-                    ),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(String,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<String>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(int,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(double,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<double>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(DateTime,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<DateTime>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(String,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<String>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(_i217.ByteData,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<_i217.ByteData>(((data as Map)['p'] as List)[0]),)
-                as T;
-    }
-    if (t == _i1.getType<(Duration,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<Duration>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(_i1.UuidValue,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<_i1.UuidValue>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(Uri,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<Uri>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(BigInt,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<BigInt>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(_i202.TestEnum,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<_i202.TestEnum>(((data as Map)['p'] as List)[0]),)
-                as T;
-    }
-    if (t == _i1.getType<(List<int>,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<List<int>>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(Map<int, int>,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<Map<int, int>>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(Set<int>,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<Set<int>>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(_i196.SimpleData,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<_i196.SimpleData>(((data as Map)['p'] as List)[0]),)
-                as T;
-    }
-    if (t == _i1.getType<({_i196.SimpleData namedModel})?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  namedModel: deserialize<_i196.SimpleData>(
-                    ((data as Map)['n'] as Map)['namedModel'],
-                  ),
-                )
-                as T;
-    }
-    if (t ==
-        _i1.getType<(_i196.SimpleData, {_i196.SimpleData namedModel})?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<_i196.SimpleData>(
-                    ((data as Map)['p'] as List)[0],
-                  ),
-                  namedModel: deserialize<_i196.SimpleData>(
-                    data['n']['namedModel'],
-                  ),
-                )
-                as T;
-    }
-    if (t ==
-        _i1.getType<((int, String), {(int, String) namedNestedRecord})?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<(int, String)>(((data as Map)['p'] as List)[0]),
-                  namedNestedRecord: deserialize<(int, String)>(
-                    data['n']['namedNestedRecord'],
-                  ),
-                )
-                as T;
-    }
-    if (t ==
-        _i1
-            .getType<
-              (
-                (List<(_i196.SimpleData,)>,), {
-                (_i196.SimpleData, Map<String, _i196.SimpleData>)
-                namedNestedRecord,
-              })?
-            >()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<(List<(_i196.SimpleData,)>,)>(
-                    ((data as Map)['p'] as List)[0],
-                  ),
-                  namedNestedRecord:
-                      deserialize<
-                        (_i196.SimpleData, Map<String, _i196.SimpleData>)
-                      >(data['n']['namedNestedRecord']),
-                )
-                as T;
-    }
-    if (t == Set<bool>) {
-      return (data as List).map((e) => deserialize<bool>(e)).toSet() as T;
-    }
-    if (t == _i1.getType<Set<bool>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<bool>(e)).toSet()
-              : null)
-          as T;
-    }
-    if (t == Set<double>) {
-      return (data as List).map((e) => deserialize<double>(e)).toSet() as T;
-    }
-    if (t == _i1.getType<Set<double>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<double>(e)).toSet()
-              : null)
-          as T;
-    }
-    if (t == Set<DateTime>) {
-      return (data as List).map((e) => deserialize<DateTime>(e)).toSet() as T;
-    }
-    if (t == _i1.getType<Set<DateTime>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<DateTime>(e)).toSet()
-              : null)
-          as T;
-    }
-    if (t == Set<String>) {
-      return (data as List).map((e) => deserialize<String>(e)).toSet() as T;
-    }
-    if (t == _i1.getType<Set<String>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<String>(e)).toSet()
-              : null)
-          as T;
-    }
-    if (t == Set<_i217.ByteData>) {
-      return (data as List).map((e) => deserialize<_i217.ByteData>(e)).toSet()
-          as T;
-    }
-    if (t == _i1.getType<Set<_i217.ByteData>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i217.ByteData>(e))
-                    .toSet()
-              : null)
-          as T;
-    }
-    if (t == Set<Duration>) {
-      return (data as List).map((e) => deserialize<Duration>(e)).toSet() as T;
-    }
-    if (t == _i1.getType<Set<Duration>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<Duration>(e)).toSet()
-              : null)
-          as T;
-    }
-    if (t == Set<_i1.UuidValue>) {
-      return (data as List).map((e) => deserialize<_i1.UuidValue>(e)).toSet()
-          as T;
-    }
-    if (t == _i1.getType<Set<_i1.UuidValue>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<_i1.UuidValue>(e)).toSet()
-              : null)
-          as T;
-    }
-    if (t == Set<BigInt>) {
-      return (data as List).map((e) => deserialize<BigInt>(e)).toSet() as T;
-    }
-    if (t == _i1.getType<Set<BigInt>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<BigInt>(e)).toSet()
-              : null)
-          as T;
-    }
-    if (t == Set<_i202.TestEnum>) {
-      return (data as List).map((e) => deserialize<_i202.TestEnum>(e)).toSet()
-          as T;
-    }
-    if (t == _i1.getType<Set<_i202.TestEnum>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i202.TestEnum>(e))
-                    .toSet()
-              : null)
-          as T;
-    }
-    if (t == Set<_i206.TestEnumStringified>) {
-      return (data as List)
-              .map((e) => deserialize<_i206.TestEnumStringified>(e))
-              .toSet()
-          as T;
-    }
-    if (t == _i1.getType<Set<_i206.TestEnumStringified>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i206.TestEnumStringified>(e))
-                    .toSet()
-              : null)
-          as T;
-    }
-    if (t == Set<_i207.Types>) {
-      return (data as List).map((e) => deserialize<_i207.Types>(e)).toSet()
-          as T;
-    }
-    if (t == _i1.getType<Set<_i207.Types>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<_i207.Types>(e)).toSet()
-              : null)
-          as T;
-    }
-    if (t == Set<Map<String, _i207.Types>>) {
-      return (data as List)
-              .map((e) => deserialize<Map<String, _i207.Types>>(e))
-              .toSet()
-          as T;
-    }
-    if (t == _i1.getType<Set<Map<String, _i207.Types>>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<Map<String, _i207.Types>>(e))
-                    .toSet()
-              : null)
-          as T;
-    }
-    if (t == Set<List<_i207.Types>>) {
-      return (data as List)
-              .map((e) => deserialize<List<_i207.Types>>(e))
-              .toSet()
-          as T;
-    }
-    if (t == _i1.getType<Set<List<_i207.Types>>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<List<_i207.Types>>(e))
-                    .toSet()
-              : null)
-          as T;
-    }
-    if (t == Set<(int,)>) {
-      return (data as List).map((e) => deserialize<(int,)>(e)).toSet() as T;
-    }
-    if (t == _i1.getType<(int,)>()) {
-      return (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<Set<(int,)>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<(int,)>(e)).toSet()
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(int,)>()) {
-      return (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == Set<(int,)?>) {
-      return (data as List).map((e) => deserialize<(int,)?>(e)).toSet() as T;
-    }
-    if (t == _i1.getType<(int,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<Set<(int,)?>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<(int,)?>(e)).toSet()
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(int,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == List<String>) {
-      return (data as List).map((e) => deserialize<String>(e)).toList() as T;
-    }
-    if (t == _i1.getType<List<String>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<String>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i219.SimpleData>) {
-      return (data as List)
-              .map((e) => deserialize<_i219.SimpleData>(e))
-              .toList()
-          as T;
-    }
-    if (t == List<int>) {
-      return (data as List).map((e) => deserialize<int>(e)).toList() as T;
-    }
-    if (t == List<List<int>>) {
-      return (data as List).map((e) => deserialize<List<int>>(e)).toList() as T;
-    }
-    if (t == _i1.getType<List<int>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<int>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == List<List<int>?>) {
-      return (data as List).map((e) => deserialize<List<int>?>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<List<int>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<int>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<List<List<int>>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<List<int>>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == List<int?>) {
-      return (data as List).map((e) => deserialize<int?>(e)).toList() as T;
-    }
-    if (t == _i1.getType<List<int?>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<int?>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == List<double>) {
-      return (data as List).map((e) => deserialize<double>(e)).toList() as T;
-    }
-    if (t == List<double?>) {
-      return (data as List).map((e) => deserialize<double?>(e)).toList() as T;
-    }
-    if (t == List<bool>) {
-      return (data as List).map((e) => deserialize<bool>(e)).toList() as T;
-    }
-    if (t == List<bool?>) {
-      return (data as List).map((e) => deserialize<bool?>(e)).toList() as T;
-    }
-    if (t == List<String?>) {
-      return (data as List).map((e) => deserialize<String?>(e)).toList() as T;
-    }
-    if (t == List<DateTime>) {
-      return (data as List).map((e) => deserialize<DateTime>(e)).toList() as T;
-    }
-    if (t == List<DateTime?>) {
-      return (data as List).map((e) => deserialize<DateTime?>(e)).toList() as T;
-    }
-    if (t == List<_i217.ByteData>) {
-      return (data as List).map((e) => deserialize<_i217.ByteData>(e)).toList()
-          as T;
-    }
-    if (t == List<_i217.ByteData?>) {
-      return (data as List).map((e) => deserialize<_i217.ByteData?>(e)).toList()
-          as T;
-    }
-    if (t == List<_i219.SimpleData?>) {
-      return (data as List)
-              .map((e) => deserialize<_i219.SimpleData?>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i219.SimpleData>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i219.SimpleData>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<List<_i219.SimpleData?>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i219.SimpleData?>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<Duration>) {
-      return (data as List).map((e) => deserialize<Duration>(e)).toList() as T;
-    }
-    if (t == List<Duration?>) {
-      return (data as List).map((e) => deserialize<Duration?>(e)).toList() as T;
-    }
-    if (t == Map<String, int>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(deserialize<String>(k), deserialize<int>(v)),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<String, int>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) =>
-                      MapEntry(deserialize<String>(k), deserialize<int>(v)),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<String, Map<String, int>>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<Map<String, int>>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == Map<String, int?>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(deserialize<String>(k), deserialize<int?>(v)),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<String, int?>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) =>
-                      MapEntry(deserialize<String>(k), deserialize<int?>(v)),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<int, int>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) =>
-                  MapEntry(deserialize<int>(e['k']), deserialize<int>(e['v'])),
-            ),
-          )
-          as T;
-    }
-    if (t == Map<String, Map<int, int>>) {
-      return (data as Map).map(
-            (k, v) =>
-                MapEntry(deserialize<String>(k), deserialize<Map<int, int>>(v)),
-          )
-          as T;
-    }
-    if (t == Map<_i220.TestEnum, int>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) => MapEntry(
-                deserialize<_i220.TestEnum>(e['k']),
-                deserialize<int>(e['v']),
-              ),
-            ),
-          )
-          as T;
-    }
-    if (t == Map<String, _i220.TestEnum>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<_i220.TestEnum>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == Map<String, double>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(deserialize<String>(k), deserialize<double>(v)),
-          )
-          as T;
-    }
-    if (t == Map<String, double?>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(deserialize<String>(k), deserialize<double?>(v)),
-          )
-          as T;
-    }
-    if (t == Map<String, bool>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(deserialize<String>(k), deserialize<bool>(v)),
-          )
-          as T;
-    }
-    if (t == Map<String, bool?>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(deserialize<String>(k), deserialize<bool?>(v)),
-          )
-          as T;
-    }
-    if (t == Map<String, String>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(deserialize<String>(k), deserialize<String>(v)),
-          )
-          as T;
-    }
-    if (t == Map<String, String?>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(deserialize<String>(k), deserialize<String?>(v)),
-          )
-          as T;
-    }
-    if (t == Map<String, DateTime>) {
-      return (data as Map).map(
-            (k, v) =>
-                MapEntry(deserialize<String>(k), deserialize<DateTime>(v)),
-          )
-          as T;
-    }
-    if (t == Map<String, DateTime?>) {
-      return (data as Map).map(
-            (k, v) =>
-                MapEntry(deserialize<String>(k), deserialize<DateTime?>(v)),
-          )
-          as T;
-    }
-    if (t == Map<String, _i217.ByteData>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<_i217.ByteData>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == Map<String, _i217.ByteData?>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<_i217.ByteData?>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == Map<String, _i219.SimpleData>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<_i219.SimpleData>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == Map<String, _i219.SimpleData?>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<_i219.SimpleData?>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<String, _i219.SimpleData>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) => MapEntry(
-                    deserialize<String>(k),
-                    deserialize<_i219.SimpleData>(v),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<Map<String, _i219.SimpleData?>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) => MapEntry(
-                    deserialize<String>(k),
-                    deserialize<_i219.SimpleData?>(v),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<String, Duration>) {
-      return (data as Map).map(
-            (k, v) =>
-                MapEntry(deserialize<String>(k), deserialize<Duration>(v)),
-          )
-          as T;
-    }
-    if (t == Map<String, Duration?>) {
-      return (data as Map).map(
-            (k, v) =>
-                MapEntry(deserialize<String>(k), deserialize<Duration?>(v)),
-          )
-          as T;
-    }
-    if (t == Map<(Map<int, String>, String), String>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) => MapEntry(
-                deserialize<(Map<int, String>, String)>(e['k']),
-                deserialize<String>(e['v']),
-              ),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(Map<int, String>, String)>()) {
-      return (
-            deserialize<Map<int, String>>(((data as Map)['p'] as List)[0]),
-            deserialize<String>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(Map<int, String>, String)>()) {
-      return (
-            deserialize<Map<int, String>>(((data as Map)['p'] as List)[0]),
-            deserialize<String>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == Map<int, String>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) => MapEntry(
-                deserialize<int>(e['k']),
-                deserialize<String>(e['v']),
-              ),
-            ),
-          )
-          as T;
-    }
-    if (t == Map<String, (Map<int, int>,)>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<(Map<int, int>,)>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(Map<int, int>,)>()) {
-      return (deserialize<Map<int, int>>(((data as Map)['p'] as List)[0]),)
-          as T;
-    }
-    if (t == _i1.getType<(Map<int, int>,)>()) {
-      return (deserialize<Map<int, int>>(((data as Map)['p'] as List)[0]),)
-          as T;
-    }
-    if (t == Map<DateTime, bool>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) => MapEntry(
-                deserialize<DateTime>(e['k']),
-                deserialize<bool>(e['v']),
-              ),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<DateTime, bool>?>()) {
-      return (data != null
-              ? Map.fromEntries(
-                  (data as List).map(
-                    (e) => MapEntry(
-                      deserialize<DateTime>(e['k']),
-                      deserialize<bool>(e['v']),
-                    ),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<Map<int, String>?>()) {
-      return (data != null
-              ? Map.fromEntries(
-                  (data as List).map(
-                    (e) => MapEntry(
-                      deserialize<int>(e['k']),
-                      deserialize<String>(e['v']),
-                    ),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == List<_i221.UserInfo>) {
-      return (data as List).map((e) => deserialize<_i221.UserInfo>(e)).toList()
-          as T;
-    }
-    if (t == Set<int>) {
-      return (data as List).map((e) => deserialize<int>(e)).toSet() as T;
-    }
-    if (t == Set<_i219.SimpleData>) {
-      return (data as List).map((e) => deserialize<_i219.SimpleData>(e)).toSet()
-          as T;
-    }
-    if (t == List<Set<_i219.SimpleData>>) {
-      return (data as List)
-              .map((e) => deserialize<Set<_i219.SimpleData>>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<(int, BigInt)>()) {
-      return (
-            deserialize<int>(((data as Map)['p'] as List)[0]),
-            deserialize<BigInt>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(String, _i222.PolymorphicParent)>()) {
-      return (
-            deserialize<String>(((data as Map)['p'] as List)[0]),
-            deserialize<_i222.PolymorphicParent>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(int,)>()) {
-      return (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(int,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(int?,)>()) {
-      return (
-            ((data as Map)['p'] as List)[0] == null
-                ? null
-                : deserialize<int>(data['p'][0]),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(int?,)?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  ((data as Map)['p'] as List)[0] == null
-                      ? null
-                      : deserialize<int>(data['p'][0]),
-                )
-                as T;
-    }
-    if (t == _i1.getType<(int, String)>()) {
-      return (
-            deserialize<int>(((data as Map)['p'] as List)[0]),
-            deserialize<String>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(int, String)?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<int>(((data as Map)['p'] as List)[0]),
-                  deserialize<String>(data['p'][1]),
-                )
-                as T;
-    }
-    if (t == _i1.getType<(int, _i219.SimpleData)>()) {
-      return (
-            deserialize<int>(((data as Map)['p'] as List)[0]),
-            deserialize<_i219.SimpleData>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(int, _i219.SimpleData)?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<int>(((data as Map)['p'] as List)[0]),
-                  deserialize<_i219.SimpleData>(data['p'][1]),
-                )
-                as T;
-    }
-    if (t == _i1.getType<(Map<String, int>,)>()) {
-      return (deserialize<Map<String, int>>(((data as Map)['p'] as List)[0]),)
-          as T;
-    }
-    if (t == _i1.getType<(Set<(int,)>,)>()) {
-      return (deserialize<Set<(int,)>>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == Set<(int,)>) {
-      return (data as List).map((e) => deserialize<(int,)>(e)).toSet() as T;
-    }
-    if (t == _i1.getType<(int,)>()) {
-      return (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<({int number, String text})>()) {
-      return (
-            number: deserialize<int>(((data as Map)['n'] as Map)['number']),
-            text: deserialize<String>(data['n']['text']),
-          )
-          as T;
-    }
-    if (t == _i1.getType<({int number, String text})?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  number: deserialize<int>(
-                    ((data as Map)['n'] as Map)['number'],
-                  ),
-                  text: deserialize<String>(data['n']['text']),
-                )
-                as T;
-    }
-    if (t == _i1.getType<({_i219.SimpleData data, int number})>()) {
-      return (
-            data: deserialize<_i219.SimpleData>(
-              ((data as Map)['n'] as Map)['data'],
-            ),
-            number: deserialize<int>(data['n']['number']),
-          )
-          as T;
-    }
-    if (t == _i1.getType<({_i219.SimpleData data, int number})?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  data: deserialize<_i219.SimpleData>(
-                    ((data as Map)['n'] as Map)['data'],
-                  ),
-                  number: deserialize<int>(data['n']['number']),
-                )
-                as T;
-    }
-    if (t == _i1.getType<({_i219.SimpleData? data, int? number})>()) {
-      return (
-            data: ((data as Map)['n'] as Map)['data'] == null
-                ? null
-                : deserialize<_i219.SimpleData>(data['n']['data']),
-            number: ((data)['n'] as Map)['number'] == null
-                ? null
-                : deserialize<int>(data['n']['number']),
-          )
-          as T;
-    }
-    if (t == _i1.getType<({Map<int, int> intIntMap})>()) {
-      return (
-            intIntMap: deserialize<Map<int, int>>(
-              ((data as Map)['n'] as Map)['intIntMap'],
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<({Set<(bool,)> boolSet})>()) {
-      return (
-            boolSet: deserialize<Set<(bool,)>>(
-              ((data as Map)['n'] as Map)['boolSet'],
-            ),
-          )
-          as T;
-    }
-    if (t == Set<(bool,)>) {
-      return (data as List).map((e) => deserialize<(bool,)>(e)).toSet() as T;
-    }
-    if (t == _i1.getType<(bool,)>()) {
-      return (deserialize<bool>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(bool,)>()) {
-      return (deserialize<bool>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(Map<(Map<int, String>, String), String>,)>()) {
-      return (
-            deserialize<Map<(Map<int, String>, String), String>>(
-              ((data as Map)['p'] as List)[0],
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(int, {_i219.SimpleData data})>()) {
-      return (
-            deserialize<int>(((data as Map)['p'] as List)[0]),
-            data: deserialize<_i219.SimpleData>(data['n']['data']),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(int, {_i219.SimpleData data})?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<int>(((data as Map)['p'] as List)[0]),
-                  data: deserialize<_i219.SimpleData>(data['n']['data']),
-                )
-                as T;
-    }
-    if (t == List<(int, _i219.SimpleData)>) {
-      return (data as List)
-              .map((e) => deserialize<(int, _i219.SimpleData)>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<(int, _i219.SimpleData)>()) {
-      return (
-            deserialize<int>(((data as Map)['p'] as List)[0]),
-            deserialize<_i219.SimpleData>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == List<(int, _i219.SimpleData)?>) {
-      return (data as List)
-              .map((e) => deserialize<(int, _i219.SimpleData)?>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<(int, _i219.SimpleData)?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<int>(((data as Map)['p'] as List)[0]),
-                  deserialize<_i219.SimpleData>(data['p'][1]),
-                )
-                as T;
-    }
-    if (t == Set<(int, _i219.SimpleData)>) {
-      return (data as List)
-              .map((e) => deserialize<(int, _i219.SimpleData)>(e))
-              .toSet()
-          as T;
-    }
-    if (t == _i1.getType<(int, _i219.SimpleData)>()) {
-      return (
-            deserialize<int>(((data as Map)['p'] as List)[0]),
-            deserialize<_i219.SimpleData>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == Set<(int, _i219.SimpleData)?>) {
-      return (data as List)
-              .map((e) => deserialize<(int, _i219.SimpleData)?>(e))
-              .toSet()
-          as T;
-    }
-    if (t == _i1.getType<(int, _i219.SimpleData)?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<int>(((data as Map)['p'] as List)[0]),
-                  deserialize<_i219.SimpleData>(data['p'][1]),
-                )
-                as T;
-    }
-    if (t == _i1.getType<(int, _i219.SimpleData)>()) {
-      return (
-            deserialize<int>(((data as Map)['p'] as List)[0]),
-            deserialize<_i219.SimpleData>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Set<(int, _i219.SimpleData)>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<(int, _i219.SimpleData)>(e))
-                    .toSet()
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(int, _i219.SimpleData)>()) {
-      return (
-            deserialize<int>(((data as Map)['p'] as List)[0]),
-            deserialize<_i219.SimpleData>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == Map<String, (int, _i219.SimpleData)>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<(int, _i219.SimpleData)>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(int, _i219.SimpleData)>()) {
-      return (
-            deserialize<int>(((data as Map)['p'] as List)[0]),
-            deserialize<_i219.SimpleData>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == Map<String, (int, _i219.SimpleData)?>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<(int, _i219.SimpleData)?>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(int, _i219.SimpleData)?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<int>(((data as Map)['p'] as List)[0]),
-                  deserialize<_i219.SimpleData>(data['p'][1]),
-                )
-                as T;
-    }
-    if (t == Map<(String, int), (int, _i219.SimpleData)>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) => MapEntry(
-                deserialize<(String, int)>(e['k']),
-                deserialize<(int, _i219.SimpleData)>(e['v']),
-              ),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(String, int)>()) {
-      return (
-            deserialize<String>(((data as Map)['p'] as List)[0]),
-            deserialize<int>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(int, _i219.SimpleData)>()) {
-      return (
-            deserialize<int>(((data as Map)['p'] as List)[0]),
-            deserialize<_i219.SimpleData>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(String, int)>()) {
-      return (
-            deserialize<String>(((data as Map)['p'] as List)[0]),
-            deserialize<int>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == Map<String, List<Set<(int,)>>>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<List<Set<(int,)>>>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == List<Set<(int,)>>) {
-      return (data as List).map((e) => deserialize<Set<(int,)>>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<(int,)>()) {
-      return (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(int,)>()) {
-      return (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == Set<List<Map<String, (int,)>>>) {
-      return (data as List)
-              .map((e) => deserialize<List<Map<String, (int,)>>>(e))
-              .toSet()
-          as T;
-    }
-    if (t == List<Map<String, (int,)>>) {
-      return (data as List)
-              .map((e) => deserialize<Map<String, (int,)>>(e))
-              .toList()
-          as T;
-    }
-    if (t == Map<String, (int,)>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(deserialize<String>(k), deserialize<(int,)>(v)),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(int,)>()) {
-      return (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(int,)>()) {
-      return (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(int,)>()) {
-      return (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<({(_i219.SimpleData, double) namedSubRecord})>()) {
-      return (
-            namedSubRecord: deserialize<(_i219.SimpleData, double)>(
-              ((data as Map)['n'] as Map)['namedSubRecord'],
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(_i219.SimpleData, double)>()) {
-      return (
-            deserialize<_i219.SimpleData>(((data as Map)['p'] as List)[0]),
-            deserialize<double>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == _i1.getType<({(_i219.SimpleData, double)? namedSubRecord})>()) {
-      return (
-            namedSubRecord:
-                ((data as Map)['n'] as Map)['namedSubRecord'] == null
-                ? null
-                : deserialize<(_i219.SimpleData, double)>(
-                    data['n']['namedSubRecord'],
-                  ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(_i219.SimpleData, double)?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<_i219.SimpleData>(
-                    ((data as Map)['p'] as List)[0],
-                  ),
-                  deserialize<double>(data['p'][1]),
-                )
-                as T;
-    }
-    if (t ==
-        _i1
-            .getType<
-              ((int, String), {(_i219.SimpleData, double) namedSubRecord})
-            >()) {
-      return (
-            deserialize<(int, String)>(((data as Map)['p'] as List)[0]),
-            namedSubRecord: deserialize<(_i219.SimpleData, double)>(
-              data['n']['namedSubRecord'],
-            ),
-          )
-          as T;
-    }
-    if (t ==
-        List<((int, String), {(_i219.SimpleData, double) namedSubRecord})>) {
-      return (data as List)
-              .map(
-                (e) =>
-                    deserialize<
-                      (
-                        (int, String), {
-                        (_i219.SimpleData, double) namedSubRecord,
-                      })
-                    >(e),
-              )
-              .toList()
-          as T;
-    }
-    if (t ==
-        _i1
-            .getType<
-              ((int, String), {(_i219.SimpleData, double) namedSubRecord})
-            >()) {
-      return (
-            deserialize<(int, String)>(((data as Map)['p'] as List)[0]),
-            namedSubRecord: deserialize<(_i219.SimpleData, double)>(
-              data['n']['namedSubRecord'],
-            ),
-          )
-          as T;
-    }
-    if (t ==
-        List<((int, String), {(_i219.SimpleData, double) namedSubRecord})?>) {
-      return (data as List)
-              .map(
-                (e) =>
-                    deserialize<
-                      (
-                        (int, String), {
-                        (_i219.SimpleData, double) namedSubRecord,
-                      })?
-                    >(e),
-              )
-              .toList()
-          as T;
-    }
-    if (t ==
-        _i1
-            .getType<
-              ((int, String), {(_i219.SimpleData, double) namedSubRecord})?
-            >()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<(int, String)>(((data as Map)['p'] as List)[0]),
-                  namedSubRecord: deserialize<(_i219.SimpleData, double)>(
-                    data['n']['namedSubRecord'],
-                  ),
-                )
-                as T;
-    }
-    if (t ==
-        _i1
-            .getType<
-              List<
-                ((int, String), {(_i219.SimpleData, double) namedSubRecord})?
-              >?
-            >()) {
-      return (data != null
-              ? (data as List)
-                    .map(
-                      (e) =>
-                          deserialize<
-                            (
-                              (int, String), {
-                              (_i219.SimpleData, double) namedSubRecord,
-                            })?
-                          >(e),
-                    )
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t ==
-        _i1
-            .getType<
-              ((int, String), {(_i219.SimpleData, double) namedSubRecord})?
-            >()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<(int, String)>(((data as Map)['p'] as List)[0]),
-                  namedSubRecord: deserialize<(_i219.SimpleData, double)>(
-                    data['n']['namedSubRecord'],
-                  ),
-                )
-                as T;
-    }
-    if (t ==
-        _i1
-            .getType<
-              ((int, String), {(_i219.SimpleData, double) namedSubRecord})?
-            >()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<(int, String)>(((data as Map)['p'] as List)[0]),
-                  namedSubRecord: deserialize<(_i219.SimpleData, double)>(
-                    data['n']['namedSubRecord'],
-                  ),
-                )
-                as T;
-    }
-    if (t == _i1.getType<(int?, _i216.ProjectStreamingClass?)>()) {
-      return (
-            ((data as Map)['p'] as List)[0] == null
-                ? null
-                : deserialize<int>(data['p'][0]),
-            ((data)['p'] as List)[1] == null
-                ? null
-                : deserialize<_i216.ProjectStreamingClass>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == Set<Set<int>>) {
-      return (data as List).map((e) => deserialize<Set<int>>(e)).toSet() as T;
-    }
-    if (t == Set<List<int>>) {
-      return (data as List).map((e) => deserialize<List<int>>(e)).toSet() as T;
-    }
-    if (t == _i1.getType<Set<int>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<int>(e)).toSet()
-              : null)
-          as T;
-    }
-    if (t == Set<Set<int>?>) {
-      return (data as List).map((e) => deserialize<Set<int>?>(e)).toSet() as T;
-    }
-    if (t == _i1.getType<Set<int>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<int>(e)).toSet()
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<Set<Set<int>>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<Set<int>>(e)).toSet()
-              : null)
-          as T;
-    }
-    if (t == Set<int?>) {
-      return (data as List).map((e) => deserialize<int?>(e)).toSet() as T;
-    }
-    if (t == _i1.getType<Set<int?>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<int?>(e)).toSet()
-              : null)
-          as T;
-    }
-    if (t == Set<double>) {
-      return (data as List).map((e) => deserialize<double>(e)).toSet() as T;
-    }
-    if (t == Set<double?>) {
-      return (data as List).map((e) => deserialize<double?>(e)).toSet() as T;
-    }
-    if (t == Set<bool>) {
-      return (data as List).map((e) => deserialize<bool>(e)).toSet() as T;
-    }
-    if (t == Set<bool?>) {
-      return (data as List).map((e) => deserialize<bool?>(e)).toSet() as T;
-    }
-    if (t == Set<String>) {
-      return (data as List).map((e) => deserialize<String>(e)).toSet() as T;
-    }
-    if (t == Set<String?>) {
-      return (data as List).map((e) => deserialize<String?>(e)).toSet() as T;
-    }
-    if (t == Set<DateTime>) {
-      return (data as List).map((e) => deserialize<DateTime>(e)).toSet() as T;
-    }
-    if (t == Set<DateTime?>) {
-      return (data as List).map((e) => deserialize<DateTime?>(e)).toSet() as T;
-    }
-    if (t == Set<_i217.ByteData>) {
-      return (data as List).map((e) => deserialize<_i217.ByteData>(e)).toSet()
-          as T;
-    }
-    if (t == Set<_i217.ByteData?>) {
-      return (data as List).map((e) => deserialize<_i217.ByteData?>(e)).toSet()
-          as T;
-    }
-    if (t == Set<_i219.SimpleData?>) {
-      return (data as List)
-              .map((e) => deserialize<_i219.SimpleData?>(e))
-              .toSet()
-          as T;
-    }
-    if (t == Set<Duration>) {
-      return (data as List).map((e) => deserialize<Duration>(e)).toSet() as T;
-    }
-    if (t == Set<Duration?>) {
-      return (data as List).map((e) => deserialize<Duration?>(e)).toSet() as T;
-    }
-    if (t == List<_i223.Types>) {
-      return (data as List).map((e) => deserialize<_i223.Types>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<(String, (int, bool))>()) {
-      return (
-            deserialize<String>(((data as Map)['p'] as List)[0]),
-            deserialize<(int, bool)>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(int, bool)>()) {
-      return (
-            deserialize<int>(((data as Map)['p'] as List)[0]),
-            deserialize<bool>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == List<(String, (int, bool))>) {
-      return (data as List)
-              .map((e) => deserialize<(String, (int, bool))>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<(String, (int, bool))>()) {
-      return (
-            deserialize<String>(((data as Map)['p'] as List)[0]),
-            deserialize<(int, bool)>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t ==
-        _i1
-            .getType<
-              (
-                String,
-                (Map<String, int>, {bool flag, _i219.SimpleData simpleData}),
-              )
-            >()) {
-      return (
-            deserialize<String>(((data as Map)['p'] as List)[0]),
-            deserialize<
-              (Map<String, int>, {bool flag, _i219.SimpleData simpleData})
-            >(data['p'][1]),
-          )
-          as T;
-    }
-    if (t ==
-        _i1
-            .getType<
-              (Map<String, int>, {bool flag, _i219.SimpleData simpleData})
-            >()) {
-      return (
-            deserialize<Map<String, int>>(((data as Map)['p'] as List)[0]),
-            flag: deserialize<bool>(data['n']['flag']),
-            simpleData: deserialize<_i219.SimpleData>(data['n']['simpleData']),
-          )
-          as T;
-    }
-    if (t == List<(String, int)>) {
-      return (data as List).map((e) => deserialize<(String, int)>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<(String, int)>()) {
-      return (
-            deserialize<String>(((data as Map)['p'] as List)[0]),
-            deserialize<int>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t ==
-        _i1
-            .getType<
-              (
-                String,
-                (Map<String, int>, {bool flag, _i219.SimpleData simpleData}),
-              )?
-            >()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<String>(((data as Map)['p'] as List)[0]),
-                  deserialize<
-                    (Map<String, int>, {bool flag, _i219.SimpleData simpleData})
-                  >(data['p'][1]),
-                )
-                as T;
-    }
-    if (t == _i1.getType<(String, int)>()) {
-      return (
-            deserialize<String>(((data as Map)['p'] as List)[0]),
-            deserialize<int>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == _i1.getType<List<(String, int)>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<(String, int)>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(String, int)>()) {
-      return (
-            deserialize<String>(((data as Map)['p'] as List)[0]),
-            deserialize<int>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(int, String)>()) {
-      return (
-            deserialize<int>(((data as Map)['p'] as List)[0]),
-            deserialize<String>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(_i216.ModuleClass,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<_i216.ModuleClass>(((data as Map)['p'] as List)[0]),)
-                as T;
-    }
-    if (t == _i1.getType<(bool,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<bool>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(_i206.TestEnumStringified,)?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<_i206.TestEnumStringified>(
-                    ((data as Map)['p'] as List)[0],
-                  ),
-                )
-                as T;
-    }
-    if (t == _i1.getType<(_i206.TestEnumStringified,)>()) {
-      return (
-            deserialize<_i206.TestEnumStringified>(
-              ((data as Map)['p'] as List)[0],
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<List<(_i206.TestEnumStringified,)>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<(_i206.TestEnumStringified,)>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(_i206.TestEnumStringified,)>()) {
-      return (
-            deserialize<_i206.TestEnumStringified>(
-              ((data as Map)['p'] as List)[0],
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(_i206.TestEnumStringified,)>()) {
-      return (
-            deserialize<_i206.TestEnumStringified>(
-              ((data as Map)['p'] as List)[0],
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(_i151.Nullability,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<_i151.Nullability>(((data as Map)['p'] as List)[0]),)
-                as T;
-    }
-    if (t == _i1.getType<({_i206.TestEnumStringified value})?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  value: deserialize<_i206.TestEnumStringified>(
-                    ((data as Map)['n'] as Map)['value'],
-                  ),
-                )
-                as T;
-    }
-    if (t == _i1.getType<({_i206.TestEnumStringified value})>()) {
-      return (
-            value: deserialize<_i206.TestEnumStringified>(
-              ((data as Map)['n'] as Map)['value'],
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<List<({_i206.TestEnumStringified value})>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map(
-                      (e) =>
-                          deserialize<({_i206.TestEnumStringified value})>(e),
-                    )
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<({_i206.TestEnumStringified value})>()) {
-      return (
-            value: deserialize<_i206.TestEnumStringified>(
-              ((data as Map)['n'] as Map)['value'],
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<({_i206.TestEnumStringified value})>()) {
-      return (
-            value: deserialize<_i206.TestEnumStringified>(
-              ((data as Map)['n'] as Map)['value'],
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<({_i216.ModuleClass value})?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  value: deserialize<_i216.ModuleClass>(
-                    ((data as Map)['n'] as Map)['value'],
-                  ),
-                )
-                as T;
-    }
-    if (t == _i1.getType<({_i151.Nullability value})?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  value: deserialize<_i151.Nullability>(
-                    ((data as Map)['n'] as Map)['value'],
-                  ),
-                )
-                as T;
-    }
-    if (t == _i1.getType<(String, {Uri? optionalUri})?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<String>(((data as Map)['p'] as List)[0]),
-                  optionalUri: ((data)['n'] as Map)['optionalUri'] == null
-                      ? null
-                      : deserialize<Uri>(data['n']['optionalUri']),
-                )
-                as T;
-    }
-    if (t == _i1.getType<(int,)>()) {
-      return (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<List<(int,)>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<(int,)>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(int,)>()) {
-      return (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(int,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<List<(int,)?>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<(int,)?>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(int,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(_i202.TestEnum,)>()) {
-      return (deserialize<_i202.TestEnum>(((data as Map)['p'] as List)[0]),)
-          as T;
-    }
-    if (t == _i1.getType<List<(_i202.TestEnum,)>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<(_i202.TestEnum,)>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(_i202.TestEnum,)>()) {
-      return (deserialize<_i202.TestEnum>(((data as Map)['p'] as List)[0]),)
-          as T;
-    }
-    if (t == _i1.getType<(_i202.TestEnum,)>()) {
-      return (deserialize<_i202.TestEnum>(((data as Map)['p'] as List)[0]),)
-          as T;
-    }
-    if (t == _i1.getType<(String,)>()) {
-      return (deserialize<String>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<Map<(String,), String>?>()) {
-      return (data != null
-              ? Map.fromEntries(
-                  (data as List).map(
-                    (e) => MapEntry(
-                      deserialize<(String,)>(e['k']),
-                      deserialize<String>(e['v']),
-                    ),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(String,)>()) {
-      return (deserialize<String>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(String,)>()) {
-      return (deserialize<String>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(String,)>()) {
-      return (deserialize<String>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<Map<String, (String,)>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) => MapEntry(
-                    deserialize<String>(k),
-                    deserialize<(String,)>(v),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(String,)>()) {
-      return (deserialize<String>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(String,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<String>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<Map<String, (String,)?>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) => MapEntry(
-                    deserialize<String>(k),
-                    deserialize<(String,)?>(v),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(String,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<String>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(String,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<String>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(String,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<String>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<Map<(String,)?, String>?>()) {
-      return (data != null
-              ? Map.fromEntries(
-                  (data as List).map(
-                    (e) => MapEntry(
-                      deserialize<(String,)?>(e['k']),
-                      deserialize<String>(e['v']),
-                    ),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(String,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<String>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(double,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<double>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(DateTime,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<DateTime>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(_i217.ByteData,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<_i217.ByteData>(((data as Map)['p'] as List)[0]),)
-                as T;
-    }
-    if (t == _i1.getType<(Duration,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<Duration>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(_i1.UuidValue,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<_i1.UuidValue>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(Uri,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<Uri>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(BigInt,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<BigInt>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(_i202.TestEnum,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<_i202.TestEnum>(((data as Map)['p'] as List)[0]),)
-                as T;
-    }
-    if (t == _i1.getType<(List<int>,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<List<int>>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(Map<int, int>,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<Map<int, int>>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(Set<int>,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<Set<int>>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(_i196.SimpleData,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<_i196.SimpleData>(((data as Map)['p'] as List)[0]),)
-                as T;
-    }
-    if (t == _i1.getType<({_i196.SimpleData namedModel})?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  namedModel: deserialize<_i196.SimpleData>(
-                    ((data as Map)['n'] as Map)['namedModel'],
-                  ),
-                )
-                as T;
-    }
-    if (t ==
-        _i1.getType<(_i196.SimpleData, {_i196.SimpleData namedModel})?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<_i196.SimpleData>(
-                    ((data as Map)['p'] as List)[0],
-                  ),
-                  namedModel: deserialize<_i196.SimpleData>(
-                    data['n']['namedModel'],
-                  ),
-                )
-                as T;
-    }
-    if (t ==
-        _i1.getType<((int, String), {(int, String) namedNestedRecord})?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<(int, String)>(((data as Map)['p'] as List)[0]),
-                  namedNestedRecord: deserialize<(int, String)>(
-                    data['n']['namedNestedRecord'],
-                  ),
-                )
-                as T;
-    }
-    if (t ==
-        _i1
-            .getType<
-              (
-                (List<(_i196.SimpleData,)>,), {
-                (_i196.SimpleData, Map<String, _i196.SimpleData>)
-                namedNestedRecord,
-              })?
-            >()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<(List<(_i196.SimpleData,)>,)>(
-                    ((data as Map)['p'] as List)[0],
-                  ),
-                  namedNestedRecord:
-                      deserialize<
-                        (_i196.SimpleData, Map<String, _i196.SimpleData>)
-                      >(data['n']['namedNestedRecord']),
-                )
-                as T;
-    }
-    if (t == _i1.getType<(List<(_i196.SimpleData,)>,)>()) {
-      return (
-            deserialize<List<(_i196.SimpleData,)>>(
-              ((data as Map)['p'] as List)[0],
-            ),
-          )
-          as T;
-    }
-    if (t == List<(_i196.SimpleData,)>) {
-      return (data as List)
-              .map((e) => deserialize<(_i196.SimpleData,)>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<(_i196.SimpleData,)>()) {
-      return (deserialize<_i196.SimpleData>(((data as Map)['p'] as List)[0]),)
-          as T;
-    }
-    if (t == _i1.getType<(_i196.SimpleData,)>()) {
-      return (deserialize<_i196.SimpleData>(((data as Map)['p'] as List)[0]),)
-          as T;
-    }
-    if (t == _i1.getType<(_i196.SimpleData, Map<String, _i196.SimpleData>)>()) {
-      return (
-            deserialize<_i196.SimpleData>(((data as Map)['p'] as List)[0]),
-            deserialize<Map<String, _i196.SimpleData>>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(int,)>()) {
-      return (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<Set<(int,)>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<(int,)>(e)).toSet()
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(int,)>()) {
-      return (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(int,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<Set<(int,)?>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<(int,)?>(e)).toSet()
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(int,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i218.CustomClass) {
-      return _i218.CustomClass.fromJson(data) as T;
-    }
-    if (t == _i218.CustomClass2) {
-      return _i218.CustomClass2.fromJson(data) as T;
-    }
-    if (t == _i218.ProtocolCustomClass) {
-      return _i218.ProtocolCustomClass.fromJson(data) as T;
-    }
-    if (t == _i218.ExternalCustomClass) {
-      return _i218.ExternalCustomClass.fromJson(data) as T;
-    }
-    if (t == _i218.FreezedCustomClass) {
-      return _i218.FreezedCustomClass.fromJson(data) as T;
-    }
-    if (t == _i1.getType<_i218.CustomClass?>()) {
-      return (data != null ? _i218.CustomClass.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i218.CustomClass2?>()) {
-      return (data != null ? _i218.CustomClass2.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i218.CustomClassWithoutProtocolSerialization?>()) {
-      return (data != null
-              ? _i218.CustomClassWithoutProtocolSerialization.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i218.CustomClassWithProtocolSerialization?>()) {
-      return (data != null
-              ? _i218.CustomClassWithProtocolSerialization.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i218.CustomClassWithProtocolSerializationMethod?>()) {
-      return (data != null
-              ? _i218.CustomClassWithProtocolSerializationMethod.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i218.ProtocolCustomClass?>()) {
-      return (data != null ? _i218.ProtocolCustomClass.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i218.ExternalCustomClass?>()) {
-      return (data != null ? _i218.ExternalCustomClass.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i218.FreezedCustomClass?>()) {
-      return (data != null ? _i218.FreezedCustomClass.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<List<_i219.SimpleData>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i219.SimpleData>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(String, _i222.PolymorphicParent)>()) {
-      return (
-            deserialize<String>(((data as Map)['p'] as List)[0]),
-            deserialize<_i222.PolymorphicParent>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(int?,)?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  ((data as Map)['p'] as List)[0] == null
-                      ? null
-                      : deserialize<int>(data['p'][0]),
-                )
-                as T;
-    }
-    if (t ==
-        _i1
-            .getType<
-              ((int, String), {(_i219.SimpleData, double) namedSubRecord})?
-            >()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<(int, String)>(((data as Map)['p'] as List)[0]),
-                  namedSubRecord: deserialize<(_i219.SimpleData, double)>(
-                    data['n']['namedSubRecord'],
-                  ),
-                )
-                as T;
-    }
-    if (t ==
-        _i1
-            .getType<
-              List<
-                ((int, String), {(_i219.SimpleData, double) namedSubRecord})?
-              >?
-            >()) {
-      return (data != null
-              ? (data as List)
-                    .map(
-                      (e) =>
-                          deserialize<
-                            (
-                              (int, String), {
-                              (_i219.SimpleData, double) namedSubRecord,
-                            })?
-                          >(e),
-                    )
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t ==
-        _i1
-            .getType<
-              ((int, String), {(_i219.SimpleData, double) namedSubRecord})?
-            >()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<(int, String)>(((data as Map)['p'] as List)[0]),
-                  namedSubRecord: deserialize<(_i219.SimpleData, double)>(
-                    data['n']['namedSubRecord'],
-                  ),
-                )
-                as T;
-    }
-    if (t == _i1.getType<(int?, _i216.ProjectStreamingClass?)>()) {
-      return (
-            ((data as Map)['p'] as List)[0] == null
-                ? null
-                : deserialize<int>(data['p'][0]),
-            ((data)['p'] as List)[1] == null
-                ? null
-                : deserialize<_i216.ProjectStreamingClass>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t ==
-        _i1
-            .getType<
-              (
-                String,
-                (Map<String, int>, {bool flag, _i219.SimpleData simpleData}),
-              )
-            >()) {
-      return (
-            deserialize<String>(((data as Map)['p'] as List)[0]),
-            deserialize<
-              (Map<String, int>, {bool flag, _i219.SimpleData simpleData})
-            >(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(String, int)>()) {
-      return (
-            deserialize<String>(((data as Map)['p'] as List)[0]),
-            deserialize<int>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t ==
-        _i1
-            .getType<
-              (
-                String,
-                (Map<String, int>, {bool flag, _i219.SimpleData simpleData}),
-              )?
-            >()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<String>(((data as Map)['p'] as List)[0]),
-                  deserialize<
-                    (Map<String, int>, {bool flag, _i219.SimpleData simpleData})
-                  >(data['p'][1]),
-                )
-                as T;
-    }
-    if (t == _i1.getType<(String, int)>()) {
-      return (
-            deserialize<String>(((data as Map)['p'] as List)[0]),
-            deserialize<int>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == _i1.getType<List<(String, int)>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<(String, int)>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(String, int)>()) {
-      return (
-            deserialize<String>(((data as Map)['p'] as List)[0]),
-            deserialize<int>(data['p'][1]),
-          )
-          as T;
+    final fn = _deserializers[t];
+    if (fn != null) {
+      return fn(data, this) as T;
     }
     try {
-      return _i221.Protocol().deserialize<T>(data, t);
+      return _i2.Protocol().deserialize<T>(data, t);
     } on _i1.DeserializationTypeNotFoundException catch (_) {}
     try {
-      return _i216.Protocol().deserialize<T>(data, t);
+      return _i3.Protocol().deserialize<T>(data, t);
     } on _i1.DeserializationTypeNotFoundException catch (_) {}
     try {
-      return _i224.Protocol().deserialize<T>(data, t);
+      return _i4.Protocol().deserialize<T>(data, t);
     } on _i1.DeserializationTypeNotFoundException catch (_) {}
     try {
-      return _i218.Protocol().deserialize<T>(data, t);
+      return _i5.Protocol().deserialize<T>(data, t);
     } on _i1.DeserializationTypeNotFoundException catch (_) {}
     return super.deserialize<T>(data, t);
   }
 
   static String? getClassNameForType(Type type) {
     return switch (type) {
-      _i218.CustomClass => 'CustomClass',
-      _i218.CustomClass2 => 'CustomClass2',
-      _i218.CustomClassWithoutProtocolSerialization =>
+      _i5.CustomClass => 'CustomClass',
+      _i5.CustomClass2 => 'CustomClass2',
+      _i5.CustomClassWithoutProtocolSerialization =>
         'CustomClassWithoutProtocolSerialization',
-      _i218.CustomClassWithProtocolSerialization =>
+      _i5.CustomClassWithProtocolSerialization =>
         'CustomClassWithProtocolSerialization',
-      _i218.CustomClassWithProtocolSerializationMethod =>
+      _i5.CustomClassWithProtocolSerializationMethod =>
         'CustomClassWithProtocolSerializationMethod',
-      _i218.ProtocolCustomClass => 'ProtocolCustomClass',
-      _i218.ExternalCustomClass => 'ExternalCustomClass',
-      _i218.FreezedCustomClass => 'FreezedCustomClass',
-      _i2.ByIndexEnumWithNameValue => 'ByIndexEnumWithNameValue',
-      _i3.ByNameEnumWithNameValue => 'ByNameEnumWithNameValue',
-      _i4.CourseUuid => 'CourseUuid',
-      _i5.EnrollmentInt => 'EnrollmentInt',
-      _i6.StudentUuid => 'StudentUuid',
-      _i7.ArenaUuid => 'ArenaUuid',
-      _i8.PlayerUuid => 'PlayerUuid',
-      _i9.TeamInt => 'TeamInt',
-      _i10.CommentInt => 'CommentInt',
-      _i11.CustomerInt => 'CustomerInt',
-      _i12.OrderUuid => 'OrderUuid',
-      _i13.AddressUuid => 'AddressUuid',
-      _i14.CitizenInt => 'CitizenInt',
-      _i15.CompanyUuid => 'CompanyUuid',
-      _i16.TownInt => 'TownInt',
-      _i17.ChangedIdTypeSelf => 'ChangedIdTypeSelf',
-      _i18.BigIntDefault => 'BigIntDefault',
-      _i19.BigIntDefaultMix => 'BigIntDefaultMix',
-      _i20.BigIntDefaultModel => 'BigIntDefaultModel',
-      _i21.BigIntDefaultPersist => 'BigIntDefaultPersist',
-      _i22.BoolDefault => 'BoolDefault',
-      _i23.BoolDefaultMix => 'BoolDefaultMix',
-      _i24.BoolDefaultModel => 'BoolDefaultModel',
-      _i25.BoolDefaultPersist => 'BoolDefaultPersist',
-      _i26.DateTimeDefault => 'DateTimeDefault',
-      _i27.DateTimeDefaultMix => 'DateTimeDefaultMix',
-      _i28.DateTimeDefaultModel => 'DateTimeDefaultModel',
-      _i29.DateTimeDefaultPersist => 'DateTimeDefaultPersist',
-      _i30.DoubleDefault => 'DoubleDefault',
-      _i31.DoubleDefaultMix => 'DoubleDefaultMix',
-      _i32.DoubleDefaultModel => 'DoubleDefaultModel',
-      _i33.DoubleDefaultPersist => 'DoubleDefaultPersist',
-      _i34.DurationDefault => 'DurationDefault',
-      _i35.DurationDefaultMix => 'DurationDefaultMix',
-      _i36.DurationDefaultModel => 'DurationDefaultModel',
-      _i37.DurationDefaultPersist => 'DurationDefaultPersist',
-      _i38.EnumDefault => 'EnumDefault',
-      _i39.EnumDefaultMix => 'EnumDefaultMix',
-      _i40.EnumDefaultModel => 'EnumDefaultModel',
-      _i41.EnumDefaultPersist => 'EnumDefaultPersist',
-      _i42.ByIndexEnum => 'ByIndexEnum',
-      _i43.ByNameEnum => 'ByNameEnum',
-      _i44.DefaultValueEnum => 'DefaultValueEnum',
-      _i45.DefaultException => 'DefaultException',
-      _i46.IntDefault => 'IntDefault',
-      _i47.IntDefaultMix => 'IntDefaultMix',
-      _i48.IntDefaultModel => 'IntDefaultModel',
-      _i49.IntDefaultPersist => 'IntDefaultPersist',
-      _i50.StringDefault => 'StringDefault',
-      _i51.StringDefaultMix => 'StringDefaultMix',
-      _i52.StringDefaultModel => 'StringDefaultModel',
-      _i53.StringDefaultPersist => 'StringDefaultPersist',
-      _i54.UriDefault => 'UriDefault',
-      _i55.UriDefaultMix => 'UriDefaultMix',
-      _i56.UriDefaultModel => 'UriDefaultModel',
-      _i57.UriDefaultPersist => 'UriDefaultPersist',
-      _i58.UuidDefault => 'UuidDefault',
-      _i59.UuidDefaultMix => 'UuidDefaultMix',
-      _i60.UuidDefaultModel => 'UuidDefaultModel',
-      _i61.UuidDefaultPersist => 'UuidDefaultPersist',
-      _i62.EmptyModel => 'EmptyModel',
-      _i63.EmptyModelRelationItem => 'EmptyModelRelationItem',
-      _i64.EmptyModelWithTable => 'EmptyModelWithTable',
-      _i65.RelationEmptyModel => 'RelationEmptyModel',
-      _i66.ExceptionWithData => 'ExceptionWithData',
-      _i67.ChildClassExplicitColumn => 'ChildClassExplicitColumn',
-      _i68.NonTableParentClass => 'NonTableParentClass',
-      _i69.ModifiedColumnName => 'ModifiedColumnName',
-      _i70.Department => 'Department',
-      _i71.Employee => 'Employee',
-      _i72.Contractor => 'Contractor',
-      _i73.Service => 'Service',
-      _i74.TableWithExplicitColumnName => 'TableWithExplicitColumnName',
-      _i75.ImmutableChildObject => 'ImmutableChildObject',
-      _i76.ImmutableChildObjectWithNoAdditionalFields =>
+      _i5.ProtocolCustomClass => 'ProtocolCustomClass',
+      _i5.ExternalCustomClass => 'ExternalCustomClass',
+      _i5.FreezedCustomClass => 'FreezedCustomClass',
+      _i6.ByIndexEnumWithNameValue => 'ByIndexEnumWithNameValue',
+      _i7.ByNameEnumWithNameValue => 'ByNameEnumWithNameValue',
+      _i8.CourseUuid => 'CourseUuid',
+      _i9.EnrollmentInt => 'EnrollmentInt',
+      _i10.StudentUuid => 'StudentUuid',
+      _i11.ArenaUuid => 'ArenaUuid',
+      _i12.PlayerUuid => 'PlayerUuid',
+      _i13.TeamInt => 'TeamInt',
+      _i14.CommentInt => 'CommentInt',
+      _i15.CustomerInt => 'CustomerInt',
+      _i16.OrderUuid => 'OrderUuid',
+      _i17.AddressUuid => 'AddressUuid',
+      _i18.CitizenInt => 'CitizenInt',
+      _i19.CompanyUuid => 'CompanyUuid',
+      _i20.TownInt => 'TownInt',
+      _i21.ChangedIdTypeSelf => 'ChangedIdTypeSelf',
+      _i22.BigIntDefault => 'BigIntDefault',
+      _i23.BigIntDefaultMix => 'BigIntDefaultMix',
+      _i24.BigIntDefaultModel => 'BigIntDefaultModel',
+      _i25.BigIntDefaultPersist => 'BigIntDefaultPersist',
+      _i26.BoolDefault => 'BoolDefault',
+      _i27.BoolDefaultMix => 'BoolDefaultMix',
+      _i28.BoolDefaultModel => 'BoolDefaultModel',
+      _i29.BoolDefaultPersist => 'BoolDefaultPersist',
+      _i30.DateTimeDefault => 'DateTimeDefault',
+      _i31.DateTimeDefaultMix => 'DateTimeDefaultMix',
+      _i32.DateTimeDefaultModel => 'DateTimeDefaultModel',
+      _i33.DateTimeDefaultPersist => 'DateTimeDefaultPersist',
+      _i34.DoubleDefault => 'DoubleDefault',
+      _i35.DoubleDefaultMix => 'DoubleDefaultMix',
+      _i36.DoubleDefaultModel => 'DoubleDefaultModel',
+      _i37.DoubleDefaultPersist => 'DoubleDefaultPersist',
+      _i38.DurationDefault => 'DurationDefault',
+      _i39.DurationDefaultMix => 'DurationDefaultMix',
+      _i40.DurationDefaultModel => 'DurationDefaultModel',
+      _i41.DurationDefaultPersist => 'DurationDefaultPersist',
+      _i42.EnumDefault => 'EnumDefault',
+      _i43.EnumDefaultMix => 'EnumDefaultMix',
+      _i44.EnumDefaultModel => 'EnumDefaultModel',
+      _i45.EnumDefaultPersist => 'EnumDefaultPersist',
+      _i46.ByIndexEnum => 'ByIndexEnum',
+      _i47.ByNameEnum => 'ByNameEnum',
+      _i48.DefaultValueEnum => 'DefaultValueEnum',
+      _i49.DefaultException => 'DefaultException',
+      _i50.IntDefault => 'IntDefault',
+      _i51.IntDefaultMix => 'IntDefaultMix',
+      _i52.IntDefaultModel => 'IntDefaultModel',
+      _i53.IntDefaultPersist => 'IntDefaultPersist',
+      _i54.StringDefault => 'StringDefault',
+      _i55.StringDefaultMix => 'StringDefaultMix',
+      _i56.StringDefaultModel => 'StringDefaultModel',
+      _i57.StringDefaultPersist => 'StringDefaultPersist',
+      _i58.UriDefault => 'UriDefault',
+      _i59.UriDefaultMix => 'UriDefaultMix',
+      _i60.UriDefaultModel => 'UriDefaultModel',
+      _i61.UriDefaultPersist => 'UriDefaultPersist',
+      _i62.UuidDefault => 'UuidDefault',
+      _i63.UuidDefaultMix => 'UuidDefaultMix',
+      _i64.UuidDefaultModel => 'UuidDefaultModel',
+      _i65.UuidDefaultPersist => 'UuidDefaultPersist',
+      _i66.EmptyModel => 'EmptyModel',
+      _i67.EmptyModelRelationItem => 'EmptyModelRelationItem',
+      _i68.EmptyModelWithTable => 'EmptyModelWithTable',
+      _i69.RelationEmptyModel => 'RelationEmptyModel',
+      _i70.ExceptionWithData => 'ExceptionWithData',
+      _i71.ChildClassExplicitColumn => 'ChildClassExplicitColumn',
+      _i72.NonTableParentClass => 'NonTableParentClass',
+      _i73.ModifiedColumnName => 'ModifiedColumnName',
+      _i74.Department => 'Department',
+      _i75.Employee => 'Employee',
+      _i76.Contractor => 'Contractor',
+      _i77.Service => 'Service',
+      _i78.TableWithExplicitColumnName => 'TableWithExplicitColumnName',
+      _i79.ImmutableChildObject => 'ImmutableChildObject',
+      _i80.ImmutableChildObjectWithNoAdditionalFields =>
         'ImmutableChildObjectWithNoAdditionalFields',
-      _i77.ImmutableObject => 'ImmutableObject',
-      _i78.ImmutableObjectWithImmutableObject =>
+      _i81.ImmutableObject => 'ImmutableObject',
+      _i82.ImmutableObjectWithImmutableObject =>
         'ImmutableObjectWithImmutableObject',
-      _i79.ImmutableObjectWithList => 'ImmutableObjectWithList',
-      _i80.ImmutableObjectWithMap => 'ImmutableObjectWithMap',
-      _i81.ImmutableObjectWithMultipleFields =>
+      _i83.ImmutableObjectWithList => 'ImmutableObjectWithList',
+      _i84.ImmutableObjectWithMap => 'ImmutableObjectWithMap',
+      _i85.ImmutableObjectWithMultipleFields =>
         'ImmutableObjectWithMultipleFields',
-      _i82.ImmutableObjectWithNoFields => 'ImmutableObjectWithNoFields',
-      _i83.ImmutableObjectWithRecord => 'ImmutableObjectWithRecord',
-      _i84.ImmutableObjectWithTable => 'ImmutableObjectWithTable',
-      _i85.ImmutableObjectWithTwentyFields => 'ImmutableObjectWithTwentyFields',
-      _i86.ChildClass => 'ChildClass',
-      _i87.ChildWithDefault => 'ChildWithDefault',
-      _i88.ChildClassWithoutId => 'ChildClassWithoutId',
-      _i89.ExtendedAppException => 'ExtendedAppException',
-      _i90.BaseAppException => 'BaseAppException',
-      _i91.NotFoundException => 'NotFoundException',
-      _i91.ValidationException => 'ValidationException',
-      _i92.ParentClass => 'ParentClass',
-      _i93.GrandparentClass => 'GrandparentClass',
-      _i94.ParentClassWithoutId => 'ParentClassWithoutId',
-      _i95.GrandparentClassWithId => 'GrandparentClassWithId',
-      _i96.ChildEntity => 'ChildEntity',
-      _i97.BaseEntity => 'BaseEntity',
-      _i98.ParentEntity => 'ParentEntity',
-      _i99.NonServerOnlyParentClass => 'NonServerOnlyParentClass',
-      _i100.ParentWithDefault => 'ParentWithDefault',
-      _i101.PolymorphicGrandChild => 'PolymorphicGrandChild',
-      _i102.PolymorphicChild => 'PolymorphicChild',
-      _i103.PolymorphicChildContainer => 'PolymorphicChildContainer',
-      _i104.ModulePolymorphicChildContainer =>
+      _i86.ImmutableObjectWithNoFields => 'ImmutableObjectWithNoFields',
+      _i87.ImmutableObjectWithRecord => 'ImmutableObjectWithRecord',
+      _i88.ImmutableObjectWithTable => 'ImmutableObjectWithTable',
+      _i89.ImmutableObjectWithTwentyFields => 'ImmutableObjectWithTwentyFields',
+      _i90.ChildClass => 'ChildClass',
+      _i91.ChildWithDefault => 'ChildWithDefault',
+      _i92.ChildClassWithoutId => 'ChildClassWithoutId',
+      _i93.ExtendedAppException => 'ExtendedAppException',
+      _i94.BaseAppException => 'BaseAppException',
+      _i95.NotFoundException => 'NotFoundException',
+      _i95.ValidationException => 'ValidationException',
+      _i96.ParentClass => 'ParentClass',
+      _i97.GrandparentClass => 'GrandparentClass',
+      _i98.ParentClassWithoutId => 'ParentClassWithoutId',
+      _i99.GrandparentClassWithId => 'GrandparentClassWithId',
+      _i100.ChildEntity => 'ChildEntity',
+      _i101.BaseEntity => 'BaseEntity',
+      _i102.ParentEntity => 'ParentEntity',
+      _i103.NonServerOnlyParentClass => 'NonServerOnlyParentClass',
+      _i104.ParentWithDefault => 'ParentWithDefault',
+      _i105.PolymorphicGrandChild => 'PolymorphicGrandChild',
+      _i106.PolymorphicChild => 'PolymorphicChild',
+      _i107.PolymorphicChildContainer => 'PolymorphicChildContainer',
+      _i108.ModulePolymorphicChildContainer =>
         'ModulePolymorphicChildContainer',
-      _i105.SimilarButNotParent => 'SimilarButNotParent',
-      _i106.PolymorphicParent => 'PolymorphicParent',
-      _i107.UnrelatedToPolymorphism => 'UnrelatedToPolymorphism',
-      _i108.SealedGrandChild => 'SealedGrandChild',
-      _i108.SealedChild => 'SealedChild',
-      _i109.SealedChildOnlyRequired => 'SealedChildOnlyRequired',
-      _i108.SealedOtherChild => 'SealedOtherChild',
-      _i110.CityWithLongTableName => 'CityWithLongTableName',
-      _i111.OrganizationWithLongTableName => 'OrganizationWithLongTableName',
-      _i112.PersonWithLongTableName => 'PersonWithLongTableName',
-      _i113.MaxFieldName => 'MaxFieldName',
-      _i114.LongImplicitIdField => 'LongImplicitIdField',
-      _i115.LongImplicitIdFieldCollection => 'LongImplicitIdFieldCollection',
-      _i116.RelationToMultipleMaxFieldName => 'RelationToMultipleMaxFieldName',
-      _i117.UserNote => 'UserNote',
-      _i118.UserNoteCollection => 'UserNoteCollection',
-      _i119.UserNoteCollectionWithALongName =>
+      _i109.SimilarButNotParent => 'SimilarButNotParent',
+      _i110.PolymorphicParent => 'PolymorphicParent',
+      _i111.UnrelatedToPolymorphism => 'UnrelatedToPolymorphism',
+      _i112.SealedGrandChild => 'SealedGrandChild',
+      _i112.SealedChild => 'SealedChild',
+      _i113.SealedChildOnlyRequired => 'SealedChildOnlyRequired',
+      _i112.SealedOtherChild => 'SealedOtherChild',
+      _i114.CityWithLongTableName => 'CityWithLongTableName',
+      _i115.OrganizationWithLongTableName => 'OrganizationWithLongTableName',
+      _i116.PersonWithLongTableName => 'PersonWithLongTableName',
+      _i117.MaxFieldName => 'MaxFieldName',
+      _i118.LongImplicitIdField => 'LongImplicitIdField',
+      _i119.LongImplicitIdFieldCollection => 'LongImplicitIdFieldCollection',
+      _i120.RelationToMultipleMaxFieldName => 'RelationToMultipleMaxFieldName',
+      _i121.UserNote => 'UserNote',
+      _i122.UserNoteCollection => 'UserNoteCollection',
+      _i123.UserNoteCollectionWithALongName =>
         'UserNoteCollectionWithALongName',
-      _i120.UserNoteWithALongName => 'UserNoteWithALongName',
-      _i121.MultipleMaxFieldName => 'MultipleMaxFieldName',
-      _i122.City => 'City',
-      _i123.Organization => 'Organization',
-      _i124.Person => 'Person',
-      _i125.BleedChild => 'BleedChild',
-      _i126.BleedRoot => 'BleedRoot',
-      _i127.Course => 'Course',
-      _i128.Enrollment => 'Enrollment',
-      _i129.Student => 'Student',
-      _i130.ObjectUser => 'ObjectUser',
-      _i131.ParentUser => 'ParentUser',
-      _i132.Arena => 'Arena',
-      _i133.Player => 'Player',
-      _i134.Team => 'Team',
-      _i135.Comment => 'Comment',
-      _i136.Customer => 'Customer',
-      _i137.Book => 'Book',
-      _i138.Chapter => 'Chapter',
-      _i139.Order => 'Order',
-      _i140.Address => 'Address',
-      _i141.Citizen => 'Citizen',
-      _i142.Company => 'Company',
-      _i143.Town => 'Town',
-      _i144.Blocking => 'Blocking',
-      _i145.Member => 'Member',
-      _i146.Cat => 'Cat',
-      _i147.Post => 'Post',
-      _i148.ModuleDatatype => 'ModuleDatatype',
-      _i149.MyFeatureModel => 'MyFeatureModel',
-      _i150.MyTriggerType => 'MyTriggerType',
-      _i151.Nullability => 'Nullability',
-      _i152.NullsDistinctData => 'NullsDistinctData',
-      _i153.ObjectFieldPersist => 'ObjectFieldPersist',
-      _i154.ObjectFieldScopes => 'ObjectFieldScopes',
-      _i155.ObjectWithBit => 'ObjectWithBit',
-      _i156.ObjectWithByteData => 'ObjectWithByteData',
-      _i157.ObjectWithCustomClass => 'ObjectWithCustomClass',
-      _i158.ObjectWithDuration => 'ObjectWithDuration',
-      _i159.ObjectWithDynamic => 'ObjectWithDynamic',
-      _i160.ObjectWithEnum => 'ObjectWithEnum',
-      _i161.ObjectWithEnumEnhanced => 'ObjectWithEnumEnhanced',
-      _i162.ObjectWithGeographyGeometryCollection =>
+      _i124.UserNoteWithALongName => 'UserNoteWithALongName',
+      _i125.MultipleMaxFieldName => 'MultipleMaxFieldName',
+      _i126.City => 'City',
+      _i127.Organization => 'Organization',
+      _i128.Person => 'Person',
+      _i129.BleedChild => 'BleedChild',
+      _i130.BleedRoot => 'BleedRoot',
+      _i131.Course => 'Course',
+      _i132.Enrollment => 'Enrollment',
+      _i133.Student => 'Student',
+      _i134.ObjectUser => 'ObjectUser',
+      _i135.ParentUser => 'ParentUser',
+      _i136.Arena => 'Arena',
+      _i137.Player => 'Player',
+      _i138.Team => 'Team',
+      _i139.Comment => 'Comment',
+      _i140.Customer => 'Customer',
+      _i141.Book => 'Book',
+      _i142.Chapter => 'Chapter',
+      _i143.Order => 'Order',
+      _i144.Address => 'Address',
+      _i145.Citizen => 'Citizen',
+      _i146.Company => 'Company',
+      _i147.Town => 'Town',
+      _i148.Blocking => 'Blocking',
+      _i149.Member => 'Member',
+      _i150.Cat => 'Cat',
+      _i151.Post => 'Post',
+      _i152.ModuleDatatype => 'ModuleDatatype',
+      _i153.MyFeatureModel => 'MyFeatureModel',
+      _i154.MyTriggerType => 'MyTriggerType',
+      _i155.Nullability => 'Nullability',
+      _i156.NullsDistinctData => 'NullsDistinctData',
+      _i157.ObjectFieldPersist => 'ObjectFieldPersist',
+      _i158.ObjectFieldScopes => 'ObjectFieldScopes',
+      _i159.ObjectWithBit => 'ObjectWithBit',
+      _i160.ObjectWithByteData => 'ObjectWithByteData',
+      _i161.ObjectWithCustomClass => 'ObjectWithCustomClass',
+      _i162.ObjectWithDuration => 'ObjectWithDuration',
+      _i163.ObjectWithDynamic => 'ObjectWithDynamic',
+      _i164.ObjectWithEnum => 'ObjectWithEnum',
+      _i165.ObjectWithEnumEnhanced => 'ObjectWithEnumEnhanced',
+      _i166.ObjectWithGeographyGeometryCollection =>
         'ObjectWithGeographyGeometryCollection',
-      _i163.ObjectWithGeographyLineString => 'ObjectWithGeographyLineString',
-      _i164.ObjectWithGeographyPoint => 'ObjectWithGeographyPoint',
-      _i165.ObjectWithGeographyPolygon => 'ObjectWithGeographyPolygon',
-      _i166.ObjectWithHalfVector => 'ObjectWithHalfVector',
-      _i167.ObjectWithIndex => 'ObjectWithIndex',
-      _i168.ObjectWithJsonb => 'ObjectWithJsonb',
-      _i169.ObjectWithJsonbClassLevel => 'ObjectWithJsonbClassLevel',
-      _i170.ObjectWithMaps => 'ObjectWithMaps',
-      _i171.ObjectWithNullableCustomClass => 'ObjectWithNullableCustomClass',
-      _i172.ObjectWithObject => 'ObjectWithObject',
-      _i173.ObjectWithParent => 'ObjectWithParent',
-      _i174.ObjectWithSealedClass => 'ObjectWithSealedClass',
-      _i175.ObjectWithSealedException => 'ObjectWithSealedException',
-      _i176.ObjectWithSelfParent => 'ObjectWithSelfParent',
-      _i177.ObjectWithSparseVector => 'ObjectWithSparseVector',
-      _i178.ObjectWithUuid => 'ObjectWithUuid',
-      _i179.ObjectWithVector => 'ObjectWithVector',
-      _i180.Record => 'Record',
-      _i181.RelatedUniqueData => 'RelatedUniqueData',
-      _i182.ExceptionWithRequiredField => 'ExceptionWithRequiredField',
-      _i183.ModelWithRequiredField => 'ModelWithRequiredField',
-      _i184.ScopeNoneFields => 'ScopeNoneFields',
-      _i185.ScopeServerOnlyFieldChild => 'ScopeServerOnlyFieldChild',
-      _i186.ScopeServerOnlyField => 'ScopeServerOnlyField',
-      _i187.DefaultServerOnlyClass => 'DefaultServerOnlyClass',
-      _i188.DefaultServerOnlyEnum => 'DefaultServerOnlyEnum',
-      _i189.NotServerOnlyClass => 'NotServerOnlyClass',
-      _i190.NotServerOnlyEnum => 'NotServerOnlyEnum',
-      _i191.ServerOnlyClassField => 'ServerOnlyClassField',
-      _i192.ServerOnlyDefault => 'ServerOnlyDefault',
-      _i193.SessionAuthInfo => 'SessionAuthInfo',
-      _i194.SharedModelContainer => 'SharedModelContainer',
-      _i195.SharedModelSubclass => 'SharedModelSubclass',
-      _i196.SimpleData => 'SimpleData',
-      _i197.SimpleDataList => 'SimpleDataList',
-      _i198.SimpleDataMap => 'SimpleDataMap',
-      _i199.SimpleDataObject => 'SimpleDataObject',
-      _i200.SimpleDateTime => 'SimpleDateTime',
-      _i201.ModelInSubfolder => 'ModelInSubfolder',
-      _i202.TestEnum => 'TestEnum',
-      _i203.TestEnumDefaultSerialization => 'TestEnumDefaultSerialization',
-      _i204.TestEnumEnhanced => 'TestEnumEnhanced',
-      _i205.TestEnumEnhancedByName => 'TestEnumEnhancedByName',
-      _i206.TestEnumStringified => 'TestEnumStringified',
-      _i207.Types => 'Types',
-      _i208.TypesList => 'TypesList',
-      _i209.TypesMap => 'TypesMap',
-      _i210.TypesRecord => 'TypesRecord',
-      _i211.TypesSet => 'TypesSet',
-      _i212.TypesSetRequired => 'TypesSetRequired',
-      _i213.UniqueData => 'UniqueData',
-      _i214.UniqueDataWithNonPersist => 'UniqueDataWithNonPersist',
-      _i215.UpsertTestModel => 'UpsertTestModel',
+      _i167.ObjectWithGeographyLineString => 'ObjectWithGeographyLineString',
+      _i168.ObjectWithGeographyPoint => 'ObjectWithGeographyPoint',
+      _i169.ObjectWithGeographyPolygon => 'ObjectWithGeographyPolygon',
+      _i170.ObjectWithHalfVector => 'ObjectWithHalfVector',
+      _i171.ObjectWithIndex => 'ObjectWithIndex',
+      _i172.ObjectWithJsonb => 'ObjectWithJsonb',
+      _i173.ObjectWithJsonbClassLevel => 'ObjectWithJsonbClassLevel',
+      _i174.ObjectWithMaps => 'ObjectWithMaps',
+      _i175.ObjectWithNullableCustomClass => 'ObjectWithNullableCustomClass',
+      _i176.ObjectWithObject => 'ObjectWithObject',
+      _i177.ObjectWithParent => 'ObjectWithParent',
+      _i178.ObjectWithSealedClass => 'ObjectWithSealedClass',
+      _i179.ObjectWithSealedException => 'ObjectWithSealedException',
+      _i180.ObjectWithSelfParent => 'ObjectWithSelfParent',
+      _i181.ObjectWithSparseVector => 'ObjectWithSparseVector',
+      _i182.ObjectWithUuid => 'ObjectWithUuid',
+      _i183.ObjectWithVector => 'ObjectWithVector',
+      _i184.Record => 'Record',
+      _i185.RelatedUniqueData => 'RelatedUniqueData',
+      _i186.ExceptionWithRequiredField => 'ExceptionWithRequiredField',
+      _i187.ModelWithRequiredField => 'ModelWithRequiredField',
+      _i188.ScopeNoneFields => 'ScopeNoneFields',
+      _i189.ScopeServerOnlyFieldChild => 'ScopeServerOnlyFieldChild',
+      _i190.ScopeServerOnlyField => 'ScopeServerOnlyField',
+      _i191.DefaultServerOnlyClass => 'DefaultServerOnlyClass',
+      _i192.DefaultServerOnlyEnum => 'DefaultServerOnlyEnum',
+      _i193.NotServerOnlyClass => 'NotServerOnlyClass',
+      _i194.NotServerOnlyEnum => 'NotServerOnlyEnum',
+      _i195.ServerOnlyClassField => 'ServerOnlyClassField',
+      _i196.ServerOnlyDefault => 'ServerOnlyDefault',
+      _i197.SessionAuthInfo => 'SessionAuthInfo',
+      _i198.SharedModelContainer => 'SharedModelContainer',
+      _i199.SharedModelSubclass => 'SharedModelSubclass',
+      _i200.SimpleData => 'SimpleData',
+      _i201.SimpleDataList => 'SimpleDataList',
+      _i202.SimpleDataMap => 'SimpleDataMap',
+      _i203.SimpleDataObject => 'SimpleDataObject',
+      _i204.SimpleDateTime => 'SimpleDateTime',
+      _i205.ModelInSubfolder => 'ModelInSubfolder',
+      _i206.TestEnum => 'TestEnum',
+      _i207.TestEnumDefaultSerialization => 'TestEnumDefaultSerialization',
+      _i208.TestEnumEnhanced => 'TestEnumEnhanced',
+      _i209.TestEnumEnhancedByName => 'TestEnumEnhancedByName',
+      _i210.TestEnumStringified => 'TestEnumStringified',
+      _i211.Types => 'Types',
+      _i212.TypesList => 'TypesList',
+      _i213.TypesMap => 'TypesMap',
+      _i214.TypesRecord => 'TypesRecord',
+      _i215.TypesSet => 'TypesSet',
+      _i216.TypesSetRequired => 'TypesSetRequired',
+      _i217.UniqueData => 'UniqueData',
+      _i218.UniqueDataWithNonPersist => 'UniqueDataWithNonPersist',
+      _i219.UpsertTestModel => 'UpsertTestModel',
       _ => null,
     };
   }
@@ -6181,482 +775,482 @@ class Protocol extends _i1.SerializationManager {
     }
 
     switch (data) {
-      case _i218.CustomClass():
+      case _i5.CustomClass():
         return 'CustomClass';
-      case _i218.CustomClass2():
+      case _i5.CustomClass2():
         return 'CustomClass2';
-      case _i218.CustomClassWithoutProtocolSerialization():
+      case _i5.CustomClassWithoutProtocolSerialization():
         return 'CustomClassWithoutProtocolSerialization';
-      case _i218.CustomClassWithProtocolSerialization():
+      case _i5.CustomClassWithProtocolSerialization():
         return 'CustomClassWithProtocolSerialization';
-      case _i218.CustomClassWithProtocolSerializationMethod():
+      case _i5.CustomClassWithProtocolSerializationMethod():
         return 'CustomClassWithProtocolSerializationMethod';
-      case _i218.ProtocolCustomClass():
+      case _i5.ProtocolCustomClass():
         return 'ProtocolCustomClass';
-      case _i218.ExternalCustomClass():
+      case _i5.ExternalCustomClass():
         return 'ExternalCustomClass';
-      case _i218.FreezedCustomClass():
+      case _i5.FreezedCustomClass():
         return 'FreezedCustomClass';
-      case _i2.ByIndexEnumWithNameValue():
+      case _i6.ByIndexEnumWithNameValue():
         return 'ByIndexEnumWithNameValue';
-      case _i3.ByNameEnumWithNameValue():
+      case _i7.ByNameEnumWithNameValue():
         return 'ByNameEnumWithNameValue';
-      case _i4.CourseUuid():
+      case _i8.CourseUuid():
         return 'CourseUuid';
-      case _i5.EnrollmentInt():
+      case _i9.EnrollmentInt():
         return 'EnrollmentInt';
-      case _i6.StudentUuid():
+      case _i10.StudentUuid():
         return 'StudentUuid';
-      case _i7.ArenaUuid():
+      case _i11.ArenaUuid():
         return 'ArenaUuid';
-      case _i8.PlayerUuid():
+      case _i12.PlayerUuid():
         return 'PlayerUuid';
-      case _i9.TeamInt():
+      case _i13.TeamInt():
         return 'TeamInt';
-      case _i10.CommentInt():
+      case _i14.CommentInt():
         return 'CommentInt';
-      case _i11.CustomerInt():
+      case _i15.CustomerInt():
         return 'CustomerInt';
-      case _i12.OrderUuid():
+      case _i16.OrderUuid():
         return 'OrderUuid';
-      case _i13.AddressUuid():
+      case _i17.AddressUuid():
         return 'AddressUuid';
-      case _i14.CitizenInt():
+      case _i18.CitizenInt():
         return 'CitizenInt';
-      case _i15.CompanyUuid():
+      case _i19.CompanyUuid():
         return 'CompanyUuid';
-      case _i16.TownInt():
+      case _i20.TownInt():
         return 'TownInt';
-      case _i17.ChangedIdTypeSelf():
+      case _i21.ChangedIdTypeSelf():
         return 'ChangedIdTypeSelf';
-      case _i18.BigIntDefault():
+      case _i22.BigIntDefault():
         return 'BigIntDefault';
-      case _i19.BigIntDefaultMix():
+      case _i23.BigIntDefaultMix():
         return 'BigIntDefaultMix';
-      case _i20.BigIntDefaultModel():
+      case _i24.BigIntDefaultModel():
         return 'BigIntDefaultModel';
-      case _i21.BigIntDefaultPersist():
+      case _i25.BigIntDefaultPersist():
         return 'BigIntDefaultPersist';
-      case _i22.BoolDefault():
+      case _i26.BoolDefault():
         return 'BoolDefault';
-      case _i23.BoolDefaultMix():
+      case _i27.BoolDefaultMix():
         return 'BoolDefaultMix';
-      case _i24.BoolDefaultModel():
+      case _i28.BoolDefaultModel():
         return 'BoolDefaultModel';
-      case _i25.BoolDefaultPersist():
+      case _i29.BoolDefaultPersist():
         return 'BoolDefaultPersist';
-      case _i26.DateTimeDefault():
+      case _i30.DateTimeDefault():
         return 'DateTimeDefault';
-      case _i27.DateTimeDefaultMix():
+      case _i31.DateTimeDefaultMix():
         return 'DateTimeDefaultMix';
-      case _i28.DateTimeDefaultModel():
+      case _i32.DateTimeDefaultModel():
         return 'DateTimeDefaultModel';
-      case _i29.DateTimeDefaultPersist():
+      case _i33.DateTimeDefaultPersist():
         return 'DateTimeDefaultPersist';
-      case _i30.DoubleDefault():
+      case _i34.DoubleDefault():
         return 'DoubleDefault';
-      case _i31.DoubleDefaultMix():
+      case _i35.DoubleDefaultMix():
         return 'DoubleDefaultMix';
-      case _i32.DoubleDefaultModel():
+      case _i36.DoubleDefaultModel():
         return 'DoubleDefaultModel';
-      case _i33.DoubleDefaultPersist():
+      case _i37.DoubleDefaultPersist():
         return 'DoubleDefaultPersist';
-      case _i34.DurationDefault():
+      case _i38.DurationDefault():
         return 'DurationDefault';
-      case _i35.DurationDefaultMix():
+      case _i39.DurationDefaultMix():
         return 'DurationDefaultMix';
-      case _i36.DurationDefaultModel():
+      case _i40.DurationDefaultModel():
         return 'DurationDefaultModel';
-      case _i37.DurationDefaultPersist():
+      case _i41.DurationDefaultPersist():
         return 'DurationDefaultPersist';
-      case _i38.EnumDefault():
+      case _i42.EnumDefault():
         return 'EnumDefault';
-      case _i39.EnumDefaultMix():
+      case _i43.EnumDefaultMix():
         return 'EnumDefaultMix';
-      case _i40.EnumDefaultModel():
+      case _i44.EnumDefaultModel():
         return 'EnumDefaultModel';
-      case _i41.EnumDefaultPersist():
+      case _i45.EnumDefaultPersist():
         return 'EnumDefaultPersist';
-      case _i42.ByIndexEnum():
+      case _i46.ByIndexEnum():
         return 'ByIndexEnum';
-      case _i43.ByNameEnum():
+      case _i47.ByNameEnum():
         return 'ByNameEnum';
-      case _i44.DefaultValueEnum():
+      case _i48.DefaultValueEnum():
         return 'DefaultValueEnum';
-      case _i45.DefaultException():
+      case _i49.DefaultException():
         return 'DefaultException';
-      case _i46.IntDefault():
+      case _i50.IntDefault():
         return 'IntDefault';
-      case _i47.IntDefaultMix():
+      case _i51.IntDefaultMix():
         return 'IntDefaultMix';
-      case _i48.IntDefaultModel():
+      case _i52.IntDefaultModel():
         return 'IntDefaultModel';
-      case _i49.IntDefaultPersist():
+      case _i53.IntDefaultPersist():
         return 'IntDefaultPersist';
-      case _i50.StringDefault():
+      case _i54.StringDefault():
         return 'StringDefault';
-      case _i51.StringDefaultMix():
+      case _i55.StringDefaultMix():
         return 'StringDefaultMix';
-      case _i52.StringDefaultModel():
+      case _i56.StringDefaultModel():
         return 'StringDefaultModel';
-      case _i53.StringDefaultPersist():
+      case _i57.StringDefaultPersist():
         return 'StringDefaultPersist';
-      case _i54.UriDefault():
+      case _i58.UriDefault():
         return 'UriDefault';
-      case _i55.UriDefaultMix():
+      case _i59.UriDefaultMix():
         return 'UriDefaultMix';
-      case _i56.UriDefaultModel():
+      case _i60.UriDefaultModel():
         return 'UriDefaultModel';
-      case _i57.UriDefaultPersist():
+      case _i61.UriDefaultPersist():
         return 'UriDefaultPersist';
-      case _i58.UuidDefault():
+      case _i62.UuidDefault():
         return 'UuidDefault';
-      case _i59.UuidDefaultMix():
+      case _i63.UuidDefaultMix():
         return 'UuidDefaultMix';
-      case _i60.UuidDefaultModel():
+      case _i64.UuidDefaultModel():
         return 'UuidDefaultModel';
-      case _i61.UuidDefaultPersist():
+      case _i65.UuidDefaultPersist():
         return 'UuidDefaultPersist';
-      case _i62.EmptyModel():
+      case _i66.EmptyModel():
         return 'EmptyModel';
-      case _i63.EmptyModelRelationItem():
+      case _i67.EmptyModelRelationItem():
         return 'EmptyModelRelationItem';
-      case _i64.EmptyModelWithTable():
+      case _i68.EmptyModelWithTable():
         return 'EmptyModelWithTable';
-      case _i65.RelationEmptyModel():
+      case _i69.RelationEmptyModel():
         return 'RelationEmptyModel';
-      case _i66.ExceptionWithData():
+      case _i70.ExceptionWithData():
         return 'ExceptionWithData';
-      case _i67.ChildClassExplicitColumn():
+      case _i71.ChildClassExplicitColumn():
         return 'ChildClassExplicitColumn';
-      case _i68.NonTableParentClass():
+      case _i72.NonTableParentClass():
         return 'NonTableParentClass';
-      case _i69.ModifiedColumnName():
+      case _i73.ModifiedColumnName():
         return 'ModifiedColumnName';
-      case _i70.Department():
+      case _i74.Department():
         return 'Department';
-      case _i71.Employee():
+      case _i75.Employee():
         return 'Employee';
-      case _i72.Contractor():
+      case _i76.Contractor():
         return 'Contractor';
-      case _i73.Service():
+      case _i77.Service():
         return 'Service';
-      case _i74.TableWithExplicitColumnName():
+      case _i78.TableWithExplicitColumnName():
         return 'TableWithExplicitColumnName';
-      case _i75.ImmutableChildObject():
+      case _i79.ImmutableChildObject():
         return 'ImmutableChildObject';
-      case _i76.ImmutableChildObjectWithNoAdditionalFields():
+      case _i80.ImmutableChildObjectWithNoAdditionalFields():
         return 'ImmutableChildObjectWithNoAdditionalFields';
-      case _i77.ImmutableObject():
+      case _i81.ImmutableObject():
         return 'ImmutableObject';
-      case _i78.ImmutableObjectWithImmutableObject():
+      case _i82.ImmutableObjectWithImmutableObject():
         return 'ImmutableObjectWithImmutableObject';
-      case _i79.ImmutableObjectWithList():
+      case _i83.ImmutableObjectWithList():
         return 'ImmutableObjectWithList';
-      case _i80.ImmutableObjectWithMap():
+      case _i84.ImmutableObjectWithMap():
         return 'ImmutableObjectWithMap';
-      case _i81.ImmutableObjectWithMultipleFields():
+      case _i85.ImmutableObjectWithMultipleFields():
         return 'ImmutableObjectWithMultipleFields';
-      case _i82.ImmutableObjectWithNoFields():
+      case _i86.ImmutableObjectWithNoFields():
         return 'ImmutableObjectWithNoFields';
-      case _i83.ImmutableObjectWithRecord():
+      case _i87.ImmutableObjectWithRecord():
         return 'ImmutableObjectWithRecord';
-      case _i84.ImmutableObjectWithTable():
+      case _i88.ImmutableObjectWithTable():
         return 'ImmutableObjectWithTable';
-      case _i85.ImmutableObjectWithTwentyFields():
+      case _i89.ImmutableObjectWithTwentyFields():
         return 'ImmutableObjectWithTwentyFields';
-      case _i86.ChildClass():
+      case _i90.ChildClass():
         return 'ChildClass';
-      case _i87.ChildWithDefault():
+      case _i91.ChildWithDefault():
         return 'ChildWithDefault';
-      case _i88.ChildClassWithoutId():
+      case _i92.ChildClassWithoutId():
         return 'ChildClassWithoutId';
-      case _i89.ExtendedAppException():
+      case _i93.ExtendedAppException():
         return 'ExtendedAppException';
-      case _i90.BaseAppException():
+      case _i94.BaseAppException():
         return 'BaseAppException';
-      case _i91.NotFoundException():
+      case _i95.NotFoundException():
         return 'NotFoundException';
-      case _i91.ValidationException():
+      case _i95.ValidationException():
         return 'ValidationException';
-      case _i92.ParentClass():
+      case _i96.ParentClass():
         return 'ParentClass';
-      case _i93.GrandparentClass():
+      case _i97.GrandparentClass():
         return 'GrandparentClass';
-      case _i94.ParentClassWithoutId():
+      case _i98.ParentClassWithoutId():
         return 'ParentClassWithoutId';
-      case _i95.GrandparentClassWithId():
+      case _i99.GrandparentClassWithId():
         return 'GrandparentClassWithId';
-      case _i96.ChildEntity():
+      case _i100.ChildEntity():
         return 'ChildEntity';
-      case _i97.BaseEntity():
+      case _i101.BaseEntity():
         return 'BaseEntity';
-      case _i98.ParentEntity():
+      case _i102.ParentEntity():
         return 'ParentEntity';
-      case _i99.NonServerOnlyParentClass():
+      case _i103.NonServerOnlyParentClass():
         return 'NonServerOnlyParentClass';
-      case _i100.ParentWithDefault():
+      case _i104.ParentWithDefault():
         return 'ParentWithDefault';
-      case _i101.PolymorphicGrandChild():
+      case _i105.PolymorphicGrandChild():
         return 'PolymorphicGrandChild';
-      case _i102.PolymorphicChild():
+      case _i106.PolymorphicChild():
         return 'PolymorphicChild';
-      case _i103.PolymorphicChildContainer():
+      case _i107.PolymorphicChildContainer():
         return 'PolymorphicChildContainer';
-      case _i104.ModulePolymorphicChildContainer():
+      case _i108.ModulePolymorphicChildContainer():
         return 'ModulePolymorphicChildContainer';
-      case _i105.SimilarButNotParent():
+      case _i109.SimilarButNotParent():
         return 'SimilarButNotParent';
-      case _i106.PolymorphicParent():
+      case _i110.PolymorphicParent():
         return 'PolymorphicParent';
-      case _i107.UnrelatedToPolymorphism():
+      case _i111.UnrelatedToPolymorphism():
         return 'UnrelatedToPolymorphism';
-      case _i108.SealedGrandChild():
+      case _i112.SealedGrandChild():
         return 'SealedGrandChild';
-      case _i108.SealedChild():
+      case _i112.SealedChild():
         return 'SealedChild';
-      case _i109.SealedChildOnlyRequired():
+      case _i113.SealedChildOnlyRequired():
         return 'SealedChildOnlyRequired';
-      case _i108.SealedOtherChild():
+      case _i112.SealedOtherChild():
         return 'SealedOtherChild';
-      case _i110.CityWithLongTableName():
+      case _i114.CityWithLongTableName():
         return 'CityWithLongTableName';
-      case _i111.OrganizationWithLongTableName():
+      case _i115.OrganizationWithLongTableName():
         return 'OrganizationWithLongTableName';
-      case _i112.PersonWithLongTableName():
+      case _i116.PersonWithLongTableName():
         return 'PersonWithLongTableName';
-      case _i113.MaxFieldName():
+      case _i117.MaxFieldName():
         return 'MaxFieldName';
-      case _i114.LongImplicitIdField():
+      case _i118.LongImplicitIdField():
         return 'LongImplicitIdField';
-      case _i115.LongImplicitIdFieldCollection():
+      case _i119.LongImplicitIdFieldCollection():
         return 'LongImplicitIdFieldCollection';
-      case _i116.RelationToMultipleMaxFieldName():
+      case _i120.RelationToMultipleMaxFieldName():
         return 'RelationToMultipleMaxFieldName';
-      case _i117.UserNote():
+      case _i121.UserNote():
         return 'UserNote';
-      case _i118.UserNoteCollection():
+      case _i122.UserNoteCollection():
         return 'UserNoteCollection';
-      case _i119.UserNoteCollectionWithALongName():
+      case _i123.UserNoteCollectionWithALongName():
         return 'UserNoteCollectionWithALongName';
-      case _i120.UserNoteWithALongName():
+      case _i124.UserNoteWithALongName():
         return 'UserNoteWithALongName';
-      case _i121.MultipleMaxFieldName():
+      case _i125.MultipleMaxFieldName():
         return 'MultipleMaxFieldName';
-      case _i122.City():
+      case _i126.City():
         return 'City';
-      case _i123.Organization():
+      case _i127.Organization():
         return 'Organization';
-      case _i124.Person():
+      case _i128.Person():
         return 'Person';
-      case _i125.BleedChild():
+      case _i129.BleedChild():
         return 'BleedChild';
-      case _i126.BleedRoot():
+      case _i130.BleedRoot():
         return 'BleedRoot';
-      case _i127.Course():
+      case _i131.Course():
         return 'Course';
-      case _i128.Enrollment():
+      case _i132.Enrollment():
         return 'Enrollment';
-      case _i129.Student():
+      case _i133.Student():
         return 'Student';
-      case _i130.ObjectUser():
+      case _i134.ObjectUser():
         return 'ObjectUser';
-      case _i131.ParentUser():
+      case _i135.ParentUser():
         return 'ParentUser';
-      case _i132.Arena():
+      case _i136.Arena():
         return 'Arena';
-      case _i133.Player():
+      case _i137.Player():
         return 'Player';
-      case _i134.Team():
+      case _i138.Team():
         return 'Team';
-      case _i135.Comment():
+      case _i139.Comment():
         return 'Comment';
-      case _i136.Customer():
+      case _i140.Customer():
         return 'Customer';
-      case _i137.Book():
+      case _i141.Book():
         return 'Book';
-      case _i138.Chapter():
+      case _i142.Chapter():
         return 'Chapter';
-      case _i139.Order():
+      case _i143.Order():
         return 'Order';
-      case _i140.Address():
+      case _i144.Address():
         return 'Address';
-      case _i141.Citizen():
+      case _i145.Citizen():
         return 'Citizen';
-      case _i142.Company():
+      case _i146.Company():
         return 'Company';
-      case _i143.Town():
+      case _i147.Town():
         return 'Town';
-      case _i144.Blocking():
+      case _i148.Blocking():
         return 'Blocking';
-      case _i145.Member():
+      case _i149.Member():
         return 'Member';
-      case _i146.Cat():
+      case _i150.Cat():
         return 'Cat';
-      case _i147.Post():
+      case _i151.Post():
         return 'Post';
-      case _i148.ModuleDatatype():
+      case _i152.ModuleDatatype():
         return 'ModuleDatatype';
-      case _i149.MyFeatureModel():
+      case _i153.MyFeatureModel():
         return 'MyFeatureModel';
-      case _i150.MyTriggerType():
+      case _i154.MyTriggerType():
         return 'MyTriggerType';
-      case _i151.Nullability():
+      case _i155.Nullability():
         return 'Nullability';
-      case _i152.NullsDistinctData():
+      case _i156.NullsDistinctData():
         return 'NullsDistinctData';
-      case _i153.ObjectFieldPersist():
+      case _i157.ObjectFieldPersist():
         return 'ObjectFieldPersist';
-      case _i154.ObjectFieldScopes():
+      case _i158.ObjectFieldScopes():
         return 'ObjectFieldScopes';
-      case _i155.ObjectWithBit():
+      case _i159.ObjectWithBit():
         return 'ObjectWithBit';
-      case _i156.ObjectWithByteData():
+      case _i160.ObjectWithByteData():
         return 'ObjectWithByteData';
-      case _i157.ObjectWithCustomClass():
+      case _i161.ObjectWithCustomClass():
         return 'ObjectWithCustomClass';
-      case _i158.ObjectWithDuration():
+      case _i162.ObjectWithDuration():
         return 'ObjectWithDuration';
-      case _i159.ObjectWithDynamic():
+      case _i163.ObjectWithDynamic():
         return 'ObjectWithDynamic';
-      case _i160.ObjectWithEnum():
+      case _i164.ObjectWithEnum():
         return 'ObjectWithEnum';
-      case _i161.ObjectWithEnumEnhanced():
+      case _i165.ObjectWithEnumEnhanced():
         return 'ObjectWithEnumEnhanced';
-      case _i162.ObjectWithGeographyGeometryCollection():
+      case _i166.ObjectWithGeographyGeometryCollection():
         return 'ObjectWithGeographyGeometryCollection';
-      case _i163.ObjectWithGeographyLineString():
+      case _i167.ObjectWithGeographyLineString():
         return 'ObjectWithGeographyLineString';
-      case _i164.ObjectWithGeographyPoint():
+      case _i168.ObjectWithGeographyPoint():
         return 'ObjectWithGeographyPoint';
-      case _i165.ObjectWithGeographyPolygon():
+      case _i169.ObjectWithGeographyPolygon():
         return 'ObjectWithGeographyPolygon';
-      case _i166.ObjectWithHalfVector():
+      case _i170.ObjectWithHalfVector():
         return 'ObjectWithHalfVector';
-      case _i167.ObjectWithIndex():
+      case _i171.ObjectWithIndex():
         return 'ObjectWithIndex';
-      case _i168.ObjectWithJsonb():
+      case _i172.ObjectWithJsonb():
         return 'ObjectWithJsonb';
-      case _i169.ObjectWithJsonbClassLevel():
+      case _i173.ObjectWithJsonbClassLevel():
         return 'ObjectWithJsonbClassLevel';
-      case _i170.ObjectWithMaps():
+      case _i174.ObjectWithMaps():
         return 'ObjectWithMaps';
-      case _i171.ObjectWithNullableCustomClass():
+      case _i175.ObjectWithNullableCustomClass():
         return 'ObjectWithNullableCustomClass';
-      case _i172.ObjectWithObject():
+      case _i176.ObjectWithObject():
         return 'ObjectWithObject';
-      case _i173.ObjectWithParent():
+      case _i177.ObjectWithParent():
         return 'ObjectWithParent';
-      case _i174.ObjectWithSealedClass():
+      case _i178.ObjectWithSealedClass():
         return 'ObjectWithSealedClass';
-      case _i175.ObjectWithSealedException():
+      case _i179.ObjectWithSealedException():
         return 'ObjectWithSealedException';
-      case _i176.ObjectWithSelfParent():
+      case _i180.ObjectWithSelfParent():
         return 'ObjectWithSelfParent';
-      case _i177.ObjectWithSparseVector():
+      case _i181.ObjectWithSparseVector():
         return 'ObjectWithSparseVector';
-      case _i178.ObjectWithUuid():
+      case _i182.ObjectWithUuid():
         return 'ObjectWithUuid';
-      case _i179.ObjectWithVector():
+      case _i183.ObjectWithVector():
         return 'ObjectWithVector';
-      case _i180.Record():
+      case _i184.Record():
         return 'Record';
-      case _i181.RelatedUniqueData():
+      case _i185.RelatedUniqueData():
         return 'RelatedUniqueData';
-      case _i182.ExceptionWithRequiredField():
+      case _i186.ExceptionWithRequiredField():
         return 'ExceptionWithRequiredField';
-      case _i183.ModelWithRequiredField():
+      case _i187.ModelWithRequiredField():
         return 'ModelWithRequiredField';
-      case _i184.ScopeNoneFields():
+      case _i188.ScopeNoneFields():
         return 'ScopeNoneFields';
-      case _i185.ScopeServerOnlyFieldChild():
+      case _i189.ScopeServerOnlyFieldChild():
         return 'ScopeServerOnlyFieldChild';
-      case _i186.ScopeServerOnlyField():
+      case _i190.ScopeServerOnlyField():
         return 'ScopeServerOnlyField';
-      case _i187.DefaultServerOnlyClass():
+      case _i191.DefaultServerOnlyClass():
         return 'DefaultServerOnlyClass';
-      case _i188.DefaultServerOnlyEnum():
+      case _i192.DefaultServerOnlyEnum():
         return 'DefaultServerOnlyEnum';
-      case _i189.NotServerOnlyClass():
+      case _i193.NotServerOnlyClass():
         return 'NotServerOnlyClass';
-      case _i190.NotServerOnlyEnum():
+      case _i194.NotServerOnlyEnum():
         return 'NotServerOnlyEnum';
-      case _i191.ServerOnlyClassField():
+      case _i195.ServerOnlyClassField():
         return 'ServerOnlyClassField';
-      case _i192.ServerOnlyDefault():
+      case _i196.ServerOnlyDefault():
         return 'ServerOnlyDefault';
-      case _i193.SessionAuthInfo():
+      case _i197.SessionAuthInfo():
         return 'SessionAuthInfo';
-      case _i194.SharedModelContainer():
+      case _i198.SharedModelContainer():
         return 'SharedModelContainer';
-      case _i195.SharedModelSubclass():
+      case _i199.SharedModelSubclass():
         return 'SharedModelSubclass';
-      case _i196.SimpleData():
+      case _i200.SimpleData():
         return 'SimpleData';
-      case _i197.SimpleDataList():
+      case _i201.SimpleDataList():
         return 'SimpleDataList';
-      case _i198.SimpleDataMap():
+      case _i202.SimpleDataMap():
         return 'SimpleDataMap';
-      case _i199.SimpleDataObject():
+      case _i203.SimpleDataObject():
         return 'SimpleDataObject';
-      case _i200.SimpleDateTime():
+      case _i204.SimpleDateTime():
         return 'SimpleDateTime';
-      case _i201.ModelInSubfolder():
+      case _i205.ModelInSubfolder():
         return 'ModelInSubfolder';
-      case _i202.TestEnum():
+      case _i206.TestEnum():
         return 'TestEnum';
-      case _i203.TestEnumDefaultSerialization():
+      case _i207.TestEnumDefaultSerialization():
         return 'TestEnumDefaultSerialization';
-      case _i204.TestEnumEnhanced():
+      case _i208.TestEnumEnhanced():
         return 'TestEnumEnhanced';
-      case _i205.TestEnumEnhancedByName():
+      case _i209.TestEnumEnhancedByName():
         return 'TestEnumEnhancedByName';
-      case _i206.TestEnumStringified():
+      case _i210.TestEnumStringified():
         return 'TestEnumStringified';
-      case _i207.Types():
+      case _i211.Types():
         return 'Types';
-      case _i208.TypesList():
+      case _i212.TypesList():
         return 'TypesList';
-      case _i209.TypesMap():
+      case _i213.TypesMap():
         return 'TypesMap';
-      case _i210.TypesRecord():
+      case _i214.TypesRecord():
         return 'TypesRecord';
-      case _i211.TypesSet():
+      case _i215.TypesSet():
         return 'TypesSet';
-      case _i212.TypesSetRequired():
+      case _i216.TypesSetRequired():
         return 'TypesSetRequired';
-      case _i213.UniqueData():
+      case _i217.UniqueData():
         return 'UniqueData';
-      case _i214.UniqueDataWithNonPersist():
+      case _i218.UniqueDataWithNonPersist():
         return 'UniqueDataWithNonPersist';
-      case _i215.UpsertTestModel():
+      case _i219.UpsertTestModel():
         return 'UpsertTestModel';
     }
     if (data is List<int>) {
       return 'List<int>';
     }
-    if (data is List<_i219.SimpleData>) {
+    if (data is List<_i220.SimpleData>) {
       return 'List<SimpleData>';
     }
-    if (data is List<_i221.UserInfo>) {
+    if (data is List<_i2.UserInfo>) {
       return 'List<serverpod_auth.UserInfo>';
     }
-    if (data is List<_i219.SimpleData>?) {
+    if (data is List<_i220.SimpleData>?) {
       return 'List<SimpleData>?';
     }
-    if (data is List<_i219.SimpleData?>) {
+    if (data is List<_i220.SimpleData?>) {
       return 'List<SimpleData?>';
     }
     if (data is Set<int>) {
       return 'Set<int>';
     }
-    if (data is Set<_i219.SimpleData>) {
+    if (data is Set<_i220.SimpleData>) {
       return 'Set<SimpleData>';
     }
-    if (data is List<Set<_i219.SimpleData>>) {
+    if (data is List<Set<_i220.SimpleData>>) {
       return 'List<Set<SimpleData>>';
     }
-    if (data is (String, _i222.PolymorphicParent)) {
+    if (data is (String, _i221.PolymorphicParent)) {
       return '(String,PolymorphicParent)';
     }
     if (data is (int?,)?) {
@@ -6664,17 +1258,17 @@ class Protocol extends _i1.SerializationManager {
     }
     if (data
         is List<
-          ((int, String), {(_i219.SimpleData, double) namedSubRecord})?
+          ((int, String), {(_i220.SimpleData, double) namedSubRecord})?
         >?) {
       return 'List<((int,String),{(SimpleData,double) namedSubRecord})?>?';
     }
-    if (data is (int?, _i216.ProjectStreamingClass?)) {
+    if (data is (int?, _i3.ProjectStreamingClass?)) {
       return '(int?,serverpod_test_module.ProjectStreamingClass?)';
     }
     if (data
         is (
           String,
-          (Map<String, int>, {bool flag, _i219.SimpleData simpleData}),
+          (Map<String, int>, {bool flag, _i220.SimpleData simpleData}),
         )) {
       return '(String,(Map<String,int>,{bool flag,SimpleData simpleData}))';
     }
@@ -6684,30 +1278,30 @@ class Protocol extends _i1.SerializationManager {
     if (data
         is (
           String,
-          (Map<String, int>, {bool flag, _i219.SimpleData simpleData}),
+          (Map<String, int>, {bool flag, _i220.SimpleData simpleData}),
         )?) {
       return '(String,(Map<String,int>,{bool flag,SimpleData simpleData}))?';
     }
     if (data is List<(String, int)>?) {
       return 'List<(String,int)>?';
     }
-    className = _i221.Protocol().getClassNameForObject(data);
+    className = _i2.Protocol().getClassNameForObject(data);
     if (className != null) {
       return className.contains('.') ? className : 'serverpod_auth.$className';
     }
-    className = _i216.Protocol().getClassNameForObject(data);
+    className = _i3.Protocol().getClassNameForObject(data);
     if (className != null) {
       return className.contains('.')
           ? className
           : 'serverpod_test_module.$className';
     }
-    className = _i224.Protocol().getClassNameForObject(data);
+    className = _i4.Protocol().getClassNameForObject(data);
     if (className != null) {
       return className.contains('.')
           ? className
           : 'serverpod_test_shared_module.$className';
     }
-    className = _i218.Protocol().getClassNameForObject(data);
+    className = _i5.Protocol().getClassNameForObject(data);
     if (className != null) {
       return className.contains('.')
           ? className
@@ -6723,732 +1317,732 @@ class Protocol extends _i1.SerializationManager {
       return super.deserializeByClassName(data);
     }
     if (dataClassName == 'CustomClass') {
-      return deserialize<_i218.CustomClass>(data['data']);
+      return deserialize<_i5.CustomClass>(data['data']);
     }
     if (dataClassName == 'CustomClass2') {
-      return deserialize<_i218.CustomClass2>(data['data']);
+      return deserialize<_i5.CustomClass2>(data['data']);
     }
     if (dataClassName == 'CustomClassWithoutProtocolSerialization') {
-      return deserialize<_i218.CustomClassWithoutProtocolSerialization>(
+      return deserialize<_i5.CustomClassWithoutProtocolSerialization>(
         data['data'],
       );
     }
     if (dataClassName == 'CustomClassWithProtocolSerialization') {
-      return deserialize<_i218.CustomClassWithProtocolSerialization>(
+      return deserialize<_i5.CustomClassWithProtocolSerialization>(
         data['data'],
       );
     }
     if (dataClassName == 'CustomClassWithProtocolSerializationMethod') {
-      return deserialize<_i218.CustomClassWithProtocolSerializationMethod>(
+      return deserialize<_i5.CustomClassWithProtocolSerializationMethod>(
         data['data'],
       );
     }
     if (dataClassName == 'ProtocolCustomClass') {
-      return deserialize<_i218.ProtocolCustomClass>(data['data']);
+      return deserialize<_i5.ProtocolCustomClass>(data['data']);
     }
     if (dataClassName == 'ExternalCustomClass') {
-      return deserialize<_i218.ExternalCustomClass>(data['data']);
+      return deserialize<_i5.ExternalCustomClass>(data['data']);
     }
     if (dataClassName == 'FreezedCustomClass') {
-      return deserialize<_i218.FreezedCustomClass>(data['data']);
+      return deserialize<_i5.FreezedCustomClass>(data['data']);
     }
     if (dataClassName == 'ByIndexEnumWithNameValue') {
-      return deserialize<_i2.ByIndexEnumWithNameValue>(data['data']);
+      return deserialize<_i6.ByIndexEnumWithNameValue>(data['data']);
     }
     if (dataClassName == 'ByNameEnumWithNameValue') {
-      return deserialize<_i3.ByNameEnumWithNameValue>(data['data']);
+      return deserialize<_i7.ByNameEnumWithNameValue>(data['data']);
     }
     if (dataClassName == 'CourseUuid') {
-      return deserialize<_i4.CourseUuid>(data['data']);
+      return deserialize<_i8.CourseUuid>(data['data']);
     }
     if (dataClassName == 'EnrollmentInt') {
-      return deserialize<_i5.EnrollmentInt>(data['data']);
+      return deserialize<_i9.EnrollmentInt>(data['data']);
     }
     if (dataClassName == 'StudentUuid') {
-      return deserialize<_i6.StudentUuid>(data['data']);
+      return deserialize<_i10.StudentUuid>(data['data']);
     }
     if (dataClassName == 'ArenaUuid') {
-      return deserialize<_i7.ArenaUuid>(data['data']);
+      return deserialize<_i11.ArenaUuid>(data['data']);
     }
     if (dataClassName == 'PlayerUuid') {
-      return deserialize<_i8.PlayerUuid>(data['data']);
+      return deserialize<_i12.PlayerUuid>(data['data']);
     }
     if (dataClassName == 'TeamInt') {
-      return deserialize<_i9.TeamInt>(data['data']);
+      return deserialize<_i13.TeamInt>(data['data']);
     }
     if (dataClassName == 'CommentInt') {
-      return deserialize<_i10.CommentInt>(data['data']);
+      return deserialize<_i14.CommentInt>(data['data']);
     }
     if (dataClassName == 'CustomerInt') {
-      return deserialize<_i11.CustomerInt>(data['data']);
+      return deserialize<_i15.CustomerInt>(data['data']);
     }
     if (dataClassName == 'OrderUuid') {
-      return deserialize<_i12.OrderUuid>(data['data']);
+      return deserialize<_i16.OrderUuid>(data['data']);
     }
     if (dataClassName == 'AddressUuid') {
-      return deserialize<_i13.AddressUuid>(data['data']);
+      return deserialize<_i17.AddressUuid>(data['data']);
     }
     if (dataClassName == 'CitizenInt') {
-      return deserialize<_i14.CitizenInt>(data['data']);
+      return deserialize<_i18.CitizenInt>(data['data']);
     }
     if (dataClassName == 'CompanyUuid') {
-      return deserialize<_i15.CompanyUuid>(data['data']);
+      return deserialize<_i19.CompanyUuid>(data['data']);
     }
     if (dataClassName == 'TownInt') {
-      return deserialize<_i16.TownInt>(data['data']);
+      return deserialize<_i20.TownInt>(data['data']);
     }
     if (dataClassName == 'ChangedIdTypeSelf') {
-      return deserialize<_i17.ChangedIdTypeSelf>(data['data']);
+      return deserialize<_i21.ChangedIdTypeSelf>(data['data']);
     }
     if (dataClassName == 'BigIntDefault') {
-      return deserialize<_i18.BigIntDefault>(data['data']);
+      return deserialize<_i22.BigIntDefault>(data['data']);
     }
     if (dataClassName == 'BigIntDefaultMix') {
-      return deserialize<_i19.BigIntDefaultMix>(data['data']);
+      return deserialize<_i23.BigIntDefaultMix>(data['data']);
     }
     if (dataClassName == 'BigIntDefaultModel') {
-      return deserialize<_i20.BigIntDefaultModel>(data['data']);
+      return deserialize<_i24.BigIntDefaultModel>(data['data']);
     }
     if (dataClassName == 'BigIntDefaultPersist') {
-      return deserialize<_i21.BigIntDefaultPersist>(data['data']);
+      return deserialize<_i25.BigIntDefaultPersist>(data['data']);
     }
     if (dataClassName == 'BoolDefault') {
-      return deserialize<_i22.BoolDefault>(data['data']);
+      return deserialize<_i26.BoolDefault>(data['data']);
     }
     if (dataClassName == 'BoolDefaultMix') {
-      return deserialize<_i23.BoolDefaultMix>(data['data']);
+      return deserialize<_i27.BoolDefaultMix>(data['data']);
     }
     if (dataClassName == 'BoolDefaultModel') {
-      return deserialize<_i24.BoolDefaultModel>(data['data']);
+      return deserialize<_i28.BoolDefaultModel>(data['data']);
     }
     if (dataClassName == 'BoolDefaultPersist') {
-      return deserialize<_i25.BoolDefaultPersist>(data['data']);
+      return deserialize<_i29.BoolDefaultPersist>(data['data']);
     }
     if (dataClassName == 'DateTimeDefault') {
-      return deserialize<_i26.DateTimeDefault>(data['data']);
+      return deserialize<_i30.DateTimeDefault>(data['data']);
     }
     if (dataClassName == 'DateTimeDefaultMix') {
-      return deserialize<_i27.DateTimeDefaultMix>(data['data']);
+      return deserialize<_i31.DateTimeDefaultMix>(data['data']);
     }
     if (dataClassName == 'DateTimeDefaultModel') {
-      return deserialize<_i28.DateTimeDefaultModel>(data['data']);
+      return deserialize<_i32.DateTimeDefaultModel>(data['data']);
     }
     if (dataClassName == 'DateTimeDefaultPersist') {
-      return deserialize<_i29.DateTimeDefaultPersist>(data['data']);
+      return deserialize<_i33.DateTimeDefaultPersist>(data['data']);
     }
     if (dataClassName == 'DoubleDefault') {
-      return deserialize<_i30.DoubleDefault>(data['data']);
+      return deserialize<_i34.DoubleDefault>(data['data']);
     }
     if (dataClassName == 'DoubleDefaultMix') {
-      return deserialize<_i31.DoubleDefaultMix>(data['data']);
+      return deserialize<_i35.DoubleDefaultMix>(data['data']);
     }
     if (dataClassName == 'DoubleDefaultModel') {
-      return deserialize<_i32.DoubleDefaultModel>(data['data']);
+      return deserialize<_i36.DoubleDefaultModel>(data['data']);
     }
     if (dataClassName == 'DoubleDefaultPersist') {
-      return deserialize<_i33.DoubleDefaultPersist>(data['data']);
+      return deserialize<_i37.DoubleDefaultPersist>(data['data']);
     }
     if (dataClassName == 'DurationDefault') {
-      return deserialize<_i34.DurationDefault>(data['data']);
+      return deserialize<_i38.DurationDefault>(data['data']);
     }
     if (dataClassName == 'DurationDefaultMix') {
-      return deserialize<_i35.DurationDefaultMix>(data['data']);
+      return deserialize<_i39.DurationDefaultMix>(data['data']);
     }
     if (dataClassName == 'DurationDefaultModel') {
-      return deserialize<_i36.DurationDefaultModel>(data['data']);
+      return deserialize<_i40.DurationDefaultModel>(data['data']);
     }
     if (dataClassName == 'DurationDefaultPersist') {
-      return deserialize<_i37.DurationDefaultPersist>(data['data']);
+      return deserialize<_i41.DurationDefaultPersist>(data['data']);
     }
     if (dataClassName == 'EnumDefault') {
-      return deserialize<_i38.EnumDefault>(data['data']);
+      return deserialize<_i42.EnumDefault>(data['data']);
     }
     if (dataClassName == 'EnumDefaultMix') {
-      return deserialize<_i39.EnumDefaultMix>(data['data']);
+      return deserialize<_i43.EnumDefaultMix>(data['data']);
     }
     if (dataClassName == 'EnumDefaultModel') {
-      return deserialize<_i40.EnumDefaultModel>(data['data']);
+      return deserialize<_i44.EnumDefaultModel>(data['data']);
     }
     if (dataClassName == 'EnumDefaultPersist') {
-      return deserialize<_i41.EnumDefaultPersist>(data['data']);
+      return deserialize<_i45.EnumDefaultPersist>(data['data']);
     }
     if (dataClassName == 'ByIndexEnum') {
-      return deserialize<_i42.ByIndexEnum>(data['data']);
+      return deserialize<_i46.ByIndexEnum>(data['data']);
     }
     if (dataClassName == 'ByNameEnum') {
-      return deserialize<_i43.ByNameEnum>(data['data']);
+      return deserialize<_i47.ByNameEnum>(data['data']);
     }
     if (dataClassName == 'DefaultValueEnum') {
-      return deserialize<_i44.DefaultValueEnum>(data['data']);
+      return deserialize<_i48.DefaultValueEnum>(data['data']);
     }
     if (dataClassName == 'DefaultException') {
-      return deserialize<_i45.DefaultException>(data['data']);
+      return deserialize<_i49.DefaultException>(data['data']);
     }
     if (dataClassName == 'IntDefault') {
-      return deserialize<_i46.IntDefault>(data['data']);
+      return deserialize<_i50.IntDefault>(data['data']);
     }
     if (dataClassName == 'IntDefaultMix') {
-      return deserialize<_i47.IntDefaultMix>(data['data']);
+      return deserialize<_i51.IntDefaultMix>(data['data']);
     }
     if (dataClassName == 'IntDefaultModel') {
-      return deserialize<_i48.IntDefaultModel>(data['data']);
+      return deserialize<_i52.IntDefaultModel>(data['data']);
     }
     if (dataClassName == 'IntDefaultPersist') {
-      return deserialize<_i49.IntDefaultPersist>(data['data']);
+      return deserialize<_i53.IntDefaultPersist>(data['data']);
     }
     if (dataClassName == 'StringDefault') {
-      return deserialize<_i50.StringDefault>(data['data']);
+      return deserialize<_i54.StringDefault>(data['data']);
     }
     if (dataClassName == 'StringDefaultMix') {
-      return deserialize<_i51.StringDefaultMix>(data['data']);
+      return deserialize<_i55.StringDefaultMix>(data['data']);
     }
     if (dataClassName == 'StringDefaultModel') {
-      return deserialize<_i52.StringDefaultModel>(data['data']);
+      return deserialize<_i56.StringDefaultModel>(data['data']);
     }
     if (dataClassName == 'StringDefaultPersist') {
-      return deserialize<_i53.StringDefaultPersist>(data['data']);
+      return deserialize<_i57.StringDefaultPersist>(data['data']);
     }
     if (dataClassName == 'UriDefault') {
-      return deserialize<_i54.UriDefault>(data['data']);
+      return deserialize<_i58.UriDefault>(data['data']);
     }
     if (dataClassName == 'UriDefaultMix') {
-      return deserialize<_i55.UriDefaultMix>(data['data']);
+      return deserialize<_i59.UriDefaultMix>(data['data']);
     }
     if (dataClassName == 'UriDefaultModel') {
-      return deserialize<_i56.UriDefaultModel>(data['data']);
+      return deserialize<_i60.UriDefaultModel>(data['data']);
     }
     if (dataClassName == 'UriDefaultPersist') {
-      return deserialize<_i57.UriDefaultPersist>(data['data']);
+      return deserialize<_i61.UriDefaultPersist>(data['data']);
     }
     if (dataClassName == 'UuidDefault') {
-      return deserialize<_i58.UuidDefault>(data['data']);
+      return deserialize<_i62.UuidDefault>(data['data']);
     }
     if (dataClassName == 'UuidDefaultMix') {
-      return deserialize<_i59.UuidDefaultMix>(data['data']);
+      return deserialize<_i63.UuidDefaultMix>(data['data']);
     }
     if (dataClassName == 'UuidDefaultModel') {
-      return deserialize<_i60.UuidDefaultModel>(data['data']);
+      return deserialize<_i64.UuidDefaultModel>(data['data']);
     }
     if (dataClassName == 'UuidDefaultPersist') {
-      return deserialize<_i61.UuidDefaultPersist>(data['data']);
+      return deserialize<_i65.UuidDefaultPersist>(data['data']);
     }
     if (dataClassName == 'EmptyModel') {
-      return deserialize<_i62.EmptyModel>(data['data']);
+      return deserialize<_i66.EmptyModel>(data['data']);
     }
     if (dataClassName == 'EmptyModelRelationItem') {
-      return deserialize<_i63.EmptyModelRelationItem>(data['data']);
+      return deserialize<_i67.EmptyModelRelationItem>(data['data']);
     }
     if (dataClassName == 'EmptyModelWithTable') {
-      return deserialize<_i64.EmptyModelWithTable>(data['data']);
+      return deserialize<_i68.EmptyModelWithTable>(data['data']);
     }
     if (dataClassName == 'RelationEmptyModel') {
-      return deserialize<_i65.RelationEmptyModel>(data['data']);
+      return deserialize<_i69.RelationEmptyModel>(data['data']);
     }
     if (dataClassName == 'ExceptionWithData') {
-      return deserialize<_i66.ExceptionWithData>(data['data']);
+      return deserialize<_i70.ExceptionWithData>(data['data']);
     }
     if (dataClassName == 'ChildClassExplicitColumn') {
-      return deserialize<_i67.ChildClassExplicitColumn>(data['data']);
+      return deserialize<_i71.ChildClassExplicitColumn>(data['data']);
     }
     if (dataClassName == 'NonTableParentClass') {
-      return deserialize<_i68.NonTableParentClass>(data['data']);
+      return deserialize<_i72.NonTableParentClass>(data['data']);
     }
     if (dataClassName == 'ModifiedColumnName') {
-      return deserialize<_i69.ModifiedColumnName>(data['data']);
+      return deserialize<_i73.ModifiedColumnName>(data['data']);
     }
     if (dataClassName == 'Department') {
-      return deserialize<_i70.Department>(data['data']);
+      return deserialize<_i74.Department>(data['data']);
     }
     if (dataClassName == 'Employee') {
-      return deserialize<_i71.Employee>(data['data']);
+      return deserialize<_i75.Employee>(data['data']);
     }
     if (dataClassName == 'Contractor') {
-      return deserialize<_i72.Contractor>(data['data']);
+      return deserialize<_i76.Contractor>(data['data']);
     }
     if (dataClassName == 'Service') {
-      return deserialize<_i73.Service>(data['data']);
+      return deserialize<_i77.Service>(data['data']);
     }
     if (dataClassName == 'TableWithExplicitColumnName') {
-      return deserialize<_i74.TableWithExplicitColumnName>(data['data']);
+      return deserialize<_i78.TableWithExplicitColumnName>(data['data']);
     }
     if (dataClassName == 'ImmutableChildObject') {
-      return deserialize<_i75.ImmutableChildObject>(data['data']);
+      return deserialize<_i79.ImmutableChildObject>(data['data']);
     }
     if (dataClassName == 'ImmutableChildObjectWithNoAdditionalFields') {
-      return deserialize<_i76.ImmutableChildObjectWithNoAdditionalFields>(
+      return deserialize<_i80.ImmutableChildObjectWithNoAdditionalFields>(
         data['data'],
       );
     }
     if (dataClassName == 'ImmutableObject') {
-      return deserialize<_i77.ImmutableObject>(data['data']);
+      return deserialize<_i81.ImmutableObject>(data['data']);
     }
     if (dataClassName == 'ImmutableObjectWithImmutableObject') {
-      return deserialize<_i78.ImmutableObjectWithImmutableObject>(data['data']);
+      return deserialize<_i82.ImmutableObjectWithImmutableObject>(data['data']);
     }
     if (dataClassName == 'ImmutableObjectWithList') {
-      return deserialize<_i79.ImmutableObjectWithList>(data['data']);
+      return deserialize<_i83.ImmutableObjectWithList>(data['data']);
     }
     if (dataClassName == 'ImmutableObjectWithMap') {
-      return deserialize<_i80.ImmutableObjectWithMap>(data['data']);
+      return deserialize<_i84.ImmutableObjectWithMap>(data['data']);
     }
     if (dataClassName == 'ImmutableObjectWithMultipleFields') {
-      return deserialize<_i81.ImmutableObjectWithMultipleFields>(data['data']);
+      return deserialize<_i85.ImmutableObjectWithMultipleFields>(data['data']);
     }
     if (dataClassName == 'ImmutableObjectWithNoFields') {
-      return deserialize<_i82.ImmutableObjectWithNoFields>(data['data']);
+      return deserialize<_i86.ImmutableObjectWithNoFields>(data['data']);
     }
     if (dataClassName == 'ImmutableObjectWithRecord') {
-      return deserialize<_i83.ImmutableObjectWithRecord>(data['data']);
+      return deserialize<_i87.ImmutableObjectWithRecord>(data['data']);
     }
     if (dataClassName == 'ImmutableObjectWithTable') {
-      return deserialize<_i84.ImmutableObjectWithTable>(data['data']);
+      return deserialize<_i88.ImmutableObjectWithTable>(data['data']);
     }
     if (dataClassName == 'ImmutableObjectWithTwentyFields') {
-      return deserialize<_i85.ImmutableObjectWithTwentyFields>(data['data']);
+      return deserialize<_i89.ImmutableObjectWithTwentyFields>(data['data']);
     }
     if (dataClassName == 'ChildClass') {
-      return deserialize<_i86.ChildClass>(data['data']);
+      return deserialize<_i90.ChildClass>(data['data']);
     }
     if (dataClassName == 'ChildWithDefault') {
-      return deserialize<_i87.ChildWithDefault>(data['data']);
+      return deserialize<_i91.ChildWithDefault>(data['data']);
     }
     if (dataClassName == 'ChildClassWithoutId') {
-      return deserialize<_i88.ChildClassWithoutId>(data['data']);
+      return deserialize<_i92.ChildClassWithoutId>(data['data']);
     }
     if (dataClassName == 'ExtendedAppException') {
-      return deserialize<_i89.ExtendedAppException>(data['data']);
+      return deserialize<_i93.ExtendedAppException>(data['data']);
     }
     if (dataClassName == 'BaseAppException') {
-      return deserialize<_i90.BaseAppException>(data['data']);
+      return deserialize<_i94.BaseAppException>(data['data']);
     }
     if (dataClassName == 'NotFoundException') {
-      return deserialize<_i91.NotFoundException>(data['data']);
+      return deserialize<_i95.NotFoundException>(data['data']);
     }
     if (dataClassName == 'ValidationException') {
-      return deserialize<_i91.ValidationException>(data['data']);
+      return deserialize<_i95.ValidationException>(data['data']);
     }
     if (dataClassName == 'ParentClass') {
-      return deserialize<_i92.ParentClass>(data['data']);
+      return deserialize<_i96.ParentClass>(data['data']);
     }
     if (dataClassName == 'GrandparentClass') {
-      return deserialize<_i93.GrandparentClass>(data['data']);
+      return deserialize<_i97.GrandparentClass>(data['data']);
     }
     if (dataClassName == 'ParentClassWithoutId') {
-      return deserialize<_i94.ParentClassWithoutId>(data['data']);
+      return deserialize<_i98.ParentClassWithoutId>(data['data']);
     }
     if (dataClassName == 'GrandparentClassWithId') {
-      return deserialize<_i95.GrandparentClassWithId>(data['data']);
+      return deserialize<_i99.GrandparentClassWithId>(data['data']);
     }
     if (dataClassName == 'ChildEntity') {
-      return deserialize<_i96.ChildEntity>(data['data']);
+      return deserialize<_i100.ChildEntity>(data['data']);
     }
     if (dataClassName == 'BaseEntity') {
-      return deserialize<_i97.BaseEntity>(data['data']);
+      return deserialize<_i101.BaseEntity>(data['data']);
     }
     if (dataClassName == 'ParentEntity') {
-      return deserialize<_i98.ParentEntity>(data['data']);
+      return deserialize<_i102.ParentEntity>(data['data']);
     }
     if (dataClassName == 'NonServerOnlyParentClass') {
-      return deserialize<_i99.NonServerOnlyParentClass>(data['data']);
+      return deserialize<_i103.NonServerOnlyParentClass>(data['data']);
     }
     if (dataClassName == 'ParentWithDefault') {
-      return deserialize<_i100.ParentWithDefault>(data['data']);
+      return deserialize<_i104.ParentWithDefault>(data['data']);
     }
     if (dataClassName == 'PolymorphicGrandChild') {
-      return deserialize<_i101.PolymorphicGrandChild>(data['data']);
+      return deserialize<_i105.PolymorphicGrandChild>(data['data']);
     }
     if (dataClassName == 'PolymorphicChild') {
-      return deserialize<_i102.PolymorphicChild>(data['data']);
+      return deserialize<_i106.PolymorphicChild>(data['data']);
     }
     if (dataClassName == 'PolymorphicChildContainer') {
-      return deserialize<_i103.PolymorphicChildContainer>(data['data']);
+      return deserialize<_i107.PolymorphicChildContainer>(data['data']);
     }
     if (dataClassName == 'ModulePolymorphicChildContainer') {
-      return deserialize<_i104.ModulePolymorphicChildContainer>(data['data']);
+      return deserialize<_i108.ModulePolymorphicChildContainer>(data['data']);
     }
     if (dataClassName == 'SimilarButNotParent') {
-      return deserialize<_i105.SimilarButNotParent>(data['data']);
+      return deserialize<_i109.SimilarButNotParent>(data['data']);
     }
     if (dataClassName == 'PolymorphicParent') {
-      return deserialize<_i106.PolymorphicParent>(data['data']);
+      return deserialize<_i110.PolymorphicParent>(data['data']);
     }
     if (dataClassName == 'UnrelatedToPolymorphism') {
-      return deserialize<_i107.UnrelatedToPolymorphism>(data['data']);
+      return deserialize<_i111.UnrelatedToPolymorphism>(data['data']);
     }
     if (dataClassName == 'SealedGrandChild') {
-      return deserialize<_i108.SealedGrandChild>(data['data']);
+      return deserialize<_i112.SealedGrandChild>(data['data']);
     }
     if (dataClassName == 'SealedChild') {
-      return deserialize<_i108.SealedChild>(data['data']);
+      return deserialize<_i112.SealedChild>(data['data']);
     }
     if (dataClassName == 'SealedChildOnlyRequired') {
-      return deserialize<_i109.SealedChildOnlyRequired>(data['data']);
+      return deserialize<_i113.SealedChildOnlyRequired>(data['data']);
     }
     if (dataClassName == 'SealedOtherChild') {
-      return deserialize<_i108.SealedOtherChild>(data['data']);
+      return deserialize<_i112.SealedOtherChild>(data['data']);
     }
     if (dataClassName == 'CityWithLongTableName') {
-      return deserialize<_i110.CityWithLongTableName>(data['data']);
+      return deserialize<_i114.CityWithLongTableName>(data['data']);
     }
     if (dataClassName == 'OrganizationWithLongTableName') {
-      return deserialize<_i111.OrganizationWithLongTableName>(data['data']);
+      return deserialize<_i115.OrganizationWithLongTableName>(data['data']);
     }
     if (dataClassName == 'PersonWithLongTableName') {
-      return deserialize<_i112.PersonWithLongTableName>(data['data']);
+      return deserialize<_i116.PersonWithLongTableName>(data['data']);
     }
     if (dataClassName == 'MaxFieldName') {
-      return deserialize<_i113.MaxFieldName>(data['data']);
+      return deserialize<_i117.MaxFieldName>(data['data']);
     }
     if (dataClassName == 'LongImplicitIdField') {
-      return deserialize<_i114.LongImplicitIdField>(data['data']);
+      return deserialize<_i118.LongImplicitIdField>(data['data']);
     }
     if (dataClassName == 'LongImplicitIdFieldCollection') {
-      return deserialize<_i115.LongImplicitIdFieldCollection>(data['data']);
+      return deserialize<_i119.LongImplicitIdFieldCollection>(data['data']);
     }
     if (dataClassName == 'RelationToMultipleMaxFieldName') {
-      return deserialize<_i116.RelationToMultipleMaxFieldName>(data['data']);
+      return deserialize<_i120.RelationToMultipleMaxFieldName>(data['data']);
     }
     if (dataClassName == 'UserNote') {
-      return deserialize<_i117.UserNote>(data['data']);
+      return deserialize<_i121.UserNote>(data['data']);
     }
     if (dataClassName == 'UserNoteCollection') {
-      return deserialize<_i118.UserNoteCollection>(data['data']);
+      return deserialize<_i122.UserNoteCollection>(data['data']);
     }
     if (dataClassName == 'UserNoteCollectionWithALongName') {
-      return deserialize<_i119.UserNoteCollectionWithALongName>(data['data']);
+      return deserialize<_i123.UserNoteCollectionWithALongName>(data['data']);
     }
     if (dataClassName == 'UserNoteWithALongName') {
-      return deserialize<_i120.UserNoteWithALongName>(data['data']);
+      return deserialize<_i124.UserNoteWithALongName>(data['data']);
     }
     if (dataClassName == 'MultipleMaxFieldName') {
-      return deserialize<_i121.MultipleMaxFieldName>(data['data']);
+      return deserialize<_i125.MultipleMaxFieldName>(data['data']);
     }
     if (dataClassName == 'City') {
-      return deserialize<_i122.City>(data['data']);
+      return deserialize<_i126.City>(data['data']);
     }
     if (dataClassName == 'Organization') {
-      return deserialize<_i123.Organization>(data['data']);
+      return deserialize<_i127.Organization>(data['data']);
     }
     if (dataClassName == 'Person') {
-      return deserialize<_i124.Person>(data['data']);
+      return deserialize<_i128.Person>(data['data']);
     }
     if (dataClassName == 'BleedChild') {
-      return deserialize<_i125.BleedChild>(data['data']);
+      return deserialize<_i129.BleedChild>(data['data']);
     }
     if (dataClassName == 'BleedRoot') {
-      return deserialize<_i126.BleedRoot>(data['data']);
+      return deserialize<_i130.BleedRoot>(data['data']);
     }
     if (dataClassName == 'Course') {
-      return deserialize<_i127.Course>(data['data']);
+      return deserialize<_i131.Course>(data['data']);
     }
     if (dataClassName == 'Enrollment') {
-      return deserialize<_i128.Enrollment>(data['data']);
+      return deserialize<_i132.Enrollment>(data['data']);
     }
     if (dataClassName == 'Student') {
-      return deserialize<_i129.Student>(data['data']);
+      return deserialize<_i133.Student>(data['data']);
     }
     if (dataClassName == 'ObjectUser') {
-      return deserialize<_i130.ObjectUser>(data['data']);
+      return deserialize<_i134.ObjectUser>(data['data']);
     }
     if (dataClassName == 'ParentUser') {
-      return deserialize<_i131.ParentUser>(data['data']);
+      return deserialize<_i135.ParentUser>(data['data']);
     }
     if (dataClassName == 'Arena') {
-      return deserialize<_i132.Arena>(data['data']);
+      return deserialize<_i136.Arena>(data['data']);
     }
     if (dataClassName == 'Player') {
-      return deserialize<_i133.Player>(data['data']);
+      return deserialize<_i137.Player>(data['data']);
     }
     if (dataClassName == 'Team') {
-      return deserialize<_i134.Team>(data['data']);
+      return deserialize<_i138.Team>(data['data']);
     }
     if (dataClassName == 'Comment') {
-      return deserialize<_i135.Comment>(data['data']);
+      return deserialize<_i139.Comment>(data['data']);
     }
     if (dataClassName == 'Customer') {
-      return deserialize<_i136.Customer>(data['data']);
+      return deserialize<_i140.Customer>(data['data']);
     }
     if (dataClassName == 'Book') {
-      return deserialize<_i137.Book>(data['data']);
+      return deserialize<_i141.Book>(data['data']);
     }
     if (dataClassName == 'Chapter') {
-      return deserialize<_i138.Chapter>(data['data']);
+      return deserialize<_i142.Chapter>(data['data']);
     }
     if (dataClassName == 'Order') {
-      return deserialize<_i139.Order>(data['data']);
+      return deserialize<_i143.Order>(data['data']);
     }
     if (dataClassName == 'Address') {
-      return deserialize<_i140.Address>(data['data']);
+      return deserialize<_i144.Address>(data['data']);
     }
     if (dataClassName == 'Citizen') {
-      return deserialize<_i141.Citizen>(data['data']);
+      return deserialize<_i145.Citizen>(data['data']);
     }
     if (dataClassName == 'Company') {
-      return deserialize<_i142.Company>(data['data']);
+      return deserialize<_i146.Company>(data['data']);
     }
     if (dataClassName == 'Town') {
-      return deserialize<_i143.Town>(data['data']);
+      return deserialize<_i147.Town>(data['data']);
     }
     if (dataClassName == 'Blocking') {
-      return deserialize<_i144.Blocking>(data['data']);
+      return deserialize<_i148.Blocking>(data['data']);
     }
     if (dataClassName == 'Member') {
-      return deserialize<_i145.Member>(data['data']);
+      return deserialize<_i149.Member>(data['data']);
     }
     if (dataClassName == 'Cat') {
-      return deserialize<_i146.Cat>(data['data']);
+      return deserialize<_i150.Cat>(data['data']);
     }
     if (dataClassName == 'Post') {
-      return deserialize<_i147.Post>(data['data']);
+      return deserialize<_i151.Post>(data['data']);
     }
     if (dataClassName == 'ModuleDatatype') {
-      return deserialize<_i148.ModuleDatatype>(data['data']);
+      return deserialize<_i152.ModuleDatatype>(data['data']);
     }
     if (dataClassName == 'MyFeatureModel') {
-      return deserialize<_i149.MyFeatureModel>(data['data']);
+      return deserialize<_i153.MyFeatureModel>(data['data']);
     }
     if (dataClassName == 'MyTriggerType') {
-      return deserialize<_i150.MyTriggerType>(data['data']);
+      return deserialize<_i154.MyTriggerType>(data['data']);
     }
     if (dataClassName == 'Nullability') {
-      return deserialize<_i151.Nullability>(data['data']);
+      return deserialize<_i155.Nullability>(data['data']);
     }
     if (dataClassName == 'NullsDistinctData') {
-      return deserialize<_i152.NullsDistinctData>(data['data']);
+      return deserialize<_i156.NullsDistinctData>(data['data']);
     }
     if (dataClassName == 'ObjectFieldPersist') {
-      return deserialize<_i153.ObjectFieldPersist>(data['data']);
+      return deserialize<_i157.ObjectFieldPersist>(data['data']);
     }
     if (dataClassName == 'ObjectFieldScopes') {
-      return deserialize<_i154.ObjectFieldScopes>(data['data']);
+      return deserialize<_i158.ObjectFieldScopes>(data['data']);
     }
     if (dataClassName == 'ObjectWithBit') {
-      return deserialize<_i155.ObjectWithBit>(data['data']);
+      return deserialize<_i159.ObjectWithBit>(data['data']);
     }
     if (dataClassName == 'ObjectWithByteData') {
-      return deserialize<_i156.ObjectWithByteData>(data['data']);
+      return deserialize<_i160.ObjectWithByteData>(data['data']);
     }
     if (dataClassName == 'ObjectWithCustomClass') {
-      return deserialize<_i157.ObjectWithCustomClass>(data['data']);
+      return deserialize<_i161.ObjectWithCustomClass>(data['data']);
     }
     if (dataClassName == 'ObjectWithDuration') {
-      return deserialize<_i158.ObjectWithDuration>(data['data']);
+      return deserialize<_i162.ObjectWithDuration>(data['data']);
     }
     if (dataClassName == 'ObjectWithDynamic') {
-      return deserialize<_i159.ObjectWithDynamic>(data['data']);
+      return deserialize<_i163.ObjectWithDynamic>(data['data']);
     }
     if (dataClassName == 'ObjectWithEnum') {
-      return deserialize<_i160.ObjectWithEnum>(data['data']);
+      return deserialize<_i164.ObjectWithEnum>(data['data']);
     }
     if (dataClassName == 'ObjectWithEnumEnhanced') {
-      return deserialize<_i161.ObjectWithEnumEnhanced>(data['data']);
+      return deserialize<_i165.ObjectWithEnumEnhanced>(data['data']);
     }
     if (dataClassName == 'ObjectWithGeographyGeometryCollection') {
-      return deserialize<_i162.ObjectWithGeographyGeometryCollection>(
+      return deserialize<_i166.ObjectWithGeographyGeometryCollection>(
         data['data'],
       );
     }
     if (dataClassName == 'ObjectWithGeographyLineString') {
-      return deserialize<_i163.ObjectWithGeographyLineString>(data['data']);
+      return deserialize<_i167.ObjectWithGeographyLineString>(data['data']);
     }
     if (dataClassName == 'ObjectWithGeographyPoint') {
-      return deserialize<_i164.ObjectWithGeographyPoint>(data['data']);
+      return deserialize<_i168.ObjectWithGeographyPoint>(data['data']);
     }
     if (dataClassName == 'ObjectWithGeographyPolygon') {
-      return deserialize<_i165.ObjectWithGeographyPolygon>(data['data']);
+      return deserialize<_i169.ObjectWithGeographyPolygon>(data['data']);
     }
     if (dataClassName == 'ObjectWithHalfVector') {
-      return deserialize<_i166.ObjectWithHalfVector>(data['data']);
+      return deserialize<_i170.ObjectWithHalfVector>(data['data']);
     }
     if (dataClassName == 'ObjectWithIndex') {
-      return deserialize<_i167.ObjectWithIndex>(data['data']);
+      return deserialize<_i171.ObjectWithIndex>(data['data']);
     }
     if (dataClassName == 'ObjectWithJsonb') {
-      return deserialize<_i168.ObjectWithJsonb>(data['data']);
+      return deserialize<_i172.ObjectWithJsonb>(data['data']);
     }
     if (dataClassName == 'ObjectWithJsonbClassLevel') {
-      return deserialize<_i169.ObjectWithJsonbClassLevel>(data['data']);
+      return deserialize<_i173.ObjectWithJsonbClassLevel>(data['data']);
     }
     if (dataClassName == 'ObjectWithMaps') {
-      return deserialize<_i170.ObjectWithMaps>(data['data']);
+      return deserialize<_i174.ObjectWithMaps>(data['data']);
     }
     if (dataClassName == 'ObjectWithNullableCustomClass') {
-      return deserialize<_i171.ObjectWithNullableCustomClass>(data['data']);
+      return deserialize<_i175.ObjectWithNullableCustomClass>(data['data']);
     }
     if (dataClassName == 'ObjectWithObject') {
-      return deserialize<_i172.ObjectWithObject>(data['data']);
+      return deserialize<_i176.ObjectWithObject>(data['data']);
     }
     if (dataClassName == 'ObjectWithParent') {
-      return deserialize<_i173.ObjectWithParent>(data['data']);
+      return deserialize<_i177.ObjectWithParent>(data['data']);
     }
     if (dataClassName == 'ObjectWithSealedClass') {
-      return deserialize<_i174.ObjectWithSealedClass>(data['data']);
+      return deserialize<_i178.ObjectWithSealedClass>(data['data']);
     }
     if (dataClassName == 'ObjectWithSealedException') {
-      return deserialize<_i175.ObjectWithSealedException>(data['data']);
+      return deserialize<_i179.ObjectWithSealedException>(data['data']);
     }
     if (dataClassName == 'ObjectWithSelfParent') {
-      return deserialize<_i176.ObjectWithSelfParent>(data['data']);
+      return deserialize<_i180.ObjectWithSelfParent>(data['data']);
     }
     if (dataClassName == 'ObjectWithSparseVector') {
-      return deserialize<_i177.ObjectWithSparseVector>(data['data']);
+      return deserialize<_i181.ObjectWithSparseVector>(data['data']);
     }
     if (dataClassName == 'ObjectWithUuid') {
-      return deserialize<_i178.ObjectWithUuid>(data['data']);
+      return deserialize<_i182.ObjectWithUuid>(data['data']);
     }
     if (dataClassName == 'ObjectWithVector') {
-      return deserialize<_i179.ObjectWithVector>(data['data']);
+      return deserialize<_i183.ObjectWithVector>(data['data']);
     }
     if (dataClassName == 'Record') {
-      return deserialize<_i180.Record>(data['data']);
+      return deserialize<_i184.Record>(data['data']);
     }
     if (dataClassName == 'RelatedUniqueData') {
-      return deserialize<_i181.RelatedUniqueData>(data['data']);
+      return deserialize<_i185.RelatedUniqueData>(data['data']);
     }
     if (dataClassName == 'ExceptionWithRequiredField') {
-      return deserialize<_i182.ExceptionWithRequiredField>(data['data']);
+      return deserialize<_i186.ExceptionWithRequiredField>(data['data']);
     }
     if (dataClassName == 'ModelWithRequiredField') {
-      return deserialize<_i183.ModelWithRequiredField>(data['data']);
+      return deserialize<_i187.ModelWithRequiredField>(data['data']);
     }
     if (dataClassName == 'ScopeNoneFields') {
-      return deserialize<_i184.ScopeNoneFields>(data['data']);
+      return deserialize<_i188.ScopeNoneFields>(data['data']);
     }
     if (dataClassName == 'ScopeServerOnlyFieldChild') {
-      return deserialize<_i185.ScopeServerOnlyFieldChild>(data['data']);
+      return deserialize<_i189.ScopeServerOnlyFieldChild>(data['data']);
     }
     if (dataClassName == 'ScopeServerOnlyField') {
-      return deserialize<_i186.ScopeServerOnlyField>(data['data']);
+      return deserialize<_i190.ScopeServerOnlyField>(data['data']);
     }
     if (dataClassName == 'DefaultServerOnlyClass') {
-      return deserialize<_i187.DefaultServerOnlyClass>(data['data']);
+      return deserialize<_i191.DefaultServerOnlyClass>(data['data']);
     }
     if (dataClassName == 'DefaultServerOnlyEnum') {
-      return deserialize<_i188.DefaultServerOnlyEnum>(data['data']);
+      return deserialize<_i192.DefaultServerOnlyEnum>(data['data']);
     }
     if (dataClassName == 'NotServerOnlyClass') {
-      return deserialize<_i189.NotServerOnlyClass>(data['data']);
+      return deserialize<_i193.NotServerOnlyClass>(data['data']);
     }
     if (dataClassName == 'NotServerOnlyEnum') {
-      return deserialize<_i190.NotServerOnlyEnum>(data['data']);
+      return deserialize<_i194.NotServerOnlyEnum>(data['data']);
     }
     if (dataClassName == 'ServerOnlyClassField') {
-      return deserialize<_i191.ServerOnlyClassField>(data['data']);
+      return deserialize<_i195.ServerOnlyClassField>(data['data']);
     }
     if (dataClassName == 'ServerOnlyDefault') {
-      return deserialize<_i192.ServerOnlyDefault>(data['data']);
+      return deserialize<_i196.ServerOnlyDefault>(data['data']);
     }
     if (dataClassName == 'SessionAuthInfo') {
-      return deserialize<_i193.SessionAuthInfo>(data['data']);
+      return deserialize<_i197.SessionAuthInfo>(data['data']);
     }
     if (dataClassName == 'SharedModelContainer') {
-      return deserialize<_i194.SharedModelContainer>(data['data']);
+      return deserialize<_i198.SharedModelContainer>(data['data']);
     }
     if (dataClassName == 'SharedModelSubclass') {
-      return deserialize<_i195.SharedModelSubclass>(data['data']);
+      return deserialize<_i199.SharedModelSubclass>(data['data']);
     }
     if (dataClassName == 'SimpleData') {
-      return deserialize<_i196.SimpleData>(data['data']);
+      return deserialize<_i200.SimpleData>(data['data']);
     }
     if (dataClassName == 'SimpleDataList') {
-      return deserialize<_i197.SimpleDataList>(data['data']);
+      return deserialize<_i201.SimpleDataList>(data['data']);
     }
     if (dataClassName == 'SimpleDataMap') {
-      return deserialize<_i198.SimpleDataMap>(data['data']);
+      return deserialize<_i202.SimpleDataMap>(data['data']);
     }
     if (dataClassName == 'SimpleDataObject') {
-      return deserialize<_i199.SimpleDataObject>(data['data']);
+      return deserialize<_i203.SimpleDataObject>(data['data']);
     }
     if (dataClassName == 'SimpleDateTime') {
-      return deserialize<_i200.SimpleDateTime>(data['data']);
+      return deserialize<_i204.SimpleDateTime>(data['data']);
     }
     if (dataClassName == 'ModelInSubfolder') {
-      return deserialize<_i201.ModelInSubfolder>(data['data']);
+      return deserialize<_i205.ModelInSubfolder>(data['data']);
     }
     if (dataClassName == 'TestEnum') {
-      return deserialize<_i202.TestEnum>(data['data']);
+      return deserialize<_i206.TestEnum>(data['data']);
     }
     if (dataClassName == 'TestEnumDefaultSerialization') {
-      return deserialize<_i203.TestEnumDefaultSerialization>(data['data']);
+      return deserialize<_i207.TestEnumDefaultSerialization>(data['data']);
     }
     if (dataClassName == 'TestEnumEnhanced') {
-      return deserialize<_i204.TestEnumEnhanced>(data['data']);
+      return deserialize<_i208.TestEnumEnhanced>(data['data']);
     }
     if (dataClassName == 'TestEnumEnhancedByName') {
-      return deserialize<_i205.TestEnumEnhancedByName>(data['data']);
+      return deserialize<_i209.TestEnumEnhancedByName>(data['data']);
     }
     if (dataClassName == 'TestEnumStringified') {
-      return deserialize<_i206.TestEnumStringified>(data['data']);
+      return deserialize<_i210.TestEnumStringified>(data['data']);
     }
     if (dataClassName == 'Types') {
-      return deserialize<_i207.Types>(data['data']);
+      return deserialize<_i211.Types>(data['data']);
     }
     if (dataClassName == 'TypesList') {
-      return deserialize<_i208.TypesList>(data['data']);
+      return deserialize<_i212.TypesList>(data['data']);
     }
     if (dataClassName == 'TypesMap') {
-      return deserialize<_i209.TypesMap>(data['data']);
+      return deserialize<_i213.TypesMap>(data['data']);
     }
     if (dataClassName == 'TypesRecord') {
-      return deserialize<_i210.TypesRecord>(data['data']);
+      return deserialize<_i214.TypesRecord>(data['data']);
     }
     if (dataClassName == 'TypesSet') {
-      return deserialize<_i211.TypesSet>(data['data']);
+      return deserialize<_i215.TypesSet>(data['data']);
     }
     if (dataClassName == 'TypesSetRequired') {
-      return deserialize<_i212.TypesSetRequired>(data['data']);
+      return deserialize<_i216.TypesSetRequired>(data['data']);
     }
     if (dataClassName == 'UniqueData') {
-      return deserialize<_i213.UniqueData>(data['data']);
+      return deserialize<_i217.UniqueData>(data['data']);
     }
     if (dataClassName == 'UniqueDataWithNonPersist') {
-      return deserialize<_i214.UniqueDataWithNonPersist>(data['data']);
+      return deserialize<_i218.UniqueDataWithNonPersist>(data['data']);
     }
     if (dataClassName == 'UpsertTestModel') {
-      return deserialize<_i215.UpsertTestModel>(data['data']);
+      return deserialize<_i219.UpsertTestModel>(data['data']);
     }
     if (dataClassName.startsWith('serverpod_auth.')) {
       data['className'] = dataClassName.substring(15);
-      return _i221.Protocol().deserializeByClassName(data);
+      return _i2.Protocol().deserializeByClassName(data);
     }
     if (dataClassName.startsWith('serverpod_test_module.')) {
       data['className'] = dataClassName.substring(22);
-      return _i216.Protocol().deserializeByClassName(data);
+      return _i3.Protocol().deserializeByClassName(data);
     }
     if (dataClassName.startsWith('serverpod_test_shared_module.')) {
       data['className'] = dataClassName.substring(29);
-      return _i224.Protocol().deserializeByClassName(data);
+      return _i4.Protocol().deserializeByClassName(data);
     }
     if (dataClassName.startsWith('serverpod_test_shared.')) {
       data['className'] = dataClassName.substring(22);
-      return _i218.Protocol().deserializeByClassName(data);
+      return _i5.Protocol().deserializeByClassName(data);
     }
     if (dataClassName == 'List<int>') {
       return deserialize<List<int>>(data['data']);
     }
     if (dataClassName == 'List<SimpleData>') {
-      return deserialize<List<_i219.SimpleData>>(data['data']);
+      return deserialize<List<_i220.SimpleData>>(data['data']);
     }
     if (dataClassName == 'List<serverpod_auth.UserInfo>') {
-      return deserialize<List<_i221.UserInfo>>(data['data']);
+      return deserialize<List<_i2.UserInfo>>(data['data']);
     }
     if (dataClassName == 'List<SimpleData>?') {
-      return deserialize<List<_i219.SimpleData>?>(data['data']);
+      return deserialize<List<_i220.SimpleData>?>(data['data']);
     }
     if (dataClassName == 'List<SimpleData?>') {
-      return deserialize<List<_i219.SimpleData?>>(data['data']);
+      return deserialize<List<_i220.SimpleData?>>(data['data']);
     }
     if (dataClassName == 'Set<int>') {
       return deserialize<Set<int>>(data['data']);
     }
     if (dataClassName == 'Set<SimpleData>') {
-      return deserialize<Set<_i219.SimpleData>>(data['data']);
+      return deserialize<Set<_i220.SimpleData>>(data['data']);
     }
     if (dataClassName == 'List<Set<SimpleData>>') {
-      return deserialize<List<Set<_i219.SimpleData>>>(data['data']);
+      return deserialize<List<Set<_i220.SimpleData>>>(data['data']);
     }
     if (dataClassName == '(String,PolymorphicParent)') {
-      return deserialize<(String, _i222.PolymorphicParent)>(data['data']);
+      return deserialize<(String, _i221.PolymorphicParent)>(data['data']);
     }
     if (dataClassName == '(int?,)?') {
       return deserialize<(int?,)?>(data['data']);
@@ -7456,17 +2050,17 @@ class Protocol extends _i1.SerializationManager {
     if (dataClassName ==
         'List<((int,String),{(SimpleData,double) namedSubRecord})?>?') {
       return deserialize<
-        List<((int, String), {(_i219.SimpleData, double) namedSubRecord})?>?
+        List<((int, String), {(_i220.SimpleData, double) namedSubRecord})?>?
       >(data['data']);
     }
     if (dataClassName ==
         '(int?,serverpod_test_module.ProjectStreamingClass?)') {
-      return deserialize<(int?, _i216.ProjectStreamingClass?)>(data['data']);
+      return deserialize<(int?, _i3.ProjectStreamingClass?)>(data['data']);
     }
     if (dataClassName ==
         '(String,(Map<String,int>,{bool flag,SimpleData simpleData}))') {
       return deserialize<
-        (String, (Map<String, int>, {bool flag, _i219.SimpleData simpleData}))
+        (String, (Map<String, int>, {bool flag, _i220.SimpleData simpleData}))
       >(data['data']);
     }
     if (dataClassName == 'List<(String,int)>') {
@@ -7475,7 +2069,7 @@ class Protocol extends _i1.SerializationManager {
     if (dataClassName ==
         '(String,(Map<String,int>,{bool flag,SimpleData simpleData}))?') {
       return deserialize<
-        (String, (Map<String, int>, {bool flag, _i219.SimpleData simpleData}))?
+        (String, (Map<String, int>, {bool flag, _i220.SimpleData simpleData}))?
       >(data['data']);
     }
     if (dataClassName == 'List<(String,int)>?') {
@@ -7485,10 +2079,10 @@ class Protocol extends _i1.SerializationManager {
   }
 
   void _registerHostProtocols() {
-    _i221.Protocol().registerHostProtocol('serverpod_test', this);
-    _i216.Protocol().registerHostProtocol('serverpod_test', this);
-    _i224.Protocol().registerHostProtocol('serverpod_test', this);
-    _i218.Protocol().registerHostProtocol('serverpod_test', this);
+    _i2.Protocol().registerHostProtocol('serverpod_test', this);
+    _i3.Protocol().registerHostProtocol('serverpod_test', this);
+    _i4.Protocol().registerHostProtocol('serverpod_test', this);
+    _i5.Protocol().registerHostProtocol('serverpod_test', this);
   }
 
   @override
@@ -7548,7 +2142,7 @@ class Protocol extends _i1.SerializationManager {
         ],
       };
     }
-    if (record is (String, _i222.PolymorphicParent)) {
+    if (record is (String, _i221.PolymorphicParent)) {
       return {
         "p": [
           record.$1,
@@ -7578,7 +2172,7 @@ class Protocol extends _i1.SerializationManager {
         ],
       };
     }
-    if (record is (int, _i219.SimpleData)) {
+    if (record is (int, _i220.SimpleData)) {
       return {
         "p": [
           record.$1,
@@ -7608,7 +2202,7 @@ class Protocol extends _i1.SerializationManager {
         },
       };
     }
-    if (record is ({_i219.SimpleData data, int number})) {
+    if (record is ({_i220.SimpleData data, int number})) {
       return {
         "n": {
           "data": record.data.toJson(),
@@ -7616,7 +2210,7 @@ class Protocol extends _i1.SerializationManager {
         },
       };
     }
-    if (record is ({_i219.SimpleData? data, int? number})) {
+    if (record is ({_i220.SimpleData? data, int? number})) {
       return {
         "n": {
           "data": record.data?.toJson(),
@@ -7652,7 +2246,7 @@ class Protocol extends _i1.SerializationManager {
         ],
       };
     }
-    if (record is (int, {_i219.SimpleData data})) {
+    if (record is (int, {_i220.SimpleData data})) {
       return {
         "p": [
           record.$1,
@@ -7670,14 +2264,14 @@ class Protocol extends _i1.SerializationManager {
         ],
       };
     }
-    if (record is ({(_i219.SimpleData, double) namedSubRecord})) {
+    if (record is ({(_i220.SimpleData, double) namedSubRecord})) {
       return {
         "n": {
           "namedSubRecord": mapRecordToJson(record.namedSubRecord),
         },
       };
     }
-    if (record is (_i219.SimpleData, double)) {
+    if (record is (_i220.SimpleData, double)) {
       return {
         "p": [
           record.$1.toJson(),
@@ -7685,7 +2279,7 @@ class Protocol extends _i1.SerializationManager {
         ],
       };
     }
-    if (record is ({(_i219.SimpleData, double)? namedSubRecord})) {
+    if (record is ({(_i220.SimpleData, double)? namedSubRecord})) {
       return {
         "n": {
           "namedSubRecord": mapRecordToJson(record.namedSubRecord),
@@ -7693,7 +2287,7 @@ class Protocol extends _i1.SerializationManager {
       };
     }
     if (record
-        is ((int, String), {(_i219.SimpleData, double) namedSubRecord})) {
+        is ((int, String), {(_i220.SimpleData, double) namedSubRecord})) {
       return {
         "p": [
           mapRecordToJson(record.$1),
@@ -7703,7 +2297,7 @@ class Protocol extends _i1.SerializationManager {
         },
       };
     }
-    if (record is (int?, _i216.ProjectStreamingClass?)) {
+    if (record is (int?, _i3.ProjectStreamingClass?)) {
       return {
         "p": [
           record.$1,
@@ -7730,7 +2324,7 @@ class Protocol extends _i1.SerializationManager {
     if (record
         is (
           String,
-          (Map<String, int>, {bool flag, _i219.SimpleData simpleData}),
+          (Map<String, int>, {bool flag, _i220.SimpleData simpleData}),
         )) {
       return {
         "p": [
@@ -7740,7 +2334,7 @@ class Protocol extends _i1.SerializationManager {
       };
     }
     if (record
-        is (Map<String, int>, {bool flag, _i219.SimpleData simpleData})) {
+        is (Map<String, int>, {bool flag, _i220.SimpleData simpleData})) {
       return {
         "p": [
           record.$1.toJson(),
@@ -7759,7 +2353,7 @@ class Protocol extends _i1.SerializationManager {
         ],
       };
     }
-    if (record is (_i216.ModuleClass,)) {
+    if (record is (_i3.ModuleClass,)) {
       return {
         "p": [
           record.$1.toJson(),
@@ -7773,35 +2367,35 @@ class Protocol extends _i1.SerializationManager {
         ],
       };
     }
-    if (record is (_i206.TestEnumStringified,)) {
+    if (record is (_i210.TestEnumStringified,)) {
       return {
         "p": [
           record.$1.toJson(),
         ],
       };
     }
-    if (record is (_i151.Nullability,)) {
+    if (record is (_i155.Nullability,)) {
       return {
         "p": [
           record.$1.toJson(),
         ],
       };
     }
-    if (record is ({_i206.TestEnumStringified value})) {
+    if (record is ({_i210.TestEnumStringified value})) {
       return {
         "n": {
           "value": record.value.toJson(),
         },
       };
     }
-    if (record is ({_i216.ModuleClass value})) {
+    if (record is ({_i3.ModuleClass value})) {
       return {
         "n": {
           "value": record.value.toJson(),
         },
       };
     }
-    if (record is ({_i151.Nullability value})) {
+    if (record is ({_i155.Nullability value})) {
       return {
         "n": {
           "value": record.value.toJson(),
@@ -7818,7 +2412,7 @@ class Protocol extends _i1.SerializationManager {
         },
       };
     }
-    if (record is (_i202.TestEnum,)) {
+    if (record is (_i206.TestEnum,)) {
       return {
         "p": [
           record.$1.toJson(),
@@ -7846,7 +2440,7 @@ class Protocol extends _i1.SerializationManager {
         ],
       };
     }
-    if (record is (_i217.ByteData,)) {
+    if (record is (_i222.ByteData,)) {
       return {
         "p": [
           record.$1.toJson(),
@@ -7902,21 +2496,21 @@ class Protocol extends _i1.SerializationManager {
         ],
       };
     }
-    if (record is (_i196.SimpleData,)) {
+    if (record is (_i200.SimpleData,)) {
       return {
         "p": [
           record.$1.toJson(),
         ],
       };
     }
-    if (record is ({_i196.SimpleData namedModel})) {
+    if (record is ({_i200.SimpleData namedModel})) {
       return {
         "n": {
           "namedModel": record.namedModel.toJson(),
         },
       };
     }
-    if (record is (_i196.SimpleData, {_i196.SimpleData namedModel})) {
+    if (record is (_i200.SimpleData, {_i200.SimpleData namedModel})) {
       return {
         "p": [
           record.$1.toJson(),
@@ -7938,8 +2532,8 @@ class Protocol extends _i1.SerializationManager {
     }
     if (record
         is (
-          (List<(_i196.SimpleData,)>,), {
-          (_i196.SimpleData, Map<String, _i196.SimpleData>) namedNestedRecord,
+          (List<(_i200.SimpleData,)>,), {
+          (_i200.SimpleData, Map<String, _i200.SimpleData>) namedNestedRecord,
         })) {
       return {
         "p": [
@@ -7950,14 +2544,14 @@ class Protocol extends _i1.SerializationManager {
         },
       };
     }
-    if (record is (List<(_i196.SimpleData,)>,)) {
+    if (record is (List<(_i200.SimpleData,)>,)) {
       return {
         "p": [
           mapContainerToJson(record.$1),
         ],
       };
     }
-    if (record is (_i196.SimpleData, Map<String, _i196.SimpleData>)) {
+    if (record is (_i200.SimpleData, Map<String, _i200.SimpleData>)) {
       return {
         "p": [
           record.$1.toJson(),
@@ -7966,13 +2560,13 @@ class Protocol extends _i1.SerializationManager {
       };
     }
     try {
-      return _i221.Protocol().mapRecordToJson(record);
+      return _i2.Protocol().mapRecordToJson(record);
     } catch (_) {}
     try {
-      return _i216.Protocol().mapRecordToJson(record);
+      return _i3.Protocol().mapRecordToJson(record);
     } catch (_) {}
     try {
-      return _i224.Protocol().mapRecordToJson(record);
+      return _i4.Protocol().mapRecordToJson(record);
     } catch (_) {}
     throw Exception('Unsupported record type ${record.runtimeType}');
   }
@@ -8027,5 +2621,4205 @@ class Protocol extends _i1.SerializationManager {
     }
 
     return obj;
+  }
+
+  static Map<Type, dynamic Function(dynamic, Protocol)> _buildDeserializers() {
+    final map = <Type, dynamic Function(dynamic, Protocol)>{};
+    map[_i6.ByIndexEnumWithNameValue] = (data, protocol) =>
+        _i6.ByIndexEnumWithNameValue.fromJson(data);
+    map[_i7.ByNameEnumWithNameValue] = (data, protocol) =>
+        _i7.ByNameEnumWithNameValue.fromJson(data);
+    map[_i8.CourseUuid] = (data, protocol) => _i8.CourseUuid.fromJson(data);
+    map[_i9.EnrollmentInt] = (data, protocol) =>
+        _i9.EnrollmentInt.fromJson(data);
+    map[_i10.StudentUuid] = (data, protocol) => _i10.StudentUuid.fromJson(data);
+    map[_i11.ArenaUuid] = (data, protocol) => _i11.ArenaUuid.fromJson(data);
+    map[_i12.PlayerUuid] = (data, protocol) => _i12.PlayerUuid.fromJson(data);
+    map[_i13.TeamInt] = (data, protocol) => _i13.TeamInt.fromJson(data);
+    map[_i14.CommentInt] = (data, protocol) => _i14.CommentInt.fromJson(data);
+    map[_i15.CustomerInt] = (data, protocol) => _i15.CustomerInt.fromJson(data);
+    map[_i16.OrderUuid] = (data, protocol) => _i16.OrderUuid.fromJson(data);
+    map[_i17.AddressUuid] = (data, protocol) => _i17.AddressUuid.fromJson(data);
+    map[_i18.CitizenInt] = (data, protocol) => _i18.CitizenInt.fromJson(data);
+    map[_i19.CompanyUuid] = (data, protocol) => _i19.CompanyUuid.fromJson(data);
+    map[_i20.TownInt] = (data, protocol) => _i20.TownInt.fromJson(data);
+    map[_i21.ChangedIdTypeSelf] = (data, protocol) =>
+        _i21.ChangedIdTypeSelf.fromJson(data);
+    map[_i22.BigIntDefault] = (data, protocol) =>
+        _i22.BigIntDefault.fromJson(data);
+    map[_i23.BigIntDefaultMix] = (data, protocol) =>
+        _i23.BigIntDefaultMix.fromJson(data);
+    map[_i24.BigIntDefaultModel] = (data, protocol) =>
+        _i24.BigIntDefaultModel.fromJson(data);
+    map[_i25.BigIntDefaultPersist] = (data, protocol) =>
+        _i25.BigIntDefaultPersist.fromJson(data);
+    map[_i26.BoolDefault] = (data, protocol) => _i26.BoolDefault.fromJson(data);
+    map[_i27.BoolDefaultMix] = (data, protocol) =>
+        _i27.BoolDefaultMix.fromJson(data);
+    map[_i28.BoolDefaultModel] = (data, protocol) =>
+        _i28.BoolDefaultModel.fromJson(data);
+    map[_i29.BoolDefaultPersist] = (data, protocol) =>
+        _i29.BoolDefaultPersist.fromJson(data);
+    map[_i30.DateTimeDefault] = (data, protocol) =>
+        _i30.DateTimeDefault.fromJson(data);
+    map[_i31.DateTimeDefaultMix] = (data, protocol) =>
+        _i31.DateTimeDefaultMix.fromJson(data);
+    map[_i32.DateTimeDefaultModel] = (data, protocol) =>
+        _i32.DateTimeDefaultModel.fromJson(data);
+    map[_i33.DateTimeDefaultPersist] = (data, protocol) =>
+        _i33.DateTimeDefaultPersist.fromJson(data);
+    map[_i34.DoubleDefault] = (data, protocol) =>
+        _i34.DoubleDefault.fromJson(data);
+    map[_i35.DoubleDefaultMix] = (data, protocol) =>
+        _i35.DoubleDefaultMix.fromJson(data);
+    map[_i36.DoubleDefaultModel] = (data, protocol) =>
+        _i36.DoubleDefaultModel.fromJson(data);
+    map[_i37.DoubleDefaultPersist] = (data, protocol) =>
+        _i37.DoubleDefaultPersist.fromJson(data);
+    map[_i38.DurationDefault] = (data, protocol) =>
+        _i38.DurationDefault.fromJson(data);
+    map[_i39.DurationDefaultMix] = (data, protocol) =>
+        _i39.DurationDefaultMix.fromJson(data);
+    map[_i40.DurationDefaultModel] = (data, protocol) =>
+        _i40.DurationDefaultModel.fromJson(data);
+    map[_i41.DurationDefaultPersist] = (data, protocol) =>
+        _i41.DurationDefaultPersist.fromJson(data);
+    map[_i42.EnumDefault] = (data, protocol) => _i42.EnumDefault.fromJson(data);
+    map[_i43.EnumDefaultMix] = (data, protocol) =>
+        _i43.EnumDefaultMix.fromJson(data);
+    map[_i44.EnumDefaultModel] = (data, protocol) =>
+        _i44.EnumDefaultModel.fromJson(data);
+    map[_i45.EnumDefaultPersist] = (data, protocol) =>
+        _i45.EnumDefaultPersist.fromJson(data);
+    map[_i46.ByIndexEnum] = (data, protocol) => _i46.ByIndexEnum.fromJson(data);
+    map[_i47.ByNameEnum] = (data, protocol) => _i47.ByNameEnum.fromJson(data);
+    map[_i48.DefaultValueEnum] = (data, protocol) =>
+        _i48.DefaultValueEnum.fromJson(data);
+    map[_i49.DefaultException] = (data, protocol) =>
+        _i49.DefaultException.fromJson(data);
+    map[_i50.IntDefault] = (data, protocol) => _i50.IntDefault.fromJson(data);
+    map[_i51.IntDefaultMix] = (data, protocol) =>
+        _i51.IntDefaultMix.fromJson(data);
+    map[_i52.IntDefaultModel] = (data, protocol) =>
+        _i52.IntDefaultModel.fromJson(data);
+    map[_i53.IntDefaultPersist] = (data, protocol) =>
+        _i53.IntDefaultPersist.fromJson(data);
+    map[_i54.StringDefault] = (data, protocol) =>
+        _i54.StringDefault.fromJson(data);
+    map[_i55.StringDefaultMix] = (data, protocol) =>
+        _i55.StringDefaultMix.fromJson(data);
+    map[_i56.StringDefaultModel] = (data, protocol) =>
+        _i56.StringDefaultModel.fromJson(data);
+    map[_i57.StringDefaultPersist] = (data, protocol) =>
+        _i57.StringDefaultPersist.fromJson(data);
+    map[_i58.UriDefault] = (data, protocol) => _i58.UriDefault.fromJson(data);
+    map[_i59.UriDefaultMix] = (data, protocol) =>
+        _i59.UriDefaultMix.fromJson(data);
+    map[_i60.UriDefaultModel] = (data, protocol) =>
+        _i60.UriDefaultModel.fromJson(data);
+    map[_i61.UriDefaultPersist] = (data, protocol) =>
+        _i61.UriDefaultPersist.fromJson(data);
+    map[_i62.UuidDefault] = (data, protocol) => _i62.UuidDefault.fromJson(data);
+    map[_i63.UuidDefaultMix] = (data, protocol) =>
+        _i63.UuidDefaultMix.fromJson(data);
+    map[_i64.UuidDefaultModel] = (data, protocol) =>
+        _i64.UuidDefaultModel.fromJson(data);
+    map[_i65.UuidDefaultPersist] = (data, protocol) =>
+        _i65.UuidDefaultPersist.fromJson(data);
+    map[_i66.EmptyModel] = (data, protocol) => _i66.EmptyModel.fromJson(data);
+    map[_i67.EmptyModelRelationItem] = (data, protocol) =>
+        _i67.EmptyModelRelationItem.fromJson(data);
+    map[_i68.EmptyModelWithTable] = (data, protocol) =>
+        _i68.EmptyModelWithTable.fromJson(data);
+    map[_i69.RelationEmptyModel] = (data, protocol) =>
+        _i69.RelationEmptyModel.fromJson(data);
+    map[_i70.ExceptionWithData] = (data, protocol) =>
+        _i70.ExceptionWithData.fromJson(data);
+    map[_i71.ChildClassExplicitColumn] = (data, protocol) =>
+        _i71.ChildClassExplicitColumn.fromJson(data);
+    map[_i72.NonTableParentClass] = (data, protocol) =>
+        _i72.NonTableParentClass.fromJson(data);
+    map[_i73.ModifiedColumnName] = (data, protocol) =>
+        _i73.ModifiedColumnName.fromJson(data);
+    map[_i74.Department] = (data, protocol) => _i74.Department.fromJson(data);
+    map[_i75.Employee] = (data, protocol) => _i75.Employee.fromJson(data);
+    map[_i76.Contractor] = (data, protocol) => _i76.Contractor.fromJson(data);
+    map[_i77.Service] = (data, protocol) => _i77.Service.fromJson(data);
+    map[_i78.TableWithExplicitColumnName] = (data, protocol) =>
+        _i78.TableWithExplicitColumnName.fromJson(data);
+    map[_i79.ImmutableChildObject] = (data, protocol) =>
+        _i79.ImmutableChildObject.fromJson(data);
+    map[_i80.ImmutableChildObjectWithNoAdditionalFields] = (data, protocol) =>
+        _i80.ImmutableChildObjectWithNoAdditionalFields.fromJson(data);
+    map[_i81.ImmutableObject] = (data, protocol) =>
+        _i81.ImmutableObject.fromJson(data);
+    map[_i82.ImmutableObjectWithImmutableObject] = (data, protocol) =>
+        _i82.ImmutableObjectWithImmutableObject.fromJson(data);
+    map[_i83.ImmutableObjectWithList] = (data, protocol) =>
+        _i83.ImmutableObjectWithList.fromJson(data);
+    map[_i84.ImmutableObjectWithMap] = (data, protocol) =>
+        _i84.ImmutableObjectWithMap.fromJson(data);
+    map[_i85.ImmutableObjectWithMultipleFields] = (data, protocol) =>
+        _i85.ImmutableObjectWithMultipleFields.fromJson(data);
+    map[_i86.ImmutableObjectWithNoFields] = (data, protocol) =>
+        _i86.ImmutableObjectWithNoFields.fromJson(data);
+    map[_i87.ImmutableObjectWithRecord] = (data, protocol) =>
+        _i87.ImmutableObjectWithRecord.fromJson(data);
+    map[_i88.ImmutableObjectWithTable] = (data, protocol) =>
+        _i88.ImmutableObjectWithTable.fromJson(data);
+    map[_i89.ImmutableObjectWithTwentyFields] = (data, protocol) =>
+        _i89.ImmutableObjectWithTwentyFields.fromJson(data);
+    map[_i90.ChildClass] = (data, protocol) => _i90.ChildClass.fromJson(data);
+    map[_i91.ChildWithDefault] = (data, protocol) =>
+        _i91.ChildWithDefault.fromJson(data);
+    map[_i92.ChildClassWithoutId] = (data, protocol) =>
+        _i92.ChildClassWithoutId.fromJson(data);
+    map[_i93.ExtendedAppException] = (data, protocol) =>
+        _i93.ExtendedAppException.fromJson(data);
+    map[_i94.BaseAppException] = (data, protocol) =>
+        _i94.BaseAppException.fromJson(data);
+    map[_i95.NotFoundException] = (data, protocol) =>
+        _i95.NotFoundException.fromJson(data);
+    map[_i95.ValidationException] = (data, protocol) =>
+        _i95.ValidationException.fromJson(data);
+    map[_i96.ParentClass] = (data, protocol) => _i96.ParentClass.fromJson(data);
+    map[_i97.GrandparentClass] = (data, protocol) =>
+        _i97.GrandparentClass.fromJson(data);
+    map[_i98.ParentClassWithoutId] = (data, protocol) =>
+        _i98.ParentClassWithoutId.fromJson(data);
+    map[_i99.GrandparentClassWithId] = (data, protocol) =>
+        _i99.GrandparentClassWithId.fromJson(data);
+    map[_i100.ChildEntity] = (data, protocol) =>
+        _i100.ChildEntity.fromJson(data);
+    map[_i101.BaseEntity] = (data, protocol) => _i101.BaseEntity.fromJson(data);
+    map[_i102.ParentEntity] = (data, protocol) =>
+        _i102.ParentEntity.fromJson(data);
+    map[_i103.NonServerOnlyParentClass] = (data, protocol) =>
+        _i103.NonServerOnlyParentClass.fromJson(data);
+    map[_i104.ParentWithDefault] = (data, protocol) =>
+        _i104.ParentWithDefault.fromJson(data);
+    map[_i105.PolymorphicGrandChild] = (data, protocol) =>
+        _i105.PolymorphicGrandChild.fromJson(data);
+    map[_i106.PolymorphicChild] = (data, protocol) =>
+        _i106.PolymorphicChild.fromJson(data);
+    map[_i107.PolymorphicChildContainer] = (data, protocol) =>
+        _i107.PolymorphicChildContainer.fromJson(data);
+    map[_i108.ModulePolymorphicChildContainer] = (data, protocol) =>
+        _i108.ModulePolymorphicChildContainer.fromJson(data);
+    map[_i109.SimilarButNotParent] = (data, protocol) =>
+        _i109.SimilarButNotParent.fromJson(data);
+    map[_i110.PolymorphicParent] = (data, protocol) =>
+        _i110.PolymorphicParent.fromJson(data);
+    map[_i111.UnrelatedToPolymorphism] = (data, protocol) =>
+        _i111.UnrelatedToPolymorphism.fromJson(data);
+    map[_i112.SealedGrandChild] = (data, protocol) =>
+        _i112.SealedGrandChild.fromJson(data);
+    map[_i112.SealedChild] = (data, protocol) =>
+        _i112.SealedChild.fromJson(data);
+    map[_i113.SealedChildOnlyRequired] = (data, protocol) =>
+        _i113.SealedChildOnlyRequired.fromJson(data);
+    map[_i112.SealedOtherChild] = (data, protocol) =>
+        _i112.SealedOtherChild.fromJson(data);
+    map[_i114.CityWithLongTableName] = (data, protocol) =>
+        _i114.CityWithLongTableName.fromJson(data);
+    map[_i115.OrganizationWithLongTableName] = (data, protocol) =>
+        _i115.OrganizationWithLongTableName.fromJson(data);
+    map[_i116.PersonWithLongTableName] = (data, protocol) =>
+        _i116.PersonWithLongTableName.fromJson(data);
+    map[_i117.MaxFieldName] = (data, protocol) =>
+        _i117.MaxFieldName.fromJson(data);
+    map[_i118.LongImplicitIdField] = (data, protocol) =>
+        _i118.LongImplicitIdField.fromJson(data);
+    map[_i119.LongImplicitIdFieldCollection] = (data, protocol) =>
+        _i119.LongImplicitIdFieldCollection.fromJson(data);
+    map[_i120.RelationToMultipleMaxFieldName] = (data, protocol) =>
+        _i120.RelationToMultipleMaxFieldName.fromJson(data);
+    map[_i121.UserNote] = (data, protocol) => _i121.UserNote.fromJson(data);
+    map[_i122.UserNoteCollection] = (data, protocol) =>
+        _i122.UserNoteCollection.fromJson(data);
+    map[_i123.UserNoteCollectionWithALongName] = (data, protocol) =>
+        _i123.UserNoteCollectionWithALongName.fromJson(data);
+    map[_i124.UserNoteWithALongName] = (data, protocol) =>
+        _i124.UserNoteWithALongName.fromJson(data);
+    map[_i125.MultipleMaxFieldName] = (data, protocol) =>
+        _i125.MultipleMaxFieldName.fromJson(data);
+    map[_i126.City] = (data, protocol) => _i126.City.fromJson(data);
+    map[_i127.Organization] = (data, protocol) =>
+        _i127.Organization.fromJson(data);
+    map[_i128.Person] = (data, protocol) => _i128.Person.fromJson(data);
+    map[_i129.BleedChild] = (data, protocol) => _i129.BleedChild.fromJson(data);
+    map[_i130.BleedRoot] = (data, protocol) => _i130.BleedRoot.fromJson(data);
+    map[_i131.Course] = (data, protocol) => _i131.Course.fromJson(data);
+    map[_i132.Enrollment] = (data, protocol) => _i132.Enrollment.fromJson(data);
+    map[_i133.Student] = (data, protocol) => _i133.Student.fromJson(data);
+    map[_i134.ObjectUser] = (data, protocol) => _i134.ObjectUser.fromJson(data);
+    map[_i135.ParentUser] = (data, protocol) => _i135.ParentUser.fromJson(data);
+    map[_i136.Arena] = (data, protocol) => _i136.Arena.fromJson(data);
+    map[_i137.Player] = (data, protocol) => _i137.Player.fromJson(data);
+    map[_i138.Team] = (data, protocol) => _i138.Team.fromJson(data);
+    map[_i139.Comment] = (data, protocol) => _i139.Comment.fromJson(data);
+    map[_i140.Customer] = (data, protocol) => _i140.Customer.fromJson(data);
+    map[_i141.Book] = (data, protocol) => _i141.Book.fromJson(data);
+    map[_i142.Chapter] = (data, protocol) => _i142.Chapter.fromJson(data);
+    map[_i143.Order] = (data, protocol) => _i143.Order.fromJson(data);
+    map[_i144.Address] = (data, protocol) => _i144.Address.fromJson(data);
+    map[_i145.Citizen] = (data, protocol) => _i145.Citizen.fromJson(data);
+    map[_i146.Company] = (data, protocol) => _i146.Company.fromJson(data);
+    map[_i147.Town] = (data, protocol) => _i147.Town.fromJson(data);
+    map[_i148.Blocking] = (data, protocol) => _i148.Blocking.fromJson(data);
+    map[_i149.Member] = (data, protocol) => _i149.Member.fromJson(data);
+    map[_i150.Cat] = (data, protocol) => _i150.Cat.fromJson(data);
+    map[_i151.Post] = (data, protocol) => _i151.Post.fromJson(data);
+    map[_i152.ModuleDatatype] = (data, protocol) =>
+        _i152.ModuleDatatype.fromJson(data);
+    map[_i153.MyFeatureModel] = (data, protocol) =>
+        _i153.MyFeatureModel.fromJson(data);
+    map[_i154.MyTriggerType] = (data, protocol) =>
+        _i154.MyTriggerType.fromJson(data);
+    map[_i155.Nullability] = (data, protocol) =>
+        _i155.Nullability.fromJson(data);
+    map[_i156.NullsDistinctData] = (data, protocol) =>
+        _i156.NullsDistinctData.fromJson(data);
+    map[_i157.ObjectFieldPersist] = (data, protocol) =>
+        _i157.ObjectFieldPersist.fromJson(data);
+    map[_i158.ObjectFieldScopes] = (data, protocol) =>
+        _i158.ObjectFieldScopes.fromJson(data);
+    map[_i159.ObjectWithBit] = (data, protocol) =>
+        _i159.ObjectWithBit.fromJson(data);
+    map[_i160.ObjectWithByteData] = (data, protocol) =>
+        _i160.ObjectWithByteData.fromJson(data);
+    map[_i161.ObjectWithCustomClass] = (data, protocol) =>
+        _i161.ObjectWithCustomClass.fromJson(data);
+    map[_i162.ObjectWithDuration] = (data, protocol) =>
+        _i162.ObjectWithDuration.fromJson(data);
+    map[_i163.ObjectWithDynamic] = (data, protocol) =>
+        _i163.ObjectWithDynamic.fromJson(data);
+    map[_i164.ObjectWithEnum] = (data, protocol) =>
+        _i164.ObjectWithEnum.fromJson(data);
+    map[_i165.ObjectWithEnumEnhanced] = (data, protocol) =>
+        _i165.ObjectWithEnumEnhanced.fromJson(data);
+    map[_i166.ObjectWithGeographyGeometryCollection] = (data, protocol) =>
+        _i166.ObjectWithGeographyGeometryCollection.fromJson(data);
+    map[_i167.ObjectWithGeographyLineString] = (data, protocol) =>
+        _i167.ObjectWithGeographyLineString.fromJson(data);
+    map[_i168.ObjectWithGeographyPoint] = (data, protocol) =>
+        _i168.ObjectWithGeographyPoint.fromJson(data);
+    map[_i169.ObjectWithGeographyPolygon] = (data, protocol) =>
+        _i169.ObjectWithGeographyPolygon.fromJson(data);
+    map[_i170.ObjectWithHalfVector] = (data, protocol) =>
+        _i170.ObjectWithHalfVector.fromJson(data);
+    map[_i171.ObjectWithIndex] = (data, protocol) =>
+        _i171.ObjectWithIndex.fromJson(data);
+    map[_i172.ObjectWithJsonb] = (data, protocol) =>
+        _i172.ObjectWithJsonb.fromJson(data);
+    map[_i173.ObjectWithJsonbClassLevel] = (data, protocol) =>
+        _i173.ObjectWithJsonbClassLevel.fromJson(data);
+    map[_i174.ObjectWithMaps] = (data, protocol) =>
+        _i174.ObjectWithMaps.fromJson(data);
+    map[_i175.ObjectWithNullableCustomClass] = (data, protocol) =>
+        _i175.ObjectWithNullableCustomClass.fromJson(data);
+    map[_i176.ObjectWithObject] = (data, protocol) =>
+        _i176.ObjectWithObject.fromJson(data);
+    map[_i177.ObjectWithParent] = (data, protocol) =>
+        _i177.ObjectWithParent.fromJson(data);
+    map[_i178.ObjectWithSealedClass] = (data, protocol) =>
+        _i178.ObjectWithSealedClass.fromJson(data);
+    map[_i179.ObjectWithSealedException] = (data, protocol) =>
+        _i179.ObjectWithSealedException.fromJson(data);
+    map[_i180.ObjectWithSelfParent] = (data, protocol) =>
+        _i180.ObjectWithSelfParent.fromJson(data);
+    map[_i181.ObjectWithSparseVector] = (data, protocol) =>
+        _i181.ObjectWithSparseVector.fromJson(data);
+    map[_i182.ObjectWithUuid] = (data, protocol) =>
+        _i182.ObjectWithUuid.fromJson(data);
+    map[_i183.ObjectWithVector] = (data, protocol) =>
+        _i183.ObjectWithVector.fromJson(data);
+    map[_i184.Record] = (data, protocol) => _i184.Record.fromJson(data);
+    map[_i185.RelatedUniqueData] = (data, protocol) =>
+        _i185.RelatedUniqueData.fromJson(data);
+    map[_i186.ExceptionWithRequiredField] = (data, protocol) =>
+        _i186.ExceptionWithRequiredField.fromJson(data);
+    map[_i187.ModelWithRequiredField] = (data, protocol) =>
+        _i187.ModelWithRequiredField.fromJson(data);
+    map[_i188.ScopeNoneFields] = (data, protocol) =>
+        _i188.ScopeNoneFields.fromJson(data);
+    map[_i189.ScopeServerOnlyFieldChild] = (data, protocol) =>
+        _i189.ScopeServerOnlyFieldChild.fromJson(data);
+    map[_i190.ScopeServerOnlyField] = (data, protocol) =>
+        _i190.ScopeServerOnlyField.fromJson(data);
+    map[_i191.DefaultServerOnlyClass] = (data, protocol) =>
+        _i191.DefaultServerOnlyClass.fromJson(data);
+    map[_i192.DefaultServerOnlyEnum] = (data, protocol) =>
+        _i192.DefaultServerOnlyEnum.fromJson(data);
+    map[_i193.NotServerOnlyClass] = (data, protocol) =>
+        _i193.NotServerOnlyClass.fromJson(data);
+    map[_i194.NotServerOnlyEnum] = (data, protocol) =>
+        _i194.NotServerOnlyEnum.fromJson(data);
+    map[_i195.ServerOnlyClassField] = (data, protocol) =>
+        _i195.ServerOnlyClassField.fromJson(data);
+    map[_i196.ServerOnlyDefault] = (data, protocol) =>
+        _i196.ServerOnlyDefault.fromJson(data);
+    map[_i197.SessionAuthInfo] = (data, protocol) =>
+        _i197.SessionAuthInfo.fromJson(data);
+    map[_i198.SharedModelContainer] = (data, protocol) =>
+        _i198.SharedModelContainer.fromJson(data);
+    map[_i199.SharedModelSubclass] = (data, protocol) =>
+        _i199.SharedModelSubclass.fromJson(data);
+    map[_i200.SimpleData] = (data, protocol) => _i200.SimpleData.fromJson(data);
+    map[_i201.SimpleDataList] = (data, protocol) =>
+        _i201.SimpleDataList.fromJson(data);
+    map[_i202.SimpleDataMap] = (data, protocol) =>
+        _i202.SimpleDataMap.fromJson(data);
+    map[_i203.SimpleDataObject] = (data, protocol) =>
+        _i203.SimpleDataObject.fromJson(data);
+    map[_i204.SimpleDateTime] = (data, protocol) =>
+        _i204.SimpleDateTime.fromJson(data);
+    map[_i205.ModelInSubfolder] = (data, protocol) =>
+        _i205.ModelInSubfolder.fromJson(data);
+    map[_i206.TestEnum] = (data, protocol) => _i206.TestEnum.fromJson(data);
+    map[_i207.TestEnumDefaultSerialization] = (data, protocol) =>
+        _i207.TestEnumDefaultSerialization.fromJson(data);
+    map[_i208.TestEnumEnhanced] = (data, protocol) =>
+        _i208.TestEnumEnhanced.fromJson(data);
+    map[_i209.TestEnumEnhancedByName] = (data, protocol) =>
+        _i209.TestEnumEnhancedByName.fromJson(data);
+    map[_i210.TestEnumStringified] = (data, protocol) =>
+        _i210.TestEnumStringified.fromJson(data);
+    map[_i211.Types] = (data, protocol) => _i211.Types.fromJson(data);
+    map[_i212.TypesList] = (data, protocol) => _i212.TypesList.fromJson(data);
+    map[_i213.TypesMap] = (data, protocol) => _i213.TypesMap.fromJson(data);
+    map[_i214.TypesRecord] = (data, protocol) =>
+        _i214.TypesRecord.fromJson(data);
+    map[_i215.TypesSet] = (data, protocol) => _i215.TypesSet.fromJson(data);
+    map[_i216.TypesSetRequired] = (data, protocol) =>
+        _i216.TypesSetRequired.fromJson(data);
+    map[_i217.UniqueData] = (data, protocol) => _i217.UniqueData.fromJson(data);
+    map[_i218.UniqueDataWithNonPersist] = (data, protocol) =>
+        _i218.UniqueDataWithNonPersist.fromJson(data);
+    map[_i219.UpsertTestModel] = (data, protocol) =>
+        _i219.UpsertTestModel.fromJson(data);
+    map[_i1.getType<_i6.ByIndexEnumWithNameValue?>()] = (data, protocol) =>
+        (data != null ? _i6.ByIndexEnumWithNameValue.fromJson(data) : null);
+    map[_i1.getType<_i7.ByNameEnumWithNameValue?>()] = (data, protocol) =>
+        (data != null ? _i7.ByNameEnumWithNameValue.fromJson(data) : null);
+    map[_i1.getType<_i8.CourseUuid?>()] = (data, protocol) =>
+        (data != null ? _i8.CourseUuid.fromJson(data) : null);
+    map[_i1.getType<_i9.EnrollmentInt?>()] = (data, protocol) =>
+        (data != null ? _i9.EnrollmentInt.fromJson(data) : null);
+    map[_i1.getType<_i10.StudentUuid?>()] = (data, protocol) =>
+        (data != null ? _i10.StudentUuid.fromJson(data) : null);
+    map[_i1.getType<_i11.ArenaUuid?>()] = (data, protocol) =>
+        (data != null ? _i11.ArenaUuid.fromJson(data) : null);
+    map[_i1.getType<_i12.PlayerUuid?>()] = (data, protocol) =>
+        (data != null ? _i12.PlayerUuid.fromJson(data) : null);
+    map[_i1.getType<_i13.TeamInt?>()] = (data, protocol) =>
+        (data != null ? _i13.TeamInt.fromJson(data) : null);
+    map[_i1.getType<_i14.CommentInt?>()] = (data, protocol) =>
+        (data != null ? _i14.CommentInt.fromJson(data) : null);
+    map[_i1.getType<_i15.CustomerInt?>()] = (data, protocol) =>
+        (data != null ? _i15.CustomerInt.fromJson(data) : null);
+    map[_i1.getType<_i16.OrderUuid?>()] = (data, protocol) =>
+        (data != null ? _i16.OrderUuid.fromJson(data) : null);
+    map[_i1.getType<_i17.AddressUuid?>()] = (data, protocol) =>
+        (data != null ? _i17.AddressUuid.fromJson(data) : null);
+    map[_i1.getType<_i18.CitizenInt?>()] = (data, protocol) =>
+        (data != null ? _i18.CitizenInt.fromJson(data) : null);
+    map[_i1.getType<_i19.CompanyUuid?>()] = (data, protocol) =>
+        (data != null ? _i19.CompanyUuid.fromJson(data) : null);
+    map[_i1.getType<_i20.TownInt?>()] = (data, protocol) =>
+        (data != null ? _i20.TownInt.fromJson(data) : null);
+    map[_i1.getType<_i21.ChangedIdTypeSelf?>()] = (data, protocol) =>
+        (data != null ? _i21.ChangedIdTypeSelf.fromJson(data) : null);
+    map[_i1.getType<_i22.BigIntDefault?>()] = (data, protocol) =>
+        (data != null ? _i22.BigIntDefault.fromJson(data) : null);
+    map[_i1.getType<_i23.BigIntDefaultMix?>()] = (data, protocol) =>
+        (data != null ? _i23.BigIntDefaultMix.fromJson(data) : null);
+    map[_i1.getType<_i24.BigIntDefaultModel?>()] = (data, protocol) =>
+        (data != null ? _i24.BigIntDefaultModel.fromJson(data) : null);
+    map[_i1.getType<_i25.BigIntDefaultPersist?>()] = (data, protocol) =>
+        (data != null ? _i25.BigIntDefaultPersist.fromJson(data) : null);
+    map[_i1.getType<_i26.BoolDefault?>()] = (data, protocol) =>
+        (data != null ? _i26.BoolDefault.fromJson(data) : null);
+    map[_i1.getType<_i27.BoolDefaultMix?>()] = (data, protocol) =>
+        (data != null ? _i27.BoolDefaultMix.fromJson(data) : null);
+    map[_i1.getType<_i28.BoolDefaultModel?>()] = (data, protocol) =>
+        (data != null ? _i28.BoolDefaultModel.fromJson(data) : null);
+    map[_i1.getType<_i29.BoolDefaultPersist?>()] = (data, protocol) =>
+        (data != null ? _i29.BoolDefaultPersist.fromJson(data) : null);
+    map[_i1.getType<_i30.DateTimeDefault?>()] = (data, protocol) =>
+        (data != null ? _i30.DateTimeDefault.fromJson(data) : null);
+    map[_i1.getType<_i31.DateTimeDefaultMix?>()] = (data, protocol) =>
+        (data != null ? _i31.DateTimeDefaultMix.fromJson(data) : null);
+    map[_i1.getType<_i32.DateTimeDefaultModel?>()] = (data, protocol) =>
+        (data != null ? _i32.DateTimeDefaultModel.fromJson(data) : null);
+    map[_i1.getType<_i33.DateTimeDefaultPersist?>()] = (data, protocol) =>
+        (data != null ? _i33.DateTimeDefaultPersist.fromJson(data) : null);
+    map[_i1.getType<_i34.DoubleDefault?>()] = (data, protocol) =>
+        (data != null ? _i34.DoubleDefault.fromJson(data) : null);
+    map[_i1.getType<_i35.DoubleDefaultMix?>()] = (data, protocol) =>
+        (data != null ? _i35.DoubleDefaultMix.fromJson(data) : null);
+    map[_i1.getType<_i36.DoubleDefaultModel?>()] = (data, protocol) =>
+        (data != null ? _i36.DoubleDefaultModel.fromJson(data) : null);
+    map[_i1.getType<_i37.DoubleDefaultPersist?>()] = (data, protocol) =>
+        (data != null ? _i37.DoubleDefaultPersist.fromJson(data) : null);
+    map[_i1.getType<_i38.DurationDefault?>()] = (data, protocol) =>
+        (data != null ? _i38.DurationDefault.fromJson(data) : null);
+    map[_i1.getType<_i39.DurationDefaultMix?>()] = (data, protocol) =>
+        (data != null ? _i39.DurationDefaultMix.fromJson(data) : null);
+    map[_i1.getType<_i40.DurationDefaultModel?>()] = (data, protocol) =>
+        (data != null ? _i40.DurationDefaultModel.fromJson(data) : null);
+    map[_i1.getType<_i41.DurationDefaultPersist?>()] = (data, protocol) =>
+        (data != null ? _i41.DurationDefaultPersist.fromJson(data) : null);
+    map[_i1.getType<_i42.EnumDefault?>()] = (data, protocol) =>
+        (data != null ? _i42.EnumDefault.fromJson(data) : null);
+    map[_i1.getType<_i43.EnumDefaultMix?>()] = (data, protocol) =>
+        (data != null ? _i43.EnumDefaultMix.fromJson(data) : null);
+    map[_i1.getType<_i44.EnumDefaultModel?>()] = (data, protocol) =>
+        (data != null ? _i44.EnumDefaultModel.fromJson(data) : null);
+    map[_i1.getType<_i45.EnumDefaultPersist?>()] = (data, protocol) =>
+        (data != null ? _i45.EnumDefaultPersist.fromJson(data) : null);
+    map[_i1.getType<_i46.ByIndexEnum?>()] = (data, protocol) =>
+        (data != null ? _i46.ByIndexEnum.fromJson(data) : null);
+    map[_i1.getType<_i47.ByNameEnum?>()] = (data, protocol) =>
+        (data != null ? _i47.ByNameEnum.fromJson(data) : null);
+    map[_i1.getType<_i48.DefaultValueEnum?>()] = (data, protocol) =>
+        (data != null ? _i48.DefaultValueEnum.fromJson(data) : null);
+    map[_i1.getType<_i49.DefaultException?>()] = (data, protocol) =>
+        (data != null ? _i49.DefaultException.fromJson(data) : null);
+    map[_i1.getType<_i50.IntDefault?>()] = (data, protocol) =>
+        (data != null ? _i50.IntDefault.fromJson(data) : null);
+    map[_i1.getType<_i51.IntDefaultMix?>()] = (data, protocol) =>
+        (data != null ? _i51.IntDefaultMix.fromJson(data) : null);
+    map[_i1.getType<_i52.IntDefaultModel?>()] = (data, protocol) =>
+        (data != null ? _i52.IntDefaultModel.fromJson(data) : null);
+    map[_i1.getType<_i53.IntDefaultPersist?>()] = (data, protocol) =>
+        (data != null ? _i53.IntDefaultPersist.fromJson(data) : null);
+    map[_i1.getType<_i54.StringDefault?>()] = (data, protocol) =>
+        (data != null ? _i54.StringDefault.fromJson(data) : null);
+    map[_i1.getType<_i55.StringDefaultMix?>()] = (data, protocol) =>
+        (data != null ? _i55.StringDefaultMix.fromJson(data) : null);
+    map[_i1.getType<_i56.StringDefaultModel?>()] = (data, protocol) =>
+        (data != null ? _i56.StringDefaultModel.fromJson(data) : null);
+    map[_i1.getType<_i57.StringDefaultPersist?>()] = (data, protocol) =>
+        (data != null ? _i57.StringDefaultPersist.fromJson(data) : null);
+    map[_i1.getType<_i58.UriDefault?>()] = (data, protocol) =>
+        (data != null ? _i58.UriDefault.fromJson(data) : null);
+    map[_i1.getType<_i59.UriDefaultMix?>()] = (data, protocol) =>
+        (data != null ? _i59.UriDefaultMix.fromJson(data) : null);
+    map[_i1.getType<_i60.UriDefaultModel?>()] = (data, protocol) =>
+        (data != null ? _i60.UriDefaultModel.fromJson(data) : null);
+    map[_i1.getType<_i61.UriDefaultPersist?>()] = (data, protocol) =>
+        (data != null ? _i61.UriDefaultPersist.fromJson(data) : null);
+    map[_i1.getType<_i62.UuidDefault?>()] = (data, protocol) =>
+        (data != null ? _i62.UuidDefault.fromJson(data) : null);
+    map[_i1.getType<_i63.UuidDefaultMix?>()] = (data, protocol) =>
+        (data != null ? _i63.UuidDefaultMix.fromJson(data) : null);
+    map[_i1.getType<_i64.UuidDefaultModel?>()] = (data, protocol) =>
+        (data != null ? _i64.UuidDefaultModel.fromJson(data) : null);
+    map[_i1.getType<_i65.UuidDefaultPersist?>()] = (data, protocol) =>
+        (data != null ? _i65.UuidDefaultPersist.fromJson(data) : null);
+    map[_i1.getType<_i66.EmptyModel?>()] = (data, protocol) =>
+        (data != null ? _i66.EmptyModel.fromJson(data) : null);
+    map[_i1.getType<_i67.EmptyModelRelationItem?>()] = (data, protocol) =>
+        (data != null ? _i67.EmptyModelRelationItem.fromJson(data) : null);
+    map[_i1.getType<_i68.EmptyModelWithTable?>()] = (data, protocol) =>
+        (data != null ? _i68.EmptyModelWithTable.fromJson(data) : null);
+    map[_i1.getType<_i69.RelationEmptyModel?>()] = (data, protocol) =>
+        (data != null ? _i69.RelationEmptyModel.fromJson(data) : null);
+    map[_i1.getType<_i70.ExceptionWithData?>()] = (data, protocol) =>
+        (data != null ? _i70.ExceptionWithData.fromJson(data) : null);
+    map[_i1.getType<_i71.ChildClassExplicitColumn?>()] = (data, protocol) =>
+        (data != null ? _i71.ChildClassExplicitColumn.fromJson(data) : null);
+    map[_i1.getType<_i72.NonTableParentClass?>()] = (data, protocol) =>
+        (data != null ? _i72.NonTableParentClass.fromJson(data) : null);
+    map[_i1.getType<_i73.ModifiedColumnName?>()] = (data, protocol) =>
+        (data != null ? _i73.ModifiedColumnName.fromJson(data) : null);
+    map[_i1.getType<_i74.Department?>()] = (data, protocol) =>
+        (data != null ? _i74.Department.fromJson(data) : null);
+    map[_i1.getType<_i75.Employee?>()] = (data, protocol) =>
+        (data != null ? _i75.Employee.fromJson(data) : null);
+    map[_i1.getType<_i76.Contractor?>()] = (data, protocol) =>
+        (data != null ? _i76.Contractor.fromJson(data) : null);
+    map[_i1.getType<_i77.Service?>()] = (data, protocol) =>
+        (data != null ? _i77.Service.fromJson(data) : null);
+    map[_i1.getType<_i78.TableWithExplicitColumnName?>()] = (data, protocol) =>
+        (data != null ? _i78.TableWithExplicitColumnName.fromJson(data) : null);
+    map[_i1.getType<_i79.ImmutableChildObject?>()] = (data, protocol) =>
+        (data != null ? _i79.ImmutableChildObject.fromJson(data) : null);
+    map[_i1.getType<_i80.ImmutableChildObjectWithNoAdditionalFields?>()] =
+        (data, protocol) => (data != null
+        ? _i80.ImmutableChildObjectWithNoAdditionalFields.fromJson(data)
+        : null);
+    map[_i1.getType<_i81.ImmutableObject?>()] = (data, protocol) =>
+        (data != null ? _i81.ImmutableObject.fromJson(data) : null);
+    map[_i1.getType<_i82.ImmutableObjectWithImmutableObject?>()] =
+        (data, protocol) => (data != null
+        ? _i82.ImmutableObjectWithImmutableObject.fromJson(data)
+        : null);
+    map[_i1.getType<_i83.ImmutableObjectWithList?>()] = (data, protocol) =>
+        (data != null ? _i83.ImmutableObjectWithList.fromJson(data) : null);
+    map[_i1.getType<_i84.ImmutableObjectWithMap?>()] = (data, protocol) =>
+        (data != null ? _i84.ImmutableObjectWithMap.fromJson(data) : null);
+    map[_i1.getType<_i85.ImmutableObjectWithMultipleFields?>()] =
+        (data, protocol) => (data != null
+        ? _i85.ImmutableObjectWithMultipleFields.fromJson(data)
+        : null);
+    map[_i1.getType<_i86.ImmutableObjectWithNoFields?>()] = (data, protocol) =>
+        (data != null ? _i86.ImmutableObjectWithNoFields.fromJson(data) : null);
+    map[_i1.getType<_i87.ImmutableObjectWithRecord?>()] = (data, protocol) =>
+        (data != null ? _i87.ImmutableObjectWithRecord.fromJson(data) : null);
+    map[_i1.getType<_i88.ImmutableObjectWithTable?>()] = (data, protocol) =>
+        (data != null ? _i88.ImmutableObjectWithTable.fromJson(data) : null);
+    map[_i1
+        .getType<_i89.ImmutableObjectWithTwentyFields?>()] = (data, protocol) =>
+        (data != null
+        ? _i89.ImmutableObjectWithTwentyFields.fromJson(data)
+        : null);
+    map[_i1.getType<_i90.ChildClass?>()] = (data, protocol) =>
+        (data != null ? _i90.ChildClass.fromJson(data) : null);
+    map[_i1.getType<_i91.ChildWithDefault?>()] = (data, protocol) =>
+        (data != null ? _i91.ChildWithDefault.fromJson(data) : null);
+    map[_i1.getType<_i92.ChildClassWithoutId?>()] = (data, protocol) =>
+        (data != null ? _i92.ChildClassWithoutId.fromJson(data) : null);
+    map[_i1.getType<_i93.ExtendedAppException?>()] = (data, protocol) =>
+        (data != null ? _i93.ExtendedAppException.fromJson(data) : null);
+    map[_i1.getType<_i94.BaseAppException?>()] = (data, protocol) =>
+        (data != null ? _i94.BaseAppException.fromJson(data) : null);
+    map[_i1.getType<_i95.NotFoundException?>()] = (data, protocol) =>
+        (data != null ? _i95.NotFoundException.fromJson(data) : null);
+    map[_i1.getType<_i95.ValidationException?>()] = (data, protocol) =>
+        (data != null ? _i95.ValidationException.fromJson(data) : null);
+    map[_i1.getType<_i96.ParentClass?>()] = (data, protocol) =>
+        (data != null ? _i96.ParentClass.fromJson(data) : null);
+    map[_i1.getType<_i97.GrandparentClass?>()] = (data, protocol) =>
+        (data != null ? _i97.GrandparentClass.fromJson(data) : null);
+    map[_i1.getType<_i98.ParentClassWithoutId?>()] = (data, protocol) =>
+        (data != null ? _i98.ParentClassWithoutId.fromJson(data) : null);
+    map[_i1.getType<_i99.GrandparentClassWithId?>()] = (data, protocol) =>
+        (data != null ? _i99.GrandparentClassWithId.fromJson(data) : null);
+    map[_i1.getType<_i100.ChildEntity?>()] = (data, protocol) =>
+        (data != null ? _i100.ChildEntity.fromJson(data) : null);
+    map[_i1.getType<_i101.BaseEntity?>()] = (data, protocol) =>
+        (data != null ? _i101.BaseEntity.fromJson(data) : null);
+    map[_i1.getType<_i102.ParentEntity?>()] = (data, protocol) =>
+        (data != null ? _i102.ParentEntity.fromJson(data) : null);
+    map[_i1.getType<_i103.NonServerOnlyParentClass?>()] = (data, protocol) =>
+        (data != null ? _i103.NonServerOnlyParentClass.fromJson(data) : null);
+    map[_i1.getType<_i104.ParentWithDefault?>()] = (data, protocol) =>
+        (data != null ? _i104.ParentWithDefault.fromJson(data) : null);
+    map[_i1.getType<_i105.PolymorphicGrandChild?>()] = (data, protocol) =>
+        (data != null ? _i105.PolymorphicGrandChild.fromJson(data) : null);
+    map[_i1.getType<_i106.PolymorphicChild?>()] = (data, protocol) =>
+        (data != null ? _i106.PolymorphicChild.fromJson(data) : null);
+    map[_i1.getType<_i107.PolymorphicChildContainer?>()] = (data, protocol) =>
+        (data != null ? _i107.PolymorphicChildContainer.fromJson(data) : null);
+    map[_i1.getType<_i108.ModulePolymorphicChildContainer?>()] =
+        (data, protocol) => (data != null
+        ? _i108.ModulePolymorphicChildContainer.fromJson(data)
+        : null);
+    map[_i1.getType<_i109.SimilarButNotParent?>()] = (data, protocol) =>
+        (data != null ? _i109.SimilarButNotParent.fromJson(data) : null);
+    map[_i1.getType<_i110.PolymorphicParent?>()] = (data, protocol) =>
+        (data != null ? _i110.PolymorphicParent.fromJson(data) : null);
+    map[_i1.getType<_i111.UnrelatedToPolymorphism?>()] = (data, protocol) =>
+        (data != null ? _i111.UnrelatedToPolymorphism.fromJson(data) : null);
+    map[_i1.getType<_i112.SealedGrandChild?>()] = (data, protocol) =>
+        (data != null ? _i112.SealedGrandChild.fromJson(data) : null);
+    map[_i1.getType<_i112.SealedChild?>()] = (data, protocol) =>
+        (data != null ? _i112.SealedChild.fromJson(data) : null);
+    map[_i1.getType<_i113.SealedChildOnlyRequired?>()] = (data, protocol) =>
+        (data != null ? _i113.SealedChildOnlyRequired.fromJson(data) : null);
+    map[_i1.getType<_i112.SealedOtherChild?>()] = (data, protocol) =>
+        (data != null ? _i112.SealedOtherChild.fromJson(data) : null);
+    map[_i1.getType<_i114.CityWithLongTableName?>()] = (data, protocol) =>
+        (data != null ? _i114.CityWithLongTableName.fromJson(data) : null);
+    map[_i1
+        .getType<_i115.OrganizationWithLongTableName?>()] = (data, protocol) =>
+        (data != null
+        ? _i115.OrganizationWithLongTableName.fromJson(data)
+        : null);
+    map[_i1.getType<_i116.PersonWithLongTableName?>()] = (data, protocol) =>
+        (data != null ? _i116.PersonWithLongTableName.fromJson(data) : null);
+    map[_i1.getType<_i117.MaxFieldName?>()] = (data, protocol) =>
+        (data != null ? _i117.MaxFieldName.fromJson(data) : null);
+    map[_i1.getType<_i118.LongImplicitIdField?>()] = (data, protocol) =>
+        (data != null ? _i118.LongImplicitIdField.fromJson(data) : null);
+    map[_i1
+        .getType<_i119.LongImplicitIdFieldCollection?>()] = (data, protocol) =>
+        (data != null
+        ? _i119.LongImplicitIdFieldCollection.fromJson(data)
+        : null);
+    map[_i1
+        .getType<_i120.RelationToMultipleMaxFieldName?>()] = (data, protocol) =>
+        (data != null
+        ? _i120.RelationToMultipleMaxFieldName.fromJson(data)
+        : null);
+    map[_i1.getType<_i121.UserNote?>()] = (data, protocol) =>
+        (data != null ? _i121.UserNote.fromJson(data) : null);
+    map[_i1.getType<_i122.UserNoteCollection?>()] = (data, protocol) =>
+        (data != null ? _i122.UserNoteCollection.fromJson(data) : null);
+    map[_i1.getType<_i123.UserNoteCollectionWithALongName?>()] =
+        (data, protocol) => (data != null
+        ? _i123.UserNoteCollectionWithALongName.fromJson(data)
+        : null);
+    map[_i1.getType<_i124.UserNoteWithALongName?>()] = (data, protocol) =>
+        (data != null ? _i124.UserNoteWithALongName.fromJson(data) : null);
+    map[_i1.getType<_i125.MultipleMaxFieldName?>()] = (data, protocol) =>
+        (data != null ? _i125.MultipleMaxFieldName.fromJson(data) : null);
+    map[_i1.getType<_i126.City?>()] = (data, protocol) =>
+        (data != null ? _i126.City.fromJson(data) : null);
+    map[_i1.getType<_i127.Organization?>()] = (data, protocol) =>
+        (data != null ? _i127.Organization.fromJson(data) : null);
+    map[_i1.getType<_i128.Person?>()] = (data, protocol) =>
+        (data != null ? _i128.Person.fromJson(data) : null);
+    map[_i1.getType<_i129.BleedChild?>()] = (data, protocol) =>
+        (data != null ? _i129.BleedChild.fromJson(data) : null);
+    map[_i1.getType<_i130.BleedRoot?>()] = (data, protocol) =>
+        (data != null ? _i130.BleedRoot.fromJson(data) : null);
+    map[_i1.getType<_i131.Course?>()] = (data, protocol) =>
+        (data != null ? _i131.Course.fromJson(data) : null);
+    map[_i1.getType<_i132.Enrollment?>()] = (data, protocol) =>
+        (data != null ? _i132.Enrollment.fromJson(data) : null);
+    map[_i1.getType<_i133.Student?>()] = (data, protocol) =>
+        (data != null ? _i133.Student.fromJson(data) : null);
+    map[_i1.getType<_i134.ObjectUser?>()] = (data, protocol) =>
+        (data != null ? _i134.ObjectUser.fromJson(data) : null);
+    map[_i1.getType<_i135.ParentUser?>()] = (data, protocol) =>
+        (data != null ? _i135.ParentUser.fromJson(data) : null);
+    map[_i1.getType<_i136.Arena?>()] = (data, protocol) =>
+        (data != null ? _i136.Arena.fromJson(data) : null);
+    map[_i1.getType<_i137.Player?>()] = (data, protocol) =>
+        (data != null ? _i137.Player.fromJson(data) : null);
+    map[_i1.getType<_i138.Team?>()] = (data, protocol) =>
+        (data != null ? _i138.Team.fromJson(data) : null);
+    map[_i1.getType<_i139.Comment?>()] = (data, protocol) =>
+        (data != null ? _i139.Comment.fromJson(data) : null);
+    map[_i1.getType<_i140.Customer?>()] = (data, protocol) =>
+        (data != null ? _i140.Customer.fromJson(data) : null);
+    map[_i1.getType<_i141.Book?>()] = (data, protocol) =>
+        (data != null ? _i141.Book.fromJson(data) : null);
+    map[_i1.getType<_i142.Chapter?>()] = (data, protocol) =>
+        (data != null ? _i142.Chapter.fromJson(data) : null);
+    map[_i1.getType<_i143.Order?>()] = (data, protocol) =>
+        (data != null ? _i143.Order.fromJson(data) : null);
+    map[_i1.getType<_i144.Address?>()] = (data, protocol) =>
+        (data != null ? _i144.Address.fromJson(data) : null);
+    map[_i1.getType<_i145.Citizen?>()] = (data, protocol) =>
+        (data != null ? _i145.Citizen.fromJson(data) : null);
+    map[_i1.getType<_i146.Company?>()] = (data, protocol) =>
+        (data != null ? _i146.Company.fromJson(data) : null);
+    map[_i1.getType<_i147.Town?>()] = (data, protocol) =>
+        (data != null ? _i147.Town.fromJson(data) : null);
+    map[_i1.getType<_i148.Blocking?>()] = (data, protocol) =>
+        (data != null ? _i148.Blocking.fromJson(data) : null);
+    map[_i1.getType<_i149.Member?>()] = (data, protocol) =>
+        (data != null ? _i149.Member.fromJson(data) : null);
+    map[_i1.getType<_i150.Cat?>()] = (data, protocol) =>
+        (data != null ? _i150.Cat.fromJson(data) : null);
+    map[_i1.getType<_i151.Post?>()] = (data, protocol) =>
+        (data != null ? _i151.Post.fromJson(data) : null);
+    map[_i1.getType<_i152.ModuleDatatype?>()] = (data, protocol) =>
+        (data != null ? _i152.ModuleDatatype.fromJson(data) : null);
+    map[_i1.getType<_i153.MyFeatureModel?>()] = (data, protocol) =>
+        (data != null ? _i153.MyFeatureModel.fromJson(data) : null);
+    map[_i1.getType<_i154.MyTriggerType?>()] = (data, protocol) =>
+        (data != null ? _i154.MyTriggerType.fromJson(data) : null);
+    map[_i1.getType<_i155.Nullability?>()] = (data, protocol) =>
+        (data != null ? _i155.Nullability.fromJson(data) : null);
+    map[_i1.getType<_i156.NullsDistinctData?>()] = (data, protocol) =>
+        (data != null ? _i156.NullsDistinctData.fromJson(data) : null);
+    map[_i1.getType<_i157.ObjectFieldPersist?>()] = (data, protocol) =>
+        (data != null ? _i157.ObjectFieldPersist.fromJson(data) : null);
+    map[_i1.getType<_i158.ObjectFieldScopes?>()] = (data, protocol) =>
+        (data != null ? _i158.ObjectFieldScopes.fromJson(data) : null);
+    map[_i1.getType<_i159.ObjectWithBit?>()] = (data, protocol) =>
+        (data != null ? _i159.ObjectWithBit.fromJson(data) : null);
+    map[_i1.getType<_i160.ObjectWithByteData?>()] = (data, protocol) =>
+        (data != null ? _i160.ObjectWithByteData.fromJson(data) : null);
+    map[_i1.getType<_i161.ObjectWithCustomClass?>()] = (data, protocol) =>
+        (data != null ? _i161.ObjectWithCustomClass.fromJson(data) : null);
+    map[_i1.getType<_i162.ObjectWithDuration?>()] = (data, protocol) =>
+        (data != null ? _i162.ObjectWithDuration.fromJson(data) : null);
+    map[_i1.getType<_i163.ObjectWithDynamic?>()] = (data, protocol) =>
+        (data != null ? _i163.ObjectWithDynamic.fromJson(data) : null);
+    map[_i1.getType<_i164.ObjectWithEnum?>()] = (data, protocol) =>
+        (data != null ? _i164.ObjectWithEnum.fromJson(data) : null);
+    map[_i1.getType<_i165.ObjectWithEnumEnhanced?>()] = (data, protocol) =>
+        (data != null ? _i165.ObjectWithEnumEnhanced.fromJson(data) : null);
+    map[_i1.getType<_i166.ObjectWithGeographyGeometryCollection?>()] =
+        (data, protocol) => (data != null
+        ? _i166.ObjectWithGeographyGeometryCollection.fromJson(data)
+        : null);
+    map[_i1
+        .getType<_i167.ObjectWithGeographyLineString?>()] = (data, protocol) =>
+        (data != null
+        ? _i167.ObjectWithGeographyLineString.fromJson(data)
+        : null);
+    map[_i1.getType<_i168.ObjectWithGeographyPoint?>()] = (data, protocol) =>
+        (data != null ? _i168.ObjectWithGeographyPoint.fromJson(data) : null);
+    map[_i1.getType<_i169.ObjectWithGeographyPolygon?>()] = (data, protocol) =>
+        (data != null ? _i169.ObjectWithGeographyPolygon.fromJson(data) : null);
+    map[_i1.getType<_i170.ObjectWithHalfVector?>()] = (data, protocol) =>
+        (data != null ? _i170.ObjectWithHalfVector.fromJson(data) : null);
+    map[_i1.getType<_i171.ObjectWithIndex?>()] = (data, protocol) =>
+        (data != null ? _i171.ObjectWithIndex.fromJson(data) : null);
+    map[_i1.getType<_i172.ObjectWithJsonb?>()] = (data, protocol) =>
+        (data != null ? _i172.ObjectWithJsonb.fromJson(data) : null);
+    map[_i1.getType<_i173.ObjectWithJsonbClassLevel?>()] = (data, protocol) =>
+        (data != null ? _i173.ObjectWithJsonbClassLevel.fromJson(data) : null);
+    map[_i1.getType<_i174.ObjectWithMaps?>()] = (data, protocol) =>
+        (data != null ? _i174.ObjectWithMaps.fromJson(data) : null);
+    map[_i1
+        .getType<_i175.ObjectWithNullableCustomClass?>()] = (data, protocol) =>
+        (data != null
+        ? _i175.ObjectWithNullableCustomClass.fromJson(data)
+        : null);
+    map[_i1.getType<_i176.ObjectWithObject?>()] = (data, protocol) =>
+        (data != null ? _i176.ObjectWithObject.fromJson(data) : null);
+    map[_i1.getType<_i177.ObjectWithParent?>()] = (data, protocol) =>
+        (data != null ? _i177.ObjectWithParent.fromJson(data) : null);
+    map[_i1.getType<_i178.ObjectWithSealedClass?>()] = (data, protocol) =>
+        (data != null ? _i178.ObjectWithSealedClass.fromJson(data) : null);
+    map[_i1.getType<_i179.ObjectWithSealedException?>()] = (data, protocol) =>
+        (data != null ? _i179.ObjectWithSealedException.fromJson(data) : null);
+    map[_i1.getType<_i180.ObjectWithSelfParent?>()] = (data, protocol) =>
+        (data != null ? _i180.ObjectWithSelfParent.fromJson(data) : null);
+    map[_i1.getType<_i181.ObjectWithSparseVector?>()] = (data, protocol) =>
+        (data != null ? _i181.ObjectWithSparseVector.fromJson(data) : null);
+    map[_i1.getType<_i182.ObjectWithUuid?>()] = (data, protocol) =>
+        (data != null ? _i182.ObjectWithUuid.fromJson(data) : null);
+    map[_i1.getType<_i183.ObjectWithVector?>()] = (data, protocol) =>
+        (data != null ? _i183.ObjectWithVector.fromJson(data) : null);
+    map[_i1.getType<_i184.Record?>()] = (data, protocol) =>
+        (data != null ? _i184.Record.fromJson(data) : null);
+    map[_i1.getType<_i185.RelatedUniqueData?>()] = (data, protocol) =>
+        (data != null ? _i185.RelatedUniqueData.fromJson(data) : null);
+    map[_i1.getType<_i186.ExceptionWithRequiredField?>()] = (data, protocol) =>
+        (data != null ? _i186.ExceptionWithRequiredField.fromJson(data) : null);
+    map[_i1.getType<_i187.ModelWithRequiredField?>()] = (data, protocol) =>
+        (data != null ? _i187.ModelWithRequiredField.fromJson(data) : null);
+    map[_i1.getType<_i188.ScopeNoneFields?>()] = (data, protocol) =>
+        (data != null ? _i188.ScopeNoneFields.fromJson(data) : null);
+    map[_i1.getType<_i189.ScopeServerOnlyFieldChild?>()] = (data, protocol) =>
+        (data != null ? _i189.ScopeServerOnlyFieldChild.fromJson(data) : null);
+    map[_i1.getType<_i190.ScopeServerOnlyField?>()] = (data, protocol) =>
+        (data != null ? _i190.ScopeServerOnlyField.fromJson(data) : null);
+    map[_i1.getType<_i191.DefaultServerOnlyClass?>()] = (data, protocol) =>
+        (data != null ? _i191.DefaultServerOnlyClass.fromJson(data) : null);
+    map[_i1.getType<_i192.DefaultServerOnlyEnum?>()] = (data, protocol) =>
+        (data != null ? _i192.DefaultServerOnlyEnum.fromJson(data) : null);
+    map[_i1.getType<_i193.NotServerOnlyClass?>()] = (data, protocol) =>
+        (data != null ? _i193.NotServerOnlyClass.fromJson(data) : null);
+    map[_i1.getType<_i194.NotServerOnlyEnum?>()] = (data, protocol) =>
+        (data != null ? _i194.NotServerOnlyEnum.fromJson(data) : null);
+    map[_i1.getType<_i195.ServerOnlyClassField?>()] = (data, protocol) =>
+        (data != null ? _i195.ServerOnlyClassField.fromJson(data) : null);
+    map[_i1.getType<_i196.ServerOnlyDefault?>()] = (data, protocol) =>
+        (data != null ? _i196.ServerOnlyDefault.fromJson(data) : null);
+    map[_i1.getType<_i197.SessionAuthInfo?>()] = (data, protocol) =>
+        (data != null ? _i197.SessionAuthInfo.fromJson(data) : null);
+    map[_i1.getType<_i198.SharedModelContainer?>()] = (data, protocol) =>
+        (data != null ? _i198.SharedModelContainer.fromJson(data) : null);
+    map[_i1.getType<_i199.SharedModelSubclass?>()] = (data, protocol) =>
+        (data != null ? _i199.SharedModelSubclass.fromJson(data) : null);
+    map[_i1.getType<_i200.SimpleData?>()] = (data, protocol) =>
+        (data != null ? _i200.SimpleData.fromJson(data) : null);
+    map[_i1.getType<_i201.SimpleDataList?>()] = (data, protocol) =>
+        (data != null ? _i201.SimpleDataList.fromJson(data) : null);
+    map[_i1.getType<_i202.SimpleDataMap?>()] = (data, protocol) =>
+        (data != null ? _i202.SimpleDataMap.fromJson(data) : null);
+    map[_i1.getType<_i203.SimpleDataObject?>()] = (data, protocol) =>
+        (data != null ? _i203.SimpleDataObject.fromJson(data) : null);
+    map[_i1.getType<_i204.SimpleDateTime?>()] = (data, protocol) =>
+        (data != null ? _i204.SimpleDateTime.fromJson(data) : null);
+    map[_i1.getType<_i205.ModelInSubfolder?>()] = (data, protocol) =>
+        (data != null ? _i205.ModelInSubfolder.fromJson(data) : null);
+    map[_i1.getType<_i206.TestEnum?>()] = (data, protocol) =>
+        (data != null ? _i206.TestEnum.fromJson(data) : null);
+    map[_i1
+        .getType<_i207.TestEnumDefaultSerialization?>()] = (data, protocol) =>
+        (data != null
+        ? _i207.TestEnumDefaultSerialization.fromJson(data)
+        : null);
+    map[_i1.getType<_i208.TestEnumEnhanced?>()] = (data, protocol) =>
+        (data != null ? _i208.TestEnumEnhanced.fromJson(data) : null);
+    map[_i1.getType<_i209.TestEnumEnhancedByName?>()] = (data, protocol) =>
+        (data != null ? _i209.TestEnumEnhancedByName.fromJson(data) : null);
+    map[_i1.getType<_i210.TestEnumStringified?>()] = (data, protocol) =>
+        (data != null ? _i210.TestEnumStringified.fromJson(data) : null);
+    map[_i1.getType<_i211.Types?>()] = (data, protocol) =>
+        (data != null ? _i211.Types.fromJson(data) : null);
+    map[_i1.getType<_i212.TypesList?>()] = (data, protocol) =>
+        (data != null ? _i212.TypesList.fromJson(data) : null);
+    map[_i1.getType<_i213.TypesMap?>()] = (data, protocol) =>
+        (data != null ? _i213.TypesMap.fromJson(data) : null);
+    map[_i1.getType<_i214.TypesRecord?>()] = (data, protocol) =>
+        (data != null ? _i214.TypesRecord.fromJson(data) : null);
+    map[_i1.getType<_i215.TypesSet?>()] = (data, protocol) =>
+        (data != null ? _i215.TypesSet.fromJson(data) : null);
+    map[_i1.getType<_i216.TypesSetRequired?>()] = (data, protocol) =>
+        (data != null ? _i216.TypesSetRequired.fromJson(data) : null);
+    map[_i1.getType<_i217.UniqueData?>()] = (data, protocol) =>
+        (data != null ? _i217.UniqueData.fromJson(data) : null);
+    map[_i1.getType<_i218.UniqueDataWithNonPersist?>()] = (data, protocol) =>
+        (data != null ? _i218.UniqueDataWithNonPersist.fromJson(data) : null);
+    map[_i1.getType<_i219.UpsertTestModel?>()] = (data, protocol) =>
+        (data != null ? _i219.UpsertTestModel.fromJson(data) : null);
+    map[List<_i9.EnrollmentInt>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i9.EnrollmentInt>(e))
+        .toList();
+    map[_i1.getType<List<_i9.EnrollmentInt>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i9.EnrollmentInt>(e))
+              .toList()
+        : null);
+    map[List<_i12.PlayerUuid>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i12.PlayerUuid>(e))
+        .toList();
+    map[_i1.getType<List<_i12.PlayerUuid>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i12.PlayerUuid>(e))
+              .toList()
+        : null);
+    map[List<_i16.OrderUuid>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i16.OrderUuid>(e))
+        .toList();
+    map[_i1.getType<List<_i16.OrderUuid>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i16.OrderUuid>(e))
+              .toList()
+        : null);
+    map[List<_i14.CommentInt>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i14.CommentInt>(e))
+        .toList();
+    map[_i1.getType<List<_i14.CommentInt>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i14.CommentInt>(e))
+              .toList()
+        : null);
+    map[List<_i21.ChangedIdTypeSelf>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i21.ChangedIdTypeSelf>(e))
+        .toList();
+    map[_i1.getType<List<_i21.ChangedIdTypeSelf>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i21.ChangedIdTypeSelf>(e))
+              .toList()
+        : null);
+    map[List<_i67.EmptyModelRelationItem>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i67.EmptyModelRelationItem>(e))
+        .toList();
+    map[_i1.getType<List<_i67.EmptyModelRelationItem>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i67.EmptyModelRelationItem>(e))
+              .toList()
+        : null);
+    map[List<_i75.Employee>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i75.Employee>(e))
+        .toList();
+    map[_i1.getType<List<_i75.Employee>?>()] = (data, protocol) => (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i75.Employee>(e))
+              .toList()
+        : null);
+    map[List<String>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<String>(e)).toList();
+    map[Map<String, String>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<String>(v),
+      ),
+    );
+    map[_i1.getType<(int, String)>()] = (data, protocol) => (
+      protocol.deserialize<int>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<String>(data['p'][1]),
+    );
+    map[List<_i100.ChildEntity>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i100.ChildEntity>(e))
+        .toList();
+    map[_i1.getType<List<_i100.ChildEntity>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i100.ChildEntity>(e))
+              .toList()
+        : null);
+    map[List<_i106.PolymorphicChild>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i106.PolymorphicChild>(e))
+        .toList();
+    map[List<_i106.PolymorphicChild?>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i106.PolymorphicChild?>(e))
+        .toList();
+    map[Map<String, _i106.PolymorphicChild>] = (data, protocol) =>
+        (data as Map).map(
+          (k, v) => MapEntry(
+            protocol.deserialize<String>(k),
+            protocol.deserialize<_i106.PolymorphicChild>(v),
+          ),
+        );
+    map[Map<String, _i106.PolymorphicChild?>] = (data, protocol) =>
+        (data as Map).map(
+          (k, v) => MapEntry(
+            protocol.deserialize<String>(k),
+            protocol.deserialize<_i106.PolymorphicChild?>(v),
+          ),
+        );
+    map[List<_i3.ModulePolymorphicChild>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i3.ModulePolymorphicChild>(e))
+        .toList();
+    map[Map<String, _i3.ModulePolymorphicChild>] = (data, protocol) =>
+        (data as Map).map(
+          (k, v) => MapEntry(
+            protocol.deserialize<String>(k),
+            protocol.deserialize<_i3.ModulePolymorphicChild>(v),
+          ),
+        );
+    map[List<_i116.PersonWithLongTableName>] = (data, protocol) =>
+        (data as List)
+            .map((e) => protocol.deserialize<_i116.PersonWithLongTableName>(e))
+            .toList();
+    map[_i1.getType<List<_i116.PersonWithLongTableName>?>()] =
+        (data, protocol) => (data != null
+        ? (data as List)
+              .map(
+                (e) => protocol.deserialize<_i116.PersonWithLongTableName>(e),
+              )
+              .toList()
+        : null);
+    map[List<_i115.OrganizationWithLongTableName>] = (data, protocol) =>
+        (data as List)
+            .map(
+              (e) =>
+                  protocol.deserialize<_i115.OrganizationWithLongTableName>(e),
+            )
+            .toList();
+    map[_i1.getType<List<_i115.OrganizationWithLongTableName>?>()] =
+        (data, protocol) => (data != null
+        ? (data as List)
+              .map(
+                (e) => protocol
+                    .deserialize<_i115.OrganizationWithLongTableName>(e),
+              )
+              .toList()
+        : null);
+    map[List<_i118.LongImplicitIdField>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i118.LongImplicitIdField>(e))
+        .toList();
+    map[_i1.getType<List<_i118.LongImplicitIdField>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i118.LongImplicitIdField>(e))
+              .toList()
+        : null);
+    map[List<_i125.MultipleMaxFieldName>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i125.MultipleMaxFieldName>(e))
+        .toList();
+    map[_i1.getType<List<_i125.MultipleMaxFieldName>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i125.MultipleMaxFieldName>(e))
+              .toList()
+        : null);
+    map[List<_i121.UserNote>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i121.UserNote>(e))
+        .toList();
+    map[_i1.getType<List<_i121.UserNote>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i121.UserNote>(e))
+              .toList()
+        : null);
+    map[List<_i124.UserNoteWithALongName>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i124.UserNoteWithALongName>(e))
+        .toList();
+    map[_i1.getType<List<_i124.UserNoteWithALongName>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i124.UserNoteWithALongName>(e))
+              .toList()
+        : null);
+    map[List<_i128.Person>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i128.Person>(e))
+        .toList();
+    map[_i1.getType<List<_i128.Person>?>()] = (data, protocol) => (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i128.Person>(e))
+              .toList()
+        : null);
+    map[List<_i127.Organization>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i127.Organization>(e))
+        .toList();
+    map[_i1.getType<List<_i127.Organization>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i127.Organization>(e))
+              .toList()
+        : null);
+    map[List<_i132.Enrollment>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i132.Enrollment>(e))
+        .toList();
+    map[_i1.getType<List<_i132.Enrollment>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i132.Enrollment>(e))
+              .toList()
+        : null);
+    map[List<_i137.Player>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i137.Player>(e))
+        .toList();
+    map[_i1.getType<List<_i137.Player>?>()] = (data, protocol) => (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i137.Player>(e))
+              .toList()
+        : null);
+    map[List<_i143.Order>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i143.Order>(e))
+        .toList();
+    map[_i1.getType<List<_i143.Order>?>()] = (data, protocol) => (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i143.Order>(e))
+              .toList()
+        : null);
+    map[List<_i142.Chapter>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i142.Chapter>(e))
+        .toList();
+    map[_i1.getType<List<_i142.Chapter>?>()] = (data, protocol) => (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i142.Chapter>(e))
+              .toList()
+        : null);
+    map[List<_i139.Comment>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i139.Comment>(e))
+        .toList();
+    map[_i1.getType<List<_i139.Comment>?>()] = (data, protocol) => (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i139.Comment>(e))
+              .toList()
+        : null);
+    map[List<_i148.Blocking>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i148.Blocking>(e))
+        .toList();
+    map[_i1.getType<List<_i148.Blocking>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i148.Blocking>(e))
+              .toList()
+        : null);
+    map[List<_i150.Cat>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<_i150.Cat>(e)).toList();
+    map[_i1.getType<List<_i150.Cat>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<_i150.Cat>(e)).toList()
+        : null);
+    map[List<_i3.ModuleClass>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i3.ModuleClass>(e))
+        .toList();
+    map[Map<String, _i3.ModuleClass>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i3.ModuleClass>(v),
+      ),
+    );
+    map[_i1.getType<(_i3.ModuleClass,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (
+            protocol.deserialize<_i3.ModuleClass>(
+              ((data as Map)['p'] as List)[0],
+            ),
+          );
+    map[List<int>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int>(e)).toList();
+    map[List<int>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int>(e)).toList();
+    map[_i1.getType<List<int>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<int>(e)).toList()
+        : null);
+    map[List<int?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int?>(e)).toList();
+    map[List<int?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int?>(e)).toList();
+    map[_i1.getType<List<int?>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<int?>(e)).toList()
+        : null);
+    map[List<_i200.SimpleData>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i200.SimpleData>(e))
+        .toList();
+    map[List<_i200.SimpleData>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i200.SimpleData>(e))
+        .toList();
+    map[_i1.getType<List<_i200.SimpleData>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i200.SimpleData>(e))
+              .toList()
+        : null);
+    map[List<_i200.SimpleData?>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i200.SimpleData?>(e))
+        .toList();
+    map[List<_i200.SimpleData?>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i200.SimpleData?>(e))
+        .toList();
+    map[_i1.getType<List<_i200.SimpleData?>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i200.SimpleData?>(e))
+              .toList()
+        : null);
+    map[List<DateTime>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<DateTime>(e)).toList();
+    map[List<DateTime>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<DateTime>(e)).toList();
+    map[_i1.getType<List<DateTime>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<DateTime>(e)).toList()
+        : null);
+    map[List<DateTime?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<DateTime?>(e)).toList();
+    map[List<DateTime?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<DateTime?>(e)).toList();
+    map[_i1.getType<List<DateTime?>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<DateTime?>(e)).toList()
+        : null);
+    map[List<_i222.ByteData>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i222.ByteData>(e))
+        .toList();
+    map[List<_i222.ByteData>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i222.ByteData>(e))
+        .toList();
+    map[_i1.getType<List<_i222.ByteData>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i222.ByteData>(e))
+              .toList()
+        : null);
+    map[List<_i222.ByteData?>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i222.ByteData?>(e))
+        .toList();
+    map[List<_i222.ByteData?>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i222.ByteData?>(e))
+        .toList();
+    map[_i1.getType<List<_i222.ByteData?>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i222.ByteData?>(e))
+              .toList()
+        : null);
+    map[List<Duration>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<Duration>(e)).toList();
+    map[List<Duration>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<Duration>(e)).toList();
+    map[_i1.getType<List<Duration>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<Duration>(e)).toList()
+        : null);
+    map[List<Duration?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<Duration?>(e)).toList();
+    map[List<Duration?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<Duration?>(e)).toList();
+    map[_i1.getType<List<Duration?>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<Duration?>(e)).toList()
+        : null);
+    map[List<_i1.UuidValue>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i1.UuidValue>(e))
+        .toList();
+    map[List<_i1.UuidValue>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i1.UuidValue>(e))
+        .toList();
+    map[_i1.getType<List<_i1.UuidValue>?>()] = (data, protocol) => (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i1.UuidValue>(e))
+              .toList()
+        : null);
+    map[List<_i1.UuidValue?>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i1.UuidValue?>(e))
+        .toList();
+    map[List<_i1.UuidValue?>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i1.UuidValue?>(e))
+        .toList();
+    map[_i1.getType<List<_i1.UuidValue?>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i1.UuidValue?>(e))
+              .toList()
+        : null);
+    map[Map<String, int>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<int>(v),
+      ),
+    );
+    map[Map<String, int>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<int>(v),
+      ),
+    );
+    map[_i1.getType<Map<String, int>?>()] = (data, protocol) => (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<int>(v),
+            ),
+          )
+        : null);
+    map[Map<String, int?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<int?>(v),
+      ),
+    );
+    map[Map<String, int?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<int?>(v),
+      ),
+    );
+    map[_i1.getType<Map<String, int?>?>()] = (data, protocol) => (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<int?>(v),
+            ),
+          )
+        : null);
+    map[_i5.CustomClassWithoutProtocolSerialization] = (data, protocol) =>
+        _i5.CustomClassWithoutProtocolSerialization.fromJson(data);
+    map[_i5.CustomClassWithProtocolSerialization] = (data, protocol) =>
+        _i5.CustomClassWithProtocolSerialization.fromJson(data);
+    map[_i5.CustomClassWithProtocolSerializationMethod] = (data, protocol) =>
+        _i5.CustomClassWithProtocolSerializationMethod.fromJson(data);
+    map[dynamic] = (data, protocol) =>
+        protocol.deserializeDynamicFieldValue(data);
+    map[List<dynamic>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<dynamic>(e)).toList();
+    map[dynamic] = (data, protocol) =>
+        protocol.deserializeDynamicFieldValue(data);
+    map[Map<String, dynamic>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<dynamic>(v),
+      ),
+    );
+    map[dynamic] = (data, protocol) =>
+        protocol.deserializeDynamicFieldValue(data);
+    map[Set<dynamic>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<dynamic>(e)).toSet();
+    map[dynamic] = (data, protocol) =>
+        protocol.deserializeDynamicFieldValue(data);
+    map[Map<dynamic, dynamic>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<dynamic>(e['k']),
+          protocol.deserialize<dynamic>(e['v']),
+        ),
+      ),
+    );
+    map[dynamic] = (data, protocol) =>
+        protocol.deserializeDynamicFieldValue(data);
+    map[dynamic] = (data, protocol) =>
+        protocol.deserializeDynamicFieldValue(data);
+    map[List<_i206.TestEnum>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i206.TestEnum>(e))
+        .toList();
+    map[List<_i206.TestEnum?>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i206.TestEnum?>(e))
+        .toList();
+    map[List<List<_i206.TestEnum>>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<List<_i206.TestEnum>>(e))
+        .toList();
+    map[List<_i206.TestEnum>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i206.TestEnum>(e))
+        .toList();
+    map[List<_i208.TestEnumEnhanced>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i208.TestEnumEnhanced>(e))
+        .toList();
+    map[List<_i209.TestEnumEnhancedByName>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i209.TestEnumEnhancedByName>(e))
+        .toList();
+    map[List<String>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<String>(e)).toList();
+    map[_i1.getType<List<String>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<String>(e)).toList()
+        : null);
+    map[Map<String, _i200.SimpleData>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i200.SimpleData>(v),
+      ),
+    );
+    map[Map<String, DateTime>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<DateTime>(v),
+      ),
+    );
+    map[Map<String, _i222.ByteData>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i222.ByteData>(v),
+      ),
+    );
+    map[Map<String, Duration>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<Duration>(v),
+      ),
+    );
+    map[Map<String, _i1.UuidValue>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i1.UuidValue>(v),
+      ),
+    );
+    map[Map<String, _i200.SimpleData?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i200.SimpleData?>(v),
+      ),
+    );
+    map[Map<String, String?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<String?>(v),
+      ),
+    );
+    map[Map<String, DateTime?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<DateTime?>(v),
+      ),
+    );
+    map[Map<String, _i222.ByteData?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i222.ByteData?>(v),
+      ),
+    );
+    map[Map<String, Duration?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<Duration?>(v),
+      ),
+    );
+    map[Map<String, _i1.UuidValue?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i1.UuidValue?>(v),
+      ),
+    );
+    map[Map<int, int>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<int>(e['k']),
+          protocol.deserialize<int>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<_i5.CustomClassWithoutProtocolSerialization?>()] =
+        (data, protocol) => (data != null
+        ? _i5.CustomClassWithoutProtocolSerialization.fromJson(data)
+        : null);
+    map[_i1.getType<_i5.CustomClassWithProtocolSerialization?>()] =
+        (data, protocol) => (data != null
+        ? _i5.CustomClassWithProtocolSerialization.fromJson(data)
+        : null);
+    map[_i1.getType<_i5.CustomClassWithProtocolSerializationMethod?>()] =
+        (data, protocol) => (data != null
+        ? _i5.CustomClassWithProtocolSerializationMethod.fromJson(data)
+        : null);
+    map[List<List<_i200.SimpleData>>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<List<_i200.SimpleData>>(e))
+        .toList();
+    map[List<_i200.SimpleData>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i200.SimpleData>(e))
+        .toList();
+    map[_i1.getType<List<List<_i200.SimpleData>>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<List<_i200.SimpleData>>(e))
+              .toList()
+        : null);
+    map[List<_i200.SimpleData>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i200.SimpleData>(e))
+        .toList();
+    map[Map<String, List<List<Map<int, _i200.SimpleData>>?>>] =
+        (data, protocol) => (data as Map).map(
+          (k, v) => MapEntry(
+            protocol.deserialize<String>(k),
+            protocol.deserialize<List<List<Map<int, _i200.SimpleData>>?>>(v),
+          ),
+        );
+    map[List<List<Map<int, _i200.SimpleData>>?>] = (data, protocol) =>
+        (data as List)
+            .map(
+              (e) => protocol.deserialize<List<Map<int, _i200.SimpleData>>?>(e),
+            )
+            .toList();
+    map[List<Map<int, _i200.SimpleData>>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<Map<int, _i200.SimpleData>>(e))
+        .toList();
+    map[Map<int, _i200.SimpleData>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<int>(e['k']),
+          protocol.deserialize<_i200.SimpleData>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<List<Map<int, _i200.SimpleData>>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<Map<int, _i200.SimpleData>>(e))
+              .toList()
+        : null);
+    map[Map<int, _i200.SimpleData>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<int>(e['k']),
+          protocol.deserialize<_i200.SimpleData>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<Map<String, List<List<Map<int, _i200.SimpleData>>?>>?>()] =
+        (data, protocol) => (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<List<List<Map<int, _i200.SimpleData>>?>>(v),
+            ),
+          )
+        : null);
+    map[List<List<Map<int, _i200.SimpleData>>?>] = (data, protocol) =>
+        (data as List)
+            .map(
+              (e) => protocol.deserialize<List<Map<int, _i200.SimpleData>>?>(e),
+            )
+            .toList();
+    map[List<Map<int, _i200.SimpleData>>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<Map<int, _i200.SimpleData>>(e))
+        .toList();
+    map[Map<int, _i200.SimpleData>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<int>(e['k']),
+          protocol.deserialize<_i200.SimpleData>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<List<Map<int, _i200.SimpleData>>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<Map<int, _i200.SimpleData>>(e))
+              .toList()
+        : null);
+    map[Map<int, _i200.SimpleData>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<int>(e['k']),
+          protocol.deserialize<_i200.SimpleData>(e['v']),
+        ),
+      ),
+    );
+    map[Map<String, Map<int, _i200.SimpleData>>] = (data, protocol) =>
+        (data as Map).map(
+          (k, v) => MapEntry(
+            protocol.deserialize<String>(k),
+            protocol.deserialize<Map<int, _i200.SimpleData>>(v),
+          ),
+        );
+    map[Map<int, _i200.SimpleData>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<int>(e['k']),
+          protocol.deserialize<_i200.SimpleData>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<Map<String, Map<int, _i200.SimpleData>>?>()] =
+        (data, protocol) => (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<Map<int, _i200.SimpleData>>(v),
+            ),
+          )
+        : null);
+    map[Map<int, _i200.SimpleData>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<int>(e['k']),
+          protocol.deserialize<_i200.SimpleData>(e['v']),
+        ),
+      ),
+    );
+    map[List<_i112.SealedParent>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i112.SealedParent>(e))
+        .toList();
+    map[List<_i95.SealedAppException>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i95.SealedAppException>(e))
+        .toList();
+    map[_i1.getType<(bool,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<bool>(((data as Map)['p'] as List)[0]),);
+    map[List<_i5.SharedModel>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i5.SharedModel>(e))
+        .toList();
+    map[List<_i5.SharedModel?>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i5.SharedModel?>(e))
+        .toList();
+    map[List<_i5.SharedModel>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i5.SharedModel>(e))
+        .toList();
+    map[_i1.getType<List<_i5.SharedModel>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i5.SharedModel>(e))
+              .toList()
+        : null);
+    map[Map<String, _i5.SharedModel>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i5.SharedModel>(v),
+      ),
+    );
+    map[Map<String, _i5.SharedModel>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i5.SharedModel>(v),
+      ),
+    );
+    map[_i1.getType<Map<String, _i5.SharedModel>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<_i5.SharedModel>(v),
+            ),
+          )
+        : null);
+    map[Map<String, _i5.SharedSubclass>] = (data, protocol) =>
+        (data as Map).map(
+          (k, v) => MapEntry(
+            protocol.deserialize<String>(k),
+            protocol.deserialize<_i5.SharedSubclass>(v),
+          ),
+        );
+    map[Set<_i5.SharedModel>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i5.SharedModel>(e))
+        .toSet();
+    map[Set<_i5.SharedModel>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i5.SharedModel>(e))
+        .toSet();
+    map[_i1.getType<Set<_i5.SharedModel>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i5.SharedModel>(e))
+              .toSet()
+        : null);
+    map[List<_i210.TestEnumStringified>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i210.TestEnumStringified>(e))
+        .toList();
+    map[_i1.getType<List<_i210.TestEnumStringified>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i210.TestEnumStringified>(e))
+              .toList()
+        : null);
+    map[_i1.getType<(_i210.TestEnumStringified,)?>()] = (data, protocol) =>
+        (data == null)
+        ? null
+        : (
+            protocol.deserialize<_i210.TestEnumStringified>(
+              ((data as Map)['p'] as List)[0],
+            ),
+          );
+    map[List<(_i210.TestEnumStringified,)>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<(_i210.TestEnumStringified,)>(e))
+        .toList();
+    map[_i1.getType<(_i210.TestEnumStringified,)>()] = (data, protocol) => (
+      protocol.deserialize<_i210.TestEnumStringified>(
+        ((data as Map)['p'] as List)[0],
+      ),
+    );
+    map[_i1.getType<List<(_i210.TestEnumStringified,)>?>()] =
+        (data, protocol) => (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<(_i210.TestEnumStringified,)>(e))
+              .toList()
+        : null);
+    map[_i1.getType<(_i210.TestEnumStringified,)>()] = (data, protocol) => (
+      protocol.deserialize<_i210.TestEnumStringified>(
+        ((data as Map)['p'] as List)[0],
+      ),
+    );
+    map[_i1.getType<(_i155.Nullability,)?>()] = (data, protocol) =>
+        (data == null)
+        ? null
+        : (
+            protocol.deserialize<_i155.Nullability>(
+              ((data as Map)['p'] as List)[0],
+            ),
+          );
+    map[_i1.getType<({_i210.TestEnumStringified value})?>()] =
+        (data, protocol) => (data == null)
+        ? null
+        : (
+            value: protocol.deserialize<_i210.TestEnumStringified>(
+              ((data as Map)['n'] as Map)['value'],
+            ),
+          );
+    map[List<({_i210.TestEnumStringified value})>] = (data, protocol) =>
+        (data as List)
+            .map(
+              (e) =>
+                  protocol.deserialize<({_i210.TestEnumStringified value})>(e),
+            )
+            .toList();
+    map[_i1
+        .getType<({_i210.TestEnumStringified value})>()] = (data, protocol) => (
+      value: protocol.deserialize<_i210.TestEnumStringified>(
+        ((data as Map)['n'] as Map)['value'],
+      ),
+    );
+    map[_i1.getType<List<({_i210.TestEnumStringified value})>?>()] =
+        (data, protocol) => (data != null
+        ? (data as List)
+              .map(
+                (e) => protocol
+                    .deserialize<({_i210.TestEnumStringified value})>(e),
+              )
+              .toList()
+        : null);
+    map[_i1
+        .getType<({_i210.TestEnumStringified value})>()] = (data, protocol) => (
+      value: protocol.deserialize<_i210.TestEnumStringified>(
+        ((data as Map)['n'] as Map)['value'],
+      ),
+    );
+    map[_i1.getType<({_i3.ModuleClass value})?>()] = (data, protocol) =>
+        (data == null)
+        ? null
+        : (
+            value: protocol.deserialize<_i3.ModuleClass>(
+              ((data as Map)['n'] as Map)['value'],
+            ),
+          );
+    map[_i1.getType<({_i155.Nullability value})?>()] = (data, protocol) =>
+        (data == null)
+        ? null
+        : (
+            value: protocol.deserialize<_i155.Nullability>(
+              ((data as Map)['n'] as Map)['value'],
+            ),
+          );
+    map[Map<int, int>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<int>(e['k']),
+          protocol.deserialize<int>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<Map<int, int>?>()] = (data, protocol) => (data != null
+        ? Map.fromEntries(
+            (data as List).map(
+              (e) => MapEntry(
+                protocol.deserialize<int>(e['k']),
+                protocol.deserialize<int>(e['v']),
+              ),
+            ),
+          )
+        : null);
+    map[Set<int>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int>(e)).toSet();
+    map[_i1.getType<Set<int>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<int>(e)).toSet()
+        : null);
+    map[_i1.getType<(String, {Uri? optionalUri})?>()] = (data, protocol) =>
+        (data == null)
+        ? null
+        : (
+            protocol.deserialize<String>(((data as Map)['p'] as List)[0]),
+            optionalUri: ((data)['n'] as Map)['optionalUri'] == null
+                ? null
+                : protocol.deserialize<Uri>(data['n']['optionalUri']),
+          );
+    map[List<bool>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<bool>(e)).toList();
+    map[_i1.getType<List<bool>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<bool>(e)).toList()
+        : null);
+    map[List<double>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<double>(e)).toList();
+    map[_i1.getType<List<double>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<double>(e)).toList()
+        : null);
+    map[List<Uri>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<Uri>(e)).toList();
+    map[_i1.getType<List<Uri>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<Uri>(e)).toList()
+        : null);
+    map[List<BigInt>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<BigInt>(e)).toList();
+    map[_i1.getType<List<BigInt>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<BigInt>(e)).toList()
+        : null);
+    map[List<_i206.TestEnum>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i206.TestEnum>(e))
+        .toList();
+    map[_i1.getType<List<_i206.TestEnum>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i206.TestEnum>(e))
+              .toList()
+        : null);
+    map[List<_i211.Types>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i211.Types>(e))
+        .toList();
+    map[_i1.getType<List<_i211.Types>?>()] = (data, protocol) => (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i211.Types>(e))
+              .toList()
+        : null);
+    map[List<Map<String, _i211.Types>>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<Map<String, _i211.Types>>(e))
+        .toList();
+    map[Map<String, _i211.Types>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i211.Types>(v),
+      ),
+    );
+    map[_i1.getType<List<Map<String, _i211.Types>>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<Map<String, _i211.Types>>(e))
+              .toList()
+        : null);
+    map[Map<String, _i211.Types>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i211.Types>(v),
+      ),
+    );
+    map[List<List<_i211.Types>>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<List<_i211.Types>>(e))
+        .toList();
+    map[List<_i211.Types>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i211.Types>(e))
+        .toList();
+    map[_i1.getType<List<List<_i211.Types>>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<List<_i211.Types>>(e))
+              .toList()
+        : null);
+    map[List<_i211.Types>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i211.Types>(e))
+        .toList();
+    map[List<(int,)>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<(int,)>(e)).toList();
+    map[_i1.getType<(int,)>()] = (data, protocol) =>
+        (protocol.deserialize<int>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<List<(int,)>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<(int,)>(e)).toList()
+        : null);
+    map[_i1.getType<(int,)>()] = (data, protocol) =>
+        (protocol.deserialize<int>(((data as Map)['p'] as List)[0]),);
+    map[List<(int,)?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<(int,)?>(e)).toList();
+    map[_i1.getType<(int,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<int>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<List<(int,)?>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<(int,)?>(e)).toList()
+        : null);
+    map[_i1.getType<(int,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<int>(((data as Map)['p'] as List)[0]),);
+    map[List<(_i206.TestEnum,)>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<(_i206.TestEnum,)>(e))
+        .toList();
+    map[_i1.getType<(_i206.TestEnum,)>()] = (data, protocol) => (
+      protocol.deserialize<_i206.TestEnum>(((data as Map)['p'] as List)[0]),
+    );
+    map[_i1.getType<List<(_i206.TestEnum,)>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<(_i206.TestEnum,)>(e))
+              .toList()
+        : null);
+    map[_i1.getType<(_i206.TestEnum,)>()] = (data, protocol) => (
+      protocol.deserialize<_i206.TestEnum>(((data as Map)['p'] as List)[0]),
+    );
+    map[Map<int, String>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<int>(e['k']),
+          protocol.deserialize<String>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<Map<int, String>?>()] = (data, protocol) => (data != null
+        ? Map.fromEntries(
+            (data as List).map(
+              (e) => MapEntry(
+                protocol.deserialize<int>(e['k']),
+                protocol.deserialize<String>(e['v']),
+              ),
+            ),
+          )
+        : null);
+    map[Map<bool, String>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<bool>(e['k']),
+          protocol.deserialize<String>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<Map<bool, String>?>()] = (data, protocol) => (data != null
+        ? Map.fromEntries(
+            (data as List).map(
+              (e) => MapEntry(
+                protocol.deserialize<bool>(e['k']),
+                protocol.deserialize<String>(e['v']),
+              ),
+            ),
+          )
+        : null);
+    map[Map<double, String>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<double>(e['k']),
+          protocol.deserialize<String>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<Map<double, String>?>()] = (data, protocol) => (data != null
+        ? Map.fromEntries(
+            (data as List).map(
+              (e) => MapEntry(
+                protocol.deserialize<double>(e['k']),
+                protocol.deserialize<String>(e['v']),
+              ),
+            ),
+          )
+        : null);
+    map[Map<DateTime, String>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<DateTime>(e['k']),
+          protocol.deserialize<String>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<Map<DateTime, String>?>()] = (data, protocol) =>
+        (data != null
+        ? Map.fromEntries(
+            (data as List).map(
+              (e) => MapEntry(
+                protocol.deserialize<DateTime>(e['k']),
+                protocol.deserialize<String>(e['v']),
+              ),
+            ),
+          )
+        : null);
+    map[Map<String, String>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<String>(v),
+      ),
+    );
+    map[_i1.getType<Map<String, String>?>()] = (data, protocol) => (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<String>(v),
+            ),
+          )
+        : null);
+    map[Map<_i222.ByteData, String>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<_i222.ByteData>(e['k']),
+          protocol.deserialize<String>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<Map<_i222.ByteData, String>?>()] = (data, protocol) =>
+        (data != null
+        ? Map.fromEntries(
+            (data as List).map(
+              (e) => MapEntry(
+                protocol.deserialize<_i222.ByteData>(e['k']),
+                protocol.deserialize<String>(e['v']),
+              ),
+            ),
+          )
+        : null);
+    map[Map<Duration, String>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<Duration>(e['k']),
+          protocol.deserialize<String>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<Map<Duration, String>?>()] = (data, protocol) =>
+        (data != null
+        ? Map.fromEntries(
+            (data as List).map(
+              (e) => MapEntry(
+                protocol.deserialize<Duration>(e['k']),
+                protocol.deserialize<String>(e['v']),
+              ),
+            ),
+          )
+        : null);
+    map[Map<_i1.UuidValue, String>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<_i1.UuidValue>(e['k']),
+          protocol.deserialize<String>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<Map<_i1.UuidValue, String>?>()] = (data, protocol) =>
+        (data != null
+        ? Map.fromEntries(
+            (data as List).map(
+              (e) => MapEntry(
+                protocol.deserialize<_i1.UuidValue>(e['k']),
+                protocol.deserialize<String>(e['v']),
+              ),
+            ),
+          )
+        : null);
+    map[Map<Uri, String>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<Uri>(e['k']),
+          protocol.deserialize<String>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<Map<Uri, String>?>()] = (data, protocol) => (data != null
+        ? Map.fromEntries(
+            (data as List).map(
+              (e) => MapEntry(
+                protocol.deserialize<Uri>(e['k']),
+                protocol.deserialize<String>(e['v']),
+              ),
+            ),
+          )
+        : null);
+    map[Map<BigInt, String>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<BigInt>(e['k']),
+          protocol.deserialize<String>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<Map<BigInt, String>?>()] = (data, protocol) => (data != null
+        ? Map.fromEntries(
+            (data as List).map(
+              (e) => MapEntry(
+                protocol.deserialize<BigInt>(e['k']),
+                protocol.deserialize<String>(e['v']),
+              ),
+            ),
+          )
+        : null);
+    map[Map<_i206.TestEnum, String>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<_i206.TestEnum>(e['k']),
+          protocol.deserialize<String>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<Map<_i206.TestEnum, String>?>()] = (data, protocol) =>
+        (data != null
+        ? Map.fromEntries(
+            (data as List).map(
+              (e) => MapEntry(
+                protocol.deserialize<_i206.TestEnum>(e['k']),
+                protocol.deserialize<String>(e['v']),
+              ),
+            ),
+          )
+        : null);
+    map[Map<_i210.TestEnumStringified, String>] = (data, protocol) =>
+        Map.fromEntries(
+          (data as List).map(
+            (e) => MapEntry(
+              protocol.deserialize<_i210.TestEnumStringified>(e['k']),
+              protocol.deserialize<String>(e['v']),
+            ),
+          ),
+        );
+    map[_i1.getType<Map<_i210.TestEnumStringified, String>?>()] =
+        (data, protocol) => (data != null
+        ? Map.fromEntries(
+            (data as List).map(
+              (e) => MapEntry(
+                protocol.deserialize<_i210.TestEnumStringified>(e['k']),
+                protocol.deserialize<String>(e['v']),
+              ),
+            ),
+          )
+        : null);
+    map[Map<_i211.Types, String>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<_i211.Types>(e['k']),
+          protocol.deserialize<String>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<Map<_i211.Types, String>?>()] = (data, protocol) =>
+        (data != null
+        ? Map.fromEntries(
+            (data as List).map(
+              (e) => MapEntry(
+                protocol.deserialize<_i211.Types>(e['k']),
+                protocol.deserialize<String>(e['v']),
+              ),
+            ),
+          )
+        : null);
+    map[Map<Map<_i211.Types, String>, String>] = (data, protocol) =>
+        Map.fromEntries(
+          (data as List).map(
+            (e) => MapEntry(
+              protocol.deserialize<Map<_i211.Types, String>>(e['k']),
+              protocol.deserialize<String>(e['v']),
+            ),
+          ),
+        );
+    map[Map<_i211.Types, String>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<_i211.Types>(e['k']),
+          protocol.deserialize<String>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<Map<Map<_i211.Types, String>, String>?>()] =
+        (data, protocol) => (data != null
+        ? Map.fromEntries(
+            (data as List).map(
+              (e) => MapEntry(
+                protocol.deserialize<Map<_i211.Types, String>>(e['k']),
+                protocol.deserialize<String>(e['v']),
+              ),
+            ),
+          )
+        : null);
+    map[Map<_i211.Types, String>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<_i211.Types>(e['k']),
+          protocol.deserialize<String>(e['v']),
+        ),
+      ),
+    );
+    map[Map<List<_i211.Types>, String>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<List<_i211.Types>>(e['k']),
+          protocol.deserialize<String>(e['v']),
+        ),
+      ),
+    );
+    map[List<_i211.Types>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i211.Types>(e))
+        .toList();
+    map[_i1.getType<Map<List<_i211.Types>, String>?>()] = (data, protocol) =>
+        (data != null
+        ? Map.fromEntries(
+            (data as List).map(
+              (e) => MapEntry(
+                protocol.deserialize<List<_i211.Types>>(e['k']),
+                protocol.deserialize<String>(e['v']),
+              ),
+            ),
+          )
+        : null);
+    map[List<_i211.Types>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i211.Types>(e))
+        .toList();
+    map[Map<(String,), String>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<(String,)>(e['k']),
+          protocol.deserialize<String>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<(String,)>()] = (data, protocol) =>
+        (protocol.deserialize<String>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<Map<(String,), String>?>()] = (data, protocol) =>
+        (data != null
+        ? Map.fromEntries(
+            (data as List).map(
+              (e) => MapEntry(
+                protocol.deserialize<(String,)>(e['k']),
+                protocol.deserialize<String>(e['v']),
+              ),
+            ),
+          )
+        : null);
+    map[_i1.getType<(String,)>()] = (data, protocol) =>
+        (protocol.deserialize<String>(((data as Map)['p'] as List)[0]),);
+    map[Map<String, bool>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<bool>(v),
+      ),
+    );
+    map[_i1.getType<Map<String, bool>?>()] = (data, protocol) => (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<bool>(v),
+            ),
+          )
+        : null);
+    map[Map<String, double>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<double>(v),
+      ),
+    );
+    map[_i1.getType<Map<String, double>?>()] = (data, protocol) => (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<double>(v),
+            ),
+          )
+        : null);
+    map[Map<String, DateTime>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<DateTime>(v),
+      ),
+    );
+    map[_i1.getType<Map<String, DateTime>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<DateTime>(v),
+            ),
+          )
+        : null);
+    map[Map<String, _i222.ByteData>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i222.ByteData>(v),
+      ),
+    );
+    map[_i1.getType<Map<String, _i222.ByteData>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<_i222.ByteData>(v),
+            ),
+          )
+        : null);
+    map[Map<String, Duration>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<Duration>(v),
+      ),
+    );
+    map[_i1.getType<Map<String, Duration>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<Duration>(v),
+            ),
+          )
+        : null);
+    map[Map<String, _i1.UuidValue>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i1.UuidValue>(v),
+      ),
+    );
+    map[_i1.getType<Map<String, _i1.UuidValue>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<_i1.UuidValue>(v),
+            ),
+          )
+        : null);
+    map[Map<String, Uri>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<Uri>(v),
+      ),
+    );
+    map[_i1.getType<Map<String, Uri>?>()] = (data, protocol) => (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<Uri>(v),
+            ),
+          )
+        : null);
+    map[Map<String, BigInt>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<BigInt>(v),
+      ),
+    );
+    map[_i1.getType<Map<String, BigInt>?>()] = (data, protocol) => (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<BigInt>(v),
+            ),
+          )
+        : null);
+    map[Map<String, _i206.TestEnum>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i206.TestEnum>(v),
+      ),
+    );
+    map[_i1.getType<Map<String, _i206.TestEnum>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<_i206.TestEnum>(v),
+            ),
+          )
+        : null);
+    map[Map<String, _i210.TestEnumStringified>] = (data, protocol) =>
+        (data as Map).map(
+          (k, v) => MapEntry(
+            protocol.deserialize<String>(k),
+            protocol.deserialize<_i210.TestEnumStringified>(v),
+          ),
+        );
+    map[_i1.getType<Map<String, _i210.TestEnumStringified>?>()] =
+        (data, protocol) => (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<_i210.TestEnumStringified>(v),
+            ),
+          )
+        : null);
+    map[Map<String, _i211.Types>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i211.Types>(v),
+      ),
+    );
+    map[_i1.getType<Map<String, _i211.Types>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<_i211.Types>(v),
+            ),
+          )
+        : null);
+    map[Map<String, Map<String, _i211.Types>>] = (data, protocol) =>
+        (data as Map).map(
+          (k, v) => MapEntry(
+            protocol.deserialize<String>(k),
+            protocol.deserialize<Map<String, _i211.Types>>(v),
+          ),
+        );
+    map[Map<String, _i211.Types>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i211.Types>(v),
+      ),
+    );
+    map[_i1.getType<Map<String, Map<String, _i211.Types>>?>()] =
+        (data, protocol) => (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<Map<String, _i211.Types>>(v),
+            ),
+          )
+        : null);
+    map[Map<String, _i211.Types>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i211.Types>(v),
+      ),
+    );
+    map[Map<String, List<_i211.Types>>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<List<_i211.Types>>(v),
+      ),
+    );
+    map[List<_i211.Types>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i211.Types>(e))
+        .toList();
+    map[_i1.getType<Map<String, List<_i211.Types>>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<List<_i211.Types>>(v),
+            ),
+          )
+        : null);
+    map[List<_i211.Types>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i211.Types>(e))
+        .toList();
+    map[Map<String, (String,)>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<(String,)>(v),
+      ),
+    );
+    map[_i1.getType<(String,)>()] = (data, protocol) =>
+        (protocol.deserialize<String>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<Map<String, (String,)>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<(String,)>(v),
+            ),
+          )
+        : null);
+    map[_i1.getType<(String,)>()] = (data, protocol) =>
+        (protocol.deserialize<String>(((data as Map)['p'] as List)[0]),);
+    map[Map<String, (String,)?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<(String,)?>(v),
+      ),
+    );
+    map[_i1.getType<(String,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<String>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<Map<String, (String,)?>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<(String,)?>(v),
+            ),
+          )
+        : null);
+    map[_i1.getType<(String,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<String>(((data as Map)['p'] as List)[0]),);
+    map[Map<(String,)?, String>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<(String,)?>(e['k']),
+          protocol.deserialize<String>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<(String,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<String>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<Map<(String,)?, String>?>()] = (data, protocol) =>
+        (data != null
+        ? Map.fromEntries(
+            (data as List).map(
+              (e) => MapEntry(
+                protocol.deserialize<(String,)?>(e['k']),
+                protocol.deserialize<String>(e['v']),
+              ),
+            ),
+          )
+        : null);
+    map[_i1.getType<(String,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<String>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(int,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<int>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(double,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<double>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(DateTime,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<DateTime>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(String,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<String>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(_i222.ByteData,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (
+            protocol.deserialize<_i222.ByteData>(
+              ((data as Map)['p'] as List)[0],
+            ),
+          );
+    map[_i1.getType<(Duration,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<Duration>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(_i1.UuidValue,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (
+            protocol.deserialize<_i1.UuidValue>(
+              ((data as Map)['p'] as List)[0],
+            ),
+          );
+    map[_i1.getType<(Uri,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<Uri>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(BigInt,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<BigInt>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(_i206.TestEnum,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (
+            protocol.deserialize<_i206.TestEnum>(
+              ((data as Map)['p'] as List)[0],
+            ),
+          );
+    map[_i1.getType<(List<int>,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<List<int>>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(Map<int, int>,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (
+            protocol.deserialize<Map<int, int>>(
+              ((data as Map)['p'] as List)[0],
+            ),
+          );
+    map[_i1.getType<(Set<int>,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<Set<int>>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(_i200.SimpleData,)?>()] = (data, protocol) =>
+        (data == null)
+        ? null
+        : (
+            protocol.deserialize<_i200.SimpleData>(
+              ((data as Map)['p'] as List)[0],
+            ),
+          );
+    map[_i1.getType<({_i200.SimpleData namedModel})?>()] = (data, protocol) =>
+        (data == null)
+        ? null
+        : (
+            namedModel: protocol.deserialize<_i200.SimpleData>(
+              ((data as Map)['n'] as Map)['namedModel'],
+            ),
+          );
+    map[_i1.getType<(_i200.SimpleData, {_i200.SimpleData namedModel})?>()] =
+        (data, protocol) => (data == null)
+        ? null
+        : (
+            protocol.deserialize<_i200.SimpleData>(
+              ((data as Map)['p'] as List)[0],
+            ),
+            namedModel: protocol.deserialize<_i200.SimpleData>(
+              data['n']['namedModel'],
+            ),
+          );
+    map[_i1.getType<((int, String), {(int, String) namedNestedRecord})?>()] =
+        (data, protocol) => (data == null)
+        ? null
+        : (
+            protocol.deserialize<(int, String)>(
+              ((data as Map)['p'] as List)[0],
+            ),
+            namedNestedRecord: protocol.deserialize<(int, String)>(
+              data['n']['namedNestedRecord'],
+            ),
+          );
+    map[_i1
+        .getType<
+          (
+            (List<(_i200.SimpleData,)>,), {
+            (_i200.SimpleData, Map<String, _i200.SimpleData>) namedNestedRecord,
+          })?
+        >()] = (data, protocol) => (data == null)
+        ? null
+        : (
+            protocol.deserialize<(List<(_i200.SimpleData,)>,)>(
+              ((data as Map)['p'] as List)[0],
+            ),
+            namedNestedRecord: protocol
+                .deserialize<(_i200.SimpleData, Map<String, _i200.SimpleData>)>(
+                  data['n']['namedNestedRecord'],
+                ),
+          );
+    map[Set<bool>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<bool>(e)).toSet();
+    map[_i1.getType<Set<bool>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<bool>(e)).toSet()
+        : null);
+    map[Set<double>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<double>(e)).toSet();
+    map[_i1.getType<Set<double>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<double>(e)).toSet()
+        : null);
+    map[Set<DateTime>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<DateTime>(e)).toSet();
+    map[_i1.getType<Set<DateTime>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<DateTime>(e)).toSet()
+        : null);
+    map[Set<String>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<String>(e)).toSet();
+    map[_i1.getType<Set<String>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<String>(e)).toSet()
+        : null);
+    map[Set<_i222.ByteData>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i222.ByteData>(e))
+        .toSet();
+    map[_i1.getType<Set<_i222.ByteData>?>()] = (data, protocol) => (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i222.ByteData>(e))
+              .toSet()
+        : null);
+    map[Set<Duration>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<Duration>(e)).toSet();
+    map[_i1.getType<Set<Duration>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<Duration>(e)).toSet()
+        : null);
+    map[Set<_i1.UuidValue>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i1.UuidValue>(e))
+        .toSet();
+    map[_i1.getType<Set<_i1.UuidValue>?>()] = (data, protocol) => (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i1.UuidValue>(e))
+              .toSet()
+        : null);
+    map[Set<BigInt>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<BigInt>(e)).toSet();
+    map[_i1.getType<Set<BigInt>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<BigInt>(e)).toSet()
+        : null);
+    map[Set<_i206.TestEnum>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i206.TestEnum>(e))
+        .toSet();
+    map[_i1.getType<Set<_i206.TestEnum>?>()] = (data, protocol) => (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i206.TestEnum>(e))
+              .toSet()
+        : null);
+    map[Set<_i210.TestEnumStringified>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i210.TestEnumStringified>(e))
+        .toSet();
+    map[_i1.getType<Set<_i210.TestEnumStringified>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i210.TestEnumStringified>(e))
+              .toSet()
+        : null);
+    map[Set<_i211.Types>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<_i211.Types>(e)).toSet();
+    map[_i1.getType<Set<_i211.Types>?>()] = (data, protocol) => (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i211.Types>(e))
+              .toSet()
+        : null);
+    map[Set<Map<String, _i211.Types>>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<Map<String, _i211.Types>>(e))
+        .toSet();
+    map[Map<String, _i211.Types>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i211.Types>(v),
+      ),
+    );
+    map[_i1.getType<Set<Map<String, _i211.Types>>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<Map<String, _i211.Types>>(e))
+              .toSet()
+        : null);
+    map[Map<String, _i211.Types>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i211.Types>(v),
+      ),
+    );
+    map[Set<List<_i211.Types>>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<List<_i211.Types>>(e))
+        .toSet();
+    map[List<_i211.Types>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i211.Types>(e))
+        .toList();
+    map[_i1.getType<Set<List<_i211.Types>>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<List<_i211.Types>>(e))
+              .toSet()
+        : null);
+    map[List<_i211.Types>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i211.Types>(e))
+        .toList();
+    map[Set<(int,)>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<(int,)>(e)).toSet();
+    map[_i1.getType<(int,)>()] = (data, protocol) =>
+        (protocol.deserialize<int>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<Set<(int,)>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<(int,)>(e)).toSet()
+        : null);
+    map[_i1.getType<(int,)>()] = (data, protocol) =>
+        (protocol.deserialize<int>(((data as Map)['p'] as List)[0]),);
+    map[Set<(int,)?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<(int,)?>(e)).toSet();
+    map[_i1.getType<(int,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<int>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<Set<(int,)?>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<(int,)?>(e)).toSet()
+        : null);
+    map[_i1.getType<(int,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<int>(((data as Map)['p'] as List)[0]),);
+    map[Set<int>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int>(e)).toSet();
+    map[List<String>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<String>(e)).toList();
+    map[_i1.getType<List<String>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<String>(e)).toList()
+        : null);
+    map[List<String>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<String>(e)).toList();
+    map[List<_i220.SimpleData>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i220.SimpleData>(e))
+        .toList();
+    map[List<int>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int>(e)).toList();
+    map[List<List<int>>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<List<int>>(e)).toList();
+    map[List<int>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int>(e)).toList();
+    map[List<int>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int>(e)).toList();
+    map[_i1.getType<List<int>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<int>(e)).toList()
+        : null);
+    map[List<List<int>?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<List<int>?>(e)).toList();
+    map[List<int>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int>(e)).toList();
+    map[_i1.getType<List<int>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<int>(e)).toList()
+        : null);
+    map[List<List<int>>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<List<int>>(e)).toList();
+    map[List<int>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int>(e)).toList();
+    map[_i1.getType<List<List<int>>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<List<int>>(e)).toList()
+        : null);
+    map[List<int>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int>(e)).toList();
+    map[List<int?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int?>(e)).toList();
+    map[List<int?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int?>(e)).toList();
+    map[_i1.getType<List<int?>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<int?>(e)).toList()
+        : null);
+    map[List<double>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<double>(e)).toList();
+    map[List<double?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<double?>(e)).toList();
+    map[List<bool>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<bool>(e)).toList();
+    map[List<bool?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<bool?>(e)).toList();
+    map[List<String?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<String?>(e)).toList();
+    map[List<DateTime>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<DateTime>(e)).toList();
+    map[List<DateTime?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<DateTime?>(e)).toList();
+    map[List<_i222.ByteData>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i222.ByteData>(e))
+        .toList();
+    map[List<_i222.ByteData?>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i222.ByteData?>(e))
+        .toList();
+    map[List<_i220.SimpleData?>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i220.SimpleData?>(e))
+        .toList();
+    map[List<_i220.SimpleData>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i220.SimpleData>(e))
+        .toList();
+    map[_i1.getType<List<_i220.SimpleData>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i220.SimpleData>(e))
+              .toList()
+        : null);
+    map[List<_i220.SimpleData?>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i220.SimpleData?>(e))
+        .toList();
+    map[_i1.getType<List<_i220.SimpleData?>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i220.SimpleData?>(e))
+              .toList()
+        : null);
+    map[List<Duration>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<Duration>(e)).toList();
+    map[List<Duration?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<Duration?>(e)).toList();
+    map[Map<String, int>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<int>(v),
+      ),
+    );
+    map[Map<String, int>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<int>(v),
+      ),
+    );
+    map[_i1.getType<Map<String, int>?>()] = (data, protocol) => (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<int>(v),
+            ),
+          )
+        : null);
+    map[Map<String, Map<String, int>>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<Map<String, int>>(v),
+      ),
+    );
+    map[Map<String, int>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<int>(v),
+      ),
+    );
+    map[Map<String, int?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<int?>(v),
+      ),
+    );
+    map[Map<String, int?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<int?>(v),
+      ),
+    );
+    map[_i1.getType<Map<String, int?>?>()] = (data, protocol) => (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<int?>(v),
+            ),
+          )
+        : null);
+    map[Map<int, int>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<int>(e['k']),
+          protocol.deserialize<int>(e['v']),
+        ),
+      ),
+    );
+    map[Map<String, Map<int, int>>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<Map<int, int>>(v),
+      ),
+    );
+    map[Map<int, int>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<int>(e['k']),
+          protocol.deserialize<int>(e['v']),
+        ),
+      ),
+    );
+    map[Map<_i223.TestEnum, int>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<_i223.TestEnum>(e['k']),
+          protocol.deserialize<int>(e['v']),
+        ),
+      ),
+    );
+    map[Map<String, _i223.TestEnum>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i223.TestEnum>(v),
+      ),
+    );
+    map[Map<String, double>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<double>(v),
+      ),
+    );
+    map[Map<String, double?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<double?>(v),
+      ),
+    );
+    map[Map<String, bool>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<bool>(v),
+      ),
+    );
+    map[Map<String, bool?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<bool?>(v),
+      ),
+    );
+    map[Map<String, String>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<String>(v),
+      ),
+    );
+    map[Map<String, String?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<String?>(v),
+      ),
+    );
+    map[Map<String, DateTime>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<DateTime>(v),
+      ),
+    );
+    map[Map<String, DateTime?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<DateTime?>(v),
+      ),
+    );
+    map[Map<String, _i222.ByteData>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i222.ByteData>(v),
+      ),
+    );
+    map[Map<String, _i222.ByteData?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i222.ByteData?>(v),
+      ),
+    );
+    map[Map<String, _i220.SimpleData>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i220.SimpleData>(v),
+      ),
+    );
+    map[Map<String, _i220.SimpleData?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i220.SimpleData?>(v),
+      ),
+    );
+    map[Map<String, _i220.SimpleData>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i220.SimpleData>(v),
+      ),
+    );
+    map[_i1.getType<Map<String, _i220.SimpleData>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<_i220.SimpleData>(v),
+            ),
+          )
+        : null);
+    map[Map<String, _i220.SimpleData?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i220.SimpleData?>(v),
+      ),
+    );
+    map[_i1.getType<Map<String, _i220.SimpleData?>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<_i220.SimpleData?>(v),
+            ),
+          )
+        : null);
+    map[Map<String, Duration>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<Duration>(v),
+      ),
+    );
+    map[Map<String, Duration?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<Duration?>(v),
+      ),
+    );
+    map[Map<(Map<int, String>, String), String>] = (data, protocol) =>
+        Map.fromEntries(
+          (data as List).map(
+            (e) => MapEntry(
+              protocol.deserialize<(Map<int, String>, String)>(e['k']),
+              protocol.deserialize<String>(e['v']),
+            ),
+          ),
+        );
+    map[_i1.getType<(Map<int, String>, String)>()] = (data, protocol) => (
+      protocol.deserialize<Map<int, String>>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<String>(data['p'][1]),
+    );
+    map[_i1.getType<(Map<int, String>, String)>()] = (data, protocol) => (
+      protocol.deserialize<Map<int, String>>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<String>(data['p'][1]),
+    );
+    map[Map<int, String>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<int>(e['k']),
+          protocol.deserialize<String>(e['v']),
+        ),
+      ),
+    );
+    map[Map<String, (Map<int, int>,)>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<(Map<int, int>,)>(v),
+      ),
+    );
+    map[_i1.getType<(Map<int, int>,)>()] = (data, protocol) =>
+        (protocol.deserialize<Map<int, int>>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(Map<int, int>,)>()] = (data, protocol) =>
+        (protocol.deserialize<Map<int, int>>(((data as Map)['p'] as List)[0]),);
+    map[Map<DateTime, bool>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<DateTime>(e['k']),
+          protocol.deserialize<bool>(e['v']),
+        ),
+      ),
+    );
+    map[Map<DateTime, bool>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<DateTime>(e['k']),
+          protocol.deserialize<bool>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<Map<DateTime, bool>?>()] = (data, protocol) => (data != null
+        ? Map.fromEntries(
+            (data as List).map(
+              (e) => MapEntry(
+                protocol.deserialize<DateTime>(e['k']),
+                protocol.deserialize<bool>(e['v']),
+              ),
+            ),
+          )
+        : null);
+    map[Map<int, String>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<int>(e['k']),
+          protocol.deserialize<String>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<Map<int, String>?>()] = (data, protocol) => (data != null
+        ? Map.fromEntries(
+            (data as List).map(
+              (e) => MapEntry(
+                protocol.deserialize<int>(e['k']),
+                protocol.deserialize<String>(e['v']),
+              ),
+            ),
+          )
+        : null);
+    map[dynamic] = (data, protocol) =>
+        protocol.deserializeDynamicFieldValue(data);
+    map[List<_i2.UserInfo>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i2.UserInfo>(e))
+        .toList();
+    map[Set<int>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int>(e)).toSet();
+    map[Set<_i220.SimpleData>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i220.SimpleData>(e))
+        .toSet();
+    map[List<Set<_i220.SimpleData>>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<Set<_i220.SimpleData>>(e))
+        .toList();
+    map[Set<_i220.SimpleData>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i220.SimpleData>(e))
+        .toSet();
+    map[_i1.getType<(int, BigInt)>()] = (data, protocol) => (
+      protocol.deserialize<int>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<BigInt>(data['p'][1]),
+    );
+    map[_i1.getType<(String, _i221.PolymorphicParent)>()] = (data, protocol) =>
+        (
+          protocol.deserialize<String>(((data as Map)['p'] as List)[0]),
+          protocol.deserialize<_i221.PolymorphicParent>(data['p'][1]),
+        );
+    map[_i1.getType<(int,)>()] = (data, protocol) =>
+        (protocol.deserialize<int>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(int,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<int>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(int?,)>()] = (data, protocol) => (
+      ((data as Map)['p'] as List)[0] == null
+          ? null
+          : protocol.deserialize<int>(data['p'][0]),
+    );
+    map[_i1.getType<(int?,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (
+            ((data as Map)['p'] as List)[0] == null
+                ? null
+                : protocol.deserialize<int>(data['p'][0]),
+          );
+    map[_i1.getType<(int, String)>()] = (data, protocol) => (
+      protocol.deserialize<int>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<String>(data['p'][1]),
+    );
+    map[_i1.getType<(int, String)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (
+            protocol.deserialize<int>(((data as Map)['p'] as List)[0]),
+            protocol.deserialize<String>(data['p'][1]),
+          );
+    map[_i1.getType<(int, _i220.SimpleData)>()] = (data, protocol) => (
+      protocol.deserialize<int>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<_i220.SimpleData>(data['p'][1]),
+    );
+    map[_i1.getType<(int, _i220.SimpleData)?>()] = (data, protocol) =>
+        (data == null)
+        ? null
+        : (
+            protocol.deserialize<int>(((data as Map)['p'] as List)[0]),
+            protocol.deserialize<_i220.SimpleData>(data['p'][1]),
+          );
+    map[_i1.getType<(Map<String, int>,)>()] = (data, protocol) => (
+      protocol.deserialize<Map<String, int>>(((data as Map)['p'] as List)[0]),
+    );
+    map[_i1.getType<(Set<(int,)>,)>()] = (data, protocol) =>
+        (protocol.deserialize<Set<(int,)>>(((data as Map)['p'] as List)[0]),);
+    map[Set<(int,)>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<(int,)>(e)).toSet();
+    map[_i1.getType<(int,)>()] = (data, protocol) =>
+        (protocol.deserialize<int>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<({int number, String text})>()] = (data, protocol) => (
+      number: protocol.deserialize<int>(((data as Map)['n'] as Map)['number']),
+      text: protocol.deserialize<String>(data['n']['text']),
+    );
+    map[_i1.getType<({int number, String text})?>()] = (data, protocol) =>
+        (data == null)
+        ? null
+        : (
+            number: protocol.deserialize<int>(
+              ((data as Map)['n'] as Map)['number'],
+            ),
+            text: protocol.deserialize<String>(data['n']['text']),
+          );
+    map[_i1.getType<({_i220.SimpleData data, int number})>()] =
+        (data, protocol) => (
+          data: protocol.deserialize<_i220.SimpleData>(
+            ((data as Map)['n'] as Map)['data'],
+          ),
+          number: protocol.deserialize<int>(data['n']['number']),
+        );
+    map[_i1.getType<({_i220.SimpleData data, int number})?>()] =
+        (data, protocol) => (data == null)
+        ? null
+        : (
+            data: protocol.deserialize<_i220.SimpleData>(
+              ((data as Map)['n'] as Map)['data'],
+            ),
+            number: protocol.deserialize<int>(data['n']['number']),
+          );
+    map[_i1.getType<({_i220.SimpleData? data, int? number})>()] =
+        (data, protocol) => (
+          data: ((data as Map)['n'] as Map)['data'] == null
+              ? null
+              : protocol.deserialize<_i220.SimpleData>(data['n']['data']),
+          number: ((data)['n'] as Map)['number'] == null
+              ? null
+              : protocol.deserialize<int>(data['n']['number']),
+        );
+    map[_i1.getType<({Map<int, int> intIntMap})>()] = (data, protocol) => (
+      intIntMap: protocol.deserialize<Map<int, int>>(
+        ((data as Map)['n'] as Map)['intIntMap'],
+      ),
+    );
+    map[_i1.getType<({Set<(bool,)> boolSet})>()] = (data, protocol) => (
+      boolSet: protocol.deserialize<Set<(bool,)>>(
+        ((data as Map)['n'] as Map)['boolSet'],
+      ),
+    );
+    map[Set<(bool,)>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<(bool,)>(e)).toSet();
+    map[_i1.getType<(bool,)>()] = (data, protocol) =>
+        (protocol.deserialize<bool>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(bool,)>()] = (data, protocol) =>
+        (protocol.deserialize<bool>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(Map<(Map<int, String>, String), String>,)>()] =
+        (data, protocol) => (
+          protocol.deserialize<Map<(Map<int, String>, String), String>>(
+            ((data as Map)['p'] as List)[0],
+          ),
+        );
+    map[_i1.getType<(int, {_i220.SimpleData data})>()] = (data, protocol) => (
+      protocol.deserialize<int>(((data as Map)['p'] as List)[0]),
+      data: protocol.deserialize<_i220.SimpleData>(data['n']['data']),
+    );
+    map[_i1.getType<(int, {_i220.SimpleData data})?>()] = (data, protocol) =>
+        (data == null)
+        ? null
+        : (
+            protocol.deserialize<int>(((data as Map)['p'] as List)[0]),
+            data: protocol.deserialize<_i220.SimpleData>(data['n']['data']),
+          );
+    map[List<(int, _i220.SimpleData)>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<(int, _i220.SimpleData)>(e))
+        .toList();
+    map[_i1.getType<(int, _i220.SimpleData)>()] = (data, protocol) => (
+      protocol.deserialize<int>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<_i220.SimpleData>(data['p'][1]),
+    );
+    map[List<(int, _i220.SimpleData)?>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<(int, _i220.SimpleData)?>(e))
+        .toList();
+    map[_i1.getType<(int, _i220.SimpleData)?>()] = (data, protocol) =>
+        (data == null)
+        ? null
+        : (
+            protocol.deserialize<int>(((data as Map)['p'] as List)[0]),
+            protocol.deserialize<_i220.SimpleData>(data['p'][1]),
+          );
+    map[Set<(int, _i220.SimpleData)>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<(int, _i220.SimpleData)>(e))
+        .toSet();
+    map[_i1.getType<(int, _i220.SimpleData)>()] = (data, protocol) => (
+      protocol.deserialize<int>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<_i220.SimpleData>(data['p'][1]),
+    );
+    map[Set<(int, _i220.SimpleData)?>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<(int, _i220.SimpleData)?>(e))
+        .toSet();
+    map[_i1.getType<(int, _i220.SimpleData)?>()] = (data, protocol) =>
+        (data == null)
+        ? null
+        : (
+            protocol.deserialize<int>(((data as Map)['p'] as List)[0]),
+            protocol.deserialize<_i220.SimpleData>(data['p'][1]),
+          );
+    map[Set<(int, _i220.SimpleData)>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<(int, _i220.SimpleData)>(e))
+        .toSet();
+    map[_i1.getType<(int, _i220.SimpleData)>()] = (data, protocol) => (
+      protocol.deserialize<int>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<_i220.SimpleData>(data['p'][1]),
+    );
+    map[_i1.getType<Set<(int, _i220.SimpleData)>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<(int, _i220.SimpleData)>(e))
+              .toSet()
+        : null);
+    map[_i1.getType<(int, _i220.SimpleData)>()] = (data, protocol) => (
+      protocol.deserialize<int>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<_i220.SimpleData>(data['p'][1]),
+    );
+    map[Map<String, (int, _i220.SimpleData)>] = (data, protocol) =>
+        (data as Map).map(
+          (k, v) => MapEntry(
+            protocol.deserialize<String>(k),
+            protocol.deserialize<(int, _i220.SimpleData)>(v),
+          ),
+        );
+    map[_i1.getType<(int, _i220.SimpleData)>()] = (data, protocol) => (
+      protocol.deserialize<int>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<_i220.SimpleData>(data['p'][1]),
+    );
+    map[Map<String, (int, _i220.SimpleData)?>] = (data, protocol) =>
+        (data as Map).map(
+          (k, v) => MapEntry(
+            protocol.deserialize<String>(k),
+            protocol.deserialize<(int, _i220.SimpleData)?>(v),
+          ),
+        );
+    map[_i1.getType<(int, _i220.SimpleData)?>()] = (data, protocol) =>
+        (data == null)
+        ? null
+        : (
+            protocol.deserialize<int>(((data as Map)['p'] as List)[0]),
+            protocol.deserialize<_i220.SimpleData>(data['p'][1]),
+          );
+    map[Map<(String, int), (int, _i220.SimpleData)>] = (data, protocol) =>
+        Map.fromEntries(
+          (data as List).map(
+            (e) => MapEntry(
+              protocol.deserialize<(String, int)>(e['k']),
+              protocol.deserialize<(int, _i220.SimpleData)>(e['v']),
+            ),
+          ),
+        );
+    map[_i1.getType<(String, int)>()] = (data, protocol) => (
+      protocol.deserialize<String>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<int>(data['p'][1]),
+    );
+    map[_i1.getType<(int, _i220.SimpleData)>()] = (data, protocol) => (
+      protocol.deserialize<int>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<_i220.SimpleData>(data['p'][1]),
+    );
+    map[_i1.getType<(String, int)>()] = (data, protocol) => (
+      protocol.deserialize<String>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<int>(data['p'][1]),
+    );
+    map[Map<String, List<Set<(int,)>>>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<List<Set<(int,)>>>(v),
+      ),
+    );
+    map[List<Set<(int,)>>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<Set<(int,)>>(e))
+        .toList();
+    map[Set<(int,)>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<(int,)>(e)).toSet();
+    map[_i1.getType<(int,)>()] = (data, protocol) =>
+        (protocol.deserialize<int>(((data as Map)['p'] as List)[0]),);
+    map[List<Set<(int,)>>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<Set<(int,)>>(e))
+        .toList();
+    map[Set<(int,)>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<(int,)>(e)).toSet();
+    map[_i1.getType<(int,)>()] = (data, protocol) =>
+        (protocol.deserialize<int>(((data as Map)['p'] as List)[0]),);
+    map[Set<List<Map<String, (int,)>>>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<List<Map<String, (int,)>>>(e))
+        .toSet();
+    map[List<Map<String, (int,)>>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<Map<String, (int,)>>(e))
+        .toList();
+    map[Map<String, (int,)>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<(int,)>(v),
+      ),
+    );
+    map[_i1.getType<(int,)>()] = (data, protocol) =>
+        (protocol.deserialize<int>(((data as Map)['p'] as List)[0]),);
+    map[List<Map<String, (int,)>>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<Map<String, (int,)>>(e))
+        .toList();
+    map[Map<String, (int,)>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<(int,)>(v),
+      ),
+    );
+    map[_i1.getType<(int,)>()] = (data, protocol) =>
+        (protocol.deserialize<int>(((data as Map)['p'] as List)[0]),);
+    map[Map<String, (int,)>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<(int,)>(v),
+      ),
+    );
+    map[_i1.getType<(int,)>()] = (data, protocol) =>
+        (protocol.deserialize<int>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<({(_i220.SimpleData, double) namedSubRecord})>()] =
+        (data, protocol) => (
+          namedSubRecord: protocol.deserialize<(_i220.SimpleData, double)>(
+            ((data as Map)['n'] as Map)['namedSubRecord'],
+          ),
+        );
+    map[_i1.getType<(_i220.SimpleData, double)>()] = (data, protocol) => (
+      protocol.deserialize<_i220.SimpleData>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<double>(data['p'][1]),
+    );
+    map[_i1.getType<({(_i220.SimpleData, double)? namedSubRecord})>()] =
+        (data, protocol) => (
+          namedSubRecord: ((data as Map)['n'] as Map)['namedSubRecord'] == null
+              ? null
+              : protocol.deserialize<(_i220.SimpleData, double)>(
+                  data['n']['namedSubRecord'],
+                ),
+        );
+    map[_i1.getType<(_i220.SimpleData, double)?>()] = (data, protocol) =>
+        (data == null)
+        ? null
+        : (
+            protocol.deserialize<_i220.SimpleData>(
+              ((data as Map)['p'] as List)[0],
+            ),
+            protocol.deserialize<double>(data['p'][1]),
+          );
+    map[_i1
+        .getType<
+          ((int, String), {(_i220.SimpleData, double) namedSubRecord})
+        >()] = (data, protocol) => (
+      protocol.deserialize<(int, String)>(((data as Map)['p'] as List)[0]),
+      namedSubRecord: protocol.deserialize<(_i220.SimpleData, double)>(
+        data['n']['namedSubRecord'],
+      ),
+    );
+    map[List<((int, String), {(_i220.SimpleData, double) namedSubRecord})>] =
+        (data, protocol) => (data as List)
+            .map(
+              (e) =>
+                  protocol.deserialize<
+                    ((int, String), {(_i220.SimpleData, double) namedSubRecord})
+                  >(e),
+            )
+            .toList();
+    map[_i1
+        .getType<
+          ((int, String), {(_i220.SimpleData, double) namedSubRecord})
+        >()] = (data, protocol) => (
+      protocol.deserialize<(int, String)>(((data as Map)['p'] as List)[0]),
+      namedSubRecord: protocol.deserialize<(_i220.SimpleData, double)>(
+        data['n']['namedSubRecord'],
+      ),
+    );
+    map[List<((int, String), {(_i220.SimpleData, double) namedSubRecord})?>] =
+        (data, protocol) => (data as List)
+            .map(
+              (e) =>
+                  protocol.deserialize<
+                    (
+                      (int, String), {
+                      (_i220.SimpleData, double) namedSubRecord,
+                    })?
+                  >(e),
+            )
+            .toList();
+    map[_i1
+        .getType<
+          ((int, String), {(_i220.SimpleData, double) namedSubRecord})?
+        >()] = (data, protocol) => (data == null)
+        ? null
+        : (
+            protocol.deserialize<(int, String)>(
+              ((data as Map)['p'] as List)[0],
+            ),
+            namedSubRecord: protocol.deserialize<(_i220.SimpleData, double)>(
+              data['n']['namedSubRecord'],
+            ),
+          );
+    map[_i1
+        .getType<
+          List<((int, String), {(_i220.SimpleData, double) namedSubRecord})?>?
+        >()] = (data, protocol) => (data != null
+        ? (data as List)
+              .map(
+                (e) =>
+                    protocol.deserialize<
+                      (
+                        (int, String), {
+                        (_i220.SimpleData, double) namedSubRecord,
+                      })?
+                    >(e),
+              )
+              .toList()
+        : null);
+    map[_i1
+        .getType<
+          ((int, String), {(_i220.SimpleData, double) namedSubRecord})?
+        >()] = (data, protocol) => (data == null)
+        ? null
+        : (
+            protocol.deserialize<(int, String)>(
+              ((data as Map)['p'] as List)[0],
+            ),
+            namedSubRecord: protocol.deserialize<(_i220.SimpleData, double)>(
+              data['n']['namedSubRecord'],
+            ),
+          );
+    map[_i1
+        .getType<
+          ((int, String), {(_i220.SimpleData, double) namedSubRecord})?
+        >()] = (data, protocol) => (data == null)
+        ? null
+        : (
+            protocol.deserialize<(int, String)>(
+              ((data as Map)['p'] as List)[0],
+            ),
+            namedSubRecord: protocol.deserialize<(_i220.SimpleData, double)>(
+              data['n']['namedSubRecord'],
+            ),
+          );
+    map[_i1.getType<(int?, _i3.ProjectStreamingClass?)>()] = (data, protocol) =>
+        (
+          ((data as Map)['p'] as List)[0] == null
+              ? null
+              : protocol.deserialize<int>(data['p'][0]),
+          ((data)['p'] as List)[1] == null
+              ? null
+              : protocol.deserialize<_i3.ProjectStreamingClass>(data['p'][1]),
+        );
+    map[Set<Set<int>>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<Set<int>>(e)).toSet();
+    map[Set<int>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int>(e)).toSet();
+    map[Set<List<int>>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<List<int>>(e)).toSet();
+    map[List<int>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int>(e)).toList();
+    map[Set<int>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int>(e)).toSet();
+    map[_i1.getType<Set<int>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<int>(e)).toSet()
+        : null);
+    map[Set<Set<int>?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<Set<int>?>(e)).toSet();
+    map[Set<int>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int>(e)).toSet();
+    map[_i1.getType<Set<int>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<int>(e)).toSet()
+        : null);
+    map[Set<Set<int>>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<Set<int>>(e)).toSet();
+    map[Set<int>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int>(e)).toSet();
+    map[_i1.getType<Set<Set<int>>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<Set<int>>(e)).toSet()
+        : null);
+    map[Set<int>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int>(e)).toSet();
+    map[Set<int?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int?>(e)).toSet();
+    map[Set<int?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int?>(e)).toSet();
+    map[_i1.getType<Set<int?>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<int?>(e)).toSet()
+        : null);
+    map[Set<double>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<double>(e)).toSet();
+    map[Set<double?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<double?>(e)).toSet();
+    map[Set<bool>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<bool>(e)).toSet();
+    map[Set<bool?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<bool?>(e)).toSet();
+    map[Set<String>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<String>(e)).toSet();
+    map[Set<String?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<String?>(e)).toSet();
+    map[Set<DateTime>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<DateTime>(e)).toSet();
+    map[Set<DateTime?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<DateTime?>(e)).toSet();
+    map[Set<_i222.ByteData>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i222.ByteData>(e))
+        .toSet();
+    map[Set<_i222.ByteData?>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i222.ByteData?>(e))
+        .toSet();
+    map[Set<_i220.SimpleData?>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i220.SimpleData?>(e))
+        .toSet();
+    map[Set<Duration>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<Duration>(e)).toSet();
+    map[Set<Duration?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<Duration?>(e)).toSet();
+    map[List<_i224.Types>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i224.Types>(e))
+        .toList();
+    map[_i1.getType<(String, (int, bool))>()] = (data, protocol) => (
+      protocol.deserialize<String>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<(int, bool)>(data['p'][1]),
+    );
+    map[_i1.getType<(int, bool)>()] = (data, protocol) => (
+      protocol.deserialize<int>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<bool>(data['p'][1]),
+    );
+    map[List<(String, (int, bool))>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<(String, (int, bool))>(e))
+        .toList();
+    map[_i1.getType<(String, (int, bool))>()] = (data, protocol) => (
+      protocol.deserialize<String>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<(int, bool)>(data['p'][1]),
+    );
+    map[_i1
+        .getType<
+          (String, (Map<String, int>, {bool flag, _i220.SimpleData simpleData}))
+        >()] = (data, protocol) => (
+      protocol.deserialize<String>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<
+        (Map<String, int>, {bool flag, _i220.SimpleData simpleData})
+      >(data['p'][1]),
+    );
+    map[_i1
+        .getType<
+          (Map<String, int>, {bool flag, _i220.SimpleData simpleData})
+        >()] = (data, protocol) => (
+      protocol.deserialize<Map<String, int>>(((data as Map)['p'] as List)[0]),
+      flag: protocol.deserialize<bool>(data['n']['flag']),
+      simpleData: protocol.deserialize<_i220.SimpleData>(
+        data['n']['simpleData'],
+      ),
+    );
+    map[List<(String, int)>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<(String, int)>(e))
+        .toList();
+    map[_i1.getType<(String, int)>()] = (data, protocol) => (
+      protocol.deserialize<String>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<int>(data['p'][1]),
+    );
+    map[_i1
+        .getType<
+          (
+            String,
+            (Map<String, int>, {bool flag, _i220.SimpleData simpleData}),
+          )?
+        >()] = (data, protocol) => (data == null)
+        ? null
+        : (
+            protocol.deserialize<String>(((data as Map)['p'] as List)[0]),
+            protocol.deserialize<
+              (Map<String, int>, {bool flag, _i220.SimpleData simpleData})
+            >(data['p'][1]),
+          );
+    map[List<(String, int)>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<(String, int)>(e))
+        .toList();
+    map[_i1.getType<(String, int)>()] = (data, protocol) => (
+      protocol.deserialize<String>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<int>(data['p'][1]),
+    );
+    map[_i1.getType<List<(String, int)>?>()] = (data, protocol) => (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<(String, int)>(e))
+              .toList()
+        : null);
+    map[_i1.getType<(String, int)>()] = (data, protocol) => (
+      protocol.deserialize<String>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<int>(data['p'][1]),
+    );
+    map[_i1.getType<(int, String)>()] = (data, protocol) => (
+      protocol.deserialize<int>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<String>(data['p'][1]),
+    );
+    map[_i1.getType<(_i3.ModuleClass,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (
+            protocol.deserialize<_i3.ModuleClass>(
+              ((data as Map)['p'] as List)[0],
+            ),
+          );
+    map[_i1.getType<(bool,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<bool>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(_i210.TestEnumStringified,)?>()] = (data, protocol) =>
+        (data == null)
+        ? null
+        : (
+            protocol.deserialize<_i210.TestEnumStringified>(
+              ((data as Map)['p'] as List)[0],
+            ),
+          );
+    map[List<(_i210.TestEnumStringified,)>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<(_i210.TestEnumStringified,)>(e))
+        .toList();
+    map[_i1.getType<(_i210.TestEnumStringified,)>()] = (data, protocol) => (
+      protocol.deserialize<_i210.TestEnumStringified>(
+        ((data as Map)['p'] as List)[0],
+      ),
+    );
+    map[_i1.getType<List<(_i210.TestEnumStringified,)>?>()] =
+        (data, protocol) => (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<(_i210.TestEnumStringified,)>(e))
+              .toList()
+        : null);
+    map[_i1.getType<(_i210.TestEnumStringified,)>()] = (data, protocol) => (
+      protocol.deserialize<_i210.TestEnumStringified>(
+        ((data as Map)['p'] as List)[0],
+      ),
+    );
+    map[_i1.getType<(_i210.TestEnumStringified,)>()] = (data, protocol) => (
+      protocol.deserialize<_i210.TestEnumStringified>(
+        ((data as Map)['p'] as List)[0],
+      ),
+    );
+    map[_i1.getType<(_i155.Nullability,)?>()] = (data, protocol) =>
+        (data == null)
+        ? null
+        : (
+            protocol.deserialize<_i155.Nullability>(
+              ((data as Map)['p'] as List)[0],
+            ),
+          );
+    map[_i1.getType<({_i210.TestEnumStringified value})?>()] =
+        (data, protocol) => (data == null)
+        ? null
+        : (
+            value: protocol.deserialize<_i210.TestEnumStringified>(
+              ((data as Map)['n'] as Map)['value'],
+            ),
+          );
+    map[List<({_i210.TestEnumStringified value})>] = (data, protocol) =>
+        (data as List)
+            .map(
+              (e) =>
+                  protocol.deserialize<({_i210.TestEnumStringified value})>(e),
+            )
+            .toList();
+    map[_i1
+        .getType<({_i210.TestEnumStringified value})>()] = (data, protocol) => (
+      value: protocol.deserialize<_i210.TestEnumStringified>(
+        ((data as Map)['n'] as Map)['value'],
+      ),
+    );
+    map[_i1.getType<List<({_i210.TestEnumStringified value})>?>()] =
+        (data, protocol) => (data != null
+        ? (data as List)
+              .map(
+                (e) => protocol
+                    .deserialize<({_i210.TestEnumStringified value})>(e),
+              )
+              .toList()
+        : null);
+    map[_i1
+        .getType<({_i210.TestEnumStringified value})>()] = (data, protocol) => (
+      value: protocol.deserialize<_i210.TestEnumStringified>(
+        ((data as Map)['n'] as Map)['value'],
+      ),
+    );
+    map[_i1
+        .getType<({_i210.TestEnumStringified value})>()] = (data, protocol) => (
+      value: protocol.deserialize<_i210.TestEnumStringified>(
+        ((data as Map)['n'] as Map)['value'],
+      ),
+    );
+    map[_i1.getType<({_i3.ModuleClass value})?>()] = (data, protocol) =>
+        (data == null)
+        ? null
+        : (
+            value: protocol.deserialize<_i3.ModuleClass>(
+              ((data as Map)['n'] as Map)['value'],
+            ),
+          );
+    map[_i1.getType<({_i155.Nullability value})?>()] = (data, protocol) =>
+        (data == null)
+        ? null
+        : (
+            value: protocol.deserialize<_i155.Nullability>(
+              ((data as Map)['n'] as Map)['value'],
+            ),
+          );
+    map[_i1.getType<(String, {Uri? optionalUri})?>()] = (data, protocol) =>
+        (data == null)
+        ? null
+        : (
+            protocol.deserialize<String>(((data as Map)['p'] as List)[0]),
+            optionalUri: ((data)['n'] as Map)['optionalUri'] == null
+                ? null
+                : protocol.deserialize<Uri>(data['n']['optionalUri']),
+          );
+    map[List<(int,)>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<(int,)>(e)).toList();
+    map[_i1.getType<(int,)>()] = (data, protocol) =>
+        (protocol.deserialize<int>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<List<(int,)>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<(int,)>(e)).toList()
+        : null);
+    map[_i1.getType<(int,)>()] = (data, protocol) =>
+        (protocol.deserialize<int>(((data as Map)['p'] as List)[0]),);
+    map[List<(int,)?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<(int,)?>(e)).toList();
+    map[_i1.getType<(int,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<int>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<List<(int,)?>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<(int,)?>(e)).toList()
+        : null);
+    map[_i1.getType<(int,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<int>(((data as Map)['p'] as List)[0]),);
+    map[List<(_i206.TestEnum,)>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<(_i206.TestEnum,)>(e))
+        .toList();
+    map[_i1.getType<(_i206.TestEnum,)>()] = (data, protocol) => (
+      protocol.deserialize<_i206.TestEnum>(((data as Map)['p'] as List)[0]),
+    );
+    map[_i1.getType<List<(_i206.TestEnum,)>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<(_i206.TestEnum,)>(e))
+              .toList()
+        : null);
+    map[_i1.getType<(_i206.TestEnum,)>()] = (data, protocol) => (
+      protocol.deserialize<_i206.TestEnum>(((data as Map)['p'] as List)[0]),
+    );
+    map[_i1.getType<(_i206.TestEnum,)>()] = (data, protocol) => (
+      protocol.deserialize<_i206.TestEnum>(((data as Map)['p'] as List)[0]),
+    );
+    map[Map<(String,), String>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<(String,)>(e['k']),
+          protocol.deserialize<String>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<(String,)>()] = (data, protocol) =>
+        (protocol.deserialize<String>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<Map<(String,), String>?>()] = (data, protocol) =>
+        (data != null
+        ? Map.fromEntries(
+            (data as List).map(
+              (e) => MapEntry(
+                protocol.deserialize<(String,)>(e['k']),
+                protocol.deserialize<String>(e['v']),
+              ),
+            ),
+          )
+        : null);
+    map[_i1.getType<(String,)>()] = (data, protocol) =>
+        (protocol.deserialize<String>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(String,)>()] = (data, protocol) =>
+        (protocol.deserialize<String>(((data as Map)['p'] as List)[0]),);
+    map[Map<String, (String,)>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<(String,)>(v),
+      ),
+    );
+    map[_i1.getType<(String,)>()] = (data, protocol) =>
+        (protocol.deserialize<String>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<Map<String, (String,)>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<(String,)>(v),
+            ),
+          )
+        : null);
+    map[_i1.getType<(String,)>()] = (data, protocol) =>
+        (protocol.deserialize<String>(((data as Map)['p'] as List)[0]),);
+    map[Map<String, (String,)?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<(String,)?>(v),
+      ),
+    );
+    map[_i1.getType<(String,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<String>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<Map<String, (String,)?>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<(String,)?>(v),
+            ),
+          )
+        : null);
+    map[_i1.getType<(String,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<String>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(String,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<String>(((data as Map)['p'] as List)[0]),);
+    map[Map<(String,)?, String>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<(String,)?>(e['k']),
+          protocol.deserialize<String>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<(String,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<String>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<Map<(String,)?, String>?>()] = (data, protocol) =>
+        (data != null
+        ? Map.fromEntries(
+            (data as List).map(
+              (e) => MapEntry(
+                protocol.deserialize<(String,)?>(e['k']),
+                protocol.deserialize<String>(e['v']),
+              ),
+            ),
+          )
+        : null);
+    map[_i1.getType<(String,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<String>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(double,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<double>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(DateTime,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<DateTime>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(_i222.ByteData,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (
+            protocol.deserialize<_i222.ByteData>(
+              ((data as Map)['p'] as List)[0],
+            ),
+          );
+    map[_i1.getType<(Duration,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<Duration>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(_i1.UuidValue,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (
+            protocol.deserialize<_i1.UuidValue>(
+              ((data as Map)['p'] as List)[0],
+            ),
+          );
+    map[_i1.getType<(Uri,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<Uri>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(BigInt,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<BigInt>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(_i206.TestEnum,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (
+            protocol.deserialize<_i206.TestEnum>(
+              ((data as Map)['p'] as List)[0],
+            ),
+          );
+    map[_i1.getType<(List<int>,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<List<int>>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(Map<int, int>,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (
+            protocol.deserialize<Map<int, int>>(
+              ((data as Map)['p'] as List)[0],
+            ),
+          );
+    map[Map<int, int>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<int>(e['k']),
+          protocol.deserialize<int>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<(Set<int>,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<Set<int>>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(_i200.SimpleData,)?>()] = (data, protocol) =>
+        (data == null)
+        ? null
+        : (
+            protocol.deserialize<_i200.SimpleData>(
+              ((data as Map)['p'] as List)[0],
+            ),
+          );
+    map[_i1.getType<({_i200.SimpleData namedModel})?>()] = (data, protocol) =>
+        (data == null)
+        ? null
+        : (
+            namedModel: protocol.deserialize<_i200.SimpleData>(
+              ((data as Map)['n'] as Map)['namedModel'],
+            ),
+          );
+    map[_i1.getType<(_i200.SimpleData, {_i200.SimpleData namedModel})?>()] =
+        (data, protocol) => (data == null)
+        ? null
+        : (
+            protocol.deserialize<_i200.SimpleData>(
+              ((data as Map)['p'] as List)[0],
+            ),
+            namedModel: protocol.deserialize<_i200.SimpleData>(
+              data['n']['namedModel'],
+            ),
+          );
+    map[_i1.getType<((int, String), {(int, String) namedNestedRecord})?>()] =
+        (data, protocol) => (data == null)
+        ? null
+        : (
+            protocol.deserialize<(int, String)>(
+              ((data as Map)['p'] as List)[0],
+            ),
+            namedNestedRecord: protocol.deserialize<(int, String)>(
+              data['n']['namedNestedRecord'],
+            ),
+          );
+    map[_i1
+        .getType<
+          (
+            (List<(_i200.SimpleData,)>,), {
+            (_i200.SimpleData, Map<String, _i200.SimpleData>) namedNestedRecord,
+          })?
+        >()] = (data, protocol) => (data == null)
+        ? null
+        : (
+            protocol.deserialize<(List<(_i200.SimpleData,)>,)>(
+              ((data as Map)['p'] as List)[0],
+            ),
+            namedNestedRecord: protocol
+                .deserialize<(_i200.SimpleData, Map<String, _i200.SimpleData>)>(
+                  data['n']['namedNestedRecord'],
+                ),
+          );
+    map[_i1.getType<(List<(_i200.SimpleData,)>,)>()] = (data, protocol) => (
+      protocol.deserialize<List<(_i200.SimpleData,)>>(
+        ((data as Map)['p'] as List)[0],
+      ),
+    );
+    map[List<(_i200.SimpleData,)>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<(_i200.SimpleData,)>(e))
+        .toList();
+    map[_i1.getType<(_i200.SimpleData,)>()] = (data, protocol) => (
+      protocol.deserialize<_i200.SimpleData>(((data as Map)['p'] as List)[0]),
+    );
+    map[_i1.getType<(_i200.SimpleData,)>()] = (data, protocol) => (
+      protocol.deserialize<_i200.SimpleData>(((data as Map)['p'] as List)[0]),
+    );
+    map[_i1.getType<(_i200.SimpleData, Map<String, _i200.SimpleData>)>()] =
+        (data, protocol) => (
+          protocol.deserialize<_i200.SimpleData>(
+            ((data as Map)['p'] as List)[0],
+          ),
+          protocol.deserialize<Map<String, _i200.SimpleData>>(data['p'][1]),
+        );
+    map[Map<String, _i200.SimpleData>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i200.SimpleData>(v),
+      ),
+    );
+    map[Set<(int,)>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<(int,)>(e)).toSet();
+    map[_i1.getType<(int,)>()] = (data, protocol) =>
+        (protocol.deserialize<int>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<Set<(int,)>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<(int,)>(e)).toSet()
+        : null);
+    map[_i1.getType<(int,)>()] = (data, protocol) =>
+        (protocol.deserialize<int>(((data as Map)['p'] as List)[0]),);
+    map[Set<(int,)?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<(int,)?>(e)).toSet();
+    map[_i1.getType<(int,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<int>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<Set<(int,)?>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<(int,)?>(e)).toSet()
+        : null);
+    map[_i1.getType<(int,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<int>(((data as Map)['p'] as List)[0]),);
+    map[_i5.CustomClass] = (data, protocol) => _i5.CustomClass.fromJson(data);
+    map[_i5.CustomClass2] = (data, protocol) => _i5.CustomClass2.fromJson(data);
+    map[_i5.CustomClassWithoutProtocolSerialization] = (data, protocol) =>
+        _i5.CustomClassWithoutProtocolSerialization.fromJson(data);
+    map[_i5.CustomClassWithProtocolSerialization] = (data, protocol) =>
+        _i5.CustomClassWithProtocolSerialization.fromJson(data);
+    map[_i5.CustomClassWithProtocolSerializationMethod] = (data, protocol) =>
+        _i5.CustomClassWithProtocolSerializationMethod.fromJson(data);
+    map[_i5.ProtocolCustomClass] = (data, protocol) =>
+        _i5.ProtocolCustomClass.fromJson(data);
+    map[_i5.ExternalCustomClass] = (data, protocol) =>
+        _i5.ExternalCustomClass.fromJson(data);
+    map[_i5.FreezedCustomClass] = (data, protocol) =>
+        _i5.FreezedCustomClass.fromJson(data);
+    map[_i1.getType<_i5.CustomClass?>()] = (data, protocol) =>
+        (data != null ? _i5.CustomClass.fromJson(data) : null);
+    map[_i1.getType<_i5.CustomClass2?>()] = (data, protocol) =>
+        (data != null ? _i5.CustomClass2.fromJson(data) : null);
+    map[_i1.getType<_i5.CustomClassWithoutProtocolSerialization?>()] =
+        (data, protocol) => (data != null
+        ? _i5.CustomClassWithoutProtocolSerialization.fromJson(data)
+        : null);
+    map[_i1.getType<_i5.CustomClassWithProtocolSerialization?>()] =
+        (data, protocol) => (data != null
+        ? _i5.CustomClassWithProtocolSerialization.fromJson(data)
+        : null);
+    map[_i1.getType<_i5.CustomClassWithProtocolSerializationMethod?>()] =
+        (data, protocol) => (data != null
+        ? _i5.CustomClassWithProtocolSerializationMethod.fromJson(data)
+        : null);
+    map[_i1.getType<_i5.ProtocolCustomClass?>()] = (data, protocol) =>
+        (data != null ? _i5.ProtocolCustomClass.fromJson(data) : null);
+    map[_i1.getType<_i5.ExternalCustomClass?>()] = (data, protocol) =>
+        (data != null ? _i5.ExternalCustomClass.fromJson(data) : null);
+    map[_i1.getType<_i5.FreezedCustomClass?>()] = (data, protocol) =>
+        (data != null ? _i5.FreezedCustomClass.fromJson(data) : null);
+    map[List<int>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int>(e)).toList();
+    map[List<_i220.SimpleData>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i220.SimpleData>(e))
+        .toList();
+    map[List<_i2.UserInfo>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i2.UserInfo>(e))
+        .toList();
+    map[List<_i220.SimpleData>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i220.SimpleData>(e))
+        .toList();
+    map[_i1.getType<List<_i220.SimpleData>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i220.SimpleData>(e))
+              .toList()
+        : null);
+    map[List<_i220.SimpleData?>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i220.SimpleData?>(e))
+        .toList();
+    map[Set<int>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int>(e)).toSet();
+    map[Set<_i220.SimpleData>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i220.SimpleData>(e))
+        .toSet();
+    map[List<Set<_i220.SimpleData>>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<Set<_i220.SimpleData>>(e))
+        .toList();
+    map[Set<_i220.SimpleData>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i220.SimpleData>(e))
+        .toSet();
+    map[_i1.getType<(String, _i221.PolymorphicParent)>()] = (data, protocol) =>
+        (
+          protocol.deserialize<String>(((data as Map)['p'] as List)[0]),
+          protocol.deserialize<_i221.PolymorphicParent>(data['p'][1]),
+        );
+    map[_i1.getType<(int?,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (
+            ((data as Map)['p'] as List)[0] == null
+                ? null
+                : protocol.deserialize<int>(data['p'][0]),
+          );
+    map[List<((int, String), {(_i220.SimpleData, double) namedSubRecord})?>] =
+        (data, protocol) => (data as List)
+            .map(
+              (e) =>
+                  protocol.deserialize<
+                    (
+                      (int, String), {
+                      (_i220.SimpleData, double) namedSubRecord,
+                    })?
+                  >(e),
+            )
+            .toList();
+    map[_i1
+        .getType<
+          ((int, String), {(_i220.SimpleData, double) namedSubRecord})?
+        >()] = (data, protocol) => (data == null)
+        ? null
+        : (
+            protocol.deserialize<(int, String)>(
+              ((data as Map)['p'] as List)[0],
+            ),
+            namedSubRecord: protocol.deserialize<(_i220.SimpleData, double)>(
+              data['n']['namedSubRecord'],
+            ),
+          );
+    map[_i1
+        .getType<
+          List<((int, String), {(_i220.SimpleData, double) namedSubRecord})?>?
+        >()] = (data, protocol) => (data != null
+        ? (data as List)
+              .map(
+                (e) =>
+                    protocol.deserialize<
+                      (
+                        (int, String), {
+                        (_i220.SimpleData, double) namedSubRecord,
+                      })?
+                    >(e),
+              )
+              .toList()
+        : null);
+    map[_i1
+        .getType<
+          ((int, String), {(_i220.SimpleData, double) namedSubRecord})?
+        >()] = (data, protocol) => (data == null)
+        ? null
+        : (
+            protocol.deserialize<(int, String)>(
+              ((data as Map)['p'] as List)[0],
+            ),
+            namedSubRecord: protocol.deserialize<(_i220.SimpleData, double)>(
+              data['n']['namedSubRecord'],
+            ),
+          );
+    map[_i1.getType<(int?, _i3.ProjectStreamingClass?)>()] = (data, protocol) =>
+        (
+          ((data as Map)['p'] as List)[0] == null
+              ? null
+              : protocol.deserialize<int>(data['p'][0]),
+          ((data)['p'] as List)[1] == null
+              ? null
+              : protocol.deserialize<_i3.ProjectStreamingClass>(data['p'][1]),
+        );
+    map[_i1
+        .getType<
+          (String, (Map<String, int>, {bool flag, _i220.SimpleData simpleData}))
+        >()] = (data, protocol) => (
+      protocol.deserialize<String>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<
+        (Map<String, int>, {bool flag, _i220.SimpleData simpleData})
+      >(data['p'][1]),
+    );
+    map[List<(String, int)>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<(String, int)>(e))
+        .toList();
+    map[_i1.getType<(String, int)>()] = (data, protocol) => (
+      protocol.deserialize<String>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<int>(data['p'][1]),
+    );
+    map[_i1
+        .getType<
+          (
+            String,
+            (Map<String, int>, {bool flag, _i220.SimpleData simpleData}),
+          )?
+        >()] = (data, protocol) => (data == null)
+        ? null
+        : (
+            protocol.deserialize<String>(((data as Map)['p'] as List)[0]),
+            protocol.deserialize<
+              (Map<String, int>, {bool flag, _i220.SimpleData simpleData})
+            >(data['p'][1]),
+          );
+    map[List<(String, int)>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<(String, int)>(e))
+        .toList();
+    map[_i1.getType<(String, int)>()] = (data, protocol) => (
+      protocol.deserialize<String>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<int>(data['p'][1]),
+    );
+    map[_i1.getType<List<(String, int)>?>()] = (data, protocol) => (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<(String, int)>(e))
+              .toList()
+        : null);
+    map[_i1.getType<(String, int)>()] = (data, protocol) => (
+      protocol.deserialize<String>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<int>(data['p'][1]),
+    );
+    return map;
   }
 }

--- a/tests/serverpod_test_module/serverpod_test_module_client/lib/src/protocol/protocol.dart
+++ b/tests/serverpod_test_module/serverpod_test_module_client/lib/src/protocol/protocol.dart
@@ -40,6 +40,70 @@ class Protocol extends _i1.SerializationManager {
 
   final Map<String, _i1.SerializationManager> _hostProtocols = {};
 
+  static final Map<Type, dynamic Function(dynamic, Protocol)> _deserializers =
+      _buildDeserializers();
+
+  static Map<Type, dynamic Function(dynamic, Protocol)> _buildDeserializers() {
+    final map = <Type, dynamic Function(dynamic, Protocol)>{};
+    map[_i2.DynamicOnModule] = (data, protocol) =>
+        _i2.DynamicOnModule.fromJson(data);
+    map[_i3.ModulePolymorphicGrandChild] = (data, protocol) =>
+        _i3.ModulePolymorphicGrandChild.fromJson(data);
+    map[_i4.ModulePolymorphicChild] = (data, protocol) =>
+        _i4.ModulePolymorphicChild.fromJson(data);
+    map[_i5.ModulePolymorphicParent] = (data, protocol) =>
+        _i5.ModulePolymorphicParent.fromJson(data);
+    map[_i6.ModuleClass] = (data, protocol) => _i6.ModuleClass.fromJson(data);
+    map[_i7.MyModuleFeatureModel] = (data, protocol) =>
+        _i7.MyModuleFeatureModel.fromJson(data);
+    map[_i8.ModuleStreamingClass] = (data, protocol) =>
+        _i8.ModuleStreamingClass.fromJson(data);
+    map[_i9.ProjectStreamingClass] = (data, protocol) =>
+        _i9.ProjectStreamingClass.fromJson(data);
+    map[_i1.getType<_i2.DynamicOnModule?>()] = (data, protocol) =>
+        (data != null ? _i2.DynamicOnModule.fromJson(data) : null);
+    map[_i1.getType<_i3.ModulePolymorphicGrandChild?>()] = (data, protocol) =>
+        (data != null ? _i3.ModulePolymorphicGrandChild.fromJson(data) : null);
+    map[_i1.getType<_i4.ModulePolymorphicChild?>()] = (data, protocol) =>
+        (data != null ? _i4.ModulePolymorphicChild.fromJson(data) : null);
+    map[_i1.getType<_i5.ModulePolymorphicParent?>()] = (data, protocol) =>
+        (data != null ? _i5.ModulePolymorphicParent.fromJson(data) : null);
+    map[_i1.getType<_i6.ModuleClass?>()] = (data, protocol) =>
+        (data != null ? _i6.ModuleClass.fromJson(data) : null);
+    map[_i1.getType<_i7.MyModuleFeatureModel?>()] = (data, protocol) =>
+        (data != null ? _i7.MyModuleFeatureModel.fromJson(data) : null);
+    map[_i1.getType<_i8.ModuleStreamingClass?>()] = (data, protocol) =>
+        (data != null ? _i8.ModuleStreamingClass.fromJson(data) : null);
+    map[_i1.getType<_i9.ProjectStreamingClass?>()] = (data, protocol) =>
+        (data != null ? _i9.ProjectStreamingClass.fromJson(data) : null);
+    map[dynamic] = (data, protocol) => deserializeDynamicFieldValue(data) as T;
+    map[_i1.getType<(bool,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<bool>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(int?, _i10.ModuleStreamingClass?)>()] = (data, protocol) =>
+        (
+          ((data as Map)['p'] as List)[0] == null
+              ? null
+              : protocol.deserialize<int>(data['p'][0]),
+          ((data)['p'] as List)[1] == null
+              ? null
+              : protocol.deserialize<_i10.ModuleStreamingClass>(data['p'][1]),
+        );
+    map[_i1.getType<(bool,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<bool>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(int?, _i10.ModuleStreamingClass?)>()] = (data, protocol) =>
+        (
+          ((data as Map)['p'] as List)[0] == null
+              ? null
+              : protocol.deserialize<int>(data['p'][0]),
+          ((data)['p'] as List)[1] == null
+              ? null
+              : protocol.deserialize<_i10.ModuleStreamingClass>(data['p'][1]),
+        );
+    return map;
+  }
+
   void registerHostProtocol(
     String projectName,
     _i1.SerializationManager protocol,
@@ -76,96 +140,9 @@ class Protocol extends _i1.SerializationManager {
       }
     }
 
-    if (t == _i2.DynamicOnModule) {
-      return _i2.DynamicOnModule.fromJson(data) as T;
-    }
-    if (t == _i3.ModulePolymorphicGrandChild) {
-      return _i3.ModulePolymorphicGrandChild.fromJson(data) as T;
-    }
-    if (t == _i4.ModulePolymorphicChild) {
-      return _i4.ModulePolymorphicChild.fromJson(data) as T;
-    }
-    if (t == _i5.ModulePolymorphicParent) {
-      return _i5.ModulePolymorphicParent.fromJson(data) as T;
-    }
-    if (t == _i6.ModuleClass) {
-      return _i6.ModuleClass.fromJson(data) as T;
-    }
-    if (t == _i7.MyModuleFeatureModel) {
-      return _i7.MyModuleFeatureModel.fromJson(data) as T;
-    }
-    if (t == _i8.ModuleStreamingClass) {
-      return _i8.ModuleStreamingClass.fromJson(data) as T;
-    }
-    if (t == _i9.ProjectStreamingClass) {
-      return _i9.ProjectStreamingClass.fromJson(data) as T;
-    }
-    if (t == _i1.getType<_i2.DynamicOnModule?>()) {
-      return (data != null ? _i2.DynamicOnModule.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i3.ModulePolymorphicGrandChild?>()) {
-      return (data != null
-              ? _i3.ModulePolymorphicGrandChild.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i4.ModulePolymorphicChild?>()) {
-      return (data != null ? _i4.ModulePolymorphicChild.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i5.ModulePolymorphicParent?>()) {
-      return (data != null ? _i5.ModulePolymorphicParent.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i6.ModuleClass?>()) {
-      return (data != null ? _i6.ModuleClass.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i7.MyModuleFeatureModel?>()) {
-      return (data != null ? _i7.MyModuleFeatureModel.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i8.ModuleStreamingClass?>()) {
-      return (data != null ? _i8.ModuleStreamingClass.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i9.ProjectStreamingClass?>()) {
-      return (data != null ? _i9.ProjectStreamingClass.fromJson(data) : null)
-          as T;
-    }
-    if (t == dynamic) {
-      return deserializeDynamicFieldValue(data) as T;
-    }
-    if (t == _i1.getType<(bool,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<bool>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(int?, _i10.ModuleStreamingClass?)>()) {
-      return (
-            ((data as Map)['p'] as List)[0] == null
-                ? null
-                : deserialize<int>(data['p'][0]),
-            ((data)['p'] as List)[1] == null
-                ? null
-                : deserialize<_i10.ModuleStreamingClass>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(bool,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<bool>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(int?, _i10.ModuleStreamingClass?)>()) {
-      return (
-            ((data as Map)['p'] as List)[0] == null
-                ? null
-                : deserialize<int>(data['p'][0]),
-            ((data)['p'] as List)[1] == null
-                ? null
-                : deserialize<_i10.ModuleStreamingClass>(data['p'][1]),
-          )
-          as T;
+    final fn = _deserializers[t];
+    if (fn != null) {
+      return fn(data, this) as T;
     }
     return super.deserialize<T>(data, t);
   }

--- a/tests/serverpod_test_module/serverpod_test_module_client/lib/src/protocol/protocol.dart
+++ b/tests/serverpod_test_module/serverpod_test_module_client/lib/src/protocol/protocol.dart
@@ -41,6 +41,9 @@ class Protocol extends _i1.SerializationManager {
 
   final Set<_i1.SerializationManager> _hostProtocols = {};
 
+  static final Map<Type, dynamic Function(dynamic, Protocol)> _deserializers =
+      _buildDeserializers();
+
   void registerHostProtocol(
     String projectName,
     _i1.SerializationManager protocol,
@@ -77,96 +80,9 @@ class Protocol extends _i1.SerializationManager {
       }
     }
 
-    if (t == _i2.DynamicOnModule) {
-      return _i2.DynamicOnModule.fromJson(data) as T;
-    }
-    if (t == _i3.ModulePolymorphicGrandChild) {
-      return _i3.ModulePolymorphicGrandChild.fromJson(data) as T;
-    }
-    if (t == _i4.ModulePolymorphicChild) {
-      return _i4.ModulePolymorphicChild.fromJson(data) as T;
-    }
-    if (t == _i5.ModulePolymorphicParent) {
-      return _i5.ModulePolymorphicParent.fromJson(data) as T;
-    }
-    if (t == _i6.ModuleClass) {
-      return _i6.ModuleClass.fromJson(data) as T;
-    }
-    if (t == _i7.MyModuleFeatureModel) {
-      return _i7.MyModuleFeatureModel.fromJson(data) as T;
-    }
-    if (t == _i8.ModuleStreamingClass) {
-      return _i8.ModuleStreamingClass.fromJson(data) as T;
-    }
-    if (t == _i9.ProjectStreamingClass) {
-      return _i9.ProjectStreamingClass.fromJson(data) as T;
-    }
-    if (t == _i1.getType<_i2.DynamicOnModule?>()) {
-      return (data != null ? _i2.DynamicOnModule.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i3.ModulePolymorphicGrandChild?>()) {
-      return (data != null
-              ? _i3.ModulePolymorphicGrandChild.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i4.ModulePolymorphicChild?>()) {
-      return (data != null ? _i4.ModulePolymorphicChild.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i5.ModulePolymorphicParent?>()) {
-      return (data != null ? _i5.ModulePolymorphicParent.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i6.ModuleClass?>()) {
-      return (data != null ? _i6.ModuleClass.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i7.MyModuleFeatureModel?>()) {
-      return (data != null ? _i7.MyModuleFeatureModel.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i8.ModuleStreamingClass?>()) {
-      return (data != null ? _i8.ModuleStreamingClass.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i9.ProjectStreamingClass?>()) {
-      return (data != null ? _i9.ProjectStreamingClass.fromJson(data) : null)
-          as T;
-    }
-    if (t == dynamic) {
-      return deserializeDynamicFieldValue(data) as T;
-    }
-    if (t == _i1.getType<(bool,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<bool>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(int?, _i10.ModuleStreamingClass?)>()) {
-      return (
-            ((data as Map)['p'] as List)[0] == null
-                ? null
-                : deserialize<int>(data['p'][0]),
-            ((data)['p'] as List)[1] == null
-                ? null
-                : deserialize<_i10.ModuleStreamingClass>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(bool,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<bool>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(int?, _i10.ModuleStreamingClass?)>()) {
-      return (
-            ((data as Map)['p'] as List)[0] == null
-                ? null
-                : deserialize<int>(data['p'][0]),
-            ((data)['p'] as List)[1] == null
-                ? null
-                : deserialize<_i10.ModuleStreamingClass>(data['p'][1]),
-          )
-          as T;
+    final fn = _deserializers[t];
+    if (fn != null) {
+      return fn(data, this) as T;
     }
     return super.deserialize<T>(data, t);
   }
@@ -418,5 +334,67 @@ class Protocol extends _i1.SerializationManager {
     }
 
     return obj;
+  }
+
+  static Map<Type, dynamic Function(dynamic, Protocol)> _buildDeserializers() {
+    final map = <Type, dynamic Function(dynamic, Protocol)>{};
+    map[_i2.DynamicOnModule] = (data, protocol) =>
+        _i2.DynamicOnModule.fromJson(data);
+    map[_i3.ModulePolymorphicGrandChild] = (data, protocol) =>
+        _i3.ModulePolymorphicGrandChild.fromJson(data);
+    map[_i4.ModulePolymorphicChild] = (data, protocol) =>
+        _i4.ModulePolymorphicChild.fromJson(data);
+    map[_i5.ModulePolymorphicParent] = (data, protocol) =>
+        _i5.ModulePolymorphicParent.fromJson(data);
+    map[_i6.ModuleClass] = (data, protocol) => _i6.ModuleClass.fromJson(data);
+    map[_i7.MyModuleFeatureModel] = (data, protocol) =>
+        _i7.MyModuleFeatureModel.fromJson(data);
+    map[_i8.ModuleStreamingClass] = (data, protocol) =>
+        _i8.ModuleStreamingClass.fromJson(data);
+    map[_i9.ProjectStreamingClass] = (data, protocol) =>
+        _i9.ProjectStreamingClass.fromJson(data);
+    map[_i1.getType<_i2.DynamicOnModule?>()] = (data, protocol) =>
+        (data != null ? _i2.DynamicOnModule.fromJson(data) : null);
+    map[_i1.getType<_i3.ModulePolymorphicGrandChild?>()] = (data, protocol) =>
+        (data != null ? _i3.ModulePolymorphicGrandChild.fromJson(data) : null);
+    map[_i1.getType<_i4.ModulePolymorphicChild?>()] = (data, protocol) =>
+        (data != null ? _i4.ModulePolymorphicChild.fromJson(data) : null);
+    map[_i1.getType<_i5.ModulePolymorphicParent?>()] = (data, protocol) =>
+        (data != null ? _i5.ModulePolymorphicParent.fromJson(data) : null);
+    map[_i1.getType<_i6.ModuleClass?>()] = (data, protocol) =>
+        (data != null ? _i6.ModuleClass.fromJson(data) : null);
+    map[_i1.getType<_i7.MyModuleFeatureModel?>()] = (data, protocol) =>
+        (data != null ? _i7.MyModuleFeatureModel.fromJson(data) : null);
+    map[_i1.getType<_i8.ModuleStreamingClass?>()] = (data, protocol) =>
+        (data != null ? _i8.ModuleStreamingClass.fromJson(data) : null);
+    map[_i1.getType<_i9.ProjectStreamingClass?>()] = (data, protocol) =>
+        (data != null ? _i9.ProjectStreamingClass.fromJson(data) : null);
+    map[dynamic] = (data, protocol) =>
+        protocol.deserializeDynamicFieldValue(data);
+    map[_i1.getType<(bool,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<bool>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(int?, _i10.ModuleStreamingClass?)>()] = (data, protocol) =>
+        (
+          ((data as Map)['p'] as List)[0] == null
+              ? null
+              : protocol.deserialize<int>(data['p'][0]),
+          ((data)['p'] as List)[1] == null
+              ? null
+              : protocol.deserialize<_i10.ModuleStreamingClass>(data['p'][1]),
+        );
+    map[_i1.getType<(bool,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<bool>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(int?, _i10.ModuleStreamingClass?)>()] = (data, protocol) =>
+        (
+          ((data as Map)['p'] as List)[0] == null
+              ? null
+              : protocol.deserialize<int>(data['p'][0]),
+          ((data)['p'] as List)[1] == null
+              ? null
+              : protocol.deserialize<_i10.ModuleStreamingClass>(data['p'][1]),
+        );
+    return map;
   }
 }

--- a/tests/serverpod_test_module/serverpod_test_module_server/lib/src/generated/protocol.dart
+++ b/tests/serverpod_test_module/serverpod_test_module_server/lib/src/generated/protocol.dart
@@ -42,6 +42,70 @@ class Protocol extends _i1.DatabaseSerializationManager {
 
   final Map<String, _i1.SerializationManager> _hostProtocols = {};
 
+  static final Map<Type, dynamic Function(dynamic, Protocol)> _deserializers =
+      _buildDeserializers();
+
+  static Map<Type, dynamic Function(dynamic, Protocol)> _buildDeserializers() {
+    final map = <Type, dynamic Function(dynamic, Protocol)>{};
+    map[_i3.DynamicOnModule] = (data, protocol) =>
+        _i3.DynamicOnModule.fromJson(data);
+    map[_i4.ModulePolymorphicGrandChild] = (data, protocol) =>
+        _i4.ModulePolymorphicGrandChild.fromJson(data);
+    map[_i5.ModulePolymorphicChild] = (data, protocol) =>
+        _i5.ModulePolymorphicChild.fromJson(data);
+    map[_i6.ModulePolymorphicParent] = (data, protocol) =>
+        _i6.ModulePolymorphicParent.fromJson(data);
+    map[_i7.ModuleClass] = (data, protocol) => _i7.ModuleClass.fromJson(data);
+    map[_i8.MyModuleFeatureModel] = (data, protocol) =>
+        _i8.MyModuleFeatureModel.fromJson(data);
+    map[_i9.ModuleStreamingClass] = (data, protocol) =>
+        _i9.ModuleStreamingClass.fromJson(data);
+    map[_i10.ProjectStreamingClass] = (data, protocol) =>
+        _i10.ProjectStreamingClass.fromJson(data);
+    map[_i1.getType<_i3.DynamicOnModule?>()] = (data, protocol) =>
+        (data != null ? _i3.DynamicOnModule.fromJson(data) : null);
+    map[_i1.getType<_i4.ModulePolymorphicGrandChild?>()] = (data, protocol) =>
+        (data != null ? _i4.ModulePolymorphicGrandChild.fromJson(data) : null);
+    map[_i1.getType<_i5.ModulePolymorphicChild?>()] = (data, protocol) =>
+        (data != null ? _i5.ModulePolymorphicChild.fromJson(data) : null);
+    map[_i1.getType<_i6.ModulePolymorphicParent?>()] = (data, protocol) =>
+        (data != null ? _i6.ModulePolymorphicParent.fromJson(data) : null);
+    map[_i1.getType<_i7.ModuleClass?>()] = (data, protocol) =>
+        (data != null ? _i7.ModuleClass.fromJson(data) : null);
+    map[_i1.getType<_i8.MyModuleFeatureModel?>()] = (data, protocol) =>
+        (data != null ? _i8.MyModuleFeatureModel.fromJson(data) : null);
+    map[_i1.getType<_i9.ModuleStreamingClass?>()] = (data, protocol) =>
+        (data != null ? _i9.ModuleStreamingClass.fromJson(data) : null);
+    map[_i1.getType<_i10.ProjectStreamingClass?>()] = (data, protocol) =>
+        (data != null ? _i10.ProjectStreamingClass.fromJson(data) : null);
+    map[dynamic] = (data, protocol) => deserializeDynamicFieldValue(data) as T;
+    map[_i1.getType<(bool,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<bool>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(int?, _i11.ModuleStreamingClass?)>()] = (data, protocol) =>
+        (
+          ((data as Map)['p'] as List)[0] == null
+              ? null
+              : protocol.deserialize<int>(data['p'][0]),
+          ((data)['p'] as List)[1] == null
+              ? null
+              : protocol.deserialize<_i11.ModuleStreamingClass>(data['p'][1]),
+        );
+    map[_i1.getType<(bool,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<bool>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(int?, _i11.ModuleStreamingClass?)>()] = (data, protocol) =>
+        (
+          ((data as Map)['p'] as List)[0] == null
+              ? null
+              : protocol.deserialize<int>(data['p'][0]),
+          ((data)['p'] as List)[1] == null
+              ? null
+              : protocol.deserialize<_i11.ModuleStreamingClass>(data['p'][1]),
+        );
+    return map;
+  }
+
   void registerHostProtocol(
     String projectName,
     _i1.SerializationManager protocol,
@@ -78,96 +142,9 @@ class Protocol extends _i1.DatabaseSerializationManager {
       }
     }
 
-    if (t == _i3.DynamicOnModule) {
-      return _i3.DynamicOnModule.fromJson(data) as T;
-    }
-    if (t == _i4.ModulePolymorphicGrandChild) {
-      return _i4.ModulePolymorphicGrandChild.fromJson(data) as T;
-    }
-    if (t == _i5.ModulePolymorphicChild) {
-      return _i5.ModulePolymorphicChild.fromJson(data) as T;
-    }
-    if (t == _i6.ModulePolymorphicParent) {
-      return _i6.ModulePolymorphicParent.fromJson(data) as T;
-    }
-    if (t == _i7.ModuleClass) {
-      return _i7.ModuleClass.fromJson(data) as T;
-    }
-    if (t == _i8.MyModuleFeatureModel) {
-      return _i8.MyModuleFeatureModel.fromJson(data) as T;
-    }
-    if (t == _i9.ModuleStreamingClass) {
-      return _i9.ModuleStreamingClass.fromJson(data) as T;
-    }
-    if (t == _i10.ProjectStreamingClass) {
-      return _i10.ProjectStreamingClass.fromJson(data) as T;
-    }
-    if (t == _i1.getType<_i3.DynamicOnModule?>()) {
-      return (data != null ? _i3.DynamicOnModule.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i4.ModulePolymorphicGrandChild?>()) {
-      return (data != null
-              ? _i4.ModulePolymorphicGrandChild.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i5.ModulePolymorphicChild?>()) {
-      return (data != null ? _i5.ModulePolymorphicChild.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i6.ModulePolymorphicParent?>()) {
-      return (data != null ? _i6.ModulePolymorphicParent.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i7.ModuleClass?>()) {
-      return (data != null ? _i7.ModuleClass.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i8.MyModuleFeatureModel?>()) {
-      return (data != null ? _i8.MyModuleFeatureModel.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i9.ModuleStreamingClass?>()) {
-      return (data != null ? _i9.ModuleStreamingClass.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i10.ProjectStreamingClass?>()) {
-      return (data != null ? _i10.ProjectStreamingClass.fromJson(data) : null)
-          as T;
-    }
-    if (t == dynamic) {
-      return deserializeDynamicFieldValue(data) as T;
-    }
-    if (t == _i1.getType<(bool,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<bool>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(int?, _i11.ModuleStreamingClass?)>()) {
-      return (
-            ((data as Map)['p'] as List)[0] == null
-                ? null
-                : deserialize<int>(data['p'][0]),
-            ((data)['p'] as List)[1] == null
-                ? null
-                : deserialize<_i11.ModuleStreamingClass>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(bool,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<bool>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(int?, _i11.ModuleStreamingClass?)>()) {
-      return (
-            ((data as Map)['p'] as List)[0] == null
-                ? null
-                : deserialize<int>(data['p'][0]),
-            ((data)['p'] as List)[1] == null
-                ? null
-                : deserialize<_i11.ModuleStreamingClass>(data['p'][1]),
-          )
-          as T;
+    final fn = _deserializers[t];
+    if (fn != null) {
+      return fn(data, this) as T;
     }
     try {
       return _i2.Protocol().deserialize<T>(data, t);

--- a/tests/serverpod_test_module/serverpod_test_module_server/lib/src/generated/protocol.dart
+++ b/tests/serverpod_test_module/serverpod_test_module_server/lib/src/generated/protocol.dart
@@ -41,6 +41,9 @@ class Protocol extends _i1.DatabaseSerializationManager {
 
   final Set<_i1.SerializationManager> _hostProtocols = {};
 
+  static final Map<Type, dynamic Function(dynamic, Protocol)> _deserializers =
+      _buildDeserializers();
+
   static List<_i2.TableDefinition> get targetTableDefinitions => [];
 
   void registerHostProtocol(
@@ -79,96 +82,9 @@ class Protocol extends _i1.DatabaseSerializationManager {
       }
     }
 
-    if (t == _i3.DynamicOnModule) {
-      return _i3.DynamicOnModule.fromJson(data) as T;
-    }
-    if (t == _i4.ModulePolymorphicGrandChild) {
-      return _i4.ModulePolymorphicGrandChild.fromJson(data) as T;
-    }
-    if (t == _i5.ModulePolymorphicChild) {
-      return _i5.ModulePolymorphicChild.fromJson(data) as T;
-    }
-    if (t == _i6.ModulePolymorphicParent) {
-      return _i6.ModulePolymorphicParent.fromJson(data) as T;
-    }
-    if (t == _i7.ModuleClass) {
-      return _i7.ModuleClass.fromJson(data) as T;
-    }
-    if (t == _i8.MyModuleFeatureModel) {
-      return _i8.MyModuleFeatureModel.fromJson(data) as T;
-    }
-    if (t == _i9.ModuleStreamingClass) {
-      return _i9.ModuleStreamingClass.fromJson(data) as T;
-    }
-    if (t == _i10.ProjectStreamingClass) {
-      return _i10.ProjectStreamingClass.fromJson(data) as T;
-    }
-    if (t == _i1.getType<_i3.DynamicOnModule?>()) {
-      return (data != null ? _i3.DynamicOnModule.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i4.ModulePolymorphicGrandChild?>()) {
-      return (data != null
-              ? _i4.ModulePolymorphicGrandChild.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i5.ModulePolymorphicChild?>()) {
-      return (data != null ? _i5.ModulePolymorphicChild.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i6.ModulePolymorphicParent?>()) {
-      return (data != null ? _i6.ModulePolymorphicParent.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i7.ModuleClass?>()) {
-      return (data != null ? _i7.ModuleClass.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i8.MyModuleFeatureModel?>()) {
-      return (data != null ? _i8.MyModuleFeatureModel.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i9.ModuleStreamingClass?>()) {
-      return (data != null ? _i9.ModuleStreamingClass.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i10.ProjectStreamingClass?>()) {
-      return (data != null ? _i10.ProjectStreamingClass.fromJson(data) : null)
-          as T;
-    }
-    if (t == dynamic) {
-      return deserializeDynamicFieldValue(data) as T;
-    }
-    if (t == _i1.getType<(bool,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<bool>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(int?, _i11.ModuleStreamingClass?)>()) {
-      return (
-            ((data as Map)['p'] as List)[0] == null
-                ? null
-                : deserialize<int>(data['p'][0]),
-            ((data)['p'] as List)[1] == null
-                ? null
-                : deserialize<_i11.ModuleStreamingClass>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(bool,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<bool>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(int?, _i11.ModuleStreamingClass?)>()) {
-      return (
-            ((data as Map)['p'] as List)[0] == null
-                ? null
-                : deserialize<int>(data['p'][0]),
-            ((data)['p'] as List)[1] == null
-                ? null
-                : deserialize<_i11.ModuleStreamingClass>(data['p'][1]),
-          )
-          as T;
+    final fn = _deserializers[t];
+    if (fn != null) {
+      return fn(data, this) as T;
     }
     try {
       return _i2.Protocol().deserialize<T>(data, t);
@@ -449,5 +365,67 @@ class Protocol extends _i1.DatabaseSerializationManager {
     }
 
     return obj;
+  }
+
+  static Map<Type, dynamic Function(dynamic, Protocol)> _buildDeserializers() {
+    final map = <Type, dynamic Function(dynamic, Protocol)>{};
+    map[_i3.DynamicOnModule] = (data, protocol) =>
+        _i3.DynamicOnModule.fromJson(data);
+    map[_i4.ModulePolymorphicGrandChild] = (data, protocol) =>
+        _i4.ModulePolymorphicGrandChild.fromJson(data);
+    map[_i5.ModulePolymorphicChild] = (data, protocol) =>
+        _i5.ModulePolymorphicChild.fromJson(data);
+    map[_i6.ModulePolymorphicParent] = (data, protocol) =>
+        _i6.ModulePolymorphicParent.fromJson(data);
+    map[_i7.ModuleClass] = (data, protocol) => _i7.ModuleClass.fromJson(data);
+    map[_i8.MyModuleFeatureModel] = (data, protocol) =>
+        _i8.MyModuleFeatureModel.fromJson(data);
+    map[_i9.ModuleStreamingClass] = (data, protocol) =>
+        _i9.ModuleStreamingClass.fromJson(data);
+    map[_i10.ProjectStreamingClass] = (data, protocol) =>
+        _i10.ProjectStreamingClass.fromJson(data);
+    map[_i1.getType<_i3.DynamicOnModule?>()] = (data, protocol) =>
+        (data != null ? _i3.DynamicOnModule.fromJson(data) : null);
+    map[_i1.getType<_i4.ModulePolymorphicGrandChild?>()] = (data, protocol) =>
+        (data != null ? _i4.ModulePolymorphicGrandChild.fromJson(data) : null);
+    map[_i1.getType<_i5.ModulePolymorphicChild?>()] = (data, protocol) =>
+        (data != null ? _i5.ModulePolymorphicChild.fromJson(data) : null);
+    map[_i1.getType<_i6.ModulePolymorphicParent?>()] = (data, protocol) =>
+        (data != null ? _i6.ModulePolymorphicParent.fromJson(data) : null);
+    map[_i1.getType<_i7.ModuleClass?>()] = (data, protocol) =>
+        (data != null ? _i7.ModuleClass.fromJson(data) : null);
+    map[_i1.getType<_i8.MyModuleFeatureModel?>()] = (data, protocol) =>
+        (data != null ? _i8.MyModuleFeatureModel.fromJson(data) : null);
+    map[_i1.getType<_i9.ModuleStreamingClass?>()] = (data, protocol) =>
+        (data != null ? _i9.ModuleStreamingClass.fromJson(data) : null);
+    map[_i1.getType<_i10.ProjectStreamingClass?>()] = (data, protocol) =>
+        (data != null ? _i10.ProjectStreamingClass.fromJson(data) : null);
+    map[dynamic] = (data, protocol) =>
+        protocol.deserializeDynamicFieldValue(data);
+    map[_i1.getType<(bool,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<bool>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(int?, _i11.ModuleStreamingClass?)>()] = (data, protocol) =>
+        (
+          ((data as Map)['p'] as List)[0] == null
+              ? null
+              : protocol.deserialize<int>(data['p'][0]),
+          ((data)['p'] as List)[1] == null
+              ? null
+              : protocol.deserialize<_i11.ModuleStreamingClass>(data['p'][1]),
+        );
+    map[_i1.getType<(bool,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<bool>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(int?, _i11.ModuleStreamingClass?)>()] = (data, protocol) =>
+        (
+          ((data as Map)['p'] as List)[0] == null
+              ? null
+              : protocol.deserialize<int>(data['p'][0]),
+          ((data)['p'] as List)[1] == null
+              ? null
+              : protocol.deserialize<_i11.ModuleStreamingClass>(data['p'][1]),
+        );
+    return map;
   }
 }

--- a/tests/serverpod_test_nonvector/serverpod_test_nonvector_client/lib/src/protocol/protocol.dart
+++ b/tests/serverpod_test_nonvector/serverpod_test_nonvector_client/lib/src/protocol/protocol.dart
@@ -22,6 +22,17 @@ class Protocol extends _i1.SerializationManager {
 
   static final Protocol _instance = Protocol._();
 
+  static final Map<Type, dynamic Function(dynamic, Protocol)> _deserializers =
+      _buildDeserializers();
+
+  static Map<Type, dynamic Function(dynamic, Protocol)> _buildDeserializers() {
+    final map = <Type, dynamic Function(dynamic, Protocol)>{};
+    map[_i2.Greeting] = (data, protocol) => _i2.Greeting.fromJson(data);
+    map[_i1.getType<_i2.Greeting?>()] = (data, protocol) =>
+        (data != null ? _i2.Greeting.fromJson(data) : null);
+    return map;
+  }
+
   static String? getClassNameFromObjectJson(dynamic data) {
     if (data is! Map) return null;
     final className = data['__className__'] as String?;
@@ -49,11 +60,9 @@ class Protocol extends _i1.SerializationManager {
       }
     }
 
-    if (t == _i2.Greeting) {
-      return _i2.Greeting.fromJson(data) as T;
-    }
-    if (t == _i1.getType<_i2.Greeting?>()) {
-      return (data != null ? _i2.Greeting.fromJson(data) : null) as T;
+    final fn = _deserializers[t];
+    if (fn != null) {
+      return fn(data, this) as T;
     }
     return super.deserialize<T>(data, t);
   }

--- a/tests/serverpod_test_nonvector/serverpod_test_nonvector_client/lib/src/protocol/protocol.dart
+++ b/tests/serverpod_test_nonvector/serverpod_test_nonvector_client/lib/src/protocol/protocol.dart
@@ -23,6 +23,9 @@ class Protocol extends _i1.SerializationManager {
 
   static final Protocol _instance = Protocol._();
 
+  static final Map<Type, dynamic Function(dynamic, Protocol)> _deserializers =
+      _buildDeserializers();
+
   static String? getClassNameFromObjectJson(dynamic data) {
     if (data is! Map) return null;
     final className = data['__className__'] as String?;
@@ -50,11 +53,9 @@ class Protocol extends _i1.SerializationManager {
       }
     }
 
-    if (t == _i2.Greeting) {
-      return _i2.Greeting.fromJson(data) as T;
-    }
-    if (t == _i1.getType<_i2.Greeting?>()) {
-      return (data != null ? _i2.Greeting.fromJson(data) : null) as T;
+    final fn = _deserializers[t];
+    if (fn != null) {
+      return fn(data, this) as T;
     }
     return super.deserialize<T>(data, t);
   }
@@ -110,5 +111,13 @@ class Protocol extends _i1.SerializationManager {
       return null;
     }
     throw Exception('Unsupported record type ${record.runtimeType}');
+  }
+
+  static Map<Type, dynamic Function(dynamic, Protocol)> _buildDeserializers() {
+    final map = <Type, dynamic Function(dynamic, Protocol)>{};
+    map[_i2.Greeting] = (data, protocol) => _i2.Greeting.fromJson(data);
+    map[_i1.getType<_i2.Greeting?>()] = (data, protocol) =>
+        (data != null ? _i2.Greeting.fromJson(data) : null);
+    return map;
   }
 }

--- a/tests/serverpod_test_nonvector/serverpod_test_nonvector_server/lib/src/generated/protocol.dart
+++ b/tests/serverpod_test_nonvector/serverpod_test_nonvector_server/lib/src/generated/protocol.dart
@@ -62,6 +62,17 @@ class Protocol extends _i1.DatabaseSerializationManager {
     ..._i2.Protocol.targetTableDefinitions,
   ];
 
+  static final Map<Type, dynamic Function(dynamic, Protocol)> _deserializers =
+      _buildDeserializers();
+
+  static Map<Type, dynamic Function(dynamic, Protocol)> _buildDeserializers() {
+    final map = <Type, dynamic Function(dynamic, Protocol)>{};
+    map[_i3.Greeting] = (data, protocol) => _i3.Greeting.fromJson(data);
+    map[_i1.getType<_i3.Greeting?>()] = (data, protocol) =>
+        (data != null ? _i3.Greeting.fromJson(data) : null);
+    return map;
+  }
+
   static String? getClassNameFromObjectJson(dynamic data) {
     if (data is! Map) return null;
     final className = data['__className__'] as String?;
@@ -89,11 +100,9 @@ class Protocol extends _i1.DatabaseSerializationManager {
       }
     }
 
-    if (t == _i3.Greeting) {
-      return _i3.Greeting.fromJson(data) as T;
-    }
-    if (t == _i1.getType<_i3.Greeting?>()) {
-      return (data != null ? _i3.Greeting.fromJson(data) : null) as T;
+    final fn = _deserializers[t];
+    if (fn != null) {
+      return fn(data, this) as T;
     }
     try {
       return _i2.Protocol().deserialize<T>(data, t);

--- a/tests/serverpod_test_nonvector/serverpod_test_nonvector_server/lib/src/generated/protocol.dart
+++ b/tests/serverpod_test_nonvector/serverpod_test_nonvector_server/lib/src/generated/protocol.dart
@@ -23,6 +23,9 @@ class Protocol extends _i1.DatabaseSerializationManager {
 
   static final Protocol _instance = Protocol._();
 
+  static final Map<Type, dynamic Function(dynamic, Protocol)> _deserializers =
+      _buildDeserializers();
+
   static List<_i2.TableDefinition> get targetTableDefinitions => [
     _i2.TableDefinition(
       name: 'greeting',
@@ -90,11 +93,9 @@ class Protocol extends _i1.DatabaseSerializationManager {
       }
     }
 
-    if (t == _i3.Greeting) {
-      return _i3.Greeting.fromJson(data) as T;
-    }
-    if (t == _i1.getType<_i3.Greeting?>()) {
-      return (data != null ? _i3.Greeting.fromJson(data) : null) as T;
+    final fn = _deserializers[t];
+    if (fn != null) {
+      return fn(data, this) as T;
     }
     try {
       return _i2.Protocol().deserialize<T>(data, t);
@@ -183,5 +184,13 @@ class Protocol extends _i1.DatabaseSerializationManager {
       return _i2.Protocol().mapRecordToJson(record);
     } catch (_) {}
     throw Exception('Unsupported record type ${record.runtimeType}');
+  }
+
+  static Map<Type, dynamic Function(dynamic, Protocol)> _buildDeserializers() {
+    final map = <Type, dynamic Function(dynamic, Protocol)>{};
+    map[_i3.Greeting] = (data, protocol) => _i3.Greeting.fromJson(data);
+    map[_i1.getType<_i3.Greeting?>()] = (data, protocol) =>
+        (data != null ? _i3.Greeting.fromJson(data) : null);
+    return map;
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/protocol.dart
+++ b/tests/serverpod_test_server/lib/src/generated/protocol.dart
@@ -6250,6 +6250,4233 @@ class Protocol extends _i1.DatabaseSerializationManager {
     ..._i2.Protocol.targetTableDefinitions,
   ];
 
+  static final Map<Type, dynamic Function(dynamic, Protocol)> _deserializers =
+      _buildDeserializers();
+
+  static Map<Type, dynamic Function(dynamic, Protocol)> _buildDeserializers() {
+    final map = <Type, dynamic Function(dynamic, Protocol)>{};
+    map[_i5.ByIndexEnumWithNameValue] = (data, protocol) =>
+        _i5.ByIndexEnumWithNameValue.fromJson(data);
+    map[_i6.ByNameEnumWithNameValue] = (data, protocol) =>
+        _i6.ByNameEnumWithNameValue.fromJson(data);
+    map[_i7.CourseUuid] = (data, protocol) => _i7.CourseUuid.fromJson(data);
+    map[_i8.EnrollmentInt] = (data, protocol) =>
+        _i8.EnrollmentInt.fromJson(data);
+    map[_i9.StudentUuid] = (data, protocol) => _i9.StudentUuid.fromJson(data);
+    map[_i10.ArenaUuid] = (data, protocol) => _i10.ArenaUuid.fromJson(data);
+    map[_i11.PlayerUuid] = (data, protocol) => _i11.PlayerUuid.fromJson(data);
+    map[_i12.TeamInt] = (data, protocol) => _i12.TeamInt.fromJson(data);
+    map[_i13.CommentInt] = (data, protocol) => _i13.CommentInt.fromJson(data);
+    map[_i14.CustomerInt] = (data, protocol) => _i14.CustomerInt.fromJson(data);
+    map[_i15.OrderUuid] = (data, protocol) => _i15.OrderUuid.fromJson(data);
+    map[_i16.AddressUuid] = (data, protocol) => _i16.AddressUuid.fromJson(data);
+    map[_i17.CitizenInt] = (data, protocol) => _i17.CitizenInt.fromJson(data);
+    map[_i18.CompanyUuid] = (data, protocol) => _i18.CompanyUuid.fromJson(data);
+    map[_i19.TownInt] = (data, protocol) => _i19.TownInt.fromJson(data);
+    map[_i20.ChangedIdTypeSelf] = (data, protocol) =>
+        _i20.ChangedIdTypeSelf.fromJson(data);
+    map[_i21.ServerOnlyChangedIdFieldClass] = (data, protocol) =>
+        _i21.ServerOnlyChangedIdFieldClass.fromJson(data);
+    map[_i22.BigIntDefault] = (data, protocol) =>
+        _i22.BigIntDefault.fromJson(data);
+    map[_i23.BigIntDefaultMix] = (data, protocol) =>
+        _i23.BigIntDefaultMix.fromJson(data);
+    map[_i24.BigIntDefaultModel] = (data, protocol) =>
+        _i24.BigIntDefaultModel.fromJson(data);
+    map[_i25.BigIntDefaultPersist] = (data, protocol) =>
+        _i25.BigIntDefaultPersist.fromJson(data);
+    map[_i26.BoolDefault] = (data, protocol) => _i26.BoolDefault.fromJson(data);
+    map[_i27.BoolDefaultMix] = (data, protocol) =>
+        _i27.BoolDefaultMix.fromJson(data);
+    map[_i28.BoolDefaultModel] = (data, protocol) =>
+        _i28.BoolDefaultModel.fromJson(data);
+    map[_i29.BoolDefaultPersist] = (data, protocol) =>
+        _i29.BoolDefaultPersist.fromJson(data);
+    map[_i30.DateTimeDefault] = (data, protocol) =>
+        _i30.DateTimeDefault.fromJson(data);
+    map[_i31.DateTimeDefaultMix] = (data, protocol) =>
+        _i31.DateTimeDefaultMix.fromJson(data);
+    map[_i32.DateTimeDefaultModel] = (data, protocol) =>
+        _i32.DateTimeDefaultModel.fromJson(data);
+    map[_i33.DateTimeDefaultPersist] = (data, protocol) =>
+        _i33.DateTimeDefaultPersist.fromJson(data);
+    map[_i34.DoubleDefault] = (data, protocol) =>
+        _i34.DoubleDefault.fromJson(data);
+    map[_i35.DoubleDefaultMix] = (data, protocol) =>
+        _i35.DoubleDefaultMix.fromJson(data);
+    map[_i36.DoubleDefaultModel] = (data, protocol) =>
+        _i36.DoubleDefaultModel.fromJson(data);
+    map[_i37.DoubleDefaultPersist] = (data, protocol) =>
+        _i37.DoubleDefaultPersist.fromJson(data);
+    map[_i38.DurationDefault] = (data, protocol) =>
+        _i38.DurationDefault.fromJson(data);
+    map[_i39.DurationDefaultMix] = (data, protocol) =>
+        _i39.DurationDefaultMix.fromJson(data);
+    map[_i40.DurationDefaultModel] = (data, protocol) =>
+        _i40.DurationDefaultModel.fromJson(data);
+    map[_i41.DurationDefaultPersist] = (data, protocol) =>
+        _i41.DurationDefaultPersist.fromJson(data);
+    map[_i42.EnumDefault] = (data, protocol) => _i42.EnumDefault.fromJson(data);
+    map[_i43.EnumDefaultMix] = (data, protocol) =>
+        _i43.EnumDefaultMix.fromJson(data);
+    map[_i44.EnumDefaultModel] = (data, protocol) =>
+        _i44.EnumDefaultModel.fromJson(data);
+    map[_i45.EnumDefaultPersist] = (data, protocol) =>
+        _i45.EnumDefaultPersist.fromJson(data);
+    map[_i46.ByIndexEnum] = (data, protocol) => _i46.ByIndexEnum.fromJson(data);
+    map[_i47.ByNameEnum] = (data, protocol) => _i47.ByNameEnum.fromJson(data);
+    map[_i48.DefaultValueEnum] = (data, protocol) =>
+        _i48.DefaultValueEnum.fromJson(data);
+    map[_i49.DefaultException] = (data, protocol) =>
+        _i49.DefaultException.fromJson(data);
+    map[_i50.IntDefault] = (data, protocol) => _i50.IntDefault.fromJson(data);
+    map[_i51.IntDefaultMix] = (data, protocol) =>
+        _i51.IntDefaultMix.fromJson(data);
+    map[_i52.IntDefaultModel] = (data, protocol) =>
+        _i52.IntDefaultModel.fromJson(data);
+    map[_i53.IntDefaultPersist] = (data, protocol) =>
+        _i53.IntDefaultPersist.fromJson(data);
+    map[_i54.StringDefault] = (data, protocol) =>
+        _i54.StringDefault.fromJson(data);
+    map[_i55.StringDefaultMix] = (data, protocol) =>
+        _i55.StringDefaultMix.fromJson(data);
+    map[_i56.StringDefaultModel] = (data, protocol) =>
+        _i56.StringDefaultModel.fromJson(data);
+    map[_i57.StringDefaultPersist] = (data, protocol) =>
+        _i57.StringDefaultPersist.fromJson(data);
+    map[_i58.UriDefault] = (data, protocol) => _i58.UriDefault.fromJson(data);
+    map[_i59.UriDefaultMix] = (data, protocol) =>
+        _i59.UriDefaultMix.fromJson(data);
+    map[_i60.UriDefaultModel] = (data, protocol) =>
+        _i60.UriDefaultModel.fromJson(data);
+    map[_i61.UriDefaultPersist] = (data, protocol) =>
+        _i61.UriDefaultPersist.fromJson(data);
+    map[_i62.UuidDefault] = (data, protocol) => _i62.UuidDefault.fromJson(data);
+    map[_i63.UuidDefaultMix] = (data, protocol) =>
+        _i63.UuidDefaultMix.fromJson(data);
+    map[_i64.UuidDefaultModel] = (data, protocol) =>
+        _i64.UuidDefaultModel.fromJson(data);
+    map[_i65.UuidDefaultPersist] = (data, protocol) =>
+        _i65.UuidDefaultPersist.fromJson(data);
+    map[_i66.EmptyModel] = (data, protocol) => _i66.EmptyModel.fromJson(data);
+    map[_i67.EmptyModelRelationItem] = (data, protocol) =>
+        _i67.EmptyModelRelationItem.fromJson(data);
+    map[_i68.EmptyModelWithTable] = (data, protocol) =>
+        _i68.EmptyModelWithTable.fromJson(data);
+    map[_i69.RelationEmptyModel] = (data, protocol) =>
+        _i69.RelationEmptyModel.fromJson(data);
+    map[_i70.ExceptionWithData] = (data, protocol) =>
+        _i70.ExceptionWithData.fromJson(data);
+    map[_i71.ChildClassExplicitColumn] = (data, protocol) =>
+        _i71.ChildClassExplicitColumn.fromJson(data);
+    map[_i72.NonTableParentClass] = (data, protocol) =>
+        _i72.NonTableParentClass.fromJson(data);
+    map[_i73.ModifiedColumnName] = (data, protocol) =>
+        _i73.ModifiedColumnName.fromJson(data);
+    map[_i74.Department] = (data, protocol) => _i74.Department.fromJson(data);
+    map[_i75.Employee] = (data, protocol) => _i75.Employee.fromJson(data);
+    map[_i76.Contractor] = (data, protocol) => _i76.Contractor.fromJson(data);
+    map[_i77.Service] = (data, protocol) => _i77.Service.fromJson(data);
+    map[_i78.TableWithExplicitColumnName] = (data, protocol) =>
+        _i78.TableWithExplicitColumnName.fromJson(data);
+    map[_i79.TestGeneratedCallByeModel] = (data, protocol) =>
+        _i79.TestGeneratedCallByeModel.fromJson(data);
+    map[_i80.TestGeneratedCallExecuteWithTriggerModel] = (data, protocol) =>
+        _i80.TestGeneratedCallExecuteWithTriggerModel.fromJson(data);
+    map[_i81.TestGeneratedCallHelloModel] = (data, protocol) =>
+        _i81.TestGeneratedCallHelloModel.fromJson(data);
+    map[_i82.ImmutableChildObject] = (data, protocol) =>
+        _i82.ImmutableChildObject.fromJson(data);
+    map[_i83.ImmutableChildObjectWithNoAdditionalFields] = (data, protocol) =>
+        _i83.ImmutableChildObjectWithNoAdditionalFields.fromJson(data);
+    map[_i84.ImmutableObject] = (data, protocol) =>
+        _i84.ImmutableObject.fromJson(data);
+    map[_i85.ImmutableObjectWithImmutableObject] = (data, protocol) =>
+        _i85.ImmutableObjectWithImmutableObject.fromJson(data);
+    map[_i86.ImmutableObjectWithList] = (data, protocol) =>
+        _i86.ImmutableObjectWithList.fromJson(data);
+    map[_i87.ImmutableObjectWithMap] = (data, protocol) =>
+        _i87.ImmutableObjectWithMap.fromJson(data);
+    map[_i88.ImmutableObjectWithMultipleFields] = (data, protocol) =>
+        _i88.ImmutableObjectWithMultipleFields.fromJson(data);
+    map[_i89.ImmutableObjectWithNoFields] = (data, protocol) =>
+        _i89.ImmutableObjectWithNoFields.fromJson(data);
+    map[_i90.ImmutableObjectWithRecord] = (data, protocol) =>
+        _i90.ImmutableObjectWithRecord.fromJson(data);
+    map[_i91.ImmutableObjectWithTable] = (data, protocol) =>
+        _i91.ImmutableObjectWithTable.fromJson(data);
+    map[_i92.ImmutableObjectWithTwentyFields] = (data, protocol) =>
+        _i92.ImmutableObjectWithTwentyFields.fromJson(data);
+    map[_i93.ChildClass] = (data, protocol) => _i93.ChildClass.fromJson(data);
+    map[_i94.ServerOnlyChildClass] = (data, protocol) =>
+        _i94.ServerOnlyChildClass.fromJson(data);
+    map[_i95.ChildWithDefault] = (data, protocol) =>
+        _i95.ChildWithDefault.fromJson(data);
+    map[_i96.ChildWithInheritedId] = (data, protocol) =>
+        _i96.ChildWithInheritedId.fromJson(data);
+    map[_i97.ChildClassWithoutId] = (data, protocol) =>
+        _i97.ChildClassWithoutId.fromJson(data);
+    map[_i98.ServerOnlyChildClassWithoutId] = (data, protocol) =>
+        _i98.ServerOnlyChildClassWithoutId.fromJson(data);
+    map[_i99.ParentClass] = (data, protocol) => _i99.ParentClass.fromJson(data);
+    map[_i100.GrandparentClass] = (data, protocol) =>
+        _i100.GrandparentClass.fromJson(data);
+    map[_i101.ParentClassWithoutId] = (data, protocol) =>
+        _i101.ParentClassWithoutId.fromJson(data);
+    map[_i102.GrandparentClassWithId] = (data, protocol) =>
+        _i102.GrandparentClassWithId.fromJson(data);
+    map[_i103.ChildEntity] = (data, protocol) =>
+        _i103.ChildEntity.fromJson(data);
+    map[_i104.BaseEntity] = (data, protocol) => _i104.BaseEntity.fromJson(data);
+    map[_i105.ParentEntity] = (data, protocol) =>
+        _i105.ParentEntity.fromJson(data);
+    map[_i106.NonServerOnlyParentClass] = (data, protocol) =>
+        _i106.NonServerOnlyParentClass.fromJson(data);
+    map[_i107.ParentWithChangedId] = (data, protocol) =>
+        _i107.ParentWithChangedId.fromJson(data);
+    map[_i108.ParentWithDefault] = (data, protocol) =>
+        _i108.ParentWithDefault.fromJson(data);
+    map[_i109.PolymorphicGrandChild] = (data, protocol) =>
+        _i109.PolymorphicGrandChild.fromJson(data);
+    map[_i110.PolymorphicChild] = (data, protocol) =>
+        _i110.PolymorphicChild.fromJson(data);
+    map[_i111.PolymorphicChildContainer] = (data, protocol) =>
+        _i111.PolymorphicChildContainer.fromJson(data);
+    map[_i112.ModulePolymorphicChildContainer] = (data, protocol) =>
+        _i112.ModulePolymorphicChildContainer.fromJson(data);
+    map[_i113.SimilarButNotParent] = (data, protocol) =>
+        _i113.SimilarButNotParent.fromJson(data);
+    map[_i114.PolymorphicParent] = (data, protocol) =>
+        _i114.PolymorphicParent.fromJson(data);
+    map[_i115.UnrelatedToPolymorphism] = (data, protocol) =>
+        _i115.UnrelatedToPolymorphism.fromJson(data);
+    map[_i116.SealedGrandChild] = (data, protocol) =>
+        _i116.SealedGrandChild.fromJson(data);
+    map[_i116.SealedChild] = (data, protocol) =>
+        _i116.SealedChild.fromJson(data);
+    map[_i117.SealedChildOnlyRequired] = (data, protocol) =>
+        _i117.SealedChildOnlyRequired.fromJson(data);
+    map[_i116.SealedOtherChild] = (data, protocol) =>
+        _i116.SealedOtherChild.fromJson(data);
+    map[_i118.CityWithLongTableName] = (data, protocol) =>
+        _i118.CityWithLongTableName.fromJson(data);
+    map[_i119.OrganizationWithLongTableName] = (data, protocol) =>
+        _i119.OrganizationWithLongTableName.fromJson(data);
+    map[_i120.PersonWithLongTableName] = (data, protocol) =>
+        _i120.PersonWithLongTableName.fromJson(data);
+    map[_i121.MaxFieldName] = (data, protocol) =>
+        _i121.MaxFieldName.fromJson(data);
+    map[_i122.LongImplicitIdField] = (data, protocol) =>
+        _i122.LongImplicitIdField.fromJson(data);
+    map[_i123.LongImplicitIdFieldCollection] = (data, protocol) =>
+        _i123.LongImplicitIdFieldCollection.fromJson(data);
+    map[_i124.RelationToMultipleMaxFieldName] = (data, protocol) =>
+        _i124.RelationToMultipleMaxFieldName.fromJson(data);
+    map[_i125.UserNote] = (data, protocol) => _i125.UserNote.fromJson(data);
+    map[_i126.UserNoteCollection] = (data, protocol) =>
+        _i126.UserNoteCollection.fromJson(data);
+    map[_i127.UserNoteCollectionWithALongName] = (data, protocol) =>
+        _i127.UserNoteCollectionWithALongName.fromJson(data);
+    map[_i128.UserNoteWithALongName] = (data, protocol) =>
+        _i128.UserNoteWithALongName.fromJson(data);
+    map[_i129.MultipleMaxFieldName] = (data, protocol) =>
+        _i129.MultipleMaxFieldName.fromJson(data);
+    map[_i130.City] = (data, protocol) => _i130.City.fromJson(data);
+    map[_i131.Organization] = (data, protocol) =>
+        _i131.Organization.fromJson(data);
+    map[_i132.Person] = (data, protocol) => _i132.Person.fromJson(data);
+    map[_i133.Course] = (data, protocol) => _i133.Course.fromJson(data);
+    map[_i134.Enrollment] = (data, protocol) => _i134.Enrollment.fromJson(data);
+    map[_i135.Student] = (data, protocol) => _i135.Student.fromJson(data);
+    map[_i136.ObjectUser] = (data, protocol) => _i136.ObjectUser.fromJson(data);
+    map[_i137.ParentUser] = (data, protocol) => _i137.ParentUser.fromJson(data);
+    map[_i138.Arena] = (data, protocol) => _i138.Arena.fromJson(data);
+    map[_i139.Player] = (data, protocol) => _i139.Player.fromJson(data);
+    map[_i140.Team] = (data, protocol) => _i140.Team.fromJson(data);
+    map[_i141.Comment] = (data, protocol) => _i141.Comment.fromJson(data);
+    map[_i142.Customer] = (data, protocol) => _i142.Customer.fromJson(data);
+    map[_i143.Book] = (data, protocol) => _i143.Book.fromJson(data);
+    map[_i144.Chapter] = (data, protocol) => _i144.Chapter.fromJson(data);
+    map[_i145.Order] = (data, protocol) => _i145.Order.fromJson(data);
+    map[_i146.Address] = (data, protocol) => _i146.Address.fromJson(data);
+    map[_i147.Citizen] = (data, protocol) => _i147.Citizen.fromJson(data);
+    map[_i148.Company] = (data, protocol) => _i148.Company.fromJson(data);
+    map[_i149.Town] = (data, protocol) => _i149.Town.fromJson(data);
+    map[_i150.Blocking] = (data, protocol) => _i150.Blocking.fromJson(data);
+    map[_i151.Member] = (data, protocol) => _i151.Member.fromJson(data);
+    map[_i152.Cat] = (data, protocol) => _i152.Cat.fromJson(data);
+    map[_i153.Post] = (data, protocol) => _i153.Post.fromJson(data);
+    map[_i154.ModuleDatatype] = (data, protocol) =>
+        _i154.ModuleDatatype.fromJson(data);
+    map[_i155.MyFeatureModel] = (data, protocol) =>
+        _i155.MyFeatureModel.fromJson(data);
+    map[_i156.MyTriggerType] = (data, protocol) =>
+        _i156.MyTriggerType.fromJson(data);
+    map[_i157.Nullability] = (data, protocol) =>
+        _i157.Nullability.fromJson(data);
+    map[_i158.ObjectFieldPersist] = (data, protocol) =>
+        _i158.ObjectFieldPersist.fromJson(data);
+    map[_i159.ObjectFieldScopes] = (data, protocol) =>
+        _i159.ObjectFieldScopes.fromJson(data);
+    map[_i160.ObjectWithBit] = (data, protocol) =>
+        _i160.ObjectWithBit.fromJson(data);
+    map[_i161.ObjectWithByteData] = (data, protocol) =>
+        _i161.ObjectWithByteData.fromJson(data);
+    map[_i162.ObjectWithCustomClass] = (data, protocol) =>
+        _i162.ObjectWithCustomClass.fromJson(data);
+    map[_i163.ObjectWithDuration] = (data, protocol) =>
+        _i163.ObjectWithDuration.fromJson(data);
+    map[_i164.ObjectWithDynamic] = (data, protocol) =>
+        _i164.ObjectWithDynamic.fromJson(data);
+    map[_i165.ObjectWithEnum] = (data, protocol) =>
+        _i165.ObjectWithEnum.fromJson(data);
+    map[_i166.ObjectWithEnumEnhanced] = (data, protocol) =>
+        _i166.ObjectWithEnumEnhanced.fromJson(data);
+    map[_i167.ObjectWithHalfVector] = (data, protocol) =>
+        _i167.ObjectWithHalfVector.fromJson(data);
+    map[_i168.ObjectWithIndex] = (data, protocol) =>
+        _i168.ObjectWithIndex.fromJson(data);
+    map[_i169.ObjectWithJsonb] = (data, protocol) =>
+        _i169.ObjectWithJsonb.fromJson(data);
+    map[_i170.ObjectWithJsonbClassLevel] = (data, protocol) =>
+        _i170.ObjectWithJsonbClassLevel.fromJson(data);
+    map[_i171.ObjectWithMaps] = (data, protocol) =>
+        _i171.ObjectWithMaps.fromJson(data);
+    map[_i172.ObjectWithNullableCustomClass] = (data, protocol) =>
+        _i172.ObjectWithNullableCustomClass.fromJson(data);
+    map[_i173.ObjectWithObject] = (data, protocol) =>
+        _i173.ObjectWithObject.fromJson(data);
+    map[_i174.ObjectWithParent] = (data, protocol) =>
+        _i174.ObjectWithParent.fromJson(data);
+    map[_i175.ObjectWithSealedClass] = (data, protocol) =>
+        _i175.ObjectWithSealedClass.fromJson(data);
+    map[_i176.ObjectWithSelfParent] = (data, protocol) =>
+        _i176.ObjectWithSelfParent.fromJson(data);
+    map[_i177.ObjectWithSparseVector] = (data, protocol) =>
+        _i177.ObjectWithSparseVector.fromJson(data);
+    map[_i178.ObjectWithUuid] = (data, protocol) =>
+        _i178.ObjectWithUuid.fromJson(data);
+    map[_i179.ObjectWithVector] = (data, protocol) =>
+        _i179.ObjectWithVector.fromJson(data);
+    map[_i180.Record] = (data, protocol) => _i180.Record.fromJson(data);
+    map[_i181.RelatedUniqueData] = (data, protocol) =>
+        _i181.RelatedUniqueData.fromJson(data);
+    map[_i182.ExceptionWithRequiredField] = (data, protocol) =>
+        _i182.ExceptionWithRequiredField.fromJson(data);
+    map[_i183.ModelWithRequiredField] = (data, protocol) =>
+        _i183.ModelWithRequiredField.fromJson(data);
+    map[_i184.ScopeNoneFields] = (data, protocol) =>
+        _i184.ScopeNoneFields.fromJson(data);
+    map[_i185.ScopeServerOnlyFieldChild] = (data, protocol) =>
+        _i185.ScopeServerOnlyFieldChild.fromJson(data);
+    map[_i186.ScopeServerOnlyField] = (data, protocol) =>
+        _i186.ScopeServerOnlyField.fromJson(data);
+    map[_i187.Article] = (data, protocol) => _i187.Article.fromJson(data);
+    map[_i188.ArticleList] = (data, protocol) =>
+        _i188.ArticleList.fromJson(data);
+    map[_i189.DefaultServerOnlyClass] = (data, protocol) =>
+        _i189.DefaultServerOnlyClass.fromJson(data);
+    map[_i190.DefaultServerOnlyEnum] = (data, protocol) =>
+        _i190.DefaultServerOnlyEnum.fromJson(data);
+    map[_i191.NotServerOnlyClass] = (data, protocol) =>
+        _i191.NotServerOnlyClass.fromJson(data);
+    map[_i192.NotServerOnlyEnum] = (data, protocol) =>
+        _i192.NotServerOnlyEnum.fromJson(data);
+    map[_i193.ServerOnlyClass] = (data, protocol) =>
+        _i193.ServerOnlyClass.fromJson(data);
+    map[_i194.ServerOnlyEnum] = (data, protocol) =>
+        _i194.ServerOnlyEnum.fromJson(data);
+    map[_i195.ServerOnlyClassField] = (data, protocol) =>
+        _i195.ServerOnlyClassField.fromJson(data);
+    map[_i196.ServerOnlyDefault] = (data, protocol) =>
+        _i196.ServerOnlyDefault.fromJson(data);
+    map[_i197.SessionAuthInfo] = (data, protocol) =>
+        _i197.SessionAuthInfo.fromJson(data);
+    map[_i198.SharedModelContainer] = (data, protocol) =>
+        _i198.SharedModelContainer.fromJson(data);
+    map[_i199.SharedModelSubclass] = (data, protocol) =>
+        _i199.SharedModelSubclass.fromJson(data);
+    map[_i200.SimpleData] = (data, protocol) => _i200.SimpleData.fromJson(data);
+    map[_i201.SimpleDataList] = (data, protocol) =>
+        _i201.SimpleDataList.fromJson(data);
+    map[_i202.SimpleDataMap] = (data, protocol) =>
+        _i202.SimpleDataMap.fromJson(data);
+    map[_i203.SimpleDataObject] = (data, protocol) =>
+        _i203.SimpleDataObject.fromJson(data);
+    map[_i204.SimpleDateTime] = (data, protocol) =>
+        _i204.SimpleDateTime.fromJson(data);
+    map[_i205.ModelInSubfolder] = (data, protocol) =>
+        _i205.ModelInSubfolder.fromJson(data);
+    map[_i206.TestEnum] = (data, protocol) => _i206.TestEnum.fromJson(data);
+    map[_i207.TestEnumDefaultSerialization] = (data, protocol) =>
+        _i207.TestEnumDefaultSerialization.fromJson(data);
+    map[_i208.TestEnumEnhanced] = (data, protocol) =>
+        _i208.TestEnumEnhanced.fromJson(data);
+    map[_i209.TestEnumEnhancedByName] = (data, protocol) =>
+        _i209.TestEnumEnhancedByName.fromJson(data);
+    map[_i210.TestEnumStringified] = (data, protocol) =>
+        _i210.TestEnumStringified.fromJson(data);
+    map[_i211.Types] = (data, protocol) => _i211.Types.fromJson(data);
+    map[_i212.TypesList] = (data, protocol) => _i212.TypesList.fromJson(data);
+    map[_i213.TypesMap] = (data, protocol) => _i213.TypesMap.fromJson(data);
+    map[_i214.TypesRecord] = (data, protocol) =>
+        _i214.TypesRecord.fromJson(data);
+    map[_i215.TypesSet] = (data, protocol) => _i215.TypesSet.fromJson(data);
+    map[_i216.TypesSetRequired] = (data, protocol) =>
+        _i216.TypesSetRequired.fromJson(data);
+    map[_i217.UniqueData] = (data, protocol) => _i217.UniqueData.fromJson(data);
+    map[_i218.UniqueDataWithNonPersist] = (data, protocol) =>
+        _i218.UniqueDataWithNonPersist.fromJson(data);
+    map[_i219.UpsertTestModel] = (data, protocol) =>
+        _i219.UpsertTestModel.fromJson(data);
+    map[_i1.getType<_i5.ByIndexEnumWithNameValue?>()] = (data, protocol) =>
+        (data != null ? _i5.ByIndexEnumWithNameValue.fromJson(data) : null);
+    map[_i1.getType<_i6.ByNameEnumWithNameValue?>()] = (data, protocol) =>
+        (data != null ? _i6.ByNameEnumWithNameValue.fromJson(data) : null);
+    map[_i1.getType<_i7.CourseUuid?>()] = (data, protocol) =>
+        (data != null ? _i7.CourseUuid.fromJson(data) : null);
+    map[_i1.getType<_i8.EnrollmentInt?>()] = (data, protocol) =>
+        (data != null ? _i8.EnrollmentInt.fromJson(data) : null);
+    map[_i1.getType<_i9.StudentUuid?>()] = (data, protocol) =>
+        (data != null ? _i9.StudentUuid.fromJson(data) : null);
+    map[_i1.getType<_i10.ArenaUuid?>()] = (data, protocol) =>
+        (data != null ? _i10.ArenaUuid.fromJson(data) : null);
+    map[_i1.getType<_i11.PlayerUuid?>()] = (data, protocol) =>
+        (data != null ? _i11.PlayerUuid.fromJson(data) : null);
+    map[_i1.getType<_i12.TeamInt?>()] = (data, protocol) =>
+        (data != null ? _i12.TeamInt.fromJson(data) : null);
+    map[_i1.getType<_i13.CommentInt?>()] = (data, protocol) =>
+        (data != null ? _i13.CommentInt.fromJson(data) : null);
+    map[_i1.getType<_i14.CustomerInt?>()] = (data, protocol) =>
+        (data != null ? _i14.CustomerInt.fromJson(data) : null);
+    map[_i1.getType<_i15.OrderUuid?>()] = (data, protocol) =>
+        (data != null ? _i15.OrderUuid.fromJson(data) : null);
+    map[_i1.getType<_i16.AddressUuid?>()] = (data, protocol) =>
+        (data != null ? _i16.AddressUuid.fromJson(data) : null);
+    map[_i1.getType<_i17.CitizenInt?>()] = (data, protocol) =>
+        (data != null ? _i17.CitizenInt.fromJson(data) : null);
+    map[_i1.getType<_i18.CompanyUuid?>()] = (data, protocol) =>
+        (data != null ? _i18.CompanyUuid.fromJson(data) : null);
+    map[_i1.getType<_i19.TownInt?>()] = (data, protocol) =>
+        (data != null ? _i19.TownInt.fromJson(data) : null);
+    map[_i1.getType<_i20.ChangedIdTypeSelf?>()] = (data, protocol) =>
+        (data != null ? _i20.ChangedIdTypeSelf.fromJson(data) : null);
+    map[_i1
+        .getType<_i21.ServerOnlyChangedIdFieldClass?>()] = (data, protocol) =>
+        (data != null
+        ? _i21.ServerOnlyChangedIdFieldClass.fromJson(data)
+        : null);
+    map[_i1.getType<_i22.BigIntDefault?>()] = (data, protocol) =>
+        (data != null ? _i22.BigIntDefault.fromJson(data) : null);
+    map[_i1.getType<_i23.BigIntDefaultMix?>()] = (data, protocol) =>
+        (data != null ? _i23.BigIntDefaultMix.fromJson(data) : null);
+    map[_i1.getType<_i24.BigIntDefaultModel?>()] = (data, protocol) =>
+        (data != null ? _i24.BigIntDefaultModel.fromJson(data) : null);
+    map[_i1.getType<_i25.BigIntDefaultPersist?>()] = (data, protocol) =>
+        (data != null ? _i25.BigIntDefaultPersist.fromJson(data) : null);
+    map[_i1.getType<_i26.BoolDefault?>()] = (data, protocol) =>
+        (data != null ? _i26.BoolDefault.fromJson(data) : null);
+    map[_i1.getType<_i27.BoolDefaultMix?>()] = (data, protocol) =>
+        (data != null ? _i27.BoolDefaultMix.fromJson(data) : null);
+    map[_i1.getType<_i28.BoolDefaultModel?>()] = (data, protocol) =>
+        (data != null ? _i28.BoolDefaultModel.fromJson(data) : null);
+    map[_i1.getType<_i29.BoolDefaultPersist?>()] = (data, protocol) =>
+        (data != null ? _i29.BoolDefaultPersist.fromJson(data) : null);
+    map[_i1.getType<_i30.DateTimeDefault?>()] = (data, protocol) =>
+        (data != null ? _i30.DateTimeDefault.fromJson(data) : null);
+    map[_i1.getType<_i31.DateTimeDefaultMix?>()] = (data, protocol) =>
+        (data != null ? _i31.DateTimeDefaultMix.fromJson(data) : null);
+    map[_i1.getType<_i32.DateTimeDefaultModel?>()] = (data, protocol) =>
+        (data != null ? _i32.DateTimeDefaultModel.fromJson(data) : null);
+    map[_i1.getType<_i33.DateTimeDefaultPersist?>()] = (data, protocol) =>
+        (data != null ? _i33.DateTimeDefaultPersist.fromJson(data) : null);
+    map[_i1.getType<_i34.DoubleDefault?>()] = (data, protocol) =>
+        (data != null ? _i34.DoubleDefault.fromJson(data) : null);
+    map[_i1.getType<_i35.DoubleDefaultMix?>()] = (data, protocol) =>
+        (data != null ? _i35.DoubleDefaultMix.fromJson(data) : null);
+    map[_i1.getType<_i36.DoubleDefaultModel?>()] = (data, protocol) =>
+        (data != null ? _i36.DoubleDefaultModel.fromJson(data) : null);
+    map[_i1.getType<_i37.DoubleDefaultPersist?>()] = (data, protocol) =>
+        (data != null ? _i37.DoubleDefaultPersist.fromJson(data) : null);
+    map[_i1.getType<_i38.DurationDefault?>()] = (data, protocol) =>
+        (data != null ? _i38.DurationDefault.fromJson(data) : null);
+    map[_i1.getType<_i39.DurationDefaultMix?>()] = (data, protocol) =>
+        (data != null ? _i39.DurationDefaultMix.fromJson(data) : null);
+    map[_i1.getType<_i40.DurationDefaultModel?>()] = (data, protocol) =>
+        (data != null ? _i40.DurationDefaultModel.fromJson(data) : null);
+    map[_i1.getType<_i41.DurationDefaultPersist?>()] = (data, protocol) =>
+        (data != null ? _i41.DurationDefaultPersist.fromJson(data) : null);
+    map[_i1.getType<_i42.EnumDefault?>()] = (data, protocol) =>
+        (data != null ? _i42.EnumDefault.fromJson(data) : null);
+    map[_i1.getType<_i43.EnumDefaultMix?>()] = (data, protocol) =>
+        (data != null ? _i43.EnumDefaultMix.fromJson(data) : null);
+    map[_i1.getType<_i44.EnumDefaultModel?>()] = (data, protocol) =>
+        (data != null ? _i44.EnumDefaultModel.fromJson(data) : null);
+    map[_i1.getType<_i45.EnumDefaultPersist?>()] = (data, protocol) =>
+        (data != null ? _i45.EnumDefaultPersist.fromJson(data) : null);
+    map[_i1.getType<_i46.ByIndexEnum?>()] = (data, protocol) =>
+        (data != null ? _i46.ByIndexEnum.fromJson(data) : null);
+    map[_i1.getType<_i47.ByNameEnum?>()] = (data, protocol) =>
+        (data != null ? _i47.ByNameEnum.fromJson(data) : null);
+    map[_i1.getType<_i48.DefaultValueEnum?>()] = (data, protocol) =>
+        (data != null ? _i48.DefaultValueEnum.fromJson(data) : null);
+    map[_i1.getType<_i49.DefaultException?>()] = (data, protocol) =>
+        (data != null ? _i49.DefaultException.fromJson(data) : null);
+    map[_i1.getType<_i50.IntDefault?>()] = (data, protocol) =>
+        (data != null ? _i50.IntDefault.fromJson(data) : null);
+    map[_i1.getType<_i51.IntDefaultMix?>()] = (data, protocol) =>
+        (data != null ? _i51.IntDefaultMix.fromJson(data) : null);
+    map[_i1.getType<_i52.IntDefaultModel?>()] = (data, protocol) =>
+        (data != null ? _i52.IntDefaultModel.fromJson(data) : null);
+    map[_i1.getType<_i53.IntDefaultPersist?>()] = (data, protocol) =>
+        (data != null ? _i53.IntDefaultPersist.fromJson(data) : null);
+    map[_i1.getType<_i54.StringDefault?>()] = (data, protocol) =>
+        (data != null ? _i54.StringDefault.fromJson(data) : null);
+    map[_i1.getType<_i55.StringDefaultMix?>()] = (data, protocol) =>
+        (data != null ? _i55.StringDefaultMix.fromJson(data) : null);
+    map[_i1.getType<_i56.StringDefaultModel?>()] = (data, protocol) =>
+        (data != null ? _i56.StringDefaultModel.fromJson(data) : null);
+    map[_i1.getType<_i57.StringDefaultPersist?>()] = (data, protocol) =>
+        (data != null ? _i57.StringDefaultPersist.fromJson(data) : null);
+    map[_i1.getType<_i58.UriDefault?>()] = (data, protocol) =>
+        (data != null ? _i58.UriDefault.fromJson(data) : null);
+    map[_i1.getType<_i59.UriDefaultMix?>()] = (data, protocol) =>
+        (data != null ? _i59.UriDefaultMix.fromJson(data) : null);
+    map[_i1.getType<_i60.UriDefaultModel?>()] = (data, protocol) =>
+        (data != null ? _i60.UriDefaultModel.fromJson(data) : null);
+    map[_i1.getType<_i61.UriDefaultPersist?>()] = (data, protocol) =>
+        (data != null ? _i61.UriDefaultPersist.fromJson(data) : null);
+    map[_i1.getType<_i62.UuidDefault?>()] = (data, protocol) =>
+        (data != null ? _i62.UuidDefault.fromJson(data) : null);
+    map[_i1.getType<_i63.UuidDefaultMix?>()] = (data, protocol) =>
+        (data != null ? _i63.UuidDefaultMix.fromJson(data) : null);
+    map[_i1.getType<_i64.UuidDefaultModel?>()] = (data, protocol) =>
+        (data != null ? _i64.UuidDefaultModel.fromJson(data) : null);
+    map[_i1.getType<_i65.UuidDefaultPersist?>()] = (data, protocol) =>
+        (data != null ? _i65.UuidDefaultPersist.fromJson(data) : null);
+    map[_i1.getType<_i66.EmptyModel?>()] = (data, protocol) =>
+        (data != null ? _i66.EmptyModel.fromJson(data) : null);
+    map[_i1.getType<_i67.EmptyModelRelationItem?>()] = (data, protocol) =>
+        (data != null ? _i67.EmptyModelRelationItem.fromJson(data) : null);
+    map[_i1.getType<_i68.EmptyModelWithTable?>()] = (data, protocol) =>
+        (data != null ? _i68.EmptyModelWithTable.fromJson(data) : null);
+    map[_i1.getType<_i69.RelationEmptyModel?>()] = (data, protocol) =>
+        (data != null ? _i69.RelationEmptyModel.fromJson(data) : null);
+    map[_i1.getType<_i70.ExceptionWithData?>()] = (data, protocol) =>
+        (data != null ? _i70.ExceptionWithData.fromJson(data) : null);
+    map[_i1.getType<_i71.ChildClassExplicitColumn?>()] = (data, protocol) =>
+        (data != null ? _i71.ChildClassExplicitColumn.fromJson(data) : null);
+    map[_i1.getType<_i72.NonTableParentClass?>()] = (data, protocol) =>
+        (data != null ? _i72.NonTableParentClass.fromJson(data) : null);
+    map[_i1.getType<_i73.ModifiedColumnName?>()] = (data, protocol) =>
+        (data != null ? _i73.ModifiedColumnName.fromJson(data) : null);
+    map[_i1.getType<_i74.Department?>()] = (data, protocol) =>
+        (data != null ? _i74.Department.fromJson(data) : null);
+    map[_i1.getType<_i75.Employee?>()] = (data, protocol) =>
+        (data != null ? _i75.Employee.fromJson(data) : null);
+    map[_i1.getType<_i76.Contractor?>()] = (data, protocol) =>
+        (data != null ? _i76.Contractor.fromJson(data) : null);
+    map[_i1.getType<_i77.Service?>()] = (data, protocol) =>
+        (data != null ? _i77.Service.fromJson(data) : null);
+    map[_i1.getType<_i78.TableWithExplicitColumnName?>()] = (data, protocol) =>
+        (data != null ? _i78.TableWithExplicitColumnName.fromJson(data) : null);
+    map[_i1.getType<_i79.TestGeneratedCallByeModel?>()] = (data, protocol) =>
+        (data != null ? _i79.TestGeneratedCallByeModel.fromJson(data) : null);
+    map[_i1.getType<_i80.TestGeneratedCallExecuteWithTriggerModel?>()] =
+        (data, protocol) => (data != null
+        ? _i80.TestGeneratedCallExecuteWithTriggerModel.fromJson(data)
+        : null);
+    map[_i1.getType<_i81.TestGeneratedCallHelloModel?>()] = (data, protocol) =>
+        (data != null ? _i81.TestGeneratedCallHelloModel.fromJson(data) : null);
+    map[_i1.getType<_i82.ImmutableChildObject?>()] = (data, protocol) =>
+        (data != null ? _i82.ImmutableChildObject.fromJson(data) : null);
+    map[_i1.getType<_i83.ImmutableChildObjectWithNoAdditionalFields?>()] =
+        (data, protocol) => (data != null
+        ? _i83.ImmutableChildObjectWithNoAdditionalFields.fromJson(data)
+        : null);
+    map[_i1.getType<_i84.ImmutableObject?>()] = (data, protocol) =>
+        (data != null ? _i84.ImmutableObject.fromJson(data) : null);
+    map[_i1.getType<_i85.ImmutableObjectWithImmutableObject?>()] =
+        (data, protocol) => (data != null
+        ? _i85.ImmutableObjectWithImmutableObject.fromJson(data)
+        : null);
+    map[_i1.getType<_i86.ImmutableObjectWithList?>()] = (data, protocol) =>
+        (data != null ? _i86.ImmutableObjectWithList.fromJson(data) : null);
+    map[_i1.getType<_i87.ImmutableObjectWithMap?>()] = (data, protocol) =>
+        (data != null ? _i87.ImmutableObjectWithMap.fromJson(data) : null);
+    map[_i1.getType<_i88.ImmutableObjectWithMultipleFields?>()] =
+        (data, protocol) => (data != null
+        ? _i88.ImmutableObjectWithMultipleFields.fromJson(data)
+        : null);
+    map[_i1.getType<_i89.ImmutableObjectWithNoFields?>()] = (data, protocol) =>
+        (data != null ? _i89.ImmutableObjectWithNoFields.fromJson(data) : null);
+    map[_i1.getType<_i90.ImmutableObjectWithRecord?>()] = (data, protocol) =>
+        (data != null ? _i90.ImmutableObjectWithRecord.fromJson(data) : null);
+    map[_i1.getType<_i91.ImmutableObjectWithTable?>()] = (data, protocol) =>
+        (data != null ? _i91.ImmutableObjectWithTable.fromJson(data) : null);
+    map[_i1
+        .getType<_i92.ImmutableObjectWithTwentyFields?>()] = (data, protocol) =>
+        (data != null
+        ? _i92.ImmutableObjectWithTwentyFields.fromJson(data)
+        : null);
+    map[_i1.getType<_i93.ChildClass?>()] = (data, protocol) =>
+        (data != null ? _i93.ChildClass.fromJson(data) : null);
+    map[_i1.getType<_i94.ServerOnlyChildClass?>()] = (data, protocol) =>
+        (data != null ? _i94.ServerOnlyChildClass.fromJson(data) : null);
+    map[_i1.getType<_i95.ChildWithDefault?>()] = (data, protocol) =>
+        (data != null ? _i95.ChildWithDefault.fromJson(data) : null);
+    map[_i1.getType<_i96.ChildWithInheritedId?>()] = (data, protocol) =>
+        (data != null ? _i96.ChildWithInheritedId.fromJson(data) : null);
+    map[_i1.getType<_i97.ChildClassWithoutId?>()] = (data, protocol) =>
+        (data != null ? _i97.ChildClassWithoutId.fromJson(data) : null);
+    map[_i1
+        .getType<_i98.ServerOnlyChildClassWithoutId?>()] = (data, protocol) =>
+        (data != null
+        ? _i98.ServerOnlyChildClassWithoutId.fromJson(data)
+        : null);
+    map[_i1.getType<_i99.ParentClass?>()] = (data, protocol) =>
+        (data != null ? _i99.ParentClass.fromJson(data) : null);
+    map[_i1.getType<_i100.GrandparentClass?>()] = (data, protocol) =>
+        (data != null ? _i100.GrandparentClass.fromJson(data) : null);
+    map[_i1.getType<_i101.ParentClassWithoutId?>()] = (data, protocol) =>
+        (data != null ? _i101.ParentClassWithoutId.fromJson(data) : null);
+    map[_i1.getType<_i102.GrandparentClassWithId?>()] = (data, protocol) =>
+        (data != null ? _i102.GrandparentClassWithId.fromJson(data) : null);
+    map[_i1.getType<_i103.ChildEntity?>()] = (data, protocol) =>
+        (data != null ? _i103.ChildEntity.fromJson(data) : null);
+    map[_i1.getType<_i104.BaseEntity?>()] = (data, protocol) =>
+        (data != null ? _i104.BaseEntity.fromJson(data) : null);
+    map[_i1.getType<_i105.ParentEntity?>()] = (data, protocol) =>
+        (data != null ? _i105.ParentEntity.fromJson(data) : null);
+    map[_i1.getType<_i106.NonServerOnlyParentClass?>()] = (data, protocol) =>
+        (data != null ? _i106.NonServerOnlyParentClass.fromJson(data) : null);
+    map[_i1.getType<_i107.ParentWithChangedId?>()] = (data, protocol) =>
+        (data != null ? _i107.ParentWithChangedId.fromJson(data) : null);
+    map[_i1.getType<_i108.ParentWithDefault?>()] = (data, protocol) =>
+        (data != null ? _i108.ParentWithDefault.fromJson(data) : null);
+    map[_i1.getType<_i109.PolymorphicGrandChild?>()] = (data, protocol) =>
+        (data != null ? _i109.PolymorphicGrandChild.fromJson(data) : null);
+    map[_i1.getType<_i110.PolymorphicChild?>()] = (data, protocol) =>
+        (data != null ? _i110.PolymorphicChild.fromJson(data) : null);
+    map[_i1.getType<_i111.PolymorphicChildContainer?>()] = (data, protocol) =>
+        (data != null ? _i111.PolymorphicChildContainer.fromJson(data) : null);
+    map[_i1.getType<_i112.ModulePolymorphicChildContainer?>()] =
+        (data, protocol) => (data != null
+        ? _i112.ModulePolymorphicChildContainer.fromJson(data)
+        : null);
+    map[_i1.getType<_i113.SimilarButNotParent?>()] = (data, protocol) =>
+        (data != null ? _i113.SimilarButNotParent.fromJson(data) : null);
+    map[_i1.getType<_i114.PolymorphicParent?>()] = (data, protocol) =>
+        (data != null ? _i114.PolymorphicParent.fromJson(data) : null);
+    map[_i1.getType<_i115.UnrelatedToPolymorphism?>()] = (data, protocol) =>
+        (data != null ? _i115.UnrelatedToPolymorphism.fromJson(data) : null);
+    map[_i1.getType<_i116.SealedGrandChild?>()] = (data, protocol) =>
+        (data != null ? _i116.SealedGrandChild.fromJson(data) : null);
+    map[_i1.getType<_i116.SealedChild?>()] = (data, protocol) =>
+        (data != null ? _i116.SealedChild.fromJson(data) : null);
+    map[_i1.getType<_i117.SealedChildOnlyRequired?>()] = (data, protocol) =>
+        (data != null ? _i117.SealedChildOnlyRequired.fromJson(data) : null);
+    map[_i1.getType<_i116.SealedOtherChild?>()] = (data, protocol) =>
+        (data != null ? _i116.SealedOtherChild.fromJson(data) : null);
+    map[_i1.getType<_i118.CityWithLongTableName?>()] = (data, protocol) =>
+        (data != null ? _i118.CityWithLongTableName.fromJson(data) : null);
+    map[_i1
+        .getType<_i119.OrganizationWithLongTableName?>()] = (data, protocol) =>
+        (data != null
+        ? _i119.OrganizationWithLongTableName.fromJson(data)
+        : null);
+    map[_i1.getType<_i120.PersonWithLongTableName?>()] = (data, protocol) =>
+        (data != null ? _i120.PersonWithLongTableName.fromJson(data) : null);
+    map[_i1.getType<_i121.MaxFieldName?>()] = (data, protocol) =>
+        (data != null ? _i121.MaxFieldName.fromJson(data) : null);
+    map[_i1.getType<_i122.LongImplicitIdField?>()] = (data, protocol) =>
+        (data != null ? _i122.LongImplicitIdField.fromJson(data) : null);
+    map[_i1
+        .getType<_i123.LongImplicitIdFieldCollection?>()] = (data, protocol) =>
+        (data != null
+        ? _i123.LongImplicitIdFieldCollection.fromJson(data)
+        : null);
+    map[_i1
+        .getType<_i124.RelationToMultipleMaxFieldName?>()] = (data, protocol) =>
+        (data != null
+        ? _i124.RelationToMultipleMaxFieldName.fromJson(data)
+        : null);
+    map[_i1.getType<_i125.UserNote?>()] = (data, protocol) =>
+        (data != null ? _i125.UserNote.fromJson(data) : null);
+    map[_i1.getType<_i126.UserNoteCollection?>()] = (data, protocol) =>
+        (data != null ? _i126.UserNoteCollection.fromJson(data) : null);
+    map[_i1.getType<_i127.UserNoteCollectionWithALongName?>()] =
+        (data, protocol) => (data != null
+        ? _i127.UserNoteCollectionWithALongName.fromJson(data)
+        : null);
+    map[_i1.getType<_i128.UserNoteWithALongName?>()] = (data, protocol) =>
+        (data != null ? _i128.UserNoteWithALongName.fromJson(data) : null);
+    map[_i1.getType<_i129.MultipleMaxFieldName?>()] = (data, protocol) =>
+        (data != null ? _i129.MultipleMaxFieldName.fromJson(data) : null);
+    map[_i1.getType<_i130.City?>()] = (data, protocol) =>
+        (data != null ? _i130.City.fromJson(data) : null);
+    map[_i1.getType<_i131.Organization?>()] = (data, protocol) =>
+        (data != null ? _i131.Organization.fromJson(data) : null);
+    map[_i1.getType<_i132.Person?>()] = (data, protocol) =>
+        (data != null ? _i132.Person.fromJson(data) : null);
+    map[_i1.getType<_i133.Course?>()] = (data, protocol) =>
+        (data != null ? _i133.Course.fromJson(data) : null);
+    map[_i1.getType<_i134.Enrollment?>()] = (data, protocol) =>
+        (data != null ? _i134.Enrollment.fromJson(data) : null);
+    map[_i1.getType<_i135.Student?>()] = (data, protocol) =>
+        (data != null ? _i135.Student.fromJson(data) : null);
+    map[_i1.getType<_i136.ObjectUser?>()] = (data, protocol) =>
+        (data != null ? _i136.ObjectUser.fromJson(data) : null);
+    map[_i1.getType<_i137.ParentUser?>()] = (data, protocol) =>
+        (data != null ? _i137.ParentUser.fromJson(data) : null);
+    map[_i1.getType<_i138.Arena?>()] = (data, protocol) =>
+        (data != null ? _i138.Arena.fromJson(data) : null);
+    map[_i1.getType<_i139.Player?>()] = (data, protocol) =>
+        (data != null ? _i139.Player.fromJson(data) : null);
+    map[_i1.getType<_i140.Team?>()] = (data, protocol) =>
+        (data != null ? _i140.Team.fromJson(data) : null);
+    map[_i1.getType<_i141.Comment?>()] = (data, protocol) =>
+        (data != null ? _i141.Comment.fromJson(data) : null);
+    map[_i1.getType<_i142.Customer?>()] = (data, protocol) =>
+        (data != null ? _i142.Customer.fromJson(data) : null);
+    map[_i1.getType<_i143.Book?>()] = (data, protocol) =>
+        (data != null ? _i143.Book.fromJson(data) : null);
+    map[_i1.getType<_i144.Chapter?>()] = (data, protocol) =>
+        (data != null ? _i144.Chapter.fromJson(data) : null);
+    map[_i1.getType<_i145.Order?>()] = (data, protocol) =>
+        (data != null ? _i145.Order.fromJson(data) : null);
+    map[_i1.getType<_i146.Address?>()] = (data, protocol) =>
+        (data != null ? _i146.Address.fromJson(data) : null);
+    map[_i1.getType<_i147.Citizen?>()] = (data, protocol) =>
+        (data != null ? _i147.Citizen.fromJson(data) : null);
+    map[_i1.getType<_i148.Company?>()] = (data, protocol) =>
+        (data != null ? _i148.Company.fromJson(data) : null);
+    map[_i1.getType<_i149.Town?>()] = (data, protocol) =>
+        (data != null ? _i149.Town.fromJson(data) : null);
+    map[_i1.getType<_i150.Blocking?>()] = (data, protocol) =>
+        (data != null ? _i150.Blocking.fromJson(data) : null);
+    map[_i1.getType<_i151.Member?>()] = (data, protocol) =>
+        (data != null ? _i151.Member.fromJson(data) : null);
+    map[_i1.getType<_i152.Cat?>()] = (data, protocol) =>
+        (data != null ? _i152.Cat.fromJson(data) : null);
+    map[_i1.getType<_i153.Post?>()] = (data, protocol) =>
+        (data != null ? _i153.Post.fromJson(data) : null);
+    map[_i1.getType<_i154.ModuleDatatype?>()] = (data, protocol) =>
+        (data != null ? _i154.ModuleDatatype.fromJson(data) : null);
+    map[_i1.getType<_i155.MyFeatureModel?>()] = (data, protocol) =>
+        (data != null ? _i155.MyFeatureModel.fromJson(data) : null);
+    map[_i1.getType<_i156.MyTriggerType?>()] = (data, protocol) =>
+        (data != null ? _i156.MyTriggerType.fromJson(data) : null);
+    map[_i1.getType<_i157.Nullability?>()] = (data, protocol) =>
+        (data != null ? _i157.Nullability.fromJson(data) : null);
+    map[_i1.getType<_i158.ObjectFieldPersist?>()] = (data, protocol) =>
+        (data != null ? _i158.ObjectFieldPersist.fromJson(data) : null);
+    map[_i1.getType<_i159.ObjectFieldScopes?>()] = (data, protocol) =>
+        (data != null ? _i159.ObjectFieldScopes.fromJson(data) : null);
+    map[_i1.getType<_i160.ObjectWithBit?>()] = (data, protocol) =>
+        (data != null ? _i160.ObjectWithBit.fromJson(data) : null);
+    map[_i1.getType<_i161.ObjectWithByteData?>()] = (data, protocol) =>
+        (data != null ? _i161.ObjectWithByteData.fromJson(data) : null);
+    map[_i1.getType<_i162.ObjectWithCustomClass?>()] = (data, protocol) =>
+        (data != null ? _i162.ObjectWithCustomClass.fromJson(data) : null);
+    map[_i1.getType<_i163.ObjectWithDuration?>()] = (data, protocol) =>
+        (data != null ? _i163.ObjectWithDuration.fromJson(data) : null);
+    map[_i1.getType<_i164.ObjectWithDynamic?>()] = (data, protocol) =>
+        (data != null ? _i164.ObjectWithDynamic.fromJson(data) : null);
+    map[_i1.getType<_i165.ObjectWithEnum?>()] = (data, protocol) =>
+        (data != null ? _i165.ObjectWithEnum.fromJson(data) : null);
+    map[_i1.getType<_i166.ObjectWithEnumEnhanced?>()] = (data, protocol) =>
+        (data != null ? _i166.ObjectWithEnumEnhanced.fromJson(data) : null);
+    map[_i1.getType<_i167.ObjectWithHalfVector?>()] = (data, protocol) =>
+        (data != null ? _i167.ObjectWithHalfVector.fromJson(data) : null);
+    map[_i1.getType<_i168.ObjectWithIndex?>()] = (data, protocol) =>
+        (data != null ? _i168.ObjectWithIndex.fromJson(data) : null);
+    map[_i1.getType<_i169.ObjectWithJsonb?>()] = (data, protocol) =>
+        (data != null ? _i169.ObjectWithJsonb.fromJson(data) : null);
+    map[_i1.getType<_i170.ObjectWithJsonbClassLevel?>()] = (data, protocol) =>
+        (data != null ? _i170.ObjectWithJsonbClassLevel.fromJson(data) : null);
+    map[_i1.getType<_i171.ObjectWithMaps?>()] = (data, protocol) =>
+        (data != null ? _i171.ObjectWithMaps.fromJson(data) : null);
+    map[_i1
+        .getType<_i172.ObjectWithNullableCustomClass?>()] = (data, protocol) =>
+        (data != null
+        ? _i172.ObjectWithNullableCustomClass.fromJson(data)
+        : null);
+    map[_i1.getType<_i173.ObjectWithObject?>()] = (data, protocol) =>
+        (data != null ? _i173.ObjectWithObject.fromJson(data) : null);
+    map[_i1.getType<_i174.ObjectWithParent?>()] = (data, protocol) =>
+        (data != null ? _i174.ObjectWithParent.fromJson(data) : null);
+    map[_i1.getType<_i175.ObjectWithSealedClass?>()] = (data, protocol) =>
+        (data != null ? _i175.ObjectWithSealedClass.fromJson(data) : null);
+    map[_i1.getType<_i176.ObjectWithSelfParent?>()] = (data, protocol) =>
+        (data != null ? _i176.ObjectWithSelfParent.fromJson(data) : null);
+    map[_i1.getType<_i177.ObjectWithSparseVector?>()] = (data, protocol) =>
+        (data != null ? _i177.ObjectWithSparseVector.fromJson(data) : null);
+    map[_i1.getType<_i178.ObjectWithUuid?>()] = (data, protocol) =>
+        (data != null ? _i178.ObjectWithUuid.fromJson(data) : null);
+    map[_i1.getType<_i179.ObjectWithVector?>()] = (data, protocol) =>
+        (data != null ? _i179.ObjectWithVector.fromJson(data) : null);
+    map[_i1.getType<_i180.Record?>()] = (data, protocol) =>
+        (data != null ? _i180.Record.fromJson(data) : null);
+    map[_i1.getType<_i181.RelatedUniqueData?>()] = (data, protocol) =>
+        (data != null ? _i181.RelatedUniqueData.fromJson(data) : null);
+    map[_i1.getType<_i182.ExceptionWithRequiredField?>()] = (data, protocol) =>
+        (data != null ? _i182.ExceptionWithRequiredField.fromJson(data) : null);
+    map[_i1.getType<_i183.ModelWithRequiredField?>()] = (data, protocol) =>
+        (data != null ? _i183.ModelWithRequiredField.fromJson(data) : null);
+    map[_i1.getType<_i184.ScopeNoneFields?>()] = (data, protocol) =>
+        (data != null ? _i184.ScopeNoneFields.fromJson(data) : null);
+    map[_i1.getType<_i185.ScopeServerOnlyFieldChild?>()] = (data, protocol) =>
+        (data != null ? _i185.ScopeServerOnlyFieldChild.fromJson(data) : null);
+    map[_i1.getType<_i186.ScopeServerOnlyField?>()] = (data, protocol) =>
+        (data != null ? _i186.ScopeServerOnlyField.fromJson(data) : null);
+    map[_i1.getType<_i187.Article?>()] = (data, protocol) =>
+        (data != null ? _i187.Article.fromJson(data) : null);
+    map[_i1.getType<_i188.ArticleList?>()] = (data, protocol) =>
+        (data != null ? _i188.ArticleList.fromJson(data) : null);
+    map[_i1.getType<_i189.DefaultServerOnlyClass?>()] = (data, protocol) =>
+        (data != null ? _i189.DefaultServerOnlyClass.fromJson(data) : null);
+    map[_i1.getType<_i190.DefaultServerOnlyEnum?>()] = (data, protocol) =>
+        (data != null ? _i190.DefaultServerOnlyEnum.fromJson(data) : null);
+    map[_i1.getType<_i191.NotServerOnlyClass?>()] = (data, protocol) =>
+        (data != null ? _i191.NotServerOnlyClass.fromJson(data) : null);
+    map[_i1.getType<_i192.NotServerOnlyEnum?>()] = (data, protocol) =>
+        (data != null ? _i192.NotServerOnlyEnum.fromJson(data) : null);
+    map[_i1.getType<_i193.ServerOnlyClass?>()] = (data, protocol) =>
+        (data != null ? _i193.ServerOnlyClass.fromJson(data) : null);
+    map[_i1.getType<_i194.ServerOnlyEnum?>()] = (data, protocol) =>
+        (data != null ? _i194.ServerOnlyEnum.fromJson(data) : null);
+    map[_i1.getType<_i195.ServerOnlyClassField?>()] = (data, protocol) =>
+        (data != null ? _i195.ServerOnlyClassField.fromJson(data) : null);
+    map[_i1.getType<_i196.ServerOnlyDefault?>()] = (data, protocol) =>
+        (data != null ? _i196.ServerOnlyDefault.fromJson(data) : null);
+    map[_i1.getType<_i197.SessionAuthInfo?>()] = (data, protocol) =>
+        (data != null ? _i197.SessionAuthInfo.fromJson(data) : null);
+    map[_i1.getType<_i198.SharedModelContainer?>()] = (data, protocol) =>
+        (data != null ? _i198.SharedModelContainer.fromJson(data) : null);
+    map[_i1.getType<_i199.SharedModelSubclass?>()] = (data, protocol) =>
+        (data != null ? _i199.SharedModelSubclass.fromJson(data) : null);
+    map[_i1.getType<_i200.SimpleData?>()] = (data, protocol) =>
+        (data != null ? _i200.SimpleData.fromJson(data) : null);
+    map[_i1.getType<_i201.SimpleDataList?>()] = (data, protocol) =>
+        (data != null ? _i201.SimpleDataList.fromJson(data) : null);
+    map[_i1.getType<_i202.SimpleDataMap?>()] = (data, protocol) =>
+        (data != null ? _i202.SimpleDataMap.fromJson(data) : null);
+    map[_i1.getType<_i203.SimpleDataObject?>()] = (data, protocol) =>
+        (data != null ? _i203.SimpleDataObject.fromJson(data) : null);
+    map[_i1.getType<_i204.SimpleDateTime?>()] = (data, protocol) =>
+        (data != null ? _i204.SimpleDateTime.fromJson(data) : null);
+    map[_i1.getType<_i205.ModelInSubfolder?>()] = (data, protocol) =>
+        (data != null ? _i205.ModelInSubfolder.fromJson(data) : null);
+    map[_i1.getType<_i206.TestEnum?>()] = (data, protocol) =>
+        (data != null ? _i206.TestEnum.fromJson(data) : null);
+    map[_i1
+        .getType<_i207.TestEnumDefaultSerialization?>()] = (data, protocol) =>
+        (data != null
+        ? _i207.TestEnumDefaultSerialization.fromJson(data)
+        : null);
+    map[_i1.getType<_i208.TestEnumEnhanced?>()] = (data, protocol) =>
+        (data != null ? _i208.TestEnumEnhanced.fromJson(data) : null);
+    map[_i1.getType<_i209.TestEnumEnhancedByName?>()] = (data, protocol) =>
+        (data != null ? _i209.TestEnumEnhancedByName.fromJson(data) : null);
+    map[_i1.getType<_i210.TestEnumStringified?>()] = (data, protocol) =>
+        (data != null ? _i210.TestEnumStringified.fromJson(data) : null);
+    map[_i1.getType<_i211.Types?>()] = (data, protocol) =>
+        (data != null ? _i211.Types.fromJson(data) : null);
+    map[_i1.getType<_i212.TypesList?>()] = (data, protocol) =>
+        (data != null ? _i212.TypesList.fromJson(data) : null);
+    map[_i1.getType<_i213.TypesMap?>()] = (data, protocol) =>
+        (data != null ? _i213.TypesMap.fromJson(data) : null);
+    map[_i1.getType<_i214.TypesRecord?>()] = (data, protocol) =>
+        (data != null ? _i214.TypesRecord.fromJson(data) : null);
+    map[_i1.getType<_i215.TypesSet?>()] = (data, protocol) =>
+        (data != null ? _i215.TypesSet.fromJson(data) : null);
+    map[_i1.getType<_i216.TypesSetRequired?>()] = (data, protocol) =>
+        (data != null ? _i216.TypesSetRequired.fromJson(data) : null);
+    map[_i1.getType<_i217.UniqueData?>()] = (data, protocol) =>
+        (data != null ? _i217.UniqueData.fromJson(data) : null);
+    map[_i1.getType<_i218.UniqueDataWithNonPersist?>()] = (data, protocol) =>
+        (data != null ? _i218.UniqueDataWithNonPersist.fromJson(data) : null);
+    map[_i1.getType<_i219.UpsertTestModel?>()] = (data, protocol) =>
+        (data != null ? _i219.UpsertTestModel.fromJson(data) : null);
+    map[List<_i8.EnrollmentInt>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i8.EnrollmentInt>(e))
+        .toList();
+    map[_i1.getType<List<_i8.EnrollmentInt>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i8.EnrollmentInt>(e))
+              .toList()
+        : null);
+    map[List<_i11.PlayerUuid>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i11.PlayerUuid>(e))
+        .toList();
+    map[_i1.getType<List<_i11.PlayerUuid>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i11.PlayerUuid>(e))
+              .toList()
+        : null);
+    map[List<_i15.OrderUuid>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i15.OrderUuid>(e))
+        .toList();
+    map[_i1.getType<List<_i15.OrderUuid>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i15.OrderUuid>(e))
+              .toList()
+        : null);
+    map[List<_i13.CommentInt>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i13.CommentInt>(e))
+        .toList();
+    map[_i1.getType<List<_i13.CommentInt>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i13.CommentInt>(e))
+              .toList()
+        : null);
+    map[List<_i20.ChangedIdTypeSelf>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i20.ChangedIdTypeSelf>(e))
+        .toList();
+    map[_i1.getType<List<_i20.ChangedIdTypeSelf>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i20.ChangedIdTypeSelf>(e))
+              .toList()
+        : null);
+    map[List<_i67.EmptyModelRelationItem>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i67.EmptyModelRelationItem>(e))
+        .toList();
+    map[_i1.getType<List<_i67.EmptyModelRelationItem>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i67.EmptyModelRelationItem>(e))
+              .toList()
+        : null);
+    map[List<_i75.Employee>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i75.Employee>(e))
+        .toList();
+    map[_i1.getType<List<_i75.Employee>?>()] = (data, protocol) => (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i75.Employee>(e))
+              .toList()
+        : null);
+    map[List<String>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<String>(e)).toList();
+    map[Map<String, String>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<String>(v),
+      ),
+    );
+    map[_i1.getType<(int, String)>()] = (data, protocol) => (
+      protocol.deserialize<int>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<String>(data['p'][1]),
+    );
+    map[List<_i103.ChildEntity>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i103.ChildEntity>(e))
+        .toList();
+    map[_i1.getType<List<_i103.ChildEntity>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i103.ChildEntity>(e))
+              .toList()
+        : null);
+    map[List<_i110.PolymorphicChild>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i110.PolymorphicChild>(e))
+        .toList();
+    map[List<_i110.PolymorphicChild?>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i110.PolymorphicChild?>(e))
+        .toList();
+    map[Map<String, _i110.PolymorphicChild>] = (data, protocol) =>
+        (data as Map).map(
+          (k, v) => MapEntry(
+            protocol.deserialize<String>(k),
+            protocol.deserialize<_i110.PolymorphicChild>(v),
+          ),
+        );
+    map[Map<String, _i110.PolymorphicChild?>] = (data, protocol) =>
+        (data as Map).map(
+          (k, v) => MapEntry(
+            protocol.deserialize<String>(k),
+            protocol.deserialize<_i110.PolymorphicChild?>(v),
+          ),
+        );
+    map[List<_i4.ModulePolymorphicChild>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i4.ModulePolymorphicChild>(e))
+        .toList();
+    map[Map<String, _i4.ModulePolymorphicChild>] = (data, protocol) =>
+        (data as Map).map(
+          (k, v) => MapEntry(
+            protocol.deserialize<String>(k),
+            protocol.deserialize<_i4.ModulePolymorphicChild>(v),
+          ),
+        );
+    map[List<_i120.PersonWithLongTableName>] = (data, protocol) =>
+        (data as List)
+            .map((e) => protocol.deserialize<_i120.PersonWithLongTableName>(e))
+            .toList();
+    map[_i1.getType<List<_i120.PersonWithLongTableName>?>()] =
+        (data, protocol) => (data != null
+        ? (data as List)
+              .map(
+                (e) => protocol.deserialize<_i120.PersonWithLongTableName>(e),
+              )
+              .toList()
+        : null);
+    map[List<_i119.OrganizationWithLongTableName>] = (data, protocol) =>
+        (data as List)
+            .map(
+              (e) =>
+                  protocol.deserialize<_i119.OrganizationWithLongTableName>(e),
+            )
+            .toList();
+    map[_i1.getType<List<_i119.OrganizationWithLongTableName>?>()] =
+        (data, protocol) => (data != null
+        ? (data as List)
+              .map(
+                (e) => protocol
+                    .deserialize<_i119.OrganizationWithLongTableName>(e),
+              )
+              .toList()
+        : null);
+    map[List<_i122.LongImplicitIdField>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i122.LongImplicitIdField>(e))
+        .toList();
+    map[_i1.getType<List<_i122.LongImplicitIdField>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i122.LongImplicitIdField>(e))
+              .toList()
+        : null);
+    map[List<_i129.MultipleMaxFieldName>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i129.MultipleMaxFieldName>(e))
+        .toList();
+    map[_i1.getType<List<_i129.MultipleMaxFieldName>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i129.MultipleMaxFieldName>(e))
+              .toList()
+        : null);
+    map[List<_i125.UserNote>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i125.UserNote>(e))
+        .toList();
+    map[_i1.getType<List<_i125.UserNote>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i125.UserNote>(e))
+              .toList()
+        : null);
+    map[List<_i128.UserNoteWithALongName>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i128.UserNoteWithALongName>(e))
+        .toList();
+    map[_i1.getType<List<_i128.UserNoteWithALongName>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i128.UserNoteWithALongName>(e))
+              .toList()
+        : null);
+    map[List<_i132.Person>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i132.Person>(e))
+        .toList();
+    map[_i1.getType<List<_i132.Person>?>()] = (data, protocol) => (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i132.Person>(e))
+              .toList()
+        : null);
+    map[List<_i131.Organization>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i131.Organization>(e))
+        .toList();
+    map[_i1.getType<List<_i131.Organization>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i131.Organization>(e))
+              .toList()
+        : null);
+    map[List<_i134.Enrollment>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i134.Enrollment>(e))
+        .toList();
+    map[_i1.getType<List<_i134.Enrollment>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i134.Enrollment>(e))
+              .toList()
+        : null);
+    map[List<_i139.Player>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i139.Player>(e))
+        .toList();
+    map[_i1.getType<List<_i139.Player>?>()] = (data, protocol) => (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i139.Player>(e))
+              .toList()
+        : null);
+    map[List<_i145.Order>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i145.Order>(e))
+        .toList();
+    map[_i1.getType<List<_i145.Order>?>()] = (data, protocol) => (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i145.Order>(e))
+              .toList()
+        : null);
+    map[List<_i144.Chapter>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i144.Chapter>(e))
+        .toList();
+    map[_i1.getType<List<_i144.Chapter>?>()] = (data, protocol) => (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i144.Chapter>(e))
+              .toList()
+        : null);
+    map[List<_i141.Comment>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i141.Comment>(e))
+        .toList();
+    map[_i1.getType<List<_i141.Comment>?>()] = (data, protocol) => (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i141.Comment>(e))
+              .toList()
+        : null);
+    map[List<_i150.Blocking>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i150.Blocking>(e))
+        .toList();
+    map[_i1.getType<List<_i150.Blocking>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i150.Blocking>(e))
+              .toList()
+        : null);
+    map[List<_i152.Cat>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<_i152.Cat>(e)).toList();
+    map[_i1.getType<List<_i152.Cat>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<_i152.Cat>(e)).toList()
+        : null);
+    map[List<_i4.ModuleClass>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i4.ModuleClass>(e))
+        .toList();
+    map[Map<String, _i4.ModuleClass>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i4.ModuleClass>(v),
+      ),
+    );
+    map[_i1.getType<(_i4.ModuleClass,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (
+            protocol.deserialize<_i4.ModuleClass>(
+              ((data as Map)['p'] as List)[0],
+            ),
+          );
+    map[List<int>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int>(e)).toList();
+    map[List<int>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int>(e)).toList();
+    map[_i1.getType<List<int>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<int>(e)).toList()
+        : null);
+    map[List<int?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int?>(e)).toList();
+    map[List<int?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int?>(e)).toList();
+    map[_i1.getType<List<int?>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<int?>(e)).toList()
+        : null);
+    map[List<_i200.SimpleData>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i200.SimpleData>(e))
+        .toList();
+    map[List<_i200.SimpleData>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i200.SimpleData>(e))
+        .toList();
+    map[_i1.getType<List<_i200.SimpleData>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i200.SimpleData>(e))
+              .toList()
+        : null);
+    map[List<_i200.SimpleData?>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i200.SimpleData?>(e))
+        .toList();
+    map[List<_i200.SimpleData?>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i200.SimpleData?>(e))
+        .toList();
+    map[_i1.getType<List<_i200.SimpleData?>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i200.SimpleData?>(e))
+              .toList()
+        : null);
+    map[List<DateTime>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<DateTime>(e)).toList();
+    map[List<DateTime>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<DateTime>(e)).toList();
+    map[_i1.getType<List<DateTime>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<DateTime>(e)).toList()
+        : null);
+    map[List<DateTime?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<DateTime?>(e)).toList();
+    map[List<DateTime?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<DateTime?>(e)).toList();
+    map[_i1.getType<List<DateTime?>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<DateTime?>(e)).toList()
+        : null);
+    map[List<_i220.ByteData>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i220.ByteData>(e))
+        .toList();
+    map[List<_i220.ByteData>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i220.ByteData>(e))
+        .toList();
+    map[_i1.getType<List<_i220.ByteData>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i220.ByteData>(e))
+              .toList()
+        : null);
+    map[List<_i220.ByteData?>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i220.ByteData?>(e))
+        .toList();
+    map[List<_i220.ByteData?>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i220.ByteData?>(e))
+        .toList();
+    map[_i1.getType<List<_i220.ByteData?>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i220.ByteData?>(e))
+              .toList()
+        : null);
+    map[List<Duration>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<Duration>(e)).toList();
+    map[List<Duration>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<Duration>(e)).toList();
+    map[_i1.getType<List<Duration>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<Duration>(e)).toList()
+        : null);
+    map[List<Duration?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<Duration?>(e)).toList();
+    map[List<Duration?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<Duration?>(e)).toList();
+    map[_i1.getType<List<Duration?>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<Duration?>(e)).toList()
+        : null);
+    map[List<_i1.UuidValue>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i1.UuidValue>(e))
+        .toList();
+    map[List<_i1.UuidValue>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i1.UuidValue>(e))
+        .toList();
+    map[_i1.getType<List<_i1.UuidValue>?>()] = (data, protocol) => (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i1.UuidValue>(e))
+              .toList()
+        : null);
+    map[List<_i1.UuidValue?>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i1.UuidValue?>(e))
+        .toList();
+    map[List<_i1.UuidValue?>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i1.UuidValue?>(e))
+        .toList();
+    map[_i1.getType<List<_i1.UuidValue?>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i1.UuidValue?>(e))
+              .toList()
+        : null);
+    map[Map<String, int>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<int>(v),
+      ),
+    );
+    map[Map<String, int>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<int>(v),
+      ),
+    );
+    map[_i1.getType<Map<String, int>?>()] = (data, protocol) => (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<int>(v),
+            ),
+          )
+        : null);
+    map[Map<String, int?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<int?>(v),
+      ),
+    );
+    map[Map<String, int?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<int?>(v),
+      ),
+    );
+    map[_i1.getType<Map<String, int?>?>()] = (data, protocol) => (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<int?>(v),
+            ),
+          )
+        : null);
+    map[_i221.CustomClassWithoutProtocolSerialization] = (data, protocol) =>
+        _i221.CustomClassWithoutProtocolSerialization.fromJson(data);
+    map[_i221.CustomClassWithProtocolSerialization] = (data, protocol) =>
+        _i221.CustomClassWithProtocolSerialization.fromJson(data);
+    map[_i221.CustomClassWithProtocolSerializationMethod] = (data, protocol) =>
+        _i221.CustomClassWithProtocolSerializationMethod.fromJson(data);
+    map[dynamic] = (data, protocol) => deserializeDynamicFieldValue(data) as T;
+    map[List<dynamic>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<dynamic>(e)).toList();
+    map[dynamic] = (data, protocol) => deserializeDynamicFieldValue(data) as T;
+    map[Map<String, dynamic>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<dynamic>(v),
+      ),
+    );
+    map[dynamic] = (data, protocol) => deserializeDynamicFieldValue(data) as T;
+    map[Set<dynamic>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<dynamic>(e)).toSet();
+    map[dynamic] = (data, protocol) => deserializeDynamicFieldValue(data) as T;
+    map[Map<dynamic, dynamic>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<dynamic>(e['k']),
+          protocol.deserialize<dynamic>(e['v']),
+        ),
+      ),
+    );
+    map[dynamic] = (data, protocol) => deserializeDynamicFieldValue(data) as T;
+    map[dynamic] = (data, protocol) => deserializeDynamicFieldValue(data) as T;
+    map[List<_i206.TestEnum>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i206.TestEnum>(e))
+        .toList();
+    map[List<_i206.TestEnum?>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i206.TestEnum?>(e))
+        .toList();
+    map[List<List<_i206.TestEnum>>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<List<_i206.TestEnum>>(e))
+        .toList();
+    map[List<_i206.TestEnum>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i206.TestEnum>(e))
+        .toList();
+    map[List<_i208.TestEnumEnhanced>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i208.TestEnumEnhanced>(e))
+        .toList();
+    map[List<_i209.TestEnumEnhancedByName>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i209.TestEnumEnhancedByName>(e))
+        .toList();
+    map[List<String>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<String>(e)).toList();
+    map[_i1.getType<List<String>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<String>(e)).toList()
+        : null);
+    map[Map<String, _i200.SimpleData>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i200.SimpleData>(v),
+      ),
+    );
+    map[Map<String, DateTime>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<DateTime>(v),
+      ),
+    );
+    map[Map<String, _i220.ByteData>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i220.ByteData>(v),
+      ),
+    );
+    map[Map<String, Duration>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<Duration>(v),
+      ),
+    );
+    map[Map<String, _i1.UuidValue>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i1.UuidValue>(v),
+      ),
+    );
+    map[Map<String, _i200.SimpleData?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i200.SimpleData?>(v),
+      ),
+    );
+    map[Map<String, String?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<String?>(v),
+      ),
+    );
+    map[Map<String, DateTime?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<DateTime?>(v),
+      ),
+    );
+    map[Map<String, _i220.ByteData?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i220.ByteData?>(v),
+      ),
+    );
+    map[Map<String, Duration?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<Duration?>(v),
+      ),
+    );
+    map[Map<String, _i1.UuidValue?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i1.UuidValue?>(v),
+      ),
+    );
+    map[Map<int, int>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<int>(e['k']),
+          protocol.deserialize<int>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<_i221.CustomClassWithoutProtocolSerialization?>()] =
+        (data, protocol) => (data != null
+        ? _i221.CustomClassWithoutProtocolSerialization.fromJson(data)
+        : null);
+    map[_i1.getType<_i221.CustomClassWithProtocolSerialization?>()] =
+        (data, protocol) => (data != null
+        ? _i221.CustomClassWithProtocolSerialization.fromJson(data)
+        : null);
+    map[_i1.getType<_i221.CustomClassWithProtocolSerializationMethod?>()] =
+        (data, protocol) => (data != null
+        ? _i221.CustomClassWithProtocolSerializationMethod.fromJson(data)
+        : null);
+    map[List<List<_i200.SimpleData>>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<List<_i200.SimpleData>>(e))
+        .toList();
+    map[List<_i200.SimpleData>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i200.SimpleData>(e))
+        .toList();
+    map[_i1.getType<List<List<_i200.SimpleData>>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<List<_i200.SimpleData>>(e))
+              .toList()
+        : null);
+    map[List<_i200.SimpleData>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i200.SimpleData>(e))
+        .toList();
+    map[Map<String, List<List<Map<int, _i200.SimpleData>>?>>] =
+        (data, protocol) => (data as Map).map(
+          (k, v) => MapEntry(
+            protocol.deserialize<String>(k),
+            protocol.deserialize<List<List<Map<int, _i200.SimpleData>>?>>(v),
+          ),
+        );
+    map[List<List<Map<int, _i200.SimpleData>>?>] = (data, protocol) =>
+        (data as List)
+            .map(
+              (e) => protocol.deserialize<List<Map<int, _i200.SimpleData>>?>(e),
+            )
+            .toList();
+    map[List<Map<int, _i200.SimpleData>>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<Map<int, _i200.SimpleData>>(e))
+        .toList();
+    map[Map<int, _i200.SimpleData>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<int>(e['k']),
+          protocol.deserialize<_i200.SimpleData>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<List<Map<int, _i200.SimpleData>>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<Map<int, _i200.SimpleData>>(e))
+              .toList()
+        : null);
+    map[Map<int, _i200.SimpleData>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<int>(e['k']),
+          protocol.deserialize<_i200.SimpleData>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<Map<String, List<List<Map<int, _i200.SimpleData>>?>>?>()] =
+        (data, protocol) => (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<List<List<Map<int, _i200.SimpleData>>?>>(v),
+            ),
+          )
+        : null);
+    map[List<List<Map<int, _i200.SimpleData>>?>] = (data, protocol) =>
+        (data as List)
+            .map(
+              (e) => protocol.deserialize<List<Map<int, _i200.SimpleData>>?>(e),
+            )
+            .toList();
+    map[List<Map<int, _i200.SimpleData>>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<Map<int, _i200.SimpleData>>(e))
+        .toList();
+    map[Map<int, _i200.SimpleData>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<int>(e['k']),
+          protocol.deserialize<_i200.SimpleData>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<List<Map<int, _i200.SimpleData>>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<Map<int, _i200.SimpleData>>(e))
+              .toList()
+        : null);
+    map[Map<int, _i200.SimpleData>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<int>(e['k']),
+          protocol.deserialize<_i200.SimpleData>(e['v']),
+        ),
+      ),
+    );
+    map[Map<String, Map<int, _i200.SimpleData>>] = (data, protocol) =>
+        (data as Map).map(
+          (k, v) => MapEntry(
+            protocol.deserialize<String>(k),
+            protocol.deserialize<Map<int, _i200.SimpleData>>(v),
+          ),
+        );
+    map[Map<int, _i200.SimpleData>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<int>(e['k']),
+          protocol.deserialize<_i200.SimpleData>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<Map<String, Map<int, _i200.SimpleData>>?>()] =
+        (data, protocol) => (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<Map<int, _i200.SimpleData>>(v),
+            ),
+          )
+        : null);
+    map[Map<int, _i200.SimpleData>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<int>(e['k']),
+          protocol.deserialize<_i200.SimpleData>(e['v']),
+        ),
+      ),
+    );
+    map[List<_i116.SealedParent>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i116.SealedParent>(e))
+        .toList();
+    map[_i1.getType<(bool,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<bool>(((data as Map)['p'] as List)[0]),);
+    map[List<_i187.Article>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i187.Article>(e))
+        .toList();
+    map[List<_i193.ServerOnlyClass>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i193.ServerOnlyClass>(e))
+        .toList();
+    map[_i1.getType<List<_i193.ServerOnlyClass>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i193.ServerOnlyClass>(e))
+              .toList()
+        : null);
+    map[Map<String, _i193.ServerOnlyClass>] = (data, protocol) =>
+        (data as Map).map(
+          (k, v) => MapEntry(
+            protocol.deserialize<String>(k),
+            protocol.deserialize<_i193.ServerOnlyClass>(v),
+          ),
+        );
+    map[_i1.getType<Map<String, _i193.ServerOnlyClass>?>()] =
+        (data, protocol) => (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<_i193.ServerOnlyClass>(v),
+            ),
+          )
+        : null);
+    map[List<_i221.SharedModel>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i221.SharedModel>(e))
+        .toList();
+    map[List<_i221.SharedModel?>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i221.SharedModel?>(e))
+        .toList();
+    map[List<_i221.SharedModel>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i221.SharedModel>(e))
+        .toList();
+    map[_i1.getType<List<_i221.SharedModel>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i221.SharedModel>(e))
+              .toList()
+        : null);
+    map[Map<String, _i221.SharedModel>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i221.SharedModel>(v),
+      ),
+    );
+    map[Map<String, _i221.SharedModel>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i221.SharedModel>(v),
+      ),
+    );
+    map[_i1.getType<Map<String, _i221.SharedModel>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<_i221.SharedModel>(v),
+            ),
+          )
+        : null);
+    map[Map<String, _i221.SharedSubclass>] = (data, protocol) =>
+        (data as Map).map(
+          (k, v) => MapEntry(
+            protocol.deserialize<String>(k),
+            protocol.deserialize<_i221.SharedSubclass>(v),
+          ),
+        );
+    map[Set<_i221.SharedModel>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i221.SharedModel>(e))
+        .toSet();
+    map[Set<_i221.SharedModel>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i221.SharedModel>(e))
+        .toSet();
+    map[_i1.getType<Set<_i221.SharedModel>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i221.SharedModel>(e))
+              .toSet()
+        : null);
+    map[List<_i210.TestEnumStringified>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i210.TestEnumStringified>(e))
+        .toList();
+    map[_i1.getType<List<_i210.TestEnumStringified>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i210.TestEnumStringified>(e))
+              .toList()
+        : null);
+    map[_i1.getType<(_i210.TestEnumStringified,)?>()] = (data, protocol) =>
+        (data == null)
+        ? null
+        : (
+            protocol.deserialize<_i210.TestEnumStringified>(
+              ((data as Map)['p'] as List)[0],
+            ),
+          );
+    map[List<(_i210.TestEnumStringified,)>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<(_i210.TestEnumStringified,)>(e))
+        .toList();
+    map[_i1.getType<(_i210.TestEnumStringified,)>()] = (data, protocol) => (
+      protocol.deserialize<_i210.TestEnumStringified>(
+        ((data as Map)['p'] as List)[0],
+      ),
+    );
+    map[_i1.getType<List<(_i210.TestEnumStringified,)>?>()] =
+        (data, protocol) => (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<(_i210.TestEnumStringified,)>(e))
+              .toList()
+        : null);
+    map[_i1.getType<(_i210.TestEnumStringified,)>()] = (data, protocol) => (
+      protocol.deserialize<_i210.TestEnumStringified>(
+        ((data as Map)['p'] as List)[0],
+      ),
+    );
+    map[_i1.getType<(_i157.Nullability,)?>()] = (data, protocol) =>
+        (data == null)
+        ? null
+        : (
+            protocol.deserialize<_i157.Nullability>(
+              ((data as Map)['p'] as List)[0],
+            ),
+          );
+    map[_i1.getType<({_i210.TestEnumStringified value})?>()] =
+        (data, protocol) => (data == null)
+        ? null
+        : (
+            value: protocol.deserialize<_i210.TestEnumStringified>(
+              ((data as Map)['n'] as Map)['value'],
+            ),
+          );
+    map[List<({_i210.TestEnumStringified value})>] = (data, protocol) =>
+        (data as List)
+            .map(
+              (e) =>
+                  protocol.deserialize<({_i210.TestEnumStringified value})>(e),
+            )
+            .toList();
+    map[_i1
+        .getType<({_i210.TestEnumStringified value})>()] = (data, protocol) => (
+      value: protocol.deserialize<_i210.TestEnumStringified>(
+        ((data as Map)['n'] as Map)['value'],
+      ),
+    );
+    map[_i1.getType<List<({_i210.TestEnumStringified value})>?>()] =
+        (data, protocol) => (data != null
+        ? (data as List)
+              .map(
+                (e) => protocol
+                    .deserialize<({_i210.TestEnumStringified value})>(e),
+              )
+              .toList()
+        : null);
+    map[_i1
+        .getType<({_i210.TestEnumStringified value})>()] = (data, protocol) => (
+      value: protocol.deserialize<_i210.TestEnumStringified>(
+        ((data as Map)['n'] as Map)['value'],
+      ),
+    );
+    map[_i1.getType<({_i4.ModuleClass value})?>()] = (data, protocol) =>
+        (data == null)
+        ? null
+        : (
+            value: protocol.deserialize<_i4.ModuleClass>(
+              ((data as Map)['n'] as Map)['value'],
+            ),
+          );
+    map[_i1.getType<({_i157.Nullability value})?>()] = (data, protocol) =>
+        (data == null)
+        ? null
+        : (
+            value: protocol.deserialize<_i157.Nullability>(
+              ((data as Map)['n'] as Map)['value'],
+            ),
+          );
+    map[Map<int, int>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<int>(e['k']),
+          protocol.deserialize<int>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<Map<int, int>?>()] = (data, protocol) => (data != null
+        ? Map.fromEntries(
+            (data as List).map(
+              (e) => MapEntry(
+                protocol.deserialize<int>(e['k']),
+                protocol.deserialize<int>(e['v']),
+              ),
+            ),
+          )
+        : null);
+    map[Set<int>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int>(e)).toSet();
+    map[_i1.getType<Set<int>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<int>(e)).toSet()
+        : null);
+    map[_i1.getType<(String, {Uri? optionalUri})?>()] = (data, protocol) =>
+        (data == null)
+        ? null
+        : (
+            protocol.deserialize<String>(((data as Map)['p'] as List)[0]),
+            optionalUri: ((data)['n'] as Map)['optionalUri'] == null
+                ? null
+                : protocol.deserialize<Uri>(data['n']['optionalUri']),
+          );
+    map[List<bool>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<bool>(e)).toList();
+    map[_i1.getType<List<bool>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<bool>(e)).toList()
+        : null);
+    map[List<double>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<double>(e)).toList();
+    map[_i1.getType<List<double>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<double>(e)).toList()
+        : null);
+    map[List<Uri>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<Uri>(e)).toList();
+    map[_i1.getType<List<Uri>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<Uri>(e)).toList()
+        : null);
+    map[List<BigInt>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<BigInt>(e)).toList();
+    map[_i1.getType<List<BigInt>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<BigInt>(e)).toList()
+        : null);
+    map[List<_i206.TestEnum>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i206.TestEnum>(e))
+        .toList();
+    map[_i1.getType<List<_i206.TestEnum>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i206.TestEnum>(e))
+              .toList()
+        : null);
+    map[List<_i211.Types>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i211.Types>(e))
+        .toList();
+    map[_i1.getType<List<_i211.Types>?>()] = (data, protocol) => (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i211.Types>(e))
+              .toList()
+        : null);
+    map[List<Map<String, _i211.Types>>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<Map<String, _i211.Types>>(e))
+        .toList();
+    map[Map<String, _i211.Types>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i211.Types>(v),
+      ),
+    );
+    map[_i1.getType<List<Map<String, _i211.Types>>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<Map<String, _i211.Types>>(e))
+              .toList()
+        : null);
+    map[Map<String, _i211.Types>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i211.Types>(v),
+      ),
+    );
+    map[List<List<_i211.Types>>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<List<_i211.Types>>(e))
+        .toList();
+    map[List<_i211.Types>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i211.Types>(e))
+        .toList();
+    map[_i1.getType<List<List<_i211.Types>>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<List<_i211.Types>>(e))
+              .toList()
+        : null);
+    map[List<_i211.Types>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i211.Types>(e))
+        .toList();
+    map[List<(int,)>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<(int,)>(e)).toList();
+    map[_i1.getType<(int,)>()] = (data, protocol) =>
+        (protocol.deserialize<int>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<List<(int,)>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<(int,)>(e)).toList()
+        : null);
+    map[_i1.getType<(int,)>()] = (data, protocol) =>
+        (protocol.deserialize<int>(((data as Map)['p'] as List)[0]),);
+    map[List<(int,)?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<(int,)?>(e)).toList();
+    map[_i1.getType<(int,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<int>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<List<(int,)?>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<(int,)?>(e)).toList()
+        : null);
+    map[_i1.getType<(int,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<int>(((data as Map)['p'] as List)[0]),);
+    map[List<(_i206.TestEnum,)>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<(_i206.TestEnum,)>(e))
+        .toList();
+    map[_i1.getType<(_i206.TestEnum,)>()] = (data, protocol) => (
+      protocol.deserialize<_i206.TestEnum>(((data as Map)['p'] as List)[0]),
+    );
+    map[_i1.getType<List<(_i206.TestEnum,)>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<(_i206.TestEnum,)>(e))
+              .toList()
+        : null);
+    map[_i1.getType<(_i206.TestEnum,)>()] = (data, protocol) => (
+      protocol.deserialize<_i206.TestEnum>(((data as Map)['p'] as List)[0]),
+    );
+    map[Map<int, String>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<int>(e['k']),
+          protocol.deserialize<String>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<Map<int, String>?>()] = (data, protocol) => (data != null
+        ? Map.fromEntries(
+            (data as List).map(
+              (e) => MapEntry(
+                protocol.deserialize<int>(e['k']),
+                protocol.deserialize<String>(e['v']),
+              ),
+            ),
+          )
+        : null);
+    map[Map<bool, String>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<bool>(e['k']),
+          protocol.deserialize<String>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<Map<bool, String>?>()] = (data, protocol) => (data != null
+        ? Map.fromEntries(
+            (data as List).map(
+              (e) => MapEntry(
+                protocol.deserialize<bool>(e['k']),
+                protocol.deserialize<String>(e['v']),
+              ),
+            ),
+          )
+        : null);
+    map[Map<double, String>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<double>(e['k']),
+          protocol.deserialize<String>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<Map<double, String>?>()] = (data, protocol) => (data != null
+        ? Map.fromEntries(
+            (data as List).map(
+              (e) => MapEntry(
+                protocol.deserialize<double>(e['k']),
+                protocol.deserialize<String>(e['v']),
+              ),
+            ),
+          )
+        : null);
+    map[Map<DateTime, String>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<DateTime>(e['k']),
+          protocol.deserialize<String>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<Map<DateTime, String>?>()] = (data, protocol) =>
+        (data != null
+        ? Map.fromEntries(
+            (data as List).map(
+              (e) => MapEntry(
+                protocol.deserialize<DateTime>(e['k']),
+                protocol.deserialize<String>(e['v']),
+              ),
+            ),
+          )
+        : null);
+    map[Map<String, String>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<String>(v),
+      ),
+    );
+    map[_i1.getType<Map<String, String>?>()] = (data, protocol) => (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<String>(v),
+            ),
+          )
+        : null);
+    map[Map<_i220.ByteData, String>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<_i220.ByteData>(e['k']),
+          protocol.deserialize<String>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<Map<_i220.ByteData, String>?>()] = (data, protocol) =>
+        (data != null
+        ? Map.fromEntries(
+            (data as List).map(
+              (e) => MapEntry(
+                protocol.deserialize<_i220.ByteData>(e['k']),
+                protocol.deserialize<String>(e['v']),
+              ),
+            ),
+          )
+        : null);
+    map[Map<Duration, String>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<Duration>(e['k']),
+          protocol.deserialize<String>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<Map<Duration, String>?>()] = (data, protocol) =>
+        (data != null
+        ? Map.fromEntries(
+            (data as List).map(
+              (e) => MapEntry(
+                protocol.deserialize<Duration>(e['k']),
+                protocol.deserialize<String>(e['v']),
+              ),
+            ),
+          )
+        : null);
+    map[Map<_i1.UuidValue, String>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<_i1.UuidValue>(e['k']),
+          protocol.deserialize<String>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<Map<_i1.UuidValue, String>?>()] = (data, protocol) =>
+        (data != null
+        ? Map.fromEntries(
+            (data as List).map(
+              (e) => MapEntry(
+                protocol.deserialize<_i1.UuidValue>(e['k']),
+                protocol.deserialize<String>(e['v']),
+              ),
+            ),
+          )
+        : null);
+    map[Map<Uri, String>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<Uri>(e['k']),
+          protocol.deserialize<String>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<Map<Uri, String>?>()] = (data, protocol) => (data != null
+        ? Map.fromEntries(
+            (data as List).map(
+              (e) => MapEntry(
+                protocol.deserialize<Uri>(e['k']),
+                protocol.deserialize<String>(e['v']),
+              ),
+            ),
+          )
+        : null);
+    map[Map<BigInt, String>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<BigInt>(e['k']),
+          protocol.deserialize<String>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<Map<BigInt, String>?>()] = (data, protocol) => (data != null
+        ? Map.fromEntries(
+            (data as List).map(
+              (e) => MapEntry(
+                protocol.deserialize<BigInt>(e['k']),
+                protocol.deserialize<String>(e['v']),
+              ),
+            ),
+          )
+        : null);
+    map[Map<_i206.TestEnum, String>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<_i206.TestEnum>(e['k']),
+          protocol.deserialize<String>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<Map<_i206.TestEnum, String>?>()] = (data, protocol) =>
+        (data != null
+        ? Map.fromEntries(
+            (data as List).map(
+              (e) => MapEntry(
+                protocol.deserialize<_i206.TestEnum>(e['k']),
+                protocol.deserialize<String>(e['v']),
+              ),
+            ),
+          )
+        : null);
+    map[Map<_i210.TestEnumStringified, String>] = (data, protocol) =>
+        Map.fromEntries(
+          (data as List).map(
+            (e) => MapEntry(
+              protocol.deserialize<_i210.TestEnumStringified>(e['k']),
+              protocol.deserialize<String>(e['v']),
+            ),
+          ),
+        );
+    map[_i1.getType<Map<_i210.TestEnumStringified, String>?>()] =
+        (data, protocol) => (data != null
+        ? Map.fromEntries(
+            (data as List).map(
+              (e) => MapEntry(
+                protocol.deserialize<_i210.TestEnumStringified>(e['k']),
+                protocol.deserialize<String>(e['v']),
+              ),
+            ),
+          )
+        : null);
+    map[Map<_i211.Types, String>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<_i211.Types>(e['k']),
+          protocol.deserialize<String>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<Map<_i211.Types, String>?>()] = (data, protocol) =>
+        (data != null
+        ? Map.fromEntries(
+            (data as List).map(
+              (e) => MapEntry(
+                protocol.deserialize<_i211.Types>(e['k']),
+                protocol.deserialize<String>(e['v']),
+              ),
+            ),
+          )
+        : null);
+    map[Map<Map<_i211.Types, String>, String>] = (data, protocol) =>
+        Map.fromEntries(
+          (data as List).map(
+            (e) => MapEntry(
+              protocol.deserialize<Map<_i211.Types, String>>(e['k']),
+              protocol.deserialize<String>(e['v']),
+            ),
+          ),
+        );
+    map[Map<_i211.Types, String>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<_i211.Types>(e['k']),
+          protocol.deserialize<String>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<Map<Map<_i211.Types, String>, String>?>()] =
+        (data, protocol) => (data != null
+        ? Map.fromEntries(
+            (data as List).map(
+              (e) => MapEntry(
+                protocol.deserialize<Map<_i211.Types, String>>(e['k']),
+                protocol.deserialize<String>(e['v']),
+              ),
+            ),
+          )
+        : null);
+    map[Map<_i211.Types, String>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<_i211.Types>(e['k']),
+          protocol.deserialize<String>(e['v']),
+        ),
+      ),
+    );
+    map[Map<List<_i211.Types>, String>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<List<_i211.Types>>(e['k']),
+          protocol.deserialize<String>(e['v']),
+        ),
+      ),
+    );
+    map[List<_i211.Types>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i211.Types>(e))
+        .toList();
+    map[_i1.getType<Map<List<_i211.Types>, String>?>()] = (data, protocol) =>
+        (data != null
+        ? Map.fromEntries(
+            (data as List).map(
+              (e) => MapEntry(
+                protocol.deserialize<List<_i211.Types>>(e['k']),
+                protocol.deserialize<String>(e['v']),
+              ),
+            ),
+          )
+        : null);
+    map[List<_i211.Types>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i211.Types>(e))
+        .toList();
+    map[Map<(String,), String>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<(String,)>(e['k']),
+          protocol.deserialize<String>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<(String,)>()] = (data, protocol) =>
+        (protocol.deserialize<String>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<Map<(String,), String>?>()] = (data, protocol) =>
+        (data != null
+        ? Map.fromEntries(
+            (data as List).map(
+              (e) => MapEntry(
+                protocol.deserialize<(String,)>(e['k']),
+                protocol.deserialize<String>(e['v']),
+              ),
+            ),
+          )
+        : null);
+    map[_i1.getType<(String,)>()] = (data, protocol) =>
+        (protocol.deserialize<String>(((data as Map)['p'] as List)[0]),);
+    map[Map<String, bool>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<bool>(v),
+      ),
+    );
+    map[_i1.getType<Map<String, bool>?>()] = (data, protocol) => (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<bool>(v),
+            ),
+          )
+        : null);
+    map[Map<String, double>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<double>(v),
+      ),
+    );
+    map[_i1.getType<Map<String, double>?>()] = (data, protocol) => (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<double>(v),
+            ),
+          )
+        : null);
+    map[Map<String, DateTime>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<DateTime>(v),
+      ),
+    );
+    map[_i1.getType<Map<String, DateTime>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<DateTime>(v),
+            ),
+          )
+        : null);
+    map[Map<String, _i220.ByteData>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i220.ByteData>(v),
+      ),
+    );
+    map[_i1.getType<Map<String, _i220.ByteData>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<_i220.ByteData>(v),
+            ),
+          )
+        : null);
+    map[Map<String, Duration>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<Duration>(v),
+      ),
+    );
+    map[_i1.getType<Map<String, Duration>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<Duration>(v),
+            ),
+          )
+        : null);
+    map[Map<String, _i1.UuidValue>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i1.UuidValue>(v),
+      ),
+    );
+    map[_i1.getType<Map<String, _i1.UuidValue>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<_i1.UuidValue>(v),
+            ),
+          )
+        : null);
+    map[Map<String, Uri>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<Uri>(v),
+      ),
+    );
+    map[_i1.getType<Map<String, Uri>?>()] = (data, protocol) => (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<Uri>(v),
+            ),
+          )
+        : null);
+    map[Map<String, BigInt>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<BigInt>(v),
+      ),
+    );
+    map[_i1.getType<Map<String, BigInt>?>()] = (data, protocol) => (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<BigInt>(v),
+            ),
+          )
+        : null);
+    map[Map<String, _i206.TestEnum>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i206.TestEnum>(v),
+      ),
+    );
+    map[_i1.getType<Map<String, _i206.TestEnum>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<_i206.TestEnum>(v),
+            ),
+          )
+        : null);
+    map[Map<String, _i210.TestEnumStringified>] = (data, protocol) =>
+        (data as Map).map(
+          (k, v) => MapEntry(
+            protocol.deserialize<String>(k),
+            protocol.deserialize<_i210.TestEnumStringified>(v),
+          ),
+        );
+    map[_i1.getType<Map<String, _i210.TestEnumStringified>?>()] =
+        (data, protocol) => (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<_i210.TestEnumStringified>(v),
+            ),
+          )
+        : null);
+    map[Map<String, _i211.Types>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i211.Types>(v),
+      ),
+    );
+    map[_i1.getType<Map<String, _i211.Types>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<_i211.Types>(v),
+            ),
+          )
+        : null);
+    map[Map<String, Map<String, _i211.Types>>] = (data, protocol) =>
+        (data as Map).map(
+          (k, v) => MapEntry(
+            protocol.deserialize<String>(k),
+            protocol.deserialize<Map<String, _i211.Types>>(v),
+          ),
+        );
+    map[Map<String, _i211.Types>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i211.Types>(v),
+      ),
+    );
+    map[_i1.getType<Map<String, Map<String, _i211.Types>>?>()] =
+        (data, protocol) => (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<Map<String, _i211.Types>>(v),
+            ),
+          )
+        : null);
+    map[Map<String, _i211.Types>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i211.Types>(v),
+      ),
+    );
+    map[Map<String, List<_i211.Types>>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<List<_i211.Types>>(v),
+      ),
+    );
+    map[List<_i211.Types>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i211.Types>(e))
+        .toList();
+    map[_i1.getType<Map<String, List<_i211.Types>>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<List<_i211.Types>>(v),
+            ),
+          )
+        : null);
+    map[List<_i211.Types>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i211.Types>(e))
+        .toList();
+    map[Map<String, (String,)>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<(String,)>(v),
+      ),
+    );
+    map[_i1.getType<(String,)>()] = (data, protocol) =>
+        (protocol.deserialize<String>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<Map<String, (String,)>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<(String,)>(v),
+            ),
+          )
+        : null);
+    map[_i1.getType<(String,)>()] = (data, protocol) =>
+        (protocol.deserialize<String>(((data as Map)['p'] as List)[0]),);
+    map[Map<String, (String,)?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<(String,)?>(v),
+      ),
+    );
+    map[_i1.getType<(String,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<String>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<Map<String, (String,)?>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<(String,)?>(v),
+            ),
+          )
+        : null);
+    map[_i1.getType<(String,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<String>(((data as Map)['p'] as List)[0]),);
+    map[Map<(String,)?, String>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<(String,)?>(e['k']),
+          protocol.deserialize<String>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<(String,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<String>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<Map<(String,)?, String>?>()] = (data, protocol) =>
+        (data != null
+        ? Map.fromEntries(
+            (data as List).map(
+              (e) => MapEntry(
+                protocol.deserialize<(String,)?>(e['k']),
+                protocol.deserialize<String>(e['v']),
+              ),
+            ),
+          )
+        : null);
+    map[_i1.getType<(String,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<String>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(int,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<int>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(double,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<double>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(DateTime,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<DateTime>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(String,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<String>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(_i220.ByteData,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (
+            protocol.deserialize<_i220.ByteData>(
+              ((data as Map)['p'] as List)[0],
+            ),
+          );
+    map[_i1.getType<(Duration,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<Duration>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(_i1.UuidValue,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (
+            protocol.deserialize<_i1.UuidValue>(
+              ((data as Map)['p'] as List)[0],
+            ),
+          );
+    map[_i1.getType<(Uri,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<Uri>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(BigInt,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<BigInt>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(_i206.TestEnum,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (
+            protocol.deserialize<_i206.TestEnum>(
+              ((data as Map)['p'] as List)[0],
+            ),
+          );
+    map[_i1.getType<(List<int>,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<List<int>>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(Map<int, int>,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (
+            protocol.deserialize<Map<int, int>>(
+              ((data as Map)['p'] as List)[0],
+            ),
+          );
+    map[_i1.getType<(Set<int>,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<Set<int>>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(_i200.SimpleData,)?>()] = (data, protocol) =>
+        (data == null)
+        ? null
+        : (
+            protocol.deserialize<_i200.SimpleData>(
+              ((data as Map)['p'] as List)[0],
+            ),
+          );
+    map[_i1.getType<({_i200.SimpleData namedModel})?>()] = (data, protocol) =>
+        (data == null)
+        ? null
+        : (
+            namedModel: protocol.deserialize<_i200.SimpleData>(
+              ((data as Map)['n'] as Map)['namedModel'],
+            ),
+          );
+    map[_i1.getType<(_i200.SimpleData, {_i200.SimpleData namedModel})?>()] =
+        (data, protocol) => (data == null)
+        ? null
+        : (
+            protocol.deserialize<_i200.SimpleData>(
+              ((data as Map)['p'] as List)[0],
+            ),
+            namedModel: protocol.deserialize<_i200.SimpleData>(
+              data['n']['namedModel'],
+            ),
+          );
+    map[_i1.getType<((int, String), {(int, String) namedNestedRecord})?>()] =
+        (data, protocol) => (data == null)
+        ? null
+        : (
+            protocol.deserialize<(int, String)>(
+              ((data as Map)['p'] as List)[0],
+            ),
+            namedNestedRecord: protocol.deserialize<(int, String)>(
+              data['n']['namedNestedRecord'],
+            ),
+          );
+    map[_i1
+        .getType<
+          (
+            (List<(_i200.SimpleData,)>,), {
+            (_i200.SimpleData, Map<String, _i200.SimpleData>) namedNestedRecord,
+          })?
+        >()] = (data, protocol) => (data == null)
+        ? null
+        : (
+            protocol.deserialize<(List<(_i200.SimpleData,)>,)>(
+              ((data as Map)['p'] as List)[0],
+            ),
+            namedNestedRecord: protocol
+                .deserialize<(_i200.SimpleData, Map<String, _i200.SimpleData>)>(
+                  data['n']['namedNestedRecord'],
+                ),
+          );
+    map[Set<bool>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<bool>(e)).toSet();
+    map[_i1.getType<Set<bool>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<bool>(e)).toSet()
+        : null);
+    map[Set<double>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<double>(e)).toSet();
+    map[_i1.getType<Set<double>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<double>(e)).toSet()
+        : null);
+    map[Set<DateTime>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<DateTime>(e)).toSet();
+    map[_i1.getType<Set<DateTime>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<DateTime>(e)).toSet()
+        : null);
+    map[Set<String>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<String>(e)).toSet();
+    map[_i1.getType<Set<String>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<String>(e)).toSet()
+        : null);
+    map[Set<_i220.ByteData>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i220.ByteData>(e))
+        .toSet();
+    map[_i1.getType<Set<_i220.ByteData>?>()] = (data, protocol) => (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i220.ByteData>(e))
+              .toSet()
+        : null);
+    map[Set<Duration>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<Duration>(e)).toSet();
+    map[_i1.getType<Set<Duration>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<Duration>(e)).toSet()
+        : null);
+    map[Set<_i1.UuidValue>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i1.UuidValue>(e))
+        .toSet();
+    map[_i1.getType<Set<_i1.UuidValue>?>()] = (data, protocol) => (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i1.UuidValue>(e))
+              .toSet()
+        : null);
+    map[Set<BigInt>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<BigInt>(e)).toSet();
+    map[_i1.getType<Set<BigInt>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<BigInt>(e)).toSet()
+        : null);
+    map[Set<_i206.TestEnum>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i206.TestEnum>(e))
+        .toSet();
+    map[_i1.getType<Set<_i206.TestEnum>?>()] = (data, protocol) => (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i206.TestEnum>(e))
+              .toSet()
+        : null);
+    map[Set<_i210.TestEnumStringified>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i210.TestEnumStringified>(e))
+        .toSet();
+    map[_i1.getType<Set<_i210.TestEnumStringified>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i210.TestEnumStringified>(e))
+              .toSet()
+        : null);
+    map[Set<_i211.Types>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<_i211.Types>(e)).toSet();
+    map[_i1.getType<Set<_i211.Types>?>()] = (data, protocol) => (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i211.Types>(e))
+              .toSet()
+        : null);
+    map[Set<Map<String, _i211.Types>>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<Map<String, _i211.Types>>(e))
+        .toSet();
+    map[Map<String, _i211.Types>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i211.Types>(v),
+      ),
+    );
+    map[_i1.getType<Set<Map<String, _i211.Types>>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<Map<String, _i211.Types>>(e))
+              .toSet()
+        : null);
+    map[Map<String, _i211.Types>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i211.Types>(v),
+      ),
+    );
+    map[Set<List<_i211.Types>>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<List<_i211.Types>>(e))
+        .toSet();
+    map[List<_i211.Types>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i211.Types>(e))
+        .toList();
+    map[_i1.getType<Set<List<_i211.Types>>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<List<_i211.Types>>(e))
+              .toSet()
+        : null);
+    map[List<_i211.Types>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i211.Types>(e))
+        .toList();
+    map[Set<(int,)>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<(int,)>(e)).toSet();
+    map[_i1.getType<(int,)>()] = (data, protocol) =>
+        (protocol.deserialize<int>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<Set<(int,)>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<(int,)>(e)).toSet()
+        : null);
+    map[_i1.getType<(int,)>()] = (data, protocol) =>
+        (protocol.deserialize<int>(((data as Map)['p'] as List)[0]),);
+    map[Set<(int,)?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<(int,)?>(e)).toSet();
+    map[_i1.getType<(int,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<int>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<Set<(int,)?>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<(int,)?>(e)).toSet()
+        : null);
+    map[_i1.getType<(int,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<int>(((data as Map)['p'] as List)[0]),);
+    map[Set<int>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int>(e)).toSet();
+    map[List<String>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<String>(e)).toList();
+    map[_i1.getType<List<String>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<String>(e)).toList()
+        : null);
+    map[List<String>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<String>(e)).toList();
+    map[List<_i222.SimpleData>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i222.SimpleData>(e))
+        .toList();
+    map[List<int>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int>(e)).toList();
+    map[List<List<int>>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<List<int>>(e)).toList();
+    map[List<int>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int>(e)).toList();
+    map[List<int>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int>(e)).toList();
+    map[_i1.getType<List<int>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<int>(e)).toList()
+        : null);
+    map[List<List<int>?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<List<int>?>(e)).toList();
+    map[List<int>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int>(e)).toList();
+    map[_i1.getType<List<int>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<int>(e)).toList()
+        : null);
+    map[List<List<int>>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<List<int>>(e)).toList();
+    map[List<int>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int>(e)).toList();
+    map[_i1.getType<List<List<int>>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<List<int>>(e)).toList()
+        : null);
+    map[List<int>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int>(e)).toList();
+    map[List<int?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int?>(e)).toList();
+    map[List<int?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int?>(e)).toList();
+    map[_i1.getType<List<int?>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<int?>(e)).toList()
+        : null);
+    map[List<double>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<double>(e)).toList();
+    map[List<double?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<double?>(e)).toList();
+    map[List<bool>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<bool>(e)).toList();
+    map[List<bool?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<bool?>(e)).toList();
+    map[List<String?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<String?>(e)).toList();
+    map[List<DateTime>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<DateTime>(e)).toList();
+    map[List<DateTime?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<DateTime?>(e)).toList();
+    map[List<_i220.ByteData>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i220.ByteData>(e))
+        .toList();
+    map[List<_i220.ByteData?>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i220.ByteData?>(e))
+        .toList();
+    map[List<_i222.SimpleData?>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i222.SimpleData?>(e))
+        .toList();
+    map[List<_i222.SimpleData>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i222.SimpleData>(e))
+        .toList();
+    map[_i1.getType<List<_i222.SimpleData>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i222.SimpleData>(e))
+              .toList()
+        : null);
+    map[List<_i222.SimpleData?>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i222.SimpleData?>(e))
+        .toList();
+    map[_i1.getType<List<_i222.SimpleData?>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i222.SimpleData?>(e))
+              .toList()
+        : null);
+    map[List<Duration>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<Duration>(e)).toList();
+    map[List<Duration?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<Duration?>(e)).toList();
+    map[Map<String, int>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<int>(v),
+      ),
+    );
+    map[Map<String, int>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<int>(v),
+      ),
+    );
+    map[_i1.getType<Map<String, int>?>()] = (data, protocol) => (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<int>(v),
+            ),
+          )
+        : null);
+    map[Map<String, Map<String, int>>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<Map<String, int>>(v),
+      ),
+    );
+    map[Map<String, int>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<int>(v),
+      ),
+    );
+    map[Map<String, int?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<int?>(v),
+      ),
+    );
+    map[Map<String, int?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<int?>(v),
+      ),
+    );
+    map[_i1.getType<Map<String, int?>?>()] = (data, protocol) => (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<int?>(v),
+            ),
+          )
+        : null);
+    map[Map<int, int>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<int>(e['k']),
+          protocol.deserialize<int>(e['v']),
+        ),
+      ),
+    );
+    map[Map<String, Map<int, int>>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<Map<int, int>>(v),
+      ),
+    );
+    map[Map<int, int>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<int>(e['k']),
+          protocol.deserialize<int>(e['v']),
+        ),
+      ),
+    );
+    map[Map<_i223.TestEnum, int>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<_i223.TestEnum>(e['k']),
+          protocol.deserialize<int>(e['v']),
+        ),
+      ),
+    );
+    map[Map<String, _i223.TestEnum>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i223.TestEnum>(v),
+      ),
+    );
+    map[Map<String, double>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<double>(v),
+      ),
+    );
+    map[Map<String, double?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<double?>(v),
+      ),
+    );
+    map[Map<String, bool>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<bool>(v),
+      ),
+    );
+    map[Map<String, bool?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<bool?>(v),
+      ),
+    );
+    map[Map<String, String>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<String>(v),
+      ),
+    );
+    map[Map<String, String?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<String?>(v),
+      ),
+    );
+    map[Map<String, DateTime>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<DateTime>(v),
+      ),
+    );
+    map[Map<String, DateTime?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<DateTime?>(v),
+      ),
+    );
+    map[Map<String, _i220.ByteData>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i220.ByteData>(v),
+      ),
+    );
+    map[Map<String, _i220.ByteData?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i220.ByteData?>(v),
+      ),
+    );
+    map[Map<String, _i222.SimpleData>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i222.SimpleData>(v),
+      ),
+    );
+    map[Map<String, _i222.SimpleData?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i222.SimpleData?>(v),
+      ),
+    );
+    map[Map<String, _i222.SimpleData>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i222.SimpleData>(v),
+      ),
+    );
+    map[_i1.getType<Map<String, _i222.SimpleData>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<_i222.SimpleData>(v),
+            ),
+          )
+        : null);
+    map[Map<String, _i222.SimpleData?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i222.SimpleData?>(v),
+      ),
+    );
+    map[_i1.getType<Map<String, _i222.SimpleData?>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<_i222.SimpleData?>(v),
+            ),
+          )
+        : null);
+    map[Map<String, Duration>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<Duration>(v),
+      ),
+    );
+    map[Map<String, Duration?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<Duration?>(v),
+      ),
+    );
+    map[Map<(Map<int, String>, String), String>] = (data, protocol) =>
+        Map.fromEntries(
+          (data as List).map(
+            (e) => MapEntry(
+              protocol.deserialize<(Map<int, String>, String)>(e['k']),
+              protocol.deserialize<String>(e['v']),
+            ),
+          ),
+        );
+    map[_i1.getType<(Map<int, String>, String)>()] = (data, protocol) => (
+      protocol.deserialize<Map<int, String>>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<String>(data['p'][1]),
+    );
+    map[_i1.getType<(Map<int, String>, String)>()] = (data, protocol) => (
+      protocol.deserialize<Map<int, String>>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<String>(data['p'][1]),
+    );
+    map[Map<int, String>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<int>(e['k']),
+          protocol.deserialize<String>(e['v']),
+        ),
+      ),
+    );
+    map[Map<String, (Map<int, int>,)>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<(Map<int, int>,)>(v),
+      ),
+    );
+    map[_i1.getType<(Map<int, int>,)>()] = (data, protocol) =>
+        (protocol.deserialize<Map<int, int>>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(Map<int, int>,)>()] = (data, protocol) =>
+        (protocol.deserialize<Map<int, int>>(((data as Map)['p'] as List)[0]),);
+    map[Map<DateTime, bool>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<DateTime>(e['k']),
+          protocol.deserialize<bool>(e['v']),
+        ),
+      ),
+    );
+    map[Map<DateTime, bool>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<DateTime>(e['k']),
+          protocol.deserialize<bool>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<Map<DateTime, bool>?>()] = (data, protocol) => (data != null
+        ? Map.fromEntries(
+            (data as List).map(
+              (e) => MapEntry(
+                protocol.deserialize<DateTime>(e['k']),
+                protocol.deserialize<bool>(e['v']),
+              ),
+            ),
+          )
+        : null);
+    map[Map<int, String>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<int>(e['k']),
+          protocol.deserialize<String>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<Map<int, String>?>()] = (data, protocol) => (data != null
+        ? Map.fromEntries(
+            (data as List).map(
+              (e) => MapEntry(
+                protocol.deserialize<int>(e['k']),
+                protocol.deserialize<String>(e['v']),
+              ),
+            ),
+          )
+        : null);
+    map[dynamic] = (data, protocol) => deserializeDynamicFieldValue(data) as T;
+    map[List<_i3.UserInfo>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i3.UserInfo>(e))
+        .toList();
+    map[Set<int>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int>(e)).toSet();
+    map[Set<_i222.SimpleData>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i222.SimpleData>(e))
+        .toSet();
+    map[List<Set<_i222.SimpleData>>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<Set<_i222.SimpleData>>(e))
+        .toList();
+    map[Set<_i222.SimpleData>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i222.SimpleData>(e))
+        .toSet();
+    map[_i1.getType<(int, BigInt)>()] = (data, protocol) => (
+      protocol.deserialize<int>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<BigInt>(data['p'][1]),
+    );
+    map[_i1.getType<(String, _i224.PolymorphicParent)>()] = (data, protocol) =>
+        (
+          protocol.deserialize<String>(((data as Map)['p'] as List)[0]),
+          protocol.deserialize<_i224.PolymorphicParent>(data['p'][1]),
+        );
+    map[_i1.getType<(int,)>()] = (data, protocol) =>
+        (protocol.deserialize<int>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(int,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<int>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(int?,)>()] = (data, protocol) => (
+      ((data as Map)['p'] as List)[0] == null
+          ? null
+          : protocol.deserialize<int>(data['p'][0]),
+    );
+    map[_i1.getType<(int?,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (
+            ((data as Map)['p'] as List)[0] == null
+                ? null
+                : protocol.deserialize<int>(data['p'][0]),
+          );
+    map[_i1.getType<(int, String)>()] = (data, protocol) => (
+      protocol.deserialize<int>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<String>(data['p'][1]),
+    );
+    map[_i1.getType<(int, String)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (
+            protocol.deserialize<int>(((data as Map)['p'] as List)[0]),
+            protocol.deserialize<String>(data['p'][1]),
+          );
+    map[_i1.getType<(int, _i222.SimpleData)>()] = (data, protocol) => (
+      protocol.deserialize<int>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<_i222.SimpleData>(data['p'][1]),
+    );
+    map[_i1.getType<(int, _i222.SimpleData)?>()] = (data, protocol) =>
+        (data == null)
+        ? null
+        : (
+            protocol.deserialize<int>(((data as Map)['p'] as List)[0]),
+            protocol.deserialize<_i222.SimpleData>(data['p'][1]),
+          );
+    map[_i1.getType<(Map<String, int>,)>()] = (data, protocol) => (
+      protocol.deserialize<Map<String, int>>(((data as Map)['p'] as List)[0]),
+    );
+    map[_i1.getType<(Set<(int,)>,)>()] = (data, protocol) =>
+        (protocol.deserialize<Set<(int,)>>(((data as Map)['p'] as List)[0]),);
+    map[Set<(int,)>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<(int,)>(e)).toSet();
+    map[_i1.getType<(int,)>()] = (data, protocol) =>
+        (protocol.deserialize<int>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<({int number, String text})>()] = (data, protocol) => (
+      number: protocol.deserialize<int>(((data as Map)['n'] as Map)['number']),
+      text: protocol.deserialize<String>(data['n']['text']),
+    );
+    map[_i1.getType<({int number, String text})?>()] = (data, protocol) =>
+        (data == null)
+        ? null
+        : (
+            number: protocol.deserialize<int>(
+              ((data as Map)['n'] as Map)['number'],
+            ),
+            text: protocol.deserialize<String>(data['n']['text']),
+          );
+    map[_i1.getType<({_i222.SimpleData data, int number})>()] =
+        (data, protocol) => (
+          data: protocol.deserialize<_i222.SimpleData>(
+            ((data as Map)['n'] as Map)['data'],
+          ),
+          number: protocol.deserialize<int>(data['n']['number']),
+        );
+    map[_i1.getType<({_i222.SimpleData data, int number})?>()] =
+        (data, protocol) => (data == null)
+        ? null
+        : (
+            data: protocol.deserialize<_i222.SimpleData>(
+              ((data as Map)['n'] as Map)['data'],
+            ),
+            number: protocol.deserialize<int>(data['n']['number']),
+          );
+    map[_i1.getType<({_i222.SimpleData? data, int? number})>()] =
+        (data, protocol) => (
+          data: ((data as Map)['n'] as Map)['data'] == null
+              ? null
+              : protocol.deserialize<_i222.SimpleData>(data['n']['data']),
+          number: ((data)['n'] as Map)['number'] == null
+              ? null
+              : protocol.deserialize<int>(data['n']['number']),
+        );
+    map[_i1.getType<({Map<int, int> intIntMap})>()] = (data, protocol) => (
+      intIntMap: protocol.deserialize<Map<int, int>>(
+        ((data as Map)['n'] as Map)['intIntMap'],
+      ),
+    );
+    map[_i1.getType<({Set<(bool,)> boolSet})>()] = (data, protocol) => (
+      boolSet: protocol.deserialize<Set<(bool,)>>(
+        ((data as Map)['n'] as Map)['boolSet'],
+      ),
+    );
+    map[Set<(bool,)>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<(bool,)>(e)).toSet();
+    map[_i1.getType<(bool,)>()] = (data, protocol) =>
+        (protocol.deserialize<bool>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(bool,)>()] = (data, protocol) =>
+        (protocol.deserialize<bool>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(Map<(Map<int, String>, String), String>,)>()] =
+        (data, protocol) => (
+          protocol.deserialize<Map<(Map<int, String>, String), String>>(
+            ((data as Map)['p'] as List)[0],
+          ),
+        );
+    map[_i1.getType<(int, {_i222.SimpleData data})>()] = (data, protocol) => (
+      protocol.deserialize<int>(((data as Map)['p'] as List)[0]),
+      data: protocol.deserialize<_i222.SimpleData>(data['n']['data']),
+    );
+    map[_i1.getType<(int, {_i222.SimpleData data})?>()] = (data, protocol) =>
+        (data == null)
+        ? null
+        : (
+            protocol.deserialize<int>(((data as Map)['p'] as List)[0]),
+            data: protocol.deserialize<_i222.SimpleData>(data['n']['data']),
+          );
+    map[List<(int, _i222.SimpleData)>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<(int, _i222.SimpleData)>(e))
+        .toList();
+    map[_i1.getType<(int, _i222.SimpleData)>()] = (data, protocol) => (
+      protocol.deserialize<int>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<_i222.SimpleData>(data['p'][1]),
+    );
+    map[List<(int, _i222.SimpleData)?>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<(int, _i222.SimpleData)?>(e))
+        .toList();
+    map[_i1.getType<(int, _i222.SimpleData)?>()] = (data, protocol) =>
+        (data == null)
+        ? null
+        : (
+            protocol.deserialize<int>(((data as Map)['p'] as List)[0]),
+            protocol.deserialize<_i222.SimpleData>(data['p'][1]),
+          );
+    map[Set<(int, _i222.SimpleData)>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<(int, _i222.SimpleData)>(e))
+        .toSet();
+    map[_i1.getType<(int, _i222.SimpleData)>()] = (data, protocol) => (
+      protocol.deserialize<int>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<_i222.SimpleData>(data['p'][1]),
+    );
+    map[Set<(int, _i222.SimpleData)?>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<(int, _i222.SimpleData)?>(e))
+        .toSet();
+    map[_i1.getType<(int, _i222.SimpleData)?>()] = (data, protocol) =>
+        (data == null)
+        ? null
+        : (
+            protocol.deserialize<int>(((data as Map)['p'] as List)[0]),
+            protocol.deserialize<_i222.SimpleData>(data['p'][1]),
+          );
+    map[Set<(int, _i222.SimpleData)>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<(int, _i222.SimpleData)>(e))
+        .toSet();
+    map[_i1.getType<(int, _i222.SimpleData)>()] = (data, protocol) => (
+      protocol.deserialize<int>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<_i222.SimpleData>(data['p'][1]),
+    );
+    map[_i1.getType<Set<(int, _i222.SimpleData)>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<(int, _i222.SimpleData)>(e))
+              .toSet()
+        : null);
+    map[_i1.getType<(int, _i222.SimpleData)>()] = (data, protocol) => (
+      protocol.deserialize<int>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<_i222.SimpleData>(data['p'][1]),
+    );
+    map[Map<String, (int, _i222.SimpleData)>] = (data, protocol) =>
+        (data as Map).map(
+          (k, v) => MapEntry(
+            protocol.deserialize<String>(k),
+            protocol.deserialize<(int, _i222.SimpleData)>(v),
+          ),
+        );
+    map[_i1.getType<(int, _i222.SimpleData)>()] = (data, protocol) => (
+      protocol.deserialize<int>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<_i222.SimpleData>(data['p'][1]),
+    );
+    map[Map<String, (int, _i222.SimpleData)?>] = (data, protocol) =>
+        (data as Map).map(
+          (k, v) => MapEntry(
+            protocol.deserialize<String>(k),
+            protocol.deserialize<(int, _i222.SimpleData)?>(v),
+          ),
+        );
+    map[_i1.getType<(int, _i222.SimpleData)?>()] = (data, protocol) =>
+        (data == null)
+        ? null
+        : (
+            protocol.deserialize<int>(((data as Map)['p'] as List)[0]),
+            protocol.deserialize<_i222.SimpleData>(data['p'][1]),
+          );
+    map[Map<(String, int), (int, _i222.SimpleData)>] = (data, protocol) =>
+        Map.fromEntries(
+          (data as List).map(
+            (e) => MapEntry(
+              protocol.deserialize<(String, int)>(e['k']),
+              protocol.deserialize<(int, _i222.SimpleData)>(e['v']),
+            ),
+          ),
+        );
+    map[_i1.getType<(String, int)>()] = (data, protocol) => (
+      protocol.deserialize<String>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<int>(data['p'][1]),
+    );
+    map[_i1.getType<(int, _i222.SimpleData)>()] = (data, protocol) => (
+      protocol.deserialize<int>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<_i222.SimpleData>(data['p'][1]),
+    );
+    map[_i1.getType<(String, int)>()] = (data, protocol) => (
+      protocol.deserialize<String>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<int>(data['p'][1]),
+    );
+    map[Map<String, List<Set<(int,)>>>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<List<Set<(int,)>>>(v),
+      ),
+    );
+    map[List<Set<(int,)>>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<Set<(int,)>>(e))
+        .toList();
+    map[Set<(int,)>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<(int,)>(e)).toSet();
+    map[_i1.getType<(int,)>()] = (data, protocol) =>
+        (protocol.deserialize<int>(((data as Map)['p'] as List)[0]),);
+    map[List<Set<(int,)>>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<Set<(int,)>>(e))
+        .toList();
+    map[Set<(int,)>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<(int,)>(e)).toSet();
+    map[_i1.getType<(int,)>()] = (data, protocol) =>
+        (protocol.deserialize<int>(((data as Map)['p'] as List)[0]),);
+    map[Set<List<Map<String, (int,)>>>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<List<Map<String, (int,)>>>(e))
+        .toSet();
+    map[List<Map<String, (int,)>>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<Map<String, (int,)>>(e))
+        .toList();
+    map[Map<String, (int,)>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<(int,)>(v),
+      ),
+    );
+    map[_i1.getType<(int,)>()] = (data, protocol) =>
+        (protocol.deserialize<int>(((data as Map)['p'] as List)[0]),);
+    map[List<Map<String, (int,)>>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<Map<String, (int,)>>(e))
+        .toList();
+    map[Map<String, (int,)>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<(int,)>(v),
+      ),
+    );
+    map[_i1.getType<(int,)>()] = (data, protocol) =>
+        (protocol.deserialize<int>(((data as Map)['p'] as List)[0]),);
+    map[Map<String, (int,)>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<(int,)>(v),
+      ),
+    );
+    map[_i1.getType<(int,)>()] = (data, protocol) =>
+        (protocol.deserialize<int>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<({(_i222.SimpleData, double) namedSubRecord})>()] =
+        (data, protocol) => (
+          namedSubRecord: protocol.deserialize<(_i222.SimpleData, double)>(
+            ((data as Map)['n'] as Map)['namedSubRecord'],
+          ),
+        );
+    map[_i1.getType<(_i222.SimpleData, double)>()] = (data, protocol) => (
+      protocol.deserialize<_i222.SimpleData>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<double>(data['p'][1]),
+    );
+    map[_i1.getType<({(_i222.SimpleData, double)? namedSubRecord})>()] =
+        (data, protocol) => (
+          namedSubRecord: ((data as Map)['n'] as Map)['namedSubRecord'] == null
+              ? null
+              : protocol.deserialize<(_i222.SimpleData, double)>(
+                  data['n']['namedSubRecord'],
+                ),
+        );
+    map[_i1.getType<(_i222.SimpleData, double)?>()] = (data, protocol) =>
+        (data == null)
+        ? null
+        : (
+            protocol.deserialize<_i222.SimpleData>(
+              ((data as Map)['p'] as List)[0],
+            ),
+            protocol.deserialize<double>(data['p'][1]),
+          );
+    map[_i1
+        .getType<
+          ((int, String), {(_i222.SimpleData, double) namedSubRecord})
+        >()] = (data, protocol) => (
+      protocol.deserialize<(int, String)>(((data as Map)['p'] as List)[0]),
+      namedSubRecord: protocol.deserialize<(_i222.SimpleData, double)>(
+        data['n']['namedSubRecord'],
+      ),
+    );
+    map[List<((int, String), {(_i222.SimpleData, double) namedSubRecord})>] =
+        (data, protocol) => (data as List)
+            .map(
+              (e) =>
+                  protocol.deserialize<
+                    ((int, String), {(_i222.SimpleData, double) namedSubRecord})
+                  >(e),
+            )
+            .toList();
+    map[_i1
+        .getType<
+          ((int, String), {(_i222.SimpleData, double) namedSubRecord})
+        >()] = (data, protocol) => (
+      protocol.deserialize<(int, String)>(((data as Map)['p'] as List)[0]),
+      namedSubRecord: protocol.deserialize<(_i222.SimpleData, double)>(
+        data['n']['namedSubRecord'],
+      ),
+    );
+    map[List<((int, String), {(_i222.SimpleData, double) namedSubRecord})?>] =
+        (data, protocol) => (data as List)
+            .map(
+              (e) =>
+                  protocol.deserialize<
+                    (
+                      (int, String), {
+                      (_i222.SimpleData, double) namedSubRecord,
+                    })?
+                  >(e),
+            )
+            .toList();
+    map[_i1
+        .getType<
+          ((int, String), {(_i222.SimpleData, double) namedSubRecord})?
+        >()] = (data, protocol) => (data == null)
+        ? null
+        : (
+            protocol.deserialize<(int, String)>(
+              ((data as Map)['p'] as List)[0],
+            ),
+            namedSubRecord: protocol.deserialize<(_i222.SimpleData, double)>(
+              data['n']['namedSubRecord'],
+            ),
+          );
+    map[_i1
+        .getType<
+          List<((int, String), {(_i222.SimpleData, double) namedSubRecord})?>?
+        >()] = (data, protocol) => (data != null
+        ? (data as List)
+              .map(
+                (e) =>
+                    protocol.deserialize<
+                      (
+                        (int, String), {
+                        (_i222.SimpleData, double) namedSubRecord,
+                      })?
+                    >(e),
+              )
+              .toList()
+        : null);
+    map[_i1
+        .getType<
+          ((int, String), {(_i222.SimpleData, double) namedSubRecord})?
+        >()] = (data, protocol) => (data == null)
+        ? null
+        : (
+            protocol.deserialize<(int, String)>(
+              ((data as Map)['p'] as List)[0],
+            ),
+            namedSubRecord: protocol.deserialize<(_i222.SimpleData, double)>(
+              data['n']['namedSubRecord'],
+            ),
+          );
+    map[_i1
+        .getType<
+          ((int, String), {(_i222.SimpleData, double) namedSubRecord})?
+        >()] = (data, protocol) => (data == null)
+        ? null
+        : (
+            protocol.deserialize<(int, String)>(
+              ((data as Map)['p'] as List)[0],
+            ),
+            namedSubRecord: protocol.deserialize<(_i222.SimpleData, double)>(
+              data['n']['namedSubRecord'],
+            ),
+          );
+    map[_i1.getType<(int?, _i4.ProjectStreamingClass?)>()] = (data, protocol) =>
+        (
+          ((data as Map)['p'] as List)[0] == null
+              ? null
+              : protocol.deserialize<int>(data['p'][0]),
+          ((data)['p'] as List)[1] == null
+              ? null
+              : protocol.deserialize<_i4.ProjectStreamingClass>(data['p'][1]),
+        );
+    map[Set<Set<int>>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<Set<int>>(e)).toSet();
+    map[Set<int>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int>(e)).toSet();
+    map[Set<List<int>>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<List<int>>(e)).toSet();
+    map[List<int>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int>(e)).toList();
+    map[Set<int>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int>(e)).toSet();
+    map[_i1.getType<Set<int>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<int>(e)).toSet()
+        : null);
+    map[Set<Set<int>?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<Set<int>?>(e)).toSet();
+    map[Set<int>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int>(e)).toSet();
+    map[_i1.getType<Set<int>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<int>(e)).toSet()
+        : null);
+    map[Set<Set<int>>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<Set<int>>(e)).toSet();
+    map[Set<int>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int>(e)).toSet();
+    map[_i1.getType<Set<Set<int>>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<Set<int>>(e)).toSet()
+        : null);
+    map[Set<int>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int>(e)).toSet();
+    map[Set<int?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int?>(e)).toSet();
+    map[Set<int?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int?>(e)).toSet();
+    map[_i1.getType<Set<int?>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<int?>(e)).toSet()
+        : null);
+    map[Set<double>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<double>(e)).toSet();
+    map[Set<double?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<double?>(e)).toSet();
+    map[Set<bool>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<bool>(e)).toSet();
+    map[Set<bool?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<bool?>(e)).toSet();
+    map[Set<String>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<String>(e)).toSet();
+    map[Set<String?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<String?>(e)).toSet();
+    map[Set<DateTime>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<DateTime>(e)).toSet();
+    map[Set<DateTime?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<DateTime?>(e)).toSet();
+    map[Set<_i220.ByteData>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i220.ByteData>(e))
+        .toSet();
+    map[Set<_i220.ByteData?>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i220.ByteData?>(e))
+        .toSet();
+    map[Set<_i222.SimpleData?>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i222.SimpleData?>(e))
+        .toSet();
+    map[Set<Duration>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<Duration>(e)).toSet();
+    map[Set<Duration?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<Duration?>(e)).toSet();
+    map[List<_i225.Types>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i225.Types>(e))
+        .toList();
+    map[_i1.getType<(String, (int, bool))>()] = (data, protocol) => (
+      protocol.deserialize<String>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<(int, bool)>(data['p'][1]),
+    );
+    map[_i1.getType<(int, bool)>()] = (data, protocol) => (
+      protocol.deserialize<int>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<bool>(data['p'][1]),
+    );
+    map[List<(String, (int, bool))>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<(String, (int, bool))>(e))
+        .toList();
+    map[_i1.getType<(String, (int, bool))>()] = (data, protocol) => (
+      protocol.deserialize<String>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<(int, bool)>(data['p'][1]),
+    );
+    map[_i1
+        .getType<
+          (String, (Map<String, int>, {bool flag, _i222.SimpleData simpleData}))
+        >()] = (data, protocol) => (
+      protocol.deserialize<String>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<
+        (Map<String, int>, {bool flag, _i222.SimpleData simpleData})
+      >(data['p'][1]),
+    );
+    map[_i1
+        .getType<
+          (Map<String, int>, {bool flag, _i222.SimpleData simpleData})
+        >()] = (data, protocol) => (
+      protocol.deserialize<Map<String, int>>(((data as Map)['p'] as List)[0]),
+      flag: protocol.deserialize<bool>(data['n']['flag']),
+      simpleData: protocol.deserialize<_i222.SimpleData>(
+        data['n']['simpleData'],
+      ),
+    );
+    map[List<(String, int)>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<(String, int)>(e))
+        .toList();
+    map[_i1.getType<(String, int)>()] = (data, protocol) => (
+      protocol.deserialize<String>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<int>(data['p'][1]),
+    );
+    map[_i1
+        .getType<
+          (
+            String,
+            (Map<String, int>, {bool flag, _i222.SimpleData simpleData}),
+          )?
+        >()] = (data, protocol) => (data == null)
+        ? null
+        : (
+            protocol.deserialize<String>(((data as Map)['p'] as List)[0]),
+            protocol.deserialize<
+              (Map<String, int>, {bool flag, _i222.SimpleData simpleData})
+            >(data['p'][1]),
+          );
+    map[List<(String, int)>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<(String, int)>(e))
+        .toList();
+    map[_i1.getType<(String, int)>()] = (data, protocol) => (
+      protocol.deserialize<String>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<int>(data['p'][1]),
+    );
+    map[_i1.getType<List<(String, int)>?>()] = (data, protocol) => (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<(String, int)>(e))
+              .toList()
+        : null);
+    map[_i1.getType<(String, int)>()] = (data, protocol) => (
+      protocol.deserialize<String>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<int>(data['p'][1]),
+    );
+    map[_i1.getType<(int, String)>()] = (data, protocol) => (
+      protocol.deserialize<int>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<String>(data['p'][1]),
+    );
+    map[_i1.getType<(_i4.ModuleClass,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (
+            protocol.deserialize<_i4.ModuleClass>(
+              ((data as Map)['p'] as List)[0],
+            ),
+          );
+    map[_i1.getType<(bool,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<bool>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(_i210.TestEnumStringified,)?>()] = (data, protocol) =>
+        (data == null)
+        ? null
+        : (
+            protocol.deserialize<_i210.TestEnumStringified>(
+              ((data as Map)['p'] as List)[0],
+            ),
+          );
+    map[List<(_i210.TestEnumStringified,)>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<(_i210.TestEnumStringified,)>(e))
+        .toList();
+    map[_i1.getType<(_i210.TestEnumStringified,)>()] = (data, protocol) => (
+      protocol.deserialize<_i210.TestEnumStringified>(
+        ((data as Map)['p'] as List)[0],
+      ),
+    );
+    map[_i1.getType<List<(_i210.TestEnumStringified,)>?>()] =
+        (data, protocol) => (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<(_i210.TestEnumStringified,)>(e))
+              .toList()
+        : null);
+    map[_i1.getType<(_i210.TestEnumStringified,)>()] = (data, protocol) => (
+      protocol.deserialize<_i210.TestEnumStringified>(
+        ((data as Map)['p'] as List)[0],
+      ),
+    );
+    map[_i1.getType<(_i210.TestEnumStringified,)>()] = (data, protocol) => (
+      protocol.deserialize<_i210.TestEnumStringified>(
+        ((data as Map)['p'] as List)[0],
+      ),
+    );
+    map[_i1.getType<(_i157.Nullability,)?>()] = (data, protocol) =>
+        (data == null)
+        ? null
+        : (
+            protocol.deserialize<_i157.Nullability>(
+              ((data as Map)['p'] as List)[0],
+            ),
+          );
+    map[_i1.getType<({_i210.TestEnumStringified value})?>()] =
+        (data, protocol) => (data == null)
+        ? null
+        : (
+            value: protocol.deserialize<_i210.TestEnumStringified>(
+              ((data as Map)['n'] as Map)['value'],
+            ),
+          );
+    map[List<({_i210.TestEnumStringified value})>] = (data, protocol) =>
+        (data as List)
+            .map(
+              (e) =>
+                  protocol.deserialize<({_i210.TestEnumStringified value})>(e),
+            )
+            .toList();
+    map[_i1
+        .getType<({_i210.TestEnumStringified value})>()] = (data, protocol) => (
+      value: protocol.deserialize<_i210.TestEnumStringified>(
+        ((data as Map)['n'] as Map)['value'],
+      ),
+    );
+    map[_i1.getType<List<({_i210.TestEnumStringified value})>?>()] =
+        (data, protocol) => (data != null
+        ? (data as List)
+              .map(
+                (e) => protocol
+                    .deserialize<({_i210.TestEnumStringified value})>(e),
+              )
+              .toList()
+        : null);
+    map[_i1
+        .getType<({_i210.TestEnumStringified value})>()] = (data, protocol) => (
+      value: protocol.deserialize<_i210.TestEnumStringified>(
+        ((data as Map)['n'] as Map)['value'],
+      ),
+    );
+    map[_i1
+        .getType<({_i210.TestEnumStringified value})>()] = (data, protocol) => (
+      value: protocol.deserialize<_i210.TestEnumStringified>(
+        ((data as Map)['n'] as Map)['value'],
+      ),
+    );
+    map[_i1.getType<({_i4.ModuleClass value})?>()] = (data, protocol) =>
+        (data == null)
+        ? null
+        : (
+            value: protocol.deserialize<_i4.ModuleClass>(
+              ((data as Map)['n'] as Map)['value'],
+            ),
+          );
+    map[_i1.getType<({_i157.Nullability value})?>()] = (data, protocol) =>
+        (data == null)
+        ? null
+        : (
+            value: protocol.deserialize<_i157.Nullability>(
+              ((data as Map)['n'] as Map)['value'],
+            ),
+          );
+    map[_i1.getType<(String, {Uri? optionalUri})?>()] = (data, protocol) =>
+        (data == null)
+        ? null
+        : (
+            protocol.deserialize<String>(((data as Map)['p'] as List)[0]),
+            optionalUri: ((data)['n'] as Map)['optionalUri'] == null
+                ? null
+                : protocol.deserialize<Uri>(data['n']['optionalUri']),
+          );
+    map[List<(int,)>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<(int,)>(e)).toList();
+    map[_i1.getType<(int,)>()] = (data, protocol) =>
+        (protocol.deserialize<int>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<List<(int,)>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<(int,)>(e)).toList()
+        : null);
+    map[_i1.getType<(int,)>()] = (data, protocol) =>
+        (protocol.deserialize<int>(((data as Map)['p'] as List)[0]),);
+    map[List<(int,)?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<(int,)?>(e)).toList();
+    map[_i1.getType<(int,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<int>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<List<(int,)?>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<(int,)?>(e)).toList()
+        : null);
+    map[_i1.getType<(int,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<int>(((data as Map)['p'] as List)[0]),);
+    map[List<(_i206.TestEnum,)>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<(_i206.TestEnum,)>(e))
+        .toList();
+    map[_i1.getType<(_i206.TestEnum,)>()] = (data, protocol) => (
+      protocol.deserialize<_i206.TestEnum>(((data as Map)['p'] as List)[0]),
+    );
+    map[_i1.getType<List<(_i206.TestEnum,)>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<(_i206.TestEnum,)>(e))
+              .toList()
+        : null);
+    map[_i1.getType<(_i206.TestEnum,)>()] = (data, protocol) => (
+      protocol.deserialize<_i206.TestEnum>(((data as Map)['p'] as List)[0]),
+    );
+    map[_i1.getType<(_i206.TestEnum,)>()] = (data, protocol) => (
+      protocol.deserialize<_i206.TestEnum>(((data as Map)['p'] as List)[0]),
+    );
+    map[Map<(String,), String>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<(String,)>(e['k']),
+          protocol.deserialize<String>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<(String,)>()] = (data, protocol) =>
+        (protocol.deserialize<String>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<Map<(String,), String>?>()] = (data, protocol) =>
+        (data != null
+        ? Map.fromEntries(
+            (data as List).map(
+              (e) => MapEntry(
+                protocol.deserialize<(String,)>(e['k']),
+                protocol.deserialize<String>(e['v']),
+              ),
+            ),
+          )
+        : null);
+    map[_i1.getType<(String,)>()] = (data, protocol) =>
+        (protocol.deserialize<String>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(String,)>()] = (data, protocol) =>
+        (protocol.deserialize<String>(((data as Map)['p'] as List)[0]),);
+    map[Map<String, (String,)>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<(String,)>(v),
+      ),
+    );
+    map[_i1.getType<(String,)>()] = (data, protocol) =>
+        (protocol.deserialize<String>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<Map<String, (String,)>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<(String,)>(v),
+            ),
+          )
+        : null);
+    map[_i1.getType<(String,)>()] = (data, protocol) =>
+        (protocol.deserialize<String>(((data as Map)['p'] as List)[0]),);
+    map[Map<String, (String,)?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<(String,)?>(v),
+      ),
+    );
+    map[_i1.getType<(String,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<String>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<Map<String, (String,)?>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<(String,)?>(v),
+            ),
+          )
+        : null);
+    map[_i1.getType<(String,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<String>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(String,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<String>(((data as Map)['p'] as List)[0]),);
+    map[Map<(String,)?, String>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<(String,)?>(e['k']),
+          protocol.deserialize<String>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<(String,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<String>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<Map<(String,)?, String>?>()] = (data, protocol) =>
+        (data != null
+        ? Map.fromEntries(
+            (data as List).map(
+              (e) => MapEntry(
+                protocol.deserialize<(String,)?>(e['k']),
+                protocol.deserialize<String>(e['v']),
+              ),
+            ),
+          )
+        : null);
+    map[_i1.getType<(String,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<String>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(double,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<double>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(DateTime,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<DateTime>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(_i220.ByteData,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (
+            protocol.deserialize<_i220.ByteData>(
+              ((data as Map)['p'] as List)[0],
+            ),
+          );
+    map[_i1.getType<(Duration,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<Duration>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(_i1.UuidValue,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (
+            protocol.deserialize<_i1.UuidValue>(
+              ((data as Map)['p'] as List)[0],
+            ),
+          );
+    map[_i1.getType<(Uri,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<Uri>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(BigInt,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<BigInt>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(_i206.TestEnum,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (
+            protocol.deserialize<_i206.TestEnum>(
+              ((data as Map)['p'] as List)[0],
+            ),
+          );
+    map[_i1.getType<(List<int>,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<List<int>>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(Map<int, int>,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (
+            protocol.deserialize<Map<int, int>>(
+              ((data as Map)['p'] as List)[0],
+            ),
+          );
+    map[Map<int, int>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<int>(e['k']),
+          protocol.deserialize<int>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<(Set<int>,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<Set<int>>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(_i200.SimpleData,)?>()] = (data, protocol) =>
+        (data == null)
+        ? null
+        : (
+            protocol.deserialize<_i200.SimpleData>(
+              ((data as Map)['p'] as List)[0],
+            ),
+          );
+    map[_i1.getType<({_i200.SimpleData namedModel})?>()] = (data, protocol) =>
+        (data == null)
+        ? null
+        : (
+            namedModel: protocol.deserialize<_i200.SimpleData>(
+              ((data as Map)['n'] as Map)['namedModel'],
+            ),
+          );
+    map[_i1.getType<(_i200.SimpleData, {_i200.SimpleData namedModel})?>()] =
+        (data, protocol) => (data == null)
+        ? null
+        : (
+            protocol.deserialize<_i200.SimpleData>(
+              ((data as Map)['p'] as List)[0],
+            ),
+            namedModel: protocol.deserialize<_i200.SimpleData>(
+              data['n']['namedModel'],
+            ),
+          );
+    map[_i1.getType<((int, String), {(int, String) namedNestedRecord})?>()] =
+        (data, protocol) => (data == null)
+        ? null
+        : (
+            protocol.deserialize<(int, String)>(
+              ((data as Map)['p'] as List)[0],
+            ),
+            namedNestedRecord: protocol.deserialize<(int, String)>(
+              data['n']['namedNestedRecord'],
+            ),
+          );
+    map[_i1
+        .getType<
+          (
+            (List<(_i200.SimpleData,)>,), {
+            (_i200.SimpleData, Map<String, _i200.SimpleData>) namedNestedRecord,
+          })?
+        >()] = (data, protocol) => (data == null)
+        ? null
+        : (
+            protocol.deserialize<(List<(_i200.SimpleData,)>,)>(
+              ((data as Map)['p'] as List)[0],
+            ),
+            namedNestedRecord: protocol
+                .deserialize<(_i200.SimpleData, Map<String, _i200.SimpleData>)>(
+                  data['n']['namedNestedRecord'],
+                ),
+          );
+    map[_i1.getType<(List<(_i200.SimpleData,)>,)>()] = (data, protocol) => (
+      protocol.deserialize<List<(_i200.SimpleData,)>>(
+        ((data as Map)['p'] as List)[0],
+      ),
+    );
+    map[List<(_i200.SimpleData,)>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<(_i200.SimpleData,)>(e))
+        .toList();
+    map[_i1.getType<(_i200.SimpleData,)>()] = (data, protocol) => (
+      protocol.deserialize<_i200.SimpleData>(((data as Map)['p'] as List)[0]),
+    );
+    map[_i1.getType<(_i200.SimpleData,)>()] = (data, protocol) => (
+      protocol.deserialize<_i200.SimpleData>(((data as Map)['p'] as List)[0]),
+    );
+    map[_i1.getType<(_i200.SimpleData, Map<String, _i200.SimpleData>)>()] =
+        (data, protocol) => (
+          protocol.deserialize<_i200.SimpleData>(
+            ((data as Map)['p'] as List)[0],
+          ),
+          protocol.deserialize<Map<String, _i200.SimpleData>>(data['p'][1]),
+        );
+    map[Map<String, _i200.SimpleData>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i200.SimpleData>(v),
+      ),
+    );
+    map[Set<(int,)>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<(int,)>(e)).toSet();
+    map[_i1.getType<(int,)>()] = (data, protocol) =>
+        (protocol.deserialize<int>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<Set<(int,)>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<(int,)>(e)).toSet()
+        : null);
+    map[_i1.getType<(int,)>()] = (data, protocol) =>
+        (protocol.deserialize<int>(((data as Map)['p'] as List)[0]),);
+    map[Set<(int,)?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<(int,)?>(e)).toSet();
+    map[_i1.getType<(int,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<int>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<Set<(int,)?>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<(int,)?>(e)).toSet()
+        : null);
+    map[_i1.getType<(int,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<int>(((data as Map)['p'] as List)[0]),);
+    map[_i221.CustomClass] = (data, protocol) =>
+        _i221.CustomClass.fromJson(data);
+    map[_i221.CustomClass2] = (data, protocol) =>
+        _i221.CustomClass2.fromJson(data);
+    map[_i221.CustomClassWithoutProtocolSerialization] = (data, protocol) =>
+        _i221.CustomClassWithoutProtocolSerialization.fromJson(data);
+    map[_i221.CustomClassWithProtocolSerialization] = (data, protocol) =>
+        _i221.CustomClassWithProtocolSerialization.fromJson(data);
+    map[_i221.CustomClassWithProtocolSerializationMethod] = (data, protocol) =>
+        _i221.CustomClassWithProtocolSerializationMethod.fromJson(data);
+    map[_i221.ProtocolCustomClass] = (data, protocol) =>
+        _i221.ProtocolCustomClass.fromJson(data);
+    map[_i221.ExternalCustomClass] = (data, protocol) =>
+        _i221.ExternalCustomClass.fromJson(data);
+    map[_i221.FreezedCustomClass] = (data, protocol) =>
+        _i221.FreezedCustomClass.fromJson(data);
+    map[_i1.getType<_i221.CustomClass?>()] = (data, protocol) =>
+        (data != null ? _i221.CustomClass.fromJson(data) : null);
+    map[_i1.getType<_i221.CustomClass2?>()] = (data, protocol) =>
+        (data != null ? _i221.CustomClass2.fromJson(data) : null);
+    map[_i1.getType<_i221.CustomClassWithoutProtocolSerialization?>()] =
+        (data, protocol) => (data != null
+        ? _i221.CustomClassWithoutProtocolSerialization.fromJson(data)
+        : null);
+    map[_i1.getType<_i221.CustomClassWithProtocolSerialization?>()] =
+        (data, protocol) => (data != null
+        ? _i221.CustomClassWithProtocolSerialization.fromJson(data)
+        : null);
+    map[_i1.getType<_i221.CustomClassWithProtocolSerializationMethod?>()] =
+        (data, protocol) => (data != null
+        ? _i221.CustomClassWithProtocolSerializationMethod.fromJson(data)
+        : null);
+    map[_i1.getType<_i221.ProtocolCustomClass?>()] = (data, protocol) =>
+        (data != null ? _i221.ProtocolCustomClass.fromJson(data) : null);
+    map[_i1.getType<_i221.ExternalCustomClass?>()] = (data, protocol) =>
+        (data != null ? _i221.ExternalCustomClass.fromJson(data) : null);
+    map[_i1.getType<_i221.FreezedCustomClass?>()] = (data, protocol) =>
+        (data != null ? _i221.FreezedCustomClass.fromJson(data) : null);
+    map[List<int>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int>(e)).toList();
+    map[List<_i222.SimpleData>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i222.SimpleData>(e))
+        .toList();
+    map[List<_i3.UserInfo>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i3.UserInfo>(e))
+        .toList();
+    map[List<_i222.SimpleData>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i222.SimpleData>(e))
+        .toList();
+    map[_i1.getType<List<_i222.SimpleData>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i222.SimpleData>(e))
+              .toList()
+        : null);
+    map[List<_i222.SimpleData?>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i222.SimpleData?>(e))
+        .toList();
+    map[Set<int>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int>(e)).toSet();
+    map[Set<_i222.SimpleData>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i222.SimpleData>(e))
+        .toSet();
+    map[List<Set<_i222.SimpleData>>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<Set<_i222.SimpleData>>(e))
+        .toList();
+    map[Set<_i222.SimpleData>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i222.SimpleData>(e))
+        .toSet();
+    map[_i1.getType<(String, _i224.PolymorphicParent)>()] = (data, protocol) =>
+        (
+          protocol.deserialize<String>(((data as Map)['p'] as List)[0]),
+          protocol.deserialize<_i224.PolymorphicParent>(data['p'][1]),
+        );
+    map[_i1.getType<(int?,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (
+            ((data as Map)['p'] as List)[0] == null
+                ? null
+                : protocol.deserialize<int>(data['p'][0]),
+          );
+    map[List<((int, String), {(_i222.SimpleData, double) namedSubRecord})?>] =
+        (data, protocol) => (data as List)
+            .map(
+              (e) =>
+                  protocol.deserialize<
+                    (
+                      (int, String), {
+                      (_i222.SimpleData, double) namedSubRecord,
+                    })?
+                  >(e),
+            )
+            .toList();
+    map[_i1
+        .getType<
+          ((int, String), {(_i222.SimpleData, double) namedSubRecord})?
+        >()] = (data, protocol) => (data == null)
+        ? null
+        : (
+            protocol.deserialize<(int, String)>(
+              ((data as Map)['p'] as List)[0],
+            ),
+            namedSubRecord: protocol.deserialize<(_i222.SimpleData, double)>(
+              data['n']['namedSubRecord'],
+            ),
+          );
+    map[_i1
+        .getType<
+          List<((int, String), {(_i222.SimpleData, double) namedSubRecord})?>?
+        >()] = (data, protocol) => (data != null
+        ? (data as List)
+              .map(
+                (e) =>
+                    protocol.deserialize<
+                      (
+                        (int, String), {
+                        (_i222.SimpleData, double) namedSubRecord,
+                      })?
+                    >(e),
+              )
+              .toList()
+        : null);
+    map[_i1
+        .getType<
+          ((int, String), {(_i222.SimpleData, double) namedSubRecord})?
+        >()] = (data, protocol) => (data == null)
+        ? null
+        : (
+            protocol.deserialize<(int, String)>(
+              ((data as Map)['p'] as List)[0],
+            ),
+            namedSubRecord: protocol.deserialize<(_i222.SimpleData, double)>(
+              data['n']['namedSubRecord'],
+            ),
+          );
+    map[_i1.getType<(int?, _i4.ProjectStreamingClass?)>()] = (data, protocol) =>
+        (
+          ((data as Map)['p'] as List)[0] == null
+              ? null
+              : protocol.deserialize<int>(data['p'][0]),
+          ((data)['p'] as List)[1] == null
+              ? null
+              : protocol.deserialize<_i4.ProjectStreamingClass>(data['p'][1]),
+        );
+    map[_i1
+        .getType<
+          (String, (Map<String, int>, {bool flag, _i222.SimpleData simpleData}))
+        >()] = (data, protocol) => (
+      protocol.deserialize<String>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<
+        (Map<String, int>, {bool flag, _i222.SimpleData simpleData})
+      >(data['p'][1]),
+    );
+    map[List<(String, int)>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<(String, int)>(e))
+        .toList();
+    map[_i1.getType<(String, int)>()] = (data, protocol) => (
+      protocol.deserialize<String>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<int>(data['p'][1]),
+    );
+    map[_i1
+        .getType<
+          (
+            String,
+            (Map<String, int>, {bool flag, _i222.SimpleData simpleData}),
+          )?
+        >()] = (data, protocol) => (data == null)
+        ? null
+        : (
+            protocol.deserialize<String>(((data as Map)['p'] as List)[0]),
+            protocol.deserialize<
+              (Map<String, int>, {bool flag, _i222.SimpleData simpleData})
+            >(data['p'][1]),
+          );
+    map[List<(String, int)>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<(String, int)>(e))
+        .toList();
+    map[_i1.getType<(String, int)>()] = (data, protocol) => (
+      protocol.deserialize<String>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<int>(data['p'][1]),
+    );
+    map[_i1.getType<List<(String, int)>?>()] = (data, protocol) => (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<(String, int)>(e))
+              .toList()
+        : null);
+    map[_i1.getType<(String, int)>()] = (data, protocol) => (
+      protocol.deserialize<String>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<int>(data['p'][1]),
+    );
+    return map;
+  }
+
   static String? getClassNameFromObjectJson(dynamic data) {
     if (data is! Map) return null;
     final className = data['__className__'] as String?;
@@ -6277,5448 +10504,9 @@ class Protocol extends _i1.DatabaseSerializationManager {
       }
     }
 
-    if (t == _i5.ByIndexEnumWithNameValue) {
-      return _i5.ByIndexEnumWithNameValue.fromJson(data) as T;
-    }
-    if (t == _i6.ByNameEnumWithNameValue) {
-      return _i6.ByNameEnumWithNameValue.fromJson(data) as T;
-    }
-    if (t == _i7.CourseUuid) {
-      return _i7.CourseUuid.fromJson(data) as T;
-    }
-    if (t == _i8.EnrollmentInt) {
-      return _i8.EnrollmentInt.fromJson(data) as T;
-    }
-    if (t == _i9.StudentUuid) {
-      return _i9.StudentUuid.fromJson(data) as T;
-    }
-    if (t == _i10.ArenaUuid) {
-      return _i10.ArenaUuid.fromJson(data) as T;
-    }
-    if (t == _i11.PlayerUuid) {
-      return _i11.PlayerUuid.fromJson(data) as T;
-    }
-    if (t == _i12.TeamInt) {
-      return _i12.TeamInt.fromJson(data) as T;
-    }
-    if (t == _i13.CommentInt) {
-      return _i13.CommentInt.fromJson(data) as T;
-    }
-    if (t == _i14.CustomerInt) {
-      return _i14.CustomerInt.fromJson(data) as T;
-    }
-    if (t == _i15.OrderUuid) {
-      return _i15.OrderUuid.fromJson(data) as T;
-    }
-    if (t == _i16.AddressUuid) {
-      return _i16.AddressUuid.fromJson(data) as T;
-    }
-    if (t == _i17.CitizenInt) {
-      return _i17.CitizenInt.fromJson(data) as T;
-    }
-    if (t == _i18.CompanyUuid) {
-      return _i18.CompanyUuid.fromJson(data) as T;
-    }
-    if (t == _i19.TownInt) {
-      return _i19.TownInt.fromJson(data) as T;
-    }
-    if (t == _i20.ChangedIdTypeSelf) {
-      return _i20.ChangedIdTypeSelf.fromJson(data) as T;
-    }
-    if (t == _i21.ServerOnlyChangedIdFieldClass) {
-      return _i21.ServerOnlyChangedIdFieldClass.fromJson(data) as T;
-    }
-    if (t == _i22.BigIntDefault) {
-      return _i22.BigIntDefault.fromJson(data) as T;
-    }
-    if (t == _i23.BigIntDefaultMix) {
-      return _i23.BigIntDefaultMix.fromJson(data) as T;
-    }
-    if (t == _i24.BigIntDefaultModel) {
-      return _i24.BigIntDefaultModel.fromJson(data) as T;
-    }
-    if (t == _i25.BigIntDefaultPersist) {
-      return _i25.BigIntDefaultPersist.fromJson(data) as T;
-    }
-    if (t == _i26.BoolDefault) {
-      return _i26.BoolDefault.fromJson(data) as T;
-    }
-    if (t == _i27.BoolDefaultMix) {
-      return _i27.BoolDefaultMix.fromJson(data) as T;
-    }
-    if (t == _i28.BoolDefaultModel) {
-      return _i28.BoolDefaultModel.fromJson(data) as T;
-    }
-    if (t == _i29.BoolDefaultPersist) {
-      return _i29.BoolDefaultPersist.fromJson(data) as T;
-    }
-    if (t == _i30.DateTimeDefault) {
-      return _i30.DateTimeDefault.fromJson(data) as T;
-    }
-    if (t == _i31.DateTimeDefaultMix) {
-      return _i31.DateTimeDefaultMix.fromJson(data) as T;
-    }
-    if (t == _i32.DateTimeDefaultModel) {
-      return _i32.DateTimeDefaultModel.fromJson(data) as T;
-    }
-    if (t == _i33.DateTimeDefaultPersist) {
-      return _i33.DateTimeDefaultPersist.fromJson(data) as T;
-    }
-    if (t == _i34.DoubleDefault) {
-      return _i34.DoubleDefault.fromJson(data) as T;
-    }
-    if (t == _i35.DoubleDefaultMix) {
-      return _i35.DoubleDefaultMix.fromJson(data) as T;
-    }
-    if (t == _i36.DoubleDefaultModel) {
-      return _i36.DoubleDefaultModel.fromJson(data) as T;
-    }
-    if (t == _i37.DoubleDefaultPersist) {
-      return _i37.DoubleDefaultPersist.fromJson(data) as T;
-    }
-    if (t == _i38.DurationDefault) {
-      return _i38.DurationDefault.fromJson(data) as T;
-    }
-    if (t == _i39.DurationDefaultMix) {
-      return _i39.DurationDefaultMix.fromJson(data) as T;
-    }
-    if (t == _i40.DurationDefaultModel) {
-      return _i40.DurationDefaultModel.fromJson(data) as T;
-    }
-    if (t == _i41.DurationDefaultPersist) {
-      return _i41.DurationDefaultPersist.fromJson(data) as T;
-    }
-    if (t == _i42.EnumDefault) {
-      return _i42.EnumDefault.fromJson(data) as T;
-    }
-    if (t == _i43.EnumDefaultMix) {
-      return _i43.EnumDefaultMix.fromJson(data) as T;
-    }
-    if (t == _i44.EnumDefaultModel) {
-      return _i44.EnumDefaultModel.fromJson(data) as T;
-    }
-    if (t == _i45.EnumDefaultPersist) {
-      return _i45.EnumDefaultPersist.fromJson(data) as T;
-    }
-    if (t == _i46.ByIndexEnum) {
-      return _i46.ByIndexEnum.fromJson(data) as T;
-    }
-    if (t == _i47.ByNameEnum) {
-      return _i47.ByNameEnum.fromJson(data) as T;
-    }
-    if (t == _i48.DefaultValueEnum) {
-      return _i48.DefaultValueEnum.fromJson(data) as T;
-    }
-    if (t == _i49.DefaultException) {
-      return _i49.DefaultException.fromJson(data) as T;
-    }
-    if (t == _i50.IntDefault) {
-      return _i50.IntDefault.fromJson(data) as T;
-    }
-    if (t == _i51.IntDefaultMix) {
-      return _i51.IntDefaultMix.fromJson(data) as T;
-    }
-    if (t == _i52.IntDefaultModel) {
-      return _i52.IntDefaultModel.fromJson(data) as T;
-    }
-    if (t == _i53.IntDefaultPersist) {
-      return _i53.IntDefaultPersist.fromJson(data) as T;
-    }
-    if (t == _i54.StringDefault) {
-      return _i54.StringDefault.fromJson(data) as T;
-    }
-    if (t == _i55.StringDefaultMix) {
-      return _i55.StringDefaultMix.fromJson(data) as T;
-    }
-    if (t == _i56.StringDefaultModel) {
-      return _i56.StringDefaultModel.fromJson(data) as T;
-    }
-    if (t == _i57.StringDefaultPersist) {
-      return _i57.StringDefaultPersist.fromJson(data) as T;
-    }
-    if (t == _i58.UriDefault) {
-      return _i58.UriDefault.fromJson(data) as T;
-    }
-    if (t == _i59.UriDefaultMix) {
-      return _i59.UriDefaultMix.fromJson(data) as T;
-    }
-    if (t == _i60.UriDefaultModel) {
-      return _i60.UriDefaultModel.fromJson(data) as T;
-    }
-    if (t == _i61.UriDefaultPersist) {
-      return _i61.UriDefaultPersist.fromJson(data) as T;
-    }
-    if (t == _i62.UuidDefault) {
-      return _i62.UuidDefault.fromJson(data) as T;
-    }
-    if (t == _i63.UuidDefaultMix) {
-      return _i63.UuidDefaultMix.fromJson(data) as T;
-    }
-    if (t == _i64.UuidDefaultModel) {
-      return _i64.UuidDefaultModel.fromJson(data) as T;
-    }
-    if (t == _i65.UuidDefaultPersist) {
-      return _i65.UuidDefaultPersist.fromJson(data) as T;
-    }
-    if (t == _i66.EmptyModel) {
-      return _i66.EmptyModel.fromJson(data) as T;
-    }
-    if (t == _i67.EmptyModelRelationItem) {
-      return _i67.EmptyModelRelationItem.fromJson(data) as T;
-    }
-    if (t == _i68.EmptyModelWithTable) {
-      return _i68.EmptyModelWithTable.fromJson(data) as T;
-    }
-    if (t == _i69.RelationEmptyModel) {
-      return _i69.RelationEmptyModel.fromJson(data) as T;
-    }
-    if (t == _i70.ExceptionWithData) {
-      return _i70.ExceptionWithData.fromJson(data) as T;
-    }
-    if (t == _i71.ChildClassExplicitColumn) {
-      return _i71.ChildClassExplicitColumn.fromJson(data) as T;
-    }
-    if (t == _i72.NonTableParentClass) {
-      return _i72.NonTableParentClass.fromJson(data) as T;
-    }
-    if (t == _i73.ModifiedColumnName) {
-      return _i73.ModifiedColumnName.fromJson(data) as T;
-    }
-    if (t == _i74.Department) {
-      return _i74.Department.fromJson(data) as T;
-    }
-    if (t == _i75.Employee) {
-      return _i75.Employee.fromJson(data) as T;
-    }
-    if (t == _i76.Contractor) {
-      return _i76.Contractor.fromJson(data) as T;
-    }
-    if (t == _i77.Service) {
-      return _i77.Service.fromJson(data) as T;
-    }
-    if (t == _i78.TableWithExplicitColumnName) {
-      return _i78.TableWithExplicitColumnName.fromJson(data) as T;
-    }
-    if (t == _i79.TestGeneratedCallByeModel) {
-      return _i79.TestGeneratedCallByeModel.fromJson(data) as T;
-    }
-    if (t == _i80.TestGeneratedCallExecuteWithTriggerModel) {
-      return _i80.TestGeneratedCallExecuteWithTriggerModel.fromJson(data) as T;
-    }
-    if (t == _i81.TestGeneratedCallHelloModel) {
-      return _i81.TestGeneratedCallHelloModel.fromJson(data) as T;
-    }
-    if (t == _i82.ImmutableChildObject) {
-      return _i82.ImmutableChildObject.fromJson(data) as T;
-    }
-    if (t == _i83.ImmutableChildObjectWithNoAdditionalFields) {
-      return _i83.ImmutableChildObjectWithNoAdditionalFields.fromJson(data)
-          as T;
-    }
-    if (t == _i84.ImmutableObject) {
-      return _i84.ImmutableObject.fromJson(data) as T;
-    }
-    if (t == _i85.ImmutableObjectWithImmutableObject) {
-      return _i85.ImmutableObjectWithImmutableObject.fromJson(data) as T;
-    }
-    if (t == _i86.ImmutableObjectWithList) {
-      return _i86.ImmutableObjectWithList.fromJson(data) as T;
-    }
-    if (t == _i87.ImmutableObjectWithMap) {
-      return _i87.ImmutableObjectWithMap.fromJson(data) as T;
-    }
-    if (t == _i88.ImmutableObjectWithMultipleFields) {
-      return _i88.ImmutableObjectWithMultipleFields.fromJson(data) as T;
-    }
-    if (t == _i89.ImmutableObjectWithNoFields) {
-      return _i89.ImmutableObjectWithNoFields.fromJson(data) as T;
-    }
-    if (t == _i90.ImmutableObjectWithRecord) {
-      return _i90.ImmutableObjectWithRecord.fromJson(data) as T;
-    }
-    if (t == _i91.ImmutableObjectWithTable) {
-      return _i91.ImmutableObjectWithTable.fromJson(data) as T;
-    }
-    if (t == _i92.ImmutableObjectWithTwentyFields) {
-      return _i92.ImmutableObjectWithTwentyFields.fromJson(data) as T;
-    }
-    if (t == _i93.ChildClass) {
-      return _i93.ChildClass.fromJson(data) as T;
-    }
-    if (t == _i94.ServerOnlyChildClass) {
-      return _i94.ServerOnlyChildClass.fromJson(data) as T;
-    }
-    if (t == _i95.ChildWithDefault) {
-      return _i95.ChildWithDefault.fromJson(data) as T;
-    }
-    if (t == _i96.ChildWithInheritedId) {
-      return _i96.ChildWithInheritedId.fromJson(data) as T;
-    }
-    if (t == _i97.ChildClassWithoutId) {
-      return _i97.ChildClassWithoutId.fromJson(data) as T;
-    }
-    if (t == _i98.ServerOnlyChildClassWithoutId) {
-      return _i98.ServerOnlyChildClassWithoutId.fromJson(data) as T;
-    }
-    if (t == _i99.ParentClass) {
-      return _i99.ParentClass.fromJson(data) as T;
-    }
-    if (t == _i100.GrandparentClass) {
-      return _i100.GrandparentClass.fromJson(data) as T;
-    }
-    if (t == _i101.ParentClassWithoutId) {
-      return _i101.ParentClassWithoutId.fromJson(data) as T;
-    }
-    if (t == _i102.GrandparentClassWithId) {
-      return _i102.GrandparentClassWithId.fromJson(data) as T;
-    }
-    if (t == _i103.ChildEntity) {
-      return _i103.ChildEntity.fromJson(data) as T;
-    }
-    if (t == _i104.BaseEntity) {
-      return _i104.BaseEntity.fromJson(data) as T;
-    }
-    if (t == _i105.ParentEntity) {
-      return _i105.ParentEntity.fromJson(data) as T;
-    }
-    if (t == _i106.NonServerOnlyParentClass) {
-      return _i106.NonServerOnlyParentClass.fromJson(data) as T;
-    }
-    if (t == _i107.ParentWithChangedId) {
-      return _i107.ParentWithChangedId.fromJson(data) as T;
-    }
-    if (t == _i108.ParentWithDefault) {
-      return _i108.ParentWithDefault.fromJson(data) as T;
-    }
-    if (t == _i109.PolymorphicGrandChild) {
-      return _i109.PolymorphicGrandChild.fromJson(data) as T;
-    }
-    if (t == _i110.PolymorphicChild) {
-      return _i110.PolymorphicChild.fromJson(data) as T;
-    }
-    if (t == _i111.PolymorphicChildContainer) {
-      return _i111.PolymorphicChildContainer.fromJson(data) as T;
-    }
-    if (t == _i112.ModulePolymorphicChildContainer) {
-      return _i112.ModulePolymorphicChildContainer.fromJson(data) as T;
-    }
-    if (t == _i113.SimilarButNotParent) {
-      return _i113.SimilarButNotParent.fromJson(data) as T;
-    }
-    if (t == _i114.PolymorphicParent) {
-      return _i114.PolymorphicParent.fromJson(data) as T;
-    }
-    if (t == _i115.UnrelatedToPolymorphism) {
-      return _i115.UnrelatedToPolymorphism.fromJson(data) as T;
-    }
-    if (t == _i116.SealedGrandChild) {
-      return _i116.SealedGrandChild.fromJson(data) as T;
-    }
-    if (t == _i116.SealedChild) {
-      return _i116.SealedChild.fromJson(data) as T;
-    }
-    if (t == _i117.SealedChildOnlyRequired) {
-      return _i117.SealedChildOnlyRequired.fromJson(data) as T;
-    }
-    if (t == _i116.SealedOtherChild) {
-      return _i116.SealedOtherChild.fromJson(data) as T;
-    }
-    if (t == _i118.CityWithLongTableName) {
-      return _i118.CityWithLongTableName.fromJson(data) as T;
-    }
-    if (t == _i119.OrganizationWithLongTableName) {
-      return _i119.OrganizationWithLongTableName.fromJson(data) as T;
-    }
-    if (t == _i120.PersonWithLongTableName) {
-      return _i120.PersonWithLongTableName.fromJson(data) as T;
-    }
-    if (t == _i121.MaxFieldName) {
-      return _i121.MaxFieldName.fromJson(data) as T;
-    }
-    if (t == _i122.LongImplicitIdField) {
-      return _i122.LongImplicitIdField.fromJson(data) as T;
-    }
-    if (t == _i123.LongImplicitIdFieldCollection) {
-      return _i123.LongImplicitIdFieldCollection.fromJson(data) as T;
-    }
-    if (t == _i124.RelationToMultipleMaxFieldName) {
-      return _i124.RelationToMultipleMaxFieldName.fromJson(data) as T;
-    }
-    if (t == _i125.UserNote) {
-      return _i125.UserNote.fromJson(data) as T;
-    }
-    if (t == _i126.UserNoteCollection) {
-      return _i126.UserNoteCollection.fromJson(data) as T;
-    }
-    if (t == _i127.UserNoteCollectionWithALongName) {
-      return _i127.UserNoteCollectionWithALongName.fromJson(data) as T;
-    }
-    if (t == _i128.UserNoteWithALongName) {
-      return _i128.UserNoteWithALongName.fromJson(data) as T;
-    }
-    if (t == _i129.MultipleMaxFieldName) {
-      return _i129.MultipleMaxFieldName.fromJson(data) as T;
-    }
-    if (t == _i130.City) {
-      return _i130.City.fromJson(data) as T;
-    }
-    if (t == _i131.Organization) {
-      return _i131.Organization.fromJson(data) as T;
-    }
-    if (t == _i132.Person) {
-      return _i132.Person.fromJson(data) as T;
-    }
-    if (t == _i133.Course) {
-      return _i133.Course.fromJson(data) as T;
-    }
-    if (t == _i134.Enrollment) {
-      return _i134.Enrollment.fromJson(data) as T;
-    }
-    if (t == _i135.Student) {
-      return _i135.Student.fromJson(data) as T;
-    }
-    if (t == _i136.ObjectUser) {
-      return _i136.ObjectUser.fromJson(data) as T;
-    }
-    if (t == _i137.ParentUser) {
-      return _i137.ParentUser.fromJson(data) as T;
-    }
-    if (t == _i138.Arena) {
-      return _i138.Arena.fromJson(data) as T;
-    }
-    if (t == _i139.Player) {
-      return _i139.Player.fromJson(data) as T;
-    }
-    if (t == _i140.Team) {
-      return _i140.Team.fromJson(data) as T;
-    }
-    if (t == _i141.Comment) {
-      return _i141.Comment.fromJson(data) as T;
-    }
-    if (t == _i142.Customer) {
-      return _i142.Customer.fromJson(data) as T;
-    }
-    if (t == _i143.Book) {
-      return _i143.Book.fromJson(data) as T;
-    }
-    if (t == _i144.Chapter) {
-      return _i144.Chapter.fromJson(data) as T;
-    }
-    if (t == _i145.Order) {
-      return _i145.Order.fromJson(data) as T;
-    }
-    if (t == _i146.Address) {
-      return _i146.Address.fromJson(data) as T;
-    }
-    if (t == _i147.Citizen) {
-      return _i147.Citizen.fromJson(data) as T;
-    }
-    if (t == _i148.Company) {
-      return _i148.Company.fromJson(data) as T;
-    }
-    if (t == _i149.Town) {
-      return _i149.Town.fromJson(data) as T;
-    }
-    if (t == _i150.Blocking) {
-      return _i150.Blocking.fromJson(data) as T;
-    }
-    if (t == _i151.Member) {
-      return _i151.Member.fromJson(data) as T;
-    }
-    if (t == _i152.Cat) {
-      return _i152.Cat.fromJson(data) as T;
-    }
-    if (t == _i153.Post) {
-      return _i153.Post.fromJson(data) as T;
-    }
-    if (t == _i154.ModuleDatatype) {
-      return _i154.ModuleDatatype.fromJson(data) as T;
-    }
-    if (t == _i155.MyFeatureModel) {
-      return _i155.MyFeatureModel.fromJson(data) as T;
-    }
-    if (t == _i156.MyTriggerType) {
-      return _i156.MyTriggerType.fromJson(data) as T;
-    }
-    if (t == _i157.Nullability) {
-      return _i157.Nullability.fromJson(data) as T;
-    }
-    if (t == _i158.ObjectFieldPersist) {
-      return _i158.ObjectFieldPersist.fromJson(data) as T;
-    }
-    if (t == _i159.ObjectFieldScopes) {
-      return _i159.ObjectFieldScopes.fromJson(data) as T;
-    }
-    if (t == _i160.ObjectWithBit) {
-      return _i160.ObjectWithBit.fromJson(data) as T;
-    }
-    if (t == _i161.ObjectWithByteData) {
-      return _i161.ObjectWithByteData.fromJson(data) as T;
-    }
-    if (t == _i162.ObjectWithCustomClass) {
-      return _i162.ObjectWithCustomClass.fromJson(data) as T;
-    }
-    if (t == _i163.ObjectWithDuration) {
-      return _i163.ObjectWithDuration.fromJson(data) as T;
-    }
-    if (t == _i164.ObjectWithDynamic) {
-      return _i164.ObjectWithDynamic.fromJson(data) as T;
-    }
-    if (t == _i165.ObjectWithEnum) {
-      return _i165.ObjectWithEnum.fromJson(data) as T;
-    }
-    if (t == _i166.ObjectWithEnumEnhanced) {
-      return _i166.ObjectWithEnumEnhanced.fromJson(data) as T;
-    }
-    if (t == _i167.ObjectWithHalfVector) {
-      return _i167.ObjectWithHalfVector.fromJson(data) as T;
-    }
-    if (t == _i168.ObjectWithIndex) {
-      return _i168.ObjectWithIndex.fromJson(data) as T;
-    }
-    if (t == _i169.ObjectWithJsonb) {
-      return _i169.ObjectWithJsonb.fromJson(data) as T;
-    }
-    if (t == _i170.ObjectWithJsonbClassLevel) {
-      return _i170.ObjectWithJsonbClassLevel.fromJson(data) as T;
-    }
-    if (t == _i171.ObjectWithMaps) {
-      return _i171.ObjectWithMaps.fromJson(data) as T;
-    }
-    if (t == _i172.ObjectWithNullableCustomClass) {
-      return _i172.ObjectWithNullableCustomClass.fromJson(data) as T;
-    }
-    if (t == _i173.ObjectWithObject) {
-      return _i173.ObjectWithObject.fromJson(data) as T;
-    }
-    if (t == _i174.ObjectWithParent) {
-      return _i174.ObjectWithParent.fromJson(data) as T;
-    }
-    if (t == _i175.ObjectWithSealedClass) {
-      return _i175.ObjectWithSealedClass.fromJson(data) as T;
-    }
-    if (t == _i176.ObjectWithSelfParent) {
-      return _i176.ObjectWithSelfParent.fromJson(data) as T;
-    }
-    if (t == _i177.ObjectWithSparseVector) {
-      return _i177.ObjectWithSparseVector.fromJson(data) as T;
-    }
-    if (t == _i178.ObjectWithUuid) {
-      return _i178.ObjectWithUuid.fromJson(data) as T;
-    }
-    if (t == _i179.ObjectWithVector) {
-      return _i179.ObjectWithVector.fromJson(data) as T;
-    }
-    if (t == _i180.Record) {
-      return _i180.Record.fromJson(data) as T;
-    }
-    if (t == _i181.RelatedUniqueData) {
-      return _i181.RelatedUniqueData.fromJson(data) as T;
-    }
-    if (t == _i182.ExceptionWithRequiredField) {
-      return _i182.ExceptionWithRequiredField.fromJson(data) as T;
-    }
-    if (t == _i183.ModelWithRequiredField) {
-      return _i183.ModelWithRequiredField.fromJson(data) as T;
-    }
-    if (t == _i184.ScopeNoneFields) {
-      return _i184.ScopeNoneFields.fromJson(data) as T;
-    }
-    if (t == _i185.ScopeServerOnlyFieldChild) {
-      return _i185.ScopeServerOnlyFieldChild.fromJson(data) as T;
-    }
-    if (t == _i186.ScopeServerOnlyField) {
-      return _i186.ScopeServerOnlyField.fromJson(data) as T;
-    }
-    if (t == _i187.Article) {
-      return _i187.Article.fromJson(data) as T;
-    }
-    if (t == _i188.ArticleList) {
-      return _i188.ArticleList.fromJson(data) as T;
-    }
-    if (t == _i189.DefaultServerOnlyClass) {
-      return _i189.DefaultServerOnlyClass.fromJson(data) as T;
-    }
-    if (t == _i190.DefaultServerOnlyEnum) {
-      return _i190.DefaultServerOnlyEnum.fromJson(data) as T;
-    }
-    if (t == _i191.NotServerOnlyClass) {
-      return _i191.NotServerOnlyClass.fromJson(data) as T;
-    }
-    if (t == _i192.NotServerOnlyEnum) {
-      return _i192.NotServerOnlyEnum.fromJson(data) as T;
-    }
-    if (t == _i193.ServerOnlyClass) {
-      return _i193.ServerOnlyClass.fromJson(data) as T;
-    }
-    if (t == _i194.ServerOnlyEnum) {
-      return _i194.ServerOnlyEnum.fromJson(data) as T;
-    }
-    if (t == _i195.ServerOnlyClassField) {
-      return _i195.ServerOnlyClassField.fromJson(data) as T;
-    }
-    if (t == _i196.ServerOnlyDefault) {
-      return _i196.ServerOnlyDefault.fromJson(data) as T;
-    }
-    if (t == _i197.SessionAuthInfo) {
-      return _i197.SessionAuthInfo.fromJson(data) as T;
-    }
-    if (t == _i198.SharedModelContainer) {
-      return _i198.SharedModelContainer.fromJson(data) as T;
-    }
-    if (t == _i199.SharedModelSubclass) {
-      return _i199.SharedModelSubclass.fromJson(data) as T;
-    }
-    if (t == _i200.SimpleData) {
-      return _i200.SimpleData.fromJson(data) as T;
-    }
-    if (t == _i201.SimpleDataList) {
-      return _i201.SimpleDataList.fromJson(data) as T;
-    }
-    if (t == _i202.SimpleDataMap) {
-      return _i202.SimpleDataMap.fromJson(data) as T;
-    }
-    if (t == _i203.SimpleDataObject) {
-      return _i203.SimpleDataObject.fromJson(data) as T;
-    }
-    if (t == _i204.SimpleDateTime) {
-      return _i204.SimpleDateTime.fromJson(data) as T;
-    }
-    if (t == _i205.ModelInSubfolder) {
-      return _i205.ModelInSubfolder.fromJson(data) as T;
-    }
-    if (t == _i206.TestEnum) {
-      return _i206.TestEnum.fromJson(data) as T;
-    }
-    if (t == _i207.TestEnumDefaultSerialization) {
-      return _i207.TestEnumDefaultSerialization.fromJson(data) as T;
-    }
-    if (t == _i208.TestEnumEnhanced) {
-      return _i208.TestEnumEnhanced.fromJson(data) as T;
-    }
-    if (t == _i209.TestEnumEnhancedByName) {
-      return _i209.TestEnumEnhancedByName.fromJson(data) as T;
-    }
-    if (t == _i210.TestEnumStringified) {
-      return _i210.TestEnumStringified.fromJson(data) as T;
-    }
-    if (t == _i211.Types) {
-      return _i211.Types.fromJson(data) as T;
-    }
-    if (t == _i212.TypesList) {
-      return _i212.TypesList.fromJson(data) as T;
-    }
-    if (t == _i213.TypesMap) {
-      return _i213.TypesMap.fromJson(data) as T;
-    }
-    if (t == _i214.TypesRecord) {
-      return _i214.TypesRecord.fromJson(data) as T;
-    }
-    if (t == _i215.TypesSet) {
-      return _i215.TypesSet.fromJson(data) as T;
-    }
-    if (t == _i216.TypesSetRequired) {
-      return _i216.TypesSetRequired.fromJson(data) as T;
-    }
-    if (t == _i217.UniqueData) {
-      return _i217.UniqueData.fromJson(data) as T;
-    }
-    if (t == _i218.UniqueDataWithNonPersist) {
-      return _i218.UniqueDataWithNonPersist.fromJson(data) as T;
-    }
-    if (t == _i219.UpsertTestModel) {
-      return _i219.UpsertTestModel.fromJson(data) as T;
-    }
-    if (t == _i1.getType<_i5.ByIndexEnumWithNameValue?>()) {
-      return (data != null ? _i5.ByIndexEnumWithNameValue.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i6.ByNameEnumWithNameValue?>()) {
-      return (data != null ? _i6.ByNameEnumWithNameValue.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i7.CourseUuid?>()) {
-      return (data != null ? _i7.CourseUuid.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i8.EnrollmentInt?>()) {
-      return (data != null ? _i8.EnrollmentInt.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i9.StudentUuid?>()) {
-      return (data != null ? _i9.StudentUuid.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i10.ArenaUuid?>()) {
-      return (data != null ? _i10.ArenaUuid.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i11.PlayerUuid?>()) {
-      return (data != null ? _i11.PlayerUuid.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i12.TeamInt?>()) {
-      return (data != null ? _i12.TeamInt.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i13.CommentInt?>()) {
-      return (data != null ? _i13.CommentInt.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i14.CustomerInt?>()) {
-      return (data != null ? _i14.CustomerInt.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i15.OrderUuid?>()) {
-      return (data != null ? _i15.OrderUuid.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i16.AddressUuid?>()) {
-      return (data != null ? _i16.AddressUuid.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i17.CitizenInt?>()) {
-      return (data != null ? _i17.CitizenInt.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i18.CompanyUuid?>()) {
-      return (data != null ? _i18.CompanyUuid.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i19.TownInt?>()) {
-      return (data != null ? _i19.TownInt.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i20.ChangedIdTypeSelf?>()) {
-      return (data != null ? _i20.ChangedIdTypeSelf.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i21.ServerOnlyChangedIdFieldClass?>()) {
-      return (data != null
-              ? _i21.ServerOnlyChangedIdFieldClass.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i22.BigIntDefault?>()) {
-      return (data != null ? _i22.BigIntDefault.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i23.BigIntDefaultMix?>()) {
-      return (data != null ? _i23.BigIntDefaultMix.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i24.BigIntDefaultModel?>()) {
-      return (data != null ? _i24.BigIntDefaultModel.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i25.BigIntDefaultPersist?>()) {
-      return (data != null ? _i25.BigIntDefaultPersist.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i26.BoolDefault?>()) {
-      return (data != null ? _i26.BoolDefault.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i27.BoolDefaultMix?>()) {
-      return (data != null ? _i27.BoolDefaultMix.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i28.BoolDefaultModel?>()) {
-      return (data != null ? _i28.BoolDefaultModel.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i29.BoolDefaultPersist?>()) {
-      return (data != null ? _i29.BoolDefaultPersist.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i30.DateTimeDefault?>()) {
-      return (data != null ? _i30.DateTimeDefault.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i31.DateTimeDefaultMix?>()) {
-      return (data != null ? _i31.DateTimeDefaultMix.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i32.DateTimeDefaultModel?>()) {
-      return (data != null ? _i32.DateTimeDefaultModel.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i33.DateTimeDefaultPersist?>()) {
-      return (data != null ? _i33.DateTimeDefaultPersist.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i34.DoubleDefault?>()) {
-      return (data != null ? _i34.DoubleDefault.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i35.DoubleDefaultMix?>()) {
-      return (data != null ? _i35.DoubleDefaultMix.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i36.DoubleDefaultModel?>()) {
-      return (data != null ? _i36.DoubleDefaultModel.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i37.DoubleDefaultPersist?>()) {
-      return (data != null ? _i37.DoubleDefaultPersist.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i38.DurationDefault?>()) {
-      return (data != null ? _i38.DurationDefault.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i39.DurationDefaultMix?>()) {
-      return (data != null ? _i39.DurationDefaultMix.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i40.DurationDefaultModel?>()) {
-      return (data != null ? _i40.DurationDefaultModel.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i41.DurationDefaultPersist?>()) {
-      return (data != null ? _i41.DurationDefaultPersist.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i42.EnumDefault?>()) {
-      return (data != null ? _i42.EnumDefault.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i43.EnumDefaultMix?>()) {
-      return (data != null ? _i43.EnumDefaultMix.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i44.EnumDefaultModel?>()) {
-      return (data != null ? _i44.EnumDefaultModel.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i45.EnumDefaultPersist?>()) {
-      return (data != null ? _i45.EnumDefaultPersist.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i46.ByIndexEnum?>()) {
-      return (data != null ? _i46.ByIndexEnum.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i47.ByNameEnum?>()) {
-      return (data != null ? _i47.ByNameEnum.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i48.DefaultValueEnum?>()) {
-      return (data != null ? _i48.DefaultValueEnum.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i49.DefaultException?>()) {
-      return (data != null ? _i49.DefaultException.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i50.IntDefault?>()) {
-      return (data != null ? _i50.IntDefault.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i51.IntDefaultMix?>()) {
-      return (data != null ? _i51.IntDefaultMix.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i52.IntDefaultModel?>()) {
-      return (data != null ? _i52.IntDefaultModel.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i53.IntDefaultPersist?>()) {
-      return (data != null ? _i53.IntDefaultPersist.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i54.StringDefault?>()) {
-      return (data != null ? _i54.StringDefault.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i55.StringDefaultMix?>()) {
-      return (data != null ? _i55.StringDefaultMix.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i56.StringDefaultModel?>()) {
-      return (data != null ? _i56.StringDefaultModel.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i57.StringDefaultPersist?>()) {
-      return (data != null ? _i57.StringDefaultPersist.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i58.UriDefault?>()) {
-      return (data != null ? _i58.UriDefault.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i59.UriDefaultMix?>()) {
-      return (data != null ? _i59.UriDefaultMix.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i60.UriDefaultModel?>()) {
-      return (data != null ? _i60.UriDefaultModel.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i61.UriDefaultPersist?>()) {
-      return (data != null ? _i61.UriDefaultPersist.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i62.UuidDefault?>()) {
-      return (data != null ? _i62.UuidDefault.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i63.UuidDefaultMix?>()) {
-      return (data != null ? _i63.UuidDefaultMix.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i64.UuidDefaultModel?>()) {
-      return (data != null ? _i64.UuidDefaultModel.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i65.UuidDefaultPersist?>()) {
-      return (data != null ? _i65.UuidDefaultPersist.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i66.EmptyModel?>()) {
-      return (data != null ? _i66.EmptyModel.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i67.EmptyModelRelationItem?>()) {
-      return (data != null ? _i67.EmptyModelRelationItem.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i68.EmptyModelWithTable?>()) {
-      return (data != null ? _i68.EmptyModelWithTable.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i69.RelationEmptyModel?>()) {
-      return (data != null ? _i69.RelationEmptyModel.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i70.ExceptionWithData?>()) {
-      return (data != null ? _i70.ExceptionWithData.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i71.ChildClassExplicitColumn?>()) {
-      return (data != null
-              ? _i71.ChildClassExplicitColumn.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i72.NonTableParentClass?>()) {
-      return (data != null ? _i72.NonTableParentClass.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i73.ModifiedColumnName?>()) {
-      return (data != null ? _i73.ModifiedColumnName.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i74.Department?>()) {
-      return (data != null ? _i74.Department.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i75.Employee?>()) {
-      return (data != null ? _i75.Employee.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i76.Contractor?>()) {
-      return (data != null ? _i76.Contractor.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i77.Service?>()) {
-      return (data != null ? _i77.Service.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i78.TableWithExplicitColumnName?>()) {
-      return (data != null
-              ? _i78.TableWithExplicitColumnName.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i79.TestGeneratedCallByeModel?>()) {
-      return (data != null
-              ? _i79.TestGeneratedCallByeModel.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i80.TestGeneratedCallExecuteWithTriggerModel?>()) {
-      return (data != null
-              ? _i80.TestGeneratedCallExecuteWithTriggerModel.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i81.TestGeneratedCallHelloModel?>()) {
-      return (data != null
-              ? _i81.TestGeneratedCallHelloModel.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i82.ImmutableChildObject?>()) {
-      return (data != null ? _i82.ImmutableChildObject.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i83.ImmutableChildObjectWithNoAdditionalFields?>()) {
-      return (data != null
-              ? _i83.ImmutableChildObjectWithNoAdditionalFields.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i84.ImmutableObject?>()) {
-      return (data != null ? _i84.ImmutableObject.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i85.ImmutableObjectWithImmutableObject?>()) {
-      return (data != null
-              ? _i85.ImmutableObjectWithImmutableObject.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i86.ImmutableObjectWithList?>()) {
-      return (data != null ? _i86.ImmutableObjectWithList.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i87.ImmutableObjectWithMap?>()) {
-      return (data != null ? _i87.ImmutableObjectWithMap.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i88.ImmutableObjectWithMultipleFields?>()) {
-      return (data != null
-              ? _i88.ImmutableObjectWithMultipleFields.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i89.ImmutableObjectWithNoFields?>()) {
-      return (data != null
-              ? _i89.ImmutableObjectWithNoFields.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i90.ImmutableObjectWithRecord?>()) {
-      return (data != null
-              ? _i90.ImmutableObjectWithRecord.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i91.ImmutableObjectWithTable?>()) {
-      return (data != null
-              ? _i91.ImmutableObjectWithTable.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i92.ImmutableObjectWithTwentyFields?>()) {
-      return (data != null
-              ? _i92.ImmutableObjectWithTwentyFields.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i93.ChildClass?>()) {
-      return (data != null ? _i93.ChildClass.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i94.ServerOnlyChildClass?>()) {
-      return (data != null ? _i94.ServerOnlyChildClass.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i95.ChildWithDefault?>()) {
-      return (data != null ? _i95.ChildWithDefault.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i96.ChildWithInheritedId?>()) {
-      return (data != null ? _i96.ChildWithInheritedId.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i97.ChildClassWithoutId?>()) {
-      return (data != null ? _i97.ChildClassWithoutId.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i98.ServerOnlyChildClassWithoutId?>()) {
-      return (data != null
-              ? _i98.ServerOnlyChildClassWithoutId.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i99.ParentClass?>()) {
-      return (data != null ? _i99.ParentClass.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i100.GrandparentClass?>()) {
-      return (data != null ? _i100.GrandparentClass.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i101.ParentClassWithoutId?>()) {
-      return (data != null ? _i101.ParentClassWithoutId.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i102.GrandparentClassWithId?>()) {
-      return (data != null ? _i102.GrandparentClassWithId.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i103.ChildEntity?>()) {
-      return (data != null ? _i103.ChildEntity.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i104.BaseEntity?>()) {
-      return (data != null ? _i104.BaseEntity.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i105.ParentEntity?>()) {
-      return (data != null ? _i105.ParentEntity.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i106.NonServerOnlyParentClass?>()) {
-      return (data != null
-              ? _i106.NonServerOnlyParentClass.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i107.ParentWithChangedId?>()) {
-      return (data != null ? _i107.ParentWithChangedId.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i108.ParentWithDefault?>()) {
-      return (data != null ? _i108.ParentWithDefault.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i109.PolymorphicGrandChild?>()) {
-      return (data != null ? _i109.PolymorphicGrandChild.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i110.PolymorphicChild?>()) {
-      return (data != null ? _i110.PolymorphicChild.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i111.PolymorphicChildContainer?>()) {
-      return (data != null
-              ? _i111.PolymorphicChildContainer.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i112.ModulePolymorphicChildContainer?>()) {
-      return (data != null
-              ? _i112.ModulePolymorphicChildContainer.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i113.SimilarButNotParent?>()) {
-      return (data != null ? _i113.SimilarButNotParent.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i114.PolymorphicParent?>()) {
-      return (data != null ? _i114.PolymorphicParent.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i115.UnrelatedToPolymorphism?>()) {
-      return (data != null
-              ? _i115.UnrelatedToPolymorphism.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i116.SealedGrandChild?>()) {
-      return (data != null ? _i116.SealedGrandChild.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i116.SealedChild?>()) {
-      return (data != null ? _i116.SealedChild.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i117.SealedChildOnlyRequired?>()) {
-      return (data != null
-              ? _i117.SealedChildOnlyRequired.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i116.SealedOtherChild?>()) {
-      return (data != null ? _i116.SealedOtherChild.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i118.CityWithLongTableName?>()) {
-      return (data != null ? _i118.CityWithLongTableName.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i119.OrganizationWithLongTableName?>()) {
-      return (data != null
-              ? _i119.OrganizationWithLongTableName.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i120.PersonWithLongTableName?>()) {
-      return (data != null
-              ? _i120.PersonWithLongTableName.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i121.MaxFieldName?>()) {
-      return (data != null ? _i121.MaxFieldName.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i122.LongImplicitIdField?>()) {
-      return (data != null ? _i122.LongImplicitIdField.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i123.LongImplicitIdFieldCollection?>()) {
-      return (data != null
-              ? _i123.LongImplicitIdFieldCollection.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i124.RelationToMultipleMaxFieldName?>()) {
-      return (data != null
-              ? _i124.RelationToMultipleMaxFieldName.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i125.UserNote?>()) {
-      return (data != null ? _i125.UserNote.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i126.UserNoteCollection?>()) {
-      return (data != null ? _i126.UserNoteCollection.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i127.UserNoteCollectionWithALongName?>()) {
-      return (data != null
-              ? _i127.UserNoteCollectionWithALongName.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i128.UserNoteWithALongName?>()) {
-      return (data != null ? _i128.UserNoteWithALongName.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i129.MultipleMaxFieldName?>()) {
-      return (data != null ? _i129.MultipleMaxFieldName.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i130.City?>()) {
-      return (data != null ? _i130.City.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i131.Organization?>()) {
-      return (data != null ? _i131.Organization.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i132.Person?>()) {
-      return (data != null ? _i132.Person.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i133.Course?>()) {
-      return (data != null ? _i133.Course.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i134.Enrollment?>()) {
-      return (data != null ? _i134.Enrollment.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i135.Student?>()) {
-      return (data != null ? _i135.Student.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i136.ObjectUser?>()) {
-      return (data != null ? _i136.ObjectUser.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i137.ParentUser?>()) {
-      return (data != null ? _i137.ParentUser.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i138.Arena?>()) {
-      return (data != null ? _i138.Arena.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i139.Player?>()) {
-      return (data != null ? _i139.Player.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i140.Team?>()) {
-      return (data != null ? _i140.Team.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i141.Comment?>()) {
-      return (data != null ? _i141.Comment.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i142.Customer?>()) {
-      return (data != null ? _i142.Customer.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i143.Book?>()) {
-      return (data != null ? _i143.Book.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i144.Chapter?>()) {
-      return (data != null ? _i144.Chapter.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i145.Order?>()) {
-      return (data != null ? _i145.Order.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i146.Address?>()) {
-      return (data != null ? _i146.Address.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i147.Citizen?>()) {
-      return (data != null ? _i147.Citizen.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i148.Company?>()) {
-      return (data != null ? _i148.Company.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i149.Town?>()) {
-      return (data != null ? _i149.Town.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i150.Blocking?>()) {
-      return (data != null ? _i150.Blocking.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i151.Member?>()) {
-      return (data != null ? _i151.Member.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i152.Cat?>()) {
-      return (data != null ? _i152.Cat.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i153.Post?>()) {
-      return (data != null ? _i153.Post.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i154.ModuleDatatype?>()) {
-      return (data != null ? _i154.ModuleDatatype.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i155.MyFeatureModel?>()) {
-      return (data != null ? _i155.MyFeatureModel.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i156.MyTriggerType?>()) {
-      return (data != null ? _i156.MyTriggerType.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i157.Nullability?>()) {
-      return (data != null ? _i157.Nullability.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i158.ObjectFieldPersist?>()) {
-      return (data != null ? _i158.ObjectFieldPersist.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i159.ObjectFieldScopes?>()) {
-      return (data != null ? _i159.ObjectFieldScopes.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i160.ObjectWithBit?>()) {
-      return (data != null ? _i160.ObjectWithBit.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i161.ObjectWithByteData?>()) {
-      return (data != null ? _i161.ObjectWithByteData.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i162.ObjectWithCustomClass?>()) {
-      return (data != null ? _i162.ObjectWithCustomClass.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i163.ObjectWithDuration?>()) {
-      return (data != null ? _i163.ObjectWithDuration.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i164.ObjectWithDynamic?>()) {
-      return (data != null ? _i164.ObjectWithDynamic.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i165.ObjectWithEnum?>()) {
-      return (data != null ? _i165.ObjectWithEnum.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i166.ObjectWithEnumEnhanced?>()) {
-      return (data != null ? _i166.ObjectWithEnumEnhanced.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i167.ObjectWithHalfVector?>()) {
-      return (data != null ? _i167.ObjectWithHalfVector.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i168.ObjectWithIndex?>()) {
-      return (data != null ? _i168.ObjectWithIndex.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i169.ObjectWithJsonb?>()) {
-      return (data != null ? _i169.ObjectWithJsonb.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i170.ObjectWithJsonbClassLevel?>()) {
-      return (data != null
-              ? _i170.ObjectWithJsonbClassLevel.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i171.ObjectWithMaps?>()) {
-      return (data != null ? _i171.ObjectWithMaps.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i172.ObjectWithNullableCustomClass?>()) {
-      return (data != null
-              ? _i172.ObjectWithNullableCustomClass.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i173.ObjectWithObject?>()) {
-      return (data != null ? _i173.ObjectWithObject.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i174.ObjectWithParent?>()) {
-      return (data != null ? _i174.ObjectWithParent.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i175.ObjectWithSealedClass?>()) {
-      return (data != null ? _i175.ObjectWithSealedClass.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i176.ObjectWithSelfParent?>()) {
-      return (data != null ? _i176.ObjectWithSelfParent.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i177.ObjectWithSparseVector?>()) {
-      return (data != null ? _i177.ObjectWithSparseVector.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i178.ObjectWithUuid?>()) {
-      return (data != null ? _i178.ObjectWithUuid.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i179.ObjectWithVector?>()) {
-      return (data != null ? _i179.ObjectWithVector.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i180.Record?>()) {
-      return (data != null ? _i180.Record.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i181.RelatedUniqueData?>()) {
-      return (data != null ? _i181.RelatedUniqueData.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i182.ExceptionWithRequiredField?>()) {
-      return (data != null
-              ? _i182.ExceptionWithRequiredField.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i183.ModelWithRequiredField?>()) {
-      return (data != null ? _i183.ModelWithRequiredField.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i184.ScopeNoneFields?>()) {
-      return (data != null ? _i184.ScopeNoneFields.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i185.ScopeServerOnlyFieldChild?>()) {
-      return (data != null
-              ? _i185.ScopeServerOnlyFieldChild.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i186.ScopeServerOnlyField?>()) {
-      return (data != null ? _i186.ScopeServerOnlyField.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i187.Article?>()) {
-      return (data != null ? _i187.Article.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i188.ArticleList?>()) {
-      return (data != null ? _i188.ArticleList.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i189.DefaultServerOnlyClass?>()) {
-      return (data != null ? _i189.DefaultServerOnlyClass.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i190.DefaultServerOnlyEnum?>()) {
-      return (data != null ? _i190.DefaultServerOnlyEnum.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i191.NotServerOnlyClass?>()) {
-      return (data != null ? _i191.NotServerOnlyClass.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i192.NotServerOnlyEnum?>()) {
-      return (data != null ? _i192.NotServerOnlyEnum.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i193.ServerOnlyClass?>()) {
-      return (data != null ? _i193.ServerOnlyClass.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i194.ServerOnlyEnum?>()) {
-      return (data != null ? _i194.ServerOnlyEnum.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i195.ServerOnlyClassField?>()) {
-      return (data != null ? _i195.ServerOnlyClassField.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i196.ServerOnlyDefault?>()) {
-      return (data != null ? _i196.ServerOnlyDefault.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i197.SessionAuthInfo?>()) {
-      return (data != null ? _i197.SessionAuthInfo.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i198.SharedModelContainer?>()) {
-      return (data != null ? _i198.SharedModelContainer.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i199.SharedModelSubclass?>()) {
-      return (data != null ? _i199.SharedModelSubclass.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i200.SimpleData?>()) {
-      return (data != null ? _i200.SimpleData.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i201.SimpleDataList?>()) {
-      return (data != null ? _i201.SimpleDataList.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i202.SimpleDataMap?>()) {
-      return (data != null ? _i202.SimpleDataMap.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i203.SimpleDataObject?>()) {
-      return (data != null ? _i203.SimpleDataObject.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i204.SimpleDateTime?>()) {
-      return (data != null ? _i204.SimpleDateTime.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i205.ModelInSubfolder?>()) {
-      return (data != null ? _i205.ModelInSubfolder.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i206.TestEnum?>()) {
-      return (data != null ? _i206.TestEnum.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i207.TestEnumDefaultSerialization?>()) {
-      return (data != null
-              ? _i207.TestEnumDefaultSerialization.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i208.TestEnumEnhanced?>()) {
-      return (data != null ? _i208.TestEnumEnhanced.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i209.TestEnumEnhancedByName?>()) {
-      return (data != null ? _i209.TestEnumEnhancedByName.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i210.TestEnumStringified?>()) {
-      return (data != null ? _i210.TestEnumStringified.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i211.Types?>()) {
-      return (data != null ? _i211.Types.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i212.TypesList?>()) {
-      return (data != null ? _i212.TypesList.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i213.TypesMap?>()) {
-      return (data != null ? _i213.TypesMap.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i214.TypesRecord?>()) {
-      return (data != null ? _i214.TypesRecord.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i215.TypesSet?>()) {
-      return (data != null ? _i215.TypesSet.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i216.TypesSetRequired?>()) {
-      return (data != null ? _i216.TypesSetRequired.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i217.UniqueData?>()) {
-      return (data != null ? _i217.UniqueData.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i218.UniqueDataWithNonPersist?>()) {
-      return (data != null
-              ? _i218.UniqueDataWithNonPersist.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i219.UpsertTestModel?>()) {
-      return (data != null ? _i219.UpsertTestModel.fromJson(data) : null) as T;
-    }
-    if (t == List<_i8.EnrollmentInt>) {
-      return (data as List)
-              .map((e) => deserialize<_i8.EnrollmentInt>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i8.EnrollmentInt>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i8.EnrollmentInt>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i11.PlayerUuid>) {
-      return (data as List).map((e) => deserialize<_i11.PlayerUuid>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i11.PlayerUuid>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i11.PlayerUuid>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i15.OrderUuid>) {
-      return (data as List).map((e) => deserialize<_i15.OrderUuid>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i15.OrderUuid>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i15.OrderUuid>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i13.CommentInt>) {
-      return (data as List).map((e) => deserialize<_i13.CommentInt>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i13.CommentInt>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i13.CommentInt>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i20.ChangedIdTypeSelf>) {
-      return (data as List)
-              .map((e) => deserialize<_i20.ChangedIdTypeSelf>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i20.ChangedIdTypeSelf>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i20.ChangedIdTypeSelf>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i67.EmptyModelRelationItem>) {
-      return (data as List)
-              .map((e) => deserialize<_i67.EmptyModelRelationItem>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i67.EmptyModelRelationItem>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i67.EmptyModelRelationItem>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i75.Employee>) {
-      return (data as List).map((e) => deserialize<_i75.Employee>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i75.Employee>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i75.Employee>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<String>) {
-      return (data as List).map((e) => deserialize<String>(e)).toList() as T;
-    }
-    if (t == Map<String, String>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(deserialize<String>(k), deserialize<String>(v)),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(int, String)>()) {
-      return (
-            deserialize<int>(((data as Map)['p'] as List)[0]),
-            deserialize<String>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == List<_i103.ChildEntity>) {
-      return (data as List)
-              .map((e) => deserialize<_i103.ChildEntity>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i103.ChildEntity>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i103.ChildEntity>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i110.PolymorphicChild>) {
-      return (data as List)
-              .map((e) => deserialize<_i110.PolymorphicChild>(e))
-              .toList()
-          as T;
-    }
-    if (t == List<_i110.PolymorphicChild?>) {
-      return (data as List)
-              .map((e) => deserialize<_i110.PolymorphicChild?>(e))
-              .toList()
-          as T;
-    }
-    if (t == Map<String, _i110.PolymorphicChild>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<_i110.PolymorphicChild>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == Map<String, _i110.PolymorphicChild?>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<_i110.PolymorphicChild?>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == List<_i4.ModulePolymorphicChild>) {
-      return (data as List)
-              .map((e) => deserialize<_i4.ModulePolymorphicChild>(e))
-              .toList()
-          as T;
-    }
-    if (t == Map<String, _i4.ModulePolymorphicChild>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<_i4.ModulePolymorphicChild>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == List<_i120.PersonWithLongTableName>) {
-      return (data as List)
-              .map((e) => deserialize<_i120.PersonWithLongTableName>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i120.PersonWithLongTableName>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i120.PersonWithLongTableName>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i119.OrganizationWithLongTableName>) {
-      return (data as List)
-              .map((e) => deserialize<_i119.OrganizationWithLongTableName>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i119.OrganizationWithLongTableName>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map(
-                      (e) =>
-                          deserialize<_i119.OrganizationWithLongTableName>(e),
-                    )
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i122.LongImplicitIdField>) {
-      return (data as List)
-              .map((e) => deserialize<_i122.LongImplicitIdField>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i122.LongImplicitIdField>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i122.LongImplicitIdField>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i129.MultipleMaxFieldName>) {
-      return (data as List)
-              .map((e) => deserialize<_i129.MultipleMaxFieldName>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i129.MultipleMaxFieldName>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i129.MultipleMaxFieldName>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i125.UserNote>) {
-      return (data as List).map((e) => deserialize<_i125.UserNote>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i125.UserNote>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i125.UserNote>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i128.UserNoteWithALongName>) {
-      return (data as List)
-              .map((e) => deserialize<_i128.UserNoteWithALongName>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i128.UserNoteWithALongName>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i128.UserNoteWithALongName>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i132.Person>) {
-      return (data as List).map((e) => deserialize<_i132.Person>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i132.Person>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<_i132.Person>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i131.Organization>) {
-      return (data as List)
-              .map((e) => deserialize<_i131.Organization>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i131.Organization>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i131.Organization>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i134.Enrollment>) {
-      return (data as List)
-              .map((e) => deserialize<_i134.Enrollment>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i134.Enrollment>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i134.Enrollment>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i139.Player>) {
-      return (data as List).map((e) => deserialize<_i139.Player>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i139.Player>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<_i139.Player>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i145.Order>) {
-      return (data as List).map((e) => deserialize<_i145.Order>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i145.Order>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<_i145.Order>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i144.Chapter>) {
-      return (data as List).map((e) => deserialize<_i144.Chapter>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i144.Chapter>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i144.Chapter>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i141.Comment>) {
-      return (data as List).map((e) => deserialize<_i141.Comment>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i141.Comment>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i141.Comment>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i150.Blocking>) {
-      return (data as List).map((e) => deserialize<_i150.Blocking>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i150.Blocking>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i150.Blocking>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i152.Cat>) {
-      return (data as List).map((e) => deserialize<_i152.Cat>(e)).toList() as T;
-    }
-    if (t == _i1.getType<List<_i152.Cat>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<_i152.Cat>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i4.ModuleClass>) {
-      return (data as List).map((e) => deserialize<_i4.ModuleClass>(e)).toList()
-          as T;
-    }
-    if (t == Map<String, _i4.ModuleClass>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<_i4.ModuleClass>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(_i4.ModuleClass,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<_i4.ModuleClass>(((data as Map)['p'] as List)[0]),)
-                as T;
-    }
-    if (t == List<int>) {
-      return (data as List).map((e) => deserialize<int>(e)).toList() as T;
-    }
-    if (t == _i1.getType<List<int>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<int>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == List<int?>) {
-      return (data as List).map((e) => deserialize<int?>(e)).toList() as T;
-    }
-    if (t == _i1.getType<List<int?>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<int?>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i200.SimpleData>) {
-      return (data as List)
-              .map((e) => deserialize<_i200.SimpleData>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i200.SimpleData>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i200.SimpleData>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i200.SimpleData?>) {
-      return (data as List)
-              .map((e) => deserialize<_i200.SimpleData?>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i200.SimpleData?>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i200.SimpleData?>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<DateTime>) {
-      return (data as List).map((e) => deserialize<DateTime>(e)).toList() as T;
-    }
-    if (t == _i1.getType<List<DateTime>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<DateTime>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == List<DateTime?>) {
-      return (data as List).map((e) => deserialize<DateTime?>(e)).toList() as T;
-    }
-    if (t == _i1.getType<List<DateTime?>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<DateTime?>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i220.ByteData>) {
-      return (data as List).map((e) => deserialize<_i220.ByteData>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i220.ByteData>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i220.ByteData>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i220.ByteData?>) {
-      return (data as List).map((e) => deserialize<_i220.ByteData?>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i220.ByteData?>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i220.ByteData?>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<Duration>) {
-      return (data as List).map((e) => deserialize<Duration>(e)).toList() as T;
-    }
-    if (t == _i1.getType<List<Duration>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<Duration>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == List<Duration?>) {
-      return (data as List).map((e) => deserialize<Duration?>(e)).toList() as T;
-    }
-    if (t == _i1.getType<List<Duration?>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<Duration?>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i1.UuidValue>) {
-      return (data as List).map((e) => deserialize<_i1.UuidValue>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i1.UuidValue>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i1.UuidValue>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i1.UuidValue?>) {
-      return (data as List).map((e) => deserialize<_i1.UuidValue?>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i1.UuidValue?>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i1.UuidValue?>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == Map<String, int>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(deserialize<String>(k), deserialize<int>(v)),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<String, int>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) =>
-                      MapEntry(deserialize<String>(k), deserialize<int>(v)),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<String, int?>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(deserialize<String>(k), deserialize<int?>(v)),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<String, int?>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) =>
-                      MapEntry(deserialize<String>(k), deserialize<int?>(v)),
-                )
-              : null)
-          as T;
-    }
-    if (t == _i221.CustomClassWithoutProtocolSerialization) {
-      return _i221.CustomClassWithoutProtocolSerialization.fromJson(data) as T;
-    }
-    if (t == _i221.CustomClassWithProtocolSerialization) {
-      return _i221.CustomClassWithProtocolSerialization.fromJson(data) as T;
-    }
-    if (t == _i221.CustomClassWithProtocolSerializationMethod) {
-      return _i221.CustomClassWithProtocolSerializationMethod.fromJson(data)
-          as T;
-    }
-    if (t == dynamic) {
-      return deserializeDynamicFieldValue(data) as T;
-    }
-    if (t == List<dynamic>) {
-      return (data as List).map((e) => deserialize<dynamic>(e)).toList() as T;
-    }
-    if (t == Map<String, dynamic>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(deserialize<String>(k), deserialize<dynamic>(v)),
-          )
-          as T;
-    }
-    if (t == Set<dynamic>) {
-      return (data as List).map((e) => deserialize<dynamic>(e)).toSet() as T;
-    }
-    if (t == Map<dynamic, dynamic>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) => MapEntry(
-                deserialize<dynamic>(e['k']),
-                deserialize<dynamic>(e['v']),
-              ),
-            ),
-          )
-          as T;
-    }
-    if (t == List<_i206.TestEnum>) {
-      return (data as List).map((e) => deserialize<_i206.TestEnum>(e)).toList()
-          as T;
-    }
-    if (t == List<_i206.TestEnum?>) {
-      return (data as List).map((e) => deserialize<_i206.TestEnum?>(e)).toList()
-          as T;
-    }
-    if (t == List<List<_i206.TestEnum>>) {
-      return (data as List)
-              .map((e) => deserialize<List<_i206.TestEnum>>(e))
-              .toList()
-          as T;
-    }
-    if (t == List<_i208.TestEnumEnhanced>) {
-      return (data as List)
-              .map((e) => deserialize<_i208.TestEnumEnhanced>(e))
-              .toList()
-          as T;
-    }
-    if (t == List<_i209.TestEnumEnhancedByName>) {
-      return (data as List)
-              .map((e) => deserialize<_i209.TestEnumEnhancedByName>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<String>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<String>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == Map<String, _i200.SimpleData>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<_i200.SimpleData>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == Map<String, DateTime>) {
-      return (data as Map).map(
-            (k, v) =>
-                MapEntry(deserialize<String>(k), deserialize<DateTime>(v)),
-          )
-          as T;
-    }
-    if (t == Map<String, _i220.ByteData>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<_i220.ByteData>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == Map<String, Duration>) {
-      return (data as Map).map(
-            (k, v) =>
-                MapEntry(deserialize<String>(k), deserialize<Duration>(v)),
-          )
-          as T;
-    }
-    if (t == Map<String, _i1.UuidValue>) {
-      return (data as Map).map(
-            (k, v) =>
-                MapEntry(deserialize<String>(k), deserialize<_i1.UuidValue>(v)),
-          )
-          as T;
-    }
-    if (t == Map<String, _i200.SimpleData?>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<_i200.SimpleData?>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == Map<String, String?>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(deserialize<String>(k), deserialize<String?>(v)),
-          )
-          as T;
-    }
-    if (t == Map<String, DateTime?>) {
-      return (data as Map).map(
-            (k, v) =>
-                MapEntry(deserialize<String>(k), deserialize<DateTime?>(v)),
-          )
-          as T;
-    }
-    if (t == Map<String, _i220.ByteData?>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<_i220.ByteData?>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == Map<String, Duration?>) {
-      return (data as Map).map(
-            (k, v) =>
-                MapEntry(deserialize<String>(k), deserialize<Duration?>(v)),
-          )
-          as T;
-    }
-    if (t == Map<String, _i1.UuidValue?>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<_i1.UuidValue?>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == Map<int, int>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) =>
-                  MapEntry(deserialize<int>(e['k']), deserialize<int>(e['v'])),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<_i221.CustomClassWithoutProtocolSerialization?>()) {
-      return (data != null
-              ? _i221.CustomClassWithoutProtocolSerialization.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i221.CustomClassWithProtocolSerialization?>()) {
-      return (data != null
-              ? _i221.CustomClassWithProtocolSerialization.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i221.CustomClassWithProtocolSerializationMethod?>()) {
-      return (data != null
-              ? _i221.CustomClassWithProtocolSerializationMethod.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == List<List<_i200.SimpleData>>) {
-      return (data as List)
-              .map((e) => deserialize<List<_i200.SimpleData>>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<List<_i200.SimpleData>>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<List<_i200.SimpleData>>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == Map<String, List<List<Map<int, _i200.SimpleData>>?>>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<List<List<Map<int, _i200.SimpleData>>?>>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == List<List<Map<int, _i200.SimpleData>>?>) {
-      return (data as List)
-              .map((e) => deserialize<List<Map<int, _i200.SimpleData>>?>(e))
-              .toList()
-          as T;
-    }
-    if (t == List<Map<int, _i200.SimpleData>>) {
-      return (data as List)
-              .map((e) => deserialize<Map<int, _i200.SimpleData>>(e))
-              .toList()
-          as T;
-    }
-    if (t == Map<int, _i200.SimpleData>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) => MapEntry(
-                deserialize<int>(e['k']),
-                deserialize<_i200.SimpleData>(e['v']),
-              ),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<List<Map<int, _i200.SimpleData>>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<Map<int, _i200.SimpleData>>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t ==
-        _i1.getType<Map<String, List<List<Map<int, _i200.SimpleData>>?>>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) => MapEntry(
-                    deserialize<String>(k),
-                    deserialize<List<List<Map<int, _i200.SimpleData>>?>>(v),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<List<Map<int, _i200.SimpleData>>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<Map<int, _i200.SimpleData>>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == Map<String, Map<int, _i200.SimpleData>>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<Map<int, _i200.SimpleData>>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<String, Map<int, _i200.SimpleData>>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) => MapEntry(
-                    deserialize<String>(k),
-                    deserialize<Map<int, _i200.SimpleData>>(v),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == List<_i116.SealedParent>) {
-      return (data as List)
-              .map((e) => deserialize<_i116.SealedParent>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<(bool,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<bool>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == List<_i187.Article>) {
-      return (data as List).map((e) => deserialize<_i187.Article>(e)).toList()
-          as T;
-    }
-    if (t == List<_i193.ServerOnlyClass>) {
-      return (data as List)
-              .map((e) => deserialize<_i193.ServerOnlyClass>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i193.ServerOnlyClass>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i193.ServerOnlyClass>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == Map<String, _i193.ServerOnlyClass>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<_i193.ServerOnlyClass>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<String, _i193.ServerOnlyClass>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) => MapEntry(
-                    deserialize<String>(k),
-                    deserialize<_i193.ServerOnlyClass>(v),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == List<_i221.SharedModel>) {
-      return (data as List)
-              .map((e) => deserialize<_i221.SharedModel>(e))
-              .toList()
-          as T;
-    }
-    if (t == List<_i221.SharedModel?>) {
-      return (data as List)
-              .map((e) => deserialize<_i221.SharedModel?>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i221.SharedModel>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i221.SharedModel>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == Map<String, _i221.SharedModel>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<_i221.SharedModel>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<String, _i221.SharedModel>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) => MapEntry(
-                    deserialize<String>(k),
-                    deserialize<_i221.SharedModel>(v),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<String, _i221.SharedSubclass>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<_i221.SharedSubclass>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == Set<_i221.SharedModel>) {
-      return (data as List)
-              .map((e) => deserialize<_i221.SharedModel>(e))
-              .toSet()
-          as T;
-    }
-    if (t == _i1.getType<Set<_i221.SharedModel>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i221.SharedModel>(e))
-                    .toSet()
-              : null)
-          as T;
-    }
-    if (t == List<_i210.TestEnumStringified>) {
-      return (data as List)
-              .map((e) => deserialize<_i210.TestEnumStringified>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i210.TestEnumStringified>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i210.TestEnumStringified>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(_i210.TestEnumStringified,)?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<_i210.TestEnumStringified>(
-                    ((data as Map)['p'] as List)[0],
-                  ),
-                )
-                as T;
-    }
-    if (t == List<(_i210.TestEnumStringified,)>) {
-      return (data as List)
-              .map((e) => deserialize<(_i210.TestEnumStringified,)>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<(_i210.TestEnumStringified,)>()) {
-      return (
-            deserialize<_i210.TestEnumStringified>(
-              ((data as Map)['p'] as List)[0],
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<List<(_i210.TestEnumStringified,)>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<(_i210.TestEnumStringified,)>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(_i210.TestEnumStringified,)>()) {
-      return (
-            deserialize<_i210.TestEnumStringified>(
-              ((data as Map)['p'] as List)[0],
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(_i157.Nullability,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<_i157.Nullability>(((data as Map)['p'] as List)[0]),)
-                as T;
-    }
-    if (t == _i1.getType<({_i210.TestEnumStringified value})?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  value: deserialize<_i210.TestEnumStringified>(
-                    ((data as Map)['n'] as Map)['value'],
-                  ),
-                )
-                as T;
-    }
-    if (t == List<({_i210.TestEnumStringified value})>) {
-      return (data as List)
-              .map((e) => deserialize<({_i210.TestEnumStringified value})>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<({_i210.TestEnumStringified value})>()) {
-      return (
-            value: deserialize<_i210.TestEnumStringified>(
-              ((data as Map)['n'] as Map)['value'],
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<List<({_i210.TestEnumStringified value})>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map(
-                      (e) =>
-                          deserialize<({_i210.TestEnumStringified value})>(e),
-                    )
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<({_i210.TestEnumStringified value})>()) {
-      return (
-            value: deserialize<_i210.TestEnumStringified>(
-              ((data as Map)['n'] as Map)['value'],
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<({_i4.ModuleClass value})?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  value: deserialize<_i4.ModuleClass>(
-                    ((data as Map)['n'] as Map)['value'],
-                  ),
-                )
-                as T;
-    }
-    if (t == _i1.getType<({_i157.Nullability value})?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  value: deserialize<_i157.Nullability>(
-                    ((data as Map)['n'] as Map)['value'],
-                  ),
-                )
-                as T;
-    }
-    if (t == _i1.getType<Map<int, int>?>()) {
-      return (data != null
-              ? Map.fromEntries(
-                  (data as List).map(
-                    (e) => MapEntry(
-                      deserialize<int>(e['k']),
-                      deserialize<int>(e['v']),
-                    ),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == Set<int>) {
-      return (data as List).map((e) => deserialize<int>(e)).toSet() as T;
-    }
-    if (t == _i1.getType<Set<int>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<int>(e)).toSet()
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(String, {Uri? optionalUri})?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<String>(((data as Map)['p'] as List)[0]),
-                  optionalUri: ((data)['n'] as Map)['optionalUri'] == null
-                      ? null
-                      : deserialize<Uri>(data['n']['optionalUri']),
-                )
-                as T;
-    }
-    if (t == List<bool>) {
-      return (data as List).map((e) => deserialize<bool>(e)).toList() as T;
-    }
-    if (t == _i1.getType<List<bool>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<bool>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == List<double>) {
-      return (data as List).map((e) => deserialize<double>(e)).toList() as T;
-    }
-    if (t == _i1.getType<List<double>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<double>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == List<Uri>) {
-      return (data as List).map((e) => deserialize<Uri>(e)).toList() as T;
-    }
-    if (t == _i1.getType<List<Uri>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<Uri>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == List<BigInt>) {
-      return (data as List).map((e) => deserialize<BigInt>(e)).toList() as T;
-    }
-    if (t == _i1.getType<List<BigInt>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<BigInt>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<List<_i206.TestEnum>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i206.TestEnum>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i211.Types>) {
-      return (data as List).map((e) => deserialize<_i211.Types>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i211.Types>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<_i211.Types>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == List<Map<String, _i211.Types>>) {
-      return (data as List)
-              .map((e) => deserialize<Map<String, _i211.Types>>(e))
-              .toList()
-          as T;
-    }
-    if (t == Map<String, _i211.Types>) {
-      return (data as Map).map(
-            (k, v) =>
-                MapEntry(deserialize<String>(k), deserialize<_i211.Types>(v)),
-          )
-          as T;
-    }
-    if (t == _i1.getType<List<Map<String, _i211.Types>>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<Map<String, _i211.Types>>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<List<_i211.Types>>) {
-      return (data as List)
-              .map((e) => deserialize<List<_i211.Types>>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<List<_i211.Types>>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<List<_i211.Types>>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<(int,)>) {
-      return (data as List).map((e) => deserialize<(int,)>(e)).toList() as T;
-    }
-    if (t == _i1.getType<(int,)>()) {
-      return (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<List<(int,)>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<(int,)>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(int,)>()) {
-      return (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == List<(int,)?>) {
-      return (data as List).map((e) => deserialize<(int,)?>(e)).toList() as T;
-    }
-    if (t == _i1.getType<(int,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<List<(int,)?>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<(int,)?>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(int,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == List<(_i206.TestEnum,)>) {
-      return (data as List)
-              .map((e) => deserialize<(_i206.TestEnum,)>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<(_i206.TestEnum,)>()) {
-      return (deserialize<_i206.TestEnum>(((data as Map)['p'] as List)[0]),)
-          as T;
-    }
-    if (t == _i1.getType<List<(_i206.TestEnum,)>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<(_i206.TestEnum,)>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(_i206.TestEnum,)>()) {
-      return (deserialize<_i206.TestEnum>(((data as Map)['p'] as List)[0]),)
-          as T;
-    }
-    if (t == Map<int, String>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) => MapEntry(
-                deserialize<int>(e['k']),
-                deserialize<String>(e['v']),
-              ),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<int, String>?>()) {
-      return (data != null
-              ? Map.fromEntries(
-                  (data as List).map(
-                    (e) => MapEntry(
-                      deserialize<int>(e['k']),
-                      deserialize<String>(e['v']),
-                    ),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<bool, String>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) => MapEntry(
-                deserialize<bool>(e['k']),
-                deserialize<String>(e['v']),
-              ),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<bool, String>?>()) {
-      return (data != null
-              ? Map.fromEntries(
-                  (data as List).map(
-                    (e) => MapEntry(
-                      deserialize<bool>(e['k']),
-                      deserialize<String>(e['v']),
-                    ),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<double, String>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) => MapEntry(
-                deserialize<double>(e['k']),
-                deserialize<String>(e['v']),
-              ),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<double, String>?>()) {
-      return (data != null
-              ? Map.fromEntries(
-                  (data as List).map(
-                    (e) => MapEntry(
-                      deserialize<double>(e['k']),
-                      deserialize<String>(e['v']),
-                    ),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<DateTime, String>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) => MapEntry(
-                deserialize<DateTime>(e['k']),
-                deserialize<String>(e['v']),
-              ),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<DateTime, String>?>()) {
-      return (data != null
-              ? Map.fromEntries(
-                  (data as List).map(
-                    (e) => MapEntry(
-                      deserialize<DateTime>(e['k']),
-                      deserialize<String>(e['v']),
-                    ),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<Map<String, String>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) =>
-                      MapEntry(deserialize<String>(k), deserialize<String>(v)),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<_i220.ByteData, String>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) => MapEntry(
-                deserialize<_i220.ByteData>(e['k']),
-                deserialize<String>(e['v']),
-              ),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<_i220.ByteData, String>?>()) {
-      return (data != null
-              ? Map.fromEntries(
-                  (data as List).map(
-                    (e) => MapEntry(
-                      deserialize<_i220.ByteData>(e['k']),
-                      deserialize<String>(e['v']),
-                    ),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<Duration, String>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) => MapEntry(
-                deserialize<Duration>(e['k']),
-                deserialize<String>(e['v']),
-              ),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<Duration, String>?>()) {
-      return (data != null
-              ? Map.fromEntries(
-                  (data as List).map(
-                    (e) => MapEntry(
-                      deserialize<Duration>(e['k']),
-                      deserialize<String>(e['v']),
-                    ),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<_i1.UuidValue, String>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) => MapEntry(
-                deserialize<_i1.UuidValue>(e['k']),
-                deserialize<String>(e['v']),
-              ),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<_i1.UuidValue, String>?>()) {
-      return (data != null
-              ? Map.fromEntries(
-                  (data as List).map(
-                    (e) => MapEntry(
-                      deserialize<_i1.UuidValue>(e['k']),
-                      deserialize<String>(e['v']),
-                    ),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<Uri, String>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) => MapEntry(
-                deserialize<Uri>(e['k']),
-                deserialize<String>(e['v']),
-              ),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<Uri, String>?>()) {
-      return (data != null
-              ? Map.fromEntries(
-                  (data as List).map(
-                    (e) => MapEntry(
-                      deserialize<Uri>(e['k']),
-                      deserialize<String>(e['v']),
-                    ),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<BigInt, String>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) => MapEntry(
-                deserialize<BigInt>(e['k']),
-                deserialize<String>(e['v']),
-              ),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<BigInt, String>?>()) {
-      return (data != null
-              ? Map.fromEntries(
-                  (data as List).map(
-                    (e) => MapEntry(
-                      deserialize<BigInt>(e['k']),
-                      deserialize<String>(e['v']),
-                    ),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<_i206.TestEnum, String>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) => MapEntry(
-                deserialize<_i206.TestEnum>(e['k']),
-                deserialize<String>(e['v']),
-              ),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<_i206.TestEnum, String>?>()) {
-      return (data != null
-              ? Map.fromEntries(
-                  (data as List).map(
-                    (e) => MapEntry(
-                      deserialize<_i206.TestEnum>(e['k']),
-                      deserialize<String>(e['v']),
-                    ),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<_i210.TestEnumStringified, String>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) => MapEntry(
-                deserialize<_i210.TestEnumStringified>(e['k']),
-                deserialize<String>(e['v']),
-              ),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<_i210.TestEnumStringified, String>?>()) {
-      return (data != null
-              ? Map.fromEntries(
-                  (data as List).map(
-                    (e) => MapEntry(
-                      deserialize<_i210.TestEnumStringified>(e['k']),
-                      deserialize<String>(e['v']),
-                    ),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<_i211.Types, String>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) => MapEntry(
-                deserialize<_i211.Types>(e['k']),
-                deserialize<String>(e['v']),
-              ),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<_i211.Types, String>?>()) {
-      return (data != null
-              ? Map.fromEntries(
-                  (data as List).map(
-                    (e) => MapEntry(
-                      deserialize<_i211.Types>(e['k']),
-                      deserialize<String>(e['v']),
-                    ),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<Map<_i211.Types, String>, String>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) => MapEntry(
-                deserialize<Map<_i211.Types, String>>(e['k']),
-                deserialize<String>(e['v']),
-              ),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<Map<_i211.Types, String>, String>?>()) {
-      return (data != null
-              ? Map.fromEntries(
-                  (data as List).map(
-                    (e) => MapEntry(
-                      deserialize<Map<_i211.Types, String>>(e['k']),
-                      deserialize<String>(e['v']),
-                    ),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<List<_i211.Types>, String>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) => MapEntry(
-                deserialize<List<_i211.Types>>(e['k']),
-                deserialize<String>(e['v']),
-              ),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<List<_i211.Types>, String>?>()) {
-      return (data != null
-              ? Map.fromEntries(
-                  (data as List).map(
-                    (e) => MapEntry(
-                      deserialize<List<_i211.Types>>(e['k']),
-                      deserialize<String>(e['v']),
-                    ),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<(String,), String>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) => MapEntry(
-                deserialize<(String,)>(e['k']),
-                deserialize<String>(e['v']),
-              ),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(String,)>()) {
-      return (deserialize<String>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<Map<(String,), String>?>()) {
-      return (data != null
-              ? Map.fromEntries(
-                  (data as List).map(
-                    (e) => MapEntry(
-                      deserialize<(String,)>(e['k']),
-                      deserialize<String>(e['v']),
-                    ),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(String,)>()) {
-      return (deserialize<String>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == Map<String, bool>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(deserialize<String>(k), deserialize<bool>(v)),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<String, bool>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) =>
-                      MapEntry(deserialize<String>(k), deserialize<bool>(v)),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<String, double>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(deserialize<String>(k), deserialize<double>(v)),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<String, double>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) =>
-                      MapEntry(deserialize<String>(k), deserialize<double>(v)),
-                )
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<Map<String, DateTime>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) => MapEntry(
-                    deserialize<String>(k),
-                    deserialize<DateTime>(v),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<Map<String, _i220.ByteData>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) => MapEntry(
-                    deserialize<String>(k),
-                    deserialize<_i220.ByteData>(v),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<Map<String, Duration>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) => MapEntry(
-                    deserialize<String>(k),
-                    deserialize<Duration>(v),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<Map<String, _i1.UuidValue>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) => MapEntry(
-                    deserialize<String>(k),
-                    deserialize<_i1.UuidValue>(v),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<String, Uri>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(deserialize<String>(k), deserialize<Uri>(v)),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<String, Uri>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) =>
-                      MapEntry(deserialize<String>(k), deserialize<Uri>(v)),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<String, BigInt>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(deserialize<String>(k), deserialize<BigInt>(v)),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<String, BigInt>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) =>
-                      MapEntry(deserialize<String>(k), deserialize<BigInt>(v)),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<String, _i206.TestEnum>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<_i206.TestEnum>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<String, _i206.TestEnum>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) => MapEntry(
-                    deserialize<String>(k),
-                    deserialize<_i206.TestEnum>(v),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<String, _i210.TestEnumStringified>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<_i210.TestEnumStringified>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<String, _i210.TestEnumStringified>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) => MapEntry(
-                    deserialize<String>(k),
-                    deserialize<_i210.TestEnumStringified>(v),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<Map<String, _i211.Types>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) => MapEntry(
-                    deserialize<String>(k),
-                    deserialize<_i211.Types>(v),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<String, Map<String, _i211.Types>>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<Map<String, _i211.Types>>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<String, Map<String, _i211.Types>>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) => MapEntry(
-                    deserialize<String>(k),
-                    deserialize<Map<String, _i211.Types>>(v),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<String, List<_i211.Types>>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<List<_i211.Types>>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<String, List<_i211.Types>>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) => MapEntry(
-                    deserialize<String>(k),
-                    deserialize<List<_i211.Types>>(v),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<String, (String,)>) {
-      return (data as Map).map(
-            (k, v) =>
-                MapEntry(deserialize<String>(k), deserialize<(String,)>(v)),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(String,)>()) {
-      return (deserialize<String>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<Map<String, (String,)>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) => MapEntry(
-                    deserialize<String>(k),
-                    deserialize<(String,)>(v),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(String,)>()) {
-      return (deserialize<String>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == Map<String, (String,)?>) {
-      return (data as Map).map(
-            (k, v) =>
-                MapEntry(deserialize<String>(k), deserialize<(String,)?>(v)),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(String,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<String>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<Map<String, (String,)?>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) => MapEntry(
-                    deserialize<String>(k),
-                    deserialize<(String,)?>(v),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(String,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<String>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == Map<(String,)?, String>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) => MapEntry(
-                deserialize<(String,)?>(e['k']),
-                deserialize<String>(e['v']),
-              ),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(String,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<String>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<Map<(String,)?, String>?>()) {
-      return (data != null
-              ? Map.fromEntries(
-                  (data as List).map(
-                    (e) => MapEntry(
-                      deserialize<(String,)?>(e['k']),
-                      deserialize<String>(e['v']),
-                    ),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(String,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<String>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(int,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(double,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<double>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(DateTime,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<DateTime>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(String,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<String>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(_i220.ByteData,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<_i220.ByteData>(((data as Map)['p'] as List)[0]),)
-                as T;
-    }
-    if (t == _i1.getType<(Duration,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<Duration>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(_i1.UuidValue,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<_i1.UuidValue>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(Uri,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<Uri>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(BigInt,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<BigInt>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(_i206.TestEnum,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<_i206.TestEnum>(((data as Map)['p'] as List)[0]),)
-                as T;
-    }
-    if (t == _i1.getType<(List<int>,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<List<int>>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(Map<int, int>,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<Map<int, int>>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(Set<int>,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<Set<int>>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(_i200.SimpleData,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<_i200.SimpleData>(((data as Map)['p'] as List)[0]),)
-                as T;
-    }
-    if (t == _i1.getType<({_i200.SimpleData namedModel})?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  namedModel: deserialize<_i200.SimpleData>(
-                    ((data as Map)['n'] as Map)['namedModel'],
-                  ),
-                )
-                as T;
-    }
-    if (t ==
-        _i1.getType<(_i200.SimpleData, {_i200.SimpleData namedModel})?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<_i200.SimpleData>(
-                    ((data as Map)['p'] as List)[0],
-                  ),
-                  namedModel: deserialize<_i200.SimpleData>(
-                    data['n']['namedModel'],
-                  ),
-                )
-                as T;
-    }
-    if (t ==
-        _i1.getType<((int, String), {(int, String) namedNestedRecord})?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<(int, String)>(((data as Map)['p'] as List)[0]),
-                  namedNestedRecord: deserialize<(int, String)>(
-                    data['n']['namedNestedRecord'],
-                  ),
-                )
-                as T;
-    }
-    if (t ==
-        _i1
-            .getType<
-              (
-                (List<(_i200.SimpleData,)>,), {
-                (_i200.SimpleData, Map<String, _i200.SimpleData>)
-                namedNestedRecord,
-              })?
-            >()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<(List<(_i200.SimpleData,)>,)>(
-                    ((data as Map)['p'] as List)[0],
-                  ),
-                  namedNestedRecord:
-                      deserialize<
-                        (_i200.SimpleData, Map<String, _i200.SimpleData>)
-                      >(data['n']['namedNestedRecord']),
-                )
-                as T;
-    }
-    if (t == Set<bool>) {
-      return (data as List).map((e) => deserialize<bool>(e)).toSet() as T;
-    }
-    if (t == _i1.getType<Set<bool>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<bool>(e)).toSet()
-              : null)
-          as T;
-    }
-    if (t == Set<double>) {
-      return (data as List).map((e) => deserialize<double>(e)).toSet() as T;
-    }
-    if (t == _i1.getType<Set<double>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<double>(e)).toSet()
-              : null)
-          as T;
-    }
-    if (t == Set<DateTime>) {
-      return (data as List).map((e) => deserialize<DateTime>(e)).toSet() as T;
-    }
-    if (t == _i1.getType<Set<DateTime>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<DateTime>(e)).toSet()
-              : null)
-          as T;
-    }
-    if (t == Set<String>) {
-      return (data as List).map((e) => deserialize<String>(e)).toSet() as T;
-    }
-    if (t == _i1.getType<Set<String>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<String>(e)).toSet()
-              : null)
-          as T;
-    }
-    if (t == Set<_i220.ByteData>) {
-      return (data as List).map((e) => deserialize<_i220.ByteData>(e)).toSet()
-          as T;
-    }
-    if (t == _i1.getType<Set<_i220.ByteData>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i220.ByteData>(e))
-                    .toSet()
-              : null)
-          as T;
-    }
-    if (t == Set<Duration>) {
-      return (data as List).map((e) => deserialize<Duration>(e)).toSet() as T;
-    }
-    if (t == _i1.getType<Set<Duration>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<Duration>(e)).toSet()
-              : null)
-          as T;
-    }
-    if (t == Set<_i1.UuidValue>) {
-      return (data as List).map((e) => deserialize<_i1.UuidValue>(e)).toSet()
-          as T;
-    }
-    if (t == _i1.getType<Set<_i1.UuidValue>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<_i1.UuidValue>(e)).toSet()
-              : null)
-          as T;
-    }
-    if (t == Set<BigInt>) {
-      return (data as List).map((e) => deserialize<BigInt>(e)).toSet() as T;
-    }
-    if (t == _i1.getType<Set<BigInt>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<BigInt>(e)).toSet()
-              : null)
-          as T;
-    }
-    if (t == Set<_i206.TestEnum>) {
-      return (data as List).map((e) => deserialize<_i206.TestEnum>(e)).toSet()
-          as T;
-    }
-    if (t == _i1.getType<Set<_i206.TestEnum>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i206.TestEnum>(e))
-                    .toSet()
-              : null)
-          as T;
-    }
-    if (t == Set<_i210.TestEnumStringified>) {
-      return (data as List)
-              .map((e) => deserialize<_i210.TestEnumStringified>(e))
-              .toSet()
-          as T;
-    }
-    if (t == _i1.getType<Set<_i210.TestEnumStringified>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i210.TestEnumStringified>(e))
-                    .toSet()
-              : null)
-          as T;
-    }
-    if (t == Set<_i211.Types>) {
-      return (data as List).map((e) => deserialize<_i211.Types>(e)).toSet()
-          as T;
-    }
-    if (t == _i1.getType<Set<_i211.Types>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<_i211.Types>(e)).toSet()
-              : null)
-          as T;
-    }
-    if (t == Set<Map<String, _i211.Types>>) {
-      return (data as List)
-              .map((e) => deserialize<Map<String, _i211.Types>>(e))
-              .toSet()
-          as T;
-    }
-    if (t == _i1.getType<Set<Map<String, _i211.Types>>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<Map<String, _i211.Types>>(e))
-                    .toSet()
-              : null)
-          as T;
-    }
-    if (t == Set<List<_i211.Types>>) {
-      return (data as List)
-              .map((e) => deserialize<List<_i211.Types>>(e))
-              .toSet()
-          as T;
-    }
-    if (t == _i1.getType<Set<List<_i211.Types>>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<List<_i211.Types>>(e))
-                    .toSet()
-              : null)
-          as T;
-    }
-    if (t == Set<(int,)>) {
-      return (data as List).map((e) => deserialize<(int,)>(e)).toSet() as T;
-    }
-    if (t == _i1.getType<(int,)>()) {
-      return (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<Set<(int,)>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<(int,)>(e)).toSet()
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(int,)>()) {
-      return (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == Set<(int,)?>) {
-      return (data as List).map((e) => deserialize<(int,)?>(e)).toSet() as T;
-    }
-    if (t == _i1.getType<(int,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<Set<(int,)?>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<(int,)?>(e)).toSet()
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(int,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == List<String>) {
-      return (data as List).map((e) => deserialize<String>(e)).toList() as T;
-    }
-    if (t == _i1.getType<List<String>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<String>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i222.SimpleData>) {
-      return (data as List)
-              .map((e) => deserialize<_i222.SimpleData>(e))
-              .toList()
-          as T;
-    }
-    if (t == List<int>) {
-      return (data as List).map((e) => deserialize<int>(e)).toList() as T;
-    }
-    if (t == List<List<int>>) {
-      return (data as List).map((e) => deserialize<List<int>>(e)).toList() as T;
-    }
-    if (t == _i1.getType<List<int>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<int>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == List<List<int>?>) {
-      return (data as List).map((e) => deserialize<List<int>?>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<List<int>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<int>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<List<List<int>>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<List<int>>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == List<int?>) {
-      return (data as List).map((e) => deserialize<int?>(e)).toList() as T;
-    }
-    if (t == _i1.getType<List<int?>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<int?>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == List<double>) {
-      return (data as List).map((e) => deserialize<double>(e)).toList() as T;
-    }
-    if (t == List<double?>) {
-      return (data as List).map((e) => deserialize<double?>(e)).toList() as T;
-    }
-    if (t == List<bool>) {
-      return (data as List).map((e) => deserialize<bool>(e)).toList() as T;
-    }
-    if (t == List<bool?>) {
-      return (data as List).map((e) => deserialize<bool?>(e)).toList() as T;
-    }
-    if (t == List<String?>) {
-      return (data as List).map((e) => deserialize<String?>(e)).toList() as T;
-    }
-    if (t == List<DateTime>) {
-      return (data as List).map((e) => deserialize<DateTime>(e)).toList() as T;
-    }
-    if (t == List<DateTime?>) {
-      return (data as List).map((e) => deserialize<DateTime?>(e)).toList() as T;
-    }
-    if (t == List<_i220.ByteData>) {
-      return (data as List).map((e) => deserialize<_i220.ByteData>(e)).toList()
-          as T;
-    }
-    if (t == List<_i220.ByteData?>) {
-      return (data as List).map((e) => deserialize<_i220.ByteData?>(e)).toList()
-          as T;
-    }
-    if (t == List<_i222.SimpleData?>) {
-      return (data as List)
-              .map((e) => deserialize<_i222.SimpleData?>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i222.SimpleData>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i222.SimpleData>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<List<_i222.SimpleData?>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i222.SimpleData?>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<Duration>) {
-      return (data as List).map((e) => deserialize<Duration>(e)).toList() as T;
-    }
-    if (t == List<Duration?>) {
-      return (data as List).map((e) => deserialize<Duration?>(e)).toList() as T;
-    }
-    if (t == Map<String, int>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(deserialize<String>(k), deserialize<int>(v)),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<String, int>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) =>
-                      MapEntry(deserialize<String>(k), deserialize<int>(v)),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<String, Map<String, int>>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<Map<String, int>>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == Map<String, int?>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(deserialize<String>(k), deserialize<int?>(v)),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<String, int?>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) =>
-                      MapEntry(deserialize<String>(k), deserialize<int?>(v)),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<int, int>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) =>
-                  MapEntry(deserialize<int>(e['k']), deserialize<int>(e['v'])),
-            ),
-          )
-          as T;
-    }
-    if (t == Map<String, Map<int, int>>) {
-      return (data as Map).map(
-            (k, v) =>
-                MapEntry(deserialize<String>(k), deserialize<Map<int, int>>(v)),
-          )
-          as T;
-    }
-    if (t == Map<_i223.TestEnum, int>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) => MapEntry(
-                deserialize<_i223.TestEnum>(e['k']),
-                deserialize<int>(e['v']),
-              ),
-            ),
-          )
-          as T;
-    }
-    if (t == Map<String, _i223.TestEnum>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<_i223.TestEnum>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == Map<String, double>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(deserialize<String>(k), deserialize<double>(v)),
-          )
-          as T;
-    }
-    if (t == Map<String, double?>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(deserialize<String>(k), deserialize<double?>(v)),
-          )
-          as T;
-    }
-    if (t == Map<String, bool>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(deserialize<String>(k), deserialize<bool>(v)),
-          )
-          as T;
-    }
-    if (t == Map<String, bool?>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(deserialize<String>(k), deserialize<bool?>(v)),
-          )
-          as T;
-    }
-    if (t == Map<String, String>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(deserialize<String>(k), deserialize<String>(v)),
-          )
-          as T;
-    }
-    if (t == Map<String, String?>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(deserialize<String>(k), deserialize<String?>(v)),
-          )
-          as T;
-    }
-    if (t == Map<String, DateTime>) {
-      return (data as Map).map(
-            (k, v) =>
-                MapEntry(deserialize<String>(k), deserialize<DateTime>(v)),
-          )
-          as T;
-    }
-    if (t == Map<String, DateTime?>) {
-      return (data as Map).map(
-            (k, v) =>
-                MapEntry(deserialize<String>(k), deserialize<DateTime?>(v)),
-          )
-          as T;
-    }
-    if (t == Map<String, _i220.ByteData>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<_i220.ByteData>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == Map<String, _i220.ByteData?>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<_i220.ByteData?>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == Map<String, _i222.SimpleData>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<_i222.SimpleData>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == Map<String, _i222.SimpleData?>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<_i222.SimpleData?>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<String, _i222.SimpleData>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) => MapEntry(
-                    deserialize<String>(k),
-                    deserialize<_i222.SimpleData>(v),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<Map<String, _i222.SimpleData?>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) => MapEntry(
-                    deserialize<String>(k),
-                    deserialize<_i222.SimpleData?>(v),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<String, Duration>) {
-      return (data as Map).map(
-            (k, v) =>
-                MapEntry(deserialize<String>(k), deserialize<Duration>(v)),
-          )
-          as T;
-    }
-    if (t == Map<String, Duration?>) {
-      return (data as Map).map(
-            (k, v) =>
-                MapEntry(deserialize<String>(k), deserialize<Duration?>(v)),
-          )
-          as T;
-    }
-    if (t == Map<(Map<int, String>, String), String>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) => MapEntry(
-                deserialize<(Map<int, String>, String)>(e['k']),
-                deserialize<String>(e['v']),
-              ),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(Map<int, String>, String)>()) {
-      return (
-            deserialize<Map<int, String>>(((data as Map)['p'] as List)[0]),
-            deserialize<String>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(Map<int, String>, String)>()) {
-      return (
-            deserialize<Map<int, String>>(((data as Map)['p'] as List)[0]),
-            deserialize<String>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == Map<int, String>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) => MapEntry(
-                deserialize<int>(e['k']),
-                deserialize<String>(e['v']),
-              ),
-            ),
-          )
-          as T;
-    }
-    if (t == Map<String, (Map<int, int>,)>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<(Map<int, int>,)>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(Map<int, int>,)>()) {
-      return (deserialize<Map<int, int>>(((data as Map)['p'] as List)[0]),)
-          as T;
-    }
-    if (t == _i1.getType<(Map<int, int>,)>()) {
-      return (deserialize<Map<int, int>>(((data as Map)['p'] as List)[0]),)
-          as T;
-    }
-    if (t == Map<DateTime, bool>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) => MapEntry(
-                deserialize<DateTime>(e['k']),
-                deserialize<bool>(e['v']),
-              ),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<DateTime, bool>?>()) {
-      return (data != null
-              ? Map.fromEntries(
-                  (data as List).map(
-                    (e) => MapEntry(
-                      deserialize<DateTime>(e['k']),
-                      deserialize<bool>(e['v']),
-                    ),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<Map<int, String>?>()) {
-      return (data != null
-              ? Map.fromEntries(
-                  (data as List).map(
-                    (e) => MapEntry(
-                      deserialize<int>(e['k']),
-                      deserialize<String>(e['v']),
-                    ),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == List<_i3.UserInfo>) {
-      return (data as List).map((e) => deserialize<_i3.UserInfo>(e)).toList()
-          as T;
-    }
-    if (t == Set<int>) {
-      return (data as List).map((e) => deserialize<int>(e)).toSet() as T;
-    }
-    if (t == Set<_i222.SimpleData>) {
-      return (data as List).map((e) => deserialize<_i222.SimpleData>(e)).toSet()
-          as T;
-    }
-    if (t == List<Set<_i222.SimpleData>>) {
-      return (data as List)
-              .map((e) => deserialize<Set<_i222.SimpleData>>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<(int, BigInt)>()) {
-      return (
-            deserialize<int>(((data as Map)['p'] as List)[0]),
-            deserialize<BigInt>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(String, _i224.PolymorphicParent)>()) {
-      return (
-            deserialize<String>(((data as Map)['p'] as List)[0]),
-            deserialize<_i224.PolymorphicParent>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(int,)>()) {
-      return (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(int,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(int?,)>()) {
-      return (
-            ((data as Map)['p'] as List)[0] == null
-                ? null
-                : deserialize<int>(data['p'][0]),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(int?,)?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  ((data as Map)['p'] as List)[0] == null
-                      ? null
-                      : deserialize<int>(data['p'][0]),
-                )
-                as T;
-    }
-    if (t == _i1.getType<(int, String)>()) {
-      return (
-            deserialize<int>(((data as Map)['p'] as List)[0]),
-            deserialize<String>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(int, String)?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<int>(((data as Map)['p'] as List)[0]),
-                  deserialize<String>(data['p'][1]),
-                )
-                as T;
-    }
-    if (t == _i1.getType<(int, _i222.SimpleData)>()) {
-      return (
-            deserialize<int>(((data as Map)['p'] as List)[0]),
-            deserialize<_i222.SimpleData>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(int, _i222.SimpleData)?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<int>(((data as Map)['p'] as List)[0]),
-                  deserialize<_i222.SimpleData>(data['p'][1]),
-                )
-                as T;
-    }
-    if (t == _i1.getType<(Map<String, int>,)>()) {
-      return (deserialize<Map<String, int>>(((data as Map)['p'] as List)[0]),)
-          as T;
-    }
-    if (t == _i1.getType<(Set<(int,)>,)>()) {
-      return (deserialize<Set<(int,)>>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == Set<(int,)>) {
-      return (data as List).map((e) => deserialize<(int,)>(e)).toSet() as T;
-    }
-    if (t == _i1.getType<(int,)>()) {
-      return (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<({int number, String text})>()) {
-      return (
-            number: deserialize<int>(((data as Map)['n'] as Map)['number']),
-            text: deserialize<String>(data['n']['text']),
-          )
-          as T;
-    }
-    if (t == _i1.getType<({int number, String text})?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  number: deserialize<int>(
-                    ((data as Map)['n'] as Map)['number'],
-                  ),
-                  text: deserialize<String>(data['n']['text']),
-                )
-                as T;
-    }
-    if (t == _i1.getType<({_i222.SimpleData data, int number})>()) {
-      return (
-            data: deserialize<_i222.SimpleData>(
-              ((data as Map)['n'] as Map)['data'],
-            ),
-            number: deserialize<int>(data['n']['number']),
-          )
-          as T;
-    }
-    if (t == _i1.getType<({_i222.SimpleData data, int number})?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  data: deserialize<_i222.SimpleData>(
-                    ((data as Map)['n'] as Map)['data'],
-                  ),
-                  number: deserialize<int>(data['n']['number']),
-                )
-                as T;
-    }
-    if (t == _i1.getType<({_i222.SimpleData? data, int? number})>()) {
-      return (
-            data: ((data as Map)['n'] as Map)['data'] == null
-                ? null
-                : deserialize<_i222.SimpleData>(data['n']['data']),
-            number: ((data)['n'] as Map)['number'] == null
-                ? null
-                : deserialize<int>(data['n']['number']),
-          )
-          as T;
-    }
-    if (t == _i1.getType<({Map<int, int> intIntMap})>()) {
-      return (
-            intIntMap: deserialize<Map<int, int>>(
-              ((data as Map)['n'] as Map)['intIntMap'],
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<({Set<(bool,)> boolSet})>()) {
-      return (
-            boolSet: deserialize<Set<(bool,)>>(
-              ((data as Map)['n'] as Map)['boolSet'],
-            ),
-          )
-          as T;
-    }
-    if (t == Set<(bool,)>) {
-      return (data as List).map((e) => deserialize<(bool,)>(e)).toSet() as T;
-    }
-    if (t == _i1.getType<(bool,)>()) {
-      return (deserialize<bool>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(bool,)>()) {
-      return (deserialize<bool>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(Map<(Map<int, String>, String), String>,)>()) {
-      return (
-            deserialize<Map<(Map<int, String>, String), String>>(
-              ((data as Map)['p'] as List)[0],
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(int, {_i222.SimpleData data})>()) {
-      return (
-            deserialize<int>(((data as Map)['p'] as List)[0]),
-            data: deserialize<_i222.SimpleData>(data['n']['data']),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(int, {_i222.SimpleData data})?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<int>(((data as Map)['p'] as List)[0]),
-                  data: deserialize<_i222.SimpleData>(data['n']['data']),
-                )
-                as T;
-    }
-    if (t == List<(int, _i222.SimpleData)>) {
-      return (data as List)
-              .map((e) => deserialize<(int, _i222.SimpleData)>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<(int, _i222.SimpleData)>()) {
-      return (
-            deserialize<int>(((data as Map)['p'] as List)[0]),
-            deserialize<_i222.SimpleData>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == List<(int, _i222.SimpleData)?>) {
-      return (data as List)
-              .map((e) => deserialize<(int, _i222.SimpleData)?>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<(int, _i222.SimpleData)?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<int>(((data as Map)['p'] as List)[0]),
-                  deserialize<_i222.SimpleData>(data['p'][1]),
-                )
-                as T;
-    }
-    if (t == Set<(int, _i222.SimpleData)>) {
-      return (data as List)
-              .map((e) => deserialize<(int, _i222.SimpleData)>(e))
-              .toSet()
-          as T;
-    }
-    if (t == _i1.getType<(int, _i222.SimpleData)>()) {
-      return (
-            deserialize<int>(((data as Map)['p'] as List)[0]),
-            deserialize<_i222.SimpleData>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == Set<(int, _i222.SimpleData)?>) {
-      return (data as List)
-              .map((e) => deserialize<(int, _i222.SimpleData)?>(e))
-              .toSet()
-          as T;
-    }
-    if (t == _i1.getType<(int, _i222.SimpleData)?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<int>(((data as Map)['p'] as List)[0]),
-                  deserialize<_i222.SimpleData>(data['p'][1]),
-                )
-                as T;
-    }
-    if (t == _i1.getType<(int, _i222.SimpleData)>()) {
-      return (
-            deserialize<int>(((data as Map)['p'] as List)[0]),
-            deserialize<_i222.SimpleData>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Set<(int, _i222.SimpleData)>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<(int, _i222.SimpleData)>(e))
-                    .toSet()
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(int, _i222.SimpleData)>()) {
-      return (
-            deserialize<int>(((data as Map)['p'] as List)[0]),
-            deserialize<_i222.SimpleData>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == Map<String, (int, _i222.SimpleData)>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<(int, _i222.SimpleData)>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(int, _i222.SimpleData)>()) {
-      return (
-            deserialize<int>(((data as Map)['p'] as List)[0]),
-            deserialize<_i222.SimpleData>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == Map<String, (int, _i222.SimpleData)?>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<(int, _i222.SimpleData)?>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(int, _i222.SimpleData)?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<int>(((data as Map)['p'] as List)[0]),
-                  deserialize<_i222.SimpleData>(data['p'][1]),
-                )
-                as T;
-    }
-    if (t == Map<(String, int), (int, _i222.SimpleData)>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) => MapEntry(
-                deserialize<(String, int)>(e['k']),
-                deserialize<(int, _i222.SimpleData)>(e['v']),
-              ),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(String, int)>()) {
-      return (
-            deserialize<String>(((data as Map)['p'] as List)[0]),
-            deserialize<int>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(int, _i222.SimpleData)>()) {
-      return (
-            deserialize<int>(((data as Map)['p'] as List)[0]),
-            deserialize<_i222.SimpleData>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(String, int)>()) {
-      return (
-            deserialize<String>(((data as Map)['p'] as List)[0]),
-            deserialize<int>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == Map<String, List<Set<(int,)>>>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<List<Set<(int,)>>>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == List<Set<(int,)>>) {
-      return (data as List).map((e) => deserialize<Set<(int,)>>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<(int,)>()) {
-      return (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(int,)>()) {
-      return (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == Set<List<Map<String, (int,)>>>) {
-      return (data as List)
-              .map((e) => deserialize<List<Map<String, (int,)>>>(e))
-              .toSet()
-          as T;
-    }
-    if (t == List<Map<String, (int,)>>) {
-      return (data as List)
-              .map((e) => deserialize<Map<String, (int,)>>(e))
-              .toList()
-          as T;
-    }
-    if (t == Map<String, (int,)>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(deserialize<String>(k), deserialize<(int,)>(v)),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(int,)>()) {
-      return (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(int,)>()) {
-      return (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(int,)>()) {
-      return (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<({(_i222.SimpleData, double) namedSubRecord})>()) {
-      return (
-            namedSubRecord: deserialize<(_i222.SimpleData, double)>(
-              ((data as Map)['n'] as Map)['namedSubRecord'],
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(_i222.SimpleData, double)>()) {
-      return (
-            deserialize<_i222.SimpleData>(((data as Map)['p'] as List)[0]),
-            deserialize<double>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == _i1.getType<({(_i222.SimpleData, double)? namedSubRecord})>()) {
-      return (
-            namedSubRecord:
-                ((data as Map)['n'] as Map)['namedSubRecord'] == null
-                ? null
-                : deserialize<(_i222.SimpleData, double)>(
-                    data['n']['namedSubRecord'],
-                  ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(_i222.SimpleData, double)?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<_i222.SimpleData>(
-                    ((data as Map)['p'] as List)[0],
-                  ),
-                  deserialize<double>(data['p'][1]),
-                )
-                as T;
-    }
-    if (t ==
-        _i1
-            .getType<
-              ((int, String), {(_i222.SimpleData, double) namedSubRecord})
-            >()) {
-      return (
-            deserialize<(int, String)>(((data as Map)['p'] as List)[0]),
-            namedSubRecord: deserialize<(_i222.SimpleData, double)>(
-              data['n']['namedSubRecord'],
-            ),
-          )
-          as T;
-    }
-    if (t ==
-        List<((int, String), {(_i222.SimpleData, double) namedSubRecord})>) {
-      return (data as List)
-              .map(
-                (e) =>
-                    deserialize<
-                      (
-                        (int, String), {
-                        (_i222.SimpleData, double) namedSubRecord,
-                      })
-                    >(e),
-              )
-              .toList()
-          as T;
-    }
-    if (t ==
-        _i1
-            .getType<
-              ((int, String), {(_i222.SimpleData, double) namedSubRecord})
-            >()) {
-      return (
-            deserialize<(int, String)>(((data as Map)['p'] as List)[0]),
-            namedSubRecord: deserialize<(_i222.SimpleData, double)>(
-              data['n']['namedSubRecord'],
-            ),
-          )
-          as T;
-    }
-    if (t ==
-        List<((int, String), {(_i222.SimpleData, double) namedSubRecord})?>) {
-      return (data as List)
-              .map(
-                (e) =>
-                    deserialize<
-                      (
-                        (int, String), {
-                        (_i222.SimpleData, double) namedSubRecord,
-                      })?
-                    >(e),
-              )
-              .toList()
-          as T;
-    }
-    if (t ==
-        _i1
-            .getType<
-              ((int, String), {(_i222.SimpleData, double) namedSubRecord})?
-            >()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<(int, String)>(((data as Map)['p'] as List)[0]),
-                  namedSubRecord: deserialize<(_i222.SimpleData, double)>(
-                    data['n']['namedSubRecord'],
-                  ),
-                )
-                as T;
-    }
-    if (t ==
-        _i1
-            .getType<
-              List<
-                ((int, String), {(_i222.SimpleData, double) namedSubRecord})?
-              >?
-            >()) {
-      return (data != null
-              ? (data as List)
-                    .map(
-                      (e) =>
-                          deserialize<
-                            (
-                              (int, String), {
-                              (_i222.SimpleData, double) namedSubRecord,
-                            })?
-                          >(e),
-                    )
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t ==
-        _i1
-            .getType<
-              ((int, String), {(_i222.SimpleData, double) namedSubRecord})?
-            >()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<(int, String)>(((data as Map)['p'] as List)[0]),
-                  namedSubRecord: deserialize<(_i222.SimpleData, double)>(
-                    data['n']['namedSubRecord'],
-                  ),
-                )
-                as T;
-    }
-    if (t ==
-        _i1
-            .getType<
-              ((int, String), {(_i222.SimpleData, double) namedSubRecord})?
-            >()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<(int, String)>(((data as Map)['p'] as List)[0]),
-                  namedSubRecord: deserialize<(_i222.SimpleData, double)>(
-                    data['n']['namedSubRecord'],
-                  ),
-                )
-                as T;
-    }
-    if (t == _i1.getType<(int?, _i4.ProjectStreamingClass?)>()) {
-      return (
-            ((data as Map)['p'] as List)[0] == null
-                ? null
-                : deserialize<int>(data['p'][0]),
-            ((data)['p'] as List)[1] == null
-                ? null
-                : deserialize<_i4.ProjectStreamingClass>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == Set<Set<int>>) {
-      return (data as List).map((e) => deserialize<Set<int>>(e)).toSet() as T;
-    }
-    if (t == Set<List<int>>) {
-      return (data as List).map((e) => deserialize<List<int>>(e)).toSet() as T;
-    }
-    if (t == _i1.getType<Set<int>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<int>(e)).toSet()
-              : null)
-          as T;
-    }
-    if (t == Set<Set<int>?>) {
-      return (data as List).map((e) => deserialize<Set<int>?>(e)).toSet() as T;
-    }
-    if (t == _i1.getType<Set<int>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<int>(e)).toSet()
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<Set<Set<int>>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<Set<int>>(e)).toSet()
-              : null)
-          as T;
-    }
-    if (t == Set<int?>) {
-      return (data as List).map((e) => deserialize<int?>(e)).toSet() as T;
-    }
-    if (t == _i1.getType<Set<int?>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<int?>(e)).toSet()
-              : null)
-          as T;
-    }
-    if (t == Set<double>) {
-      return (data as List).map((e) => deserialize<double>(e)).toSet() as T;
-    }
-    if (t == Set<double?>) {
-      return (data as List).map((e) => deserialize<double?>(e)).toSet() as T;
-    }
-    if (t == Set<bool>) {
-      return (data as List).map((e) => deserialize<bool>(e)).toSet() as T;
-    }
-    if (t == Set<bool?>) {
-      return (data as List).map((e) => deserialize<bool?>(e)).toSet() as T;
-    }
-    if (t == Set<String>) {
-      return (data as List).map((e) => deserialize<String>(e)).toSet() as T;
-    }
-    if (t == Set<String?>) {
-      return (data as List).map((e) => deserialize<String?>(e)).toSet() as T;
-    }
-    if (t == Set<DateTime>) {
-      return (data as List).map((e) => deserialize<DateTime>(e)).toSet() as T;
-    }
-    if (t == Set<DateTime?>) {
-      return (data as List).map((e) => deserialize<DateTime?>(e)).toSet() as T;
-    }
-    if (t == Set<_i220.ByteData>) {
-      return (data as List).map((e) => deserialize<_i220.ByteData>(e)).toSet()
-          as T;
-    }
-    if (t == Set<_i220.ByteData?>) {
-      return (data as List).map((e) => deserialize<_i220.ByteData?>(e)).toSet()
-          as T;
-    }
-    if (t == Set<_i222.SimpleData?>) {
-      return (data as List)
-              .map((e) => deserialize<_i222.SimpleData?>(e))
-              .toSet()
-          as T;
-    }
-    if (t == Set<Duration>) {
-      return (data as List).map((e) => deserialize<Duration>(e)).toSet() as T;
-    }
-    if (t == Set<Duration?>) {
-      return (data as List).map((e) => deserialize<Duration?>(e)).toSet() as T;
-    }
-    if (t == List<_i225.Types>) {
-      return (data as List).map((e) => deserialize<_i225.Types>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<(String, (int, bool))>()) {
-      return (
-            deserialize<String>(((data as Map)['p'] as List)[0]),
-            deserialize<(int, bool)>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(int, bool)>()) {
-      return (
-            deserialize<int>(((data as Map)['p'] as List)[0]),
-            deserialize<bool>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == List<(String, (int, bool))>) {
-      return (data as List)
-              .map((e) => deserialize<(String, (int, bool))>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<(String, (int, bool))>()) {
-      return (
-            deserialize<String>(((data as Map)['p'] as List)[0]),
-            deserialize<(int, bool)>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t ==
-        _i1
-            .getType<
-              (
-                String,
-                (Map<String, int>, {bool flag, _i222.SimpleData simpleData}),
-              )
-            >()) {
-      return (
-            deserialize<String>(((data as Map)['p'] as List)[0]),
-            deserialize<
-              (Map<String, int>, {bool flag, _i222.SimpleData simpleData})
-            >(data['p'][1]),
-          )
-          as T;
-    }
-    if (t ==
-        _i1
-            .getType<
-              (Map<String, int>, {bool flag, _i222.SimpleData simpleData})
-            >()) {
-      return (
-            deserialize<Map<String, int>>(((data as Map)['p'] as List)[0]),
-            flag: deserialize<bool>(data['n']['flag']),
-            simpleData: deserialize<_i222.SimpleData>(data['n']['simpleData']),
-          )
-          as T;
-    }
-    if (t == List<(String, int)>) {
-      return (data as List).map((e) => deserialize<(String, int)>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<(String, int)>()) {
-      return (
-            deserialize<String>(((data as Map)['p'] as List)[0]),
-            deserialize<int>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t ==
-        _i1
-            .getType<
-              (
-                String,
-                (Map<String, int>, {bool flag, _i222.SimpleData simpleData}),
-              )?
-            >()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<String>(((data as Map)['p'] as List)[0]),
-                  deserialize<
-                    (Map<String, int>, {bool flag, _i222.SimpleData simpleData})
-                  >(data['p'][1]),
-                )
-                as T;
-    }
-    if (t == _i1.getType<(String, int)>()) {
-      return (
-            deserialize<String>(((data as Map)['p'] as List)[0]),
-            deserialize<int>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == _i1.getType<List<(String, int)>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<(String, int)>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(String, int)>()) {
-      return (
-            deserialize<String>(((data as Map)['p'] as List)[0]),
-            deserialize<int>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(int, String)>()) {
-      return (
-            deserialize<int>(((data as Map)['p'] as List)[0]),
-            deserialize<String>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(_i4.ModuleClass,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<_i4.ModuleClass>(((data as Map)['p'] as List)[0]),)
-                as T;
-    }
-    if (t == _i1.getType<(bool,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<bool>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(_i210.TestEnumStringified,)?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<_i210.TestEnumStringified>(
-                    ((data as Map)['p'] as List)[0],
-                  ),
-                )
-                as T;
-    }
-    if (t == _i1.getType<(_i210.TestEnumStringified,)>()) {
-      return (
-            deserialize<_i210.TestEnumStringified>(
-              ((data as Map)['p'] as List)[0],
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<List<(_i210.TestEnumStringified,)>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<(_i210.TestEnumStringified,)>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(_i210.TestEnumStringified,)>()) {
-      return (
-            deserialize<_i210.TestEnumStringified>(
-              ((data as Map)['p'] as List)[0],
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(_i210.TestEnumStringified,)>()) {
-      return (
-            deserialize<_i210.TestEnumStringified>(
-              ((data as Map)['p'] as List)[0],
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(_i157.Nullability,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<_i157.Nullability>(((data as Map)['p'] as List)[0]),)
-                as T;
-    }
-    if (t == _i1.getType<({_i210.TestEnumStringified value})?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  value: deserialize<_i210.TestEnumStringified>(
-                    ((data as Map)['n'] as Map)['value'],
-                  ),
-                )
-                as T;
-    }
-    if (t == _i1.getType<({_i210.TestEnumStringified value})>()) {
-      return (
-            value: deserialize<_i210.TestEnumStringified>(
-              ((data as Map)['n'] as Map)['value'],
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<List<({_i210.TestEnumStringified value})>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map(
-                      (e) =>
-                          deserialize<({_i210.TestEnumStringified value})>(e),
-                    )
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<({_i210.TestEnumStringified value})>()) {
-      return (
-            value: deserialize<_i210.TestEnumStringified>(
-              ((data as Map)['n'] as Map)['value'],
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<({_i210.TestEnumStringified value})>()) {
-      return (
-            value: deserialize<_i210.TestEnumStringified>(
-              ((data as Map)['n'] as Map)['value'],
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<({_i4.ModuleClass value})?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  value: deserialize<_i4.ModuleClass>(
-                    ((data as Map)['n'] as Map)['value'],
-                  ),
-                )
-                as T;
-    }
-    if (t == _i1.getType<({_i157.Nullability value})?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  value: deserialize<_i157.Nullability>(
-                    ((data as Map)['n'] as Map)['value'],
-                  ),
-                )
-                as T;
-    }
-    if (t == _i1.getType<(String, {Uri? optionalUri})?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<String>(((data as Map)['p'] as List)[0]),
-                  optionalUri: ((data)['n'] as Map)['optionalUri'] == null
-                      ? null
-                      : deserialize<Uri>(data['n']['optionalUri']),
-                )
-                as T;
-    }
-    if (t == _i1.getType<(int,)>()) {
-      return (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<List<(int,)>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<(int,)>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(int,)>()) {
-      return (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(int,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<List<(int,)?>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<(int,)?>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(int,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(_i206.TestEnum,)>()) {
-      return (deserialize<_i206.TestEnum>(((data as Map)['p'] as List)[0]),)
-          as T;
-    }
-    if (t == _i1.getType<List<(_i206.TestEnum,)>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<(_i206.TestEnum,)>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(_i206.TestEnum,)>()) {
-      return (deserialize<_i206.TestEnum>(((data as Map)['p'] as List)[0]),)
-          as T;
-    }
-    if (t == _i1.getType<(_i206.TestEnum,)>()) {
-      return (deserialize<_i206.TestEnum>(((data as Map)['p'] as List)[0]),)
-          as T;
-    }
-    if (t == _i1.getType<(String,)>()) {
-      return (deserialize<String>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<Map<(String,), String>?>()) {
-      return (data != null
-              ? Map.fromEntries(
-                  (data as List).map(
-                    (e) => MapEntry(
-                      deserialize<(String,)>(e['k']),
-                      deserialize<String>(e['v']),
-                    ),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(String,)>()) {
-      return (deserialize<String>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(String,)>()) {
-      return (deserialize<String>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(String,)>()) {
-      return (deserialize<String>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<Map<String, (String,)>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) => MapEntry(
-                    deserialize<String>(k),
-                    deserialize<(String,)>(v),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(String,)>()) {
-      return (deserialize<String>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(String,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<String>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<Map<String, (String,)?>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) => MapEntry(
-                    deserialize<String>(k),
-                    deserialize<(String,)?>(v),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(String,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<String>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(String,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<String>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(String,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<String>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<Map<(String,)?, String>?>()) {
-      return (data != null
-              ? Map.fromEntries(
-                  (data as List).map(
-                    (e) => MapEntry(
-                      deserialize<(String,)?>(e['k']),
-                      deserialize<String>(e['v']),
-                    ),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(String,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<String>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(double,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<double>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(DateTime,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<DateTime>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(_i220.ByteData,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<_i220.ByteData>(((data as Map)['p'] as List)[0]),)
-                as T;
-    }
-    if (t == _i1.getType<(Duration,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<Duration>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(_i1.UuidValue,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<_i1.UuidValue>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(Uri,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<Uri>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(BigInt,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<BigInt>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(_i206.TestEnum,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<_i206.TestEnum>(((data as Map)['p'] as List)[0]),)
-                as T;
-    }
-    if (t == _i1.getType<(List<int>,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<List<int>>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(Map<int, int>,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<Map<int, int>>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(Set<int>,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<Set<int>>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(_i200.SimpleData,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<_i200.SimpleData>(((data as Map)['p'] as List)[0]),)
-                as T;
-    }
-    if (t == _i1.getType<({_i200.SimpleData namedModel})?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  namedModel: deserialize<_i200.SimpleData>(
-                    ((data as Map)['n'] as Map)['namedModel'],
-                  ),
-                )
-                as T;
-    }
-    if (t ==
-        _i1.getType<(_i200.SimpleData, {_i200.SimpleData namedModel})?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<_i200.SimpleData>(
-                    ((data as Map)['p'] as List)[0],
-                  ),
-                  namedModel: deserialize<_i200.SimpleData>(
-                    data['n']['namedModel'],
-                  ),
-                )
-                as T;
-    }
-    if (t ==
-        _i1.getType<((int, String), {(int, String) namedNestedRecord})?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<(int, String)>(((data as Map)['p'] as List)[0]),
-                  namedNestedRecord: deserialize<(int, String)>(
-                    data['n']['namedNestedRecord'],
-                  ),
-                )
-                as T;
-    }
-    if (t ==
-        _i1
-            .getType<
-              (
-                (List<(_i200.SimpleData,)>,), {
-                (_i200.SimpleData, Map<String, _i200.SimpleData>)
-                namedNestedRecord,
-              })?
-            >()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<(List<(_i200.SimpleData,)>,)>(
-                    ((data as Map)['p'] as List)[0],
-                  ),
-                  namedNestedRecord:
-                      deserialize<
-                        (_i200.SimpleData, Map<String, _i200.SimpleData>)
-                      >(data['n']['namedNestedRecord']),
-                )
-                as T;
-    }
-    if (t == _i1.getType<(List<(_i200.SimpleData,)>,)>()) {
-      return (
-            deserialize<List<(_i200.SimpleData,)>>(
-              ((data as Map)['p'] as List)[0],
-            ),
-          )
-          as T;
-    }
-    if (t == List<(_i200.SimpleData,)>) {
-      return (data as List)
-              .map((e) => deserialize<(_i200.SimpleData,)>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<(_i200.SimpleData,)>()) {
-      return (deserialize<_i200.SimpleData>(((data as Map)['p'] as List)[0]),)
-          as T;
-    }
-    if (t == _i1.getType<(_i200.SimpleData,)>()) {
-      return (deserialize<_i200.SimpleData>(((data as Map)['p'] as List)[0]),)
-          as T;
-    }
-    if (t == _i1.getType<(_i200.SimpleData, Map<String, _i200.SimpleData>)>()) {
-      return (
-            deserialize<_i200.SimpleData>(((data as Map)['p'] as List)[0]),
-            deserialize<Map<String, _i200.SimpleData>>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(int,)>()) {
-      return (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<Set<(int,)>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<(int,)>(e)).toSet()
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(int,)>()) {
-      return (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(int,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<Set<(int,)?>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<(int,)?>(e)).toSet()
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(int,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i221.CustomClass) {
-      return _i221.CustomClass.fromJson(data) as T;
-    }
-    if (t == _i221.CustomClass2) {
-      return _i221.CustomClass2.fromJson(data) as T;
-    }
-    if (t == _i221.ProtocolCustomClass) {
-      return _i221.ProtocolCustomClass.fromJson(data) as T;
-    }
-    if (t == _i221.ExternalCustomClass) {
-      return _i221.ExternalCustomClass.fromJson(data) as T;
-    }
-    if (t == _i221.FreezedCustomClass) {
-      return _i221.FreezedCustomClass.fromJson(data) as T;
-    }
-    if (t == _i1.getType<_i221.CustomClass?>()) {
-      return (data != null ? _i221.CustomClass.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i221.CustomClass2?>()) {
-      return (data != null ? _i221.CustomClass2.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i221.CustomClassWithoutProtocolSerialization?>()) {
-      return (data != null
-              ? _i221.CustomClassWithoutProtocolSerialization.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i221.CustomClassWithProtocolSerialization?>()) {
-      return (data != null
-              ? _i221.CustomClassWithProtocolSerialization.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i221.CustomClassWithProtocolSerializationMethod?>()) {
-      return (data != null
-              ? _i221.CustomClassWithProtocolSerializationMethod.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i221.ProtocolCustomClass?>()) {
-      return (data != null ? _i221.ProtocolCustomClass.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i221.ExternalCustomClass?>()) {
-      return (data != null ? _i221.ExternalCustomClass.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i221.FreezedCustomClass?>()) {
-      return (data != null ? _i221.FreezedCustomClass.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<List<_i222.SimpleData>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i222.SimpleData>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(String, _i224.PolymorphicParent)>()) {
-      return (
-            deserialize<String>(((data as Map)['p'] as List)[0]),
-            deserialize<_i224.PolymorphicParent>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(int?,)?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  ((data as Map)['p'] as List)[0] == null
-                      ? null
-                      : deserialize<int>(data['p'][0]),
-                )
-                as T;
-    }
-    if (t ==
-        _i1
-            .getType<
-              ((int, String), {(_i222.SimpleData, double) namedSubRecord})?
-            >()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<(int, String)>(((data as Map)['p'] as List)[0]),
-                  namedSubRecord: deserialize<(_i222.SimpleData, double)>(
-                    data['n']['namedSubRecord'],
-                  ),
-                )
-                as T;
-    }
-    if (t ==
-        _i1
-            .getType<
-              List<
-                ((int, String), {(_i222.SimpleData, double) namedSubRecord})?
-              >?
-            >()) {
-      return (data != null
-              ? (data as List)
-                    .map(
-                      (e) =>
-                          deserialize<
-                            (
-                              (int, String), {
-                              (_i222.SimpleData, double) namedSubRecord,
-                            })?
-                          >(e),
-                    )
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t ==
-        _i1
-            .getType<
-              ((int, String), {(_i222.SimpleData, double) namedSubRecord})?
-            >()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<(int, String)>(((data as Map)['p'] as List)[0]),
-                  namedSubRecord: deserialize<(_i222.SimpleData, double)>(
-                    data['n']['namedSubRecord'],
-                  ),
-                )
-                as T;
-    }
-    if (t == _i1.getType<(int?, _i4.ProjectStreamingClass?)>()) {
-      return (
-            ((data as Map)['p'] as List)[0] == null
-                ? null
-                : deserialize<int>(data['p'][0]),
-            ((data)['p'] as List)[1] == null
-                ? null
-                : deserialize<_i4.ProjectStreamingClass>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t ==
-        _i1
-            .getType<
-              (
-                String,
-                (Map<String, int>, {bool flag, _i222.SimpleData simpleData}),
-              )
-            >()) {
-      return (
-            deserialize<String>(((data as Map)['p'] as List)[0]),
-            deserialize<
-              (Map<String, int>, {bool flag, _i222.SimpleData simpleData})
-            >(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(String, int)>()) {
-      return (
-            deserialize<String>(((data as Map)['p'] as List)[0]),
-            deserialize<int>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t ==
-        _i1
-            .getType<
-              (
-                String,
-                (Map<String, int>, {bool flag, _i222.SimpleData simpleData}),
-              )?
-            >()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<String>(((data as Map)['p'] as List)[0]),
-                  deserialize<
-                    (Map<String, int>, {bool flag, _i222.SimpleData simpleData})
-                  >(data['p'][1]),
-                )
-                as T;
-    }
-    if (t == _i1.getType<(String, int)>()) {
-      return (
-            deserialize<String>(((data as Map)['p'] as List)[0]),
-            deserialize<int>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == _i1.getType<List<(String, int)>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<(String, int)>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(String, int)>()) {
-      return (
-            deserialize<String>(((data as Map)['p'] as List)[0]),
-            deserialize<int>(data['p'][1]),
-          )
-          as T;
+    final fn = _deserializers[t];
+    if (fn != null) {
+      return fn(data, this) as T;
     }
     try {
       return _i3.Protocol().deserialize<T>(data, t);

--- a/tests/serverpod_test_server/lib/src/generated/protocol.dart
+++ b/tests/serverpod_test_server/lib/src/generated/protocol.dart
@@ -261,11 +261,11 @@ import 'types_set_required.dart' as _i230;
 import 'unique_data.dart' as _i231;
 import 'unique_data_with_non_persist.dart' as _i232;
 import 'upsert_test_model.dart' as _i233;
-import 'dart:typed_data' as _i234;
-import 'package:serverpod_test_server/src/generated/simple_data.dart' as _i235;
-import 'package:serverpod_test_server/src/generated/test_enum.dart' as _i236;
+import 'package:serverpod_test_server/src/generated/simple_data.dart' as _i234;
 import 'package:serverpod_test_server/src/generated/inheritance/polymorphism/parent.dart'
-    as _i237;
+    as _i235;
+import 'dart:typed_data' as _i236;
+import 'package:serverpod_test_server/src/generated/test_enum.dart' as _i237;
 import 'package:serverpod_test_server/src/generated/types.dart' as _i238;
 export 'by_index_enum_with_name_value.dart';
 export 'by_name_enum_with_name_value.dart';
@@ -498,6 +498,9 @@ class Protocol extends _i1.DatabaseSerializationManager {
   factory Protocol() => _instance;
 
   static final Protocol _instance = Protocol._().._registerHostProtocols();
+
+  static final Map<Type, dynamic Function(dynamic, Protocol)> _deserializers =
+      _buildDeserializers();
 
   static List<_i2.TableDefinition> get targetTableDefinitions => [
     _i2.TableDefinition(
@@ -6817,5548 +6820,9 @@ class Protocol extends _i1.DatabaseSerializationManager {
       }
     }
 
-    if (t == _i7.ByIndexEnumWithNameValue) {
-      return _i7.ByIndexEnumWithNameValue.fromJson(data) as T;
-    }
-    if (t == _i8.ByNameEnumWithNameValue) {
-      return _i8.ByNameEnumWithNameValue.fromJson(data) as T;
-    }
-    if (t == _i9.CourseUuid) {
-      return _i9.CourseUuid.fromJson(data) as T;
-    }
-    if (t == _i10.EnrollmentInt) {
-      return _i10.EnrollmentInt.fromJson(data) as T;
-    }
-    if (t == _i11.StudentUuid) {
-      return _i11.StudentUuid.fromJson(data) as T;
-    }
-    if (t == _i12.ArenaUuid) {
-      return _i12.ArenaUuid.fromJson(data) as T;
-    }
-    if (t == _i13.PlayerUuid) {
-      return _i13.PlayerUuid.fromJson(data) as T;
-    }
-    if (t == _i14.TeamInt) {
-      return _i14.TeamInt.fromJson(data) as T;
-    }
-    if (t == _i15.CommentInt) {
-      return _i15.CommentInt.fromJson(data) as T;
-    }
-    if (t == _i16.CustomerInt) {
-      return _i16.CustomerInt.fromJson(data) as T;
-    }
-    if (t == _i17.OrderUuid) {
-      return _i17.OrderUuid.fromJson(data) as T;
-    }
-    if (t == _i18.AddressUuid) {
-      return _i18.AddressUuid.fromJson(data) as T;
-    }
-    if (t == _i19.CitizenInt) {
-      return _i19.CitizenInt.fromJson(data) as T;
-    }
-    if (t == _i20.CompanyUuid) {
-      return _i20.CompanyUuid.fromJson(data) as T;
-    }
-    if (t == _i21.TownInt) {
-      return _i21.TownInt.fromJson(data) as T;
-    }
-    if (t == _i22.ChangedIdTypeSelf) {
-      return _i22.ChangedIdTypeSelf.fromJson(data) as T;
-    }
-    if (t == _i23.ServerOnlyChangedIdFieldClass) {
-      return _i23.ServerOnlyChangedIdFieldClass.fromJson(data) as T;
-    }
-    if (t == _i24.BigIntDefault) {
-      return _i24.BigIntDefault.fromJson(data) as T;
-    }
-    if (t == _i25.BigIntDefaultMix) {
-      return _i25.BigIntDefaultMix.fromJson(data) as T;
-    }
-    if (t == _i26.BigIntDefaultModel) {
-      return _i26.BigIntDefaultModel.fromJson(data) as T;
-    }
-    if (t == _i27.BigIntDefaultPersist) {
-      return _i27.BigIntDefaultPersist.fromJson(data) as T;
-    }
-    if (t == _i28.BoolDefault) {
-      return _i28.BoolDefault.fromJson(data) as T;
-    }
-    if (t == _i29.BoolDefaultMix) {
-      return _i29.BoolDefaultMix.fromJson(data) as T;
-    }
-    if (t == _i30.BoolDefaultModel) {
-      return _i30.BoolDefaultModel.fromJson(data) as T;
-    }
-    if (t == _i31.BoolDefaultPersist) {
-      return _i31.BoolDefaultPersist.fromJson(data) as T;
-    }
-    if (t == _i32.DateTimeDefault) {
-      return _i32.DateTimeDefault.fromJson(data) as T;
-    }
-    if (t == _i33.DateTimeDefaultMix) {
-      return _i33.DateTimeDefaultMix.fromJson(data) as T;
-    }
-    if (t == _i34.DateTimeDefaultModel) {
-      return _i34.DateTimeDefaultModel.fromJson(data) as T;
-    }
-    if (t == _i35.DateTimeDefaultPersist) {
-      return _i35.DateTimeDefaultPersist.fromJson(data) as T;
-    }
-    if (t == _i36.DoubleDefault) {
-      return _i36.DoubleDefault.fromJson(data) as T;
-    }
-    if (t == _i37.DoubleDefaultMix) {
-      return _i37.DoubleDefaultMix.fromJson(data) as T;
-    }
-    if (t == _i38.DoubleDefaultModel) {
-      return _i38.DoubleDefaultModel.fromJson(data) as T;
-    }
-    if (t == _i39.DoubleDefaultPersist) {
-      return _i39.DoubleDefaultPersist.fromJson(data) as T;
-    }
-    if (t == _i40.DurationDefault) {
-      return _i40.DurationDefault.fromJson(data) as T;
-    }
-    if (t == _i41.DurationDefaultMix) {
-      return _i41.DurationDefaultMix.fromJson(data) as T;
-    }
-    if (t == _i42.DurationDefaultModel) {
-      return _i42.DurationDefaultModel.fromJson(data) as T;
-    }
-    if (t == _i43.DurationDefaultPersist) {
-      return _i43.DurationDefaultPersist.fromJson(data) as T;
-    }
-    if (t == _i44.EnumDefault) {
-      return _i44.EnumDefault.fromJson(data) as T;
-    }
-    if (t == _i45.EnumDefaultMix) {
-      return _i45.EnumDefaultMix.fromJson(data) as T;
-    }
-    if (t == _i46.EnumDefaultModel) {
-      return _i46.EnumDefaultModel.fromJson(data) as T;
-    }
-    if (t == _i47.EnumDefaultPersist) {
-      return _i47.EnumDefaultPersist.fromJson(data) as T;
-    }
-    if (t == _i48.ByIndexEnum) {
-      return _i48.ByIndexEnum.fromJson(data) as T;
-    }
-    if (t == _i49.ByNameEnum) {
-      return _i49.ByNameEnum.fromJson(data) as T;
-    }
-    if (t == _i50.DefaultValueEnum) {
-      return _i50.DefaultValueEnum.fromJson(data) as T;
-    }
-    if (t == _i51.DefaultException) {
-      return _i51.DefaultException.fromJson(data) as T;
-    }
-    if (t == _i52.IntDefault) {
-      return _i52.IntDefault.fromJson(data) as T;
-    }
-    if (t == _i53.IntDefaultMix) {
-      return _i53.IntDefaultMix.fromJson(data) as T;
-    }
-    if (t == _i54.IntDefaultModel) {
-      return _i54.IntDefaultModel.fromJson(data) as T;
-    }
-    if (t == _i55.IntDefaultPersist) {
-      return _i55.IntDefaultPersist.fromJson(data) as T;
-    }
-    if (t == _i56.StringDefault) {
-      return _i56.StringDefault.fromJson(data) as T;
-    }
-    if (t == _i57.StringDefaultMix) {
-      return _i57.StringDefaultMix.fromJson(data) as T;
-    }
-    if (t == _i58.StringDefaultModel) {
-      return _i58.StringDefaultModel.fromJson(data) as T;
-    }
-    if (t == _i59.StringDefaultPersist) {
-      return _i59.StringDefaultPersist.fromJson(data) as T;
-    }
-    if (t == _i60.UriDefault) {
-      return _i60.UriDefault.fromJson(data) as T;
-    }
-    if (t == _i61.UriDefaultMix) {
-      return _i61.UriDefaultMix.fromJson(data) as T;
-    }
-    if (t == _i62.UriDefaultModel) {
-      return _i62.UriDefaultModel.fromJson(data) as T;
-    }
-    if (t == _i63.UriDefaultPersist) {
-      return _i63.UriDefaultPersist.fromJson(data) as T;
-    }
-    if (t == _i64.UuidDefault) {
-      return _i64.UuidDefault.fromJson(data) as T;
-    }
-    if (t == _i65.UuidDefaultMix) {
-      return _i65.UuidDefaultMix.fromJson(data) as T;
-    }
-    if (t == _i66.UuidDefaultModel) {
-      return _i66.UuidDefaultModel.fromJson(data) as T;
-    }
-    if (t == _i67.UuidDefaultPersist) {
-      return _i67.UuidDefaultPersist.fromJson(data) as T;
-    }
-    if (t == _i68.EmptyModel) {
-      return _i68.EmptyModel.fromJson(data) as T;
-    }
-    if (t == _i69.EmptyModelRelationItem) {
-      return _i69.EmptyModelRelationItem.fromJson(data) as T;
-    }
-    if (t == _i70.EmptyModelWithTable) {
-      return _i70.EmptyModelWithTable.fromJson(data) as T;
-    }
-    if (t == _i71.RelationEmptyModel) {
-      return _i71.RelationEmptyModel.fromJson(data) as T;
-    }
-    if (t == _i72.ExceptionWithData) {
-      return _i72.ExceptionWithData.fromJson(data) as T;
-    }
-    if (t == _i73.ChildClassExplicitColumn) {
-      return _i73.ChildClassExplicitColumn.fromJson(data) as T;
-    }
-    if (t == _i74.NonTableParentClass) {
-      return _i74.NonTableParentClass.fromJson(data) as T;
-    }
-    if (t == _i75.ModifiedColumnName) {
-      return _i75.ModifiedColumnName.fromJson(data) as T;
-    }
-    if (t == _i76.Department) {
-      return _i76.Department.fromJson(data) as T;
-    }
-    if (t == _i77.Employee) {
-      return _i77.Employee.fromJson(data) as T;
-    }
-    if (t == _i78.Contractor) {
-      return _i78.Contractor.fromJson(data) as T;
-    }
-    if (t == _i79.Service) {
-      return _i79.Service.fromJson(data) as T;
-    }
-    if (t == _i80.TableWithExplicitColumnName) {
-      return _i80.TableWithExplicitColumnName.fromJson(data) as T;
-    }
-    if (t == _i81.TestGeneratedCallByeModel) {
-      return _i81.TestGeneratedCallByeModel.fromJson(data) as T;
-    }
-    if (t == _i82.TestGeneratedCallExecuteWithTriggerModel) {
-      return _i82.TestGeneratedCallExecuteWithTriggerModel.fromJson(data) as T;
-    }
-    if (t == _i83.TestGeneratedCallHelloModel) {
-      return _i83.TestGeneratedCallHelloModel.fromJson(data) as T;
-    }
-    if (t == _i84.TestGeneratedCallInvokeModel) {
-      return _i84.TestGeneratedCallInvokeModel.fromJson(data) as T;
-    }
-    if (t == _i85.ImmutableChildObject) {
-      return _i85.ImmutableChildObject.fromJson(data) as T;
-    }
-    if (t == _i86.ImmutableChildObjectWithNoAdditionalFields) {
-      return _i86.ImmutableChildObjectWithNoAdditionalFields.fromJson(data)
-          as T;
-    }
-    if (t == _i87.ImmutableObject) {
-      return _i87.ImmutableObject.fromJson(data) as T;
-    }
-    if (t == _i88.ImmutableObjectWithImmutableObject) {
-      return _i88.ImmutableObjectWithImmutableObject.fromJson(data) as T;
-    }
-    if (t == _i89.ImmutableObjectWithList) {
-      return _i89.ImmutableObjectWithList.fromJson(data) as T;
-    }
-    if (t == _i90.ImmutableObjectWithMap) {
-      return _i90.ImmutableObjectWithMap.fromJson(data) as T;
-    }
-    if (t == _i91.ImmutableObjectWithMultipleFields) {
-      return _i91.ImmutableObjectWithMultipleFields.fromJson(data) as T;
-    }
-    if (t == _i92.ImmutableObjectWithNoFields) {
-      return _i92.ImmutableObjectWithNoFields.fromJson(data) as T;
-    }
-    if (t == _i93.ImmutableObjectWithRecord) {
-      return _i93.ImmutableObjectWithRecord.fromJson(data) as T;
-    }
-    if (t == _i94.ImmutableObjectWithTable) {
-      return _i94.ImmutableObjectWithTable.fromJson(data) as T;
-    }
-    if (t == _i95.ImmutableObjectWithTwentyFields) {
-      return _i95.ImmutableObjectWithTwentyFields.fromJson(data) as T;
-    }
-    if (t == _i96.ChildClass) {
-      return _i96.ChildClass.fromJson(data) as T;
-    }
-    if (t == _i97.ServerOnlyChildClass) {
-      return _i97.ServerOnlyChildClass.fromJson(data) as T;
-    }
-    if (t == _i98.ChildWithDefault) {
-      return _i98.ChildWithDefault.fromJson(data) as T;
-    }
-    if (t == _i99.ChildWithInheritedId) {
-      return _i99.ChildWithInheritedId.fromJson(data) as T;
-    }
-    if (t == _i100.ChildClassWithoutId) {
-      return _i100.ChildClassWithoutId.fromJson(data) as T;
-    }
-    if (t == _i101.ServerOnlyChildClassWithoutId) {
-      return _i101.ServerOnlyChildClassWithoutId.fromJson(data) as T;
-    }
-    if (t == _i102.ExtendedAppException) {
-      return _i102.ExtendedAppException.fromJson(data) as T;
-    }
-    if (t == _i103.BaseAppException) {
-      return _i103.BaseAppException.fromJson(data) as T;
-    }
-    if (t == _i104.NotFoundException) {
-      return _i104.NotFoundException.fromJson(data) as T;
-    }
-    if (t == _i104.ValidationException) {
-      return _i104.ValidationException.fromJson(data) as T;
-    }
-    if (t == _i105.ParentClass) {
-      return _i105.ParentClass.fromJson(data) as T;
-    }
-    if (t == _i106.GrandparentClass) {
-      return _i106.GrandparentClass.fromJson(data) as T;
-    }
-    if (t == _i107.ParentClassWithoutId) {
-      return _i107.ParentClassWithoutId.fromJson(data) as T;
-    }
-    if (t == _i108.GrandparentClassWithId) {
-      return _i108.GrandparentClassWithId.fromJson(data) as T;
-    }
-    if (t == _i109.ChildEntity) {
-      return _i109.ChildEntity.fromJson(data) as T;
-    }
-    if (t == _i110.BaseEntity) {
-      return _i110.BaseEntity.fromJson(data) as T;
-    }
-    if (t == _i111.ParentEntity) {
-      return _i111.ParentEntity.fromJson(data) as T;
-    }
-    if (t == _i112.NonServerOnlyParentClass) {
-      return _i112.NonServerOnlyParentClass.fromJson(data) as T;
-    }
-    if (t == _i113.ParentWithChangedId) {
-      return _i113.ParentWithChangedId.fromJson(data) as T;
-    }
-    if (t == _i114.ParentWithDefault) {
-      return _i114.ParentWithDefault.fromJson(data) as T;
-    }
-    if (t == _i115.PolymorphicGrandChild) {
-      return _i115.PolymorphicGrandChild.fromJson(data) as T;
-    }
-    if (t == _i116.PolymorphicChild) {
-      return _i116.PolymorphicChild.fromJson(data) as T;
-    }
-    if (t == _i117.PolymorphicChildContainer) {
-      return _i117.PolymorphicChildContainer.fromJson(data) as T;
-    }
-    if (t == _i118.ModulePolymorphicChildContainer) {
-      return _i118.ModulePolymorphicChildContainer.fromJson(data) as T;
-    }
-    if (t == _i119.SimilarButNotParent) {
-      return _i119.SimilarButNotParent.fromJson(data) as T;
-    }
-    if (t == _i120.PolymorphicParent) {
-      return _i120.PolymorphicParent.fromJson(data) as T;
-    }
-    if (t == _i121.UnrelatedToPolymorphism) {
-      return _i121.UnrelatedToPolymorphism.fromJson(data) as T;
-    }
-    if (t == _i122.SealedGrandChild) {
-      return _i122.SealedGrandChild.fromJson(data) as T;
-    }
-    if (t == _i122.SealedChild) {
-      return _i122.SealedChild.fromJson(data) as T;
-    }
-    if (t == _i123.SealedChildOnlyRequired) {
-      return _i123.SealedChildOnlyRequired.fromJson(data) as T;
-    }
-    if (t == _i122.SealedOtherChild) {
-      return _i122.SealedOtherChild.fromJson(data) as T;
-    }
-    if (t == _i124.CityWithLongTableName) {
-      return _i124.CityWithLongTableName.fromJson(data) as T;
-    }
-    if (t == _i125.OrganizationWithLongTableName) {
-      return _i125.OrganizationWithLongTableName.fromJson(data) as T;
-    }
-    if (t == _i126.PersonWithLongTableName) {
-      return _i126.PersonWithLongTableName.fromJson(data) as T;
-    }
-    if (t == _i127.MaxFieldName) {
-      return _i127.MaxFieldName.fromJson(data) as T;
-    }
-    if (t == _i128.LongImplicitIdField) {
-      return _i128.LongImplicitIdField.fromJson(data) as T;
-    }
-    if (t == _i129.LongImplicitIdFieldCollection) {
-      return _i129.LongImplicitIdFieldCollection.fromJson(data) as T;
-    }
-    if (t == _i130.RelationToMultipleMaxFieldName) {
-      return _i130.RelationToMultipleMaxFieldName.fromJson(data) as T;
-    }
-    if (t == _i131.UserNote) {
-      return _i131.UserNote.fromJson(data) as T;
-    }
-    if (t == _i132.UserNoteCollection) {
-      return _i132.UserNoteCollection.fromJson(data) as T;
-    }
-    if (t == _i133.UserNoteCollectionWithALongName) {
-      return _i133.UserNoteCollectionWithALongName.fromJson(data) as T;
-    }
-    if (t == _i134.UserNoteWithALongName) {
-      return _i134.UserNoteWithALongName.fromJson(data) as T;
-    }
-    if (t == _i135.MultipleMaxFieldName) {
-      return _i135.MultipleMaxFieldName.fromJson(data) as T;
-    }
-    if (t == _i136.City) {
-      return _i136.City.fromJson(data) as T;
-    }
-    if (t == _i137.Organization) {
-      return _i137.Organization.fromJson(data) as T;
-    }
-    if (t == _i138.Person) {
-      return _i138.Person.fromJson(data) as T;
-    }
-    if (t == _i139.BleedChild) {
-      return _i139.BleedChild.fromJson(data) as T;
-    }
-    if (t == _i140.BleedRoot) {
-      return _i140.BleedRoot.fromJson(data) as T;
-    }
-    if (t == _i141.Course) {
-      return _i141.Course.fromJson(data) as T;
-    }
-    if (t == _i142.Enrollment) {
-      return _i142.Enrollment.fromJson(data) as T;
-    }
-    if (t == _i143.Student) {
-      return _i143.Student.fromJson(data) as T;
-    }
-    if (t == _i144.ObjectUser) {
-      return _i144.ObjectUser.fromJson(data) as T;
-    }
-    if (t == _i145.ParentUser) {
-      return _i145.ParentUser.fromJson(data) as T;
-    }
-    if (t == _i146.Arena) {
-      return _i146.Arena.fromJson(data) as T;
-    }
-    if (t == _i147.Player) {
-      return _i147.Player.fromJson(data) as T;
-    }
-    if (t == _i148.Team) {
-      return _i148.Team.fromJson(data) as T;
-    }
-    if (t == _i149.Comment) {
-      return _i149.Comment.fromJson(data) as T;
-    }
-    if (t == _i150.Customer) {
-      return _i150.Customer.fromJson(data) as T;
-    }
-    if (t == _i151.Book) {
-      return _i151.Book.fromJson(data) as T;
-    }
-    if (t == _i152.Chapter) {
-      return _i152.Chapter.fromJson(data) as T;
-    }
-    if (t == _i153.Order) {
-      return _i153.Order.fromJson(data) as T;
-    }
-    if (t == _i154.Address) {
-      return _i154.Address.fromJson(data) as T;
-    }
-    if (t == _i155.Citizen) {
-      return _i155.Citizen.fromJson(data) as T;
-    }
-    if (t == _i156.Company) {
-      return _i156.Company.fromJson(data) as T;
-    }
-    if (t == _i157.Town) {
-      return _i157.Town.fromJson(data) as T;
-    }
-    if (t == _i158.Blocking) {
-      return _i158.Blocking.fromJson(data) as T;
-    }
-    if (t == _i159.Member) {
-      return _i159.Member.fromJson(data) as T;
-    }
-    if (t == _i160.Cat) {
-      return _i160.Cat.fromJson(data) as T;
-    }
-    if (t == _i161.Post) {
-      return _i161.Post.fromJson(data) as T;
-    }
-    if (t == _i162.ModuleDatatype) {
-      return _i162.ModuleDatatype.fromJson(data) as T;
-    }
-    if (t == _i163.MyFeatureModel) {
-      return _i163.MyFeatureModel.fromJson(data) as T;
-    }
-    if (t == _i164.MyTriggerType) {
-      return _i164.MyTriggerType.fromJson(data) as T;
-    }
-    if (t == _i165.Nullability) {
-      return _i165.Nullability.fromJson(data) as T;
-    }
-    if (t == _i166.NullsDistinctData) {
-      return _i166.NullsDistinctData.fromJson(data) as T;
-    }
-    if (t == _i167.ObjectFieldPersist) {
-      return _i167.ObjectFieldPersist.fromJson(data) as T;
-    }
-    if (t == _i168.ObjectFieldScopes) {
-      return _i168.ObjectFieldScopes.fromJson(data) as T;
-    }
-    if (t == _i169.ObjectWithBit) {
-      return _i169.ObjectWithBit.fromJson(data) as T;
-    }
-    if (t == _i170.ObjectWithByteData) {
-      return _i170.ObjectWithByteData.fromJson(data) as T;
-    }
-    if (t == _i171.ObjectWithCustomClass) {
-      return _i171.ObjectWithCustomClass.fromJson(data) as T;
-    }
-    if (t == _i172.ObjectWithDuration) {
-      return _i172.ObjectWithDuration.fromJson(data) as T;
-    }
-    if (t == _i173.ObjectWithDynamic) {
-      return _i173.ObjectWithDynamic.fromJson(data) as T;
-    }
-    if (t == _i174.ObjectWithEnum) {
-      return _i174.ObjectWithEnum.fromJson(data) as T;
-    }
-    if (t == _i175.ObjectWithEnumEnhanced) {
-      return _i175.ObjectWithEnumEnhanced.fromJson(data) as T;
-    }
-    if (t == _i176.ObjectWithGeographyGeometryCollection) {
-      return _i176.ObjectWithGeographyGeometryCollection.fromJson(data) as T;
-    }
-    if (t == _i177.ObjectWithGeographyLineString) {
-      return _i177.ObjectWithGeographyLineString.fromJson(data) as T;
-    }
-    if (t == _i178.ObjectWithGeographyPoint) {
-      return _i178.ObjectWithGeographyPoint.fromJson(data) as T;
-    }
-    if (t == _i179.ObjectWithGeographyPolygon) {
-      return _i179.ObjectWithGeographyPolygon.fromJson(data) as T;
-    }
-    if (t == _i180.ObjectWithHalfVector) {
-      return _i180.ObjectWithHalfVector.fromJson(data) as T;
-    }
-    if (t == _i181.ObjectWithIndex) {
-      return _i181.ObjectWithIndex.fromJson(data) as T;
-    }
-    if (t == _i182.ObjectWithJsonb) {
-      return _i182.ObjectWithJsonb.fromJson(data) as T;
-    }
-    if (t == _i183.ObjectWithJsonbClassLevel) {
-      return _i183.ObjectWithJsonbClassLevel.fromJson(data) as T;
-    }
-    if (t == _i184.ObjectWithMaps) {
-      return _i184.ObjectWithMaps.fromJson(data) as T;
-    }
-    if (t == _i185.ObjectWithNullableCustomClass) {
-      return _i185.ObjectWithNullableCustomClass.fromJson(data) as T;
-    }
-    if (t == _i186.ObjectWithObject) {
-      return _i186.ObjectWithObject.fromJson(data) as T;
-    }
-    if (t == _i187.ObjectWithParent) {
-      return _i187.ObjectWithParent.fromJson(data) as T;
-    }
-    if (t == _i188.ObjectWithSealedClass) {
-      return _i188.ObjectWithSealedClass.fromJson(data) as T;
-    }
-    if (t == _i189.ObjectWithSealedException) {
-      return _i189.ObjectWithSealedException.fromJson(data) as T;
-    }
-    if (t == _i190.ObjectWithSelfParent) {
-      return _i190.ObjectWithSelfParent.fromJson(data) as T;
-    }
-    if (t == _i191.ObjectWithSparseVector) {
-      return _i191.ObjectWithSparseVector.fromJson(data) as T;
-    }
-    if (t == _i192.ObjectWithUuid) {
-      return _i192.ObjectWithUuid.fromJson(data) as T;
-    }
-    if (t == _i193.ObjectWithVector) {
-      return _i193.ObjectWithVector.fromJson(data) as T;
-    }
-    if (t == _i194.Record) {
-      return _i194.Record.fromJson(data) as T;
-    }
-    if (t == _i195.RelatedUniqueData) {
-      return _i195.RelatedUniqueData.fromJson(data) as T;
-    }
-    if (t == _i196.ExceptionWithRequiredField) {
-      return _i196.ExceptionWithRequiredField.fromJson(data) as T;
-    }
-    if (t == _i197.ModelWithRequiredField) {
-      return _i197.ModelWithRequiredField.fromJson(data) as T;
-    }
-    if (t == _i198.ScopeNoneFields) {
-      return _i198.ScopeNoneFields.fromJson(data) as T;
-    }
-    if (t == _i199.ScopeServerOnlyFieldChild) {
-      return _i199.ScopeServerOnlyFieldChild.fromJson(data) as T;
-    }
-    if (t == _i200.ScopeServerOnlyField) {
-      return _i200.ScopeServerOnlyField.fromJson(data) as T;
-    }
-    if (t == _i201.Article) {
-      return _i201.Article.fromJson(data) as T;
-    }
-    if (t == _i202.ArticleList) {
-      return _i202.ArticleList.fromJson(data) as T;
-    }
-    if (t == _i203.DefaultServerOnlyClass) {
-      return _i203.DefaultServerOnlyClass.fromJson(data) as T;
-    }
-    if (t == _i204.DefaultServerOnlyEnum) {
-      return _i204.DefaultServerOnlyEnum.fromJson(data) as T;
-    }
-    if (t == _i205.NotServerOnlyClass) {
-      return _i205.NotServerOnlyClass.fromJson(data) as T;
-    }
-    if (t == _i206.NotServerOnlyEnum) {
-      return _i206.NotServerOnlyEnum.fromJson(data) as T;
-    }
-    if (t == _i207.ServerOnlyClass) {
-      return _i207.ServerOnlyClass.fromJson(data) as T;
-    }
-    if (t == _i208.ServerOnlyEnum) {
-      return _i208.ServerOnlyEnum.fromJson(data) as T;
-    }
-    if (t == _i209.ServerOnlyClassField) {
-      return _i209.ServerOnlyClassField.fromJson(data) as T;
-    }
-    if (t == _i210.ServerOnlyDefault) {
-      return _i210.ServerOnlyDefault.fromJson(data) as T;
-    }
-    if (t == _i211.SessionAuthInfo) {
-      return _i211.SessionAuthInfo.fromJson(data) as T;
-    }
-    if (t == _i212.SharedModelContainer) {
-      return _i212.SharedModelContainer.fromJson(data) as T;
-    }
-    if (t == _i213.SharedModelSubclass) {
-      return _i213.SharedModelSubclass.fromJson(data) as T;
-    }
-    if (t == _i214.SimpleData) {
-      return _i214.SimpleData.fromJson(data) as T;
-    }
-    if (t == _i215.SimpleDataList) {
-      return _i215.SimpleDataList.fromJson(data) as T;
-    }
-    if (t == _i216.SimpleDataMap) {
-      return _i216.SimpleDataMap.fromJson(data) as T;
-    }
-    if (t == _i217.SimpleDataObject) {
-      return _i217.SimpleDataObject.fromJson(data) as T;
-    }
-    if (t == _i218.SimpleDateTime) {
-      return _i218.SimpleDateTime.fromJson(data) as T;
-    }
-    if (t == _i219.ModelInSubfolder) {
-      return _i219.ModelInSubfolder.fromJson(data) as T;
-    }
-    if (t == _i220.TestEnum) {
-      return _i220.TestEnum.fromJson(data) as T;
-    }
-    if (t == _i221.TestEnumDefaultSerialization) {
-      return _i221.TestEnumDefaultSerialization.fromJson(data) as T;
-    }
-    if (t == _i222.TestEnumEnhanced) {
-      return _i222.TestEnumEnhanced.fromJson(data) as T;
-    }
-    if (t == _i223.TestEnumEnhancedByName) {
-      return _i223.TestEnumEnhancedByName.fromJson(data) as T;
-    }
-    if (t == _i224.TestEnumStringified) {
-      return _i224.TestEnumStringified.fromJson(data) as T;
-    }
-    if (t == _i225.Types) {
-      return _i225.Types.fromJson(data) as T;
-    }
-    if (t == _i226.TypesList) {
-      return _i226.TypesList.fromJson(data) as T;
-    }
-    if (t == _i227.TypesMap) {
-      return _i227.TypesMap.fromJson(data) as T;
-    }
-    if (t == _i228.TypesRecord) {
-      return _i228.TypesRecord.fromJson(data) as T;
-    }
-    if (t == _i229.TypesSet) {
-      return _i229.TypesSet.fromJson(data) as T;
-    }
-    if (t == _i230.TypesSetRequired) {
-      return _i230.TypesSetRequired.fromJson(data) as T;
-    }
-    if (t == _i231.UniqueData) {
-      return _i231.UniqueData.fromJson(data) as T;
-    }
-    if (t == _i232.UniqueDataWithNonPersist) {
-      return _i232.UniqueDataWithNonPersist.fromJson(data) as T;
-    }
-    if (t == _i233.UpsertTestModel) {
-      return _i233.UpsertTestModel.fromJson(data) as T;
-    }
-    if (t == _i1.getType<_i7.ByIndexEnumWithNameValue?>()) {
-      return (data != null ? _i7.ByIndexEnumWithNameValue.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i8.ByNameEnumWithNameValue?>()) {
-      return (data != null ? _i8.ByNameEnumWithNameValue.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i9.CourseUuid?>()) {
-      return (data != null ? _i9.CourseUuid.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i10.EnrollmentInt?>()) {
-      return (data != null ? _i10.EnrollmentInt.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i11.StudentUuid?>()) {
-      return (data != null ? _i11.StudentUuid.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i12.ArenaUuid?>()) {
-      return (data != null ? _i12.ArenaUuid.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i13.PlayerUuid?>()) {
-      return (data != null ? _i13.PlayerUuid.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i14.TeamInt?>()) {
-      return (data != null ? _i14.TeamInt.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i15.CommentInt?>()) {
-      return (data != null ? _i15.CommentInt.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i16.CustomerInt?>()) {
-      return (data != null ? _i16.CustomerInt.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i17.OrderUuid?>()) {
-      return (data != null ? _i17.OrderUuid.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i18.AddressUuid?>()) {
-      return (data != null ? _i18.AddressUuid.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i19.CitizenInt?>()) {
-      return (data != null ? _i19.CitizenInt.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i20.CompanyUuid?>()) {
-      return (data != null ? _i20.CompanyUuid.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i21.TownInt?>()) {
-      return (data != null ? _i21.TownInt.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i22.ChangedIdTypeSelf?>()) {
-      return (data != null ? _i22.ChangedIdTypeSelf.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i23.ServerOnlyChangedIdFieldClass?>()) {
-      return (data != null
-              ? _i23.ServerOnlyChangedIdFieldClass.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i24.BigIntDefault?>()) {
-      return (data != null ? _i24.BigIntDefault.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i25.BigIntDefaultMix?>()) {
-      return (data != null ? _i25.BigIntDefaultMix.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i26.BigIntDefaultModel?>()) {
-      return (data != null ? _i26.BigIntDefaultModel.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i27.BigIntDefaultPersist?>()) {
-      return (data != null ? _i27.BigIntDefaultPersist.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i28.BoolDefault?>()) {
-      return (data != null ? _i28.BoolDefault.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i29.BoolDefaultMix?>()) {
-      return (data != null ? _i29.BoolDefaultMix.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i30.BoolDefaultModel?>()) {
-      return (data != null ? _i30.BoolDefaultModel.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i31.BoolDefaultPersist?>()) {
-      return (data != null ? _i31.BoolDefaultPersist.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i32.DateTimeDefault?>()) {
-      return (data != null ? _i32.DateTimeDefault.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i33.DateTimeDefaultMix?>()) {
-      return (data != null ? _i33.DateTimeDefaultMix.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i34.DateTimeDefaultModel?>()) {
-      return (data != null ? _i34.DateTimeDefaultModel.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i35.DateTimeDefaultPersist?>()) {
-      return (data != null ? _i35.DateTimeDefaultPersist.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i36.DoubleDefault?>()) {
-      return (data != null ? _i36.DoubleDefault.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i37.DoubleDefaultMix?>()) {
-      return (data != null ? _i37.DoubleDefaultMix.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i38.DoubleDefaultModel?>()) {
-      return (data != null ? _i38.DoubleDefaultModel.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i39.DoubleDefaultPersist?>()) {
-      return (data != null ? _i39.DoubleDefaultPersist.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i40.DurationDefault?>()) {
-      return (data != null ? _i40.DurationDefault.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i41.DurationDefaultMix?>()) {
-      return (data != null ? _i41.DurationDefaultMix.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i42.DurationDefaultModel?>()) {
-      return (data != null ? _i42.DurationDefaultModel.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i43.DurationDefaultPersist?>()) {
-      return (data != null ? _i43.DurationDefaultPersist.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i44.EnumDefault?>()) {
-      return (data != null ? _i44.EnumDefault.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i45.EnumDefaultMix?>()) {
-      return (data != null ? _i45.EnumDefaultMix.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i46.EnumDefaultModel?>()) {
-      return (data != null ? _i46.EnumDefaultModel.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i47.EnumDefaultPersist?>()) {
-      return (data != null ? _i47.EnumDefaultPersist.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i48.ByIndexEnum?>()) {
-      return (data != null ? _i48.ByIndexEnum.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i49.ByNameEnum?>()) {
-      return (data != null ? _i49.ByNameEnum.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i50.DefaultValueEnum?>()) {
-      return (data != null ? _i50.DefaultValueEnum.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i51.DefaultException?>()) {
-      return (data != null ? _i51.DefaultException.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i52.IntDefault?>()) {
-      return (data != null ? _i52.IntDefault.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i53.IntDefaultMix?>()) {
-      return (data != null ? _i53.IntDefaultMix.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i54.IntDefaultModel?>()) {
-      return (data != null ? _i54.IntDefaultModel.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i55.IntDefaultPersist?>()) {
-      return (data != null ? _i55.IntDefaultPersist.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i56.StringDefault?>()) {
-      return (data != null ? _i56.StringDefault.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i57.StringDefaultMix?>()) {
-      return (data != null ? _i57.StringDefaultMix.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i58.StringDefaultModel?>()) {
-      return (data != null ? _i58.StringDefaultModel.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i59.StringDefaultPersist?>()) {
-      return (data != null ? _i59.StringDefaultPersist.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i60.UriDefault?>()) {
-      return (data != null ? _i60.UriDefault.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i61.UriDefaultMix?>()) {
-      return (data != null ? _i61.UriDefaultMix.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i62.UriDefaultModel?>()) {
-      return (data != null ? _i62.UriDefaultModel.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i63.UriDefaultPersist?>()) {
-      return (data != null ? _i63.UriDefaultPersist.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i64.UuidDefault?>()) {
-      return (data != null ? _i64.UuidDefault.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i65.UuidDefaultMix?>()) {
-      return (data != null ? _i65.UuidDefaultMix.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i66.UuidDefaultModel?>()) {
-      return (data != null ? _i66.UuidDefaultModel.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i67.UuidDefaultPersist?>()) {
-      return (data != null ? _i67.UuidDefaultPersist.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i68.EmptyModel?>()) {
-      return (data != null ? _i68.EmptyModel.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i69.EmptyModelRelationItem?>()) {
-      return (data != null ? _i69.EmptyModelRelationItem.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i70.EmptyModelWithTable?>()) {
-      return (data != null ? _i70.EmptyModelWithTable.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i71.RelationEmptyModel?>()) {
-      return (data != null ? _i71.RelationEmptyModel.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i72.ExceptionWithData?>()) {
-      return (data != null ? _i72.ExceptionWithData.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i73.ChildClassExplicitColumn?>()) {
-      return (data != null
-              ? _i73.ChildClassExplicitColumn.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i74.NonTableParentClass?>()) {
-      return (data != null ? _i74.NonTableParentClass.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i75.ModifiedColumnName?>()) {
-      return (data != null ? _i75.ModifiedColumnName.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i76.Department?>()) {
-      return (data != null ? _i76.Department.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i77.Employee?>()) {
-      return (data != null ? _i77.Employee.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i78.Contractor?>()) {
-      return (data != null ? _i78.Contractor.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i79.Service?>()) {
-      return (data != null ? _i79.Service.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i80.TableWithExplicitColumnName?>()) {
-      return (data != null
-              ? _i80.TableWithExplicitColumnName.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i81.TestGeneratedCallByeModel?>()) {
-      return (data != null
-              ? _i81.TestGeneratedCallByeModel.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i82.TestGeneratedCallExecuteWithTriggerModel?>()) {
-      return (data != null
-              ? _i82.TestGeneratedCallExecuteWithTriggerModel.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i83.TestGeneratedCallHelloModel?>()) {
-      return (data != null
-              ? _i83.TestGeneratedCallHelloModel.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i84.TestGeneratedCallInvokeModel?>()) {
-      return (data != null
-              ? _i84.TestGeneratedCallInvokeModel.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i85.ImmutableChildObject?>()) {
-      return (data != null ? _i85.ImmutableChildObject.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i86.ImmutableChildObjectWithNoAdditionalFields?>()) {
-      return (data != null
-              ? _i86.ImmutableChildObjectWithNoAdditionalFields.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i87.ImmutableObject?>()) {
-      return (data != null ? _i87.ImmutableObject.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i88.ImmutableObjectWithImmutableObject?>()) {
-      return (data != null
-              ? _i88.ImmutableObjectWithImmutableObject.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i89.ImmutableObjectWithList?>()) {
-      return (data != null ? _i89.ImmutableObjectWithList.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i90.ImmutableObjectWithMap?>()) {
-      return (data != null ? _i90.ImmutableObjectWithMap.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i91.ImmutableObjectWithMultipleFields?>()) {
-      return (data != null
-              ? _i91.ImmutableObjectWithMultipleFields.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i92.ImmutableObjectWithNoFields?>()) {
-      return (data != null
-              ? _i92.ImmutableObjectWithNoFields.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i93.ImmutableObjectWithRecord?>()) {
-      return (data != null
-              ? _i93.ImmutableObjectWithRecord.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i94.ImmutableObjectWithTable?>()) {
-      return (data != null
-              ? _i94.ImmutableObjectWithTable.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i95.ImmutableObjectWithTwentyFields?>()) {
-      return (data != null
-              ? _i95.ImmutableObjectWithTwentyFields.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i96.ChildClass?>()) {
-      return (data != null ? _i96.ChildClass.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i97.ServerOnlyChildClass?>()) {
-      return (data != null ? _i97.ServerOnlyChildClass.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i98.ChildWithDefault?>()) {
-      return (data != null ? _i98.ChildWithDefault.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i99.ChildWithInheritedId?>()) {
-      return (data != null ? _i99.ChildWithInheritedId.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i100.ChildClassWithoutId?>()) {
-      return (data != null ? _i100.ChildClassWithoutId.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i101.ServerOnlyChildClassWithoutId?>()) {
-      return (data != null
-              ? _i101.ServerOnlyChildClassWithoutId.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i102.ExtendedAppException?>()) {
-      return (data != null ? _i102.ExtendedAppException.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i103.BaseAppException?>()) {
-      return (data != null ? _i103.BaseAppException.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i104.NotFoundException?>()) {
-      return (data != null ? _i104.NotFoundException.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i104.ValidationException?>()) {
-      return (data != null ? _i104.ValidationException.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i105.ParentClass?>()) {
-      return (data != null ? _i105.ParentClass.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i106.GrandparentClass?>()) {
-      return (data != null ? _i106.GrandparentClass.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i107.ParentClassWithoutId?>()) {
-      return (data != null ? _i107.ParentClassWithoutId.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i108.GrandparentClassWithId?>()) {
-      return (data != null ? _i108.GrandparentClassWithId.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i109.ChildEntity?>()) {
-      return (data != null ? _i109.ChildEntity.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i110.BaseEntity?>()) {
-      return (data != null ? _i110.BaseEntity.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i111.ParentEntity?>()) {
-      return (data != null ? _i111.ParentEntity.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i112.NonServerOnlyParentClass?>()) {
-      return (data != null
-              ? _i112.NonServerOnlyParentClass.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i113.ParentWithChangedId?>()) {
-      return (data != null ? _i113.ParentWithChangedId.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i114.ParentWithDefault?>()) {
-      return (data != null ? _i114.ParentWithDefault.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i115.PolymorphicGrandChild?>()) {
-      return (data != null ? _i115.PolymorphicGrandChild.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i116.PolymorphicChild?>()) {
-      return (data != null ? _i116.PolymorphicChild.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i117.PolymorphicChildContainer?>()) {
-      return (data != null
-              ? _i117.PolymorphicChildContainer.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i118.ModulePolymorphicChildContainer?>()) {
-      return (data != null
-              ? _i118.ModulePolymorphicChildContainer.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i119.SimilarButNotParent?>()) {
-      return (data != null ? _i119.SimilarButNotParent.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i120.PolymorphicParent?>()) {
-      return (data != null ? _i120.PolymorphicParent.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i121.UnrelatedToPolymorphism?>()) {
-      return (data != null
-              ? _i121.UnrelatedToPolymorphism.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i122.SealedGrandChild?>()) {
-      return (data != null ? _i122.SealedGrandChild.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i122.SealedChild?>()) {
-      return (data != null ? _i122.SealedChild.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i123.SealedChildOnlyRequired?>()) {
-      return (data != null
-              ? _i123.SealedChildOnlyRequired.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i122.SealedOtherChild?>()) {
-      return (data != null ? _i122.SealedOtherChild.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i124.CityWithLongTableName?>()) {
-      return (data != null ? _i124.CityWithLongTableName.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i125.OrganizationWithLongTableName?>()) {
-      return (data != null
-              ? _i125.OrganizationWithLongTableName.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i126.PersonWithLongTableName?>()) {
-      return (data != null
-              ? _i126.PersonWithLongTableName.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i127.MaxFieldName?>()) {
-      return (data != null ? _i127.MaxFieldName.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i128.LongImplicitIdField?>()) {
-      return (data != null ? _i128.LongImplicitIdField.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i129.LongImplicitIdFieldCollection?>()) {
-      return (data != null
-              ? _i129.LongImplicitIdFieldCollection.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i130.RelationToMultipleMaxFieldName?>()) {
-      return (data != null
-              ? _i130.RelationToMultipleMaxFieldName.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i131.UserNote?>()) {
-      return (data != null ? _i131.UserNote.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i132.UserNoteCollection?>()) {
-      return (data != null ? _i132.UserNoteCollection.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i133.UserNoteCollectionWithALongName?>()) {
-      return (data != null
-              ? _i133.UserNoteCollectionWithALongName.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i134.UserNoteWithALongName?>()) {
-      return (data != null ? _i134.UserNoteWithALongName.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i135.MultipleMaxFieldName?>()) {
-      return (data != null ? _i135.MultipleMaxFieldName.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i136.City?>()) {
-      return (data != null ? _i136.City.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i137.Organization?>()) {
-      return (data != null ? _i137.Organization.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i138.Person?>()) {
-      return (data != null ? _i138.Person.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i139.BleedChild?>()) {
-      return (data != null ? _i139.BleedChild.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i140.BleedRoot?>()) {
-      return (data != null ? _i140.BleedRoot.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i141.Course?>()) {
-      return (data != null ? _i141.Course.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i142.Enrollment?>()) {
-      return (data != null ? _i142.Enrollment.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i143.Student?>()) {
-      return (data != null ? _i143.Student.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i144.ObjectUser?>()) {
-      return (data != null ? _i144.ObjectUser.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i145.ParentUser?>()) {
-      return (data != null ? _i145.ParentUser.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i146.Arena?>()) {
-      return (data != null ? _i146.Arena.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i147.Player?>()) {
-      return (data != null ? _i147.Player.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i148.Team?>()) {
-      return (data != null ? _i148.Team.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i149.Comment?>()) {
-      return (data != null ? _i149.Comment.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i150.Customer?>()) {
-      return (data != null ? _i150.Customer.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i151.Book?>()) {
-      return (data != null ? _i151.Book.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i152.Chapter?>()) {
-      return (data != null ? _i152.Chapter.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i153.Order?>()) {
-      return (data != null ? _i153.Order.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i154.Address?>()) {
-      return (data != null ? _i154.Address.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i155.Citizen?>()) {
-      return (data != null ? _i155.Citizen.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i156.Company?>()) {
-      return (data != null ? _i156.Company.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i157.Town?>()) {
-      return (data != null ? _i157.Town.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i158.Blocking?>()) {
-      return (data != null ? _i158.Blocking.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i159.Member?>()) {
-      return (data != null ? _i159.Member.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i160.Cat?>()) {
-      return (data != null ? _i160.Cat.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i161.Post?>()) {
-      return (data != null ? _i161.Post.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i162.ModuleDatatype?>()) {
-      return (data != null ? _i162.ModuleDatatype.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i163.MyFeatureModel?>()) {
-      return (data != null ? _i163.MyFeatureModel.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i164.MyTriggerType?>()) {
-      return (data != null ? _i164.MyTriggerType.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i165.Nullability?>()) {
-      return (data != null ? _i165.Nullability.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i166.NullsDistinctData?>()) {
-      return (data != null ? _i166.NullsDistinctData.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i167.ObjectFieldPersist?>()) {
-      return (data != null ? _i167.ObjectFieldPersist.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i168.ObjectFieldScopes?>()) {
-      return (data != null ? _i168.ObjectFieldScopes.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i169.ObjectWithBit?>()) {
-      return (data != null ? _i169.ObjectWithBit.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i170.ObjectWithByteData?>()) {
-      return (data != null ? _i170.ObjectWithByteData.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i171.ObjectWithCustomClass?>()) {
-      return (data != null ? _i171.ObjectWithCustomClass.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i172.ObjectWithDuration?>()) {
-      return (data != null ? _i172.ObjectWithDuration.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i173.ObjectWithDynamic?>()) {
-      return (data != null ? _i173.ObjectWithDynamic.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i174.ObjectWithEnum?>()) {
-      return (data != null ? _i174.ObjectWithEnum.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i175.ObjectWithEnumEnhanced?>()) {
-      return (data != null ? _i175.ObjectWithEnumEnhanced.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i176.ObjectWithGeographyGeometryCollection?>()) {
-      return (data != null
-              ? _i176.ObjectWithGeographyGeometryCollection.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i177.ObjectWithGeographyLineString?>()) {
-      return (data != null
-              ? _i177.ObjectWithGeographyLineString.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i178.ObjectWithGeographyPoint?>()) {
-      return (data != null
-              ? _i178.ObjectWithGeographyPoint.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i179.ObjectWithGeographyPolygon?>()) {
-      return (data != null
-              ? _i179.ObjectWithGeographyPolygon.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i180.ObjectWithHalfVector?>()) {
-      return (data != null ? _i180.ObjectWithHalfVector.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i181.ObjectWithIndex?>()) {
-      return (data != null ? _i181.ObjectWithIndex.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i182.ObjectWithJsonb?>()) {
-      return (data != null ? _i182.ObjectWithJsonb.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i183.ObjectWithJsonbClassLevel?>()) {
-      return (data != null
-              ? _i183.ObjectWithJsonbClassLevel.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i184.ObjectWithMaps?>()) {
-      return (data != null ? _i184.ObjectWithMaps.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i185.ObjectWithNullableCustomClass?>()) {
-      return (data != null
-              ? _i185.ObjectWithNullableCustomClass.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i186.ObjectWithObject?>()) {
-      return (data != null ? _i186.ObjectWithObject.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i187.ObjectWithParent?>()) {
-      return (data != null ? _i187.ObjectWithParent.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i188.ObjectWithSealedClass?>()) {
-      return (data != null ? _i188.ObjectWithSealedClass.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i189.ObjectWithSealedException?>()) {
-      return (data != null
-              ? _i189.ObjectWithSealedException.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i190.ObjectWithSelfParent?>()) {
-      return (data != null ? _i190.ObjectWithSelfParent.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i191.ObjectWithSparseVector?>()) {
-      return (data != null ? _i191.ObjectWithSparseVector.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i192.ObjectWithUuid?>()) {
-      return (data != null ? _i192.ObjectWithUuid.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i193.ObjectWithVector?>()) {
-      return (data != null ? _i193.ObjectWithVector.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i194.Record?>()) {
-      return (data != null ? _i194.Record.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i195.RelatedUniqueData?>()) {
-      return (data != null ? _i195.RelatedUniqueData.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i196.ExceptionWithRequiredField?>()) {
-      return (data != null
-              ? _i196.ExceptionWithRequiredField.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i197.ModelWithRequiredField?>()) {
-      return (data != null ? _i197.ModelWithRequiredField.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i198.ScopeNoneFields?>()) {
-      return (data != null ? _i198.ScopeNoneFields.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i199.ScopeServerOnlyFieldChild?>()) {
-      return (data != null
-              ? _i199.ScopeServerOnlyFieldChild.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i200.ScopeServerOnlyField?>()) {
-      return (data != null ? _i200.ScopeServerOnlyField.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i201.Article?>()) {
-      return (data != null ? _i201.Article.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i202.ArticleList?>()) {
-      return (data != null ? _i202.ArticleList.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i203.DefaultServerOnlyClass?>()) {
-      return (data != null ? _i203.DefaultServerOnlyClass.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i204.DefaultServerOnlyEnum?>()) {
-      return (data != null ? _i204.DefaultServerOnlyEnum.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i205.NotServerOnlyClass?>()) {
-      return (data != null ? _i205.NotServerOnlyClass.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i206.NotServerOnlyEnum?>()) {
-      return (data != null ? _i206.NotServerOnlyEnum.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i207.ServerOnlyClass?>()) {
-      return (data != null ? _i207.ServerOnlyClass.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i208.ServerOnlyEnum?>()) {
-      return (data != null ? _i208.ServerOnlyEnum.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i209.ServerOnlyClassField?>()) {
-      return (data != null ? _i209.ServerOnlyClassField.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i210.ServerOnlyDefault?>()) {
-      return (data != null ? _i210.ServerOnlyDefault.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i211.SessionAuthInfo?>()) {
-      return (data != null ? _i211.SessionAuthInfo.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i212.SharedModelContainer?>()) {
-      return (data != null ? _i212.SharedModelContainer.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i213.SharedModelSubclass?>()) {
-      return (data != null ? _i213.SharedModelSubclass.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i214.SimpleData?>()) {
-      return (data != null ? _i214.SimpleData.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i215.SimpleDataList?>()) {
-      return (data != null ? _i215.SimpleDataList.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i216.SimpleDataMap?>()) {
-      return (data != null ? _i216.SimpleDataMap.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i217.SimpleDataObject?>()) {
-      return (data != null ? _i217.SimpleDataObject.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i218.SimpleDateTime?>()) {
-      return (data != null ? _i218.SimpleDateTime.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i219.ModelInSubfolder?>()) {
-      return (data != null ? _i219.ModelInSubfolder.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i220.TestEnum?>()) {
-      return (data != null ? _i220.TestEnum.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i221.TestEnumDefaultSerialization?>()) {
-      return (data != null
-              ? _i221.TestEnumDefaultSerialization.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i222.TestEnumEnhanced?>()) {
-      return (data != null ? _i222.TestEnumEnhanced.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i223.TestEnumEnhancedByName?>()) {
-      return (data != null ? _i223.TestEnumEnhancedByName.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i224.TestEnumStringified?>()) {
-      return (data != null ? _i224.TestEnumStringified.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i225.Types?>()) {
-      return (data != null ? _i225.Types.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i226.TypesList?>()) {
-      return (data != null ? _i226.TypesList.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i227.TypesMap?>()) {
-      return (data != null ? _i227.TypesMap.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i228.TypesRecord?>()) {
-      return (data != null ? _i228.TypesRecord.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i229.TypesSet?>()) {
-      return (data != null ? _i229.TypesSet.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i230.TypesSetRequired?>()) {
-      return (data != null ? _i230.TypesSetRequired.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i231.UniqueData?>()) {
-      return (data != null ? _i231.UniqueData.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i232.UniqueDataWithNonPersist?>()) {
-      return (data != null
-              ? _i232.UniqueDataWithNonPersist.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i233.UpsertTestModel?>()) {
-      return (data != null ? _i233.UpsertTestModel.fromJson(data) : null) as T;
-    }
-    if (t == List<_i10.EnrollmentInt>) {
-      return (data as List)
-              .map((e) => deserialize<_i10.EnrollmentInt>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i10.EnrollmentInt>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i10.EnrollmentInt>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i13.PlayerUuid>) {
-      return (data as List).map((e) => deserialize<_i13.PlayerUuid>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i13.PlayerUuid>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i13.PlayerUuid>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i17.OrderUuid>) {
-      return (data as List).map((e) => deserialize<_i17.OrderUuid>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i17.OrderUuid>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i17.OrderUuid>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i15.CommentInt>) {
-      return (data as List).map((e) => deserialize<_i15.CommentInt>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i15.CommentInt>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i15.CommentInt>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i22.ChangedIdTypeSelf>) {
-      return (data as List)
-              .map((e) => deserialize<_i22.ChangedIdTypeSelf>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i22.ChangedIdTypeSelf>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i22.ChangedIdTypeSelf>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i69.EmptyModelRelationItem>) {
-      return (data as List)
-              .map((e) => deserialize<_i69.EmptyModelRelationItem>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i69.EmptyModelRelationItem>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i69.EmptyModelRelationItem>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i77.Employee>) {
-      return (data as List).map((e) => deserialize<_i77.Employee>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i77.Employee>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i77.Employee>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<String>) {
-      return (data as List).map((e) => deserialize<String>(e)).toList() as T;
-    }
-    if (t == Map<String, String>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(deserialize<String>(k), deserialize<String>(v)),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(int, String)>()) {
-      return (
-            deserialize<int>(((data as Map)['p'] as List)[0]),
-            deserialize<String>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == List<_i109.ChildEntity>) {
-      return (data as List)
-              .map((e) => deserialize<_i109.ChildEntity>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i109.ChildEntity>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i109.ChildEntity>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i116.PolymorphicChild>) {
-      return (data as List)
-              .map((e) => deserialize<_i116.PolymorphicChild>(e))
-              .toList()
-          as T;
-    }
-    if (t == List<_i116.PolymorphicChild?>) {
-      return (data as List)
-              .map((e) => deserialize<_i116.PolymorphicChild?>(e))
-              .toList()
-          as T;
-    }
-    if (t == Map<String, _i116.PolymorphicChild>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<_i116.PolymorphicChild>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == Map<String, _i116.PolymorphicChild?>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<_i116.PolymorphicChild?>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == List<_i4.ModulePolymorphicChild>) {
-      return (data as List)
-              .map((e) => deserialize<_i4.ModulePolymorphicChild>(e))
-              .toList()
-          as T;
-    }
-    if (t == Map<String, _i4.ModulePolymorphicChild>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<_i4.ModulePolymorphicChild>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == List<_i126.PersonWithLongTableName>) {
-      return (data as List)
-              .map((e) => deserialize<_i126.PersonWithLongTableName>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i126.PersonWithLongTableName>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i126.PersonWithLongTableName>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i125.OrganizationWithLongTableName>) {
-      return (data as List)
-              .map((e) => deserialize<_i125.OrganizationWithLongTableName>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i125.OrganizationWithLongTableName>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map(
-                      (e) =>
-                          deserialize<_i125.OrganizationWithLongTableName>(e),
-                    )
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i128.LongImplicitIdField>) {
-      return (data as List)
-              .map((e) => deserialize<_i128.LongImplicitIdField>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i128.LongImplicitIdField>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i128.LongImplicitIdField>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i135.MultipleMaxFieldName>) {
-      return (data as List)
-              .map((e) => deserialize<_i135.MultipleMaxFieldName>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i135.MultipleMaxFieldName>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i135.MultipleMaxFieldName>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i131.UserNote>) {
-      return (data as List).map((e) => deserialize<_i131.UserNote>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i131.UserNote>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i131.UserNote>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i134.UserNoteWithALongName>) {
-      return (data as List)
-              .map((e) => deserialize<_i134.UserNoteWithALongName>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i134.UserNoteWithALongName>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i134.UserNoteWithALongName>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i138.Person>) {
-      return (data as List).map((e) => deserialize<_i138.Person>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i138.Person>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<_i138.Person>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i137.Organization>) {
-      return (data as List)
-              .map((e) => deserialize<_i137.Organization>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i137.Organization>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i137.Organization>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i142.Enrollment>) {
-      return (data as List)
-              .map((e) => deserialize<_i142.Enrollment>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i142.Enrollment>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i142.Enrollment>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i147.Player>) {
-      return (data as List).map((e) => deserialize<_i147.Player>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i147.Player>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<_i147.Player>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i153.Order>) {
-      return (data as List).map((e) => deserialize<_i153.Order>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i153.Order>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<_i153.Order>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i152.Chapter>) {
-      return (data as List).map((e) => deserialize<_i152.Chapter>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i152.Chapter>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i152.Chapter>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i149.Comment>) {
-      return (data as List).map((e) => deserialize<_i149.Comment>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i149.Comment>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i149.Comment>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i158.Blocking>) {
-      return (data as List).map((e) => deserialize<_i158.Blocking>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i158.Blocking>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i158.Blocking>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i160.Cat>) {
-      return (data as List).map((e) => deserialize<_i160.Cat>(e)).toList() as T;
-    }
-    if (t == _i1.getType<List<_i160.Cat>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<_i160.Cat>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i4.ModuleClass>) {
-      return (data as List).map((e) => deserialize<_i4.ModuleClass>(e)).toList()
-          as T;
-    }
-    if (t == Map<String, _i4.ModuleClass>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<_i4.ModuleClass>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(_i4.ModuleClass,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<_i4.ModuleClass>(((data as Map)['p'] as List)[0]),)
-                as T;
-    }
-    if (t == List<int>) {
-      return (data as List).map((e) => deserialize<int>(e)).toList() as T;
-    }
-    if (t == _i1.getType<List<int>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<int>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == List<int?>) {
-      return (data as List).map((e) => deserialize<int?>(e)).toList() as T;
-    }
-    if (t == _i1.getType<List<int?>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<int?>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i214.SimpleData>) {
-      return (data as List)
-              .map((e) => deserialize<_i214.SimpleData>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i214.SimpleData>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i214.SimpleData>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i214.SimpleData?>) {
-      return (data as List)
-              .map((e) => deserialize<_i214.SimpleData?>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i214.SimpleData?>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i214.SimpleData?>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<DateTime>) {
-      return (data as List).map((e) => deserialize<DateTime>(e)).toList() as T;
-    }
-    if (t == _i1.getType<List<DateTime>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<DateTime>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == List<DateTime?>) {
-      return (data as List).map((e) => deserialize<DateTime?>(e)).toList() as T;
-    }
-    if (t == _i1.getType<List<DateTime?>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<DateTime?>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i234.ByteData>) {
-      return (data as List).map((e) => deserialize<_i234.ByteData>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i234.ByteData>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i234.ByteData>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i234.ByteData?>) {
-      return (data as List).map((e) => deserialize<_i234.ByteData?>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i234.ByteData?>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i234.ByteData?>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<Duration>) {
-      return (data as List).map((e) => deserialize<Duration>(e)).toList() as T;
-    }
-    if (t == _i1.getType<List<Duration>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<Duration>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == List<Duration?>) {
-      return (data as List).map((e) => deserialize<Duration?>(e)).toList() as T;
-    }
-    if (t == _i1.getType<List<Duration?>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<Duration?>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i1.UuidValue>) {
-      return (data as List).map((e) => deserialize<_i1.UuidValue>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i1.UuidValue>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i1.UuidValue>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i1.UuidValue?>) {
-      return (data as List).map((e) => deserialize<_i1.UuidValue?>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i1.UuidValue?>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i1.UuidValue?>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == Map<String, int>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(deserialize<String>(k), deserialize<int>(v)),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<String, int>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) =>
-                      MapEntry(deserialize<String>(k), deserialize<int>(v)),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<String, int?>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(deserialize<String>(k), deserialize<int?>(v)),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<String, int?>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) =>
-                      MapEntry(deserialize<String>(k), deserialize<int?>(v)),
-                )
-              : null)
-          as T;
-    }
-    if (t == _i6.CustomClassWithoutProtocolSerialization) {
-      return _i6.CustomClassWithoutProtocolSerialization.fromJson(data) as T;
-    }
-    if (t == _i6.CustomClassWithProtocolSerialization) {
-      return _i6.CustomClassWithProtocolSerialization.fromJson(data) as T;
-    }
-    if (t == _i6.CustomClassWithProtocolSerializationMethod) {
-      return _i6.CustomClassWithProtocolSerializationMethod.fromJson(data) as T;
-    }
-    if (t == dynamic) {
-      return deserializeDynamicFieldValue(data) as T;
-    }
-    if (t == List<dynamic>) {
-      return (data as List).map((e) => deserialize<dynamic>(e)).toList() as T;
-    }
-    if (t == Map<String, dynamic>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(deserialize<String>(k), deserialize<dynamic>(v)),
-          )
-          as T;
-    }
-    if (t == Set<dynamic>) {
-      return (data as List).map((e) => deserialize<dynamic>(e)).toSet() as T;
-    }
-    if (t == Map<dynamic, dynamic>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) => MapEntry(
-                deserialize<dynamic>(e['k']),
-                deserialize<dynamic>(e['v']),
-              ),
-            ),
-          )
-          as T;
-    }
-    if (t == List<_i220.TestEnum>) {
-      return (data as List).map((e) => deserialize<_i220.TestEnum>(e)).toList()
-          as T;
-    }
-    if (t == List<_i220.TestEnum?>) {
-      return (data as List).map((e) => deserialize<_i220.TestEnum?>(e)).toList()
-          as T;
-    }
-    if (t == List<List<_i220.TestEnum>>) {
-      return (data as List)
-              .map((e) => deserialize<List<_i220.TestEnum>>(e))
-              .toList()
-          as T;
-    }
-    if (t == List<_i222.TestEnumEnhanced>) {
-      return (data as List)
-              .map((e) => deserialize<_i222.TestEnumEnhanced>(e))
-              .toList()
-          as T;
-    }
-    if (t == List<_i223.TestEnumEnhancedByName>) {
-      return (data as List)
-              .map((e) => deserialize<_i223.TestEnumEnhancedByName>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<String>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<String>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == Map<String, _i214.SimpleData>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<_i214.SimpleData>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == Map<String, DateTime>) {
-      return (data as Map).map(
-            (k, v) =>
-                MapEntry(deserialize<String>(k), deserialize<DateTime>(v)),
-          )
-          as T;
-    }
-    if (t == Map<String, _i234.ByteData>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<_i234.ByteData>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == Map<String, Duration>) {
-      return (data as Map).map(
-            (k, v) =>
-                MapEntry(deserialize<String>(k), deserialize<Duration>(v)),
-          )
-          as T;
-    }
-    if (t == Map<String, _i1.UuidValue>) {
-      return (data as Map).map(
-            (k, v) =>
-                MapEntry(deserialize<String>(k), deserialize<_i1.UuidValue>(v)),
-          )
-          as T;
-    }
-    if (t == Map<String, _i214.SimpleData?>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<_i214.SimpleData?>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == Map<String, String?>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(deserialize<String>(k), deserialize<String?>(v)),
-          )
-          as T;
-    }
-    if (t == Map<String, DateTime?>) {
-      return (data as Map).map(
-            (k, v) =>
-                MapEntry(deserialize<String>(k), deserialize<DateTime?>(v)),
-          )
-          as T;
-    }
-    if (t == Map<String, _i234.ByteData?>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<_i234.ByteData?>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == Map<String, Duration?>) {
-      return (data as Map).map(
-            (k, v) =>
-                MapEntry(deserialize<String>(k), deserialize<Duration?>(v)),
-          )
-          as T;
-    }
-    if (t == Map<String, _i1.UuidValue?>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<_i1.UuidValue?>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == Map<int, int>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) =>
-                  MapEntry(deserialize<int>(e['k']), deserialize<int>(e['v'])),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<_i6.CustomClassWithoutProtocolSerialization?>()) {
-      return (data != null
-              ? _i6.CustomClassWithoutProtocolSerialization.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i6.CustomClassWithProtocolSerialization?>()) {
-      return (data != null
-              ? _i6.CustomClassWithProtocolSerialization.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i6.CustomClassWithProtocolSerializationMethod?>()) {
-      return (data != null
-              ? _i6.CustomClassWithProtocolSerializationMethod.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == List<List<_i214.SimpleData>>) {
-      return (data as List)
-              .map((e) => deserialize<List<_i214.SimpleData>>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<List<_i214.SimpleData>>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<List<_i214.SimpleData>>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == Map<String, List<List<Map<int, _i214.SimpleData>>?>>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<List<List<Map<int, _i214.SimpleData>>?>>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == List<List<Map<int, _i214.SimpleData>>?>) {
-      return (data as List)
-              .map((e) => deserialize<List<Map<int, _i214.SimpleData>>?>(e))
-              .toList()
-          as T;
-    }
-    if (t == List<Map<int, _i214.SimpleData>>) {
-      return (data as List)
-              .map((e) => deserialize<Map<int, _i214.SimpleData>>(e))
-              .toList()
-          as T;
-    }
-    if (t == Map<int, _i214.SimpleData>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) => MapEntry(
-                deserialize<int>(e['k']),
-                deserialize<_i214.SimpleData>(e['v']),
-              ),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<List<Map<int, _i214.SimpleData>>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<Map<int, _i214.SimpleData>>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t ==
-        _i1.getType<Map<String, List<List<Map<int, _i214.SimpleData>>?>>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) => MapEntry(
-                    deserialize<String>(k),
-                    deserialize<List<List<Map<int, _i214.SimpleData>>?>>(v),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<List<Map<int, _i214.SimpleData>>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<Map<int, _i214.SimpleData>>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == Map<String, Map<int, _i214.SimpleData>>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<Map<int, _i214.SimpleData>>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<String, Map<int, _i214.SimpleData>>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) => MapEntry(
-                    deserialize<String>(k),
-                    deserialize<Map<int, _i214.SimpleData>>(v),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == List<_i122.SealedParent>) {
-      return (data as List)
-              .map((e) => deserialize<_i122.SealedParent>(e))
-              .toList()
-          as T;
-    }
-    if (t == List<_i104.SealedAppException>) {
-      return (data as List)
-              .map((e) => deserialize<_i104.SealedAppException>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<(bool,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<bool>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == List<_i201.Article>) {
-      return (data as List).map((e) => deserialize<_i201.Article>(e)).toList()
-          as T;
-    }
-    if (t == List<_i207.ServerOnlyClass>) {
-      return (data as List)
-              .map((e) => deserialize<_i207.ServerOnlyClass>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i207.ServerOnlyClass>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i207.ServerOnlyClass>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == Map<String, _i207.ServerOnlyClass>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<_i207.ServerOnlyClass>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<String, _i207.ServerOnlyClass>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) => MapEntry(
-                    deserialize<String>(k),
-                    deserialize<_i207.ServerOnlyClass>(v),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == List<_i6.SharedModel>) {
-      return (data as List).map((e) => deserialize<_i6.SharedModel>(e)).toList()
-          as T;
-    }
-    if (t == List<_i6.SharedModel?>) {
-      return (data as List)
-              .map((e) => deserialize<_i6.SharedModel?>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i6.SharedModel>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i6.SharedModel>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == Map<String, _i6.SharedModel>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<_i6.SharedModel>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<String, _i6.SharedModel>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) => MapEntry(
-                    deserialize<String>(k),
-                    deserialize<_i6.SharedModel>(v),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<String, _i6.SharedSubclass>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<_i6.SharedSubclass>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == Set<_i6.SharedModel>) {
-      return (data as List).map((e) => deserialize<_i6.SharedModel>(e)).toSet()
-          as T;
-    }
-    if (t == _i1.getType<Set<_i6.SharedModel>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i6.SharedModel>(e))
-                    .toSet()
-              : null)
-          as T;
-    }
-    if (t == List<_i224.TestEnumStringified>) {
-      return (data as List)
-              .map((e) => deserialize<_i224.TestEnumStringified>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i224.TestEnumStringified>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i224.TestEnumStringified>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(_i224.TestEnumStringified,)?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<_i224.TestEnumStringified>(
-                    ((data as Map)['p'] as List)[0],
-                  ),
-                )
-                as T;
-    }
-    if (t == List<(_i224.TestEnumStringified,)>) {
-      return (data as List)
-              .map((e) => deserialize<(_i224.TestEnumStringified,)>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<(_i224.TestEnumStringified,)>()) {
-      return (
-            deserialize<_i224.TestEnumStringified>(
-              ((data as Map)['p'] as List)[0],
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<List<(_i224.TestEnumStringified,)>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<(_i224.TestEnumStringified,)>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(_i224.TestEnumStringified,)>()) {
-      return (
-            deserialize<_i224.TestEnumStringified>(
-              ((data as Map)['p'] as List)[0],
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(_i165.Nullability,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<_i165.Nullability>(((data as Map)['p'] as List)[0]),)
-                as T;
-    }
-    if (t == _i1.getType<({_i224.TestEnumStringified value})?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  value: deserialize<_i224.TestEnumStringified>(
-                    ((data as Map)['n'] as Map)['value'],
-                  ),
-                )
-                as T;
-    }
-    if (t == List<({_i224.TestEnumStringified value})>) {
-      return (data as List)
-              .map((e) => deserialize<({_i224.TestEnumStringified value})>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<({_i224.TestEnumStringified value})>()) {
-      return (
-            value: deserialize<_i224.TestEnumStringified>(
-              ((data as Map)['n'] as Map)['value'],
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<List<({_i224.TestEnumStringified value})>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map(
-                      (e) =>
-                          deserialize<({_i224.TestEnumStringified value})>(e),
-                    )
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<({_i224.TestEnumStringified value})>()) {
-      return (
-            value: deserialize<_i224.TestEnumStringified>(
-              ((data as Map)['n'] as Map)['value'],
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<({_i4.ModuleClass value})?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  value: deserialize<_i4.ModuleClass>(
-                    ((data as Map)['n'] as Map)['value'],
-                  ),
-                )
-                as T;
-    }
-    if (t == _i1.getType<({_i165.Nullability value})?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  value: deserialize<_i165.Nullability>(
-                    ((data as Map)['n'] as Map)['value'],
-                  ),
-                )
-                as T;
-    }
-    if (t == _i1.getType<Map<int, int>?>()) {
-      return (data != null
-              ? Map.fromEntries(
-                  (data as List).map(
-                    (e) => MapEntry(
-                      deserialize<int>(e['k']),
-                      deserialize<int>(e['v']),
-                    ),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == Set<int>) {
-      return (data as List).map((e) => deserialize<int>(e)).toSet() as T;
-    }
-    if (t == _i1.getType<Set<int>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<int>(e)).toSet()
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(String, {Uri? optionalUri})?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<String>(((data as Map)['p'] as List)[0]),
-                  optionalUri: ((data)['n'] as Map)['optionalUri'] == null
-                      ? null
-                      : deserialize<Uri>(data['n']['optionalUri']),
-                )
-                as T;
-    }
-    if (t == List<bool>) {
-      return (data as List).map((e) => deserialize<bool>(e)).toList() as T;
-    }
-    if (t == _i1.getType<List<bool>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<bool>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == List<double>) {
-      return (data as List).map((e) => deserialize<double>(e)).toList() as T;
-    }
-    if (t == _i1.getType<List<double>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<double>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == List<Uri>) {
-      return (data as List).map((e) => deserialize<Uri>(e)).toList() as T;
-    }
-    if (t == _i1.getType<List<Uri>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<Uri>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == List<BigInt>) {
-      return (data as List).map((e) => deserialize<BigInt>(e)).toList() as T;
-    }
-    if (t == _i1.getType<List<BigInt>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<BigInt>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<List<_i220.TestEnum>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i220.TestEnum>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i225.Types>) {
-      return (data as List).map((e) => deserialize<_i225.Types>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i225.Types>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<_i225.Types>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == List<Map<String, _i225.Types>>) {
-      return (data as List)
-              .map((e) => deserialize<Map<String, _i225.Types>>(e))
-              .toList()
-          as T;
-    }
-    if (t == Map<String, _i225.Types>) {
-      return (data as Map).map(
-            (k, v) =>
-                MapEntry(deserialize<String>(k), deserialize<_i225.Types>(v)),
-          )
-          as T;
-    }
-    if (t == _i1.getType<List<Map<String, _i225.Types>>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<Map<String, _i225.Types>>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<List<_i225.Types>>) {
-      return (data as List)
-              .map((e) => deserialize<List<_i225.Types>>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<List<_i225.Types>>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<List<_i225.Types>>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<(int,)>) {
-      return (data as List).map((e) => deserialize<(int,)>(e)).toList() as T;
-    }
-    if (t == _i1.getType<(int,)>()) {
-      return (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<List<(int,)>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<(int,)>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(int,)>()) {
-      return (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == List<(int,)?>) {
-      return (data as List).map((e) => deserialize<(int,)?>(e)).toList() as T;
-    }
-    if (t == _i1.getType<(int,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<List<(int,)?>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<(int,)?>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(int,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == List<(_i220.TestEnum,)>) {
-      return (data as List)
-              .map((e) => deserialize<(_i220.TestEnum,)>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<(_i220.TestEnum,)>()) {
-      return (deserialize<_i220.TestEnum>(((data as Map)['p'] as List)[0]),)
-          as T;
-    }
-    if (t == _i1.getType<List<(_i220.TestEnum,)>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<(_i220.TestEnum,)>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(_i220.TestEnum,)>()) {
-      return (deserialize<_i220.TestEnum>(((data as Map)['p'] as List)[0]),)
-          as T;
-    }
-    if (t == Map<int, String>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) => MapEntry(
-                deserialize<int>(e['k']),
-                deserialize<String>(e['v']),
-              ),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<int, String>?>()) {
-      return (data != null
-              ? Map.fromEntries(
-                  (data as List).map(
-                    (e) => MapEntry(
-                      deserialize<int>(e['k']),
-                      deserialize<String>(e['v']),
-                    ),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<bool, String>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) => MapEntry(
-                deserialize<bool>(e['k']),
-                deserialize<String>(e['v']),
-              ),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<bool, String>?>()) {
-      return (data != null
-              ? Map.fromEntries(
-                  (data as List).map(
-                    (e) => MapEntry(
-                      deserialize<bool>(e['k']),
-                      deserialize<String>(e['v']),
-                    ),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<double, String>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) => MapEntry(
-                deserialize<double>(e['k']),
-                deserialize<String>(e['v']),
-              ),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<double, String>?>()) {
-      return (data != null
-              ? Map.fromEntries(
-                  (data as List).map(
-                    (e) => MapEntry(
-                      deserialize<double>(e['k']),
-                      deserialize<String>(e['v']),
-                    ),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<DateTime, String>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) => MapEntry(
-                deserialize<DateTime>(e['k']),
-                deserialize<String>(e['v']),
-              ),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<DateTime, String>?>()) {
-      return (data != null
-              ? Map.fromEntries(
-                  (data as List).map(
-                    (e) => MapEntry(
-                      deserialize<DateTime>(e['k']),
-                      deserialize<String>(e['v']),
-                    ),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<Map<String, String>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) =>
-                      MapEntry(deserialize<String>(k), deserialize<String>(v)),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<_i234.ByteData, String>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) => MapEntry(
-                deserialize<_i234.ByteData>(e['k']),
-                deserialize<String>(e['v']),
-              ),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<_i234.ByteData, String>?>()) {
-      return (data != null
-              ? Map.fromEntries(
-                  (data as List).map(
-                    (e) => MapEntry(
-                      deserialize<_i234.ByteData>(e['k']),
-                      deserialize<String>(e['v']),
-                    ),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<Duration, String>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) => MapEntry(
-                deserialize<Duration>(e['k']),
-                deserialize<String>(e['v']),
-              ),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<Duration, String>?>()) {
-      return (data != null
-              ? Map.fromEntries(
-                  (data as List).map(
-                    (e) => MapEntry(
-                      deserialize<Duration>(e['k']),
-                      deserialize<String>(e['v']),
-                    ),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<_i1.UuidValue, String>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) => MapEntry(
-                deserialize<_i1.UuidValue>(e['k']),
-                deserialize<String>(e['v']),
-              ),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<_i1.UuidValue, String>?>()) {
-      return (data != null
-              ? Map.fromEntries(
-                  (data as List).map(
-                    (e) => MapEntry(
-                      deserialize<_i1.UuidValue>(e['k']),
-                      deserialize<String>(e['v']),
-                    ),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<Uri, String>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) => MapEntry(
-                deserialize<Uri>(e['k']),
-                deserialize<String>(e['v']),
-              ),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<Uri, String>?>()) {
-      return (data != null
-              ? Map.fromEntries(
-                  (data as List).map(
-                    (e) => MapEntry(
-                      deserialize<Uri>(e['k']),
-                      deserialize<String>(e['v']),
-                    ),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<BigInt, String>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) => MapEntry(
-                deserialize<BigInt>(e['k']),
-                deserialize<String>(e['v']),
-              ),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<BigInt, String>?>()) {
-      return (data != null
-              ? Map.fromEntries(
-                  (data as List).map(
-                    (e) => MapEntry(
-                      deserialize<BigInt>(e['k']),
-                      deserialize<String>(e['v']),
-                    ),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<_i220.TestEnum, String>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) => MapEntry(
-                deserialize<_i220.TestEnum>(e['k']),
-                deserialize<String>(e['v']),
-              ),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<_i220.TestEnum, String>?>()) {
-      return (data != null
-              ? Map.fromEntries(
-                  (data as List).map(
-                    (e) => MapEntry(
-                      deserialize<_i220.TestEnum>(e['k']),
-                      deserialize<String>(e['v']),
-                    ),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<_i224.TestEnumStringified, String>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) => MapEntry(
-                deserialize<_i224.TestEnumStringified>(e['k']),
-                deserialize<String>(e['v']),
-              ),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<_i224.TestEnumStringified, String>?>()) {
-      return (data != null
-              ? Map.fromEntries(
-                  (data as List).map(
-                    (e) => MapEntry(
-                      deserialize<_i224.TestEnumStringified>(e['k']),
-                      deserialize<String>(e['v']),
-                    ),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<_i225.Types, String>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) => MapEntry(
-                deserialize<_i225.Types>(e['k']),
-                deserialize<String>(e['v']),
-              ),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<_i225.Types, String>?>()) {
-      return (data != null
-              ? Map.fromEntries(
-                  (data as List).map(
-                    (e) => MapEntry(
-                      deserialize<_i225.Types>(e['k']),
-                      deserialize<String>(e['v']),
-                    ),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<Map<_i225.Types, String>, String>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) => MapEntry(
-                deserialize<Map<_i225.Types, String>>(e['k']),
-                deserialize<String>(e['v']),
-              ),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<Map<_i225.Types, String>, String>?>()) {
-      return (data != null
-              ? Map.fromEntries(
-                  (data as List).map(
-                    (e) => MapEntry(
-                      deserialize<Map<_i225.Types, String>>(e['k']),
-                      deserialize<String>(e['v']),
-                    ),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<List<_i225.Types>, String>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) => MapEntry(
-                deserialize<List<_i225.Types>>(e['k']),
-                deserialize<String>(e['v']),
-              ),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<List<_i225.Types>, String>?>()) {
-      return (data != null
-              ? Map.fromEntries(
-                  (data as List).map(
-                    (e) => MapEntry(
-                      deserialize<List<_i225.Types>>(e['k']),
-                      deserialize<String>(e['v']),
-                    ),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<(String,), String>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) => MapEntry(
-                deserialize<(String,)>(e['k']),
-                deserialize<String>(e['v']),
-              ),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(String,)>()) {
-      return (deserialize<String>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<Map<(String,), String>?>()) {
-      return (data != null
-              ? Map.fromEntries(
-                  (data as List).map(
-                    (e) => MapEntry(
-                      deserialize<(String,)>(e['k']),
-                      deserialize<String>(e['v']),
-                    ),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(String,)>()) {
-      return (deserialize<String>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == Map<String, bool>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(deserialize<String>(k), deserialize<bool>(v)),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<String, bool>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) =>
-                      MapEntry(deserialize<String>(k), deserialize<bool>(v)),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<String, double>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(deserialize<String>(k), deserialize<double>(v)),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<String, double>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) =>
-                      MapEntry(deserialize<String>(k), deserialize<double>(v)),
-                )
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<Map<String, DateTime>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) => MapEntry(
-                    deserialize<String>(k),
-                    deserialize<DateTime>(v),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<Map<String, _i234.ByteData>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) => MapEntry(
-                    deserialize<String>(k),
-                    deserialize<_i234.ByteData>(v),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<Map<String, Duration>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) => MapEntry(
-                    deserialize<String>(k),
-                    deserialize<Duration>(v),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<Map<String, _i1.UuidValue>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) => MapEntry(
-                    deserialize<String>(k),
-                    deserialize<_i1.UuidValue>(v),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<String, Uri>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(deserialize<String>(k), deserialize<Uri>(v)),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<String, Uri>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) =>
-                      MapEntry(deserialize<String>(k), deserialize<Uri>(v)),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<String, BigInt>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(deserialize<String>(k), deserialize<BigInt>(v)),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<String, BigInt>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) =>
-                      MapEntry(deserialize<String>(k), deserialize<BigInt>(v)),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<String, _i220.TestEnum>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<_i220.TestEnum>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<String, _i220.TestEnum>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) => MapEntry(
-                    deserialize<String>(k),
-                    deserialize<_i220.TestEnum>(v),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<String, _i224.TestEnumStringified>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<_i224.TestEnumStringified>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<String, _i224.TestEnumStringified>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) => MapEntry(
-                    deserialize<String>(k),
-                    deserialize<_i224.TestEnumStringified>(v),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<Map<String, _i225.Types>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) => MapEntry(
-                    deserialize<String>(k),
-                    deserialize<_i225.Types>(v),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<String, Map<String, _i225.Types>>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<Map<String, _i225.Types>>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<String, Map<String, _i225.Types>>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) => MapEntry(
-                    deserialize<String>(k),
-                    deserialize<Map<String, _i225.Types>>(v),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<String, List<_i225.Types>>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<List<_i225.Types>>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<String, List<_i225.Types>>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) => MapEntry(
-                    deserialize<String>(k),
-                    deserialize<List<_i225.Types>>(v),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<String, (String,)>) {
-      return (data as Map).map(
-            (k, v) =>
-                MapEntry(deserialize<String>(k), deserialize<(String,)>(v)),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(String,)>()) {
-      return (deserialize<String>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<Map<String, (String,)>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) => MapEntry(
-                    deserialize<String>(k),
-                    deserialize<(String,)>(v),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(String,)>()) {
-      return (deserialize<String>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == Map<String, (String,)?>) {
-      return (data as Map).map(
-            (k, v) =>
-                MapEntry(deserialize<String>(k), deserialize<(String,)?>(v)),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(String,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<String>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<Map<String, (String,)?>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) => MapEntry(
-                    deserialize<String>(k),
-                    deserialize<(String,)?>(v),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(String,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<String>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == Map<(String,)?, String>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) => MapEntry(
-                deserialize<(String,)?>(e['k']),
-                deserialize<String>(e['v']),
-              ),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(String,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<String>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<Map<(String,)?, String>?>()) {
-      return (data != null
-              ? Map.fromEntries(
-                  (data as List).map(
-                    (e) => MapEntry(
-                      deserialize<(String,)?>(e['k']),
-                      deserialize<String>(e['v']),
-                    ),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(String,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<String>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(int,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(double,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<double>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(DateTime,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<DateTime>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(String,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<String>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(_i234.ByteData,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<_i234.ByteData>(((data as Map)['p'] as List)[0]),)
-                as T;
-    }
-    if (t == _i1.getType<(Duration,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<Duration>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(_i1.UuidValue,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<_i1.UuidValue>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(Uri,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<Uri>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(BigInt,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<BigInt>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(_i220.TestEnum,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<_i220.TestEnum>(((data as Map)['p'] as List)[0]),)
-                as T;
-    }
-    if (t == _i1.getType<(List<int>,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<List<int>>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(Map<int, int>,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<Map<int, int>>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(Set<int>,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<Set<int>>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(_i214.SimpleData,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<_i214.SimpleData>(((data as Map)['p'] as List)[0]),)
-                as T;
-    }
-    if (t == _i1.getType<({_i214.SimpleData namedModel})?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  namedModel: deserialize<_i214.SimpleData>(
-                    ((data as Map)['n'] as Map)['namedModel'],
-                  ),
-                )
-                as T;
-    }
-    if (t ==
-        _i1.getType<(_i214.SimpleData, {_i214.SimpleData namedModel})?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<_i214.SimpleData>(
-                    ((data as Map)['p'] as List)[0],
-                  ),
-                  namedModel: deserialize<_i214.SimpleData>(
-                    data['n']['namedModel'],
-                  ),
-                )
-                as T;
-    }
-    if (t ==
-        _i1.getType<((int, String), {(int, String) namedNestedRecord})?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<(int, String)>(((data as Map)['p'] as List)[0]),
-                  namedNestedRecord: deserialize<(int, String)>(
-                    data['n']['namedNestedRecord'],
-                  ),
-                )
-                as T;
-    }
-    if (t ==
-        _i1
-            .getType<
-              (
-                (List<(_i214.SimpleData,)>,), {
-                (_i214.SimpleData, Map<String, _i214.SimpleData>)
-                namedNestedRecord,
-              })?
-            >()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<(List<(_i214.SimpleData,)>,)>(
-                    ((data as Map)['p'] as List)[0],
-                  ),
-                  namedNestedRecord:
-                      deserialize<
-                        (_i214.SimpleData, Map<String, _i214.SimpleData>)
-                      >(data['n']['namedNestedRecord']),
-                )
-                as T;
-    }
-    if (t == Set<bool>) {
-      return (data as List).map((e) => deserialize<bool>(e)).toSet() as T;
-    }
-    if (t == _i1.getType<Set<bool>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<bool>(e)).toSet()
-              : null)
-          as T;
-    }
-    if (t == Set<double>) {
-      return (data as List).map((e) => deserialize<double>(e)).toSet() as T;
-    }
-    if (t == _i1.getType<Set<double>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<double>(e)).toSet()
-              : null)
-          as T;
-    }
-    if (t == Set<DateTime>) {
-      return (data as List).map((e) => deserialize<DateTime>(e)).toSet() as T;
-    }
-    if (t == _i1.getType<Set<DateTime>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<DateTime>(e)).toSet()
-              : null)
-          as T;
-    }
-    if (t == Set<String>) {
-      return (data as List).map((e) => deserialize<String>(e)).toSet() as T;
-    }
-    if (t == _i1.getType<Set<String>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<String>(e)).toSet()
-              : null)
-          as T;
-    }
-    if (t == Set<_i234.ByteData>) {
-      return (data as List).map((e) => deserialize<_i234.ByteData>(e)).toSet()
-          as T;
-    }
-    if (t == _i1.getType<Set<_i234.ByteData>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i234.ByteData>(e))
-                    .toSet()
-              : null)
-          as T;
-    }
-    if (t == Set<Duration>) {
-      return (data as List).map((e) => deserialize<Duration>(e)).toSet() as T;
-    }
-    if (t == _i1.getType<Set<Duration>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<Duration>(e)).toSet()
-              : null)
-          as T;
-    }
-    if (t == Set<_i1.UuidValue>) {
-      return (data as List).map((e) => deserialize<_i1.UuidValue>(e)).toSet()
-          as T;
-    }
-    if (t == _i1.getType<Set<_i1.UuidValue>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<_i1.UuidValue>(e)).toSet()
-              : null)
-          as T;
-    }
-    if (t == Set<BigInt>) {
-      return (data as List).map((e) => deserialize<BigInt>(e)).toSet() as T;
-    }
-    if (t == _i1.getType<Set<BigInt>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<BigInt>(e)).toSet()
-              : null)
-          as T;
-    }
-    if (t == Set<_i220.TestEnum>) {
-      return (data as List).map((e) => deserialize<_i220.TestEnum>(e)).toSet()
-          as T;
-    }
-    if (t == _i1.getType<Set<_i220.TestEnum>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i220.TestEnum>(e))
-                    .toSet()
-              : null)
-          as T;
-    }
-    if (t == Set<_i224.TestEnumStringified>) {
-      return (data as List)
-              .map((e) => deserialize<_i224.TestEnumStringified>(e))
-              .toSet()
-          as T;
-    }
-    if (t == _i1.getType<Set<_i224.TestEnumStringified>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i224.TestEnumStringified>(e))
-                    .toSet()
-              : null)
-          as T;
-    }
-    if (t == Set<_i225.Types>) {
-      return (data as List).map((e) => deserialize<_i225.Types>(e)).toSet()
-          as T;
-    }
-    if (t == _i1.getType<Set<_i225.Types>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<_i225.Types>(e)).toSet()
-              : null)
-          as T;
-    }
-    if (t == Set<Map<String, _i225.Types>>) {
-      return (data as List)
-              .map((e) => deserialize<Map<String, _i225.Types>>(e))
-              .toSet()
-          as T;
-    }
-    if (t == _i1.getType<Set<Map<String, _i225.Types>>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<Map<String, _i225.Types>>(e))
-                    .toSet()
-              : null)
-          as T;
-    }
-    if (t == Set<List<_i225.Types>>) {
-      return (data as List)
-              .map((e) => deserialize<List<_i225.Types>>(e))
-              .toSet()
-          as T;
-    }
-    if (t == _i1.getType<Set<List<_i225.Types>>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<List<_i225.Types>>(e))
-                    .toSet()
-              : null)
-          as T;
-    }
-    if (t == Set<(int,)>) {
-      return (data as List).map((e) => deserialize<(int,)>(e)).toSet() as T;
-    }
-    if (t == _i1.getType<(int,)>()) {
-      return (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<Set<(int,)>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<(int,)>(e)).toSet()
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(int,)>()) {
-      return (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == Set<(int,)?>) {
-      return (data as List).map((e) => deserialize<(int,)?>(e)).toSet() as T;
-    }
-    if (t == _i1.getType<(int,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<Set<(int,)?>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<(int,)?>(e)).toSet()
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(int,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == List<String>) {
-      return (data as List).map((e) => deserialize<String>(e)).toList() as T;
-    }
-    if (t == _i1.getType<List<String>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<String>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i235.SimpleData>) {
-      return (data as List)
-              .map((e) => deserialize<_i235.SimpleData>(e))
-              .toList()
-          as T;
-    }
-    if (t == List<int>) {
-      return (data as List).map((e) => deserialize<int>(e)).toList() as T;
-    }
-    if (t == List<List<int>>) {
-      return (data as List).map((e) => deserialize<List<int>>(e)).toList() as T;
-    }
-    if (t == _i1.getType<List<int>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<int>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == List<List<int>?>) {
-      return (data as List).map((e) => deserialize<List<int>?>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<List<int>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<int>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<List<List<int>>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<List<int>>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == List<int?>) {
-      return (data as List).map((e) => deserialize<int?>(e)).toList() as T;
-    }
-    if (t == _i1.getType<List<int?>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<int?>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == List<double>) {
-      return (data as List).map((e) => deserialize<double>(e)).toList() as T;
-    }
-    if (t == List<double?>) {
-      return (data as List).map((e) => deserialize<double?>(e)).toList() as T;
-    }
-    if (t == List<bool>) {
-      return (data as List).map((e) => deserialize<bool>(e)).toList() as T;
-    }
-    if (t == List<bool?>) {
-      return (data as List).map((e) => deserialize<bool?>(e)).toList() as T;
-    }
-    if (t == List<String?>) {
-      return (data as List).map((e) => deserialize<String?>(e)).toList() as T;
-    }
-    if (t == List<DateTime>) {
-      return (data as List).map((e) => deserialize<DateTime>(e)).toList() as T;
-    }
-    if (t == List<DateTime?>) {
-      return (data as List).map((e) => deserialize<DateTime?>(e)).toList() as T;
-    }
-    if (t == List<_i234.ByteData>) {
-      return (data as List).map((e) => deserialize<_i234.ByteData>(e)).toList()
-          as T;
-    }
-    if (t == List<_i234.ByteData?>) {
-      return (data as List).map((e) => deserialize<_i234.ByteData?>(e)).toList()
-          as T;
-    }
-    if (t == List<_i235.SimpleData?>) {
-      return (data as List)
-              .map((e) => deserialize<_i235.SimpleData?>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i235.SimpleData>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i235.SimpleData>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<List<_i235.SimpleData?>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i235.SimpleData?>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<Duration>) {
-      return (data as List).map((e) => deserialize<Duration>(e)).toList() as T;
-    }
-    if (t == List<Duration?>) {
-      return (data as List).map((e) => deserialize<Duration?>(e)).toList() as T;
-    }
-    if (t == Map<String, int>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(deserialize<String>(k), deserialize<int>(v)),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<String, int>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) =>
-                      MapEntry(deserialize<String>(k), deserialize<int>(v)),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<String, Map<String, int>>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<Map<String, int>>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == Map<String, int?>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(deserialize<String>(k), deserialize<int?>(v)),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<String, int?>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) =>
-                      MapEntry(deserialize<String>(k), deserialize<int?>(v)),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<int, int>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) =>
-                  MapEntry(deserialize<int>(e['k']), deserialize<int>(e['v'])),
-            ),
-          )
-          as T;
-    }
-    if (t == Map<String, Map<int, int>>) {
-      return (data as Map).map(
-            (k, v) =>
-                MapEntry(deserialize<String>(k), deserialize<Map<int, int>>(v)),
-          )
-          as T;
-    }
-    if (t == Map<_i236.TestEnum, int>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) => MapEntry(
-                deserialize<_i236.TestEnum>(e['k']),
-                deserialize<int>(e['v']),
-              ),
-            ),
-          )
-          as T;
-    }
-    if (t == Map<String, _i236.TestEnum>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<_i236.TestEnum>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == Map<String, double>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(deserialize<String>(k), deserialize<double>(v)),
-          )
-          as T;
-    }
-    if (t == Map<String, double?>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(deserialize<String>(k), deserialize<double?>(v)),
-          )
-          as T;
-    }
-    if (t == Map<String, bool>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(deserialize<String>(k), deserialize<bool>(v)),
-          )
-          as T;
-    }
-    if (t == Map<String, bool?>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(deserialize<String>(k), deserialize<bool?>(v)),
-          )
-          as T;
-    }
-    if (t == Map<String, String>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(deserialize<String>(k), deserialize<String>(v)),
-          )
-          as T;
-    }
-    if (t == Map<String, String?>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(deserialize<String>(k), deserialize<String?>(v)),
-          )
-          as T;
-    }
-    if (t == Map<String, DateTime>) {
-      return (data as Map).map(
-            (k, v) =>
-                MapEntry(deserialize<String>(k), deserialize<DateTime>(v)),
-          )
-          as T;
-    }
-    if (t == Map<String, DateTime?>) {
-      return (data as Map).map(
-            (k, v) =>
-                MapEntry(deserialize<String>(k), deserialize<DateTime?>(v)),
-          )
-          as T;
-    }
-    if (t == Map<String, _i234.ByteData>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<_i234.ByteData>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == Map<String, _i234.ByteData?>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<_i234.ByteData?>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == Map<String, _i235.SimpleData>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<_i235.SimpleData>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == Map<String, _i235.SimpleData?>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<_i235.SimpleData?>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<String, _i235.SimpleData>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) => MapEntry(
-                    deserialize<String>(k),
-                    deserialize<_i235.SimpleData>(v),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<Map<String, _i235.SimpleData?>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) => MapEntry(
-                    deserialize<String>(k),
-                    deserialize<_i235.SimpleData?>(v),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == Map<String, Duration>) {
-      return (data as Map).map(
-            (k, v) =>
-                MapEntry(deserialize<String>(k), deserialize<Duration>(v)),
-          )
-          as T;
-    }
-    if (t == Map<String, Duration?>) {
-      return (data as Map).map(
-            (k, v) =>
-                MapEntry(deserialize<String>(k), deserialize<Duration?>(v)),
-          )
-          as T;
-    }
-    if (t == Map<(Map<int, String>, String), String>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) => MapEntry(
-                deserialize<(Map<int, String>, String)>(e['k']),
-                deserialize<String>(e['v']),
-              ),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(Map<int, String>, String)>()) {
-      return (
-            deserialize<Map<int, String>>(((data as Map)['p'] as List)[0]),
-            deserialize<String>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(Map<int, String>, String)>()) {
-      return (
-            deserialize<Map<int, String>>(((data as Map)['p'] as List)[0]),
-            deserialize<String>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == Map<int, String>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) => MapEntry(
-                deserialize<int>(e['k']),
-                deserialize<String>(e['v']),
-              ),
-            ),
-          )
-          as T;
-    }
-    if (t == Map<String, (Map<int, int>,)>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<(Map<int, int>,)>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(Map<int, int>,)>()) {
-      return (deserialize<Map<int, int>>(((data as Map)['p'] as List)[0]),)
-          as T;
-    }
-    if (t == _i1.getType<(Map<int, int>,)>()) {
-      return (deserialize<Map<int, int>>(((data as Map)['p'] as List)[0]),)
-          as T;
-    }
-    if (t == Map<DateTime, bool>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) => MapEntry(
-                deserialize<DateTime>(e['k']),
-                deserialize<bool>(e['v']),
-              ),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<DateTime, bool>?>()) {
-      return (data != null
-              ? Map.fromEntries(
-                  (data as List).map(
-                    (e) => MapEntry(
-                      deserialize<DateTime>(e['k']),
-                      deserialize<bool>(e['v']),
-                    ),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<Map<int, String>?>()) {
-      return (data != null
-              ? Map.fromEntries(
-                  (data as List).map(
-                    (e) => MapEntry(
-                      deserialize<int>(e['k']),
-                      deserialize<String>(e['v']),
-                    ),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == List<_i3.UserInfo>) {
-      return (data as List).map((e) => deserialize<_i3.UserInfo>(e)).toList()
-          as T;
-    }
-    if (t == Set<int>) {
-      return (data as List).map((e) => deserialize<int>(e)).toSet() as T;
-    }
-    if (t == Set<_i235.SimpleData>) {
-      return (data as List).map((e) => deserialize<_i235.SimpleData>(e)).toSet()
-          as T;
-    }
-    if (t == List<Set<_i235.SimpleData>>) {
-      return (data as List)
-              .map((e) => deserialize<Set<_i235.SimpleData>>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<(int, BigInt)>()) {
-      return (
-            deserialize<int>(((data as Map)['p'] as List)[0]),
-            deserialize<BigInt>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(String, _i237.PolymorphicParent)>()) {
-      return (
-            deserialize<String>(((data as Map)['p'] as List)[0]),
-            deserialize<_i237.PolymorphicParent>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(int,)>()) {
-      return (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(int,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(int?,)>()) {
-      return (
-            ((data as Map)['p'] as List)[0] == null
-                ? null
-                : deserialize<int>(data['p'][0]),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(int?,)?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  ((data as Map)['p'] as List)[0] == null
-                      ? null
-                      : deserialize<int>(data['p'][0]),
-                )
-                as T;
-    }
-    if (t == _i1.getType<(int, String)>()) {
-      return (
-            deserialize<int>(((data as Map)['p'] as List)[0]),
-            deserialize<String>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(int, String)?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<int>(((data as Map)['p'] as List)[0]),
-                  deserialize<String>(data['p'][1]),
-                )
-                as T;
-    }
-    if (t == _i1.getType<(int, _i235.SimpleData)>()) {
-      return (
-            deserialize<int>(((data as Map)['p'] as List)[0]),
-            deserialize<_i235.SimpleData>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(int, _i235.SimpleData)?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<int>(((data as Map)['p'] as List)[0]),
-                  deserialize<_i235.SimpleData>(data['p'][1]),
-                )
-                as T;
-    }
-    if (t == _i1.getType<(Map<String, int>,)>()) {
-      return (deserialize<Map<String, int>>(((data as Map)['p'] as List)[0]),)
-          as T;
-    }
-    if (t == _i1.getType<(Set<(int,)>,)>()) {
-      return (deserialize<Set<(int,)>>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == Set<(int,)>) {
-      return (data as List).map((e) => deserialize<(int,)>(e)).toSet() as T;
-    }
-    if (t == _i1.getType<(int,)>()) {
-      return (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<({int number, String text})>()) {
-      return (
-            number: deserialize<int>(((data as Map)['n'] as Map)['number']),
-            text: deserialize<String>(data['n']['text']),
-          )
-          as T;
-    }
-    if (t == _i1.getType<({int number, String text})?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  number: deserialize<int>(
-                    ((data as Map)['n'] as Map)['number'],
-                  ),
-                  text: deserialize<String>(data['n']['text']),
-                )
-                as T;
-    }
-    if (t == _i1.getType<({_i235.SimpleData data, int number})>()) {
-      return (
-            data: deserialize<_i235.SimpleData>(
-              ((data as Map)['n'] as Map)['data'],
-            ),
-            number: deserialize<int>(data['n']['number']),
-          )
-          as T;
-    }
-    if (t == _i1.getType<({_i235.SimpleData data, int number})?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  data: deserialize<_i235.SimpleData>(
-                    ((data as Map)['n'] as Map)['data'],
-                  ),
-                  number: deserialize<int>(data['n']['number']),
-                )
-                as T;
-    }
-    if (t == _i1.getType<({_i235.SimpleData? data, int? number})>()) {
-      return (
-            data: ((data as Map)['n'] as Map)['data'] == null
-                ? null
-                : deserialize<_i235.SimpleData>(data['n']['data']),
-            number: ((data)['n'] as Map)['number'] == null
-                ? null
-                : deserialize<int>(data['n']['number']),
-          )
-          as T;
-    }
-    if (t == _i1.getType<({Map<int, int> intIntMap})>()) {
-      return (
-            intIntMap: deserialize<Map<int, int>>(
-              ((data as Map)['n'] as Map)['intIntMap'],
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<({Set<(bool,)> boolSet})>()) {
-      return (
-            boolSet: deserialize<Set<(bool,)>>(
-              ((data as Map)['n'] as Map)['boolSet'],
-            ),
-          )
-          as T;
-    }
-    if (t == Set<(bool,)>) {
-      return (data as List).map((e) => deserialize<(bool,)>(e)).toSet() as T;
-    }
-    if (t == _i1.getType<(bool,)>()) {
-      return (deserialize<bool>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(bool,)>()) {
-      return (deserialize<bool>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(Map<(Map<int, String>, String), String>,)>()) {
-      return (
-            deserialize<Map<(Map<int, String>, String), String>>(
-              ((data as Map)['p'] as List)[0],
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(int, {_i235.SimpleData data})>()) {
-      return (
-            deserialize<int>(((data as Map)['p'] as List)[0]),
-            data: deserialize<_i235.SimpleData>(data['n']['data']),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(int, {_i235.SimpleData data})?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<int>(((data as Map)['p'] as List)[0]),
-                  data: deserialize<_i235.SimpleData>(data['n']['data']),
-                )
-                as T;
-    }
-    if (t == List<(int, _i235.SimpleData)>) {
-      return (data as List)
-              .map((e) => deserialize<(int, _i235.SimpleData)>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<(int, _i235.SimpleData)>()) {
-      return (
-            deserialize<int>(((data as Map)['p'] as List)[0]),
-            deserialize<_i235.SimpleData>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == List<(int, _i235.SimpleData)?>) {
-      return (data as List)
-              .map((e) => deserialize<(int, _i235.SimpleData)?>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<(int, _i235.SimpleData)?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<int>(((data as Map)['p'] as List)[0]),
-                  deserialize<_i235.SimpleData>(data['p'][1]),
-                )
-                as T;
-    }
-    if (t == Set<(int, _i235.SimpleData)>) {
-      return (data as List)
-              .map((e) => deserialize<(int, _i235.SimpleData)>(e))
-              .toSet()
-          as T;
-    }
-    if (t == _i1.getType<(int, _i235.SimpleData)>()) {
-      return (
-            deserialize<int>(((data as Map)['p'] as List)[0]),
-            deserialize<_i235.SimpleData>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == Set<(int, _i235.SimpleData)?>) {
-      return (data as List)
-              .map((e) => deserialize<(int, _i235.SimpleData)?>(e))
-              .toSet()
-          as T;
-    }
-    if (t == _i1.getType<(int, _i235.SimpleData)?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<int>(((data as Map)['p'] as List)[0]),
-                  deserialize<_i235.SimpleData>(data['p'][1]),
-                )
-                as T;
-    }
-    if (t == _i1.getType<(int, _i235.SimpleData)>()) {
-      return (
-            deserialize<int>(((data as Map)['p'] as List)[0]),
-            deserialize<_i235.SimpleData>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Set<(int, _i235.SimpleData)>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<(int, _i235.SimpleData)>(e))
-                    .toSet()
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(int, _i235.SimpleData)>()) {
-      return (
-            deserialize<int>(((data as Map)['p'] as List)[0]),
-            deserialize<_i235.SimpleData>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == Map<String, (int, _i235.SimpleData)>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<(int, _i235.SimpleData)>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(int, _i235.SimpleData)>()) {
-      return (
-            deserialize<int>(((data as Map)['p'] as List)[0]),
-            deserialize<_i235.SimpleData>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == Map<String, (int, _i235.SimpleData)?>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<(int, _i235.SimpleData)?>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(int, _i235.SimpleData)?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<int>(((data as Map)['p'] as List)[0]),
-                  deserialize<_i235.SimpleData>(data['p'][1]),
-                )
-                as T;
-    }
-    if (t == Map<(String, int), (int, _i235.SimpleData)>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) => MapEntry(
-                deserialize<(String, int)>(e['k']),
-                deserialize<(int, _i235.SimpleData)>(e['v']),
-              ),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(String, int)>()) {
-      return (
-            deserialize<String>(((data as Map)['p'] as List)[0]),
-            deserialize<int>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(int, _i235.SimpleData)>()) {
-      return (
-            deserialize<int>(((data as Map)['p'] as List)[0]),
-            deserialize<_i235.SimpleData>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(String, int)>()) {
-      return (
-            deserialize<String>(((data as Map)['p'] as List)[0]),
-            deserialize<int>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == Map<String, List<Set<(int,)>>>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<List<Set<(int,)>>>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == List<Set<(int,)>>) {
-      return (data as List).map((e) => deserialize<Set<(int,)>>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<(int,)>()) {
-      return (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(int,)>()) {
-      return (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == Set<List<Map<String, (int,)>>>) {
-      return (data as List)
-              .map((e) => deserialize<List<Map<String, (int,)>>>(e))
-              .toSet()
-          as T;
-    }
-    if (t == List<Map<String, (int,)>>) {
-      return (data as List)
-              .map((e) => deserialize<Map<String, (int,)>>(e))
-              .toList()
-          as T;
-    }
-    if (t == Map<String, (int,)>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(deserialize<String>(k), deserialize<(int,)>(v)),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(int,)>()) {
-      return (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(int,)>()) {
-      return (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(int,)>()) {
-      return (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<({(_i235.SimpleData, double) namedSubRecord})>()) {
-      return (
-            namedSubRecord: deserialize<(_i235.SimpleData, double)>(
-              ((data as Map)['n'] as Map)['namedSubRecord'],
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(_i235.SimpleData, double)>()) {
-      return (
-            deserialize<_i235.SimpleData>(((data as Map)['p'] as List)[0]),
-            deserialize<double>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == _i1.getType<({(_i235.SimpleData, double)? namedSubRecord})>()) {
-      return (
-            namedSubRecord:
-                ((data as Map)['n'] as Map)['namedSubRecord'] == null
-                ? null
-                : deserialize<(_i235.SimpleData, double)>(
-                    data['n']['namedSubRecord'],
-                  ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(_i235.SimpleData, double)?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<_i235.SimpleData>(
-                    ((data as Map)['p'] as List)[0],
-                  ),
-                  deserialize<double>(data['p'][1]),
-                )
-                as T;
-    }
-    if (t ==
-        _i1
-            .getType<
-              ((int, String), {(_i235.SimpleData, double) namedSubRecord})
-            >()) {
-      return (
-            deserialize<(int, String)>(((data as Map)['p'] as List)[0]),
-            namedSubRecord: deserialize<(_i235.SimpleData, double)>(
-              data['n']['namedSubRecord'],
-            ),
-          )
-          as T;
-    }
-    if (t ==
-        List<((int, String), {(_i235.SimpleData, double) namedSubRecord})>) {
-      return (data as List)
-              .map(
-                (e) =>
-                    deserialize<
-                      (
-                        (int, String), {
-                        (_i235.SimpleData, double) namedSubRecord,
-                      })
-                    >(e),
-              )
-              .toList()
-          as T;
-    }
-    if (t ==
-        _i1
-            .getType<
-              ((int, String), {(_i235.SimpleData, double) namedSubRecord})
-            >()) {
-      return (
-            deserialize<(int, String)>(((data as Map)['p'] as List)[0]),
-            namedSubRecord: deserialize<(_i235.SimpleData, double)>(
-              data['n']['namedSubRecord'],
-            ),
-          )
-          as T;
-    }
-    if (t ==
-        List<((int, String), {(_i235.SimpleData, double) namedSubRecord})?>) {
-      return (data as List)
-              .map(
-                (e) =>
-                    deserialize<
-                      (
-                        (int, String), {
-                        (_i235.SimpleData, double) namedSubRecord,
-                      })?
-                    >(e),
-              )
-              .toList()
-          as T;
-    }
-    if (t ==
-        _i1
-            .getType<
-              ((int, String), {(_i235.SimpleData, double) namedSubRecord})?
-            >()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<(int, String)>(((data as Map)['p'] as List)[0]),
-                  namedSubRecord: deserialize<(_i235.SimpleData, double)>(
-                    data['n']['namedSubRecord'],
-                  ),
-                )
-                as T;
-    }
-    if (t ==
-        _i1
-            .getType<
-              List<
-                ((int, String), {(_i235.SimpleData, double) namedSubRecord})?
-              >?
-            >()) {
-      return (data != null
-              ? (data as List)
-                    .map(
-                      (e) =>
-                          deserialize<
-                            (
-                              (int, String), {
-                              (_i235.SimpleData, double) namedSubRecord,
-                            })?
-                          >(e),
-                    )
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t ==
-        _i1
-            .getType<
-              ((int, String), {(_i235.SimpleData, double) namedSubRecord})?
-            >()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<(int, String)>(((data as Map)['p'] as List)[0]),
-                  namedSubRecord: deserialize<(_i235.SimpleData, double)>(
-                    data['n']['namedSubRecord'],
-                  ),
-                )
-                as T;
-    }
-    if (t ==
-        _i1
-            .getType<
-              ((int, String), {(_i235.SimpleData, double) namedSubRecord})?
-            >()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<(int, String)>(((data as Map)['p'] as List)[0]),
-                  namedSubRecord: deserialize<(_i235.SimpleData, double)>(
-                    data['n']['namedSubRecord'],
-                  ),
-                )
-                as T;
-    }
-    if (t == _i1.getType<(int?, _i4.ProjectStreamingClass?)>()) {
-      return (
-            ((data as Map)['p'] as List)[0] == null
-                ? null
-                : deserialize<int>(data['p'][0]),
-            ((data)['p'] as List)[1] == null
-                ? null
-                : deserialize<_i4.ProjectStreamingClass>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == Set<Set<int>>) {
-      return (data as List).map((e) => deserialize<Set<int>>(e)).toSet() as T;
-    }
-    if (t == Set<List<int>>) {
-      return (data as List).map((e) => deserialize<List<int>>(e)).toSet() as T;
-    }
-    if (t == _i1.getType<Set<int>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<int>(e)).toSet()
-              : null)
-          as T;
-    }
-    if (t == Set<Set<int>?>) {
-      return (data as List).map((e) => deserialize<Set<int>?>(e)).toSet() as T;
-    }
-    if (t == _i1.getType<Set<int>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<int>(e)).toSet()
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<Set<Set<int>>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<Set<int>>(e)).toSet()
-              : null)
-          as T;
-    }
-    if (t == Set<int?>) {
-      return (data as List).map((e) => deserialize<int?>(e)).toSet() as T;
-    }
-    if (t == _i1.getType<Set<int?>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<int?>(e)).toSet()
-              : null)
-          as T;
-    }
-    if (t == Set<double>) {
-      return (data as List).map((e) => deserialize<double>(e)).toSet() as T;
-    }
-    if (t == Set<double?>) {
-      return (data as List).map((e) => deserialize<double?>(e)).toSet() as T;
-    }
-    if (t == Set<bool>) {
-      return (data as List).map((e) => deserialize<bool>(e)).toSet() as T;
-    }
-    if (t == Set<bool?>) {
-      return (data as List).map((e) => deserialize<bool?>(e)).toSet() as T;
-    }
-    if (t == Set<String>) {
-      return (data as List).map((e) => deserialize<String>(e)).toSet() as T;
-    }
-    if (t == Set<String?>) {
-      return (data as List).map((e) => deserialize<String?>(e)).toSet() as T;
-    }
-    if (t == Set<DateTime>) {
-      return (data as List).map((e) => deserialize<DateTime>(e)).toSet() as T;
-    }
-    if (t == Set<DateTime?>) {
-      return (data as List).map((e) => deserialize<DateTime?>(e)).toSet() as T;
-    }
-    if (t == Set<_i234.ByteData>) {
-      return (data as List).map((e) => deserialize<_i234.ByteData>(e)).toSet()
-          as T;
-    }
-    if (t == Set<_i234.ByteData?>) {
-      return (data as List).map((e) => deserialize<_i234.ByteData?>(e)).toSet()
-          as T;
-    }
-    if (t == Set<_i235.SimpleData?>) {
-      return (data as List)
-              .map((e) => deserialize<_i235.SimpleData?>(e))
-              .toSet()
-          as T;
-    }
-    if (t == Set<Duration>) {
-      return (data as List).map((e) => deserialize<Duration>(e)).toSet() as T;
-    }
-    if (t == Set<Duration?>) {
-      return (data as List).map((e) => deserialize<Duration?>(e)).toSet() as T;
-    }
-    if (t == List<_i238.Types>) {
-      return (data as List).map((e) => deserialize<_i238.Types>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<(String, (int, bool))>()) {
-      return (
-            deserialize<String>(((data as Map)['p'] as List)[0]),
-            deserialize<(int, bool)>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(int, bool)>()) {
-      return (
-            deserialize<int>(((data as Map)['p'] as List)[0]),
-            deserialize<bool>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == List<(String, (int, bool))>) {
-      return (data as List)
-              .map((e) => deserialize<(String, (int, bool))>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<(String, (int, bool))>()) {
-      return (
-            deserialize<String>(((data as Map)['p'] as List)[0]),
-            deserialize<(int, bool)>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t ==
-        _i1
-            .getType<
-              (
-                String,
-                (Map<String, int>, {bool flag, _i235.SimpleData simpleData}),
-              )
-            >()) {
-      return (
-            deserialize<String>(((data as Map)['p'] as List)[0]),
-            deserialize<
-              (Map<String, int>, {bool flag, _i235.SimpleData simpleData})
-            >(data['p'][1]),
-          )
-          as T;
-    }
-    if (t ==
-        _i1
-            .getType<
-              (Map<String, int>, {bool flag, _i235.SimpleData simpleData})
-            >()) {
-      return (
-            deserialize<Map<String, int>>(((data as Map)['p'] as List)[0]),
-            flag: deserialize<bool>(data['n']['flag']),
-            simpleData: deserialize<_i235.SimpleData>(data['n']['simpleData']),
-          )
-          as T;
-    }
-    if (t == List<(String, int)>) {
-      return (data as List).map((e) => deserialize<(String, int)>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<(String, int)>()) {
-      return (
-            deserialize<String>(((data as Map)['p'] as List)[0]),
-            deserialize<int>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t ==
-        _i1
-            .getType<
-              (
-                String,
-                (Map<String, int>, {bool flag, _i235.SimpleData simpleData}),
-              )?
-            >()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<String>(((data as Map)['p'] as List)[0]),
-                  deserialize<
-                    (Map<String, int>, {bool flag, _i235.SimpleData simpleData})
-                  >(data['p'][1]),
-                )
-                as T;
-    }
-    if (t == _i1.getType<(String, int)>()) {
-      return (
-            deserialize<String>(((data as Map)['p'] as List)[0]),
-            deserialize<int>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == _i1.getType<List<(String, int)>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<(String, int)>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(String, int)>()) {
-      return (
-            deserialize<String>(((data as Map)['p'] as List)[0]),
-            deserialize<int>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(int, String)>()) {
-      return (
-            deserialize<int>(((data as Map)['p'] as List)[0]),
-            deserialize<String>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(_i4.ModuleClass,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<_i4.ModuleClass>(((data as Map)['p'] as List)[0]),)
-                as T;
-    }
-    if (t == _i1.getType<(bool,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<bool>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(_i224.TestEnumStringified,)?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<_i224.TestEnumStringified>(
-                    ((data as Map)['p'] as List)[0],
-                  ),
-                )
-                as T;
-    }
-    if (t == _i1.getType<(_i224.TestEnumStringified,)>()) {
-      return (
-            deserialize<_i224.TestEnumStringified>(
-              ((data as Map)['p'] as List)[0],
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<List<(_i224.TestEnumStringified,)>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<(_i224.TestEnumStringified,)>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(_i224.TestEnumStringified,)>()) {
-      return (
-            deserialize<_i224.TestEnumStringified>(
-              ((data as Map)['p'] as List)[0],
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(_i224.TestEnumStringified,)>()) {
-      return (
-            deserialize<_i224.TestEnumStringified>(
-              ((data as Map)['p'] as List)[0],
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(_i165.Nullability,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<_i165.Nullability>(((data as Map)['p'] as List)[0]),)
-                as T;
-    }
-    if (t == _i1.getType<({_i224.TestEnumStringified value})?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  value: deserialize<_i224.TestEnumStringified>(
-                    ((data as Map)['n'] as Map)['value'],
-                  ),
-                )
-                as T;
-    }
-    if (t == _i1.getType<({_i224.TestEnumStringified value})>()) {
-      return (
-            value: deserialize<_i224.TestEnumStringified>(
-              ((data as Map)['n'] as Map)['value'],
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<List<({_i224.TestEnumStringified value})>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map(
-                      (e) =>
-                          deserialize<({_i224.TestEnumStringified value})>(e),
-                    )
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<({_i224.TestEnumStringified value})>()) {
-      return (
-            value: deserialize<_i224.TestEnumStringified>(
-              ((data as Map)['n'] as Map)['value'],
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<({_i224.TestEnumStringified value})>()) {
-      return (
-            value: deserialize<_i224.TestEnumStringified>(
-              ((data as Map)['n'] as Map)['value'],
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<({_i4.ModuleClass value})?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  value: deserialize<_i4.ModuleClass>(
-                    ((data as Map)['n'] as Map)['value'],
-                  ),
-                )
-                as T;
-    }
-    if (t == _i1.getType<({_i165.Nullability value})?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  value: deserialize<_i165.Nullability>(
-                    ((data as Map)['n'] as Map)['value'],
-                  ),
-                )
-                as T;
-    }
-    if (t == _i1.getType<(String, {Uri? optionalUri})?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<String>(((data as Map)['p'] as List)[0]),
-                  optionalUri: ((data)['n'] as Map)['optionalUri'] == null
-                      ? null
-                      : deserialize<Uri>(data['n']['optionalUri']),
-                )
-                as T;
-    }
-    if (t == _i1.getType<(int,)>()) {
-      return (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<List<(int,)>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<(int,)>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(int,)>()) {
-      return (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(int,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<List<(int,)?>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<(int,)?>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(int,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(_i220.TestEnum,)>()) {
-      return (deserialize<_i220.TestEnum>(((data as Map)['p'] as List)[0]),)
-          as T;
-    }
-    if (t == _i1.getType<List<(_i220.TestEnum,)>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<(_i220.TestEnum,)>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(_i220.TestEnum,)>()) {
-      return (deserialize<_i220.TestEnum>(((data as Map)['p'] as List)[0]),)
-          as T;
-    }
-    if (t == _i1.getType<(_i220.TestEnum,)>()) {
-      return (deserialize<_i220.TestEnum>(((data as Map)['p'] as List)[0]),)
-          as T;
-    }
-    if (t == _i1.getType<(String,)>()) {
-      return (deserialize<String>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<Map<(String,), String>?>()) {
-      return (data != null
-              ? Map.fromEntries(
-                  (data as List).map(
-                    (e) => MapEntry(
-                      deserialize<(String,)>(e['k']),
-                      deserialize<String>(e['v']),
-                    ),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(String,)>()) {
-      return (deserialize<String>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(String,)>()) {
-      return (deserialize<String>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(String,)>()) {
-      return (deserialize<String>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<Map<String, (String,)>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) => MapEntry(
-                    deserialize<String>(k),
-                    deserialize<(String,)>(v),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(String,)>()) {
-      return (deserialize<String>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(String,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<String>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<Map<String, (String,)?>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) => MapEntry(
-                    deserialize<String>(k),
-                    deserialize<(String,)?>(v),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(String,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<String>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(String,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<String>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(String,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<String>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<Map<(String,)?, String>?>()) {
-      return (data != null
-              ? Map.fromEntries(
-                  (data as List).map(
-                    (e) => MapEntry(
-                      deserialize<(String,)?>(e['k']),
-                      deserialize<String>(e['v']),
-                    ),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(String,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<String>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(double,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<double>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(DateTime,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<DateTime>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(_i234.ByteData,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<_i234.ByteData>(((data as Map)['p'] as List)[0]),)
-                as T;
-    }
-    if (t == _i1.getType<(Duration,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<Duration>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(_i1.UuidValue,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<_i1.UuidValue>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(Uri,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<Uri>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(BigInt,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<BigInt>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(_i220.TestEnum,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<_i220.TestEnum>(((data as Map)['p'] as List)[0]),)
-                as T;
-    }
-    if (t == _i1.getType<(List<int>,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<List<int>>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(Map<int, int>,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<Map<int, int>>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(Set<int>,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<Set<int>>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(_i214.SimpleData,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<_i214.SimpleData>(((data as Map)['p'] as List)[0]),)
-                as T;
-    }
-    if (t == _i1.getType<({_i214.SimpleData namedModel})?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  namedModel: deserialize<_i214.SimpleData>(
-                    ((data as Map)['n'] as Map)['namedModel'],
-                  ),
-                )
-                as T;
-    }
-    if (t ==
-        _i1.getType<(_i214.SimpleData, {_i214.SimpleData namedModel})?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<_i214.SimpleData>(
-                    ((data as Map)['p'] as List)[0],
-                  ),
-                  namedModel: deserialize<_i214.SimpleData>(
-                    data['n']['namedModel'],
-                  ),
-                )
-                as T;
-    }
-    if (t ==
-        _i1.getType<((int, String), {(int, String) namedNestedRecord})?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<(int, String)>(((data as Map)['p'] as List)[0]),
-                  namedNestedRecord: deserialize<(int, String)>(
-                    data['n']['namedNestedRecord'],
-                  ),
-                )
-                as T;
-    }
-    if (t ==
-        _i1
-            .getType<
-              (
-                (List<(_i214.SimpleData,)>,), {
-                (_i214.SimpleData, Map<String, _i214.SimpleData>)
-                namedNestedRecord,
-              })?
-            >()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<(List<(_i214.SimpleData,)>,)>(
-                    ((data as Map)['p'] as List)[0],
-                  ),
-                  namedNestedRecord:
-                      deserialize<
-                        (_i214.SimpleData, Map<String, _i214.SimpleData>)
-                      >(data['n']['namedNestedRecord']),
-                )
-                as T;
-    }
-    if (t == _i1.getType<(List<(_i214.SimpleData,)>,)>()) {
-      return (
-            deserialize<List<(_i214.SimpleData,)>>(
-              ((data as Map)['p'] as List)[0],
-            ),
-          )
-          as T;
-    }
-    if (t == List<(_i214.SimpleData,)>) {
-      return (data as List)
-              .map((e) => deserialize<(_i214.SimpleData,)>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<(_i214.SimpleData,)>()) {
-      return (deserialize<_i214.SimpleData>(((data as Map)['p'] as List)[0]),)
-          as T;
-    }
-    if (t == _i1.getType<(_i214.SimpleData,)>()) {
-      return (deserialize<_i214.SimpleData>(((data as Map)['p'] as List)[0]),)
-          as T;
-    }
-    if (t == _i1.getType<(_i214.SimpleData, Map<String, _i214.SimpleData>)>()) {
-      return (
-            deserialize<_i214.SimpleData>(((data as Map)['p'] as List)[0]),
-            deserialize<Map<String, _i214.SimpleData>>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(int,)>()) {
-      return (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<Set<(int,)>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<(int,)>(e)).toSet()
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(int,)>()) {
-      return (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<(int,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i1.getType<Set<(int,)?>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<(int,)?>(e)).toSet()
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(int,)?>()) {
-      return (data == null)
-          ? null as T
-          : (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
-    }
-    if (t == _i6.CustomClass) {
-      return _i6.CustomClass.fromJson(data) as T;
-    }
-    if (t == _i6.CustomClass2) {
-      return _i6.CustomClass2.fromJson(data) as T;
-    }
-    if (t == _i6.ProtocolCustomClass) {
-      return _i6.ProtocolCustomClass.fromJson(data) as T;
-    }
-    if (t == _i6.ExternalCustomClass) {
-      return _i6.ExternalCustomClass.fromJson(data) as T;
-    }
-    if (t == _i6.FreezedCustomClass) {
-      return _i6.FreezedCustomClass.fromJson(data) as T;
-    }
-    if (t == _i1.getType<_i6.CustomClass?>()) {
-      return (data != null ? _i6.CustomClass.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i6.CustomClass2?>()) {
-      return (data != null ? _i6.CustomClass2.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i6.CustomClassWithoutProtocolSerialization?>()) {
-      return (data != null
-              ? _i6.CustomClassWithoutProtocolSerialization.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i6.CustomClassWithProtocolSerialization?>()) {
-      return (data != null
-              ? _i6.CustomClassWithProtocolSerialization.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i6.CustomClassWithProtocolSerializationMethod?>()) {
-      return (data != null
-              ? _i6.CustomClassWithProtocolSerializationMethod.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i6.ProtocolCustomClass?>()) {
-      return (data != null ? _i6.ProtocolCustomClass.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i6.ExternalCustomClass?>()) {
-      return (data != null ? _i6.ExternalCustomClass.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i6.FreezedCustomClass?>()) {
-      return (data != null ? _i6.FreezedCustomClass.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<List<_i235.SimpleData>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i235.SimpleData>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(String, _i237.PolymorphicParent)>()) {
-      return (
-            deserialize<String>(((data as Map)['p'] as List)[0]),
-            deserialize<_i237.PolymorphicParent>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(int?,)?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  ((data as Map)['p'] as List)[0] == null
-                      ? null
-                      : deserialize<int>(data['p'][0]),
-                )
-                as T;
-    }
-    if (t ==
-        _i1
-            .getType<
-              ((int, String), {(_i235.SimpleData, double) namedSubRecord})?
-            >()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<(int, String)>(((data as Map)['p'] as List)[0]),
-                  namedSubRecord: deserialize<(_i235.SimpleData, double)>(
-                    data['n']['namedSubRecord'],
-                  ),
-                )
-                as T;
-    }
-    if (t ==
-        _i1
-            .getType<
-              List<
-                ((int, String), {(_i235.SimpleData, double) namedSubRecord})?
-              >?
-            >()) {
-      return (data != null
-              ? (data as List)
-                    .map(
-                      (e) =>
-                          deserialize<
-                            (
-                              (int, String), {
-                              (_i235.SimpleData, double) namedSubRecord,
-                            })?
-                          >(e),
-                    )
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t ==
-        _i1
-            .getType<
-              ((int, String), {(_i235.SimpleData, double) namedSubRecord})?
-            >()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<(int, String)>(((data as Map)['p'] as List)[0]),
-                  namedSubRecord: deserialize<(_i235.SimpleData, double)>(
-                    data['n']['namedSubRecord'],
-                  ),
-                )
-                as T;
-    }
-    if (t == _i1.getType<(int?, _i4.ProjectStreamingClass?)>()) {
-      return (
-            ((data as Map)['p'] as List)[0] == null
-                ? null
-                : deserialize<int>(data['p'][0]),
-            ((data)['p'] as List)[1] == null
-                ? null
-                : deserialize<_i4.ProjectStreamingClass>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t ==
-        _i1
-            .getType<
-              (
-                String,
-                (Map<String, int>, {bool flag, _i235.SimpleData simpleData}),
-              )
-            >()) {
-      return (
-            deserialize<String>(((data as Map)['p'] as List)[0]),
-            deserialize<
-              (Map<String, int>, {bool flag, _i235.SimpleData simpleData})
-            >(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == _i1.getType<(String, int)>()) {
-      return (
-            deserialize<String>(((data as Map)['p'] as List)[0]),
-            deserialize<int>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t ==
-        _i1
-            .getType<
-              (
-                String,
-                (Map<String, int>, {bool flag, _i235.SimpleData simpleData}),
-              )?
-            >()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<String>(((data as Map)['p'] as List)[0]),
-                  deserialize<
-                    (Map<String, int>, {bool flag, _i235.SimpleData simpleData})
-                  >(data['p'][1]),
-                )
-                as T;
-    }
-    if (t == _i1.getType<(String, int)>()) {
-      return (
-            deserialize<String>(((data as Map)['p'] as List)[0]),
-            deserialize<int>(data['p'][1]),
-          )
-          as T;
-    }
-    if (t == _i1.getType<List<(String, int)>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<(String, int)>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(String, int)>()) {
-      return (
-            deserialize<String>(((data as Map)['p'] as List)[0]),
-            deserialize<int>(data['p'][1]),
-          )
-          as T;
+    final fn = _deserializers[t];
+    if (fn != null) {
+      return fn(data, this) as T;
     }
     try {
       return _i3.Protocol().deserialize<T>(data, t);
@@ -13125,28 +7589,28 @@ class Protocol extends _i1.DatabaseSerializationManager {
     if (data is List<int>) {
       return 'List<int>';
     }
-    if (data is List<_i235.SimpleData>) {
+    if (data is List<_i234.SimpleData>) {
       return 'List<SimpleData>';
     }
     if (data is List<_i3.UserInfo>) {
       return 'List<serverpod_auth.UserInfo>';
     }
-    if (data is List<_i235.SimpleData>?) {
+    if (data is List<_i234.SimpleData>?) {
       return 'List<SimpleData>?';
     }
-    if (data is List<_i235.SimpleData?>) {
+    if (data is List<_i234.SimpleData?>) {
       return 'List<SimpleData?>';
     }
     if (data is Set<int>) {
       return 'Set<int>';
     }
-    if (data is Set<_i235.SimpleData>) {
+    if (data is Set<_i234.SimpleData>) {
       return 'Set<SimpleData>';
     }
-    if (data is List<Set<_i235.SimpleData>>) {
+    if (data is List<Set<_i234.SimpleData>>) {
       return 'List<Set<SimpleData>>';
     }
-    if (data is (String, _i237.PolymorphicParent)) {
+    if (data is (String, _i235.PolymorphicParent)) {
       return '(String,PolymorphicParent)';
     }
     if (data is (int?,)?) {
@@ -13154,7 +7618,7 @@ class Protocol extends _i1.DatabaseSerializationManager {
     }
     if (data
         is List<
-          ((int, String), {(_i235.SimpleData, double) namedSubRecord})?
+          ((int, String), {(_i234.SimpleData, double) namedSubRecord})?
         >?) {
       return 'List<((int,String),{(SimpleData,double) namedSubRecord})?>?';
     }
@@ -13164,7 +7628,7 @@ class Protocol extends _i1.DatabaseSerializationManager {
     if (data
         is (
           String,
-          (Map<String, int>, {bool flag, _i235.SimpleData simpleData}),
+          (Map<String, int>, {bool flag, _i234.SimpleData simpleData}),
         )) {
       return '(String,(Map<String,int>,{bool flag,SimpleData simpleData}))';
     }
@@ -13174,7 +7638,7 @@ class Protocol extends _i1.DatabaseSerializationManager {
     if (data
         is (
           String,
-          (Map<String, int>, {bool flag, _i235.SimpleData simpleData}),
+          (Map<String, int>, {bool flag, _i234.SimpleData simpleData}),
         )?) {
       return '(String,(Map<String,int>,{bool flag,SimpleData simpleData}))?';
     }
@@ -13966,28 +8430,28 @@ class Protocol extends _i1.DatabaseSerializationManager {
       return deserialize<List<int>>(data['data']);
     }
     if (dataClassName == 'List<SimpleData>') {
-      return deserialize<List<_i235.SimpleData>>(data['data']);
+      return deserialize<List<_i234.SimpleData>>(data['data']);
     }
     if (dataClassName == 'List<serverpod_auth.UserInfo>') {
       return deserialize<List<_i3.UserInfo>>(data['data']);
     }
     if (dataClassName == 'List<SimpleData>?') {
-      return deserialize<List<_i235.SimpleData>?>(data['data']);
+      return deserialize<List<_i234.SimpleData>?>(data['data']);
     }
     if (dataClassName == 'List<SimpleData?>') {
-      return deserialize<List<_i235.SimpleData?>>(data['data']);
+      return deserialize<List<_i234.SimpleData?>>(data['data']);
     }
     if (dataClassName == 'Set<int>') {
       return deserialize<Set<int>>(data['data']);
     }
     if (dataClassName == 'Set<SimpleData>') {
-      return deserialize<Set<_i235.SimpleData>>(data['data']);
+      return deserialize<Set<_i234.SimpleData>>(data['data']);
     }
     if (dataClassName == 'List<Set<SimpleData>>') {
-      return deserialize<List<Set<_i235.SimpleData>>>(data['data']);
+      return deserialize<List<Set<_i234.SimpleData>>>(data['data']);
     }
     if (dataClassName == '(String,PolymorphicParent)') {
-      return deserialize<(String, _i237.PolymorphicParent)>(data['data']);
+      return deserialize<(String, _i235.PolymorphicParent)>(data['data']);
     }
     if (dataClassName == '(int?,)?') {
       return deserialize<(int?,)?>(data['data']);
@@ -13995,7 +8459,7 @@ class Protocol extends _i1.DatabaseSerializationManager {
     if (dataClassName ==
         'List<((int,String),{(SimpleData,double) namedSubRecord})?>?') {
       return deserialize<
-        List<((int, String), {(_i235.SimpleData, double) namedSubRecord})?>?
+        List<((int, String), {(_i234.SimpleData, double) namedSubRecord})?>?
       >(data['data']);
     }
     if (dataClassName ==
@@ -14005,7 +8469,7 @@ class Protocol extends _i1.DatabaseSerializationManager {
     if (dataClassName ==
         '(String,(Map<String,int>,{bool flag,SimpleData simpleData}))') {
       return deserialize<
-        (String, (Map<String, int>, {bool flag, _i235.SimpleData simpleData}))
+        (String, (Map<String, int>, {bool flag, _i234.SimpleData simpleData}))
       >(data['data']);
     }
     if (dataClassName == 'List<(String,int)>') {
@@ -14014,7 +8478,7 @@ class Protocol extends _i1.DatabaseSerializationManager {
     if (dataClassName ==
         '(String,(Map<String,int>,{bool flag,SimpleData simpleData}))?') {
       return deserialize<
-        (String, (Map<String, int>, {bool flag, _i235.SimpleData simpleData}))?
+        (String, (Map<String, int>, {bool flag, _i234.SimpleData simpleData}))?
       >(data['data']);
     }
     if (dataClassName == 'List<(String,int)>?') {
@@ -14415,7 +8879,7 @@ class Protocol extends _i1.DatabaseSerializationManager {
         ],
       };
     }
-    if (record is (String, _i237.PolymorphicParent)) {
+    if (record is (String, _i235.PolymorphicParent)) {
       return {
         "p": [
           record.$1,
@@ -14445,7 +8909,7 @@ class Protocol extends _i1.DatabaseSerializationManager {
         ],
       };
     }
-    if (record is (int, _i235.SimpleData)) {
+    if (record is (int, _i234.SimpleData)) {
       return {
         "p": [
           record.$1,
@@ -14475,7 +8939,7 @@ class Protocol extends _i1.DatabaseSerializationManager {
         },
       };
     }
-    if (record is ({_i235.SimpleData data, int number})) {
+    if (record is ({_i234.SimpleData data, int number})) {
       return {
         "n": {
           "data": record.data.toJson(),
@@ -14483,7 +8947,7 @@ class Protocol extends _i1.DatabaseSerializationManager {
         },
       };
     }
-    if (record is ({_i235.SimpleData? data, int? number})) {
+    if (record is ({_i234.SimpleData? data, int? number})) {
       return {
         "n": {
           "data": record.data?.toJson(),
@@ -14519,7 +8983,7 @@ class Protocol extends _i1.DatabaseSerializationManager {
         ],
       };
     }
-    if (record is (int, {_i235.SimpleData data})) {
+    if (record is (int, {_i234.SimpleData data})) {
       return {
         "p": [
           record.$1,
@@ -14537,14 +9001,14 @@ class Protocol extends _i1.DatabaseSerializationManager {
         ],
       };
     }
-    if (record is ({(_i235.SimpleData, double) namedSubRecord})) {
+    if (record is ({(_i234.SimpleData, double) namedSubRecord})) {
       return {
         "n": {
           "namedSubRecord": mapRecordToJson(record.namedSubRecord),
         },
       };
     }
-    if (record is (_i235.SimpleData, double)) {
+    if (record is (_i234.SimpleData, double)) {
       return {
         "p": [
           record.$1.toJson(),
@@ -14552,7 +9016,7 @@ class Protocol extends _i1.DatabaseSerializationManager {
         ],
       };
     }
-    if (record is ({(_i235.SimpleData, double)? namedSubRecord})) {
+    if (record is ({(_i234.SimpleData, double)? namedSubRecord})) {
       return {
         "n": {
           "namedSubRecord": mapRecordToJson(record.namedSubRecord),
@@ -14560,7 +9024,7 @@ class Protocol extends _i1.DatabaseSerializationManager {
       };
     }
     if (record
-        is ((int, String), {(_i235.SimpleData, double) namedSubRecord})) {
+        is ((int, String), {(_i234.SimpleData, double) namedSubRecord})) {
       return {
         "p": [
           mapRecordToJson(record.$1),
@@ -14597,7 +9061,7 @@ class Protocol extends _i1.DatabaseSerializationManager {
     if (record
         is (
           String,
-          (Map<String, int>, {bool flag, _i235.SimpleData simpleData}),
+          (Map<String, int>, {bool flag, _i234.SimpleData simpleData}),
         )) {
       return {
         "p": [
@@ -14607,7 +9071,7 @@ class Protocol extends _i1.DatabaseSerializationManager {
       };
     }
     if (record
-        is (Map<String, int>, {bool flag, _i235.SimpleData simpleData})) {
+        is (Map<String, int>, {bool flag, _i234.SimpleData simpleData})) {
       return {
         "p": [
           record.$1.toJson(),
@@ -14713,7 +9177,7 @@ class Protocol extends _i1.DatabaseSerializationManager {
         ],
       };
     }
-    if (record is (_i234.ByteData,)) {
+    if (record is (_i236.ByteData,)) {
       return {
         "p": [
           record.$1.toJson(),
@@ -14894,5 +9358,4295 @@ class Protocol extends _i1.DatabaseSerializationManager {
     }
 
     return obj;
+  }
+
+  static Map<Type, dynamic Function(dynamic, Protocol)> _buildDeserializers() {
+    final map = <Type, dynamic Function(dynamic, Protocol)>{};
+    map[_i7.ByIndexEnumWithNameValue] = (data, protocol) =>
+        _i7.ByIndexEnumWithNameValue.fromJson(data);
+    map[_i8.ByNameEnumWithNameValue] = (data, protocol) =>
+        _i8.ByNameEnumWithNameValue.fromJson(data);
+    map[_i9.CourseUuid] = (data, protocol) => _i9.CourseUuid.fromJson(data);
+    map[_i10.EnrollmentInt] = (data, protocol) =>
+        _i10.EnrollmentInt.fromJson(data);
+    map[_i11.StudentUuid] = (data, protocol) => _i11.StudentUuid.fromJson(data);
+    map[_i12.ArenaUuid] = (data, protocol) => _i12.ArenaUuid.fromJson(data);
+    map[_i13.PlayerUuid] = (data, protocol) => _i13.PlayerUuid.fromJson(data);
+    map[_i14.TeamInt] = (data, protocol) => _i14.TeamInt.fromJson(data);
+    map[_i15.CommentInt] = (data, protocol) => _i15.CommentInt.fromJson(data);
+    map[_i16.CustomerInt] = (data, protocol) => _i16.CustomerInt.fromJson(data);
+    map[_i17.OrderUuid] = (data, protocol) => _i17.OrderUuid.fromJson(data);
+    map[_i18.AddressUuid] = (data, protocol) => _i18.AddressUuid.fromJson(data);
+    map[_i19.CitizenInt] = (data, protocol) => _i19.CitizenInt.fromJson(data);
+    map[_i20.CompanyUuid] = (data, protocol) => _i20.CompanyUuid.fromJson(data);
+    map[_i21.TownInt] = (data, protocol) => _i21.TownInt.fromJson(data);
+    map[_i22.ChangedIdTypeSelf] = (data, protocol) =>
+        _i22.ChangedIdTypeSelf.fromJson(data);
+    map[_i23.ServerOnlyChangedIdFieldClass] = (data, protocol) =>
+        _i23.ServerOnlyChangedIdFieldClass.fromJson(data);
+    map[_i24.BigIntDefault] = (data, protocol) =>
+        _i24.BigIntDefault.fromJson(data);
+    map[_i25.BigIntDefaultMix] = (data, protocol) =>
+        _i25.BigIntDefaultMix.fromJson(data);
+    map[_i26.BigIntDefaultModel] = (data, protocol) =>
+        _i26.BigIntDefaultModel.fromJson(data);
+    map[_i27.BigIntDefaultPersist] = (data, protocol) =>
+        _i27.BigIntDefaultPersist.fromJson(data);
+    map[_i28.BoolDefault] = (data, protocol) => _i28.BoolDefault.fromJson(data);
+    map[_i29.BoolDefaultMix] = (data, protocol) =>
+        _i29.BoolDefaultMix.fromJson(data);
+    map[_i30.BoolDefaultModel] = (data, protocol) =>
+        _i30.BoolDefaultModel.fromJson(data);
+    map[_i31.BoolDefaultPersist] = (data, protocol) =>
+        _i31.BoolDefaultPersist.fromJson(data);
+    map[_i32.DateTimeDefault] = (data, protocol) =>
+        _i32.DateTimeDefault.fromJson(data);
+    map[_i33.DateTimeDefaultMix] = (data, protocol) =>
+        _i33.DateTimeDefaultMix.fromJson(data);
+    map[_i34.DateTimeDefaultModel] = (data, protocol) =>
+        _i34.DateTimeDefaultModel.fromJson(data);
+    map[_i35.DateTimeDefaultPersist] = (data, protocol) =>
+        _i35.DateTimeDefaultPersist.fromJson(data);
+    map[_i36.DoubleDefault] = (data, protocol) =>
+        _i36.DoubleDefault.fromJson(data);
+    map[_i37.DoubleDefaultMix] = (data, protocol) =>
+        _i37.DoubleDefaultMix.fromJson(data);
+    map[_i38.DoubleDefaultModel] = (data, protocol) =>
+        _i38.DoubleDefaultModel.fromJson(data);
+    map[_i39.DoubleDefaultPersist] = (data, protocol) =>
+        _i39.DoubleDefaultPersist.fromJson(data);
+    map[_i40.DurationDefault] = (data, protocol) =>
+        _i40.DurationDefault.fromJson(data);
+    map[_i41.DurationDefaultMix] = (data, protocol) =>
+        _i41.DurationDefaultMix.fromJson(data);
+    map[_i42.DurationDefaultModel] = (data, protocol) =>
+        _i42.DurationDefaultModel.fromJson(data);
+    map[_i43.DurationDefaultPersist] = (data, protocol) =>
+        _i43.DurationDefaultPersist.fromJson(data);
+    map[_i44.EnumDefault] = (data, protocol) => _i44.EnumDefault.fromJson(data);
+    map[_i45.EnumDefaultMix] = (data, protocol) =>
+        _i45.EnumDefaultMix.fromJson(data);
+    map[_i46.EnumDefaultModel] = (data, protocol) =>
+        _i46.EnumDefaultModel.fromJson(data);
+    map[_i47.EnumDefaultPersist] = (data, protocol) =>
+        _i47.EnumDefaultPersist.fromJson(data);
+    map[_i48.ByIndexEnum] = (data, protocol) => _i48.ByIndexEnum.fromJson(data);
+    map[_i49.ByNameEnum] = (data, protocol) => _i49.ByNameEnum.fromJson(data);
+    map[_i50.DefaultValueEnum] = (data, protocol) =>
+        _i50.DefaultValueEnum.fromJson(data);
+    map[_i51.DefaultException] = (data, protocol) =>
+        _i51.DefaultException.fromJson(data);
+    map[_i52.IntDefault] = (data, protocol) => _i52.IntDefault.fromJson(data);
+    map[_i53.IntDefaultMix] = (data, protocol) =>
+        _i53.IntDefaultMix.fromJson(data);
+    map[_i54.IntDefaultModel] = (data, protocol) =>
+        _i54.IntDefaultModel.fromJson(data);
+    map[_i55.IntDefaultPersist] = (data, protocol) =>
+        _i55.IntDefaultPersist.fromJson(data);
+    map[_i56.StringDefault] = (data, protocol) =>
+        _i56.StringDefault.fromJson(data);
+    map[_i57.StringDefaultMix] = (data, protocol) =>
+        _i57.StringDefaultMix.fromJson(data);
+    map[_i58.StringDefaultModel] = (data, protocol) =>
+        _i58.StringDefaultModel.fromJson(data);
+    map[_i59.StringDefaultPersist] = (data, protocol) =>
+        _i59.StringDefaultPersist.fromJson(data);
+    map[_i60.UriDefault] = (data, protocol) => _i60.UriDefault.fromJson(data);
+    map[_i61.UriDefaultMix] = (data, protocol) =>
+        _i61.UriDefaultMix.fromJson(data);
+    map[_i62.UriDefaultModel] = (data, protocol) =>
+        _i62.UriDefaultModel.fromJson(data);
+    map[_i63.UriDefaultPersist] = (data, protocol) =>
+        _i63.UriDefaultPersist.fromJson(data);
+    map[_i64.UuidDefault] = (data, protocol) => _i64.UuidDefault.fromJson(data);
+    map[_i65.UuidDefaultMix] = (data, protocol) =>
+        _i65.UuidDefaultMix.fromJson(data);
+    map[_i66.UuidDefaultModel] = (data, protocol) =>
+        _i66.UuidDefaultModel.fromJson(data);
+    map[_i67.UuidDefaultPersist] = (data, protocol) =>
+        _i67.UuidDefaultPersist.fromJson(data);
+    map[_i68.EmptyModel] = (data, protocol) => _i68.EmptyModel.fromJson(data);
+    map[_i69.EmptyModelRelationItem] = (data, protocol) =>
+        _i69.EmptyModelRelationItem.fromJson(data);
+    map[_i70.EmptyModelWithTable] = (data, protocol) =>
+        _i70.EmptyModelWithTable.fromJson(data);
+    map[_i71.RelationEmptyModel] = (data, protocol) =>
+        _i71.RelationEmptyModel.fromJson(data);
+    map[_i72.ExceptionWithData] = (data, protocol) =>
+        _i72.ExceptionWithData.fromJson(data);
+    map[_i73.ChildClassExplicitColumn] = (data, protocol) =>
+        _i73.ChildClassExplicitColumn.fromJson(data);
+    map[_i74.NonTableParentClass] = (data, protocol) =>
+        _i74.NonTableParentClass.fromJson(data);
+    map[_i75.ModifiedColumnName] = (data, protocol) =>
+        _i75.ModifiedColumnName.fromJson(data);
+    map[_i76.Department] = (data, protocol) => _i76.Department.fromJson(data);
+    map[_i77.Employee] = (data, protocol) => _i77.Employee.fromJson(data);
+    map[_i78.Contractor] = (data, protocol) => _i78.Contractor.fromJson(data);
+    map[_i79.Service] = (data, protocol) => _i79.Service.fromJson(data);
+    map[_i80.TableWithExplicitColumnName] = (data, protocol) =>
+        _i80.TableWithExplicitColumnName.fromJson(data);
+    map[_i81.TestGeneratedCallByeModel] = (data, protocol) =>
+        _i81.TestGeneratedCallByeModel.fromJson(data);
+    map[_i82.TestGeneratedCallExecuteWithTriggerModel] = (data, protocol) =>
+        _i82.TestGeneratedCallExecuteWithTriggerModel.fromJson(data);
+    map[_i83.TestGeneratedCallHelloModel] = (data, protocol) =>
+        _i83.TestGeneratedCallHelloModel.fromJson(data);
+    map[_i84.TestGeneratedCallInvokeModel] = (data, protocol) =>
+        _i84.TestGeneratedCallInvokeModel.fromJson(data);
+    map[_i85.ImmutableChildObject] = (data, protocol) =>
+        _i85.ImmutableChildObject.fromJson(data);
+    map[_i86.ImmutableChildObjectWithNoAdditionalFields] = (data, protocol) =>
+        _i86.ImmutableChildObjectWithNoAdditionalFields.fromJson(data);
+    map[_i87.ImmutableObject] = (data, protocol) =>
+        _i87.ImmutableObject.fromJson(data);
+    map[_i88.ImmutableObjectWithImmutableObject] = (data, protocol) =>
+        _i88.ImmutableObjectWithImmutableObject.fromJson(data);
+    map[_i89.ImmutableObjectWithList] = (data, protocol) =>
+        _i89.ImmutableObjectWithList.fromJson(data);
+    map[_i90.ImmutableObjectWithMap] = (data, protocol) =>
+        _i90.ImmutableObjectWithMap.fromJson(data);
+    map[_i91.ImmutableObjectWithMultipleFields] = (data, protocol) =>
+        _i91.ImmutableObjectWithMultipleFields.fromJson(data);
+    map[_i92.ImmutableObjectWithNoFields] = (data, protocol) =>
+        _i92.ImmutableObjectWithNoFields.fromJson(data);
+    map[_i93.ImmutableObjectWithRecord] = (data, protocol) =>
+        _i93.ImmutableObjectWithRecord.fromJson(data);
+    map[_i94.ImmutableObjectWithTable] = (data, protocol) =>
+        _i94.ImmutableObjectWithTable.fromJson(data);
+    map[_i95.ImmutableObjectWithTwentyFields] = (data, protocol) =>
+        _i95.ImmutableObjectWithTwentyFields.fromJson(data);
+    map[_i96.ChildClass] = (data, protocol) => _i96.ChildClass.fromJson(data);
+    map[_i97.ServerOnlyChildClass] = (data, protocol) =>
+        _i97.ServerOnlyChildClass.fromJson(data);
+    map[_i98.ChildWithDefault] = (data, protocol) =>
+        _i98.ChildWithDefault.fromJson(data);
+    map[_i99.ChildWithInheritedId] = (data, protocol) =>
+        _i99.ChildWithInheritedId.fromJson(data);
+    map[_i100.ChildClassWithoutId] = (data, protocol) =>
+        _i100.ChildClassWithoutId.fromJson(data);
+    map[_i101.ServerOnlyChildClassWithoutId] = (data, protocol) =>
+        _i101.ServerOnlyChildClassWithoutId.fromJson(data);
+    map[_i102.ExtendedAppException] = (data, protocol) =>
+        _i102.ExtendedAppException.fromJson(data);
+    map[_i103.BaseAppException] = (data, protocol) =>
+        _i103.BaseAppException.fromJson(data);
+    map[_i104.NotFoundException] = (data, protocol) =>
+        _i104.NotFoundException.fromJson(data);
+    map[_i104.ValidationException] = (data, protocol) =>
+        _i104.ValidationException.fromJson(data);
+    map[_i105.ParentClass] = (data, protocol) =>
+        _i105.ParentClass.fromJson(data);
+    map[_i106.GrandparentClass] = (data, protocol) =>
+        _i106.GrandparentClass.fromJson(data);
+    map[_i107.ParentClassWithoutId] = (data, protocol) =>
+        _i107.ParentClassWithoutId.fromJson(data);
+    map[_i108.GrandparentClassWithId] = (data, protocol) =>
+        _i108.GrandparentClassWithId.fromJson(data);
+    map[_i109.ChildEntity] = (data, protocol) =>
+        _i109.ChildEntity.fromJson(data);
+    map[_i110.BaseEntity] = (data, protocol) => _i110.BaseEntity.fromJson(data);
+    map[_i111.ParentEntity] = (data, protocol) =>
+        _i111.ParentEntity.fromJson(data);
+    map[_i112.NonServerOnlyParentClass] = (data, protocol) =>
+        _i112.NonServerOnlyParentClass.fromJson(data);
+    map[_i113.ParentWithChangedId] = (data, protocol) =>
+        _i113.ParentWithChangedId.fromJson(data);
+    map[_i114.ParentWithDefault] = (data, protocol) =>
+        _i114.ParentWithDefault.fromJson(data);
+    map[_i115.PolymorphicGrandChild] = (data, protocol) =>
+        _i115.PolymorphicGrandChild.fromJson(data);
+    map[_i116.PolymorphicChild] = (data, protocol) =>
+        _i116.PolymorphicChild.fromJson(data);
+    map[_i117.PolymorphicChildContainer] = (data, protocol) =>
+        _i117.PolymorphicChildContainer.fromJson(data);
+    map[_i118.ModulePolymorphicChildContainer] = (data, protocol) =>
+        _i118.ModulePolymorphicChildContainer.fromJson(data);
+    map[_i119.SimilarButNotParent] = (data, protocol) =>
+        _i119.SimilarButNotParent.fromJson(data);
+    map[_i120.PolymorphicParent] = (data, protocol) =>
+        _i120.PolymorphicParent.fromJson(data);
+    map[_i121.UnrelatedToPolymorphism] = (data, protocol) =>
+        _i121.UnrelatedToPolymorphism.fromJson(data);
+    map[_i122.SealedGrandChild] = (data, protocol) =>
+        _i122.SealedGrandChild.fromJson(data);
+    map[_i122.SealedChild] = (data, protocol) =>
+        _i122.SealedChild.fromJson(data);
+    map[_i123.SealedChildOnlyRequired] = (data, protocol) =>
+        _i123.SealedChildOnlyRequired.fromJson(data);
+    map[_i122.SealedOtherChild] = (data, protocol) =>
+        _i122.SealedOtherChild.fromJson(data);
+    map[_i124.CityWithLongTableName] = (data, protocol) =>
+        _i124.CityWithLongTableName.fromJson(data);
+    map[_i125.OrganizationWithLongTableName] = (data, protocol) =>
+        _i125.OrganizationWithLongTableName.fromJson(data);
+    map[_i126.PersonWithLongTableName] = (data, protocol) =>
+        _i126.PersonWithLongTableName.fromJson(data);
+    map[_i127.MaxFieldName] = (data, protocol) =>
+        _i127.MaxFieldName.fromJson(data);
+    map[_i128.LongImplicitIdField] = (data, protocol) =>
+        _i128.LongImplicitIdField.fromJson(data);
+    map[_i129.LongImplicitIdFieldCollection] = (data, protocol) =>
+        _i129.LongImplicitIdFieldCollection.fromJson(data);
+    map[_i130.RelationToMultipleMaxFieldName] = (data, protocol) =>
+        _i130.RelationToMultipleMaxFieldName.fromJson(data);
+    map[_i131.UserNote] = (data, protocol) => _i131.UserNote.fromJson(data);
+    map[_i132.UserNoteCollection] = (data, protocol) =>
+        _i132.UserNoteCollection.fromJson(data);
+    map[_i133.UserNoteCollectionWithALongName] = (data, protocol) =>
+        _i133.UserNoteCollectionWithALongName.fromJson(data);
+    map[_i134.UserNoteWithALongName] = (data, protocol) =>
+        _i134.UserNoteWithALongName.fromJson(data);
+    map[_i135.MultipleMaxFieldName] = (data, protocol) =>
+        _i135.MultipleMaxFieldName.fromJson(data);
+    map[_i136.City] = (data, protocol) => _i136.City.fromJson(data);
+    map[_i137.Organization] = (data, protocol) =>
+        _i137.Organization.fromJson(data);
+    map[_i138.Person] = (data, protocol) => _i138.Person.fromJson(data);
+    map[_i139.BleedChild] = (data, protocol) => _i139.BleedChild.fromJson(data);
+    map[_i140.BleedRoot] = (data, protocol) => _i140.BleedRoot.fromJson(data);
+    map[_i141.Course] = (data, protocol) => _i141.Course.fromJson(data);
+    map[_i142.Enrollment] = (data, protocol) => _i142.Enrollment.fromJson(data);
+    map[_i143.Student] = (data, protocol) => _i143.Student.fromJson(data);
+    map[_i144.ObjectUser] = (data, protocol) => _i144.ObjectUser.fromJson(data);
+    map[_i145.ParentUser] = (data, protocol) => _i145.ParentUser.fromJson(data);
+    map[_i146.Arena] = (data, protocol) => _i146.Arena.fromJson(data);
+    map[_i147.Player] = (data, protocol) => _i147.Player.fromJson(data);
+    map[_i148.Team] = (data, protocol) => _i148.Team.fromJson(data);
+    map[_i149.Comment] = (data, protocol) => _i149.Comment.fromJson(data);
+    map[_i150.Customer] = (data, protocol) => _i150.Customer.fromJson(data);
+    map[_i151.Book] = (data, protocol) => _i151.Book.fromJson(data);
+    map[_i152.Chapter] = (data, protocol) => _i152.Chapter.fromJson(data);
+    map[_i153.Order] = (data, protocol) => _i153.Order.fromJson(data);
+    map[_i154.Address] = (data, protocol) => _i154.Address.fromJson(data);
+    map[_i155.Citizen] = (data, protocol) => _i155.Citizen.fromJson(data);
+    map[_i156.Company] = (data, protocol) => _i156.Company.fromJson(data);
+    map[_i157.Town] = (data, protocol) => _i157.Town.fromJson(data);
+    map[_i158.Blocking] = (data, protocol) => _i158.Blocking.fromJson(data);
+    map[_i159.Member] = (data, protocol) => _i159.Member.fromJson(data);
+    map[_i160.Cat] = (data, protocol) => _i160.Cat.fromJson(data);
+    map[_i161.Post] = (data, protocol) => _i161.Post.fromJson(data);
+    map[_i162.ModuleDatatype] = (data, protocol) =>
+        _i162.ModuleDatatype.fromJson(data);
+    map[_i163.MyFeatureModel] = (data, protocol) =>
+        _i163.MyFeatureModel.fromJson(data);
+    map[_i164.MyTriggerType] = (data, protocol) =>
+        _i164.MyTriggerType.fromJson(data);
+    map[_i165.Nullability] = (data, protocol) =>
+        _i165.Nullability.fromJson(data);
+    map[_i166.NullsDistinctData] = (data, protocol) =>
+        _i166.NullsDistinctData.fromJson(data);
+    map[_i167.ObjectFieldPersist] = (data, protocol) =>
+        _i167.ObjectFieldPersist.fromJson(data);
+    map[_i168.ObjectFieldScopes] = (data, protocol) =>
+        _i168.ObjectFieldScopes.fromJson(data);
+    map[_i169.ObjectWithBit] = (data, protocol) =>
+        _i169.ObjectWithBit.fromJson(data);
+    map[_i170.ObjectWithByteData] = (data, protocol) =>
+        _i170.ObjectWithByteData.fromJson(data);
+    map[_i171.ObjectWithCustomClass] = (data, protocol) =>
+        _i171.ObjectWithCustomClass.fromJson(data);
+    map[_i172.ObjectWithDuration] = (data, protocol) =>
+        _i172.ObjectWithDuration.fromJson(data);
+    map[_i173.ObjectWithDynamic] = (data, protocol) =>
+        _i173.ObjectWithDynamic.fromJson(data);
+    map[_i174.ObjectWithEnum] = (data, protocol) =>
+        _i174.ObjectWithEnum.fromJson(data);
+    map[_i175.ObjectWithEnumEnhanced] = (data, protocol) =>
+        _i175.ObjectWithEnumEnhanced.fromJson(data);
+    map[_i176.ObjectWithGeographyGeometryCollection] = (data, protocol) =>
+        _i176.ObjectWithGeographyGeometryCollection.fromJson(data);
+    map[_i177.ObjectWithGeographyLineString] = (data, protocol) =>
+        _i177.ObjectWithGeographyLineString.fromJson(data);
+    map[_i178.ObjectWithGeographyPoint] = (data, protocol) =>
+        _i178.ObjectWithGeographyPoint.fromJson(data);
+    map[_i179.ObjectWithGeographyPolygon] = (data, protocol) =>
+        _i179.ObjectWithGeographyPolygon.fromJson(data);
+    map[_i180.ObjectWithHalfVector] = (data, protocol) =>
+        _i180.ObjectWithHalfVector.fromJson(data);
+    map[_i181.ObjectWithIndex] = (data, protocol) =>
+        _i181.ObjectWithIndex.fromJson(data);
+    map[_i182.ObjectWithJsonb] = (data, protocol) =>
+        _i182.ObjectWithJsonb.fromJson(data);
+    map[_i183.ObjectWithJsonbClassLevel] = (data, protocol) =>
+        _i183.ObjectWithJsonbClassLevel.fromJson(data);
+    map[_i184.ObjectWithMaps] = (data, protocol) =>
+        _i184.ObjectWithMaps.fromJson(data);
+    map[_i185.ObjectWithNullableCustomClass] = (data, protocol) =>
+        _i185.ObjectWithNullableCustomClass.fromJson(data);
+    map[_i186.ObjectWithObject] = (data, protocol) =>
+        _i186.ObjectWithObject.fromJson(data);
+    map[_i187.ObjectWithParent] = (data, protocol) =>
+        _i187.ObjectWithParent.fromJson(data);
+    map[_i188.ObjectWithSealedClass] = (data, protocol) =>
+        _i188.ObjectWithSealedClass.fromJson(data);
+    map[_i189.ObjectWithSealedException] = (data, protocol) =>
+        _i189.ObjectWithSealedException.fromJson(data);
+    map[_i190.ObjectWithSelfParent] = (data, protocol) =>
+        _i190.ObjectWithSelfParent.fromJson(data);
+    map[_i191.ObjectWithSparseVector] = (data, protocol) =>
+        _i191.ObjectWithSparseVector.fromJson(data);
+    map[_i192.ObjectWithUuid] = (data, protocol) =>
+        _i192.ObjectWithUuid.fromJson(data);
+    map[_i193.ObjectWithVector] = (data, protocol) =>
+        _i193.ObjectWithVector.fromJson(data);
+    map[_i194.Record] = (data, protocol) => _i194.Record.fromJson(data);
+    map[_i195.RelatedUniqueData] = (data, protocol) =>
+        _i195.RelatedUniqueData.fromJson(data);
+    map[_i196.ExceptionWithRequiredField] = (data, protocol) =>
+        _i196.ExceptionWithRequiredField.fromJson(data);
+    map[_i197.ModelWithRequiredField] = (data, protocol) =>
+        _i197.ModelWithRequiredField.fromJson(data);
+    map[_i198.ScopeNoneFields] = (data, protocol) =>
+        _i198.ScopeNoneFields.fromJson(data);
+    map[_i199.ScopeServerOnlyFieldChild] = (data, protocol) =>
+        _i199.ScopeServerOnlyFieldChild.fromJson(data);
+    map[_i200.ScopeServerOnlyField] = (data, protocol) =>
+        _i200.ScopeServerOnlyField.fromJson(data);
+    map[_i201.Article] = (data, protocol) => _i201.Article.fromJson(data);
+    map[_i202.ArticleList] = (data, protocol) =>
+        _i202.ArticleList.fromJson(data);
+    map[_i203.DefaultServerOnlyClass] = (data, protocol) =>
+        _i203.DefaultServerOnlyClass.fromJson(data);
+    map[_i204.DefaultServerOnlyEnum] = (data, protocol) =>
+        _i204.DefaultServerOnlyEnum.fromJson(data);
+    map[_i205.NotServerOnlyClass] = (data, protocol) =>
+        _i205.NotServerOnlyClass.fromJson(data);
+    map[_i206.NotServerOnlyEnum] = (data, protocol) =>
+        _i206.NotServerOnlyEnum.fromJson(data);
+    map[_i207.ServerOnlyClass] = (data, protocol) =>
+        _i207.ServerOnlyClass.fromJson(data);
+    map[_i208.ServerOnlyEnum] = (data, protocol) =>
+        _i208.ServerOnlyEnum.fromJson(data);
+    map[_i209.ServerOnlyClassField] = (data, protocol) =>
+        _i209.ServerOnlyClassField.fromJson(data);
+    map[_i210.ServerOnlyDefault] = (data, protocol) =>
+        _i210.ServerOnlyDefault.fromJson(data);
+    map[_i211.SessionAuthInfo] = (data, protocol) =>
+        _i211.SessionAuthInfo.fromJson(data);
+    map[_i212.SharedModelContainer] = (data, protocol) =>
+        _i212.SharedModelContainer.fromJson(data);
+    map[_i213.SharedModelSubclass] = (data, protocol) =>
+        _i213.SharedModelSubclass.fromJson(data);
+    map[_i214.SimpleData] = (data, protocol) => _i214.SimpleData.fromJson(data);
+    map[_i215.SimpleDataList] = (data, protocol) =>
+        _i215.SimpleDataList.fromJson(data);
+    map[_i216.SimpleDataMap] = (data, protocol) =>
+        _i216.SimpleDataMap.fromJson(data);
+    map[_i217.SimpleDataObject] = (data, protocol) =>
+        _i217.SimpleDataObject.fromJson(data);
+    map[_i218.SimpleDateTime] = (data, protocol) =>
+        _i218.SimpleDateTime.fromJson(data);
+    map[_i219.ModelInSubfolder] = (data, protocol) =>
+        _i219.ModelInSubfolder.fromJson(data);
+    map[_i220.TestEnum] = (data, protocol) => _i220.TestEnum.fromJson(data);
+    map[_i221.TestEnumDefaultSerialization] = (data, protocol) =>
+        _i221.TestEnumDefaultSerialization.fromJson(data);
+    map[_i222.TestEnumEnhanced] = (data, protocol) =>
+        _i222.TestEnumEnhanced.fromJson(data);
+    map[_i223.TestEnumEnhancedByName] = (data, protocol) =>
+        _i223.TestEnumEnhancedByName.fromJson(data);
+    map[_i224.TestEnumStringified] = (data, protocol) =>
+        _i224.TestEnumStringified.fromJson(data);
+    map[_i225.Types] = (data, protocol) => _i225.Types.fromJson(data);
+    map[_i226.TypesList] = (data, protocol) => _i226.TypesList.fromJson(data);
+    map[_i227.TypesMap] = (data, protocol) => _i227.TypesMap.fromJson(data);
+    map[_i228.TypesRecord] = (data, protocol) =>
+        _i228.TypesRecord.fromJson(data);
+    map[_i229.TypesSet] = (data, protocol) => _i229.TypesSet.fromJson(data);
+    map[_i230.TypesSetRequired] = (data, protocol) =>
+        _i230.TypesSetRequired.fromJson(data);
+    map[_i231.UniqueData] = (data, protocol) => _i231.UniqueData.fromJson(data);
+    map[_i232.UniqueDataWithNonPersist] = (data, protocol) =>
+        _i232.UniqueDataWithNonPersist.fromJson(data);
+    map[_i233.UpsertTestModel] = (data, protocol) =>
+        _i233.UpsertTestModel.fromJson(data);
+    map[_i1.getType<_i7.ByIndexEnumWithNameValue?>()] = (data, protocol) =>
+        (data != null ? _i7.ByIndexEnumWithNameValue.fromJson(data) : null);
+    map[_i1.getType<_i8.ByNameEnumWithNameValue?>()] = (data, protocol) =>
+        (data != null ? _i8.ByNameEnumWithNameValue.fromJson(data) : null);
+    map[_i1.getType<_i9.CourseUuid?>()] = (data, protocol) =>
+        (data != null ? _i9.CourseUuid.fromJson(data) : null);
+    map[_i1.getType<_i10.EnrollmentInt?>()] = (data, protocol) =>
+        (data != null ? _i10.EnrollmentInt.fromJson(data) : null);
+    map[_i1.getType<_i11.StudentUuid?>()] = (data, protocol) =>
+        (data != null ? _i11.StudentUuid.fromJson(data) : null);
+    map[_i1.getType<_i12.ArenaUuid?>()] = (data, protocol) =>
+        (data != null ? _i12.ArenaUuid.fromJson(data) : null);
+    map[_i1.getType<_i13.PlayerUuid?>()] = (data, protocol) =>
+        (data != null ? _i13.PlayerUuid.fromJson(data) : null);
+    map[_i1.getType<_i14.TeamInt?>()] = (data, protocol) =>
+        (data != null ? _i14.TeamInt.fromJson(data) : null);
+    map[_i1.getType<_i15.CommentInt?>()] = (data, protocol) =>
+        (data != null ? _i15.CommentInt.fromJson(data) : null);
+    map[_i1.getType<_i16.CustomerInt?>()] = (data, protocol) =>
+        (data != null ? _i16.CustomerInt.fromJson(data) : null);
+    map[_i1.getType<_i17.OrderUuid?>()] = (data, protocol) =>
+        (data != null ? _i17.OrderUuid.fromJson(data) : null);
+    map[_i1.getType<_i18.AddressUuid?>()] = (data, protocol) =>
+        (data != null ? _i18.AddressUuid.fromJson(data) : null);
+    map[_i1.getType<_i19.CitizenInt?>()] = (data, protocol) =>
+        (data != null ? _i19.CitizenInt.fromJson(data) : null);
+    map[_i1.getType<_i20.CompanyUuid?>()] = (data, protocol) =>
+        (data != null ? _i20.CompanyUuid.fromJson(data) : null);
+    map[_i1.getType<_i21.TownInt?>()] = (data, protocol) =>
+        (data != null ? _i21.TownInt.fromJson(data) : null);
+    map[_i1.getType<_i22.ChangedIdTypeSelf?>()] = (data, protocol) =>
+        (data != null ? _i22.ChangedIdTypeSelf.fromJson(data) : null);
+    map[_i1
+        .getType<_i23.ServerOnlyChangedIdFieldClass?>()] = (data, protocol) =>
+        (data != null
+        ? _i23.ServerOnlyChangedIdFieldClass.fromJson(data)
+        : null);
+    map[_i1.getType<_i24.BigIntDefault?>()] = (data, protocol) =>
+        (data != null ? _i24.BigIntDefault.fromJson(data) : null);
+    map[_i1.getType<_i25.BigIntDefaultMix?>()] = (data, protocol) =>
+        (data != null ? _i25.BigIntDefaultMix.fromJson(data) : null);
+    map[_i1.getType<_i26.BigIntDefaultModel?>()] = (data, protocol) =>
+        (data != null ? _i26.BigIntDefaultModel.fromJson(data) : null);
+    map[_i1.getType<_i27.BigIntDefaultPersist?>()] = (data, protocol) =>
+        (data != null ? _i27.BigIntDefaultPersist.fromJson(data) : null);
+    map[_i1.getType<_i28.BoolDefault?>()] = (data, protocol) =>
+        (data != null ? _i28.BoolDefault.fromJson(data) : null);
+    map[_i1.getType<_i29.BoolDefaultMix?>()] = (data, protocol) =>
+        (data != null ? _i29.BoolDefaultMix.fromJson(data) : null);
+    map[_i1.getType<_i30.BoolDefaultModel?>()] = (data, protocol) =>
+        (data != null ? _i30.BoolDefaultModel.fromJson(data) : null);
+    map[_i1.getType<_i31.BoolDefaultPersist?>()] = (data, protocol) =>
+        (data != null ? _i31.BoolDefaultPersist.fromJson(data) : null);
+    map[_i1.getType<_i32.DateTimeDefault?>()] = (data, protocol) =>
+        (data != null ? _i32.DateTimeDefault.fromJson(data) : null);
+    map[_i1.getType<_i33.DateTimeDefaultMix?>()] = (data, protocol) =>
+        (data != null ? _i33.DateTimeDefaultMix.fromJson(data) : null);
+    map[_i1.getType<_i34.DateTimeDefaultModel?>()] = (data, protocol) =>
+        (data != null ? _i34.DateTimeDefaultModel.fromJson(data) : null);
+    map[_i1.getType<_i35.DateTimeDefaultPersist?>()] = (data, protocol) =>
+        (data != null ? _i35.DateTimeDefaultPersist.fromJson(data) : null);
+    map[_i1.getType<_i36.DoubleDefault?>()] = (data, protocol) =>
+        (data != null ? _i36.DoubleDefault.fromJson(data) : null);
+    map[_i1.getType<_i37.DoubleDefaultMix?>()] = (data, protocol) =>
+        (data != null ? _i37.DoubleDefaultMix.fromJson(data) : null);
+    map[_i1.getType<_i38.DoubleDefaultModel?>()] = (data, protocol) =>
+        (data != null ? _i38.DoubleDefaultModel.fromJson(data) : null);
+    map[_i1.getType<_i39.DoubleDefaultPersist?>()] = (data, protocol) =>
+        (data != null ? _i39.DoubleDefaultPersist.fromJson(data) : null);
+    map[_i1.getType<_i40.DurationDefault?>()] = (data, protocol) =>
+        (data != null ? _i40.DurationDefault.fromJson(data) : null);
+    map[_i1.getType<_i41.DurationDefaultMix?>()] = (data, protocol) =>
+        (data != null ? _i41.DurationDefaultMix.fromJson(data) : null);
+    map[_i1.getType<_i42.DurationDefaultModel?>()] = (data, protocol) =>
+        (data != null ? _i42.DurationDefaultModel.fromJson(data) : null);
+    map[_i1.getType<_i43.DurationDefaultPersist?>()] = (data, protocol) =>
+        (data != null ? _i43.DurationDefaultPersist.fromJson(data) : null);
+    map[_i1.getType<_i44.EnumDefault?>()] = (data, protocol) =>
+        (data != null ? _i44.EnumDefault.fromJson(data) : null);
+    map[_i1.getType<_i45.EnumDefaultMix?>()] = (data, protocol) =>
+        (data != null ? _i45.EnumDefaultMix.fromJson(data) : null);
+    map[_i1.getType<_i46.EnumDefaultModel?>()] = (data, protocol) =>
+        (data != null ? _i46.EnumDefaultModel.fromJson(data) : null);
+    map[_i1.getType<_i47.EnumDefaultPersist?>()] = (data, protocol) =>
+        (data != null ? _i47.EnumDefaultPersist.fromJson(data) : null);
+    map[_i1.getType<_i48.ByIndexEnum?>()] = (data, protocol) =>
+        (data != null ? _i48.ByIndexEnum.fromJson(data) : null);
+    map[_i1.getType<_i49.ByNameEnum?>()] = (data, protocol) =>
+        (data != null ? _i49.ByNameEnum.fromJson(data) : null);
+    map[_i1.getType<_i50.DefaultValueEnum?>()] = (data, protocol) =>
+        (data != null ? _i50.DefaultValueEnum.fromJson(data) : null);
+    map[_i1.getType<_i51.DefaultException?>()] = (data, protocol) =>
+        (data != null ? _i51.DefaultException.fromJson(data) : null);
+    map[_i1.getType<_i52.IntDefault?>()] = (data, protocol) =>
+        (data != null ? _i52.IntDefault.fromJson(data) : null);
+    map[_i1.getType<_i53.IntDefaultMix?>()] = (data, protocol) =>
+        (data != null ? _i53.IntDefaultMix.fromJson(data) : null);
+    map[_i1.getType<_i54.IntDefaultModel?>()] = (data, protocol) =>
+        (data != null ? _i54.IntDefaultModel.fromJson(data) : null);
+    map[_i1.getType<_i55.IntDefaultPersist?>()] = (data, protocol) =>
+        (data != null ? _i55.IntDefaultPersist.fromJson(data) : null);
+    map[_i1.getType<_i56.StringDefault?>()] = (data, protocol) =>
+        (data != null ? _i56.StringDefault.fromJson(data) : null);
+    map[_i1.getType<_i57.StringDefaultMix?>()] = (data, protocol) =>
+        (data != null ? _i57.StringDefaultMix.fromJson(data) : null);
+    map[_i1.getType<_i58.StringDefaultModel?>()] = (data, protocol) =>
+        (data != null ? _i58.StringDefaultModel.fromJson(data) : null);
+    map[_i1.getType<_i59.StringDefaultPersist?>()] = (data, protocol) =>
+        (data != null ? _i59.StringDefaultPersist.fromJson(data) : null);
+    map[_i1.getType<_i60.UriDefault?>()] = (data, protocol) =>
+        (data != null ? _i60.UriDefault.fromJson(data) : null);
+    map[_i1.getType<_i61.UriDefaultMix?>()] = (data, protocol) =>
+        (data != null ? _i61.UriDefaultMix.fromJson(data) : null);
+    map[_i1.getType<_i62.UriDefaultModel?>()] = (data, protocol) =>
+        (data != null ? _i62.UriDefaultModel.fromJson(data) : null);
+    map[_i1.getType<_i63.UriDefaultPersist?>()] = (data, protocol) =>
+        (data != null ? _i63.UriDefaultPersist.fromJson(data) : null);
+    map[_i1.getType<_i64.UuidDefault?>()] = (data, protocol) =>
+        (data != null ? _i64.UuidDefault.fromJson(data) : null);
+    map[_i1.getType<_i65.UuidDefaultMix?>()] = (data, protocol) =>
+        (data != null ? _i65.UuidDefaultMix.fromJson(data) : null);
+    map[_i1.getType<_i66.UuidDefaultModel?>()] = (data, protocol) =>
+        (data != null ? _i66.UuidDefaultModel.fromJson(data) : null);
+    map[_i1.getType<_i67.UuidDefaultPersist?>()] = (data, protocol) =>
+        (data != null ? _i67.UuidDefaultPersist.fromJson(data) : null);
+    map[_i1.getType<_i68.EmptyModel?>()] = (data, protocol) =>
+        (data != null ? _i68.EmptyModel.fromJson(data) : null);
+    map[_i1.getType<_i69.EmptyModelRelationItem?>()] = (data, protocol) =>
+        (data != null ? _i69.EmptyModelRelationItem.fromJson(data) : null);
+    map[_i1.getType<_i70.EmptyModelWithTable?>()] = (data, protocol) =>
+        (data != null ? _i70.EmptyModelWithTable.fromJson(data) : null);
+    map[_i1.getType<_i71.RelationEmptyModel?>()] = (data, protocol) =>
+        (data != null ? _i71.RelationEmptyModel.fromJson(data) : null);
+    map[_i1.getType<_i72.ExceptionWithData?>()] = (data, protocol) =>
+        (data != null ? _i72.ExceptionWithData.fromJson(data) : null);
+    map[_i1.getType<_i73.ChildClassExplicitColumn?>()] = (data, protocol) =>
+        (data != null ? _i73.ChildClassExplicitColumn.fromJson(data) : null);
+    map[_i1.getType<_i74.NonTableParentClass?>()] = (data, protocol) =>
+        (data != null ? _i74.NonTableParentClass.fromJson(data) : null);
+    map[_i1.getType<_i75.ModifiedColumnName?>()] = (data, protocol) =>
+        (data != null ? _i75.ModifiedColumnName.fromJson(data) : null);
+    map[_i1.getType<_i76.Department?>()] = (data, protocol) =>
+        (data != null ? _i76.Department.fromJson(data) : null);
+    map[_i1.getType<_i77.Employee?>()] = (data, protocol) =>
+        (data != null ? _i77.Employee.fromJson(data) : null);
+    map[_i1.getType<_i78.Contractor?>()] = (data, protocol) =>
+        (data != null ? _i78.Contractor.fromJson(data) : null);
+    map[_i1.getType<_i79.Service?>()] = (data, protocol) =>
+        (data != null ? _i79.Service.fromJson(data) : null);
+    map[_i1.getType<_i80.TableWithExplicitColumnName?>()] = (data, protocol) =>
+        (data != null ? _i80.TableWithExplicitColumnName.fromJson(data) : null);
+    map[_i1.getType<_i81.TestGeneratedCallByeModel?>()] = (data, protocol) =>
+        (data != null ? _i81.TestGeneratedCallByeModel.fromJson(data) : null);
+    map[_i1.getType<_i82.TestGeneratedCallExecuteWithTriggerModel?>()] =
+        (data, protocol) => (data != null
+        ? _i82.TestGeneratedCallExecuteWithTriggerModel.fromJson(data)
+        : null);
+    map[_i1.getType<_i83.TestGeneratedCallHelloModel?>()] = (data, protocol) =>
+        (data != null ? _i83.TestGeneratedCallHelloModel.fromJson(data) : null);
+    map[_i1.getType<_i84.TestGeneratedCallInvokeModel?>()] = (data, protocol) =>
+        (data != null
+        ? _i84.TestGeneratedCallInvokeModel.fromJson(data)
+        : null);
+    map[_i1.getType<_i85.ImmutableChildObject?>()] = (data, protocol) =>
+        (data != null ? _i85.ImmutableChildObject.fromJson(data) : null);
+    map[_i1.getType<_i86.ImmutableChildObjectWithNoAdditionalFields?>()] =
+        (data, protocol) => (data != null
+        ? _i86.ImmutableChildObjectWithNoAdditionalFields.fromJson(data)
+        : null);
+    map[_i1.getType<_i87.ImmutableObject?>()] = (data, protocol) =>
+        (data != null ? _i87.ImmutableObject.fromJson(data) : null);
+    map[_i1.getType<_i88.ImmutableObjectWithImmutableObject?>()] =
+        (data, protocol) => (data != null
+        ? _i88.ImmutableObjectWithImmutableObject.fromJson(data)
+        : null);
+    map[_i1.getType<_i89.ImmutableObjectWithList?>()] = (data, protocol) =>
+        (data != null ? _i89.ImmutableObjectWithList.fromJson(data) : null);
+    map[_i1.getType<_i90.ImmutableObjectWithMap?>()] = (data, protocol) =>
+        (data != null ? _i90.ImmutableObjectWithMap.fromJson(data) : null);
+    map[_i1.getType<_i91.ImmutableObjectWithMultipleFields?>()] =
+        (data, protocol) => (data != null
+        ? _i91.ImmutableObjectWithMultipleFields.fromJson(data)
+        : null);
+    map[_i1.getType<_i92.ImmutableObjectWithNoFields?>()] = (data, protocol) =>
+        (data != null ? _i92.ImmutableObjectWithNoFields.fromJson(data) : null);
+    map[_i1.getType<_i93.ImmutableObjectWithRecord?>()] = (data, protocol) =>
+        (data != null ? _i93.ImmutableObjectWithRecord.fromJson(data) : null);
+    map[_i1.getType<_i94.ImmutableObjectWithTable?>()] = (data, protocol) =>
+        (data != null ? _i94.ImmutableObjectWithTable.fromJson(data) : null);
+    map[_i1
+        .getType<_i95.ImmutableObjectWithTwentyFields?>()] = (data, protocol) =>
+        (data != null
+        ? _i95.ImmutableObjectWithTwentyFields.fromJson(data)
+        : null);
+    map[_i1.getType<_i96.ChildClass?>()] = (data, protocol) =>
+        (data != null ? _i96.ChildClass.fromJson(data) : null);
+    map[_i1.getType<_i97.ServerOnlyChildClass?>()] = (data, protocol) =>
+        (data != null ? _i97.ServerOnlyChildClass.fromJson(data) : null);
+    map[_i1.getType<_i98.ChildWithDefault?>()] = (data, protocol) =>
+        (data != null ? _i98.ChildWithDefault.fromJson(data) : null);
+    map[_i1.getType<_i99.ChildWithInheritedId?>()] = (data, protocol) =>
+        (data != null ? _i99.ChildWithInheritedId.fromJson(data) : null);
+    map[_i1.getType<_i100.ChildClassWithoutId?>()] = (data, protocol) =>
+        (data != null ? _i100.ChildClassWithoutId.fromJson(data) : null);
+    map[_i1
+        .getType<_i101.ServerOnlyChildClassWithoutId?>()] = (data, protocol) =>
+        (data != null
+        ? _i101.ServerOnlyChildClassWithoutId.fromJson(data)
+        : null);
+    map[_i1.getType<_i102.ExtendedAppException?>()] = (data, protocol) =>
+        (data != null ? _i102.ExtendedAppException.fromJson(data) : null);
+    map[_i1.getType<_i103.BaseAppException?>()] = (data, protocol) =>
+        (data != null ? _i103.BaseAppException.fromJson(data) : null);
+    map[_i1.getType<_i104.NotFoundException?>()] = (data, protocol) =>
+        (data != null ? _i104.NotFoundException.fromJson(data) : null);
+    map[_i1.getType<_i104.ValidationException?>()] = (data, protocol) =>
+        (data != null ? _i104.ValidationException.fromJson(data) : null);
+    map[_i1.getType<_i105.ParentClass?>()] = (data, protocol) =>
+        (data != null ? _i105.ParentClass.fromJson(data) : null);
+    map[_i1.getType<_i106.GrandparentClass?>()] = (data, protocol) =>
+        (data != null ? _i106.GrandparentClass.fromJson(data) : null);
+    map[_i1.getType<_i107.ParentClassWithoutId?>()] = (data, protocol) =>
+        (data != null ? _i107.ParentClassWithoutId.fromJson(data) : null);
+    map[_i1.getType<_i108.GrandparentClassWithId?>()] = (data, protocol) =>
+        (data != null ? _i108.GrandparentClassWithId.fromJson(data) : null);
+    map[_i1.getType<_i109.ChildEntity?>()] = (data, protocol) =>
+        (data != null ? _i109.ChildEntity.fromJson(data) : null);
+    map[_i1.getType<_i110.BaseEntity?>()] = (data, protocol) =>
+        (data != null ? _i110.BaseEntity.fromJson(data) : null);
+    map[_i1.getType<_i111.ParentEntity?>()] = (data, protocol) =>
+        (data != null ? _i111.ParentEntity.fromJson(data) : null);
+    map[_i1.getType<_i112.NonServerOnlyParentClass?>()] = (data, protocol) =>
+        (data != null ? _i112.NonServerOnlyParentClass.fromJson(data) : null);
+    map[_i1.getType<_i113.ParentWithChangedId?>()] = (data, protocol) =>
+        (data != null ? _i113.ParentWithChangedId.fromJson(data) : null);
+    map[_i1.getType<_i114.ParentWithDefault?>()] = (data, protocol) =>
+        (data != null ? _i114.ParentWithDefault.fromJson(data) : null);
+    map[_i1.getType<_i115.PolymorphicGrandChild?>()] = (data, protocol) =>
+        (data != null ? _i115.PolymorphicGrandChild.fromJson(data) : null);
+    map[_i1.getType<_i116.PolymorphicChild?>()] = (data, protocol) =>
+        (data != null ? _i116.PolymorphicChild.fromJson(data) : null);
+    map[_i1.getType<_i117.PolymorphicChildContainer?>()] = (data, protocol) =>
+        (data != null ? _i117.PolymorphicChildContainer.fromJson(data) : null);
+    map[_i1.getType<_i118.ModulePolymorphicChildContainer?>()] =
+        (data, protocol) => (data != null
+        ? _i118.ModulePolymorphicChildContainer.fromJson(data)
+        : null);
+    map[_i1.getType<_i119.SimilarButNotParent?>()] = (data, protocol) =>
+        (data != null ? _i119.SimilarButNotParent.fromJson(data) : null);
+    map[_i1.getType<_i120.PolymorphicParent?>()] = (data, protocol) =>
+        (data != null ? _i120.PolymorphicParent.fromJson(data) : null);
+    map[_i1.getType<_i121.UnrelatedToPolymorphism?>()] = (data, protocol) =>
+        (data != null ? _i121.UnrelatedToPolymorphism.fromJson(data) : null);
+    map[_i1.getType<_i122.SealedGrandChild?>()] = (data, protocol) =>
+        (data != null ? _i122.SealedGrandChild.fromJson(data) : null);
+    map[_i1.getType<_i122.SealedChild?>()] = (data, protocol) =>
+        (data != null ? _i122.SealedChild.fromJson(data) : null);
+    map[_i1.getType<_i123.SealedChildOnlyRequired?>()] = (data, protocol) =>
+        (data != null ? _i123.SealedChildOnlyRequired.fromJson(data) : null);
+    map[_i1.getType<_i122.SealedOtherChild?>()] = (data, protocol) =>
+        (data != null ? _i122.SealedOtherChild.fromJson(data) : null);
+    map[_i1.getType<_i124.CityWithLongTableName?>()] = (data, protocol) =>
+        (data != null ? _i124.CityWithLongTableName.fromJson(data) : null);
+    map[_i1
+        .getType<_i125.OrganizationWithLongTableName?>()] = (data, protocol) =>
+        (data != null
+        ? _i125.OrganizationWithLongTableName.fromJson(data)
+        : null);
+    map[_i1.getType<_i126.PersonWithLongTableName?>()] = (data, protocol) =>
+        (data != null ? _i126.PersonWithLongTableName.fromJson(data) : null);
+    map[_i1.getType<_i127.MaxFieldName?>()] = (data, protocol) =>
+        (data != null ? _i127.MaxFieldName.fromJson(data) : null);
+    map[_i1.getType<_i128.LongImplicitIdField?>()] = (data, protocol) =>
+        (data != null ? _i128.LongImplicitIdField.fromJson(data) : null);
+    map[_i1
+        .getType<_i129.LongImplicitIdFieldCollection?>()] = (data, protocol) =>
+        (data != null
+        ? _i129.LongImplicitIdFieldCollection.fromJson(data)
+        : null);
+    map[_i1
+        .getType<_i130.RelationToMultipleMaxFieldName?>()] = (data, protocol) =>
+        (data != null
+        ? _i130.RelationToMultipleMaxFieldName.fromJson(data)
+        : null);
+    map[_i1.getType<_i131.UserNote?>()] = (data, protocol) =>
+        (data != null ? _i131.UserNote.fromJson(data) : null);
+    map[_i1.getType<_i132.UserNoteCollection?>()] = (data, protocol) =>
+        (data != null ? _i132.UserNoteCollection.fromJson(data) : null);
+    map[_i1.getType<_i133.UserNoteCollectionWithALongName?>()] =
+        (data, protocol) => (data != null
+        ? _i133.UserNoteCollectionWithALongName.fromJson(data)
+        : null);
+    map[_i1.getType<_i134.UserNoteWithALongName?>()] = (data, protocol) =>
+        (data != null ? _i134.UserNoteWithALongName.fromJson(data) : null);
+    map[_i1.getType<_i135.MultipleMaxFieldName?>()] = (data, protocol) =>
+        (data != null ? _i135.MultipleMaxFieldName.fromJson(data) : null);
+    map[_i1.getType<_i136.City?>()] = (data, protocol) =>
+        (data != null ? _i136.City.fromJson(data) : null);
+    map[_i1.getType<_i137.Organization?>()] = (data, protocol) =>
+        (data != null ? _i137.Organization.fromJson(data) : null);
+    map[_i1.getType<_i138.Person?>()] = (data, protocol) =>
+        (data != null ? _i138.Person.fromJson(data) : null);
+    map[_i1.getType<_i139.BleedChild?>()] = (data, protocol) =>
+        (data != null ? _i139.BleedChild.fromJson(data) : null);
+    map[_i1.getType<_i140.BleedRoot?>()] = (data, protocol) =>
+        (data != null ? _i140.BleedRoot.fromJson(data) : null);
+    map[_i1.getType<_i141.Course?>()] = (data, protocol) =>
+        (data != null ? _i141.Course.fromJson(data) : null);
+    map[_i1.getType<_i142.Enrollment?>()] = (data, protocol) =>
+        (data != null ? _i142.Enrollment.fromJson(data) : null);
+    map[_i1.getType<_i143.Student?>()] = (data, protocol) =>
+        (data != null ? _i143.Student.fromJson(data) : null);
+    map[_i1.getType<_i144.ObjectUser?>()] = (data, protocol) =>
+        (data != null ? _i144.ObjectUser.fromJson(data) : null);
+    map[_i1.getType<_i145.ParentUser?>()] = (data, protocol) =>
+        (data != null ? _i145.ParentUser.fromJson(data) : null);
+    map[_i1.getType<_i146.Arena?>()] = (data, protocol) =>
+        (data != null ? _i146.Arena.fromJson(data) : null);
+    map[_i1.getType<_i147.Player?>()] = (data, protocol) =>
+        (data != null ? _i147.Player.fromJson(data) : null);
+    map[_i1.getType<_i148.Team?>()] = (data, protocol) =>
+        (data != null ? _i148.Team.fromJson(data) : null);
+    map[_i1.getType<_i149.Comment?>()] = (data, protocol) =>
+        (data != null ? _i149.Comment.fromJson(data) : null);
+    map[_i1.getType<_i150.Customer?>()] = (data, protocol) =>
+        (data != null ? _i150.Customer.fromJson(data) : null);
+    map[_i1.getType<_i151.Book?>()] = (data, protocol) =>
+        (data != null ? _i151.Book.fromJson(data) : null);
+    map[_i1.getType<_i152.Chapter?>()] = (data, protocol) =>
+        (data != null ? _i152.Chapter.fromJson(data) : null);
+    map[_i1.getType<_i153.Order?>()] = (data, protocol) =>
+        (data != null ? _i153.Order.fromJson(data) : null);
+    map[_i1.getType<_i154.Address?>()] = (data, protocol) =>
+        (data != null ? _i154.Address.fromJson(data) : null);
+    map[_i1.getType<_i155.Citizen?>()] = (data, protocol) =>
+        (data != null ? _i155.Citizen.fromJson(data) : null);
+    map[_i1.getType<_i156.Company?>()] = (data, protocol) =>
+        (data != null ? _i156.Company.fromJson(data) : null);
+    map[_i1.getType<_i157.Town?>()] = (data, protocol) =>
+        (data != null ? _i157.Town.fromJson(data) : null);
+    map[_i1.getType<_i158.Blocking?>()] = (data, protocol) =>
+        (data != null ? _i158.Blocking.fromJson(data) : null);
+    map[_i1.getType<_i159.Member?>()] = (data, protocol) =>
+        (data != null ? _i159.Member.fromJson(data) : null);
+    map[_i1.getType<_i160.Cat?>()] = (data, protocol) =>
+        (data != null ? _i160.Cat.fromJson(data) : null);
+    map[_i1.getType<_i161.Post?>()] = (data, protocol) =>
+        (data != null ? _i161.Post.fromJson(data) : null);
+    map[_i1.getType<_i162.ModuleDatatype?>()] = (data, protocol) =>
+        (data != null ? _i162.ModuleDatatype.fromJson(data) : null);
+    map[_i1.getType<_i163.MyFeatureModel?>()] = (data, protocol) =>
+        (data != null ? _i163.MyFeatureModel.fromJson(data) : null);
+    map[_i1.getType<_i164.MyTriggerType?>()] = (data, protocol) =>
+        (data != null ? _i164.MyTriggerType.fromJson(data) : null);
+    map[_i1.getType<_i165.Nullability?>()] = (data, protocol) =>
+        (data != null ? _i165.Nullability.fromJson(data) : null);
+    map[_i1.getType<_i166.NullsDistinctData?>()] = (data, protocol) =>
+        (data != null ? _i166.NullsDistinctData.fromJson(data) : null);
+    map[_i1.getType<_i167.ObjectFieldPersist?>()] = (data, protocol) =>
+        (data != null ? _i167.ObjectFieldPersist.fromJson(data) : null);
+    map[_i1.getType<_i168.ObjectFieldScopes?>()] = (data, protocol) =>
+        (data != null ? _i168.ObjectFieldScopes.fromJson(data) : null);
+    map[_i1.getType<_i169.ObjectWithBit?>()] = (data, protocol) =>
+        (data != null ? _i169.ObjectWithBit.fromJson(data) : null);
+    map[_i1.getType<_i170.ObjectWithByteData?>()] = (data, protocol) =>
+        (data != null ? _i170.ObjectWithByteData.fromJson(data) : null);
+    map[_i1.getType<_i171.ObjectWithCustomClass?>()] = (data, protocol) =>
+        (data != null ? _i171.ObjectWithCustomClass.fromJson(data) : null);
+    map[_i1.getType<_i172.ObjectWithDuration?>()] = (data, protocol) =>
+        (data != null ? _i172.ObjectWithDuration.fromJson(data) : null);
+    map[_i1.getType<_i173.ObjectWithDynamic?>()] = (data, protocol) =>
+        (data != null ? _i173.ObjectWithDynamic.fromJson(data) : null);
+    map[_i1.getType<_i174.ObjectWithEnum?>()] = (data, protocol) =>
+        (data != null ? _i174.ObjectWithEnum.fromJson(data) : null);
+    map[_i1.getType<_i175.ObjectWithEnumEnhanced?>()] = (data, protocol) =>
+        (data != null ? _i175.ObjectWithEnumEnhanced.fromJson(data) : null);
+    map[_i1.getType<_i176.ObjectWithGeographyGeometryCollection?>()] =
+        (data, protocol) => (data != null
+        ? _i176.ObjectWithGeographyGeometryCollection.fromJson(data)
+        : null);
+    map[_i1
+        .getType<_i177.ObjectWithGeographyLineString?>()] = (data, protocol) =>
+        (data != null
+        ? _i177.ObjectWithGeographyLineString.fromJson(data)
+        : null);
+    map[_i1.getType<_i178.ObjectWithGeographyPoint?>()] = (data, protocol) =>
+        (data != null ? _i178.ObjectWithGeographyPoint.fromJson(data) : null);
+    map[_i1.getType<_i179.ObjectWithGeographyPolygon?>()] = (data, protocol) =>
+        (data != null ? _i179.ObjectWithGeographyPolygon.fromJson(data) : null);
+    map[_i1.getType<_i180.ObjectWithHalfVector?>()] = (data, protocol) =>
+        (data != null ? _i180.ObjectWithHalfVector.fromJson(data) : null);
+    map[_i1.getType<_i181.ObjectWithIndex?>()] = (data, protocol) =>
+        (data != null ? _i181.ObjectWithIndex.fromJson(data) : null);
+    map[_i1.getType<_i182.ObjectWithJsonb?>()] = (data, protocol) =>
+        (data != null ? _i182.ObjectWithJsonb.fromJson(data) : null);
+    map[_i1.getType<_i183.ObjectWithJsonbClassLevel?>()] = (data, protocol) =>
+        (data != null ? _i183.ObjectWithJsonbClassLevel.fromJson(data) : null);
+    map[_i1.getType<_i184.ObjectWithMaps?>()] = (data, protocol) =>
+        (data != null ? _i184.ObjectWithMaps.fromJson(data) : null);
+    map[_i1
+        .getType<_i185.ObjectWithNullableCustomClass?>()] = (data, protocol) =>
+        (data != null
+        ? _i185.ObjectWithNullableCustomClass.fromJson(data)
+        : null);
+    map[_i1.getType<_i186.ObjectWithObject?>()] = (data, protocol) =>
+        (data != null ? _i186.ObjectWithObject.fromJson(data) : null);
+    map[_i1.getType<_i187.ObjectWithParent?>()] = (data, protocol) =>
+        (data != null ? _i187.ObjectWithParent.fromJson(data) : null);
+    map[_i1.getType<_i188.ObjectWithSealedClass?>()] = (data, protocol) =>
+        (data != null ? _i188.ObjectWithSealedClass.fromJson(data) : null);
+    map[_i1.getType<_i189.ObjectWithSealedException?>()] = (data, protocol) =>
+        (data != null ? _i189.ObjectWithSealedException.fromJson(data) : null);
+    map[_i1.getType<_i190.ObjectWithSelfParent?>()] = (data, protocol) =>
+        (data != null ? _i190.ObjectWithSelfParent.fromJson(data) : null);
+    map[_i1.getType<_i191.ObjectWithSparseVector?>()] = (data, protocol) =>
+        (data != null ? _i191.ObjectWithSparseVector.fromJson(data) : null);
+    map[_i1.getType<_i192.ObjectWithUuid?>()] = (data, protocol) =>
+        (data != null ? _i192.ObjectWithUuid.fromJson(data) : null);
+    map[_i1.getType<_i193.ObjectWithVector?>()] = (data, protocol) =>
+        (data != null ? _i193.ObjectWithVector.fromJson(data) : null);
+    map[_i1.getType<_i194.Record?>()] = (data, protocol) =>
+        (data != null ? _i194.Record.fromJson(data) : null);
+    map[_i1.getType<_i195.RelatedUniqueData?>()] = (data, protocol) =>
+        (data != null ? _i195.RelatedUniqueData.fromJson(data) : null);
+    map[_i1.getType<_i196.ExceptionWithRequiredField?>()] = (data, protocol) =>
+        (data != null ? _i196.ExceptionWithRequiredField.fromJson(data) : null);
+    map[_i1.getType<_i197.ModelWithRequiredField?>()] = (data, protocol) =>
+        (data != null ? _i197.ModelWithRequiredField.fromJson(data) : null);
+    map[_i1.getType<_i198.ScopeNoneFields?>()] = (data, protocol) =>
+        (data != null ? _i198.ScopeNoneFields.fromJson(data) : null);
+    map[_i1.getType<_i199.ScopeServerOnlyFieldChild?>()] = (data, protocol) =>
+        (data != null ? _i199.ScopeServerOnlyFieldChild.fromJson(data) : null);
+    map[_i1.getType<_i200.ScopeServerOnlyField?>()] = (data, protocol) =>
+        (data != null ? _i200.ScopeServerOnlyField.fromJson(data) : null);
+    map[_i1.getType<_i201.Article?>()] = (data, protocol) =>
+        (data != null ? _i201.Article.fromJson(data) : null);
+    map[_i1.getType<_i202.ArticleList?>()] = (data, protocol) =>
+        (data != null ? _i202.ArticleList.fromJson(data) : null);
+    map[_i1.getType<_i203.DefaultServerOnlyClass?>()] = (data, protocol) =>
+        (data != null ? _i203.DefaultServerOnlyClass.fromJson(data) : null);
+    map[_i1.getType<_i204.DefaultServerOnlyEnum?>()] = (data, protocol) =>
+        (data != null ? _i204.DefaultServerOnlyEnum.fromJson(data) : null);
+    map[_i1.getType<_i205.NotServerOnlyClass?>()] = (data, protocol) =>
+        (data != null ? _i205.NotServerOnlyClass.fromJson(data) : null);
+    map[_i1.getType<_i206.NotServerOnlyEnum?>()] = (data, protocol) =>
+        (data != null ? _i206.NotServerOnlyEnum.fromJson(data) : null);
+    map[_i1.getType<_i207.ServerOnlyClass?>()] = (data, protocol) =>
+        (data != null ? _i207.ServerOnlyClass.fromJson(data) : null);
+    map[_i1.getType<_i208.ServerOnlyEnum?>()] = (data, protocol) =>
+        (data != null ? _i208.ServerOnlyEnum.fromJson(data) : null);
+    map[_i1.getType<_i209.ServerOnlyClassField?>()] = (data, protocol) =>
+        (data != null ? _i209.ServerOnlyClassField.fromJson(data) : null);
+    map[_i1.getType<_i210.ServerOnlyDefault?>()] = (data, protocol) =>
+        (data != null ? _i210.ServerOnlyDefault.fromJson(data) : null);
+    map[_i1.getType<_i211.SessionAuthInfo?>()] = (data, protocol) =>
+        (data != null ? _i211.SessionAuthInfo.fromJson(data) : null);
+    map[_i1.getType<_i212.SharedModelContainer?>()] = (data, protocol) =>
+        (data != null ? _i212.SharedModelContainer.fromJson(data) : null);
+    map[_i1.getType<_i213.SharedModelSubclass?>()] = (data, protocol) =>
+        (data != null ? _i213.SharedModelSubclass.fromJson(data) : null);
+    map[_i1.getType<_i214.SimpleData?>()] = (data, protocol) =>
+        (data != null ? _i214.SimpleData.fromJson(data) : null);
+    map[_i1.getType<_i215.SimpleDataList?>()] = (data, protocol) =>
+        (data != null ? _i215.SimpleDataList.fromJson(data) : null);
+    map[_i1.getType<_i216.SimpleDataMap?>()] = (data, protocol) =>
+        (data != null ? _i216.SimpleDataMap.fromJson(data) : null);
+    map[_i1.getType<_i217.SimpleDataObject?>()] = (data, protocol) =>
+        (data != null ? _i217.SimpleDataObject.fromJson(data) : null);
+    map[_i1.getType<_i218.SimpleDateTime?>()] = (data, protocol) =>
+        (data != null ? _i218.SimpleDateTime.fromJson(data) : null);
+    map[_i1.getType<_i219.ModelInSubfolder?>()] = (data, protocol) =>
+        (data != null ? _i219.ModelInSubfolder.fromJson(data) : null);
+    map[_i1.getType<_i220.TestEnum?>()] = (data, protocol) =>
+        (data != null ? _i220.TestEnum.fromJson(data) : null);
+    map[_i1
+        .getType<_i221.TestEnumDefaultSerialization?>()] = (data, protocol) =>
+        (data != null
+        ? _i221.TestEnumDefaultSerialization.fromJson(data)
+        : null);
+    map[_i1.getType<_i222.TestEnumEnhanced?>()] = (data, protocol) =>
+        (data != null ? _i222.TestEnumEnhanced.fromJson(data) : null);
+    map[_i1.getType<_i223.TestEnumEnhancedByName?>()] = (data, protocol) =>
+        (data != null ? _i223.TestEnumEnhancedByName.fromJson(data) : null);
+    map[_i1.getType<_i224.TestEnumStringified?>()] = (data, protocol) =>
+        (data != null ? _i224.TestEnumStringified.fromJson(data) : null);
+    map[_i1.getType<_i225.Types?>()] = (data, protocol) =>
+        (data != null ? _i225.Types.fromJson(data) : null);
+    map[_i1.getType<_i226.TypesList?>()] = (data, protocol) =>
+        (data != null ? _i226.TypesList.fromJson(data) : null);
+    map[_i1.getType<_i227.TypesMap?>()] = (data, protocol) =>
+        (data != null ? _i227.TypesMap.fromJson(data) : null);
+    map[_i1.getType<_i228.TypesRecord?>()] = (data, protocol) =>
+        (data != null ? _i228.TypesRecord.fromJson(data) : null);
+    map[_i1.getType<_i229.TypesSet?>()] = (data, protocol) =>
+        (data != null ? _i229.TypesSet.fromJson(data) : null);
+    map[_i1.getType<_i230.TypesSetRequired?>()] = (data, protocol) =>
+        (data != null ? _i230.TypesSetRequired.fromJson(data) : null);
+    map[_i1.getType<_i231.UniqueData?>()] = (data, protocol) =>
+        (data != null ? _i231.UniqueData.fromJson(data) : null);
+    map[_i1.getType<_i232.UniqueDataWithNonPersist?>()] = (data, protocol) =>
+        (data != null ? _i232.UniqueDataWithNonPersist.fromJson(data) : null);
+    map[_i1.getType<_i233.UpsertTestModel?>()] = (data, protocol) =>
+        (data != null ? _i233.UpsertTestModel.fromJson(data) : null);
+    map[List<_i10.EnrollmentInt>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i10.EnrollmentInt>(e))
+        .toList();
+    map[_i1.getType<List<_i10.EnrollmentInt>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i10.EnrollmentInt>(e))
+              .toList()
+        : null);
+    map[List<_i13.PlayerUuid>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i13.PlayerUuid>(e))
+        .toList();
+    map[_i1.getType<List<_i13.PlayerUuid>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i13.PlayerUuid>(e))
+              .toList()
+        : null);
+    map[List<_i17.OrderUuid>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i17.OrderUuid>(e))
+        .toList();
+    map[_i1.getType<List<_i17.OrderUuid>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i17.OrderUuid>(e))
+              .toList()
+        : null);
+    map[List<_i15.CommentInt>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i15.CommentInt>(e))
+        .toList();
+    map[_i1.getType<List<_i15.CommentInt>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i15.CommentInt>(e))
+              .toList()
+        : null);
+    map[List<_i22.ChangedIdTypeSelf>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i22.ChangedIdTypeSelf>(e))
+        .toList();
+    map[_i1.getType<List<_i22.ChangedIdTypeSelf>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i22.ChangedIdTypeSelf>(e))
+              .toList()
+        : null);
+    map[List<_i69.EmptyModelRelationItem>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i69.EmptyModelRelationItem>(e))
+        .toList();
+    map[_i1.getType<List<_i69.EmptyModelRelationItem>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i69.EmptyModelRelationItem>(e))
+              .toList()
+        : null);
+    map[List<_i77.Employee>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i77.Employee>(e))
+        .toList();
+    map[_i1.getType<List<_i77.Employee>?>()] = (data, protocol) => (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i77.Employee>(e))
+              .toList()
+        : null);
+    map[List<String>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<String>(e)).toList();
+    map[Map<String, String>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<String>(v),
+      ),
+    );
+    map[_i1.getType<(int, String)>()] = (data, protocol) => (
+      protocol.deserialize<int>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<String>(data['p'][1]),
+    );
+    map[List<_i109.ChildEntity>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i109.ChildEntity>(e))
+        .toList();
+    map[_i1.getType<List<_i109.ChildEntity>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i109.ChildEntity>(e))
+              .toList()
+        : null);
+    map[List<_i116.PolymorphicChild>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i116.PolymorphicChild>(e))
+        .toList();
+    map[List<_i116.PolymorphicChild?>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i116.PolymorphicChild?>(e))
+        .toList();
+    map[Map<String, _i116.PolymorphicChild>] = (data, protocol) =>
+        (data as Map).map(
+          (k, v) => MapEntry(
+            protocol.deserialize<String>(k),
+            protocol.deserialize<_i116.PolymorphicChild>(v),
+          ),
+        );
+    map[Map<String, _i116.PolymorphicChild?>] = (data, protocol) =>
+        (data as Map).map(
+          (k, v) => MapEntry(
+            protocol.deserialize<String>(k),
+            protocol.deserialize<_i116.PolymorphicChild?>(v),
+          ),
+        );
+    map[List<_i4.ModulePolymorphicChild>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i4.ModulePolymorphicChild>(e))
+        .toList();
+    map[Map<String, _i4.ModulePolymorphicChild>] = (data, protocol) =>
+        (data as Map).map(
+          (k, v) => MapEntry(
+            protocol.deserialize<String>(k),
+            protocol.deserialize<_i4.ModulePolymorphicChild>(v),
+          ),
+        );
+    map[List<_i126.PersonWithLongTableName>] = (data, protocol) =>
+        (data as List)
+            .map((e) => protocol.deserialize<_i126.PersonWithLongTableName>(e))
+            .toList();
+    map[_i1.getType<List<_i126.PersonWithLongTableName>?>()] =
+        (data, protocol) => (data != null
+        ? (data as List)
+              .map(
+                (e) => protocol.deserialize<_i126.PersonWithLongTableName>(e),
+              )
+              .toList()
+        : null);
+    map[List<_i125.OrganizationWithLongTableName>] = (data, protocol) =>
+        (data as List)
+            .map(
+              (e) =>
+                  protocol.deserialize<_i125.OrganizationWithLongTableName>(e),
+            )
+            .toList();
+    map[_i1.getType<List<_i125.OrganizationWithLongTableName>?>()] =
+        (data, protocol) => (data != null
+        ? (data as List)
+              .map(
+                (e) => protocol
+                    .deserialize<_i125.OrganizationWithLongTableName>(e),
+              )
+              .toList()
+        : null);
+    map[List<_i128.LongImplicitIdField>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i128.LongImplicitIdField>(e))
+        .toList();
+    map[_i1.getType<List<_i128.LongImplicitIdField>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i128.LongImplicitIdField>(e))
+              .toList()
+        : null);
+    map[List<_i135.MultipleMaxFieldName>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i135.MultipleMaxFieldName>(e))
+        .toList();
+    map[_i1.getType<List<_i135.MultipleMaxFieldName>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i135.MultipleMaxFieldName>(e))
+              .toList()
+        : null);
+    map[List<_i131.UserNote>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i131.UserNote>(e))
+        .toList();
+    map[_i1.getType<List<_i131.UserNote>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i131.UserNote>(e))
+              .toList()
+        : null);
+    map[List<_i134.UserNoteWithALongName>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i134.UserNoteWithALongName>(e))
+        .toList();
+    map[_i1.getType<List<_i134.UserNoteWithALongName>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i134.UserNoteWithALongName>(e))
+              .toList()
+        : null);
+    map[List<_i138.Person>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i138.Person>(e))
+        .toList();
+    map[_i1.getType<List<_i138.Person>?>()] = (data, protocol) => (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i138.Person>(e))
+              .toList()
+        : null);
+    map[List<_i137.Organization>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i137.Organization>(e))
+        .toList();
+    map[_i1.getType<List<_i137.Organization>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i137.Organization>(e))
+              .toList()
+        : null);
+    map[List<_i142.Enrollment>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i142.Enrollment>(e))
+        .toList();
+    map[_i1.getType<List<_i142.Enrollment>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i142.Enrollment>(e))
+              .toList()
+        : null);
+    map[List<_i147.Player>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i147.Player>(e))
+        .toList();
+    map[_i1.getType<List<_i147.Player>?>()] = (data, protocol) => (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i147.Player>(e))
+              .toList()
+        : null);
+    map[List<_i153.Order>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i153.Order>(e))
+        .toList();
+    map[_i1.getType<List<_i153.Order>?>()] = (data, protocol) => (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i153.Order>(e))
+              .toList()
+        : null);
+    map[List<_i152.Chapter>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i152.Chapter>(e))
+        .toList();
+    map[_i1.getType<List<_i152.Chapter>?>()] = (data, protocol) => (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i152.Chapter>(e))
+              .toList()
+        : null);
+    map[List<_i149.Comment>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i149.Comment>(e))
+        .toList();
+    map[_i1.getType<List<_i149.Comment>?>()] = (data, protocol) => (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i149.Comment>(e))
+              .toList()
+        : null);
+    map[List<_i158.Blocking>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i158.Blocking>(e))
+        .toList();
+    map[_i1.getType<List<_i158.Blocking>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i158.Blocking>(e))
+              .toList()
+        : null);
+    map[List<_i160.Cat>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<_i160.Cat>(e)).toList();
+    map[_i1.getType<List<_i160.Cat>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<_i160.Cat>(e)).toList()
+        : null);
+    map[List<_i4.ModuleClass>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i4.ModuleClass>(e))
+        .toList();
+    map[Map<String, _i4.ModuleClass>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i4.ModuleClass>(v),
+      ),
+    );
+    map[_i1.getType<(_i4.ModuleClass,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (
+            protocol.deserialize<_i4.ModuleClass>(
+              ((data as Map)['p'] as List)[0],
+            ),
+          );
+    map[List<int>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int>(e)).toList();
+    map[List<int>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int>(e)).toList();
+    map[_i1.getType<List<int>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<int>(e)).toList()
+        : null);
+    map[List<int?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int?>(e)).toList();
+    map[List<int?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int?>(e)).toList();
+    map[_i1.getType<List<int?>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<int?>(e)).toList()
+        : null);
+    map[List<_i214.SimpleData>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i214.SimpleData>(e))
+        .toList();
+    map[List<_i214.SimpleData>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i214.SimpleData>(e))
+        .toList();
+    map[_i1.getType<List<_i214.SimpleData>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i214.SimpleData>(e))
+              .toList()
+        : null);
+    map[List<_i214.SimpleData?>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i214.SimpleData?>(e))
+        .toList();
+    map[List<_i214.SimpleData?>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i214.SimpleData?>(e))
+        .toList();
+    map[_i1.getType<List<_i214.SimpleData?>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i214.SimpleData?>(e))
+              .toList()
+        : null);
+    map[List<DateTime>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<DateTime>(e)).toList();
+    map[List<DateTime>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<DateTime>(e)).toList();
+    map[_i1.getType<List<DateTime>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<DateTime>(e)).toList()
+        : null);
+    map[List<DateTime?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<DateTime?>(e)).toList();
+    map[List<DateTime?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<DateTime?>(e)).toList();
+    map[_i1.getType<List<DateTime?>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<DateTime?>(e)).toList()
+        : null);
+    map[List<_i236.ByteData>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i236.ByteData>(e))
+        .toList();
+    map[List<_i236.ByteData>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i236.ByteData>(e))
+        .toList();
+    map[_i1.getType<List<_i236.ByteData>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i236.ByteData>(e))
+              .toList()
+        : null);
+    map[List<_i236.ByteData?>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i236.ByteData?>(e))
+        .toList();
+    map[List<_i236.ByteData?>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i236.ByteData?>(e))
+        .toList();
+    map[_i1.getType<List<_i236.ByteData?>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i236.ByteData?>(e))
+              .toList()
+        : null);
+    map[List<Duration>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<Duration>(e)).toList();
+    map[List<Duration>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<Duration>(e)).toList();
+    map[_i1.getType<List<Duration>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<Duration>(e)).toList()
+        : null);
+    map[List<Duration?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<Duration?>(e)).toList();
+    map[List<Duration?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<Duration?>(e)).toList();
+    map[_i1.getType<List<Duration?>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<Duration?>(e)).toList()
+        : null);
+    map[List<_i1.UuidValue>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i1.UuidValue>(e))
+        .toList();
+    map[List<_i1.UuidValue>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i1.UuidValue>(e))
+        .toList();
+    map[_i1.getType<List<_i1.UuidValue>?>()] = (data, protocol) => (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i1.UuidValue>(e))
+              .toList()
+        : null);
+    map[List<_i1.UuidValue?>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i1.UuidValue?>(e))
+        .toList();
+    map[List<_i1.UuidValue?>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i1.UuidValue?>(e))
+        .toList();
+    map[_i1.getType<List<_i1.UuidValue?>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i1.UuidValue?>(e))
+              .toList()
+        : null);
+    map[Map<String, int>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<int>(v),
+      ),
+    );
+    map[Map<String, int>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<int>(v),
+      ),
+    );
+    map[_i1.getType<Map<String, int>?>()] = (data, protocol) => (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<int>(v),
+            ),
+          )
+        : null);
+    map[Map<String, int?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<int?>(v),
+      ),
+    );
+    map[Map<String, int?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<int?>(v),
+      ),
+    );
+    map[_i1.getType<Map<String, int?>?>()] = (data, protocol) => (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<int?>(v),
+            ),
+          )
+        : null);
+    map[_i6.CustomClassWithoutProtocolSerialization] = (data, protocol) =>
+        _i6.CustomClassWithoutProtocolSerialization.fromJson(data);
+    map[_i6.CustomClassWithProtocolSerialization] = (data, protocol) =>
+        _i6.CustomClassWithProtocolSerialization.fromJson(data);
+    map[_i6.CustomClassWithProtocolSerializationMethod] = (data, protocol) =>
+        _i6.CustomClassWithProtocolSerializationMethod.fromJson(data);
+    map[dynamic] = (data, protocol) =>
+        protocol.deserializeDynamicFieldValue(data);
+    map[List<dynamic>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<dynamic>(e)).toList();
+    map[dynamic] = (data, protocol) =>
+        protocol.deserializeDynamicFieldValue(data);
+    map[Map<String, dynamic>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<dynamic>(v),
+      ),
+    );
+    map[dynamic] = (data, protocol) =>
+        protocol.deserializeDynamicFieldValue(data);
+    map[Set<dynamic>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<dynamic>(e)).toSet();
+    map[dynamic] = (data, protocol) =>
+        protocol.deserializeDynamicFieldValue(data);
+    map[Map<dynamic, dynamic>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<dynamic>(e['k']),
+          protocol.deserialize<dynamic>(e['v']),
+        ),
+      ),
+    );
+    map[dynamic] = (data, protocol) =>
+        protocol.deserializeDynamicFieldValue(data);
+    map[dynamic] = (data, protocol) =>
+        protocol.deserializeDynamicFieldValue(data);
+    map[List<_i220.TestEnum>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i220.TestEnum>(e))
+        .toList();
+    map[List<_i220.TestEnum?>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i220.TestEnum?>(e))
+        .toList();
+    map[List<List<_i220.TestEnum>>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<List<_i220.TestEnum>>(e))
+        .toList();
+    map[List<_i220.TestEnum>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i220.TestEnum>(e))
+        .toList();
+    map[List<_i222.TestEnumEnhanced>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i222.TestEnumEnhanced>(e))
+        .toList();
+    map[List<_i223.TestEnumEnhancedByName>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i223.TestEnumEnhancedByName>(e))
+        .toList();
+    map[List<String>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<String>(e)).toList();
+    map[_i1.getType<List<String>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<String>(e)).toList()
+        : null);
+    map[Map<String, _i214.SimpleData>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i214.SimpleData>(v),
+      ),
+    );
+    map[Map<String, DateTime>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<DateTime>(v),
+      ),
+    );
+    map[Map<String, _i236.ByteData>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i236.ByteData>(v),
+      ),
+    );
+    map[Map<String, Duration>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<Duration>(v),
+      ),
+    );
+    map[Map<String, _i1.UuidValue>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i1.UuidValue>(v),
+      ),
+    );
+    map[Map<String, _i214.SimpleData?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i214.SimpleData?>(v),
+      ),
+    );
+    map[Map<String, String?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<String?>(v),
+      ),
+    );
+    map[Map<String, DateTime?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<DateTime?>(v),
+      ),
+    );
+    map[Map<String, _i236.ByteData?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i236.ByteData?>(v),
+      ),
+    );
+    map[Map<String, Duration?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<Duration?>(v),
+      ),
+    );
+    map[Map<String, _i1.UuidValue?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i1.UuidValue?>(v),
+      ),
+    );
+    map[Map<int, int>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<int>(e['k']),
+          protocol.deserialize<int>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<_i6.CustomClassWithoutProtocolSerialization?>()] =
+        (data, protocol) => (data != null
+        ? _i6.CustomClassWithoutProtocolSerialization.fromJson(data)
+        : null);
+    map[_i1.getType<_i6.CustomClassWithProtocolSerialization?>()] =
+        (data, protocol) => (data != null
+        ? _i6.CustomClassWithProtocolSerialization.fromJson(data)
+        : null);
+    map[_i1.getType<_i6.CustomClassWithProtocolSerializationMethod?>()] =
+        (data, protocol) => (data != null
+        ? _i6.CustomClassWithProtocolSerializationMethod.fromJson(data)
+        : null);
+    map[List<List<_i214.SimpleData>>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<List<_i214.SimpleData>>(e))
+        .toList();
+    map[List<_i214.SimpleData>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i214.SimpleData>(e))
+        .toList();
+    map[_i1.getType<List<List<_i214.SimpleData>>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<List<_i214.SimpleData>>(e))
+              .toList()
+        : null);
+    map[List<_i214.SimpleData>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i214.SimpleData>(e))
+        .toList();
+    map[Map<String, List<List<Map<int, _i214.SimpleData>>?>>] =
+        (data, protocol) => (data as Map).map(
+          (k, v) => MapEntry(
+            protocol.deserialize<String>(k),
+            protocol.deserialize<List<List<Map<int, _i214.SimpleData>>?>>(v),
+          ),
+        );
+    map[List<List<Map<int, _i214.SimpleData>>?>] = (data, protocol) =>
+        (data as List)
+            .map(
+              (e) => protocol.deserialize<List<Map<int, _i214.SimpleData>>?>(e),
+            )
+            .toList();
+    map[List<Map<int, _i214.SimpleData>>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<Map<int, _i214.SimpleData>>(e))
+        .toList();
+    map[Map<int, _i214.SimpleData>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<int>(e['k']),
+          protocol.deserialize<_i214.SimpleData>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<List<Map<int, _i214.SimpleData>>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<Map<int, _i214.SimpleData>>(e))
+              .toList()
+        : null);
+    map[Map<int, _i214.SimpleData>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<int>(e['k']),
+          protocol.deserialize<_i214.SimpleData>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<Map<String, List<List<Map<int, _i214.SimpleData>>?>>?>()] =
+        (data, protocol) => (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<List<List<Map<int, _i214.SimpleData>>?>>(v),
+            ),
+          )
+        : null);
+    map[List<List<Map<int, _i214.SimpleData>>?>] = (data, protocol) =>
+        (data as List)
+            .map(
+              (e) => protocol.deserialize<List<Map<int, _i214.SimpleData>>?>(e),
+            )
+            .toList();
+    map[List<Map<int, _i214.SimpleData>>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<Map<int, _i214.SimpleData>>(e))
+        .toList();
+    map[Map<int, _i214.SimpleData>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<int>(e['k']),
+          protocol.deserialize<_i214.SimpleData>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<List<Map<int, _i214.SimpleData>>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<Map<int, _i214.SimpleData>>(e))
+              .toList()
+        : null);
+    map[Map<int, _i214.SimpleData>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<int>(e['k']),
+          protocol.deserialize<_i214.SimpleData>(e['v']),
+        ),
+      ),
+    );
+    map[Map<String, Map<int, _i214.SimpleData>>] = (data, protocol) =>
+        (data as Map).map(
+          (k, v) => MapEntry(
+            protocol.deserialize<String>(k),
+            protocol.deserialize<Map<int, _i214.SimpleData>>(v),
+          ),
+        );
+    map[Map<int, _i214.SimpleData>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<int>(e['k']),
+          protocol.deserialize<_i214.SimpleData>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<Map<String, Map<int, _i214.SimpleData>>?>()] =
+        (data, protocol) => (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<Map<int, _i214.SimpleData>>(v),
+            ),
+          )
+        : null);
+    map[Map<int, _i214.SimpleData>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<int>(e['k']),
+          protocol.deserialize<_i214.SimpleData>(e['v']),
+        ),
+      ),
+    );
+    map[List<_i122.SealedParent>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i122.SealedParent>(e))
+        .toList();
+    map[List<_i104.SealedAppException>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i104.SealedAppException>(e))
+        .toList();
+    map[_i1.getType<(bool,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<bool>(((data as Map)['p'] as List)[0]),);
+    map[List<_i201.Article>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i201.Article>(e))
+        .toList();
+    map[List<_i207.ServerOnlyClass>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i207.ServerOnlyClass>(e))
+        .toList();
+    map[_i1.getType<List<_i207.ServerOnlyClass>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i207.ServerOnlyClass>(e))
+              .toList()
+        : null);
+    map[Map<String, _i207.ServerOnlyClass>] = (data, protocol) =>
+        (data as Map).map(
+          (k, v) => MapEntry(
+            protocol.deserialize<String>(k),
+            protocol.deserialize<_i207.ServerOnlyClass>(v),
+          ),
+        );
+    map[_i1.getType<Map<String, _i207.ServerOnlyClass>?>()] =
+        (data, protocol) => (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<_i207.ServerOnlyClass>(v),
+            ),
+          )
+        : null);
+    map[List<_i6.SharedModel>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i6.SharedModel>(e))
+        .toList();
+    map[List<_i6.SharedModel?>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i6.SharedModel?>(e))
+        .toList();
+    map[List<_i6.SharedModel>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i6.SharedModel>(e))
+        .toList();
+    map[_i1.getType<List<_i6.SharedModel>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i6.SharedModel>(e))
+              .toList()
+        : null);
+    map[Map<String, _i6.SharedModel>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i6.SharedModel>(v),
+      ),
+    );
+    map[Map<String, _i6.SharedModel>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i6.SharedModel>(v),
+      ),
+    );
+    map[_i1.getType<Map<String, _i6.SharedModel>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<_i6.SharedModel>(v),
+            ),
+          )
+        : null);
+    map[Map<String, _i6.SharedSubclass>] = (data, protocol) =>
+        (data as Map).map(
+          (k, v) => MapEntry(
+            protocol.deserialize<String>(k),
+            protocol.deserialize<_i6.SharedSubclass>(v),
+          ),
+        );
+    map[Set<_i6.SharedModel>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i6.SharedModel>(e))
+        .toSet();
+    map[Set<_i6.SharedModel>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i6.SharedModel>(e))
+        .toSet();
+    map[_i1.getType<Set<_i6.SharedModel>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i6.SharedModel>(e))
+              .toSet()
+        : null);
+    map[List<_i224.TestEnumStringified>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i224.TestEnumStringified>(e))
+        .toList();
+    map[_i1.getType<List<_i224.TestEnumStringified>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i224.TestEnumStringified>(e))
+              .toList()
+        : null);
+    map[_i1.getType<(_i224.TestEnumStringified,)?>()] = (data, protocol) =>
+        (data == null)
+        ? null
+        : (
+            protocol.deserialize<_i224.TestEnumStringified>(
+              ((data as Map)['p'] as List)[0],
+            ),
+          );
+    map[List<(_i224.TestEnumStringified,)>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<(_i224.TestEnumStringified,)>(e))
+        .toList();
+    map[_i1.getType<(_i224.TestEnumStringified,)>()] = (data, protocol) => (
+      protocol.deserialize<_i224.TestEnumStringified>(
+        ((data as Map)['p'] as List)[0],
+      ),
+    );
+    map[_i1.getType<List<(_i224.TestEnumStringified,)>?>()] =
+        (data, protocol) => (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<(_i224.TestEnumStringified,)>(e))
+              .toList()
+        : null);
+    map[_i1.getType<(_i224.TestEnumStringified,)>()] = (data, protocol) => (
+      protocol.deserialize<_i224.TestEnumStringified>(
+        ((data as Map)['p'] as List)[0],
+      ),
+    );
+    map[_i1.getType<(_i165.Nullability,)?>()] = (data, protocol) =>
+        (data == null)
+        ? null
+        : (
+            protocol.deserialize<_i165.Nullability>(
+              ((data as Map)['p'] as List)[0],
+            ),
+          );
+    map[_i1.getType<({_i224.TestEnumStringified value})?>()] =
+        (data, protocol) => (data == null)
+        ? null
+        : (
+            value: protocol.deserialize<_i224.TestEnumStringified>(
+              ((data as Map)['n'] as Map)['value'],
+            ),
+          );
+    map[List<({_i224.TestEnumStringified value})>] = (data, protocol) =>
+        (data as List)
+            .map(
+              (e) =>
+                  protocol.deserialize<({_i224.TestEnumStringified value})>(e),
+            )
+            .toList();
+    map[_i1
+        .getType<({_i224.TestEnumStringified value})>()] = (data, protocol) => (
+      value: protocol.deserialize<_i224.TestEnumStringified>(
+        ((data as Map)['n'] as Map)['value'],
+      ),
+    );
+    map[_i1.getType<List<({_i224.TestEnumStringified value})>?>()] =
+        (data, protocol) => (data != null
+        ? (data as List)
+              .map(
+                (e) => protocol
+                    .deserialize<({_i224.TestEnumStringified value})>(e),
+              )
+              .toList()
+        : null);
+    map[_i1
+        .getType<({_i224.TestEnumStringified value})>()] = (data, protocol) => (
+      value: protocol.deserialize<_i224.TestEnumStringified>(
+        ((data as Map)['n'] as Map)['value'],
+      ),
+    );
+    map[_i1.getType<({_i4.ModuleClass value})?>()] = (data, protocol) =>
+        (data == null)
+        ? null
+        : (
+            value: protocol.deserialize<_i4.ModuleClass>(
+              ((data as Map)['n'] as Map)['value'],
+            ),
+          );
+    map[_i1.getType<({_i165.Nullability value})?>()] = (data, protocol) =>
+        (data == null)
+        ? null
+        : (
+            value: protocol.deserialize<_i165.Nullability>(
+              ((data as Map)['n'] as Map)['value'],
+            ),
+          );
+    map[Map<int, int>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<int>(e['k']),
+          protocol.deserialize<int>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<Map<int, int>?>()] = (data, protocol) => (data != null
+        ? Map.fromEntries(
+            (data as List).map(
+              (e) => MapEntry(
+                protocol.deserialize<int>(e['k']),
+                protocol.deserialize<int>(e['v']),
+              ),
+            ),
+          )
+        : null);
+    map[Set<int>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int>(e)).toSet();
+    map[_i1.getType<Set<int>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<int>(e)).toSet()
+        : null);
+    map[_i1.getType<(String, {Uri? optionalUri})?>()] = (data, protocol) =>
+        (data == null)
+        ? null
+        : (
+            protocol.deserialize<String>(((data as Map)['p'] as List)[0]),
+            optionalUri: ((data)['n'] as Map)['optionalUri'] == null
+                ? null
+                : protocol.deserialize<Uri>(data['n']['optionalUri']),
+          );
+    map[List<bool>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<bool>(e)).toList();
+    map[_i1.getType<List<bool>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<bool>(e)).toList()
+        : null);
+    map[List<double>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<double>(e)).toList();
+    map[_i1.getType<List<double>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<double>(e)).toList()
+        : null);
+    map[List<Uri>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<Uri>(e)).toList();
+    map[_i1.getType<List<Uri>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<Uri>(e)).toList()
+        : null);
+    map[List<BigInt>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<BigInt>(e)).toList();
+    map[_i1.getType<List<BigInt>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<BigInt>(e)).toList()
+        : null);
+    map[List<_i220.TestEnum>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i220.TestEnum>(e))
+        .toList();
+    map[_i1.getType<List<_i220.TestEnum>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i220.TestEnum>(e))
+              .toList()
+        : null);
+    map[List<_i225.Types>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i225.Types>(e))
+        .toList();
+    map[_i1.getType<List<_i225.Types>?>()] = (data, protocol) => (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i225.Types>(e))
+              .toList()
+        : null);
+    map[List<Map<String, _i225.Types>>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<Map<String, _i225.Types>>(e))
+        .toList();
+    map[Map<String, _i225.Types>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i225.Types>(v),
+      ),
+    );
+    map[_i1.getType<List<Map<String, _i225.Types>>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<Map<String, _i225.Types>>(e))
+              .toList()
+        : null);
+    map[Map<String, _i225.Types>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i225.Types>(v),
+      ),
+    );
+    map[List<List<_i225.Types>>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<List<_i225.Types>>(e))
+        .toList();
+    map[List<_i225.Types>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i225.Types>(e))
+        .toList();
+    map[_i1.getType<List<List<_i225.Types>>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<List<_i225.Types>>(e))
+              .toList()
+        : null);
+    map[List<_i225.Types>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i225.Types>(e))
+        .toList();
+    map[List<(int,)>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<(int,)>(e)).toList();
+    map[_i1.getType<(int,)>()] = (data, protocol) =>
+        (protocol.deserialize<int>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<List<(int,)>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<(int,)>(e)).toList()
+        : null);
+    map[_i1.getType<(int,)>()] = (data, protocol) =>
+        (protocol.deserialize<int>(((data as Map)['p'] as List)[0]),);
+    map[List<(int,)?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<(int,)?>(e)).toList();
+    map[_i1.getType<(int,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<int>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<List<(int,)?>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<(int,)?>(e)).toList()
+        : null);
+    map[_i1.getType<(int,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<int>(((data as Map)['p'] as List)[0]),);
+    map[List<(_i220.TestEnum,)>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<(_i220.TestEnum,)>(e))
+        .toList();
+    map[_i1.getType<(_i220.TestEnum,)>()] = (data, protocol) => (
+      protocol.deserialize<_i220.TestEnum>(((data as Map)['p'] as List)[0]),
+    );
+    map[_i1.getType<List<(_i220.TestEnum,)>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<(_i220.TestEnum,)>(e))
+              .toList()
+        : null);
+    map[_i1.getType<(_i220.TestEnum,)>()] = (data, protocol) => (
+      protocol.deserialize<_i220.TestEnum>(((data as Map)['p'] as List)[0]),
+    );
+    map[Map<int, String>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<int>(e['k']),
+          protocol.deserialize<String>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<Map<int, String>?>()] = (data, protocol) => (data != null
+        ? Map.fromEntries(
+            (data as List).map(
+              (e) => MapEntry(
+                protocol.deserialize<int>(e['k']),
+                protocol.deserialize<String>(e['v']),
+              ),
+            ),
+          )
+        : null);
+    map[Map<bool, String>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<bool>(e['k']),
+          protocol.deserialize<String>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<Map<bool, String>?>()] = (data, protocol) => (data != null
+        ? Map.fromEntries(
+            (data as List).map(
+              (e) => MapEntry(
+                protocol.deserialize<bool>(e['k']),
+                protocol.deserialize<String>(e['v']),
+              ),
+            ),
+          )
+        : null);
+    map[Map<double, String>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<double>(e['k']),
+          protocol.deserialize<String>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<Map<double, String>?>()] = (data, protocol) => (data != null
+        ? Map.fromEntries(
+            (data as List).map(
+              (e) => MapEntry(
+                protocol.deserialize<double>(e['k']),
+                protocol.deserialize<String>(e['v']),
+              ),
+            ),
+          )
+        : null);
+    map[Map<DateTime, String>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<DateTime>(e['k']),
+          protocol.deserialize<String>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<Map<DateTime, String>?>()] = (data, protocol) =>
+        (data != null
+        ? Map.fromEntries(
+            (data as List).map(
+              (e) => MapEntry(
+                protocol.deserialize<DateTime>(e['k']),
+                protocol.deserialize<String>(e['v']),
+              ),
+            ),
+          )
+        : null);
+    map[Map<String, String>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<String>(v),
+      ),
+    );
+    map[_i1.getType<Map<String, String>?>()] = (data, protocol) => (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<String>(v),
+            ),
+          )
+        : null);
+    map[Map<_i236.ByteData, String>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<_i236.ByteData>(e['k']),
+          protocol.deserialize<String>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<Map<_i236.ByteData, String>?>()] = (data, protocol) =>
+        (data != null
+        ? Map.fromEntries(
+            (data as List).map(
+              (e) => MapEntry(
+                protocol.deserialize<_i236.ByteData>(e['k']),
+                protocol.deserialize<String>(e['v']),
+              ),
+            ),
+          )
+        : null);
+    map[Map<Duration, String>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<Duration>(e['k']),
+          protocol.deserialize<String>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<Map<Duration, String>?>()] = (data, protocol) =>
+        (data != null
+        ? Map.fromEntries(
+            (data as List).map(
+              (e) => MapEntry(
+                protocol.deserialize<Duration>(e['k']),
+                protocol.deserialize<String>(e['v']),
+              ),
+            ),
+          )
+        : null);
+    map[Map<_i1.UuidValue, String>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<_i1.UuidValue>(e['k']),
+          protocol.deserialize<String>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<Map<_i1.UuidValue, String>?>()] = (data, protocol) =>
+        (data != null
+        ? Map.fromEntries(
+            (data as List).map(
+              (e) => MapEntry(
+                protocol.deserialize<_i1.UuidValue>(e['k']),
+                protocol.deserialize<String>(e['v']),
+              ),
+            ),
+          )
+        : null);
+    map[Map<Uri, String>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<Uri>(e['k']),
+          protocol.deserialize<String>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<Map<Uri, String>?>()] = (data, protocol) => (data != null
+        ? Map.fromEntries(
+            (data as List).map(
+              (e) => MapEntry(
+                protocol.deserialize<Uri>(e['k']),
+                protocol.deserialize<String>(e['v']),
+              ),
+            ),
+          )
+        : null);
+    map[Map<BigInt, String>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<BigInt>(e['k']),
+          protocol.deserialize<String>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<Map<BigInt, String>?>()] = (data, protocol) => (data != null
+        ? Map.fromEntries(
+            (data as List).map(
+              (e) => MapEntry(
+                protocol.deserialize<BigInt>(e['k']),
+                protocol.deserialize<String>(e['v']),
+              ),
+            ),
+          )
+        : null);
+    map[Map<_i220.TestEnum, String>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<_i220.TestEnum>(e['k']),
+          protocol.deserialize<String>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<Map<_i220.TestEnum, String>?>()] = (data, protocol) =>
+        (data != null
+        ? Map.fromEntries(
+            (data as List).map(
+              (e) => MapEntry(
+                protocol.deserialize<_i220.TestEnum>(e['k']),
+                protocol.deserialize<String>(e['v']),
+              ),
+            ),
+          )
+        : null);
+    map[Map<_i224.TestEnumStringified, String>] = (data, protocol) =>
+        Map.fromEntries(
+          (data as List).map(
+            (e) => MapEntry(
+              protocol.deserialize<_i224.TestEnumStringified>(e['k']),
+              protocol.deserialize<String>(e['v']),
+            ),
+          ),
+        );
+    map[_i1.getType<Map<_i224.TestEnumStringified, String>?>()] =
+        (data, protocol) => (data != null
+        ? Map.fromEntries(
+            (data as List).map(
+              (e) => MapEntry(
+                protocol.deserialize<_i224.TestEnumStringified>(e['k']),
+                protocol.deserialize<String>(e['v']),
+              ),
+            ),
+          )
+        : null);
+    map[Map<_i225.Types, String>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<_i225.Types>(e['k']),
+          protocol.deserialize<String>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<Map<_i225.Types, String>?>()] = (data, protocol) =>
+        (data != null
+        ? Map.fromEntries(
+            (data as List).map(
+              (e) => MapEntry(
+                protocol.deserialize<_i225.Types>(e['k']),
+                protocol.deserialize<String>(e['v']),
+              ),
+            ),
+          )
+        : null);
+    map[Map<Map<_i225.Types, String>, String>] = (data, protocol) =>
+        Map.fromEntries(
+          (data as List).map(
+            (e) => MapEntry(
+              protocol.deserialize<Map<_i225.Types, String>>(e['k']),
+              protocol.deserialize<String>(e['v']),
+            ),
+          ),
+        );
+    map[Map<_i225.Types, String>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<_i225.Types>(e['k']),
+          protocol.deserialize<String>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<Map<Map<_i225.Types, String>, String>?>()] =
+        (data, protocol) => (data != null
+        ? Map.fromEntries(
+            (data as List).map(
+              (e) => MapEntry(
+                protocol.deserialize<Map<_i225.Types, String>>(e['k']),
+                protocol.deserialize<String>(e['v']),
+              ),
+            ),
+          )
+        : null);
+    map[Map<_i225.Types, String>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<_i225.Types>(e['k']),
+          protocol.deserialize<String>(e['v']),
+        ),
+      ),
+    );
+    map[Map<List<_i225.Types>, String>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<List<_i225.Types>>(e['k']),
+          protocol.deserialize<String>(e['v']),
+        ),
+      ),
+    );
+    map[List<_i225.Types>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i225.Types>(e))
+        .toList();
+    map[_i1.getType<Map<List<_i225.Types>, String>?>()] = (data, protocol) =>
+        (data != null
+        ? Map.fromEntries(
+            (data as List).map(
+              (e) => MapEntry(
+                protocol.deserialize<List<_i225.Types>>(e['k']),
+                protocol.deserialize<String>(e['v']),
+              ),
+            ),
+          )
+        : null);
+    map[List<_i225.Types>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i225.Types>(e))
+        .toList();
+    map[Map<(String,), String>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<(String,)>(e['k']),
+          protocol.deserialize<String>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<(String,)>()] = (data, protocol) =>
+        (protocol.deserialize<String>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<Map<(String,), String>?>()] = (data, protocol) =>
+        (data != null
+        ? Map.fromEntries(
+            (data as List).map(
+              (e) => MapEntry(
+                protocol.deserialize<(String,)>(e['k']),
+                protocol.deserialize<String>(e['v']),
+              ),
+            ),
+          )
+        : null);
+    map[_i1.getType<(String,)>()] = (data, protocol) =>
+        (protocol.deserialize<String>(((data as Map)['p'] as List)[0]),);
+    map[Map<String, bool>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<bool>(v),
+      ),
+    );
+    map[_i1.getType<Map<String, bool>?>()] = (data, protocol) => (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<bool>(v),
+            ),
+          )
+        : null);
+    map[Map<String, double>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<double>(v),
+      ),
+    );
+    map[_i1.getType<Map<String, double>?>()] = (data, protocol) => (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<double>(v),
+            ),
+          )
+        : null);
+    map[Map<String, DateTime>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<DateTime>(v),
+      ),
+    );
+    map[_i1.getType<Map<String, DateTime>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<DateTime>(v),
+            ),
+          )
+        : null);
+    map[Map<String, _i236.ByteData>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i236.ByteData>(v),
+      ),
+    );
+    map[_i1.getType<Map<String, _i236.ByteData>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<_i236.ByteData>(v),
+            ),
+          )
+        : null);
+    map[Map<String, Duration>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<Duration>(v),
+      ),
+    );
+    map[_i1.getType<Map<String, Duration>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<Duration>(v),
+            ),
+          )
+        : null);
+    map[Map<String, _i1.UuidValue>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i1.UuidValue>(v),
+      ),
+    );
+    map[_i1.getType<Map<String, _i1.UuidValue>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<_i1.UuidValue>(v),
+            ),
+          )
+        : null);
+    map[Map<String, Uri>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<Uri>(v),
+      ),
+    );
+    map[_i1.getType<Map<String, Uri>?>()] = (data, protocol) => (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<Uri>(v),
+            ),
+          )
+        : null);
+    map[Map<String, BigInt>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<BigInt>(v),
+      ),
+    );
+    map[_i1.getType<Map<String, BigInt>?>()] = (data, protocol) => (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<BigInt>(v),
+            ),
+          )
+        : null);
+    map[Map<String, _i220.TestEnum>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i220.TestEnum>(v),
+      ),
+    );
+    map[_i1.getType<Map<String, _i220.TestEnum>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<_i220.TestEnum>(v),
+            ),
+          )
+        : null);
+    map[Map<String, _i224.TestEnumStringified>] = (data, protocol) =>
+        (data as Map).map(
+          (k, v) => MapEntry(
+            protocol.deserialize<String>(k),
+            protocol.deserialize<_i224.TestEnumStringified>(v),
+          ),
+        );
+    map[_i1.getType<Map<String, _i224.TestEnumStringified>?>()] =
+        (data, protocol) => (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<_i224.TestEnumStringified>(v),
+            ),
+          )
+        : null);
+    map[Map<String, _i225.Types>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i225.Types>(v),
+      ),
+    );
+    map[_i1.getType<Map<String, _i225.Types>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<_i225.Types>(v),
+            ),
+          )
+        : null);
+    map[Map<String, Map<String, _i225.Types>>] = (data, protocol) =>
+        (data as Map).map(
+          (k, v) => MapEntry(
+            protocol.deserialize<String>(k),
+            protocol.deserialize<Map<String, _i225.Types>>(v),
+          ),
+        );
+    map[Map<String, _i225.Types>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i225.Types>(v),
+      ),
+    );
+    map[_i1.getType<Map<String, Map<String, _i225.Types>>?>()] =
+        (data, protocol) => (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<Map<String, _i225.Types>>(v),
+            ),
+          )
+        : null);
+    map[Map<String, _i225.Types>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i225.Types>(v),
+      ),
+    );
+    map[Map<String, List<_i225.Types>>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<List<_i225.Types>>(v),
+      ),
+    );
+    map[List<_i225.Types>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i225.Types>(e))
+        .toList();
+    map[_i1.getType<Map<String, List<_i225.Types>>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<List<_i225.Types>>(v),
+            ),
+          )
+        : null);
+    map[List<_i225.Types>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i225.Types>(e))
+        .toList();
+    map[Map<String, (String,)>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<(String,)>(v),
+      ),
+    );
+    map[_i1.getType<(String,)>()] = (data, protocol) =>
+        (protocol.deserialize<String>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<Map<String, (String,)>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<(String,)>(v),
+            ),
+          )
+        : null);
+    map[_i1.getType<(String,)>()] = (data, protocol) =>
+        (protocol.deserialize<String>(((data as Map)['p'] as List)[0]),);
+    map[Map<String, (String,)?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<(String,)?>(v),
+      ),
+    );
+    map[_i1.getType<(String,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<String>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<Map<String, (String,)?>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<(String,)?>(v),
+            ),
+          )
+        : null);
+    map[_i1.getType<(String,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<String>(((data as Map)['p'] as List)[0]),);
+    map[Map<(String,)?, String>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<(String,)?>(e['k']),
+          protocol.deserialize<String>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<(String,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<String>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<Map<(String,)?, String>?>()] = (data, protocol) =>
+        (data != null
+        ? Map.fromEntries(
+            (data as List).map(
+              (e) => MapEntry(
+                protocol.deserialize<(String,)?>(e['k']),
+                protocol.deserialize<String>(e['v']),
+              ),
+            ),
+          )
+        : null);
+    map[_i1.getType<(String,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<String>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(int,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<int>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(double,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<double>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(DateTime,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<DateTime>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(String,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<String>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(_i236.ByteData,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (
+            protocol.deserialize<_i236.ByteData>(
+              ((data as Map)['p'] as List)[0],
+            ),
+          );
+    map[_i1.getType<(Duration,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<Duration>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(_i1.UuidValue,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (
+            protocol.deserialize<_i1.UuidValue>(
+              ((data as Map)['p'] as List)[0],
+            ),
+          );
+    map[_i1.getType<(Uri,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<Uri>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(BigInt,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<BigInt>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(_i220.TestEnum,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (
+            protocol.deserialize<_i220.TestEnum>(
+              ((data as Map)['p'] as List)[0],
+            ),
+          );
+    map[_i1.getType<(List<int>,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<List<int>>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(Map<int, int>,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (
+            protocol.deserialize<Map<int, int>>(
+              ((data as Map)['p'] as List)[0],
+            ),
+          );
+    map[_i1.getType<(Set<int>,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<Set<int>>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(_i214.SimpleData,)?>()] = (data, protocol) =>
+        (data == null)
+        ? null
+        : (
+            protocol.deserialize<_i214.SimpleData>(
+              ((data as Map)['p'] as List)[0],
+            ),
+          );
+    map[_i1.getType<({_i214.SimpleData namedModel})?>()] = (data, protocol) =>
+        (data == null)
+        ? null
+        : (
+            namedModel: protocol.deserialize<_i214.SimpleData>(
+              ((data as Map)['n'] as Map)['namedModel'],
+            ),
+          );
+    map[_i1.getType<(_i214.SimpleData, {_i214.SimpleData namedModel})?>()] =
+        (data, protocol) => (data == null)
+        ? null
+        : (
+            protocol.deserialize<_i214.SimpleData>(
+              ((data as Map)['p'] as List)[0],
+            ),
+            namedModel: protocol.deserialize<_i214.SimpleData>(
+              data['n']['namedModel'],
+            ),
+          );
+    map[_i1.getType<((int, String), {(int, String) namedNestedRecord})?>()] =
+        (data, protocol) => (data == null)
+        ? null
+        : (
+            protocol.deserialize<(int, String)>(
+              ((data as Map)['p'] as List)[0],
+            ),
+            namedNestedRecord: protocol.deserialize<(int, String)>(
+              data['n']['namedNestedRecord'],
+            ),
+          );
+    map[_i1
+        .getType<
+          (
+            (List<(_i214.SimpleData,)>,), {
+            (_i214.SimpleData, Map<String, _i214.SimpleData>) namedNestedRecord,
+          })?
+        >()] = (data, protocol) => (data == null)
+        ? null
+        : (
+            protocol.deserialize<(List<(_i214.SimpleData,)>,)>(
+              ((data as Map)['p'] as List)[0],
+            ),
+            namedNestedRecord: protocol
+                .deserialize<(_i214.SimpleData, Map<String, _i214.SimpleData>)>(
+                  data['n']['namedNestedRecord'],
+                ),
+          );
+    map[Set<bool>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<bool>(e)).toSet();
+    map[_i1.getType<Set<bool>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<bool>(e)).toSet()
+        : null);
+    map[Set<double>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<double>(e)).toSet();
+    map[_i1.getType<Set<double>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<double>(e)).toSet()
+        : null);
+    map[Set<DateTime>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<DateTime>(e)).toSet();
+    map[_i1.getType<Set<DateTime>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<DateTime>(e)).toSet()
+        : null);
+    map[Set<String>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<String>(e)).toSet();
+    map[_i1.getType<Set<String>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<String>(e)).toSet()
+        : null);
+    map[Set<_i236.ByteData>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i236.ByteData>(e))
+        .toSet();
+    map[_i1.getType<Set<_i236.ByteData>?>()] = (data, protocol) => (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i236.ByteData>(e))
+              .toSet()
+        : null);
+    map[Set<Duration>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<Duration>(e)).toSet();
+    map[_i1.getType<Set<Duration>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<Duration>(e)).toSet()
+        : null);
+    map[Set<_i1.UuidValue>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i1.UuidValue>(e))
+        .toSet();
+    map[_i1.getType<Set<_i1.UuidValue>?>()] = (data, protocol) => (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i1.UuidValue>(e))
+              .toSet()
+        : null);
+    map[Set<BigInt>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<BigInt>(e)).toSet();
+    map[_i1.getType<Set<BigInt>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<BigInt>(e)).toSet()
+        : null);
+    map[Set<_i220.TestEnum>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i220.TestEnum>(e))
+        .toSet();
+    map[_i1.getType<Set<_i220.TestEnum>?>()] = (data, protocol) => (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i220.TestEnum>(e))
+              .toSet()
+        : null);
+    map[Set<_i224.TestEnumStringified>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i224.TestEnumStringified>(e))
+        .toSet();
+    map[_i1.getType<Set<_i224.TestEnumStringified>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i224.TestEnumStringified>(e))
+              .toSet()
+        : null);
+    map[Set<_i225.Types>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<_i225.Types>(e)).toSet();
+    map[_i1.getType<Set<_i225.Types>?>()] = (data, protocol) => (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i225.Types>(e))
+              .toSet()
+        : null);
+    map[Set<Map<String, _i225.Types>>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<Map<String, _i225.Types>>(e))
+        .toSet();
+    map[Map<String, _i225.Types>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i225.Types>(v),
+      ),
+    );
+    map[_i1.getType<Set<Map<String, _i225.Types>>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<Map<String, _i225.Types>>(e))
+              .toSet()
+        : null);
+    map[Map<String, _i225.Types>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i225.Types>(v),
+      ),
+    );
+    map[Set<List<_i225.Types>>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<List<_i225.Types>>(e))
+        .toSet();
+    map[List<_i225.Types>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i225.Types>(e))
+        .toList();
+    map[_i1.getType<Set<List<_i225.Types>>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<List<_i225.Types>>(e))
+              .toSet()
+        : null);
+    map[List<_i225.Types>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i225.Types>(e))
+        .toList();
+    map[Set<(int,)>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<(int,)>(e)).toSet();
+    map[_i1.getType<(int,)>()] = (data, protocol) =>
+        (protocol.deserialize<int>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<Set<(int,)>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<(int,)>(e)).toSet()
+        : null);
+    map[_i1.getType<(int,)>()] = (data, protocol) =>
+        (protocol.deserialize<int>(((data as Map)['p'] as List)[0]),);
+    map[Set<(int,)?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<(int,)?>(e)).toSet();
+    map[_i1.getType<(int,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<int>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<Set<(int,)?>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<(int,)?>(e)).toSet()
+        : null);
+    map[_i1.getType<(int,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<int>(((data as Map)['p'] as List)[0]),);
+    map[Set<int>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int>(e)).toSet();
+    map[List<String>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<String>(e)).toList();
+    map[_i1.getType<List<String>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<String>(e)).toList()
+        : null);
+    map[List<String>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<String>(e)).toList();
+    map[List<_i234.SimpleData>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i234.SimpleData>(e))
+        .toList();
+    map[List<int>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int>(e)).toList();
+    map[List<List<int>>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<List<int>>(e)).toList();
+    map[List<int>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int>(e)).toList();
+    map[List<int>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int>(e)).toList();
+    map[_i1.getType<List<int>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<int>(e)).toList()
+        : null);
+    map[List<List<int>?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<List<int>?>(e)).toList();
+    map[List<int>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int>(e)).toList();
+    map[_i1.getType<List<int>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<int>(e)).toList()
+        : null);
+    map[List<List<int>>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<List<int>>(e)).toList();
+    map[List<int>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int>(e)).toList();
+    map[_i1.getType<List<List<int>>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<List<int>>(e)).toList()
+        : null);
+    map[List<int>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int>(e)).toList();
+    map[List<int?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int?>(e)).toList();
+    map[List<int?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int?>(e)).toList();
+    map[_i1.getType<List<int?>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<int?>(e)).toList()
+        : null);
+    map[List<double>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<double>(e)).toList();
+    map[List<double?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<double?>(e)).toList();
+    map[List<bool>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<bool>(e)).toList();
+    map[List<bool?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<bool?>(e)).toList();
+    map[List<String?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<String?>(e)).toList();
+    map[List<DateTime>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<DateTime>(e)).toList();
+    map[List<DateTime?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<DateTime?>(e)).toList();
+    map[List<_i236.ByteData>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i236.ByteData>(e))
+        .toList();
+    map[List<_i236.ByteData?>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i236.ByteData?>(e))
+        .toList();
+    map[List<_i234.SimpleData?>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i234.SimpleData?>(e))
+        .toList();
+    map[List<_i234.SimpleData>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i234.SimpleData>(e))
+        .toList();
+    map[_i1.getType<List<_i234.SimpleData>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i234.SimpleData>(e))
+              .toList()
+        : null);
+    map[List<_i234.SimpleData?>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i234.SimpleData?>(e))
+        .toList();
+    map[_i1.getType<List<_i234.SimpleData?>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i234.SimpleData?>(e))
+              .toList()
+        : null);
+    map[List<Duration>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<Duration>(e)).toList();
+    map[List<Duration?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<Duration?>(e)).toList();
+    map[Map<String, int>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<int>(v),
+      ),
+    );
+    map[Map<String, int>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<int>(v),
+      ),
+    );
+    map[_i1.getType<Map<String, int>?>()] = (data, protocol) => (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<int>(v),
+            ),
+          )
+        : null);
+    map[Map<String, Map<String, int>>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<Map<String, int>>(v),
+      ),
+    );
+    map[Map<String, int>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<int>(v),
+      ),
+    );
+    map[Map<String, int?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<int?>(v),
+      ),
+    );
+    map[Map<String, int?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<int?>(v),
+      ),
+    );
+    map[_i1.getType<Map<String, int?>?>()] = (data, protocol) => (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<int?>(v),
+            ),
+          )
+        : null);
+    map[Map<int, int>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<int>(e['k']),
+          protocol.deserialize<int>(e['v']),
+        ),
+      ),
+    );
+    map[Map<String, Map<int, int>>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<Map<int, int>>(v),
+      ),
+    );
+    map[Map<int, int>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<int>(e['k']),
+          protocol.deserialize<int>(e['v']),
+        ),
+      ),
+    );
+    map[Map<_i237.TestEnum, int>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<_i237.TestEnum>(e['k']),
+          protocol.deserialize<int>(e['v']),
+        ),
+      ),
+    );
+    map[Map<String, _i237.TestEnum>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i237.TestEnum>(v),
+      ),
+    );
+    map[Map<String, double>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<double>(v),
+      ),
+    );
+    map[Map<String, double?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<double?>(v),
+      ),
+    );
+    map[Map<String, bool>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<bool>(v),
+      ),
+    );
+    map[Map<String, bool?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<bool?>(v),
+      ),
+    );
+    map[Map<String, String>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<String>(v),
+      ),
+    );
+    map[Map<String, String?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<String?>(v),
+      ),
+    );
+    map[Map<String, DateTime>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<DateTime>(v),
+      ),
+    );
+    map[Map<String, DateTime?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<DateTime?>(v),
+      ),
+    );
+    map[Map<String, _i236.ByteData>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i236.ByteData>(v),
+      ),
+    );
+    map[Map<String, _i236.ByteData?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i236.ByteData?>(v),
+      ),
+    );
+    map[Map<String, _i234.SimpleData>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i234.SimpleData>(v),
+      ),
+    );
+    map[Map<String, _i234.SimpleData?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i234.SimpleData?>(v),
+      ),
+    );
+    map[Map<String, _i234.SimpleData>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i234.SimpleData>(v),
+      ),
+    );
+    map[_i1.getType<Map<String, _i234.SimpleData>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<_i234.SimpleData>(v),
+            ),
+          )
+        : null);
+    map[Map<String, _i234.SimpleData?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i234.SimpleData?>(v),
+      ),
+    );
+    map[_i1.getType<Map<String, _i234.SimpleData?>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<_i234.SimpleData?>(v),
+            ),
+          )
+        : null);
+    map[Map<String, Duration>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<Duration>(v),
+      ),
+    );
+    map[Map<String, Duration?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<Duration?>(v),
+      ),
+    );
+    map[Map<(Map<int, String>, String), String>] = (data, protocol) =>
+        Map.fromEntries(
+          (data as List).map(
+            (e) => MapEntry(
+              protocol.deserialize<(Map<int, String>, String)>(e['k']),
+              protocol.deserialize<String>(e['v']),
+            ),
+          ),
+        );
+    map[_i1.getType<(Map<int, String>, String)>()] = (data, protocol) => (
+      protocol.deserialize<Map<int, String>>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<String>(data['p'][1]),
+    );
+    map[_i1.getType<(Map<int, String>, String)>()] = (data, protocol) => (
+      protocol.deserialize<Map<int, String>>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<String>(data['p'][1]),
+    );
+    map[Map<int, String>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<int>(e['k']),
+          protocol.deserialize<String>(e['v']),
+        ),
+      ),
+    );
+    map[Map<String, (Map<int, int>,)>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<(Map<int, int>,)>(v),
+      ),
+    );
+    map[_i1.getType<(Map<int, int>,)>()] = (data, protocol) =>
+        (protocol.deserialize<Map<int, int>>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(Map<int, int>,)>()] = (data, protocol) =>
+        (protocol.deserialize<Map<int, int>>(((data as Map)['p'] as List)[0]),);
+    map[Map<DateTime, bool>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<DateTime>(e['k']),
+          protocol.deserialize<bool>(e['v']),
+        ),
+      ),
+    );
+    map[Map<DateTime, bool>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<DateTime>(e['k']),
+          protocol.deserialize<bool>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<Map<DateTime, bool>?>()] = (data, protocol) => (data != null
+        ? Map.fromEntries(
+            (data as List).map(
+              (e) => MapEntry(
+                protocol.deserialize<DateTime>(e['k']),
+                protocol.deserialize<bool>(e['v']),
+              ),
+            ),
+          )
+        : null);
+    map[Map<int, String>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<int>(e['k']),
+          protocol.deserialize<String>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<Map<int, String>?>()] = (data, protocol) => (data != null
+        ? Map.fromEntries(
+            (data as List).map(
+              (e) => MapEntry(
+                protocol.deserialize<int>(e['k']),
+                protocol.deserialize<String>(e['v']),
+              ),
+            ),
+          )
+        : null);
+    map[dynamic] = (data, protocol) =>
+        protocol.deserializeDynamicFieldValue(data);
+    map[List<_i3.UserInfo>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i3.UserInfo>(e))
+        .toList();
+    map[Set<int>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int>(e)).toSet();
+    map[Set<_i234.SimpleData>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i234.SimpleData>(e))
+        .toSet();
+    map[List<Set<_i234.SimpleData>>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<Set<_i234.SimpleData>>(e))
+        .toList();
+    map[Set<_i234.SimpleData>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i234.SimpleData>(e))
+        .toSet();
+    map[_i1.getType<(int, BigInt)>()] = (data, protocol) => (
+      protocol.deserialize<int>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<BigInt>(data['p'][1]),
+    );
+    map[_i1.getType<(String, _i235.PolymorphicParent)>()] = (data, protocol) =>
+        (
+          protocol.deserialize<String>(((data as Map)['p'] as List)[0]),
+          protocol.deserialize<_i235.PolymorphicParent>(data['p'][1]),
+        );
+    map[_i1.getType<(int,)>()] = (data, protocol) =>
+        (protocol.deserialize<int>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(int,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<int>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(int?,)>()] = (data, protocol) => (
+      ((data as Map)['p'] as List)[0] == null
+          ? null
+          : protocol.deserialize<int>(data['p'][0]),
+    );
+    map[_i1.getType<(int?,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (
+            ((data as Map)['p'] as List)[0] == null
+                ? null
+                : protocol.deserialize<int>(data['p'][0]),
+          );
+    map[_i1.getType<(int, String)>()] = (data, protocol) => (
+      protocol.deserialize<int>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<String>(data['p'][1]),
+    );
+    map[_i1.getType<(int, String)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (
+            protocol.deserialize<int>(((data as Map)['p'] as List)[0]),
+            protocol.deserialize<String>(data['p'][1]),
+          );
+    map[_i1.getType<(int, _i234.SimpleData)>()] = (data, protocol) => (
+      protocol.deserialize<int>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<_i234.SimpleData>(data['p'][1]),
+    );
+    map[_i1.getType<(int, _i234.SimpleData)?>()] = (data, protocol) =>
+        (data == null)
+        ? null
+        : (
+            protocol.deserialize<int>(((data as Map)['p'] as List)[0]),
+            protocol.deserialize<_i234.SimpleData>(data['p'][1]),
+          );
+    map[_i1.getType<(Map<String, int>,)>()] = (data, protocol) => (
+      protocol.deserialize<Map<String, int>>(((data as Map)['p'] as List)[0]),
+    );
+    map[_i1.getType<(Set<(int,)>,)>()] = (data, protocol) =>
+        (protocol.deserialize<Set<(int,)>>(((data as Map)['p'] as List)[0]),);
+    map[Set<(int,)>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<(int,)>(e)).toSet();
+    map[_i1.getType<(int,)>()] = (data, protocol) =>
+        (protocol.deserialize<int>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<({int number, String text})>()] = (data, protocol) => (
+      number: protocol.deserialize<int>(((data as Map)['n'] as Map)['number']),
+      text: protocol.deserialize<String>(data['n']['text']),
+    );
+    map[_i1.getType<({int number, String text})?>()] = (data, protocol) =>
+        (data == null)
+        ? null
+        : (
+            number: protocol.deserialize<int>(
+              ((data as Map)['n'] as Map)['number'],
+            ),
+            text: protocol.deserialize<String>(data['n']['text']),
+          );
+    map[_i1.getType<({_i234.SimpleData data, int number})>()] =
+        (data, protocol) => (
+          data: protocol.deserialize<_i234.SimpleData>(
+            ((data as Map)['n'] as Map)['data'],
+          ),
+          number: protocol.deserialize<int>(data['n']['number']),
+        );
+    map[_i1.getType<({_i234.SimpleData data, int number})?>()] =
+        (data, protocol) => (data == null)
+        ? null
+        : (
+            data: protocol.deserialize<_i234.SimpleData>(
+              ((data as Map)['n'] as Map)['data'],
+            ),
+            number: protocol.deserialize<int>(data['n']['number']),
+          );
+    map[_i1.getType<({_i234.SimpleData? data, int? number})>()] =
+        (data, protocol) => (
+          data: ((data as Map)['n'] as Map)['data'] == null
+              ? null
+              : protocol.deserialize<_i234.SimpleData>(data['n']['data']),
+          number: ((data)['n'] as Map)['number'] == null
+              ? null
+              : protocol.deserialize<int>(data['n']['number']),
+        );
+    map[_i1.getType<({Map<int, int> intIntMap})>()] = (data, protocol) => (
+      intIntMap: protocol.deserialize<Map<int, int>>(
+        ((data as Map)['n'] as Map)['intIntMap'],
+      ),
+    );
+    map[_i1.getType<({Set<(bool,)> boolSet})>()] = (data, protocol) => (
+      boolSet: protocol.deserialize<Set<(bool,)>>(
+        ((data as Map)['n'] as Map)['boolSet'],
+      ),
+    );
+    map[Set<(bool,)>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<(bool,)>(e)).toSet();
+    map[_i1.getType<(bool,)>()] = (data, protocol) =>
+        (protocol.deserialize<bool>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(bool,)>()] = (data, protocol) =>
+        (protocol.deserialize<bool>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(Map<(Map<int, String>, String), String>,)>()] =
+        (data, protocol) => (
+          protocol.deserialize<Map<(Map<int, String>, String), String>>(
+            ((data as Map)['p'] as List)[0],
+          ),
+        );
+    map[_i1.getType<(int, {_i234.SimpleData data})>()] = (data, protocol) => (
+      protocol.deserialize<int>(((data as Map)['p'] as List)[0]),
+      data: protocol.deserialize<_i234.SimpleData>(data['n']['data']),
+    );
+    map[_i1.getType<(int, {_i234.SimpleData data})?>()] = (data, protocol) =>
+        (data == null)
+        ? null
+        : (
+            protocol.deserialize<int>(((data as Map)['p'] as List)[0]),
+            data: protocol.deserialize<_i234.SimpleData>(data['n']['data']),
+          );
+    map[List<(int, _i234.SimpleData)>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<(int, _i234.SimpleData)>(e))
+        .toList();
+    map[_i1.getType<(int, _i234.SimpleData)>()] = (data, protocol) => (
+      protocol.deserialize<int>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<_i234.SimpleData>(data['p'][1]),
+    );
+    map[List<(int, _i234.SimpleData)?>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<(int, _i234.SimpleData)?>(e))
+        .toList();
+    map[_i1.getType<(int, _i234.SimpleData)?>()] = (data, protocol) =>
+        (data == null)
+        ? null
+        : (
+            protocol.deserialize<int>(((data as Map)['p'] as List)[0]),
+            protocol.deserialize<_i234.SimpleData>(data['p'][1]),
+          );
+    map[Set<(int, _i234.SimpleData)>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<(int, _i234.SimpleData)>(e))
+        .toSet();
+    map[_i1.getType<(int, _i234.SimpleData)>()] = (data, protocol) => (
+      protocol.deserialize<int>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<_i234.SimpleData>(data['p'][1]),
+    );
+    map[Set<(int, _i234.SimpleData)?>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<(int, _i234.SimpleData)?>(e))
+        .toSet();
+    map[_i1.getType<(int, _i234.SimpleData)?>()] = (data, protocol) =>
+        (data == null)
+        ? null
+        : (
+            protocol.deserialize<int>(((data as Map)['p'] as List)[0]),
+            protocol.deserialize<_i234.SimpleData>(data['p'][1]),
+          );
+    map[Set<(int, _i234.SimpleData)>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<(int, _i234.SimpleData)>(e))
+        .toSet();
+    map[_i1.getType<(int, _i234.SimpleData)>()] = (data, protocol) => (
+      protocol.deserialize<int>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<_i234.SimpleData>(data['p'][1]),
+    );
+    map[_i1.getType<Set<(int, _i234.SimpleData)>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<(int, _i234.SimpleData)>(e))
+              .toSet()
+        : null);
+    map[_i1.getType<(int, _i234.SimpleData)>()] = (data, protocol) => (
+      protocol.deserialize<int>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<_i234.SimpleData>(data['p'][1]),
+    );
+    map[Map<String, (int, _i234.SimpleData)>] = (data, protocol) =>
+        (data as Map).map(
+          (k, v) => MapEntry(
+            protocol.deserialize<String>(k),
+            protocol.deserialize<(int, _i234.SimpleData)>(v),
+          ),
+        );
+    map[_i1.getType<(int, _i234.SimpleData)>()] = (data, protocol) => (
+      protocol.deserialize<int>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<_i234.SimpleData>(data['p'][1]),
+    );
+    map[Map<String, (int, _i234.SimpleData)?>] = (data, protocol) =>
+        (data as Map).map(
+          (k, v) => MapEntry(
+            protocol.deserialize<String>(k),
+            protocol.deserialize<(int, _i234.SimpleData)?>(v),
+          ),
+        );
+    map[_i1.getType<(int, _i234.SimpleData)?>()] = (data, protocol) =>
+        (data == null)
+        ? null
+        : (
+            protocol.deserialize<int>(((data as Map)['p'] as List)[0]),
+            protocol.deserialize<_i234.SimpleData>(data['p'][1]),
+          );
+    map[Map<(String, int), (int, _i234.SimpleData)>] = (data, protocol) =>
+        Map.fromEntries(
+          (data as List).map(
+            (e) => MapEntry(
+              protocol.deserialize<(String, int)>(e['k']),
+              protocol.deserialize<(int, _i234.SimpleData)>(e['v']),
+            ),
+          ),
+        );
+    map[_i1.getType<(String, int)>()] = (data, protocol) => (
+      protocol.deserialize<String>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<int>(data['p'][1]),
+    );
+    map[_i1.getType<(int, _i234.SimpleData)>()] = (data, protocol) => (
+      protocol.deserialize<int>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<_i234.SimpleData>(data['p'][1]),
+    );
+    map[_i1.getType<(String, int)>()] = (data, protocol) => (
+      protocol.deserialize<String>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<int>(data['p'][1]),
+    );
+    map[Map<String, List<Set<(int,)>>>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<List<Set<(int,)>>>(v),
+      ),
+    );
+    map[List<Set<(int,)>>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<Set<(int,)>>(e))
+        .toList();
+    map[Set<(int,)>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<(int,)>(e)).toSet();
+    map[_i1.getType<(int,)>()] = (data, protocol) =>
+        (protocol.deserialize<int>(((data as Map)['p'] as List)[0]),);
+    map[List<Set<(int,)>>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<Set<(int,)>>(e))
+        .toList();
+    map[Set<(int,)>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<(int,)>(e)).toSet();
+    map[_i1.getType<(int,)>()] = (data, protocol) =>
+        (protocol.deserialize<int>(((data as Map)['p'] as List)[0]),);
+    map[Set<List<Map<String, (int,)>>>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<List<Map<String, (int,)>>>(e))
+        .toSet();
+    map[List<Map<String, (int,)>>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<Map<String, (int,)>>(e))
+        .toList();
+    map[Map<String, (int,)>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<(int,)>(v),
+      ),
+    );
+    map[_i1.getType<(int,)>()] = (data, protocol) =>
+        (protocol.deserialize<int>(((data as Map)['p'] as List)[0]),);
+    map[List<Map<String, (int,)>>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<Map<String, (int,)>>(e))
+        .toList();
+    map[Map<String, (int,)>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<(int,)>(v),
+      ),
+    );
+    map[_i1.getType<(int,)>()] = (data, protocol) =>
+        (protocol.deserialize<int>(((data as Map)['p'] as List)[0]),);
+    map[Map<String, (int,)>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<(int,)>(v),
+      ),
+    );
+    map[_i1.getType<(int,)>()] = (data, protocol) =>
+        (protocol.deserialize<int>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<({(_i234.SimpleData, double) namedSubRecord})>()] =
+        (data, protocol) => (
+          namedSubRecord: protocol.deserialize<(_i234.SimpleData, double)>(
+            ((data as Map)['n'] as Map)['namedSubRecord'],
+          ),
+        );
+    map[_i1.getType<(_i234.SimpleData, double)>()] = (data, protocol) => (
+      protocol.deserialize<_i234.SimpleData>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<double>(data['p'][1]),
+    );
+    map[_i1.getType<({(_i234.SimpleData, double)? namedSubRecord})>()] =
+        (data, protocol) => (
+          namedSubRecord: ((data as Map)['n'] as Map)['namedSubRecord'] == null
+              ? null
+              : protocol.deserialize<(_i234.SimpleData, double)>(
+                  data['n']['namedSubRecord'],
+                ),
+        );
+    map[_i1.getType<(_i234.SimpleData, double)?>()] = (data, protocol) =>
+        (data == null)
+        ? null
+        : (
+            protocol.deserialize<_i234.SimpleData>(
+              ((data as Map)['p'] as List)[0],
+            ),
+            protocol.deserialize<double>(data['p'][1]),
+          );
+    map[_i1
+        .getType<
+          ((int, String), {(_i234.SimpleData, double) namedSubRecord})
+        >()] = (data, protocol) => (
+      protocol.deserialize<(int, String)>(((data as Map)['p'] as List)[0]),
+      namedSubRecord: protocol.deserialize<(_i234.SimpleData, double)>(
+        data['n']['namedSubRecord'],
+      ),
+    );
+    map[List<((int, String), {(_i234.SimpleData, double) namedSubRecord})>] =
+        (data, protocol) => (data as List)
+            .map(
+              (e) =>
+                  protocol.deserialize<
+                    ((int, String), {(_i234.SimpleData, double) namedSubRecord})
+                  >(e),
+            )
+            .toList();
+    map[_i1
+        .getType<
+          ((int, String), {(_i234.SimpleData, double) namedSubRecord})
+        >()] = (data, protocol) => (
+      protocol.deserialize<(int, String)>(((data as Map)['p'] as List)[0]),
+      namedSubRecord: protocol.deserialize<(_i234.SimpleData, double)>(
+        data['n']['namedSubRecord'],
+      ),
+    );
+    map[List<((int, String), {(_i234.SimpleData, double) namedSubRecord})?>] =
+        (data, protocol) => (data as List)
+            .map(
+              (e) =>
+                  protocol.deserialize<
+                    (
+                      (int, String), {
+                      (_i234.SimpleData, double) namedSubRecord,
+                    })?
+                  >(e),
+            )
+            .toList();
+    map[_i1
+        .getType<
+          ((int, String), {(_i234.SimpleData, double) namedSubRecord})?
+        >()] = (data, protocol) => (data == null)
+        ? null
+        : (
+            protocol.deserialize<(int, String)>(
+              ((data as Map)['p'] as List)[0],
+            ),
+            namedSubRecord: protocol.deserialize<(_i234.SimpleData, double)>(
+              data['n']['namedSubRecord'],
+            ),
+          );
+    map[_i1
+        .getType<
+          List<((int, String), {(_i234.SimpleData, double) namedSubRecord})?>?
+        >()] = (data, protocol) => (data != null
+        ? (data as List)
+              .map(
+                (e) =>
+                    protocol.deserialize<
+                      (
+                        (int, String), {
+                        (_i234.SimpleData, double) namedSubRecord,
+                      })?
+                    >(e),
+              )
+              .toList()
+        : null);
+    map[_i1
+        .getType<
+          ((int, String), {(_i234.SimpleData, double) namedSubRecord})?
+        >()] = (data, protocol) => (data == null)
+        ? null
+        : (
+            protocol.deserialize<(int, String)>(
+              ((data as Map)['p'] as List)[0],
+            ),
+            namedSubRecord: protocol.deserialize<(_i234.SimpleData, double)>(
+              data['n']['namedSubRecord'],
+            ),
+          );
+    map[_i1
+        .getType<
+          ((int, String), {(_i234.SimpleData, double) namedSubRecord})?
+        >()] = (data, protocol) => (data == null)
+        ? null
+        : (
+            protocol.deserialize<(int, String)>(
+              ((data as Map)['p'] as List)[0],
+            ),
+            namedSubRecord: protocol.deserialize<(_i234.SimpleData, double)>(
+              data['n']['namedSubRecord'],
+            ),
+          );
+    map[_i1.getType<(int?, _i4.ProjectStreamingClass?)>()] = (data, protocol) =>
+        (
+          ((data as Map)['p'] as List)[0] == null
+              ? null
+              : protocol.deserialize<int>(data['p'][0]),
+          ((data)['p'] as List)[1] == null
+              ? null
+              : protocol.deserialize<_i4.ProjectStreamingClass>(data['p'][1]),
+        );
+    map[Set<Set<int>>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<Set<int>>(e)).toSet();
+    map[Set<int>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int>(e)).toSet();
+    map[Set<List<int>>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<List<int>>(e)).toSet();
+    map[List<int>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int>(e)).toList();
+    map[Set<int>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int>(e)).toSet();
+    map[_i1.getType<Set<int>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<int>(e)).toSet()
+        : null);
+    map[Set<Set<int>?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<Set<int>?>(e)).toSet();
+    map[Set<int>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int>(e)).toSet();
+    map[_i1.getType<Set<int>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<int>(e)).toSet()
+        : null);
+    map[Set<Set<int>>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<Set<int>>(e)).toSet();
+    map[Set<int>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int>(e)).toSet();
+    map[_i1.getType<Set<Set<int>>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<Set<int>>(e)).toSet()
+        : null);
+    map[Set<int>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int>(e)).toSet();
+    map[Set<int?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int?>(e)).toSet();
+    map[Set<int?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int?>(e)).toSet();
+    map[_i1.getType<Set<int?>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<int?>(e)).toSet()
+        : null);
+    map[Set<double>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<double>(e)).toSet();
+    map[Set<double?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<double?>(e)).toSet();
+    map[Set<bool>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<bool>(e)).toSet();
+    map[Set<bool?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<bool?>(e)).toSet();
+    map[Set<String>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<String>(e)).toSet();
+    map[Set<String?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<String?>(e)).toSet();
+    map[Set<DateTime>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<DateTime>(e)).toSet();
+    map[Set<DateTime?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<DateTime?>(e)).toSet();
+    map[Set<_i236.ByteData>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i236.ByteData>(e))
+        .toSet();
+    map[Set<_i236.ByteData?>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i236.ByteData?>(e))
+        .toSet();
+    map[Set<_i234.SimpleData?>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i234.SimpleData?>(e))
+        .toSet();
+    map[Set<Duration>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<Duration>(e)).toSet();
+    map[Set<Duration?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<Duration?>(e)).toSet();
+    map[List<_i238.Types>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i238.Types>(e))
+        .toList();
+    map[_i1.getType<(String, (int, bool))>()] = (data, protocol) => (
+      protocol.deserialize<String>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<(int, bool)>(data['p'][1]),
+    );
+    map[_i1.getType<(int, bool)>()] = (data, protocol) => (
+      protocol.deserialize<int>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<bool>(data['p'][1]),
+    );
+    map[List<(String, (int, bool))>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<(String, (int, bool))>(e))
+        .toList();
+    map[_i1.getType<(String, (int, bool))>()] = (data, protocol) => (
+      protocol.deserialize<String>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<(int, bool)>(data['p'][1]),
+    );
+    map[_i1
+        .getType<
+          (String, (Map<String, int>, {bool flag, _i234.SimpleData simpleData}))
+        >()] = (data, protocol) => (
+      protocol.deserialize<String>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<
+        (Map<String, int>, {bool flag, _i234.SimpleData simpleData})
+      >(data['p'][1]),
+    );
+    map[_i1
+        .getType<
+          (Map<String, int>, {bool flag, _i234.SimpleData simpleData})
+        >()] = (data, protocol) => (
+      protocol.deserialize<Map<String, int>>(((data as Map)['p'] as List)[0]),
+      flag: protocol.deserialize<bool>(data['n']['flag']),
+      simpleData: protocol.deserialize<_i234.SimpleData>(
+        data['n']['simpleData'],
+      ),
+    );
+    map[List<(String, int)>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<(String, int)>(e))
+        .toList();
+    map[_i1.getType<(String, int)>()] = (data, protocol) => (
+      protocol.deserialize<String>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<int>(data['p'][1]),
+    );
+    map[_i1
+        .getType<
+          (
+            String,
+            (Map<String, int>, {bool flag, _i234.SimpleData simpleData}),
+          )?
+        >()] = (data, protocol) => (data == null)
+        ? null
+        : (
+            protocol.deserialize<String>(((data as Map)['p'] as List)[0]),
+            protocol.deserialize<
+              (Map<String, int>, {bool flag, _i234.SimpleData simpleData})
+            >(data['p'][1]),
+          );
+    map[List<(String, int)>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<(String, int)>(e))
+        .toList();
+    map[_i1.getType<(String, int)>()] = (data, protocol) => (
+      protocol.deserialize<String>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<int>(data['p'][1]),
+    );
+    map[_i1.getType<List<(String, int)>?>()] = (data, protocol) => (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<(String, int)>(e))
+              .toList()
+        : null);
+    map[_i1.getType<(String, int)>()] = (data, protocol) => (
+      protocol.deserialize<String>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<int>(data['p'][1]),
+    );
+    map[_i1.getType<(int, String)>()] = (data, protocol) => (
+      protocol.deserialize<int>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<String>(data['p'][1]),
+    );
+    map[_i1.getType<(_i4.ModuleClass,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (
+            protocol.deserialize<_i4.ModuleClass>(
+              ((data as Map)['p'] as List)[0],
+            ),
+          );
+    map[_i1.getType<(bool,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<bool>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(_i224.TestEnumStringified,)?>()] = (data, protocol) =>
+        (data == null)
+        ? null
+        : (
+            protocol.deserialize<_i224.TestEnumStringified>(
+              ((data as Map)['p'] as List)[0],
+            ),
+          );
+    map[List<(_i224.TestEnumStringified,)>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<(_i224.TestEnumStringified,)>(e))
+        .toList();
+    map[_i1.getType<(_i224.TestEnumStringified,)>()] = (data, protocol) => (
+      protocol.deserialize<_i224.TestEnumStringified>(
+        ((data as Map)['p'] as List)[0],
+      ),
+    );
+    map[_i1.getType<List<(_i224.TestEnumStringified,)>?>()] =
+        (data, protocol) => (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<(_i224.TestEnumStringified,)>(e))
+              .toList()
+        : null);
+    map[_i1.getType<(_i224.TestEnumStringified,)>()] = (data, protocol) => (
+      protocol.deserialize<_i224.TestEnumStringified>(
+        ((data as Map)['p'] as List)[0],
+      ),
+    );
+    map[_i1.getType<(_i224.TestEnumStringified,)>()] = (data, protocol) => (
+      protocol.deserialize<_i224.TestEnumStringified>(
+        ((data as Map)['p'] as List)[0],
+      ),
+    );
+    map[_i1.getType<(_i165.Nullability,)?>()] = (data, protocol) =>
+        (data == null)
+        ? null
+        : (
+            protocol.deserialize<_i165.Nullability>(
+              ((data as Map)['p'] as List)[0],
+            ),
+          );
+    map[_i1.getType<({_i224.TestEnumStringified value})?>()] =
+        (data, protocol) => (data == null)
+        ? null
+        : (
+            value: protocol.deserialize<_i224.TestEnumStringified>(
+              ((data as Map)['n'] as Map)['value'],
+            ),
+          );
+    map[List<({_i224.TestEnumStringified value})>] = (data, protocol) =>
+        (data as List)
+            .map(
+              (e) =>
+                  protocol.deserialize<({_i224.TestEnumStringified value})>(e),
+            )
+            .toList();
+    map[_i1
+        .getType<({_i224.TestEnumStringified value})>()] = (data, protocol) => (
+      value: protocol.deserialize<_i224.TestEnumStringified>(
+        ((data as Map)['n'] as Map)['value'],
+      ),
+    );
+    map[_i1.getType<List<({_i224.TestEnumStringified value})>?>()] =
+        (data, protocol) => (data != null
+        ? (data as List)
+              .map(
+                (e) => protocol
+                    .deserialize<({_i224.TestEnumStringified value})>(e),
+              )
+              .toList()
+        : null);
+    map[_i1
+        .getType<({_i224.TestEnumStringified value})>()] = (data, protocol) => (
+      value: protocol.deserialize<_i224.TestEnumStringified>(
+        ((data as Map)['n'] as Map)['value'],
+      ),
+    );
+    map[_i1
+        .getType<({_i224.TestEnumStringified value})>()] = (data, protocol) => (
+      value: protocol.deserialize<_i224.TestEnumStringified>(
+        ((data as Map)['n'] as Map)['value'],
+      ),
+    );
+    map[_i1.getType<({_i4.ModuleClass value})?>()] = (data, protocol) =>
+        (data == null)
+        ? null
+        : (
+            value: protocol.deserialize<_i4.ModuleClass>(
+              ((data as Map)['n'] as Map)['value'],
+            ),
+          );
+    map[_i1.getType<({_i165.Nullability value})?>()] = (data, protocol) =>
+        (data == null)
+        ? null
+        : (
+            value: protocol.deserialize<_i165.Nullability>(
+              ((data as Map)['n'] as Map)['value'],
+            ),
+          );
+    map[_i1.getType<(String, {Uri? optionalUri})?>()] = (data, protocol) =>
+        (data == null)
+        ? null
+        : (
+            protocol.deserialize<String>(((data as Map)['p'] as List)[0]),
+            optionalUri: ((data)['n'] as Map)['optionalUri'] == null
+                ? null
+                : protocol.deserialize<Uri>(data['n']['optionalUri']),
+          );
+    map[List<(int,)>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<(int,)>(e)).toList();
+    map[_i1.getType<(int,)>()] = (data, protocol) =>
+        (protocol.deserialize<int>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<List<(int,)>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<(int,)>(e)).toList()
+        : null);
+    map[_i1.getType<(int,)>()] = (data, protocol) =>
+        (protocol.deserialize<int>(((data as Map)['p'] as List)[0]),);
+    map[List<(int,)?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<(int,)?>(e)).toList();
+    map[_i1.getType<(int,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<int>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<List<(int,)?>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<(int,)?>(e)).toList()
+        : null);
+    map[_i1.getType<(int,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<int>(((data as Map)['p'] as List)[0]),);
+    map[List<(_i220.TestEnum,)>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<(_i220.TestEnum,)>(e))
+        .toList();
+    map[_i1.getType<(_i220.TestEnum,)>()] = (data, protocol) => (
+      protocol.deserialize<_i220.TestEnum>(((data as Map)['p'] as List)[0]),
+    );
+    map[_i1.getType<List<(_i220.TestEnum,)>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<(_i220.TestEnum,)>(e))
+              .toList()
+        : null);
+    map[_i1.getType<(_i220.TestEnum,)>()] = (data, protocol) => (
+      protocol.deserialize<_i220.TestEnum>(((data as Map)['p'] as List)[0]),
+    );
+    map[_i1.getType<(_i220.TestEnum,)>()] = (data, protocol) => (
+      protocol.deserialize<_i220.TestEnum>(((data as Map)['p'] as List)[0]),
+    );
+    map[Map<(String,), String>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<(String,)>(e['k']),
+          protocol.deserialize<String>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<(String,)>()] = (data, protocol) =>
+        (protocol.deserialize<String>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<Map<(String,), String>?>()] = (data, protocol) =>
+        (data != null
+        ? Map.fromEntries(
+            (data as List).map(
+              (e) => MapEntry(
+                protocol.deserialize<(String,)>(e['k']),
+                protocol.deserialize<String>(e['v']),
+              ),
+            ),
+          )
+        : null);
+    map[_i1.getType<(String,)>()] = (data, protocol) =>
+        (protocol.deserialize<String>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(String,)>()] = (data, protocol) =>
+        (protocol.deserialize<String>(((data as Map)['p'] as List)[0]),);
+    map[Map<String, (String,)>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<(String,)>(v),
+      ),
+    );
+    map[_i1.getType<(String,)>()] = (data, protocol) =>
+        (protocol.deserialize<String>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<Map<String, (String,)>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<(String,)>(v),
+            ),
+          )
+        : null);
+    map[_i1.getType<(String,)>()] = (data, protocol) =>
+        (protocol.deserialize<String>(((data as Map)['p'] as List)[0]),);
+    map[Map<String, (String,)?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<(String,)?>(v),
+      ),
+    );
+    map[_i1.getType<(String,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<String>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<Map<String, (String,)?>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<(String,)?>(v),
+            ),
+          )
+        : null);
+    map[_i1.getType<(String,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<String>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(String,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<String>(((data as Map)['p'] as List)[0]),);
+    map[Map<(String,)?, String>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<(String,)?>(e['k']),
+          protocol.deserialize<String>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<(String,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<String>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<Map<(String,)?, String>?>()] = (data, protocol) =>
+        (data != null
+        ? Map.fromEntries(
+            (data as List).map(
+              (e) => MapEntry(
+                protocol.deserialize<(String,)?>(e['k']),
+                protocol.deserialize<String>(e['v']),
+              ),
+            ),
+          )
+        : null);
+    map[_i1.getType<(String,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<String>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(double,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<double>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(DateTime,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<DateTime>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(_i236.ByteData,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (
+            protocol.deserialize<_i236.ByteData>(
+              ((data as Map)['p'] as List)[0],
+            ),
+          );
+    map[_i1.getType<(Duration,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<Duration>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(_i1.UuidValue,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (
+            protocol.deserialize<_i1.UuidValue>(
+              ((data as Map)['p'] as List)[0],
+            ),
+          );
+    map[_i1.getType<(Uri,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<Uri>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(BigInt,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<BigInt>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(_i220.TestEnum,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (
+            protocol.deserialize<_i220.TestEnum>(
+              ((data as Map)['p'] as List)[0],
+            ),
+          );
+    map[_i1.getType<(List<int>,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<List<int>>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(Map<int, int>,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (
+            protocol.deserialize<Map<int, int>>(
+              ((data as Map)['p'] as List)[0],
+            ),
+          );
+    map[Map<int, int>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<int>(e['k']),
+          protocol.deserialize<int>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<(Set<int>,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<Set<int>>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<(_i214.SimpleData,)?>()] = (data, protocol) =>
+        (data == null)
+        ? null
+        : (
+            protocol.deserialize<_i214.SimpleData>(
+              ((data as Map)['p'] as List)[0],
+            ),
+          );
+    map[_i1.getType<({_i214.SimpleData namedModel})?>()] = (data, protocol) =>
+        (data == null)
+        ? null
+        : (
+            namedModel: protocol.deserialize<_i214.SimpleData>(
+              ((data as Map)['n'] as Map)['namedModel'],
+            ),
+          );
+    map[_i1.getType<(_i214.SimpleData, {_i214.SimpleData namedModel})?>()] =
+        (data, protocol) => (data == null)
+        ? null
+        : (
+            protocol.deserialize<_i214.SimpleData>(
+              ((data as Map)['p'] as List)[0],
+            ),
+            namedModel: protocol.deserialize<_i214.SimpleData>(
+              data['n']['namedModel'],
+            ),
+          );
+    map[_i1.getType<((int, String), {(int, String) namedNestedRecord})?>()] =
+        (data, protocol) => (data == null)
+        ? null
+        : (
+            protocol.deserialize<(int, String)>(
+              ((data as Map)['p'] as List)[0],
+            ),
+            namedNestedRecord: protocol.deserialize<(int, String)>(
+              data['n']['namedNestedRecord'],
+            ),
+          );
+    map[_i1
+        .getType<
+          (
+            (List<(_i214.SimpleData,)>,), {
+            (_i214.SimpleData, Map<String, _i214.SimpleData>) namedNestedRecord,
+          })?
+        >()] = (data, protocol) => (data == null)
+        ? null
+        : (
+            protocol.deserialize<(List<(_i214.SimpleData,)>,)>(
+              ((data as Map)['p'] as List)[0],
+            ),
+            namedNestedRecord: protocol
+                .deserialize<(_i214.SimpleData, Map<String, _i214.SimpleData>)>(
+                  data['n']['namedNestedRecord'],
+                ),
+          );
+    map[_i1.getType<(List<(_i214.SimpleData,)>,)>()] = (data, protocol) => (
+      protocol.deserialize<List<(_i214.SimpleData,)>>(
+        ((data as Map)['p'] as List)[0],
+      ),
+    );
+    map[List<(_i214.SimpleData,)>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<(_i214.SimpleData,)>(e))
+        .toList();
+    map[_i1.getType<(_i214.SimpleData,)>()] = (data, protocol) => (
+      protocol.deserialize<_i214.SimpleData>(((data as Map)['p'] as List)[0]),
+    );
+    map[_i1.getType<(_i214.SimpleData,)>()] = (data, protocol) => (
+      protocol.deserialize<_i214.SimpleData>(((data as Map)['p'] as List)[0]),
+    );
+    map[_i1.getType<(_i214.SimpleData, Map<String, _i214.SimpleData>)>()] =
+        (data, protocol) => (
+          protocol.deserialize<_i214.SimpleData>(
+            ((data as Map)['p'] as List)[0],
+          ),
+          protocol.deserialize<Map<String, _i214.SimpleData>>(data['p'][1]),
+        );
+    map[Map<String, _i214.SimpleData>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i214.SimpleData>(v),
+      ),
+    );
+    map[Set<(int,)>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<(int,)>(e)).toSet();
+    map[_i1.getType<(int,)>()] = (data, protocol) =>
+        (protocol.deserialize<int>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<Set<(int,)>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<(int,)>(e)).toSet()
+        : null);
+    map[_i1.getType<(int,)>()] = (data, protocol) =>
+        (protocol.deserialize<int>(((data as Map)['p'] as List)[0]),);
+    map[Set<(int,)?>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<(int,)?>(e)).toSet();
+    map[_i1.getType<(int,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<int>(((data as Map)['p'] as List)[0]),);
+    map[_i1.getType<Set<(int,)?>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<(int,)?>(e)).toSet()
+        : null);
+    map[_i1.getType<(int,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (protocol.deserialize<int>(((data as Map)['p'] as List)[0]),);
+    map[_i6.CustomClass] = (data, protocol) => _i6.CustomClass.fromJson(data);
+    map[_i6.CustomClass2] = (data, protocol) => _i6.CustomClass2.fromJson(data);
+    map[_i6.CustomClassWithoutProtocolSerialization] = (data, protocol) =>
+        _i6.CustomClassWithoutProtocolSerialization.fromJson(data);
+    map[_i6.CustomClassWithProtocolSerialization] = (data, protocol) =>
+        _i6.CustomClassWithProtocolSerialization.fromJson(data);
+    map[_i6.CustomClassWithProtocolSerializationMethod] = (data, protocol) =>
+        _i6.CustomClassWithProtocolSerializationMethod.fromJson(data);
+    map[_i6.ProtocolCustomClass] = (data, protocol) =>
+        _i6.ProtocolCustomClass.fromJson(data);
+    map[_i6.ExternalCustomClass] = (data, protocol) =>
+        _i6.ExternalCustomClass.fromJson(data);
+    map[_i6.FreezedCustomClass] = (data, protocol) =>
+        _i6.FreezedCustomClass.fromJson(data);
+    map[_i1.getType<_i6.CustomClass?>()] = (data, protocol) =>
+        (data != null ? _i6.CustomClass.fromJson(data) : null);
+    map[_i1.getType<_i6.CustomClass2?>()] = (data, protocol) =>
+        (data != null ? _i6.CustomClass2.fromJson(data) : null);
+    map[_i1.getType<_i6.CustomClassWithoutProtocolSerialization?>()] =
+        (data, protocol) => (data != null
+        ? _i6.CustomClassWithoutProtocolSerialization.fromJson(data)
+        : null);
+    map[_i1.getType<_i6.CustomClassWithProtocolSerialization?>()] =
+        (data, protocol) => (data != null
+        ? _i6.CustomClassWithProtocolSerialization.fromJson(data)
+        : null);
+    map[_i1.getType<_i6.CustomClassWithProtocolSerializationMethod?>()] =
+        (data, protocol) => (data != null
+        ? _i6.CustomClassWithProtocolSerializationMethod.fromJson(data)
+        : null);
+    map[_i1.getType<_i6.ProtocolCustomClass?>()] = (data, protocol) =>
+        (data != null ? _i6.ProtocolCustomClass.fromJson(data) : null);
+    map[_i1.getType<_i6.ExternalCustomClass?>()] = (data, protocol) =>
+        (data != null ? _i6.ExternalCustomClass.fromJson(data) : null);
+    map[_i1.getType<_i6.FreezedCustomClass?>()] = (data, protocol) =>
+        (data != null ? _i6.FreezedCustomClass.fromJson(data) : null);
+    map[List<int>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int>(e)).toList();
+    map[List<_i234.SimpleData>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i234.SimpleData>(e))
+        .toList();
+    map[List<_i3.UserInfo>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i3.UserInfo>(e))
+        .toList();
+    map[List<_i234.SimpleData>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i234.SimpleData>(e))
+        .toList();
+    map[_i1.getType<List<_i234.SimpleData>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i234.SimpleData>(e))
+              .toList()
+        : null);
+    map[List<_i234.SimpleData?>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i234.SimpleData?>(e))
+        .toList();
+    map[Set<int>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int>(e)).toSet();
+    map[Set<_i234.SimpleData>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i234.SimpleData>(e))
+        .toSet();
+    map[List<Set<_i234.SimpleData>>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<Set<_i234.SimpleData>>(e))
+        .toList();
+    map[Set<_i234.SimpleData>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i234.SimpleData>(e))
+        .toSet();
+    map[_i1.getType<(String, _i235.PolymorphicParent)>()] = (data, protocol) =>
+        (
+          protocol.deserialize<String>(((data as Map)['p'] as List)[0]),
+          protocol.deserialize<_i235.PolymorphicParent>(data['p'][1]),
+        );
+    map[_i1.getType<(int?,)?>()] = (data, protocol) => (data == null)
+        ? null
+        : (
+            ((data as Map)['p'] as List)[0] == null
+                ? null
+                : protocol.deserialize<int>(data['p'][0]),
+          );
+    map[List<((int, String), {(_i234.SimpleData, double) namedSubRecord})?>] =
+        (data, protocol) => (data as List)
+            .map(
+              (e) =>
+                  protocol.deserialize<
+                    (
+                      (int, String), {
+                      (_i234.SimpleData, double) namedSubRecord,
+                    })?
+                  >(e),
+            )
+            .toList();
+    map[_i1
+        .getType<
+          ((int, String), {(_i234.SimpleData, double) namedSubRecord})?
+        >()] = (data, protocol) => (data == null)
+        ? null
+        : (
+            protocol.deserialize<(int, String)>(
+              ((data as Map)['p'] as List)[0],
+            ),
+            namedSubRecord: protocol.deserialize<(_i234.SimpleData, double)>(
+              data['n']['namedSubRecord'],
+            ),
+          );
+    map[_i1
+        .getType<
+          List<((int, String), {(_i234.SimpleData, double) namedSubRecord})?>?
+        >()] = (data, protocol) => (data != null
+        ? (data as List)
+              .map(
+                (e) =>
+                    protocol.deserialize<
+                      (
+                        (int, String), {
+                        (_i234.SimpleData, double) namedSubRecord,
+                      })?
+                    >(e),
+              )
+              .toList()
+        : null);
+    map[_i1
+        .getType<
+          ((int, String), {(_i234.SimpleData, double) namedSubRecord})?
+        >()] = (data, protocol) => (data == null)
+        ? null
+        : (
+            protocol.deserialize<(int, String)>(
+              ((data as Map)['p'] as List)[0],
+            ),
+            namedSubRecord: protocol.deserialize<(_i234.SimpleData, double)>(
+              data['n']['namedSubRecord'],
+            ),
+          );
+    map[_i1.getType<(int?, _i4.ProjectStreamingClass?)>()] = (data, protocol) =>
+        (
+          ((data as Map)['p'] as List)[0] == null
+              ? null
+              : protocol.deserialize<int>(data['p'][0]),
+          ((data)['p'] as List)[1] == null
+              ? null
+              : protocol.deserialize<_i4.ProjectStreamingClass>(data['p'][1]),
+        );
+    map[_i1
+        .getType<
+          (String, (Map<String, int>, {bool flag, _i234.SimpleData simpleData}))
+        >()] = (data, protocol) => (
+      protocol.deserialize<String>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<
+        (Map<String, int>, {bool flag, _i234.SimpleData simpleData})
+      >(data['p'][1]),
+    );
+    map[List<(String, int)>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<(String, int)>(e))
+        .toList();
+    map[_i1.getType<(String, int)>()] = (data, protocol) => (
+      protocol.deserialize<String>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<int>(data['p'][1]),
+    );
+    map[_i1
+        .getType<
+          (
+            String,
+            (Map<String, int>, {bool flag, _i234.SimpleData simpleData}),
+          )?
+        >()] = (data, protocol) => (data == null)
+        ? null
+        : (
+            protocol.deserialize<String>(((data as Map)['p'] as List)[0]),
+            protocol.deserialize<
+              (Map<String, int>, {bool flag, _i234.SimpleData simpleData})
+            >(data['p'][1]),
+          );
+    map[List<(String, int)>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<(String, int)>(e))
+        .toList();
+    map[_i1.getType<(String, int)>()] = (data, protocol) => (
+      protocol.deserialize<String>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<int>(data['p'][1]),
+    );
+    map[_i1.getType<List<(String, int)>?>()] = (data, protocol) => (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<(String, int)>(e))
+              .toList()
+        : null);
+    map[_i1.getType<(String, int)>()] = (data, protocol) => (
+      protocol.deserialize<String>(((data as Map)['p'] as List)[0]),
+      protocol.deserialize<int>(data['p'][1]),
+    );
+    return map;
   }
 }

--- a/tests/serverpod_test_shared/lib/src/generated/protocol.dart
+++ b/tests/serverpod_test_shared/lib/src/generated/protocol.dart
@@ -35,6 +35,41 @@ class Protocol extends _i1.SerializationManager {
 
   final Map<String, _i1.SerializationManager> _hostProtocols = {};
 
+  static final Map<Type, dynamic Function(dynamic, Protocol)> _deserializers =
+      _buildDeserializers();
+
+  static Map<Type, dynamic Function(dynamic, Protocol)> _buildDeserializers() {
+    final map = <Type, dynamic Function(dynamic, Protocol)>{};
+    map[_i2.SharedContainer] = (data, protocol) =>
+        _i2.SharedContainer.fromJson(data);
+    map[_i3.DynamicOnShared] = (data, protocol) =>
+        _i3.DynamicOnShared.fromJson(data);
+    map[_i4.SharedEnum] = (data, protocol) => _i4.SharedEnum.fromJson(data);
+    map[_i5.SharedException] = (data, protocol) =>
+        _i5.SharedException.fromJson(data);
+    map[_i6.SharedSubclass] = (data, protocol) =>
+        _i6.SharedSubclass.fromJson(data);
+    map[_i7.SharedModel] = (data, protocol) => _i7.SharedModel.fromJson(data);
+    map[_i8.SharedSealedChild] = (data, protocol) =>
+        _i8.SharedSealedChild.fromJson(data);
+    map[_i1.getType<_i2.SharedContainer?>()] = (data, protocol) =>
+        (data != null ? _i2.SharedContainer.fromJson(data) : null);
+    map[_i1.getType<_i3.DynamicOnShared?>()] = (data, protocol) =>
+        (data != null ? _i3.DynamicOnShared.fromJson(data) : null);
+    map[_i1.getType<_i4.SharedEnum?>()] = (data, protocol) =>
+        (data != null ? _i4.SharedEnum.fromJson(data) : null);
+    map[_i1.getType<_i5.SharedException?>()] = (data, protocol) =>
+        (data != null ? _i5.SharedException.fromJson(data) : null);
+    map[_i1.getType<_i6.SharedSubclass?>()] = (data, protocol) =>
+        (data != null ? _i6.SharedSubclass.fromJson(data) : null);
+    map[_i1.getType<_i7.SharedModel?>()] = (data, protocol) =>
+        (data != null ? _i7.SharedModel.fromJson(data) : null);
+    map[_i1.getType<_i8.SharedSealedChild?>()] = (data, protocol) =>
+        (data != null ? _i8.SharedSealedChild.fromJson(data) : null);
+    map[dynamic] = (data, protocol) => deserializeDynamicFieldValue(data) as T;
+    return map;
+  }
+
   void registerHostProtocol(
     String projectName,
     _i1.SerializationManager protocol,
@@ -69,50 +104,9 @@ class Protocol extends _i1.SerializationManager {
       }
     }
 
-    if (t == _i2.SharedContainer) {
-      return _i2.SharedContainer.fromJson(data) as T;
-    }
-    if (t == _i3.DynamicOnShared) {
-      return _i3.DynamicOnShared.fromJson(data) as T;
-    }
-    if (t == _i4.SharedEnum) {
-      return _i4.SharedEnum.fromJson(data) as T;
-    }
-    if (t == _i5.SharedException) {
-      return _i5.SharedException.fromJson(data) as T;
-    }
-    if (t == _i6.SharedSubclass) {
-      return _i6.SharedSubclass.fromJson(data) as T;
-    }
-    if (t == _i7.SharedModel) {
-      return _i7.SharedModel.fromJson(data) as T;
-    }
-    if (t == _i8.SharedSealedChild) {
-      return _i8.SharedSealedChild.fromJson(data) as T;
-    }
-    if (t == _i1.getType<_i2.SharedContainer?>()) {
-      return (data != null ? _i2.SharedContainer.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i3.DynamicOnShared?>()) {
-      return (data != null ? _i3.DynamicOnShared.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i4.SharedEnum?>()) {
-      return (data != null ? _i4.SharedEnum.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i5.SharedException?>()) {
-      return (data != null ? _i5.SharedException.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i6.SharedSubclass?>()) {
-      return (data != null ? _i6.SharedSubclass.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i7.SharedModel?>()) {
-      return (data != null ? _i7.SharedModel.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i8.SharedSealedChild?>()) {
-      return (data != null ? _i8.SharedSealedChild.fromJson(data) : null) as T;
-    }
-    if (t == dynamic) {
-      return deserializeDynamicFieldValue(data) as T;
+    final fn = _deserializers[t];
+    if (fn != null) {
+      return fn(data, this) as T;
     }
     return super.deserialize<T>(data, t);
   }

--- a/tests/serverpod_test_shared/lib/src/generated/protocol.dart
+++ b/tests/serverpod_test_shared/lib/src/generated/protocol.dart
@@ -48,6 +48,9 @@ class Protocol extends _i1.DatabaseSerializationManager {
 
   final Set<_i2.SerializationManager> _hostProtocols = {};
 
+  static final Map<Type, dynamic Function(dynamic, Protocol)> _deserializers =
+      _buildDeserializers();
+
   static List<_i1.TableDefinition> get targetTableDefinitions => [
     _i1.TableDefinition(
       name: 'shared_table_record',
@@ -128,103 +131,9 @@ class Protocol extends _i1.DatabaseSerializationManager {
       }
     }
 
-    if (t == _i3.SharedContainer) {
-      return _i3.SharedContainer.fromJson(data) as T;
-    }
-    if (t == _i4.DynamicOnShared) {
-      return _i4.DynamicOnShared.fromJson(data) as T;
-    }
-    if (t == _i5.SharedEnum) {
-      return _i5.SharedEnum.fromJson(data) as T;
-    }
-    if (t == _i6.SharedException) {
-      return _i6.SharedException.fromJson(data) as T;
-    }
-    if (t == _i7.SharedExtendedAppException) {
-      return _i7.SharedExtendedAppException.fromJson(data) as T;
-    }
-    if (t == _i8.SharedBaseAppException) {
-      return _i8.SharedBaseAppException.fromJson(data) as T;
-    }
-    if (t == _i9.SharedSubclass) {
-      return _i9.SharedSubclass.fromJson(data) as T;
-    }
-    if (t == _i10.SharedModel) {
-      return _i10.SharedModel.fromJson(data) as T;
-    }
-    if (t == _i11.SharedSealedChild) {
-      return _i11.SharedSealedChild.fromJson(data) as T;
-    }
-    if (t == _i12.SharedNotFoundException) {
-      return _i12.SharedNotFoundException.fromJson(data) as T;
-    }
-    if (t == _i12.SharedValidationException) {
-      return _i12.SharedValidationException.fromJson(data) as T;
-    }
-    if (t == _i13.SharedObjectWithSealedException) {
-      return _i13.SharedObjectWithSealedException.fromJson(data) as T;
-    }
-    if (t == _i14.SharedTableRecord) {
-      return _i14.SharedTableRecord.fromJson(data) as T;
-    }
-    if (t == _i2.getType<_i3.SharedContainer?>()) {
-      return (data != null ? _i3.SharedContainer.fromJson(data) : null) as T;
-    }
-    if (t == _i2.getType<_i4.DynamicOnShared?>()) {
-      return (data != null ? _i4.DynamicOnShared.fromJson(data) : null) as T;
-    }
-    if (t == _i2.getType<_i5.SharedEnum?>()) {
-      return (data != null ? _i5.SharedEnum.fromJson(data) : null) as T;
-    }
-    if (t == _i2.getType<_i6.SharedException?>()) {
-      return (data != null ? _i6.SharedException.fromJson(data) : null) as T;
-    }
-    if (t == _i2.getType<_i7.SharedExtendedAppException?>()) {
-      return (data != null
-              ? _i7.SharedExtendedAppException.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i2.getType<_i8.SharedBaseAppException?>()) {
-      return (data != null ? _i8.SharedBaseAppException.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i2.getType<_i9.SharedSubclass?>()) {
-      return (data != null ? _i9.SharedSubclass.fromJson(data) : null) as T;
-    }
-    if (t == _i2.getType<_i10.SharedModel?>()) {
-      return (data != null ? _i10.SharedModel.fromJson(data) : null) as T;
-    }
-    if (t == _i2.getType<_i11.SharedSealedChild?>()) {
-      return (data != null ? _i11.SharedSealedChild.fromJson(data) : null) as T;
-    }
-    if (t == _i2.getType<_i12.SharedNotFoundException?>()) {
-      return (data != null ? _i12.SharedNotFoundException.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i2.getType<_i12.SharedValidationException?>()) {
-      return (data != null
-              ? _i12.SharedValidationException.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i2.getType<_i13.SharedObjectWithSealedException?>()) {
-      return (data != null
-              ? _i13.SharedObjectWithSealedException.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i2.getType<_i14.SharedTableRecord?>()) {
-      return (data != null ? _i14.SharedTableRecord.fromJson(data) : null) as T;
-    }
-    if (t == dynamic) {
-      return deserializeDynamicFieldValue(data) as T;
-    }
-    if (t == List<_i15.SharedSealedAppException>) {
-      return (data as List)
-              .map((e) => deserialize<_i15.SharedSealedAppException>(e))
-              .toList()
-          as T;
+    final fn = _deserializers[t];
+    if (fn != null) {
+      return fn(data, this) as T;
     }
     return super.deserialize<T>(data, t);
   }
@@ -424,5 +333,69 @@ class Protocol extends _i1.DatabaseSerializationManager {
       return null;
     }
     throw Exception('Unsupported record type ${record.runtimeType}');
+  }
+
+  static Map<Type, dynamic Function(dynamic, Protocol)> _buildDeserializers() {
+    final map = <Type, dynamic Function(dynamic, Protocol)>{};
+    map[_i3.SharedContainer] = (data, protocol) =>
+        _i3.SharedContainer.fromJson(data);
+    map[_i4.DynamicOnShared] = (data, protocol) =>
+        _i4.DynamicOnShared.fromJson(data);
+    map[_i5.SharedEnum] = (data, protocol) => _i5.SharedEnum.fromJson(data);
+    map[_i6.SharedException] = (data, protocol) =>
+        _i6.SharedException.fromJson(data);
+    map[_i7.SharedExtendedAppException] = (data, protocol) =>
+        _i7.SharedExtendedAppException.fromJson(data);
+    map[_i8.SharedBaseAppException] = (data, protocol) =>
+        _i8.SharedBaseAppException.fromJson(data);
+    map[_i9.SharedSubclass] = (data, protocol) =>
+        _i9.SharedSubclass.fromJson(data);
+    map[_i10.SharedModel] = (data, protocol) => _i10.SharedModel.fromJson(data);
+    map[_i11.SharedSealedChild] = (data, protocol) =>
+        _i11.SharedSealedChild.fromJson(data);
+    map[_i12.SharedNotFoundException] = (data, protocol) =>
+        _i12.SharedNotFoundException.fromJson(data);
+    map[_i12.SharedValidationException] = (data, protocol) =>
+        _i12.SharedValidationException.fromJson(data);
+    map[_i13.SharedObjectWithSealedException] = (data, protocol) =>
+        _i13.SharedObjectWithSealedException.fromJson(data);
+    map[_i14.SharedTableRecord] = (data, protocol) =>
+        _i14.SharedTableRecord.fromJson(data);
+    map[_i2.getType<_i3.SharedContainer?>()] = (data, protocol) =>
+        (data != null ? _i3.SharedContainer.fromJson(data) : null);
+    map[_i2.getType<_i4.DynamicOnShared?>()] = (data, protocol) =>
+        (data != null ? _i4.DynamicOnShared.fromJson(data) : null);
+    map[_i2.getType<_i5.SharedEnum?>()] = (data, protocol) =>
+        (data != null ? _i5.SharedEnum.fromJson(data) : null);
+    map[_i2.getType<_i6.SharedException?>()] = (data, protocol) =>
+        (data != null ? _i6.SharedException.fromJson(data) : null);
+    map[_i2.getType<_i7.SharedExtendedAppException?>()] = (data, protocol) =>
+        (data != null ? _i7.SharedExtendedAppException.fromJson(data) : null);
+    map[_i2.getType<_i8.SharedBaseAppException?>()] = (data, protocol) =>
+        (data != null ? _i8.SharedBaseAppException.fromJson(data) : null);
+    map[_i2.getType<_i9.SharedSubclass?>()] = (data, protocol) =>
+        (data != null ? _i9.SharedSubclass.fromJson(data) : null);
+    map[_i2.getType<_i10.SharedModel?>()] = (data, protocol) =>
+        (data != null ? _i10.SharedModel.fromJson(data) : null);
+    map[_i2.getType<_i11.SharedSealedChild?>()] = (data, protocol) =>
+        (data != null ? _i11.SharedSealedChild.fromJson(data) : null);
+    map[_i2.getType<_i12.SharedNotFoundException?>()] = (data, protocol) =>
+        (data != null ? _i12.SharedNotFoundException.fromJson(data) : null);
+    map[_i2.getType<_i12.SharedValidationException?>()] = (data, protocol) =>
+        (data != null ? _i12.SharedValidationException.fromJson(data) : null);
+    map[_i2
+        .getType<_i13.SharedObjectWithSealedException?>()] = (data, protocol) =>
+        (data != null
+        ? _i13.SharedObjectWithSealedException.fromJson(data)
+        : null);
+    map[_i2.getType<_i14.SharedTableRecord?>()] = (data, protocol) =>
+        (data != null ? _i14.SharedTableRecord.fromJson(data) : null);
+    map[dynamic] = (data, protocol) =>
+        protocol.deserializeDynamicFieldValue(data);
+    map[List<_i15.SharedSealedAppException>] = (data, protocol) =>
+        (data as List)
+            .map((e) => protocol.deserialize<_i15.SharedSealedAppException>(e))
+            .toList();
+    return map;
   }
 }

--- a/tests/serverpod_test_shared_module/serverpod_test_shared_module_client/lib/src/protocol/protocol.dart
+++ b/tests/serverpod_test_shared_module/serverpod_test_shared_module_client/lib/src/protocol/protocol.dart
@@ -12,9 +12,9 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_database/serverpod_database.dart' as _i1;
+import 'package:serverpod_client/serverpod_client.dart' as _i2;
 import 'package:serverpod_test_shared_module_shared/serverpod_test_shared_module_shared.dart'
-    as _i2;
-import 'package:serverpod_client/serverpod_client.dart' as _i3;
+    as _i3;
 export 'package:serverpod_test_shared_module_shared/serverpod_test_shared_module_shared.dart'
     hide Protocol;
 export 'client.dart';
@@ -26,21 +26,24 @@ class Protocol extends _i1.DatabaseSerializationManager {
 
   static final Protocol _instance = Protocol._();
 
-  final Set<_i3.SerializationManager> _hostProtocols = {};
+  final Set<_i2.SerializationManager> _hostProtocols = {};
+
+  static final Map<Type, dynamic Function(dynamic, Protocol)> _deserializers =
+      _buildDeserializers();
 
   static List<_i1.TableDefinition> get targetTableDefinitions => [
-    ..._i2.Protocol() is _i1.DatabaseSerializationManager
-        ? (_i2.Protocol() as _i1.DatabaseSerializationManager)
+    ..._i3.Protocol() is _i1.DatabaseSerializationManager
+        ? (_i3.Protocol() as _i1.DatabaseSerializationManager)
               .getTargetTableDefinitions()
         : [],
   ];
 
   void registerHostProtocol(
     String projectName,
-    _i3.SerializationManager protocol,
+    _i2.SerializationManager protocol,
   ) {
     _hostProtocols.add(protocol);
-    _i2.Protocol().registerHostProtocol(projectName, protocol);
+    _i3.Protocol().registerHostProtocol(projectName, protocol);
   }
 
   static String? getClassNameFromObjectJson(dynamic data) {
@@ -73,9 +76,13 @@ class Protocol extends _i1.DatabaseSerializationManager {
       }
     }
 
+    final fn = _deserializers[t];
+    if (fn != null) {
+      return fn(data, this) as T;
+    }
     try {
-      return _i2.Protocol().deserialize<T>(data, t);
-    } on _i3.DeserializationTypeNotFoundException catch (_) {}
+      return _i3.Protocol().deserialize<T>(data, t);
+    } on _i2.DeserializationTypeNotFoundException catch (_) {}
     return super.deserialize<T>(data, t);
   }
 
@@ -97,7 +104,7 @@ class Protocol extends _i1.DatabaseSerializationManager {
       );
     }
 
-    className = _i2.Protocol().getClassNameForObject(data);
+    className = _i3.Protocol().getClassNameForObject(data);
     if (className != null) return className;
     return null;
   }
@@ -109,7 +116,7 @@ class Protocol extends _i1.DatabaseSerializationManager {
       return super.deserializeByClassName(data);
     }
     try {
-      return _i2.Protocol().deserializeByClassName(data);
+      return _i3.Protocol().deserializeByClassName(data);
     } on FormatException catch (_) {}
     return super.deserializeByClassName(data);
   }
@@ -132,8 +139,8 @@ class Protocol extends _i1.DatabaseSerializationManager {
         'data': object,
       };
       return forProtocol
-          ? _i3.SerializationManager.toEncodableForProtocol(wrapped)
-          : _i3.SerializationManager.toEncodable(wrapped);
+          ? _i2.SerializationManager.toEncodableForProtocol(wrapped)
+          : _i2.SerializationManager.toEncodable(wrapped);
     }
     return super.dynamicFieldToJson(object, forProtocol: forProtocol);
   }
@@ -176,7 +183,7 @@ class Protocol extends _i1.DatabaseSerializationManager {
   @override
   _i1.Table? getTableForType(Type t) {
     {
-      var protocol = _i2.Protocol();
+      var protocol = _i3.Protocol();
       var table = protocol is _i1.DatabaseSerializationManager
           ? (protocol as _i1.DatabaseSerializationManager).getTableForType(t)
           : null;
@@ -204,5 +211,10 @@ class Protocol extends _i1.DatabaseSerializationManager {
       return null;
     }
     throw Exception('Unsupported record type ${record.runtimeType}');
+  }
+
+  static Map<Type, dynamic Function(dynamic, Protocol)> _buildDeserializers() {
+    final map = <Type, dynamic Function(dynamic, Protocol)>{};
+    return map;
   }
 }

--- a/tests/serverpod_test_shared_module/serverpod_test_shared_module_server/lib/src/generated/protocol.dart
+++ b/tests/serverpod_test_shared_module/serverpod_test_shared_module_server/lib/src/generated/protocol.dart
@@ -27,6 +27,9 @@ class Protocol extends _i1.DatabaseSerializationManager {
 
   final Set<_i1.SerializationManager> _hostProtocols = {};
 
+  static final Map<Type, dynamic Function(dynamic, Protocol)> _deserializers =
+      _buildDeserializers();
+
   static List<_i2.TableDefinition> get targetTableDefinitions => [
     ..._i3.Protocol() is _i1.DatabaseSerializationManager
         ? (_i3.Protocol() as _i1.DatabaseSerializationManager)
@@ -72,6 +75,10 @@ class Protocol extends _i1.DatabaseSerializationManager {
       }
     }
 
+    final fn = _deserializers[t];
+    if (fn != null) {
+      return fn(data, this) as T;
+    }
     try {
       return _i3.Protocol().deserialize<T>(data, t);
     } on _i1.DeserializationTypeNotFoundException catch (_) {}
@@ -223,5 +230,10 @@ class Protocol extends _i1.DatabaseSerializationManager {
       return _i2.Protocol().mapRecordToJson(record);
     } catch (_) {}
     throw Exception('Unsupported record type ${record.runtimeType}');
+  }
+
+  static Map<Type, dynamic Function(dynamic, Protocol)> _buildDeserializers() {
+    final map = <Type, dynamic Function(dynamic, Protocol)>{};
+    return map;
   }
 }

--- a/tests/serverpod_test_shared_module/serverpod_test_shared_module_shared/lib/src/generated/protocol.dart
+++ b/tests/serverpod_test_shared_module/serverpod_test_shared_module_shared/lib/src/generated/protocol.dart
@@ -25,6 +25,9 @@ class Protocol extends _i1.DatabaseSerializationManager {
 
   final Set<_i2.SerializationManager> _hostProtocols = {};
 
+  static final Map<Type, dynamic Function(dynamic, Protocol)> _deserializers =
+      _buildDeserializers();
+
   static List<_i1.TableDefinition> get targetTableDefinitions => [
     _i1.TableDefinition(
       name: 'shared_module_table',
@@ -95,14 +98,9 @@ class Protocol extends _i1.DatabaseSerializationManager {
       }
     }
 
-    if (t == _i3.SharedModuleTable) {
-      return _i3.SharedModuleTable.fromJson(data) as T;
-    }
-    if (t == _i2.getType<_i3.SharedModuleTable?>()) {
-      return (data != null ? _i3.SharedModuleTable.fromJson(data) : null) as T;
-    }
-    if (t == dynamic) {
-      return deserializeDynamicFieldValue(data) as T;
+    final fn = _deserializers[t];
+    if (fn != null) {
+      return fn(data, this) as T;
     }
     return super.deserialize<T>(data, t);
   }
@@ -230,5 +228,16 @@ class Protocol extends _i1.DatabaseSerializationManager {
       return null;
     }
     throw Exception('Unsupported record type ${record.runtimeType}');
+  }
+
+  static Map<Type, dynamic Function(dynamic, Protocol)> _buildDeserializers() {
+    final map = <Type, dynamic Function(dynamic, Protocol)>{};
+    map[_i3.SharedModuleTable] = (data, protocol) =>
+        _i3.SharedModuleTable.fromJson(data);
+    map[_i2.getType<_i3.SharedModuleTable?>()] = (data, protocol) =>
+        (data != null ? _i3.SharedModuleTable.fromJson(data) : null);
+    map[dynamic] = (data, protocol) =>
+        protocol.deserializeDynamicFieldValue(data);
+    return map;
   }
 }

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/protocol.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/protocol.dart
@@ -1684,6 +1684,1079 @@ class Protocol extends _i1.DatabaseSerializationManager {
     ),
   ];
 
+  static final Map<Type, dynamic Function(dynamic, Protocol)> _deserializers =
+      _buildDeserializers();
+
+  static Map<Type, dynamic Function(dynamic, Protocol)> _buildDeserializers() {
+    final map = <Type, dynamic Function(dynamic, Protocol)>{};
+    map[_i2.CourseUuid] = (data, protocol) => _i2.CourseUuid.fromJson(data);
+    map[_i3.EnrollmentInt] = (data, protocol) =>
+        _i3.EnrollmentInt.fromJson(data);
+    map[_i4.StudentUuid] = (data, protocol) => _i4.StudentUuid.fromJson(data);
+    map[_i5.ArenaUuid] = (data, protocol) => _i5.ArenaUuid.fromJson(data);
+    map[_i6.PlayerUuid] = (data, protocol) => _i6.PlayerUuid.fromJson(data);
+    map[_i7.TeamInt] = (data, protocol) => _i7.TeamInt.fromJson(data);
+    map[_i8.CommentInt] = (data, protocol) => _i8.CommentInt.fromJson(data);
+    map[_i9.CustomerInt] = (data, protocol) => _i9.CustomerInt.fromJson(data);
+    map[_i10.OrderUuid] = (data, protocol) => _i10.OrderUuid.fromJson(data);
+    map[_i11.AddressUuid] = (data, protocol) => _i11.AddressUuid.fromJson(data);
+    map[_i12.CitizenInt] = (data, protocol) => _i12.CitizenInt.fromJson(data);
+    map[_i13.CompanyUuid] = (data, protocol) => _i13.CompanyUuid.fromJson(data);
+    map[_i14.TownInt] = (data, protocol) => _i14.TownInt.fromJson(data);
+    map[_i15.ChangedIdTypeSelf] = (data, protocol) =>
+        _i15.ChangedIdTypeSelf.fromJson(data);
+    map[_i16.BigIntDefault] = (data, protocol) =>
+        _i16.BigIntDefault.fromJson(data);
+    map[_i17.BigIntDefaultMix] = (data, protocol) =>
+        _i17.BigIntDefaultMix.fromJson(data);
+    map[_i18.BigIntDefaultModel] = (data, protocol) =>
+        _i18.BigIntDefaultModel.fromJson(data);
+    map[_i19.BigIntDefaultPersist] = (data, protocol) =>
+        _i19.BigIntDefaultPersist.fromJson(data);
+    map[_i20.BoolDefault] = (data, protocol) => _i20.BoolDefault.fromJson(data);
+    map[_i21.BoolDefaultMix] = (data, protocol) =>
+        _i21.BoolDefaultMix.fromJson(data);
+    map[_i22.BoolDefaultModel] = (data, protocol) =>
+        _i22.BoolDefaultModel.fromJson(data);
+    map[_i23.BoolDefaultPersist] = (data, protocol) =>
+        _i23.BoolDefaultPersist.fromJson(data);
+    map[_i24.DateTimeDefault] = (data, protocol) =>
+        _i24.DateTimeDefault.fromJson(data);
+    map[_i25.DateTimeDefaultMix] = (data, protocol) =>
+        _i25.DateTimeDefaultMix.fromJson(data);
+    map[_i26.DateTimeDefaultModel] = (data, protocol) =>
+        _i26.DateTimeDefaultModel.fromJson(data);
+    map[_i27.DateTimeDefaultPersist] = (data, protocol) =>
+        _i27.DateTimeDefaultPersist.fromJson(data);
+    map[_i28.DoubleDefault] = (data, protocol) =>
+        _i28.DoubleDefault.fromJson(data);
+    map[_i29.DoubleDefaultMix] = (data, protocol) =>
+        _i29.DoubleDefaultMix.fromJson(data);
+    map[_i30.DoubleDefaultModel] = (data, protocol) =>
+        _i30.DoubleDefaultModel.fromJson(data);
+    map[_i31.DoubleDefaultPersist] = (data, protocol) =>
+        _i31.DoubleDefaultPersist.fromJson(data);
+    map[_i32.DurationDefault] = (data, protocol) =>
+        _i32.DurationDefault.fromJson(data);
+    map[_i33.DurationDefaultMix] = (data, protocol) =>
+        _i33.DurationDefaultMix.fromJson(data);
+    map[_i34.DurationDefaultModel] = (data, protocol) =>
+        _i34.DurationDefaultModel.fromJson(data);
+    map[_i35.DurationDefaultPersist] = (data, protocol) =>
+        _i35.DurationDefaultPersist.fromJson(data);
+    map[_i36.EnumDefault] = (data, protocol) => _i36.EnumDefault.fromJson(data);
+    map[_i37.EnumDefaultMix] = (data, protocol) =>
+        _i37.EnumDefaultMix.fromJson(data);
+    map[_i38.EnumDefaultModel] = (data, protocol) =>
+        _i38.EnumDefaultModel.fromJson(data);
+    map[_i39.EnumDefaultPersist] = (data, protocol) =>
+        _i39.EnumDefaultPersist.fromJson(data);
+    map[_i40.ByIndexEnum] = (data, protocol) => _i40.ByIndexEnum.fromJson(data);
+    map[_i41.ByNameEnum] = (data, protocol) => _i41.ByNameEnum.fromJson(data);
+    map[_i42.DefaultValueEnum] = (data, protocol) =>
+        _i42.DefaultValueEnum.fromJson(data);
+    map[_i43.DefaultException] = (data, protocol) =>
+        _i43.DefaultException.fromJson(data);
+    map[_i44.IntDefault] = (data, protocol) => _i44.IntDefault.fromJson(data);
+    map[_i45.IntDefaultMix] = (data, protocol) =>
+        _i45.IntDefaultMix.fromJson(data);
+    map[_i46.IntDefaultModel] = (data, protocol) =>
+        _i46.IntDefaultModel.fromJson(data);
+    map[_i47.IntDefaultPersist] = (data, protocol) =>
+        _i47.IntDefaultPersist.fromJson(data);
+    map[_i48.StringDefault] = (data, protocol) =>
+        _i48.StringDefault.fromJson(data);
+    map[_i49.StringDefaultMix] = (data, protocol) =>
+        _i49.StringDefaultMix.fromJson(data);
+    map[_i50.StringDefaultModel] = (data, protocol) =>
+        _i50.StringDefaultModel.fromJson(data);
+    map[_i51.StringDefaultPersist] = (data, protocol) =>
+        _i51.StringDefaultPersist.fromJson(data);
+    map[_i52.UriDefault] = (data, protocol) => _i52.UriDefault.fromJson(data);
+    map[_i53.UriDefaultMix] = (data, protocol) =>
+        _i53.UriDefaultMix.fromJson(data);
+    map[_i54.UriDefaultModel] = (data, protocol) =>
+        _i54.UriDefaultModel.fromJson(data);
+    map[_i55.UriDefaultPersist] = (data, protocol) =>
+        _i55.UriDefaultPersist.fromJson(data);
+    map[_i56.UuidDefault] = (data, protocol) => _i56.UuidDefault.fromJson(data);
+    map[_i57.UuidDefaultMix] = (data, protocol) =>
+        _i57.UuidDefaultMix.fromJson(data);
+    map[_i58.UuidDefaultModel] = (data, protocol) =>
+        _i58.UuidDefaultModel.fromJson(data);
+    map[_i59.UuidDefaultPersist] = (data, protocol) =>
+        _i59.UuidDefaultPersist.fromJson(data);
+    map[_i60.EmptyModel] = (data, protocol) => _i60.EmptyModel.fromJson(data);
+    map[_i61.EmptyModelRelationItem] = (data, protocol) =>
+        _i61.EmptyModelRelationItem.fromJson(data);
+    map[_i62.EmptyModelWithTable] = (data, protocol) =>
+        _i62.EmptyModelWithTable.fromJson(data);
+    map[_i63.RelationEmptyModel] = (data, protocol) =>
+        _i63.RelationEmptyModel.fromJson(data);
+    map[_i64.ChildClassExplicitColumn] = (data, protocol) =>
+        _i64.ChildClassExplicitColumn.fromJson(data);
+    map[_i65.NonTableParentClass] = (data, protocol) =>
+        _i65.NonTableParentClass.fromJson(data);
+    map[_i66.ModifiedColumnName] = (data, protocol) =>
+        _i66.ModifiedColumnName.fromJson(data);
+    map[_i67.Department] = (data, protocol) => _i67.Department.fromJson(data);
+    map[_i68.Employee] = (data, protocol) => _i68.Employee.fromJson(data);
+    map[_i69.Contractor] = (data, protocol) => _i69.Contractor.fromJson(data);
+    map[_i70.Service] = (data, protocol) => _i70.Service.fromJson(data);
+    map[_i71.TableWithExplicitColumnName] = (data, protocol) =>
+        _i71.TableWithExplicitColumnName.fromJson(data);
+    map[_i72.SealedGrandChild] = (data, protocol) =>
+        _i72.SealedGrandChild.fromJson(data);
+    map[_i72.SealedChild] = (data, protocol) => _i72.SealedChild.fromJson(data);
+    map[_i72.SealedOtherChild] = (data, protocol) =>
+        _i72.SealedOtherChild.fromJson(data);
+    map[_i73.CityWithLongTableName] = (data, protocol) =>
+        _i73.CityWithLongTableName.fromJson(data);
+    map[_i74.OrganizationWithLongTableName] = (data, protocol) =>
+        _i74.OrganizationWithLongTableName.fromJson(data);
+    map[_i75.PersonWithLongTableName] = (data, protocol) =>
+        _i75.PersonWithLongTableName.fromJson(data);
+    map[_i76.MaxFieldName] = (data, protocol) =>
+        _i76.MaxFieldName.fromJson(data);
+    map[_i77.LongImplicitIdField] = (data, protocol) =>
+        _i77.LongImplicitIdField.fromJson(data);
+    map[_i78.LongImplicitIdFieldCollection] = (data, protocol) =>
+        _i78.LongImplicitIdFieldCollection.fromJson(data);
+    map[_i79.RelationToMultipleMaxFieldName] = (data, protocol) =>
+        _i79.RelationToMultipleMaxFieldName.fromJson(data);
+    map[_i80.UserNote] = (data, protocol) => _i80.UserNote.fromJson(data);
+    map[_i81.UserNoteCollection] = (data, protocol) =>
+        _i81.UserNoteCollection.fromJson(data);
+    map[_i82.UserNoteCollectionWithALongName] = (data, protocol) =>
+        _i82.UserNoteCollectionWithALongName.fromJson(data);
+    map[_i83.UserNoteWithALongName] = (data, protocol) =>
+        _i83.UserNoteWithALongName.fromJson(data);
+    map[_i84.MultipleMaxFieldName] = (data, protocol) =>
+        _i84.MultipleMaxFieldName.fromJson(data);
+    map[_i85.City] = (data, protocol) => _i85.City.fromJson(data);
+    map[_i86.Organization] = (data, protocol) =>
+        _i86.Organization.fromJson(data);
+    map[_i87.Person] = (data, protocol) => _i87.Person.fromJson(data);
+    map[_i88.Course] = (data, protocol) => _i88.Course.fromJson(data);
+    map[_i89.Enrollment] = (data, protocol) => _i89.Enrollment.fromJson(data);
+    map[_i90.Student] = (data, protocol) => _i90.Student.fromJson(data);
+    map[_i91.Arena] = (data, protocol) => _i91.Arena.fromJson(data);
+    map[_i92.Player] = (data, protocol) => _i92.Player.fromJson(data);
+    map[_i93.Team] = (data, protocol) => _i93.Team.fromJson(data);
+    map[_i94.Comment] = (data, protocol) => _i94.Comment.fromJson(data);
+    map[_i95.Customer] = (data, protocol) => _i95.Customer.fromJson(data);
+    map[_i96.Book] = (data, protocol) => _i96.Book.fromJson(data);
+    map[_i97.Chapter] = (data, protocol) => _i97.Chapter.fromJson(data);
+    map[_i98.Order] = (data, protocol) => _i98.Order.fromJson(data);
+    map[_i99.Address] = (data, protocol) => _i99.Address.fromJson(data);
+    map[_i100.Citizen] = (data, protocol) => _i100.Citizen.fromJson(data);
+    map[_i101.Company] = (data, protocol) => _i101.Company.fromJson(data);
+    map[_i102.Town] = (data, protocol) => _i102.Town.fromJson(data);
+    map[_i103.Blocking] = (data, protocol) => _i103.Blocking.fromJson(data);
+    map[_i104.Member] = (data, protocol) => _i104.Member.fromJson(data);
+    map[_i105.Cat] = (data, protocol) => _i105.Cat.fromJson(data);
+    map[_i106.Post] = (data, protocol) => _i106.Post.fromJson(data);
+    map[_i107.ObjectFieldPersist] = (data, protocol) =>
+        _i107.ObjectFieldPersist.fromJson(data);
+    map[_i108.ObjectFieldScopes] = (data, protocol) =>
+        _i108.ObjectFieldScopes.fromJson(data);
+    map[_i109.ObjectWithBit] = (data, protocol) =>
+        _i109.ObjectWithBit.fromJson(data);
+    map[_i110.ObjectWithByteData] = (data, protocol) =>
+        _i110.ObjectWithByteData.fromJson(data);
+    map[_i111.ObjectWithDuration] = (data, protocol) =>
+        _i111.ObjectWithDuration.fromJson(data);
+    map[_i112.ObjectWithDynamic] = (data, protocol) =>
+        _i112.ObjectWithDynamic.fromJson(data);
+    map[_i113.ObjectWithEnum] = (data, protocol) =>
+        _i113.ObjectWithEnum.fromJson(data);
+    map[_i114.ObjectWithEnumEnhanced] = (data, protocol) =>
+        _i114.ObjectWithEnumEnhanced.fromJson(data);
+    map[_i115.ObjectWithHalfVector] = (data, protocol) =>
+        _i115.ObjectWithHalfVector.fromJson(data);
+    map[_i116.ObjectWithIndex] = (data, protocol) =>
+        _i116.ObjectWithIndex.fromJson(data);
+    map[_i117.ObjectWithJsonb] = (data, protocol) =>
+        _i117.ObjectWithJsonb.fromJson(data);
+    map[_i118.ObjectWithJsonbClassLevel] = (data, protocol) =>
+        _i118.ObjectWithJsonbClassLevel.fromJson(data);
+    map[_i119.ObjectWithMaps] = (data, protocol) =>
+        _i119.ObjectWithMaps.fromJson(data);
+    map[_i120.ObjectWithObject] = (data, protocol) =>
+        _i120.ObjectWithObject.fromJson(data);
+    map[_i121.ObjectWithParent] = (data, protocol) =>
+        _i121.ObjectWithParent.fromJson(data);
+    map[_i122.ObjectWithSealedClass] = (data, protocol) =>
+        _i122.ObjectWithSealedClass.fromJson(data);
+    map[_i123.ObjectWithSelfParent] = (data, protocol) =>
+        _i123.ObjectWithSelfParent.fromJson(data);
+    map[_i124.ObjectWithSparseVector] = (data, protocol) =>
+        _i124.ObjectWithSparseVector.fromJson(data);
+    map[_i125.ObjectWithUuid] = (data, protocol) =>
+        _i125.ObjectWithUuid.fromJson(data);
+    map[_i126.ObjectWithVector] = (data, protocol) =>
+        _i126.ObjectWithVector.fromJson(data);
+    map[_i127.RelatedUniqueData] = (data, protocol) =>
+        _i127.RelatedUniqueData.fromJson(data);
+    map[_i128.ModelWithRequiredField] = (data, protocol) =>
+        _i128.ModelWithRequiredField.fromJson(data);
+    map[_i129.SimpleData] = (data, protocol) => _i129.SimpleData.fromJson(data);
+    map[_i130.SimpleDateTime] = (data, protocol) =>
+        _i130.SimpleDateTime.fromJson(data);
+    map[_i131.TestEnum] = (data, protocol) => _i131.TestEnum.fromJson(data);
+    map[_i132.TestEnumDefaultSerialization] = (data, protocol) =>
+        _i132.TestEnumDefaultSerialization.fromJson(data);
+    map[_i133.TestEnumEnhanced] = (data, protocol) =>
+        _i133.TestEnumEnhanced.fromJson(data);
+    map[_i134.TestEnumEnhancedByName] = (data, protocol) =>
+        _i134.TestEnumEnhancedByName.fromJson(data);
+    map[_i135.TestEnumStringified] = (data, protocol) =>
+        _i135.TestEnumStringified.fromJson(data);
+    map[_i136.Types] = (data, protocol) => _i136.Types.fromJson(data);
+    map[_i137.UniqueData] = (data, protocol) => _i137.UniqueData.fromJson(data);
+    map[_i138.UniqueDataWithNonPersist] = (data, protocol) =>
+        _i138.UniqueDataWithNonPersist.fromJson(data);
+    map[_i139.UpsertTestModel] = (data, protocol) =>
+        _i139.UpsertTestModel.fromJson(data);
+    map[_i140.getType<_i2.CourseUuid?>()] = (data, protocol) =>
+        (data != null ? _i2.CourseUuid.fromJson(data) : null);
+    map[_i140.getType<_i3.EnrollmentInt?>()] = (data, protocol) =>
+        (data != null ? _i3.EnrollmentInt.fromJson(data) : null);
+    map[_i140.getType<_i4.StudentUuid?>()] = (data, protocol) =>
+        (data != null ? _i4.StudentUuid.fromJson(data) : null);
+    map[_i140.getType<_i5.ArenaUuid?>()] = (data, protocol) =>
+        (data != null ? _i5.ArenaUuid.fromJson(data) : null);
+    map[_i140.getType<_i6.PlayerUuid?>()] = (data, protocol) =>
+        (data != null ? _i6.PlayerUuid.fromJson(data) : null);
+    map[_i140.getType<_i7.TeamInt?>()] = (data, protocol) =>
+        (data != null ? _i7.TeamInt.fromJson(data) : null);
+    map[_i140.getType<_i8.CommentInt?>()] = (data, protocol) =>
+        (data != null ? _i8.CommentInt.fromJson(data) : null);
+    map[_i140.getType<_i9.CustomerInt?>()] = (data, protocol) =>
+        (data != null ? _i9.CustomerInt.fromJson(data) : null);
+    map[_i140.getType<_i10.OrderUuid?>()] = (data, protocol) =>
+        (data != null ? _i10.OrderUuid.fromJson(data) : null);
+    map[_i140.getType<_i11.AddressUuid?>()] = (data, protocol) =>
+        (data != null ? _i11.AddressUuid.fromJson(data) : null);
+    map[_i140.getType<_i12.CitizenInt?>()] = (data, protocol) =>
+        (data != null ? _i12.CitizenInt.fromJson(data) : null);
+    map[_i140.getType<_i13.CompanyUuid?>()] = (data, protocol) =>
+        (data != null ? _i13.CompanyUuid.fromJson(data) : null);
+    map[_i140.getType<_i14.TownInt?>()] = (data, protocol) =>
+        (data != null ? _i14.TownInt.fromJson(data) : null);
+    map[_i140.getType<_i15.ChangedIdTypeSelf?>()] = (data, protocol) =>
+        (data != null ? _i15.ChangedIdTypeSelf.fromJson(data) : null);
+    map[_i140.getType<_i16.BigIntDefault?>()] = (data, protocol) =>
+        (data != null ? _i16.BigIntDefault.fromJson(data) : null);
+    map[_i140.getType<_i17.BigIntDefaultMix?>()] = (data, protocol) =>
+        (data != null ? _i17.BigIntDefaultMix.fromJson(data) : null);
+    map[_i140.getType<_i18.BigIntDefaultModel?>()] = (data, protocol) =>
+        (data != null ? _i18.BigIntDefaultModel.fromJson(data) : null);
+    map[_i140.getType<_i19.BigIntDefaultPersist?>()] = (data, protocol) =>
+        (data != null ? _i19.BigIntDefaultPersist.fromJson(data) : null);
+    map[_i140.getType<_i20.BoolDefault?>()] = (data, protocol) =>
+        (data != null ? _i20.BoolDefault.fromJson(data) : null);
+    map[_i140.getType<_i21.BoolDefaultMix?>()] = (data, protocol) =>
+        (data != null ? _i21.BoolDefaultMix.fromJson(data) : null);
+    map[_i140.getType<_i22.BoolDefaultModel?>()] = (data, protocol) =>
+        (data != null ? _i22.BoolDefaultModel.fromJson(data) : null);
+    map[_i140.getType<_i23.BoolDefaultPersist?>()] = (data, protocol) =>
+        (data != null ? _i23.BoolDefaultPersist.fromJson(data) : null);
+    map[_i140.getType<_i24.DateTimeDefault?>()] = (data, protocol) =>
+        (data != null ? _i24.DateTimeDefault.fromJson(data) : null);
+    map[_i140.getType<_i25.DateTimeDefaultMix?>()] = (data, protocol) =>
+        (data != null ? _i25.DateTimeDefaultMix.fromJson(data) : null);
+    map[_i140.getType<_i26.DateTimeDefaultModel?>()] = (data, protocol) =>
+        (data != null ? _i26.DateTimeDefaultModel.fromJson(data) : null);
+    map[_i140.getType<_i27.DateTimeDefaultPersist?>()] = (data, protocol) =>
+        (data != null ? _i27.DateTimeDefaultPersist.fromJson(data) : null);
+    map[_i140.getType<_i28.DoubleDefault?>()] = (data, protocol) =>
+        (data != null ? _i28.DoubleDefault.fromJson(data) : null);
+    map[_i140.getType<_i29.DoubleDefaultMix?>()] = (data, protocol) =>
+        (data != null ? _i29.DoubleDefaultMix.fromJson(data) : null);
+    map[_i140.getType<_i30.DoubleDefaultModel?>()] = (data, protocol) =>
+        (data != null ? _i30.DoubleDefaultModel.fromJson(data) : null);
+    map[_i140.getType<_i31.DoubleDefaultPersist?>()] = (data, protocol) =>
+        (data != null ? _i31.DoubleDefaultPersist.fromJson(data) : null);
+    map[_i140.getType<_i32.DurationDefault?>()] = (data, protocol) =>
+        (data != null ? _i32.DurationDefault.fromJson(data) : null);
+    map[_i140.getType<_i33.DurationDefaultMix?>()] = (data, protocol) =>
+        (data != null ? _i33.DurationDefaultMix.fromJson(data) : null);
+    map[_i140.getType<_i34.DurationDefaultModel?>()] = (data, protocol) =>
+        (data != null ? _i34.DurationDefaultModel.fromJson(data) : null);
+    map[_i140.getType<_i35.DurationDefaultPersist?>()] = (data, protocol) =>
+        (data != null ? _i35.DurationDefaultPersist.fromJson(data) : null);
+    map[_i140.getType<_i36.EnumDefault?>()] = (data, protocol) =>
+        (data != null ? _i36.EnumDefault.fromJson(data) : null);
+    map[_i140.getType<_i37.EnumDefaultMix?>()] = (data, protocol) =>
+        (data != null ? _i37.EnumDefaultMix.fromJson(data) : null);
+    map[_i140.getType<_i38.EnumDefaultModel?>()] = (data, protocol) =>
+        (data != null ? _i38.EnumDefaultModel.fromJson(data) : null);
+    map[_i140.getType<_i39.EnumDefaultPersist?>()] = (data, protocol) =>
+        (data != null ? _i39.EnumDefaultPersist.fromJson(data) : null);
+    map[_i140.getType<_i40.ByIndexEnum?>()] = (data, protocol) =>
+        (data != null ? _i40.ByIndexEnum.fromJson(data) : null);
+    map[_i140.getType<_i41.ByNameEnum?>()] = (data, protocol) =>
+        (data != null ? _i41.ByNameEnum.fromJson(data) : null);
+    map[_i140.getType<_i42.DefaultValueEnum?>()] = (data, protocol) =>
+        (data != null ? _i42.DefaultValueEnum.fromJson(data) : null);
+    map[_i140.getType<_i43.DefaultException?>()] = (data, protocol) =>
+        (data != null ? _i43.DefaultException.fromJson(data) : null);
+    map[_i140.getType<_i44.IntDefault?>()] = (data, protocol) =>
+        (data != null ? _i44.IntDefault.fromJson(data) : null);
+    map[_i140.getType<_i45.IntDefaultMix?>()] = (data, protocol) =>
+        (data != null ? _i45.IntDefaultMix.fromJson(data) : null);
+    map[_i140.getType<_i46.IntDefaultModel?>()] = (data, protocol) =>
+        (data != null ? _i46.IntDefaultModel.fromJson(data) : null);
+    map[_i140.getType<_i47.IntDefaultPersist?>()] = (data, protocol) =>
+        (data != null ? _i47.IntDefaultPersist.fromJson(data) : null);
+    map[_i140.getType<_i48.StringDefault?>()] = (data, protocol) =>
+        (data != null ? _i48.StringDefault.fromJson(data) : null);
+    map[_i140.getType<_i49.StringDefaultMix?>()] = (data, protocol) =>
+        (data != null ? _i49.StringDefaultMix.fromJson(data) : null);
+    map[_i140.getType<_i50.StringDefaultModel?>()] = (data, protocol) =>
+        (data != null ? _i50.StringDefaultModel.fromJson(data) : null);
+    map[_i140.getType<_i51.StringDefaultPersist?>()] = (data, protocol) =>
+        (data != null ? _i51.StringDefaultPersist.fromJson(data) : null);
+    map[_i140.getType<_i52.UriDefault?>()] = (data, protocol) =>
+        (data != null ? _i52.UriDefault.fromJson(data) : null);
+    map[_i140.getType<_i53.UriDefaultMix?>()] = (data, protocol) =>
+        (data != null ? _i53.UriDefaultMix.fromJson(data) : null);
+    map[_i140.getType<_i54.UriDefaultModel?>()] = (data, protocol) =>
+        (data != null ? _i54.UriDefaultModel.fromJson(data) : null);
+    map[_i140.getType<_i55.UriDefaultPersist?>()] = (data, protocol) =>
+        (data != null ? _i55.UriDefaultPersist.fromJson(data) : null);
+    map[_i140.getType<_i56.UuidDefault?>()] = (data, protocol) =>
+        (data != null ? _i56.UuidDefault.fromJson(data) : null);
+    map[_i140.getType<_i57.UuidDefaultMix?>()] = (data, protocol) =>
+        (data != null ? _i57.UuidDefaultMix.fromJson(data) : null);
+    map[_i140.getType<_i58.UuidDefaultModel?>()] = (data, protocol) =>
+        (data != null ? _i58.UuidDefaultModel.fromJson(data) : null);
+    map[_i140.getType<_i59.UuidDefaultPersist?>()] = (data, protocol) =>
+        (data != null ? _i59.UuidDefaultPersist.fromJson(data) : null);
+    map[_i140.getType<_i60.EmptyModel?>()] = (data, protocol) =>
+        (data != null ? _i60.EmptyModel.fromJson(data) : null);
+    map[_i140.getType<_i61.EmptyModelRelationItem?>()] = (data, protocol) =>
+        (data != null ? _i61.EmptyModelRelationItem.fromJson(data) : null);
+    map[_i140.getType<_i62.EmptyModelWithTable?>()] = (data, protocol) =>
+        (data != null ? _i62.EmptyModelWithTable.fromJson(data) : null);
+    map[_i140.getType<_i63.RelationEmptyModel?>()] = (data, protocol) =>
+        (data != null ? _i63.RelationEmptyModel.fromJson(data) : null);
+    map[_i140.getType<_i64.ChildClassExplicitColumn?>()] = (data, protocol) =>
+        (data != null ? _i64.ChildClassExplicitColumn.fromJson(data) : null);
+    map[_i140.getType<_i65.NonTableParentClass?>()] = (data, protocol) =>
+        (data != null ? _i65.NonTableParentClass.fromJson(data) : null);
+    map[_i140.getType<_i66.ModifiedColumnName?>()] = (data, protocol) =>
+        (data != null ? _i66.ModifiedColumnName.fromJson(data) : null);
+    map[_i140.getType<_i67.Department?>()] = (data, protocol) =>
+        (data != null ? _i67.Department.fromJson(data) : null);
+    map[_i140.getType<_i68.Employee?>()] = (data, protocol) =>
+        (data != null ? _i68.Employee.fromJson(data) : null);
+    map[_i140.getType<_i69.Contractor?>()] = (data, protocol) =>
+        (data != null ? _i69.Contractor.fromJson(data) : null);
+    map[_i140.getType<_i70.Service?>()] = (data, protocol) =>
+        (data != null ? _i70.Service.fromJson(data) : null);
+    map[_i140
+        .getType<_i71.TableWithExplicitColumnName?>()] = (data, protocol) =>
+        (data != null ? _i71.TableWithExplicitColumnName.fromJson(data) : null);
+    map[_i140.getType<_i72.SealedGrandChild?>()] = (data, protocol) =>
+        (data != null ? _i72.SealedGrandChild.fromJson(data) : null);
+    map[_i140.getType<_i72.SealedChild?>()] = (data, protocol) =>
+        (data != null ? _i72.SealedChild.fromJson(data) : null);
+    map[_i140.getType<_i72.SealedOtherChild?>()] = (data, protocol) =>
+        (data != null ? _i72.SealedOtherChild.fromJson(data) : null);
+    map[_i140.getType<_i73.CityWithLongTableName?>()] = (data, protocol) =>
+        (data != null ? _i73.CityWithLongTableName.fromJson(data) : null);
+    map[_i140
+        .getType<_i74.OrganizationWithLongTableName?>()] = (data, protocol) =>
+        (data != null
+        ? _i74.OrganizationWithLongTableName.fromJson(data)
+        : null);
+    map[_i140.getType<_i75.PersonWithLongTableName?>()] = (data, protocol) =>
+        (data != null ? _i75.PersonWithLongTableName.fromJson(data) : null);
+    map[_i140.getType<_i76.MaxFieldName?>()] = (data, protocol) =>
+        (data != null ? _i76.MaxFieldName.fromJson(data) : null);
+    map[_i140.getType<_i77.LongImplicitIdField?>()] = (data, protocol) =>
+        (data != null ? _i77.LongImplicitIdField.fromJson(data) : null);
+    map[_i140
+        .getType<_i78.LongImplicitIdFieldCollection?>()] = (data, protocol) =>
+        (data != null
+        ? _i78.LongImplicitIdFieldCollection.fromJson(data)
+        : null);
+    map[_i140
+        .getType<_i79.RelationToMultipleMaxFieldName?>()] = (data, protocol) =>
+        (data != null
+        ? _i79.RelationToMultipleMaxFieldName.fromJson(data)
+        : null);
+    map[_i140.getType<_i80.UserNote?>()] = (data, protocol) =>
+        (data != null ? _i80.UserNote.fromJson(data) : null);
+    map[_i140.getType<_i81.UserNoteCollection?>()] = (data, protocol) =>
+        (data != null ? _i81.UserNoteCollection.fromJson(data) : null);
+    map[_i140
+        .getType<_i82.UserNoteCollectionWithALongName?>()] = (data, protocol) =>
+        (data != null
+        ? _i82.UserNoteCollectionWithALongName.fromJson(data)
+        : null);
+    map[_i140.getType<_i83.UserNoteWithALongName?>()] = (data, protocol) =>
+        (data != null ? _i83.UserNoteWithALongName.fromJson(data) : null);
+    map[_i140.getType<_i84.MultipleMaxFieldName?>()] = (data, protocol) =>
+        (data != null ? _i84.MultipleMaxFieldName.fromJson(data) : null);
+    map[_i140.getType<_i85.City?>()] = (data, protocol) =>
+        (data != null ? _i85.City.fromJson(data) : null);
+    map[_i140.getType<_i86.Organization?>()] = (data, protocol) =>
+        (data != null ? _i86.Organization.fromJson(data) : null);
+    map[_i140.getType<_i87.Person?>()] = (data, protocol) =>
+        (data != null ? _i87.Person.fromJson(data) : null);
+    map[_i140.getType<_i88.Course?>()] = (data, protocol) =>
+        (data != null ? _i88.Course.fromJson(data) : null);
+    map[_i140.getType<_i89.Enrollment?>()] = (data, protocol) =>
+        (data != null ? _i89.Enrollment.fromJson(data) : null);
+    map[_i140.getType<_i90.Student?>()] = (data, protocol) =>
+        (data != null ? _i90.Student.fromJson(data) : null);
+    map[_i140.getType<_i91.Arena?>()] = (data, protocol) =>
+        (data != null ? _i91.Arena.fromJson(data) : null);
+    map[_i140.getType<_i92.Player?>()] = (data, protocol) =>
+        (data != null ? _i92.Player.fromJson(data) : null);
+    map[_i140.getType<_i93.Team?>()] = (data, protocol) =>
+        (data != null ? _i93.Team.fromJson(data) : null);
+    map[_i140.getType<_i94.Comment?>()] = (data, protocol) =>
+        (data != null ? _i94.Comment.fromJson(data) : null);
+    map[_i140.getType<_i95.Customer?>()] = (data, protocol) =>
+        (data != null ? _i95.Customer.fromJson(data) : null);
+    map[_i140.getType<_i96.Book?>()] = (data, protocol) =>
+        (data != null ? _i96.Book.fromJson(data) : null);
+    map[_i140.getType<_i97.Chapter?>()] = (data, protocol) =>
+        (data != null ? _i97.Chapter.fromJson(data) : null);
+    map[_i140.getType<_i98.Order?>()] = (data, protocol) =>
+        (data != null ? _i98.Order.fromJson(data) : null);
+    map[_i140.getType<_i99.Address?>()] = (data, protocol) =>
+        (data != null ? _i99.Address.fromJson(data) : null);
+    map[_i140.getType<_i100.Citizen?>()] = (data, protocol) =>
+        (data != null ? _i100.Citizen.fromJson(data) : null);
+    map[_i140.getType<_i101.Company?>()] = (data, protocol) =>
+        (data != null ? _i101.Company.fromJson(data) : null);
+    map[_i140.getType<_i102.Town?>()] = (data, protocol) =>
+        (data != null ? _i102.Town.fromJson(data) : null);
+    map[_i140.getType<_i103.Blocking?>()] = (data, protocol) =>
+        (data != null ? _i103.Blocking.fromJson(data) : null);
+    map[_i140.getType<_i104.Member?>()] = (data, protocol) =>
+        (data != null ? _i104.Member.fromJson(data) : null);
+    map[_i140.getType<_i105.Cat?>()] = (data, protocol) =>
+        (data != null ? _i105.Cat.fromJson(data) : null);
+    map[_i140.getType<_i106.Post?>()] = (data, protocol) =>
+        (data != null ? _i106.Post.fromJson(data) : null);
+    map[_i140.getType<_i107.ObjectFieldPersist?>()] = (data, protocol) =>
+        (data != null ? _i107.ObjectFieldPersist.fromJson(data) : null);
+    map[_i140.getType<_i108.ObjectFieldScopes?>()] = (data, protocol) =>
+        (data != null ? _i108.ObjectFieldScopes.fromJson(data) : null);
+    map[_i140.getType<_i109.ObjectWithBit?>()] = (data, protocol) =>
+        (data != null ? _i109.ObjectWithBit.fromJson(data) : null);
+    map[_i140.getType<_i110.ObjectWithByteData?>()] = (data, protocol) =>
+        (data != null ? _i110.ObjectWithByteData.fromJson(data) : null);
+    map[_i140.getType<_i111.ObjectWithDuration?>()] = (data, protocol) =>
+        (data != null ? _i111.ObjectWithDuration.fromJson(data) : null);
+    map[_i140.getType<_i112.ObjectWithDynamic?>()] = (data, protocol) =>
+        (data != null ? _i112.ObjectWithDynamic.fromJson(data) : null);
+    map[_i140.getType<_i113.ObjectWithEnum?>()] = (data, protocol) =>
+        (data != null ? _i113.ObjectWithEnum.fromJson(data) : null);
+    map[_i140.getType<_i114.ObjectWithEnumEnhanced?>()] = (data, protocol) =>
+        (data != null ? _i114.ObjectWithEnumEnhanced.fromJson(data) : null);
+    map[_i140.getType<_i115.ObjectWithHalfVector?>()] = (data, protocol) =>
+        (data != null ? _i115.ObjectWithHalfVector.fromJson(data) : null);
+    map[_i140.getType<_i116.ObjectWithIndex?>()] = (data, protocol) =>
+        (data != null ? _i116.ObjectWithIndex.fromJson(data) : null);
+    map[_i140.getType<_i117.ObjectWithJsonb?>()] = (data, protocol) =>
+        (data != null ? _i117.ObjectWithJsonb.fromJson(data) : null);
+    map[_i140.getType<_i118.ObjectWithJsonbClassLevel?>()] = (data, protocol) =>
+        (data != null ? _i118.ObjectWithJsonbClassLevel.fromJson(data) : null);
+    map[_i140.getType<_i119.ObjectWithMaps?>()] = (data, protocol) =>
+        (data != null ? _i119.ObjectWithMaps.fromJson(data) : null);
+    map[_i140.getType<_i120.ObjectWithObject?>()] = (data, protocol) =>
+        (data != null ? _i120.ObjectWithObject.fromJson(data) : null);
+    map[_i140.getType<_i121.ObjectWithParent?>()] = (data, protocol) =>
+        (data != null ? _i121.ObjectWithParent.fromJson(data) : null);
+    map[_i140.getType<_i122.ObjectWithSealedClass?>()] = (data, protocol) =>
+        (data != null ? _i122.ObjectWithSealedClass.fromJson(data) : null);
+    map[_i140.getType<_i123.ObjectWithSelfParent?>()] = (data, protocol) =>
+        (data != null ? _i123.ObjectWithSelfParent.fromJson(data) : null);
+    map[_i140.getType<_i124.ObjectWithSparseVector?>()] = (data, protocol) =>
+        (data != null ? _i124.ObjectWithSparseVector.fromJson(data) : null);
+    map[_i140.getType<_i125.ObjectWithUuid?>()] = (data, protocol) =>
+        (data != null ? _i125.ObjectWithUuid.fromJson(data) : null);
+    map[_i140.getType<_i126.ObjectWithVector?>()] = (data, protocol) =>
+        (data != null ? _i126.ObjectWithVector.fromJson(data) : null);
+    map[_i140.getType<_i127.RelatedUniqueData?>()] = (data, protocol) =>
+        (data != null ? _i127.RelatedUniqueData.fromJson(data) : null);
+    map[_i140.getType<_i128.ModelWithRequiredField?>()] = (data, protocol) =>
+        (data != null ? _i128.ModelWithRequiredField.fromJson(data) : null);
+    map[_i140.getType<_i129.SimpleData?>()] = (data, protocol) =>
+        (data != null ? _i129.SimpleData.fromJson(data) : null);
+    map[_i140.getType<_i130.SimpleDateTime?>()] = (data, protocol) =>
+        (data != null ? _i130.SimpleDateTime.fromJson(data) : null);
+    map[_i140.getType<_i131.TestEnum?>()] = (data, protocol) =>
+        (data != null ? _i131.TestEnum.fromJson(data) : null);
+    map[_i140
+        .getType<_i132.TestEnumDefaultSerialization?>()] = (data, protocol) =>
+        (data != null
+        ? _i132.TestEnumDefaultSerialization.fromJson(data)
+        : null);
+    map[_i140.getType<_i133.TestEnumEnhanced?>()] = (data, protocol) =>
+        (data != null ? _i133.TestEnumEnhanced.fromJson(data) : null);
+    map[_i140.getType<_i134.TestEnumEnhancedByName?>()] = (data, protocol) =>
+        (data != null ? _i134.TestEnumEnhancedByName.fromJson(data) : null);
+    map[_i140.getType<_i135.TestEnumStringified?>()] = (data, protocol) =>
+        (data != null ? _i135.TestEnumStringified.fromJson(data) : null);
+    map[_i140.getType<_i136.Types?>()] = (data, protocol) =>
+        (data != null ? _i136.Types.fromJson(data) : null);
+    map[_i140.getType<_i137.UniqueData?>()] = (data, protocol) =>
+        (data != null ? _i137.UniqueData.fromJson(data) : null);
+    map[_i140.getType<_i138.UniqueDataWithNonPersist?>()] = (data, protocol) =>
+        (data != null ? _i138.UniqueDataWithNonPersist.fromJson(data) : null);
+    map[_i140.getType<_i139.UpsertTestModel?>()] = (data, protocol) =>
+        (data != null ? _i139.UpsertTestModel.fromJson(data) : null);
+    map[List<_i3.EnrollmentInt>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i3.EnrollmentInt>(e))
+        .toList();
+    map[_i140.getType<List<_i3.EnrollmentInt>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i3.EnrollmentInt>(e))
+              .toList()
+        : null);
+    map[List<_i6.PlayerUuid>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i6.PlayerUuid>(e))
+        .toList();
+    map[_i140.getType<List<_i6.PlayerUuid>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i6.PlayerUuid>(e))
+              .toList()
+        : null);
+    map[List<_i10.OrderUuid>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i10.OrderUuid>(e))
+        .toList();
+    map[_i140.getType<List<_i10.OrderUuid>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i10.OrderUuid>(e))
+              .toList()
+        : null);
+    map[List<_i8.CommentInt>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i8.CommentInt>(e))
+        .toList();
+    map[_i140.getType<List<_i8.CommentInt>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i8.CommentInt>(e))
+              .toList()
+        : null);
+    map[List<_i15.ChangedIdTypeSelf>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i15.ChangedIdTypeSelf>(e))
+        .toList();
+    map[_i140.getType<List<_i15.ChangedIdTypeSelf>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i15.ChangedIdTypeSelf>(e))
+              .toList()
+        : null);
+    map[List<_i61.EmptyModelRelationItem>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i61.EmptyModelRelationItem>(e))
+        .toList();
+    map[_i140.getType<List<_i61.EmptyModelRelationItem>?>()] =
+        (data, protocol) => (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i61.EmptyModelRelationItem>(e))
+              .toList()
+        : null);
+    map[List<_i68.Employee>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i68.Employee>(e))
+        .toList();
+    map[_i140.getType<List<_i68.Employee>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i68.Employee>(e))
+              .toList()
+        : null);
+    map[List<_i75.PersonWithLongTableName>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i75.PersonWithLongTableName>(e))
+        .toList();
+    map[_i140.getType<List<_i75.PersonWithLongTableName>?>()] =
+        (data, protocol) => (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i75.PersonWithLongTableName>(e))
+              .toList()
+        : null);
+    map[List<_i74.OrganizationWithLongTableName>] = (data, protocol) =>
+        (data as List)
+            .map(
+              (e) =>
+                  protocol.deserialize<_i74.OrganizationWithLongTableName>(e),
+            )
+            .toList();
+    map[_i140.getType<List<_i74.OrganizationWithLongTableName>?>()] =
+        (data, protocol) => (data != null
+        ? (data as List)
+              .map(
+                (e) =>
+                    protocol.deserialize<_i74.OrganizationWithLongTableName>(e),
+              )
+              .toList()
+        : null);
+    map[List<_i77.LongImplicitIdField>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i77.LongImplicitIdField>(e))
+        .toList();
+    map[_i140.getType<List<_i77.LongImplicitIdField>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i77.LongImplicitIdField>(e))
+              .toList()
+        : null);
+    map[List<_i84.MultipleMaxFieldName>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i84.MultipleMaxFieldName>(e))
+        .toList();
+    map[_i140.getType<List<_i84.MultipleMaxFieldName>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i84.MultipleMaxFieldName>(e))
+              .toList()
+        : null);
+    map[List<_i80.UserNote>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i80.UserNote>(e))
+        .toList();
+    map[_i140.getType<List<_i80.UserNote>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i80.UserNote>(e))
+              .toList()
+        : null);
+    map[List<_i83.UserNoteWithALongName>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i83.UserNoteWithALongName>(e))
+        .toList();
+    map[_i140.getType<List<_i83.UserNoteWithALongName>?>()] =
+        (data, protocol) => (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i83.UserNoteWithALongName>(e))
+              .toList()
+        : null);
+    map[List<_i87.Person>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i87.Person>(e))
+        .toList();
+    map[_i140.getType<List<_i87.Person>?>()] = (data, protocol) => (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i87.Person>(e))
+              .toList()
+        : null);
+    map[List<_i86.Organization>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i86.Organization>(e))
+        .toList();
+    map[_i140.getType<List<_i86.Organization>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i86.Organization>(e))
+              .toList()
+        : null);
+    map[List<_i89.Enrollment>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i89.Enrollment>(e))
+        .toList();
+    map[_i140.getType<List<_i89.Enrollment>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i89.Enrollment>(e))
+              .toList()
+        : null);
+    map[List<_i92.Player>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i92.Player>(e))
+        .toList();
+    map[_i140.getType<List<_i92.Player>?>()] = (data, protocol) => (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i92.Player>(e))
+              .toList()
+        : null);
+    map[List<_i98.Order>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<_i98.Order>(e)).toList();
+    map[_i140.getType<List<_i98.Order>?>()] = (data, protocol) => (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i98.Order>(e))
+              .toList()
+        : null);
+    map[List<_i97.Chapter>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i97.Chapter>(e))
+        .toList();
+    map[_i140.getType<List<_i97.Chapter>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i97.Chapter>(e))
+              .toList()
+        : null);
+    map[List<_i94.Comment>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i94.Comment>(e))
+        .toList();
+    map[_i140.getType<List<_i94.Comment>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i94.Comment>(e))
+              .toList()
+        : null);
+    map[List<_i103.Blocking>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i103.Blocking>(e))
+        .toList();
+    map[_i140.getType<List<_i103.Blocking>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i103.Blocking>(e))
+              .toList()
+        : null);
+    map[List<_i105.Cat>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<_i105.Cat>(e)).toList();
+    map[_i140.getType<List<_i105.Cat>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<_i105.Cat>(e)).toList()
+        : null);
+    map[dynamic] = (data, protocol) => deserializeDynamicFieldValue(data) as T;
+    map[List<dynamic>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<dynamic>(e)).toList();
+    map[dynamic] = (data, protocol) => deserializeDynamicFieldValue(data) as T;
+    map[Map<String, dynamic>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<dynamic>(v),
+      ),
+    );
+    map[dynamic] = (data, protocol) => deserializeDynamicFieldValue(data) as T;
+    map[Set<dynamic>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<dynamic>(e)).toSet();
+    map[dynamic] = (data, protocol) => deserializeDynamicFieldValue(data) as T;
+    map[Map<dynamic, dynamic>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<dynamic>(e['k']),
+          protocol.deserialize<dynamic>(e['v']),
+        ),
+      ),
+    );
+    map[dynamic] = (data, protocol) => deserializeDynamicFieldValue(data) as T;
+    map[dynamic] = (data, protocol) => deserializeDynamicFieldValue(data) as T;
+    map[List<_i131.TestEnum>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i131.TestEnum>(e))
+        .toList();
+    map[List<_i131.TestEnum?>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i131.TestEnum?>(e))
+        .toList();
+    map[List<List<_i131.TestEnum>>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<List<_i131.TestEnum>>(e))
+        .toList();
+    map[List<_i131.TestEnum>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i131.TestEnum>(e))
+        .toList();
+    map[List<_i133.TestEnumEnhanced>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i133.TestEnumEnhanced>(e))
+        .toList();
+    map[List<_i134.TestEnumEnhancedByName>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i134.TestEnumEnhancedByName>(e))
+        .toList();
+    map[List<String>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<String>(e)).toList();
+    map[Map<String, String>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<String>(v),
+      ),
+    );
+    map[List<String>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<String>(e)).toList();
+    map[_i140.getType<List<String>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<String>(e)).toList()
+        : null);
+    map[Map<String, _i129.SimpleData>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i129.SimpleData>(v),
+      ),
+    );
+    map[Map<String, int>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<int>(v),
+      ),
+    );
+    map[Map<String, DateTime>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<DateTime>(v),
+      ),
+    );
+    map[Map<String, _i141.ByteData>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i141.ByteData>(v),
+      ),
+    );
+    map[Map<String, Duration>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<Duration>(v),
+      ),
+    );
+    map[Map<String, _i140.UuidValue>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i140.UuidValue>(v),
+      ),
+    );
+    map[Map<String, _i129.SimpleData?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i129.SimpleData?>(v),
+      ),
+    );
+    map[Map<String, int?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<int?>(v),
+      ),
+    );
+    map[Map<String, String?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<String?>(v),
+      ),
+    );
+    map[Map<String, DateTime?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<DateTime?>(v),
+      ),
+    );
+    map[Map<String, _i141.ByteData?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i141.ByteData?>(v),
+      ),
+    );
+    map[Map<String, Duration?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<Duration?>(v),
+      ),
+    );
+    map[Map<String, _i140.UuidValue?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i140.UuidValue?>(v),
+      ),
+    );
+    map[Map<int, int>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<int>(e['k']),
+          protocol.deserialize<int>(e['v']),
+        ),
+      ),
+    );
+    map[List<_i129.SimpleData>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i129.SimpleData>(e))
+        .toList();
+    map[List<_i129.SimpleData>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i129.SimpleData>(e))
+        .toList();
+    map[_i140.getType<List<_i129.SimpleData>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i129.SimpleData>(e))
+              .toList()
+        : null);
+    map[List<_i129.SimpleData?>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i129.SimpleData?>(e))
+        .toList();
+    map[List<_i129.SimpleData?>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i129.SimpleData?>(e))
+        .toList();
+    map[_i140.getType<List<_i129.SimpleData?>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i129.SimpleData?>(e))
+              .toList()
+        : null);
+    map[List<List<_i129.SimpleData>>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<List<_i129.SimpleData>>(e))
+        .toList();
+    map[List<_i129.SimpleData>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i129.SimpleData>(e))
+        .toList();
+    map[_i140.getType<List<List<_i129.SimpleData>>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<List<_i129.SimpleData>>(e))
+              .toList()
+        : null);
+    map[List<_i129.SimpleData>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i129.SimpleData>(e))
+        .toList();
+    map[Map<String, List<List<Map<int, _i129.SimpleData>>?>>] =
+        (data, protocol) => (data as Map).map(
+          (k, v) => MapEntry(
+            protocol.deserialize<String>(k),
+            protocol.deserialize<List<List<Map<int, _i129.SimpleData>>?>>(v),
+          ),
+        );
+    map[List<List<Map<int, _i129.SimpleData>>?>] = (data, protocol) =>
+        (data as List)
+            .map(
+              (e) => protocol.deserialize<List<Map<int, _i129.SimpleData>>?>(e),
+            )
+            .toList();
+    map[List<Map<int, _i129.SimpleData>>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<Map<int, _i129.SimpleData>>(e))
+        .toList();
+    map[Map<int, _i129.SimpleData>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<int>(e['k']),
+          protocol.deserialize<_i129.SimpleData>(e['v']),
+        ),
+      ),
+    );
+    map[_i140.getType<List<Map<int, _i129.SimpleData>>?>()] =
+        (data, protocol) => (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<Map<int, _i129.SimpleData>>(e))
+              .toList()
+        : null);
+    map[Map<int, _i129.SimpleData>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<int>(e['k']),
+          protocol.deserialize<_i129.SimpleData>(e['v']),
+        ),
+      ),
+    );
+    map[_i140
+            .getType<Map<String, List<List<Map<int, _i129.SimpleData>>?>>?>()] =
+        (data, protocol) => (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<List<List<Map<int, _i129.SimpleData>>?>>(v),
+            ),
+          )
+        : null);
+    map[List<List<Map<int, _i129.SimpleData>>?>] = (data, protocol) =>
+        (data as List)
+            .map(
+              (e) => protocol.deserialize<List<Map<int, _i129.SimpleData>>?>(e),
+            )
+            .toList();
+    map[List<Map<int, _i129.SimpleData>>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<Map<int, _i129.SimpleData>>(e))
+        .toList();
+    map[Map<int, _i129.SimpleData>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<int>(e['k']),
+          protocol.deserialize<_i129.SimpleData>(e['v']),
+        ),
+      ),
+    );
+    map[_i140.getType<List<Map<int, _i129.SimpleData>>?>()] =
+        (data, protocol) => (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<Map<int, _i129.SimpleData>>(e))
+              .toList()
+        : null);
+    map[Map<int, _i129.SimpleData>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<int>(e['k']),
+          protocol.deserialize<_i129.SimpleData>(e['v']),
+        ),
+      ),
+    );
+    map[Map<String, Map<int, _i129.SimpleData>>] = (data, protocol) =>
+        (data as Map).map(
+          (k, v) => MapEntry(
+            protocol.deserialize<String>(k),
+            protocol.deserialize<Map<int, _i129.SimpleData>>(v),
+          ),
+        );
+    map[Map<int, _i129.SimpleData>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<int>(e['k']),
+          protocol.deserialize<_i129.SimpleData>(e['v']),
+        ),
+      ),
+    );
+    map[_i140.getType<Map<String, Map<int, _i129.SimpleData>>?>()] =
+        (data, protocol) => (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<Map<int, _i129.SimpleData>>(v),
+            ),
+          )
+        : null);
+    map[Map<int, _i129.SimpleData>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<int>(e['k']),
+          protocol.deserialize<_i129.SimpleData>(e['v']),
+        ),
+      ),
+    );
+    map[List<_i72.SealedParent>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i72.SealedParent>(e))
+        .toList();
+    map[List<int>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int>(e)).toList();
+    map[_i140.getType<List<int>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<int>(e)).toList()
+        : null);
+    map[Map<int, int>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<int>(e['k']),
+          protocol.deserialize<int>(e['v']),
+        ),
+      ),
+    );
+    map[_i140.getType<Map<int, int>?>()] = (data, protocol) => (data != null
+        ? Map.fromEntries(
+            (data as List).map(
+              (e) => MapEntry(
+                protocol.deserialize<int>(e['k']),
+                protocol.deserialize<int>(e['v']),
+              ),
+            ),
+          )
+        : null);
+    map[Set<int>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int>(e)).toSet();
+    map[_i140.getType<Set<int>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<int>(e)).toSet()
+        : null);
+    map[_i140.getType<(String, {Uri? optionalUri})?>()] = (data, protocol) =>
+        (data == null)
+        ? null
+        : (
+            protocol.deserialize<String>(((data as Map)['p'] as List)[0]),
+            optionalUri: ((data)['n'] as Map)['optionalUri'] == null
+                ? null
+                : protocol.deserialize<Uri>(data['n']['optionalUri']),
+          );
+    map[List<_i142.SimpleData>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i142.SimpleData>(e))
+        .toList();
+    map[_i140.getType<(String, {Uri? optionalUri})?>()] = (data, protocol) =>
+        (data == null)
+        ? null
+        : (
+            protocol.deserialize<String>(((data as Map)['p'] as List)[0]),
+            optionalUri: ((data)['n'] as Map)['optionalUri'] == null
+                ? null
+                : protocol.deserialize<Uri>(data['n']['optionalUri']),
+          );
+    return map;
+  }
+
   static String? getClassNameFromObjectJson(dynamic data) {
     if (data is! Map) return null;
     final className = data['__className__'] as String?;
@@ -1711,1547 +2784,9 @@ class Protocol extends _i1.DatabaseSerializationManager {
       }
     }
 
-    if (t == _i2.CourseUuid) {
-      return _i2.CourseUuid.fromJson(data) as T;
-    }
-    if (t == _i3.EnrollmentInt) {
-      return _i3.EnrollmentInt.fromJson(data) as T;
-    }
-    if (t == _i4.StudentUuid) {
-      return _i4.StudentUuid.fromJson(data) as T;
-    }
-    if (t == _i5.ArenaUuid) {
-      return _i5.ArenaUuid.fromJson(data) as T;
-    }
-    if (t == _i6.PlayerUuid) {
-      return _i6.PlayerUuid.fromJson(data) as T;
-    }
-    if (t == _i7.TeamInt) {
-      return _i7.TeamInt.fromJson(data) as T;
-    }
-    if (t == _i8.CommentInt) {
-      return _i8.CommentInt.fromJson(data) as T;
-    }
-    if (t == _i9.CustomerInt) {
-      return _i9.CustomerInt.fromJson(data) as T;
-    }
-    if (t == _i10.OrderUuid) {
-      return _i10.OrderUuid.fromJson(data) as T;
-    }
-    if (t == _i11.AddressUuid) {
-      return _i11.AddressUuid.fromJson(data) as T;
-    }
-    if (t == _i12.CitizenInt) {
-      return _i12.CitizenInt.fromJson(data) as T;
-    }
-    if (t == _i13.CompanyUuid) {
-      return _i13.CompanyUuid.fromJson(data) as T;
-    }
-    if (t == _i14.TownInt) {
-      return _i14.TownInt.fromJson(data) as T;
-    }
-    if (t == _i15.ChangedIdTypeSelf) {
-      return _i15.ChangedIdTypeSelf.fromJson(data) as T;
-    }
-    if (t == _i16.BigIntDefault) {
-      return _i16.BigIntDefault.fromJson(data) as T;
-    }
-    if (t == _i17.BigIntDefaultMix) {
-      return _i17.BigIntDefaultMix.fromJson(data) as T;
-    }
-    if (t == _i18.BigIntDefaultModel) {
-      return _i18.BigIntDefaultModel.fromJson(data) as T;
-    }
-    if (t == _i19.BigIntDefaultPersist) {
-      return _i19.BigIntDefaultPersist.fromJson(data) as T;
-    }
-    if (t == _i20.BoolDefault) {
-      return _i20.BoolDefault.fromJson(data) as T;
-    }
-    if (t == _i21.BoolDefaultMix) {
-      return _i21.BoolDefaultMix.fromJson(data) as T;
-    }
-    if (t == _i22.BoolDefaultModel) {
-      return _i22.BoolDefaultModel.fromJson(data) as T;
-    }
-    if (t == _i23.BoolDefaultPersist) {
-      return _i23.BoolDefaultPersist.fromJson(data) as T;
-    }
-    if (t == _i24.DateTimeDefault) {
-      return _i24.DateTimeDefault.fromJson(data) as T;
-    }
-    if (t == _i25.DateTimeDefaultMix) {
-      return _i25.DateTimeDefaultMix.fromJson(data) as T;
-    }
-    if (t == _i26.DateTimeDefaultModel) {
-      return _i26.DateTimeDefaultModel.fromJson(data) as T;
-    }
-    if (t == _i27.DateTimeDefaultPersist) {
-      return _i27.DateTimeDefaultPersist.fromJson(data) as T;
-    }
-    if (t == _i28.DoubleDefault) {
-      return _i28.DoubleDefault.fromJson(data) as T;
-    }
-    if (t == _i29.DoubleDefaultMix) {
-      return _i29.DoubleDefaultMix.fromJson(data) as T;
-    }
-    if (t == _i30.DoubleDefaultModel) {
-      return _i30.DoubleDefaultModel.fromJson(data) as T;
-    }
-    if (t == _i31.DoubleDefaultPersist) {
-      return _i31.DoubleDefaultPersist.fromJson(data) as T;
-    }
-    if (t == _i32.DurationDefault) {
-      return _i32.DurationDefault.fromJson(data) as T;
-    }
-    if (t == _i33.DurationDefaultMix) {
-      return _i33.DurationDefaultMix.fromJson(data) as T;
-    }
-    if (t == _i34.DurationDefaultModel) {
-      return _i34.DurationDefaultModel.fromJson(data) as T;
-    }
-    if (t == _i35.DurationDefaultPersist) {
-      return _i35.DurationDefaultPersist.fromJson(data) as T;
-    }
-    if (t == _i36.EnumDefault) {
-      return _i36.EnumDefault.fromJson(data) as T;
-    }
-    if (t == _i37.EnumDefaultMix) {
-      return _i37.EnumDefaultMix.fromJson(data) as T;
-    }
-    if (t == _i38.EnumDefaultModel) {
-      return _i38.EnumDefaultModel.fromJson(data) as T;
-    }
-    if (t == _i39.EnumDefaultPersist) {
-      return _i39.EnumDefaultPersist.fromJson(data) as T;
-    }
-    if (t == _i40.ByIndexEnum) {
-      return _i40.ByIndexEnum.fromJson(data) as T;
-    }
-    if (t == _i41.ByNameEnum) {
-      return _i41.ByNameEnum.fromJson(data) as T;
-    }
-    if (t == _i42.DefaultValueEnum) {
-      return _i42.DefaultValueEnum.fromJson(data) as T;
-    }
-    if (t == _i43.DefaultException) {
-      return _i43.DefaultException.fromJson(data) as T;
-    }
-    if (t == _i44.IntDefault) {
-      return _i44.IntDefault.fromJson(data) as T;
-    }
-    if (t == _i45.IntDefaultMix) {
-      return _i45.IntDefaultMix.fromJson(data) as T;
-    }
-    if (t == _i46.IntDefaultModel) {
-      return _i46.IntDefaultModel.fromJson(data) as T;
-    }
-    if (t == _i47.IntDefaultPersist) {
-      return _i47.IntDefaultPersist.fromJson(data) as T;
-    }
-    if (t == _i48.StringDefault) {
-      return _i48.StringDefault.fromJson(data) as T;
-    }
-    if (t == _i49.StringDefaultMix) {
-      return _i49.StringDefaultMix.fromJson(data) as T;
-    }
-    if (t == _i50.StringDefaultModel) {
-      return _i50.StringDefaultModel.fromJson(data) as T;
-    }
-    if (t == _i51.StringDefaultPersist) {
-      return _i51.StringDefaultPersist.fromJson(data) as T;
-    }
-    if (t == _i52.UriDefault) {
-      return _i52.UriDefault.fromJson(data) as T;
-    }
-    if (t == _i53.UriDefaultMix) {
-      return _i53.UriDefaultMix.fromJson(data) as T;
-    }
-    if (t == _i54.UriDefaultModel) {
-      return _i54.UriDefaultModel.fromJson(data) as T;
-    }
-    if (t == _i55.UriDefaultPersist) {
-      return _i55.UriDefaultPersist.fromJson(data) as T;
-    }
-    if (t == _i56.UuidDefault) {
-      return _i56.UuidDefault.fromJson(data) as T;
-    }
-    if (t == _i57.UuidDefaultMix) {
-      return _i57.UuidDefaultMix.fromJson(data) as T;
-    }
-    if (t == _i58.UuidDefaultModel) {
-      return _i58.UuidDefaultModel.fromJson(data) as T;
-    }
-    if (t == _i59.UuidDefaultPersist) {
-      return _i59.UuidDefaultPersist.fromJson(data) as T;
-    }
-    if (t == _i60.EmptyModel) {
-      return _i60.EmptyModel.fromJson(data) as T;
-    }
-    if (t == _i61.EmptyModelRelationItem) {
-      return _i61.EmptyModelRelationItem.fromJson(data) as T;
-    }
-    if (t == _i62.EmptyModelWithTable) {
-      return _i62.EmptyModelWithTable.fromJson(data) as T;
-    }
-    if (t == _i63.RelationEmptyModel) {
-      return _i63.RelationEmptyModel.fromJson(data) as T;
-    }
-    if (t == _i64.ChildClassExplicitColumn) {
-      return _i64.ChildClassExplicitColumn.fromJson(data) as T;
-    }
-    if (t == _i65.NonTableParentClass) {
-      return _i65.NonTableParentClass.fromJson(data) as T;
-    }
-    if (t == _i66.ModifiedColumnName) {
-      return _i66.ModifiedColumnName.fromJson(data) as T;
-    }
-    if (t == _i67.Department) {
-      return _i67.Department.fromJson(data) as T;
-    }
-    if (t == _i68.Employee) {
-      return _i68.Employee.fromJson(data) as T;
-    }
-    if (t == _i69.Contractor) {
-      return _i69.Contractor.fromJson(data) as T;
-    }
-    if (t == _i70.Service) {
-      return _i70.Service.fromJson(data) as T;
-    }
-    if (t == _i71.TableWithExplicitColumnName) {
-      return _i71.TableWithExplicitColumnName.fromJson(data) as T;
-    }
-    if (t == _i72.SealedGrandChild) {
-      return _i72.SealedGrandChild.fromJson(data) as T;
-    }
-    if (t == _i72.SealedChild) {
-      return _i72.SealedChild.fromJson(data) as T;
-    }
-    if (t == _i72.SealedOtherChild) {
-      return _i72.SealedOtherChild.fromJson(data) as T;
-    }
-    if (t == _i73.CityWithLongTableName) {
-      return _i73.CityWithLongTableName.fromJson(data) as T;
-    }
-    if (t == _i74.OrganizationWithLongTableName) {
-      return _i74.OrganizationWithLongTableName.fromJson(data) as T;
-    }
-    if (t == _i75.PersonWithLongTableName) {
-      return _i75.PersonWithLongTableName.fromJson(data) as T;
-    }
-    if (t == _i76.MaxFieldName) {
-      return _i76.MaxFieldName.fromJson(data) as T;
-    }
-    if (t == _i77.LongImplicitIdField) {
-      return _i77.LongImplicitIdField.fromJson(data) as T;
-    }
-    if (t == _i78.LongImplicitIdFieldCollection) {
-      return _i78.LongImplicitIdFieldCollection.fromJson(data) as T;
-    }
-    if (t == _i79.RelationToMultipleMaxFieldName) {
-      return _i79.RelationToMultipleMaxFieldName.fromJson(data) as T;
-    }
-    if (t == _i80.UserNote) {
-      return _i80.UserNote.fromJson(data) as T;
-    }
-    if (t == _i81.UserNoteCollection) {
-      return _i81.UserNoteCollection.fromJson(data) as T;
-    }
-    if (t == _i82.UserNoteCollectionWithALongName) {
-      return _i82.UserNoteCollectionWithALongName.fromJson(data) as T;
-    }
-    if (t == _i83.UserNoteWithALongName) {
-      return _i83.UserNoteWithALongName.fromJson(data) as T;
-    }
-    if (t == _i84.MultipleMaxFieldName) {
-      return _i84.MultipleMaxFieldName.fromJson(data) as T;
-    }
-    if (t == _i85.City) {
-      return _i85.City.fromJson(data) as T;
-    }
-    if (t == _i86.Organization) {
-      return _i86.Organization.fromJson(data) as T;
-    }
-    if (t == _i87.Person) {
-      return _i87.Person.fromJson(data) as T;
-    }
-    if (t == _i88.Course) {
-      return _i88.Course.fromJson(data) as T;
-    }
-    if (t == _i89.Enrollment) {
-      return _i89.Enrollment.fromJson(data) as T;
-    }
-    if (t == _i90.Student) {
-      return _i90.Student.fromJson(data) as T;
-    }
-    if (t == _i91.Arena) {
-      return _i91.Arena.fromJson(data) as T;
-    }
-    if (t == _i92.Player) {
-      return _i92.Player.fromJson(data) as T;
-    }
-    if (t == _i93.Team) {
-      return _i93.Team.fromJson(data) as T;
-    }
-    if (t == _i94.Comment) {
-      return _i94.Comment.fromJson(data) as T;
-    }
-    if (t == _i95.Customer) {
-      return _i95.Customer.fromJson(data) as T;
-    }
-    if (t == _i96.Book) {
-      return _i96.Book.fromJson(data) as T;
-    }
-    if (t == _i97.Chapter) {
-      return _i97.Chapter.fromJson(data) as T;
-    }
-    if (t == _i98.Order) {
-      return _i98.Order.fromJson(data) as T;
-    }
-    if (t == _i99.Address) {
-      return _i99.Address.fromJson(data) as T;
-    }
-    if (t == _i100.Citizen) {
-      return _i100.Citizen.fromJson(data) as T;
-    }
-    if (t == _i101.Company) {
-      return _i101.Company.fromJson(data) as T;
-    }
-    if (t == _i102.Town) {
-      return _i102.Town.fromJson(data) as T;
-    }
-    if (t == _i103.Blocking) {
-      return _i103.Blocking.fromJson(data) as T;
-    }
-    if (t == _i104.Member) {
-      return _i104.Member.fromJson(data) as T;
-    }
-    if (t == _i105.Cat) {
-      return _i105.Cat.fromJson(data) as T;
-    }
-    if (t == _i106.Post) {
-      return _i106.Post.fromJson(data) as T;
-    }
-    if (t == _i107.ObjectFieldPersist) {
-      return _i107.ObjectFieldPersist.fromJson(data) as T;
-    }
-    if (t == _i108.ObjectFieldScopes) {
-      return _i108.ObjectFieldScopes.fromJson(data) as T;
-    }
-    if (t == _i109.ObjectWithBit) {
-      return _i109.ObjectWithBit.fromJson(data) as T;
-    }
-    if (t == _i110.ObjectWithByteData) {
-      return _i110.ObjectWithByteData.fromJson(data) as T;
-    }
-    if (t == _i111.ObjectWithDuration) {
-      return _i111.ObjectWithDuration.fromJson(data) as T;
-    }
-    if (t == _i112.ObjectWithDynamic) {
-      return _i112.ObjectWithDynamic.fromJson(data) as T;
-    }
-    if (t == _i113.ObjectWithEnum) {
-      return _i113.ObjectWithEnum.fromJson(data) as T;
-    }
-    if (t == _i114.ObjectWithEnumEnhanced) {
-      return _i114.ObjectWithEnumEnhanced.fromJson(data) as T;
-    }
-    if (t == _i115.ObjectWithHalfVector) {
-      return _i115.ObjectWithHalfVector.fromJson(data) as T;
-    }
-    if (t == _i116.ObjectWithIndex) {
-      return _i116.ObjectWithIndex.fromJson(data) as T;
-    }
-    if (t == _i117.ObjectWithJsonb) {
-      return _i117.ObjectWithJsonb.fromJson(data) as T;
-    }
-    if (t == _i118.ObjectWithJsonbClassLevel) {
-      return _i118.ObjectWithJsonbClassLevel.fromJson(data) as T;
-    }
-    if (t == _i119.ObjectWithMaps) {
-      return _i119.ObjectWithMaps.fromJson(data) as T;
-    }
-    if (t == _i120.ObjectWithObject) {
-      return _i120.ObjectWithObject.fromJson(data) as T;
-    }
-    if (t == _i121.ObjectWithParent) {
-      return _i121.ObjectWithParent.fromJson(data) as T;
-    }
-    if (t == _i122.ObjectWithSealedClass) {
-      return _i122.ObjectWithSealedClass.fromJson(data) as T;
-    }
-    if (t == _i123.ObjectWithSelfParent) {
-      return _i123.ObjectWithSelfParent.fromJson(data) as T;
-    }
-    if (t == _i124.ObjectWithSparseVector) {
-      return _i124.ObjectWithSparseVector.fromJson(data) as T;
-    }
-    if (t == _i125.ObjectWithUuid) {
-      return _i125.ObjectWithUuid.fromJson(data) as T;
-    }
-    if (t == _i126.ObjectWithVector) {
-      return _i126.ObjectWithVector.fromJson(data) as T;
-    }
-    if (t == _i127.RelatedUniqueData) {
-      return _i127.RelatedUniqueData.fromJson(data) as T;
-    }
-    if (t == _i128.ModelWithRequiredField) {
-      return _i128.ModelWithRequiredField.fromJson(data) as T;
-    }
-    if (t == _i129.SimpleData) {
-      return _i129.SimpleData.fromJson(data) as T;
-    }
-    if (t == _i130.SimpleDateTime) {
-      return _i130.SimpleDateTime.fromJson(data) as T;
-    }
-    if (t == _i131.TestEnum) {
-      return _i131.TestEnum.fromJson(data) as T;
-    }
-    if (t == _i132.TestEnumDefaultSerialization) {
-      return _i132.TestEnumDefaultSerialization.fromJson(data) as T;
-    }
-    if (t == _i133.TestEnumEnhanced) {
-      return _i133.TestEnumEnhanced.fromJson(data) as T;
-    }
-    if (t == _i134.TestEnumEnhancedByName) {
-      return _i134.TestEnumEnhancedByName.fromJson(data) as T;
-    }
-    if (t == _i135.TestEnumStringified) {
-      return _i135.TestEnumStringified.fromJson(data) as T;
-    }
-    if (t == _i136.Types) {
-      return _i136.Types.fromJson(data) as T;
-    }
-    if (t == _i137.UniqueData) {
-      return _i137.UniqueData.fromJson(data) as T;
-    }
-    if (t == _i138.UniqueDataWithNonPersist) {
-      return _i138.UniqueDataWithNonPersist.fromJson(data) as T;
-    }
-    if (t == _i139.UpsertTestModel) {
-      return _i139.UpsertTestModel.fromJson(data) as T;
-    }
-    if (t == _i140.getType<_i2.CourseUuid?>()) {
-      return (data != null ? _i2.CourseUuid.fromJson(data) : null) as T;
-    }
-    if (t == _i140.getType<_i3.EnrollmentInt?>()) {
-      return (data != null ? _i3.EnrollmentInt.fromJson(data) : null) as T;
-    }
-    if (t == _i140.getType<_i4.StudentUuid?>()) {
-      return (data != null ? _i4.StudentUuid.fromJson(data) : null) as T;
-    }
-    if (t == _i140.getType<_i5.ArenaUuid?>()) {
-      return (data != null ? _i5.ArenaUuid.fromJson(data) : null) as T;
-    }
-    if (t == _i140.getType<_i6.PlayerUuid?>()) {
-      return (data != null ? _i6.PlayerUuid.fromJson(data) : null) as T;
-    }
-    if (t == _i140.getType<_i7.TeamInt?>()) {
-      return (data != null ? _i7.TeamInt.fromJson(data) : null) as T;
-    }
-    if (t == _i140.getType<_i8.CommentInt?>()) {
-      return (data != null ? _i8.CommentInt.fromJson(data) : null) as T;
-    }
-    if (t == _i140.getType<_i9.CustomerInt?>()) {
-      return (data != null ? _i9.CustomerInt.fromJson(data) : null) as T;
-    }
-    if (t == _i140.getType<_i10.OrderUuid?>()) {
-      return (data != null ? _i10.OrderUuid.fromJson(data) : null) as T;
-    }
-    if (t == _i140.getType<_i11.AddressUuid?>()) {
-      return (data != null ? _i11.AddressUuid.fromJson(data) : null) as T;
-    }
-    if (t == _i140.getType<_i12.CitizenInt?>()) {
-      return (data != null ? _i12.CitizenInt.fromJson(data) : null) as T;
-    }
-    if (t == _i140.getType<_i13.CompanyUuid?>()) {
-      return (data != null ? _i13.CompanyUuid.fromJson(data) : null) as T;
-    }
-    if (t == _i140.getType<_i14.TownInt?>()) {
-      return (data != null ? _i14.TownInt.fromJson(data) : null) as T;
-    }
-    if (t == _i140.getType<_i15.ChangedIdTypeSelf?>()) {
-      return (data != null ? _i15.ChangedIdTypeSelf.fromJson(data) : null) as T;
-    }
-    if (t == _i140.getType<_i16.BigIntDefault?>()) {
-      return (data != null ? _i16.BigIntDefault.fromJson(data) : null) as T;
-    }
-    if (t == _i140.getType<_i17.BigIntDefaultMix?>()) {
-      return (data != null ? _i17.BigIntDefaultMix.fromJson(data) : null) as T;
-    }
-    if (t == _i140.getType<_i18.BigIntDefaultModel?>()) {
-      return (data != null ? _i18.BigIntDefaultModel.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i140.getType<_i19.BigIntDefaultPersist?>()) {
-      return (data != null ? _i19.BigIntDefaultPersist.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i140.getType<_i20.BoolDefault?>()) {
-      return (data != null ? _i20.BoolDefault.fromJson(data) : null) as T;
-    }
-    if (t == _i140.getType<_i21.BoolDefaultMix?>()) {
-      return (data != null ? _i21.BoolDefaultMix.fromJson(data) : null) as T;
-    }
-    if (t == _i140.getType<_i22.BoolDefaultModel?>()) {
-      return (data != null ? _i22.BoolDefaultModel.fromJson(data) : null) as T;
-    }
-    if (t == _i140.getType<_i23.BoolDefaultPersist?>()) {
-      return (data != null ? _i23.BoolDefaultPersist.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i140.getType<_i24.DateTimeDefault?>()) {
-      return (data != null ? _i24.DateTimeDefault.fromJson(data) : null) as T;
-    }
-    if (t == _i140.getType<_i25.DateTimeDefaultMix?>()) {
-      return (data != null ? _i25.DateTimeDefaultMix.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i140.getType<_i26.DateTimeDefaultModel?>()) {
-      return (data != null ? _i26.DateTimeDefaultModel.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i140.getType<_i27.DateTimeDefaultPersist?>()) {
-      return (data != null ? _i27.DateTimeDefaultPersist.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i140.getType<_i28.DoubleDefault?>()) {
-      return (data != null ? _i28.DoubleDefault.fromJson(data) : null) as T;
-    }
-    if (t == _i140.getType<_i29.DoubleDefaultMix?>()) {
-      return (data != null ? _i29.DoubleDefaultMix.fromJson(data) : null) as T;
-    }
-    if (t == _i140.getType<_i30.DoubleDefaultModel?>()) {
-      return (data != null ? _i30.DoubleDefaultModel.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i140.getType<_i31.DoubleDefaultPersist?>()) {
-      return (data != null ? _i31.DoubleDefaultPersist.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i140.getType<_i32.DurationDefault?>()) {
-      return (data != null ? _i32.DurationDefault.fromJson(data) : null) as T;
-    }
-    if (t == _i140.getType<_i33.DurationDefaultMix?>()) {
-      return (data != null ? _i33.DurationDefaultMix.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i140.getType<_i34.DurationDefaultModel?>()) {
-      return (data != null ? _i34.DurationDefaultModel.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i140.getType<_i35.DurationDefaultPersist?>()) {
-      return (data != null ? _i35.DurationDefaultPersist.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i140.getType<_i36.EnumDefault?>()) {
-      return (data != null ? _i36.EnumDefault.fromJson(data) : null) as T;
-    }
-    if (t == _i140.getType<_i37.EnumDefaultMix?>()) {
-      return (data != null ? _i37.EnumDefaultMix.fromJson(data) : null) as T;
-    }
-    if (t == _i140.getType<_i38.EnumDefaultModel?>()) {
-      return (data != null ? _i38.EnumDefaultModel.fromJson(data) : null) as T;
-    }
-    if (t == _i140.getType<_i39.EnumDefaultPersist?>()) {
-      return (data != null ? _i39.EnumDefaultPersist.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i140.getType<_i40.ByIndexEnum?>()) {
-      return (data != null ? _i40.ByIndexEnum.fromJson(data) : null) as T;
-    }
-    if (t == _i140.getType<_i41.ByNameEnum?>()) {
-      return (data != null ? _i41.ByNameEnum.fromJson(data) : null) as T;
-    }
-    if (t == _i140.getType<_i42.DefaultValueEnum?>()) {
-      return (data != null ? _i42.DefaultValueEnum.fromJson(data) : null) as T;
-    }
-    if (t == _i140.getType<_i43.DefaultException?>()) {
-      return (data != null ? _i43.DefaultException.fromJson(data) : null) as T;
-    }
-    if (t == _i140.getType<_i44.IntDefault?>()) {
-      return (data != null ? _i44.IntDefault.fromJson(data) : null) as T;
-    }
-    if (t == _i140.getType<_i45.IntDefaultMix?>()) {
-      return (data != null ? _i45.IntDefaultMix.fromJson(data) : null) as T;
-    }
-    if (t == _i140.getType<_i46.IntDefaultModel?>()) {
-      return (data != null ? _i46.IntDefaultModel.fromJson(data) : null) as T;
-    }
-    if (t == _i140.getType<_i47.IntDefaultPersist?>()) {
-      return (data != null ? _i47.IntDefaultPersist.fromJson(data) : null) as T;
-    }
-    if (t == _i140.getType<_i48.StringDefault?>()) {
-      return (data != null ? _i48.StringDefault.fromJson(data) : null) as T;
-    }
-    if (t == _i140.getType<_i49.StringDefaultMix?>()) {
-      return (data != null ? _i49.StringDefaultMix.fromJson(data) : null) as T;
-    }
-    if (t == _i140.getType<_i50.StringDefaultModel?>()) {
-      return (data != null ? _i50.StringDefaultModel.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i140.getType<_i51.StringDefaultPersist?>()) {
-      return (data != null ? _i51.StringDefaultPersist.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i140.getType<_i52.UriDefault?>()) {
-      return (data != null ? _i52.UriDefault.fromJson(data) : null) as T;
-    }
-    if (t == _i140.getType<_i53.UriDefaultMix?>()) {
-      return (data != null ? _i53.UriDefaultMix.fromJson(data) : null) as T;
-    }
-    if (t == _i140.getType<_i54.UriDefaultModel?>()) {
-      return (data != null ? _i54.UriDefaultModel.fromJson(data) : null) as T;
-    }
-    if (t == _i140.getType<_i55.UriDefaultPersist?>()) {
-      return (data != null ? _i55.UriDefaultPersist.fromJson(data) : null) as T;
-    }
-    if (t == _i140.getType<_i56.UuidDefault?>()) {
-      return (data != null ? _i56.UuidDefault.fromJson(data) : null) as T;
-    }
-    if (t == _i140.getType<_i57.UuidDefaultMix?>()) {
-      return (data != null ? _i57.UuidDefaultMix.fromJson(data) : null) as T;
-    }
-    if (t == _i140.getType<_i58.UuidDefaultModel?>()) {
-      return (data != null ? _i58.UuidDefaultModel.fromJson(data) : null) as T;
-    }
-    if (t == _i140.getType<_i59.UuidDefaultPersist?>()) {
-      return (data != null ? _i59.UuidDefaultPersist.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i140.getType<_i60.EmptyModel?>()) {
-      return (data != null ? _i60.EmptyModel.fromJson(data) : null) as T;
-    }
-    if (t == _i140.getType<_i61.EmptyModelRelationItem?>()) {
-      return (data != null ? _i61.EmptyModelRelationItem.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i140.getType<_i62.EmptyModelWithTable?>()) {
-      return (data != null ? _i62.EmptyModelWithTable.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i140.getType<_i63.RelationEmptyModel?>()) {
-      return (data != null ? _i63.RelationEmptyModel.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i140.getType<_i64.ChildClassExplicitColumn?>()) {
-      return (data != null
-              ? _i64.ChildClassExplicitColumn.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i140.getType<_i65.NonTableParentClass?>()) {
-      return (data != null ? _i65.NonTableParentClass.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i140.getType<_i66.ModifiedColumnName?>()) {
-      return (data != null ? _i66.ModifiedColumnName.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i140.getType<_i67.Department?>()) {
-      return (data != null ? _i67.Department.fromJson(data) : null) as T;
-    }
-    if (t == _i140.getType<_i68.Employee?>()) {
-      return (data != null ? _i68.Employee.fromJson(data) : null) as T;
-    }
-    if (t == _i140.getType<_i69.Contractor?>()) {
-      return (data != null ? _i69.Contractor.fromJson(data) : null) as T;
-    }
-    if (t == _i140.getType<_i70.Service?>()) {
-      return (data != null ? _i70.Service.fromJson(data) : null) as T;
-    }
-    if (t == _i140.getType<_i71.TableWithExplicitColumnName?>()) {
-      return (data != null
-              ? _i71.TableWithExplicitColumnName.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i140.getType<_i72.SealedGrandChild?>()) {
-      return (data != null ? _i72.SealedGrandChild.fromJson(data) : null) as T;
-    }
-    if (t == _i140.getType<_i72.SealedChild?>()) {
-      return (data != null ? _i72.SealedChild.fromJson(data) : null) as T;
-    }
-    if (t == _i140.getType<_i72.SealedOtherChild?>()) {
-      return (data != null ? _i72.SealedOtherChild.fromJson(data) : null) as T;
-    }
-    if (t == _i140.getType<_i73.CityWithLongTableName?>()) {
-      return (data != null ? _i73.CityWithLongTableName.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i140.getType<_i74.OrganizationWithLongTableName?>()) {
-      return (data != null
-              ? _i74.OrganizationWithLongTableName.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i140.getType<_i75.PersonWithLongTableName?>()) {
-      return (data != null ? _i75.PersonWithLongTableName.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i140.getType<_i76.MaxFieldName?>()) {
-      return (data != null ? _i76.MaxFieldName.fromJson(data) : null) as T;
-    }
-    if (t == _i140.getType<_i77.LongImplicitIdField?>()) {
-      return (data != null ? _i77.LongImplicitIdField.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i140.getType<_i78.LongImplicitIdFieldCollection?>()) {
-      return (data != null
-              ? _i78.LongImplicitIdFieldCollection.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i140.getType<_i79.RelationToMultipleMaxFieldName?>()) {
-      return (data != null
-              ? _i79.RelationToMultipleMaxFieldName.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i140.getType<_i80.UserNote?>()) {
-      return (data != null ? _i80.UserNote.fromJson(data) : null) as T;
-    }
-    if (t == _i140.getType<_i81.UserNoteCollection?>()) {
-      return (data != null ? _i81.UserNoteCollection.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i140.getType<_i82.UserNoteCollectionWithALongName?>()) {
-      return (data != null
-              ? _i82.UserNoteCollectionWithALongName.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i140.getType<_i83.UserNoteWithALongName?>()) {
-      return (data != null ? _i83.UserNoteWithALongName.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i140.getType<_i84.MultipleMaxFieldName?>()) {
-      return (data != null ? _i84.MultipleMaxFieldName.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i140.getType<_i85.City?>()) {
-      return (data != null ? _i85.City.fromJson(data) : null) as T;
-    }
-    if (t == _i140.getType<_i86.Organization?>()) {
-      return (data != null ? _i86.Organization.fromJson(data) : null) as T;
-    }
-    if (t == _i140.getType<_i87.Person?>()) {
-      return (data != null ? _i87.Person.fromJson(data) : null) as T;
-    }
-    if (t == _i140.getType<_i88.Course?>()) {
-      return (data != null ? _i88.Course.fromJson(data) : null) as T;
-    }
-    if (t == _i140.getType<_i89.Enrollment?>()) {
-      return (data != null ? _i89.Enrollment.fromJson(data) : null) as T;
-    }
-    if (t == _i140.getType<_i90.Student?>()) {
-      return (data != null ? _i90.Student.fromJson(data) : null) as T;
-    }
-    if (t == _i140.getType<_i91.Arena?>()) {
-      return (data != null ? _i91.Arena.fromJson(data) : null) as T;
-    }
-    if (t == _i140.getType<_i92.Player?>()) {
-      return (data != null ? _i92.Player.fromJson(data) : null) as T;
-    }
-    if (t == _i140.getType<_i93.Team?>()) {
-      return (data != null ? _i93.Team.fromJson(data) : null) as T;
-    }
-    if (t == _i140.getType<_i94.Comment?>()) {
-      return (data != null ? _i94.Comment.fromJson(data) : null) as T;
-    }
-    if (t == _i140.getType<_i95.Customer?>()) {
-      return (data != null ? _i95.Customer.fromJson(data) : null) as T;
-    }
-    if (t == _i140.getType<_i96.Book?>()) {
-      return (data != null ? _i96.Book.fromJson(data) : null) as T;
-    }
-    if (t == _i140.getType<_i97.Chapter?>()) {
-      return (data != null ? _i97.Chapter.fromJson(data) : null) as T;
-    }
-    if (t == _i140.getType<_i98.Order?>()) {
-      return (data != null ? _i98.Order.fromJson(data) : null) as T;
-    }
-    if (t == _i140.getType<_i99.Address?>()) {
-      return (data != null ? _i99.Address.fromJson(data) : null) as T;
-    }
-    if (t == _i140.getType<_i100.Citizen?>()) {
-      return (data != null ? _i100.Citizen.fromJson(data) : null) as T;
-    }
-    if (t == _i140.getType<_i101.Company?>()) {
-      return (data != null ? _i101.Company.fromJson(data) : null) as T;
-    }
-    if (t == _i140.getType<_i102.Town?>()) {
-      return (data != null ? _i102.Town.fromJson(data) : null) as T;
-    }
-    if (t == _i140.getType<_i103.Blocking?>()) {
-      return (data != null ? _i103.Blocking.fromJson(data) : null) as T;
-    }
-    if (t == _i140.getType<_i104.Member?>()) {
-      return (data != null ? _i104.Member.fromJson(data) : null) as T;
-    }
-    if (t == _i140.getType<_i105.Cat?>()) {
-      return (data != null ? _i105.Cat.fromJson(data) : null) as T;
-    }
-    if (t == _i140.getType<_i106.Post?>()) {
-      return (data != null ? _i106.Post.fromJson(data) : null) as T;
-    }
-    if (t == _i140.getType<_i107.ObjectFieldPersist?>()) {
-      return (data != null ? _i107.ObjectFieldPersist.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i140.getType<_i108.ObjectFieldScopes?>()) {
-      return (data != null ? _i108.ObjectFieldScopes.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i140.getType<_i109.ObjectWithBit?>()) {
-      return (data != null ? _i109.ObjectWithBit.fromJson(data) : null) as T;
-    }
-    if (t == _i140.getType<_i110.ObjectWithByteData?>()) {
-      return (data != null ? _i110.ObjectWithByteData.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i140.getType<_i111.ObjectWithDuration?>()) {
-      return (data != null ? _i111.ObjectWithDuration.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i140.getType<_i112.ObjectWithDynamic?>()) {
-      return (data != null ? _i112.ObjectWithDynamic.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i140.getType<_i113.ObjectWithEnum?>()) {
-      return (data != null ? _i113.ObjectWithEnum.fromJson(data) : null) as T;
-    }
-    if (t == _i140.getType<_i114.ObjectWithEnumEnhanced?>()) {
-      return (data != null ? _i114.ObjectWithEnumEnhanced.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i140.getType<_i115.ObjectWithHalfVector?>()) {
-      return (data != null ? _i115.ObjectWithHalfVector.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i140.getType<_i116.ObjectWithIndex?>()) {
-      return (data != null ? _i116.ObjectWithIndex.fromJson(data) : null) as T;
-    }
-    if (t == _i140.getType<_i117.ObjectWithJsonb?>()) {
-      return (data != null ? _i117.ObjectWithJsonb.fromJson(data) : null) as T;
-    }
-    if (t == _i140.getType<_i118.ObjectWithJsonbClassLevel?>()) {
-      return (data != null
-              ? _i118.ObjectWithJsonbClassLevel.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i140.getType<_i119.ObjectWithMaps?>()) {
-      return (data != null ? _i119.ObjectWithMaps.fromJson(data) : null) as T;
-    }
-    if (t == _i140.getType<_i120.ObjectWithObject?>()) {
-      return (data != null ? _i120.ObjectWithObject.fromJson(data) : null) as T;
-    }
-    if (t == _i140.getType<_i121.ObjectWithParent?>()) {
-      return (data != null ? _i121.ObjectWithParent.fromJson(data) : null) as T;
-    }
-    if (t == _i140.getType<_i122.ObjectWithSealedClass?>()) {
-      return (data != null ? _i122.ObjectWithSealedClass.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i140.getType<_i123.ObjectWithSelfParent?>()) {
-      return (data != null ? _i123.ObjectWithSelfParent.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i140.getType<_i124.ObjectWithSparseVector?>()) {
-      return (data != null ? _i124.ObjectWithSparseVector.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i140.getType<_i125.ObjectWithUuid?>()) {
-      return (data != null ? _i125.ObjectWithUuid.fromJson(data) : null) as T;
-    }
-    if (t == _i140.getType<_i126.ObjectWithVector?>()) {
-      return (data != null ? _i126.ObjectWithVector.fromJson(data) : null) as T;
-    }
-    if (t == _i140.getType<_i127.RelatedUniqueData?>()) {
-      return (data != null ? _i127.RelatedUniqueData.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i140.getType<_i128.ModelWithRequiredField?>()) {
-      return (data != null ? _i128.ModelWithRequiredField.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i140.getType<_i129.SimpleData?>()) {
-      return (data != null ? _i129.SimpleData.fromJson(data) : null) as T;
-    }
-    if (t == _i140.getType<_i130.SimpleDateTime?>()) {
-      return (data != null ? _i130.SimpleDateTime.fromJson(data) : null) as T;
-    }
-    if (t == _i140.getType<_i131.TestEnum?>()) {
-      return (data != null ? _i131.TestEnum.fromJson(data) : null) as T;
-    }
-    if (t == _i140.getType<_i132.TestEnumDefaultSerialization?>()) {
-      return (data != null
-              ? _i132.TestEnumDefaultSerialization.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i140.getType<_i133.TestEnumEnhanced?>()) {
-      return (data != null ? _i133.TestEnumEnhanced.fromJson(data) : null) as T;
-    }
-    if (t == _i140.getType<_i134.TestEnumEnhancedByName?>()) {
-      return (data != null ? _i134.TestEnumEnhancedByName.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i140.getType<_i135.TestEnumStringified?>()) {
-      return (data != null ? _i135.TestEnumStringified.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i140.getType<_i136.Types?>()) {
-      return (data != null ? _i136.Types.fromJson(data) : null) as T;
-    }
-    if (t == _i140.getType<_i137.UniqueData?>()) {
-      return (data != null ? _i137.UniqueData.fromJson(data) : null) as T;
-    }
-    if (t == _i140.getType<_i138.UniqueDataWithNonPersist?>()) {
-      return (data != null
-              ? _i138.UniqueDataWithNonPersist.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i140.getType<_i139.UpsertTestModel?>()) {
-      return (data != null ? _i139.UpsertTestModel.fromJson(data) : null) as T;
-    }
-    if (t == List<_i3.EnrollmentInt>) {
-      return (data as List)
-              .map((e) => deserialize<_i3.EnrollmentInt>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i140.getType<List<_i3.EnrollmentInt>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i3.EnrollmentInt>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i6.PlayerUuid>) {
-      return (data as List).map((e) => deserialize<_i6.PlayerUuid>(e)).toList()
-          as T;
-    }
-    if (t == _i140.getType<List<_i6.PlayerUuid>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i6.PlayerUuid>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i10.OrderUuid>) {
-      return (data as List).map((e) => deserialize<_i10.OrderUuid>(e)).toList()
-          as T;
-    }
-    if (t == _i140.getType<List<_i10.OrderUuid>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i10.OrderUuid>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i8.CommentInt>) {
-      return (data as List).map((e) => deserialize<_i8.CommentInt>(e)).toList()
-          as T;
-    }
-    if (t == _i140.getType<List<_i8.CommentInt>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i8.CommentInt>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i15.ChangedIdTypeSelf>) {
-      return (data as List)
-              .map((e) => deserialize<_i15.ChangedIdTypeSelf>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i140.getType<List<_i15.ChangedIdTypeSelf>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i15.ChangedIdTypeSelf>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i61.EmptyModelRelationItem>) {
-      return (data as List)
-              .map((e) => deserialize<_i61.EmptyModelRelationItem>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i140.getType<List<_i61.EmptyModelRelationItem>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i61.EmptyModelRelationItem>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i68.Employee>) {
-      return (data as List).map((e) => deserialize<_i68.Employee>(e)).toList()
-          as T;
-    }
-    if (t == _i140.getType<List<_i68.Employee>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i68.Employee>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i75.PersonWithLongTableName>) {
-      return (data as List)
-              .map((e) => deserialize<_i75.PersonWithLongTableName>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i140.getType<List<_i75.PersonWithLongTableName>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i75.PersonWithLongTableName>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i74.OrganizationWithLongTableName>) {
-      return (data as List)
-              .map((e) => deserialize<_i74.OrganizationWithLongTableName>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i140.getType<List<_i74.OrganizationWithLongTableName>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map(
-                      (e) => deserialize<_i74.OrganizationWithLongTableName>(e),
-                    )
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i77.LongImplicitIdField>) {
-      return (data as List)
-              .map((e) => deserialize<_i77.LongImplicitIdField>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i140.getType<List<_i77.LongImplicitIdField>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i77.LongImplicitIdField>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i84.MultipleMaxFieldName>) {
-      return (data as List)
-              .map((e) => deserialize<_i84.MultipleMaxFieldName>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i140.getType<List<_i84.MultipleMaxFieldName>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i84.MultipleMaxFieldName>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i80.UserNote>) {
-      return (data as List).map((e) => deserialize<_i80.UserNote>(e)).toList()
-          as T;
-    }
-    if (t == _i140.getType<List<_i80.UserNote>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i80.UserNote>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i83.UserNoteWithALongName>) {
-      return (data as List)
-              .map((e) => deserialize<_i83.UserNoteWithALongName>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i140.getType<List<_i83.UserNoteWithALongName>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i83.UserNoteWithALongName>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i87.Person>) {
-      return (data as List).map((e) => deserialize<_i87.Person>(e)).toList()
-          as T;
-    }
-    if (t == _i140.getType<List<_i87.Person>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<_i87.Person>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i86.Organization>) {
-      return (data as List)
-              .map((e) => deserialize<_i86.Organization>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i140.getType<List<_i86.Organization>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i86.Organization>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i89.Enrollment>) {
-      return (data as List).map((e) => deserialize<_i89.Enrollment>(e)).toList()
-          as T;
-    }
-    if (t == _i140.getType<List<_i89.Enrollment>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i89.Enrollment>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i92.Player>) {
-      return (data as List).map((e) => deserialize<_i92.Player>(e)).toList()
-          as T;
-    }
-    if (t == _i140.getType<List<_i92.Player>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<_i92.Player>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i98.Order>) {
-      return (data as List).map((e) => deserialize<_i98.Order>(e)).toList()
-          as T;
-    }
-    if (t == _i140.getType<List<_i98.Order>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<_i98.Order>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i97.Chapter>) {
-      return (data as List).map((e) => deserialize<_i97.Chapter>(e)).toList()
-          as T;
-    }
-    if (t == _i140.getType<List<_i97.Chapter>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<_i97.Chapter>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i94.Comment>) {
-      return (data as List).map((e) => deserialize<_i94.Comment>(e)).toList()
-          as T;
-    }
-    if (t == _i140.getType<List<_i94.Comment>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<_i94.Comment>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i103.Blocking>) {
-      return (data as List).map((e) => deserialize<_i103.Blocking>(e)).toList()
-          as T;
-    }
-    if (t == _i140.getType<List<_i103.Blocking>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i103.Blocking>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i105.Cat>) {
-      return (data as List).map((e) => deserialize<_i105.Cat>(e)).toList() as T;
-    }
-    if (t == _i140.getType<List<_i105.Cat>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<_i105.Cat>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == dynamic) {
-      return deserializeDynamicFieldValue(data) as T;
-    }
-    if (t == List<dynamic>) {
-      return (data as List).map((e) => deserialize<dynamic>(e)).toList() as T;
-    }
-    if (t == Map<String, dynamic>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(deserialize<String>(k), deserialize<dynamic>(v)),
-          )
-          as T;
-    }
-    if (t == Set<dynamic>) {
-      return (data as List).map((e) => deserialize<dynamic>(e)).toSet() as T;
-    }
-    if (t == Map<dynamic, dynamic>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) => MapEntry(
-                deserialize<dynamic>(e['k']),
-                deserialize<dynamic>(e['v']),
-              ),
-            ),
-          )
-          as T;
-    }
-    if (t == List<_i131.TestEnum>) {
-      return (data as List).map((e) => deserialize<_i131.TestEnum>(e)).toList()
-          as T;
-    }
-    if (t == List<_i131.TestEnum?>) {
-      return (data as List).map((e) => deserialize<_i131.TestEnum?>(e)).toList()
-          as T;
-    }
-    if (t == List<List<_i131.TestEnum>>) {
-      return (data as List)
-              .map((e) => deserialize<List<_i131.TestEnum>>(e))
-              .toList()
-          as T;
-    }
-    if (t == List<_i133.TestEnumEnhanced>) {
-      return (data as List)
-              .map((e) => deserialize<_i133.TestEnumEnhanced>(e))
-              .toList()
-          as T;
-    }
-    if (t == List<_i134.TestEnumEnhancedByName>) {
-      return (data as List)
-              .map((e) => deserialize<_i134.TestEnumEnhancedByName>(e))
-              .toList()
-          as T;
-    }
-    if (t == List<String>) {
-      return (data as List).map((e) => deserialize<String>(e)).toList() as T;
-    }
-    if (t == Map<String, String>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(deserialize<String>(k), deserialize<String>(v)),
-          )
-          as T;
-    }
-    if (t == _i140.getType<List<String>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<String>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == Map<String, _i129.SimpleData>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<_i129.SimpleData>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == Map<String, int>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(deserialize<String>(k), deserialize<int>(v)),
-          )
-          as T;
-    }
-    if (t == Map<String, DateTime>) {
-      return (data as Map).map(
-            (k, v) =>
-                MapEntry(deserialize<String>(k), deserialize<DateTime>(v)),
-          )
-          as T;
-    }
-    if (t == Map<String, _i141.ByteData>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<_i141.ByteData>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == Map<String, Duration>) {
-      return (data as Map).map(
-            (k, v) =>
-                MapEntry(deserialize<String>(k), deserialize<Duration>(v)),
-          )
-          as T;
-    }
-    if (t == Map<String, _i140.UuidValue>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<_i140.UuidValue>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == Map<String, _i129.SimpleData?>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<_i129.SimpleData?>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == Map<String, int?>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(deserialize<String>(k), deserialize<int?>(v)),
-          )
-          as T;
-    }
-    if (t == Map<String, String?>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(deserialize<String>(k), deserialize<String?>(v)),
-          )
-          as T;
-    }
-    if (t == Map<String, DateTime?>) {
-      return (data as Map).map(
-            (k, v) =>
-                MapEntry(deserialize<String>(k), deserialize<DateTime?>(v)),
-          )
-          as T;
-    }
-    if (t == Map<String, _i141.ByteData?>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<_i141.ByteData?>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == Map<String, Duration?>) {
-      return (data as Map).map(
-            (k, v) =>
-                MapEntry(deserialize<String>(k), deserialize<Duration?>(v)),
-          )
-          as T;
-    }
-    if (t == Map<String, _i140.UuidValue?>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<_i140.UuidValue?>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == Map<int, int>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) =>
-                  MapEntry(deserialize<int>(e['k']), deserialize<int>(e['v'])),
-            ),
-          )
-          as T;
-    }
-    if (t == List<_i129.SimpleData>) {
-      return (data as List)
-              .map((e) => deserialize<_i129.SimpleData>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i140.getType<List<_i129.SimpleData>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i129.SimpleData>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i129.SimpleData?>) {
-      return (data as List)
-              .map((e) => deserialize<_i129.SimpleData?>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i140.getType<List<_i129.SimpleData?>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i129.SimpleData?>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<List<_i129.SimpleData>>) {
-      return (data as List)
-              .map((e) => deserialize<List<_i129.SimpleData>>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i140.getType<List<List<_i129.SimpleData>>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<List<_i129.SimpleData>>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == Map<String, List<List<Map<int, _i129.SimpleData>>?>>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<List<List<Map<int, _i129.SimpleData>>?>>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == List<List<Map<int, _i129.SimpleData>>?>) {
-      return (data as List)
-              .map((e) => deserialize<List<Map<int, _i129.SimpleData>>?>(e))
-              .toList()
-          as T;
-    }
-    if (t == List<Map<int, _i129.SimpleData>>) {
-      return (data as List)
-              .map((e) => deserialize<Map<int, _i129.SimpleData>>(e))
-              .toList()
-          as T;
-    }
-    if (t == Map<int, _i129.SimpleData>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) => MapEntry(
-                deserialize<int>(e['k']),
-                deserialize<_i129.SimpleData>(e['v']),
-              ),
-            ),
-          )
-          as T;
-    }
-    if (t == _i140.getType<List<Map<int, _i129.SimpleData>>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<Map<int, _i129.SimpleData>>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t ==
-        _i140
-            .getType<Map<String, List<List<Map<int, _i129.SimpleData>>?>>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) => MapEntry(
-                    deserialize<String>(k),
-                    deserialize<List<List<Map<int, _i129.SimpleData>>?>>(v),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == _i140.getType<List<Map<int, _i129.SimpleData>>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<Map<int, _i129.SimpleData>>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == Map<String, Map<int, _i129.SimpleData>>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<Map<int, _i129.SimpleData>>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == _i140.getType<Map<String, Map<int, _i129.SimpleData>>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) => MapEntry(
-                    deserialize<String>(k),
-                    deserialize<Map<int, _i129.SimpleData>>(v),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == List<_i72.SealedParent>) {
-      return (data as List)
-              .map((e) => deserialize<_i72.SealedParent>(e))
-              .toList()
-          as T;
-    }
-    if (t == List<int>) {
-      return (data as List).map((e) => deserialize<int>(e)).toList() as T;
-    }
-    if (t == _i140.getType<List<int>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<int>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == _i140.getType<Map<int, int>?>()) {
-      return (data != null
-              ? Map.fromEntries(
-                  (data as List).map(
-                    (e) => MapEntry(
-                      deserialize<int>(e['k']),
-                      deserialize<int>(e['v']),
-                    ),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == Set<int>) {
-      return (data as List).map((e) => deserialize<int>(e)).toSet() as T;
-    }
-    if (t == _i140.getType<Set<int>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<int>(e)).toSet()
-              : null)
-          as T;
-    }
-    if (t == _i140.getType<(String, {Uri? optionalUri})?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<String>(((data as Map)['p'] as List)[0]),
-                  optionalUri: ((data)['n'] as Map)['optionalUri'] == null
-                      ? null
-                      : deserialize<Uri>(data['n']['optionalUri']),
-                )
-                as T;
-    }
-    if (t == List<_i142.SimpleData>) {
-      return (data as List)
-              .map((e) => deserialize<_i142.SimpleData>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i140.getType<(String, {Uri? optionalUri})?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<String>(((data as Map)['p'] as List)[0]),
-                  optionalUri: ((data)['n'] as Map)['optionalUri'] == null
-                      ? null
-                      : deserialize<Uri>(data['n']['optionalUri']),
-                )
-                as T;
+    final fn = _deserializers[t];
+    if (fn != null) {
+      return fn(data, this) as T;
     }
     try {
       return _i143.Protocol().deserialize<T>(data, t);

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/protocol.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/protocol.dart
@@ -20,160 +20,159 @@ import 'package:serverpod_test_shared_module_client/serverpod_test_shared_module
     as _i4;
 import 'package:serverpod_test_sqlite_shared/serverpod_test_sqlite_shared.dart'
     as _i5;
-import 'changed_id_type/many_to_many/course.dart' as _i6;
-import 'changed_id_type/many_to_many/enrollment.dart' as _i7;
-import 'changed_id_type/many_to_many/student.dart' as _i8;
-import 'changed_id_type/nested_one_to_many/arena.dart' as _i9;
-import 'changed_id_type/nested_one_to_many/player.dart' as _i10;
-import 'changed_id_type/nested_one_to_many/team.dart' as _i11;
-import 'changed_id_type/one_to_many/comment.dart' as _i12;
-import 'changed_id_type/one_to_many/customer.dart' as _i13;
-import 'changed_id_type/one_to_many/order.dart' as _i14;
-import 'changed_id_type/one_to_one/address.dart' as _i15;
-import 'changed_id_type/one_to_one/citizen.dart' as _i16;
-import 'changed_id_type/one_to_one/company.dart' as _i17;
-import 'changed_id_type/one_to_one/town.dart' as _i18;
-import 'changed_id_type/self.dart' as _i19;
-import 'defaults/bigint/bigint_default.dart' as _i20;
-import 'defaults/bigint/bigint_default_mix.dart' as _i21;
-import 'defaults/bigint/bigint_default_model.dart' as _i22;
-import 'defaults/bigint/bigint_default_persist.dart' as _i23;
-import 'defaults/boolean/bool_default.dart' as _i24;
-import 'defaults/boolean/bool_default_mix.dart' as _i25;
-import 'defaults/boolean/bool_default_model.dart' as _i26;
-import 'defaults/boolean/bool_default_persist.dart' as _i27;
-import 'defaults/datetime/datetime_default.dart' as _i28;
-import 'defaults/datetime/datetime_default_mix.dart' as _i29;
-import 'defaults/datetime/datetime_default_model.dart' as _i30;
-import 'defaults/datetime/datetime_default_persist.dart' as _i31;
-import 'defaults/double/double_default.dart' as _i32;
-import 'defaults/double/double_default_mix.dart' as _i33;
-import 'defaults/double/double_default_model.dart' as _i34;
-import 'defaults/double/double_default_persist.dart' as _i35;
-import 'defaults/duration/duration_default.dart' as _i36;
-import 'defaults/duration/duration_default_mix.dart' as _i37;
-import 'defaults/duration/duration_default_model.dart' as _i38;
-import 'defaults/duration/duration_default_persist.dart' as _i39;
-import 'defaults/enum/enum_default.dart' as _i40;
-import 'defaults/enum/enum_default_mix.dart' as _i41;
-import 'defaults/enum/enum_default_model.dart' as _i42;
-import 'defaults/enum/enum_default_persist.dart' as _i43;
-import 'defaults/enum/enums/by_index_enum.dart' as _i44;
-import 'defaults/enum/enums/by_name_enum.dart' as _i45;
-import 'defaults/enum/enums/default_value_enum.dart' as _i46;
-import 'defaults/exception/default_exception.dart' as _i47;
-import 'defaults/integer/int_default.dart' as _i48;
-import 'defaults/integer/int_default_mix.dart' as _i49;
-import 'defaults/integer/int_default_model.dart' as _i50;
-import 'defaults/integer/int_default_persist.dart' as _i51;
-import 'defaults/string/string_default.dart' as _i52;
-import 'defaults/string/string_default_mix.dart' as _i53;
-import 'defaults/string/string_default_model.dart' as _i54;
-import 'defaults/string/string_default_persist.dart' as _i55;
-import 'defaults/uri/uri_default.dart' as _i56;
-import 'defaults/uri/uri_default_mix.dart' as _i57;
-import 'defaults/uri/uri_default_model.dart' as _i58;
-import 'defaults/uri/uri_default_persist.dart' as _i59;
-import 'defaults/uuid/uuid_default.dart' as _i60;
-import 'defaults/uuid/uuid_default_mix.dart' as _i61;
-import 'defaults/uuid/uuid_default_model.dart' as _i62;
-import 'defaults/uuid/uuid_default_persist.dart' as _i63;
-import 'empty_model/empty_model.dart' as _i64;
-import 'empty_model/empty_model_relation_item.dart' as _i65;
-import 'empty_model/empty_model_with_table.dart' as _i66;
-import 'empty_model/relation_empy_model.dart' as _i67;
+import 'package:serverpod_client/serverpod_client.dart' as _i6;
+import 'package:serverpod_service_client/serverpod_service_client.dart' as _i7;
+import 'changed_id_type/many_to_many/course.dart' as _i8;
+import 'changed_id_type/many_to_many/enrollment.dart' as _i9;
+import 'changed_id_type/many_to_many/student.dart' as _i10;
+import 'changed_id_type/nested_one_to_many/arena.dart' as _i11;
+import 'changed_id_type/nested_one_to_many/player.dart' as _i12;
+import 'changed_id_type/nested_one_to_many/team.dart' as _i13;
+import 'changed_id_type/one_to_many/comment.dart' as _i14;
+import 'changed_id_type/one_to_many/customer.dart' as _i15;
+import 'changed_id_type/one_to_many/order.dart' as _i16;
+import 'changed_id_type/one_to_one/address.dart' as _i17;
+import 'changed_id_type/one_to_one/citizen.dart' as _i18;
+import 'changed_id_type/one_to_one/company.dart' as _i19;
+import 'changed_id_type/one_to_one/town.dart' as _i20;
+import 'changed_id_type/self.dart' as _i21;
+import 'defaults/bigint/bigint_default.dart' as _i22;
+import 'defaults/bigint/bigint_default_mix.dart' as _i23;
+import 'defaults/bigint/bigint_default_model.dart' as _i24;
+import 'defaults/bigint/bigint_default_persist.dart' as _i25;
+import 'defaults/boolean/bool_default.dart' as _i26;
+import 'defaults/boolean/bool_default_mix.dart' as _i27;
+import 'defaults/boolean/bool_default_model.dart' as _i28;
+import 'defaults/boolean/bool_default_persist.dart' as _i29;
+import 'defaults/datetime/datetime_default.dart' as _i30;
+import 'defaults/datetime/datetime_default_mix.dart' as _i31;
+import 'defaults/datetime/datetime_default_model.dart' as _i32;
+import 'defaults/datetime/datetime_default_persist.dart' as _i33;
+import 'defaults/double/double_default.dart' as _i34;
+import 'defaults/double/double_default_mix.dart' as _i35;
+import 'defaults/double/double_default_model.dart' as _i36;
+import 'defaults/double/double_default_persist.dart' as _i37;
+import 'defaults/duration/duration_default.dart' as _i38;
+import 'defaults/duration/duration_default_mix.dart' as _i39;
+import 'defaults/duration/duration_default_model.dart' as _i40;
+import 'defaults/duration/duration_default_persist.dart' as _i41;
+import 'defaults/enum/enum_default.dart' as _i42;
+import 'defaults/enum/enum_default_mix.dart' as _i43;
+import 'defaults/enum/enum_default_model.dart' as _i44;
+import 'defaults/enum/enum_default_persist.dart' as _i45;
+import 'defaults/enum/enums/by_index_enum.dart' as _i46;
+import 'defaults/enum/enums/by_name_enum.dart' as _i47;
+import 'defaults/enum/enums/default_value_enum.dart' as _i48;
+import 'defaults/exception/default_exception.dart' as _i49;
+import 'defaults/integer/int_default.dart' as _i50;
+import 'defaults/integer/int_default_mix.dart' as _i51;
+import 'defaults/integer/int_default_model.dart' as _i52;
+import 'defaults/integer/int_default_persist.dart' as _i53;
+import 'defaults/string/string_default.dart' as _i54;
+import 'defaults/string/string_default_mix.dart' as _i55;
+import 'defaults/string/string_default_model.dart' as _i56;
+import 'defaults/string/string_default_persist.dart' as _i57;
+import 'defaults/uri/uri_default.dart' as _i58;
+import 'defaults/uri/uri_default_mix.dart' as _i59;
+import 'defaults/uri/uri_default_model.dart' as _i60;
+import 'defaults/uri/uri_default_persist.dart' as _i61;
+import 'defaults/uuid/uuid_default.dart' as _i62;
+import 'defaults/uuid/uuid_default_mix.dart' as _i63;
+import 'defaults/uuid/uuid_default_model.dart' as _i64;
+import 'defaults/uuid/uuid_default_persist.dart' as _i65;
+import 'empty_model/empty_model.dart' as _i66;
+import 'empty_model/empty_model_relation_item.dart' as _i67;
+import 'empty_model/empty_model_with_table.dart' as _i68;
+import 'empty_model/relation_empy_model.dart' as _i69;
 import 'explicit_column_name/inheritance/child_class_explicit_column.dart'
-    as _i68;
-import 'explicit_column_name/inheritance/non_table_parent_class.dart' as _i69;
-import 'explicit_column_name/modified_column_name.dart' as _i70;
-import 'explicit_column_name/relations/one_to_many/department.dart' as _i71;
-import 'explicit_column_name/relations/one_to_many/employee.dart' as _i72;
-import 'explicit_column_name/relations/one_to_one/contractor.dart' as _i73;
-import 'explicit_column_name/relations/one_to_one/service.dart' as _i74;
-import 'explicit_column_name/table_with_explicit_column_names.dart' as _i75;
-import 'inheritance/sealed_parent.dart' as _i76;
-import 'long_identifiers/deep_includes/city_with_long_table_name.dart' as _i77;
+    as _i70;
+import 'explicit_column_name/inheritance/non_table_parent_class.dart' as _i71;
+import 'explicit_column_name/modified_column_name.dart' as _i72;
+import 'explicit_column_name/relations/one_to_many/department.dart' as _i73;
+import 'explicit_column_name/relations/one_to_many/employee.dart' as _i74;
+import 'explicit_column_name/relations/one_to_one/contractor.dart' as _i75;
+import 'explicit_column_name/relations/one_to_one/service.dart' as _i76;
+import 'explicit_column_name/table_with_explicit_column_names.dart' as _i77;
+import 'inheritance/sealed_parent.dart' as _i78;
+import 'long_identifiers/deep_includes/city_with_long_table_name.dart' as _i79;
 import 'long_identifiers/deep_includes/organization_with_long_table_name.dart'
-    as _i78;
+    as _i80;
 import 'long_identifiers/deep_includes/person_with_long_table_name.dart'
-    as _i79;
-import 'long_identifiers/max_field_name.dart' as _i80;
-import 'long_identifiers/models_with_relations/long_implicit_id_field.dart'
     as _i81;
-import 'long_identifiers/models_with_relations/long_implicit_id_field_collection.dart'
-    as _i82;
-import 'long_identifiers/models_with_relations/relation_to_mutiple_max_field_name.dart'
+import 'long_identifiers/max_field_name.dart' as _i82;
+import 'long_identifiers/models_with_relations/long_implicit_id_field.dart'
     as _i83;
-import 'long_identifiers/models_with_relations/user_note.dart' as _i84;
-import 'long_identifiers/models_with_relations/user_note_collection.dart'
+import 'long_identifiers/models_with_relations/long_implicit_id_field_collection.dart'
+    as _i84;
+import 'long_identifiers/models_with_relations/relation_to_mutiple_max_field_name.dart'
     as _i85;
-import 'long_identifiers/models_with_relations/user_note_collection_with_a_long_name.dart'
-    as _i86;
-import 'long_identifiers/models_with_relations/user_note_with_a_long_name.dart'
+import 'long_identifiers/models_with_relations/user_note.dart' as _i86;
+import 'long_identifiers/models_with_relations/user_note_collection.dart'
     as _i87;
-import 'long_identifiers/multiple_max_field_name.dart' as _i88;
-import 'models_with_list_relations/city.dart' as _i89;
-import 'models_with_list_relations/organization.dart' as _i90;
-import 'models_with_list_relations/person.dart' as _i91;
-import 'models_with_relations/many_to_many/course.dart' as _i92;
-import 'models_with_relations/many_to_many/enrollment.dart' as _i93;
-import 'models_with_relations/many_to_many/student.dart' as _i94;
-import 'models_with_relations/nested_one_to_many/arena.dart' as _i95;
-import 'models_with_relations/nested_one_to_many/player.dart' as _i96;
-import 'models_with_relations/nested_one_to_many/team.dart' as _i97;
-import 'models_with_relations/one_to_many/comment.dart' as _i98;
-import 'models_with_relations/one_to_many/customer.dart' as _i99;
-import 'models_with_relations/one_to_many/implicit/book.dart' as _i100;
-import 'models_with_relations/one_to_many/implicit/chapter.dart' as _i101;
-import 'models_with_relations/one_to_many/order.dart' as _i102;
-import 'models_with_relations/one_to_one/address.dart' as _i103;
-import 'models_with_relations/one_to_one/citizen.dart' as _i104;
-import 'models_with_relations/one_to_one/company.dart' as _i105;
-import 'models_with_relations/one_to_one/town.dart' as _i106;
+import 'long_identifiers/models_with_relations/user_note_collection_with_a_long_name.dart'
+    as _i88;
+import 'long_identifiers/models_with_relations/user_note_with_a_long_name.dart'
+    as _i89;
+import 'long_identifiers/multiple_max_field_name.dart' as _i90;
+import 'models_with_list_relations/city.dart' as _i91;
+import 'models_with_list_relations/organization.dart' as _i92;
+import 'models_with_list_relations/person.dart' as _i93;
+import 'models_with_relations/many_to_many/course.dart' as _i94;
+import 'models_with_relations/many_to_many/enrollment.dart' as _i95;
+import 'models_with_relations/many_to_many/student.dart' as _i96;
+import 'models_with_relations/nested_one_to_many/arena.dart' as _i97;
+import 'models_with_relations/nested_one_to_many/player.dart' as _i98;
+import 'models_with_relations/nested_one_to_many/team.dart' as _i99;
+import 'models_with_relations/one_to_many/comment.dart' as _i100;
+import 'models_with_relations/one_to_many/customer.dart' as _i101;
+import 'models_with_relations/one_to_many/implicit/book.dart' as _i102;
+import 'models_with_relations/one_to_many/implicit/chapter.dart' as _i103;
+import 'models_with_relations/one_to_many/order.dart' as _i104;
+import 'models_with_relations/one_to_one/address.dart' as _i105;
+import 'models_with_relations/one_to_one/citizen.dart' as _i106;
+import 'models_with_relations/one_to_one/company.dart' as _i107;
+import 'models_with_relations/one_to_one/town.dart' as _i108;
 import 'models_with_relations/self_relation/many_to_many/blocking.dart'
-    as _i107;
-import 'models_with_relations/self_relation/many_to_many/member.dart' as _i108;
-import 'models_with_relations/self_relation/one_to_many/cat.dart' as _i109;
-import 'models_with_relations/self_relation/one_to_one/post.dart' as _i110;
-import 'nulls_distinct_data.dart' as _i111;
-import 'object_field_persist.dart' as _i112;
-import 'object_field_scopes.dart' as _i113;
-import 'object_with_bit.dart' as _i114;
-import 'object_with_bytedata.dart' as _i115;
-import 'object_with_duration.dart' as _i116;
-import 'object_with_dynamic.dart' as _i117;
-import 'object_with_enum.dart' as _i118;
-import 'object_with_enum_enhanced.dart' as _i119;
-import 'object_with_half_vector.dart' as _i120;
-import 'object_with_index.dart' as _i121;
-import 'object_with_jsonb.dart' as _i122;
-import 'object_with_jsonb_class_level.dart' as _i123;
-import 'object_with_maps.dart' as _i124;
-import 'object_with_object.dart' as _i125;
-import 'object_with_parent.dart' as _i126;
-import 'object_with_sealed_class.dart' as _i127;
-import 'object_with_self_parent.dart' as _i128;
-import 'object_with_sparse_vector.dart' as _i129;
-import 'object_with_uuid.dart' as _i130;
-import 'object_with_vector.dart' as _i131;
-import 'related_unique_data.dart' as _i132;
-import 'required/model_with_required_field.dart' as _i133;
-import 'simple_data.dart' as _i134;
-import 'simple_date_time.dart' as _i135;
-import 'test_enum.dart' as _i136;
-import 'test_enum_default_serialization.dart' as _i137;
-import 'test_enum_enhanced.dart' as _i138;
-import 'test_enum_enhanced_by_name.dart' as _i139;
-import 'test_enum_stringified.dart' as _i140;
-import 'types.dart' as _i141;
-import 'unique_data.dart' as _i142;
-import 'unique_data_with_non_persist.dart' as _i143;
-import 'upsert_test_model.dart' as _i144;
-import 'package:serverpod_client/serverpod_client.dart' as _i145;
-import 'dart:typed_data' as _i146;
+    as _i109;
+import 'models_with_relations/self_relation/many_to_many/member.dart' as _i110;
+import 'models_with_relations/self_relation/one_to_many/cat.dart' as _i111;
+import 'models_with_relations/self_relation/one_to_one/post.dart' as _i112;
+import 'nulls_distinct_data.dart' as _i113;
+import 'object_field_persist.dart' as _i114;
+import 'object_field_scopes.dart' as _i115;
+import 'object_with_bit.dart' as _i116;
+import 'object_with_bytedata.dart' as _i117;
+import 'object_with_duration.dart' as _i118;
+import 'object_with_dynamic.dart' as _i119;
+import 'object_with_enum.dart' as _i120;
+import 'object_with_enum_enhanced.dart' as _i121;
+import 'object_with_half_vector.dart' as _i122;
+import 'object_with_index.dart' as _i123;
+import 'object_with_jsonb.dart' as _i124;
+import 'object_with_jsonb_class_level.dart' as _i125;
+import 'object_with_maps.dart' as _i126;
+import 'object_with_object.dart' as _i127;
+import 'object_with_parent.dart' as _i128;
+import 'object_with_sealed_class.dart' as _i129;
+import 'object_with_self_parent.dart' as _i130;
+import 'object_with_sparse_vector.dart' as _i131;
+import 'object_with_uuid.dart' as _i132;
+import 'object_with_vector.dart' as _i133;
+import 'related_unique_data.dart' as _i134;
+import 'required/model_with_required_field.dart' as _i135;
+import 'simple_data.dart' as _i136;
+import 'simple_date_time.dart' as _i137;
+import 'test_enum.dart' as _i138;
+import 'test_enum_default_serialization.dart' as _i139;
+import 'test_enum_enhanced.dart' as _i140;
+import 'test_enum_enhanced_by_name.dart' as _i141;
+import 'test_enum_stringified.dart' as _i142;
+import 'types.dart' as _i143;
+import 'unique_data.dart' as _i144;
+import 'unique_data_with_non_persist.dart' as _i145;
+import 'upsert_test_model.dart' as _i146;
+import 'dart:typed_data' as _i147;
 import 'package:serverpod_test_sqlite_client/src/protocol/simple_data.dart'
-    as _i147;
-import 'package:serverpod_service_client/serverpod_service_client.dart'
     as _i148;
 export 'changed_id_type/many_to_many/course.dart';
 export 'changed_id_type/many_to_many/enrollment.dart';
@@ -322,6 +321,9 @@ class Protocol extends _i1.DatabaseSerializationManager {
   factory Protocol() => _instance;
 
   static final Protocol _instance = Protocol._().._registerHostProtocols();
+
+  static final Map<Type, dynamic Function(dynamic, Protocol)> _deserializers =
+      _buildDeserializers();
 
   static List<_i1.TableDefinition> get targetTableDefinitions => [
     _i1.TableDefinition(
@@ -1821,1718 +1823,171 @@ class Protocol extends _i1.DatabaseSerializationManager {
       }
     }
 
-    if (t == _i6.CourseUuid) {
-      return _i6.CourseUuid.fromJson(data) as T;
-    }
-    if (t == _i7.EnrollmentInt) {
-      return _i7.EnrollmentInt.fromJson(data) as T;
-    }
-    if (t == _i8.StudentUuid) {
-      return _i8.StudentUuid.fromJson(data) as T;
-    }
-    if (t == _i9.ArenaUuid) {
-      return _i9.ArenaUuid.fromJson(data) as T;
-    }
-    if (t == _i10.PlayerUuid) {
-      return _i10.PlayerUuid.fromJson(data) as T;
-    }
-    if (t == _i11.TeamInt) {
-      return _i11.TeamInt.fromJson(data) as T;
-    }
-    if (t == _i12.CommentInt) {
-      return _i12.CommentInt.fromJson(data) as T;
-    }
-    if (t == _i13.CustomerInt) {
-      return _i13.CustomerInt.fromJson(data) as T;
-    }
-    if (t == _i14.OrderUuid) {
-      return _i14.OrderUuid.fromJson(data) as T;
-    }
-    if (t == _i15.AddressUuid) {
-      return _i15.AddressUuid.fromJson(data) as T;
-    }
-    if (t == _i16.CitizenInt) {
-      return _i16.CitizenInt.fromJson(data) as T;
-    }
-    if (t == _i17.CompanyUuid) {
-      return _i17.CompanyUuid.fromJson(data) as T;
-    }
-    if (t == _i18.TownInt) {
-      return _i18.TownInt.fromJson(data) as T;
-    }
-    if (t == _i19.ChangedIdTypeSelf) {
-      return _i19.ChangedIdTypeSelf.fromJson(data) as T;
-    }
-    if (t == _i20.BigIntDefault) {
-      return _i20.BigIntDefault.fromJson(data) as T;
-    }
-    if (t == _i21.BigIntDefaultMix) {
-      return _i21.BigIntDefaultMix.fromJson(data) as T;
-    }
-    if (t == _i22.BigIntDefaultModel) {
-      return _i22.BigIntDefaultModel.fromJson(data) as T;
-    }
-    if (t == _i23.BigIntDefaultPersist) {
-      return _i23.BigIntDefaultPersist.fromJson(data) as T;
-    }
-    if (t == _i24.BoolDefault) {
-      return _i24.BoolDefault.fromJson(data) as T;
-    }
-    if (t == _i25.BoolDefaultMix) {
-      return _i25.BoolDefaultMix.fromJson(data) as T;
-    }
-    if (t == _i26.BoolDefaultModel) {
-      return _i26.BoolDefaultModel.fromJson(data) as T;
-    }
-    if (t == _i27.BoolDefaultPersist) {
-      return _i27.BoolDefaultPersist.fromJson(data) as T;
-    }
-    if (t == _i28.DateTimeDefault) {
-      return _i28.DateTimeDefault.fromJson(data) as T;
-    }
-    if (t == _i29.DateTimeDefaultMix) {
-      return _i29.DateTimeDefaultMix.fromJson(data) as T;
-    }
-    if (t == _i30.DateTimeDefaultModel) {
-      return _i30.DateTimeDefaultModel.fromJson(data) as T;
-    }
-    if (t == _i31.DateTimeDefaultPersist) {
-      return _i31.DateTimeDefaultPersist.fromJson(data) as T;
-    }
-    if (t == _i32.DoubleDefault) {
-      return _i32.DoubleDefault.fromJson(data) as T;
-    }
-    if (t == _i33.DoubleDefaultMix) {
-      return _i33.DoubleDefaultMix.fromJson(data) as T;
-    }
-    if (t == _i34.DoubleDefaultModel) {
-      return _i34.DoubleDefaultModel.fromJson(data) as T;
-    }
-    if (t == _i35.DoubleDefaultPersist) {
-      return _i35.DoubleDefaultPersist.fromJson(data) as T;
-    }
-    if (t == _i36.DurationDefault) {
-      return _i36.DurationDefault.fromJson(data) as T;
-    }
-    if (t == _i37.DurationDefaultMix) {
-      return _i37.DurationDefaultMix.fromJson(data) as T;
-    }
-    if (t == _i38.DurationDefaultModel) {
-      return _i38.DurationDefaultModel.fromJson(data) as T;
-    }
-    if (t == _i39.DurationDefaultPersist) {
-      return _i39.DurationDefaultPersist.fromJson(data) as T;
-    }
-    if (t == _i40.EnumDefault) {
-      return _i40.EnumDefault.fromJson(data) as T;
-    }
-    if (t == _i41.EnumDefaultMix) {
-      return _i41.EnumDefaultMix.fromJson(data) as T;
-    }
-    if (t == _i42.EnumDefaultModel) {
-      return _i42.EnumDefaultModel.fromJson(data) as T;
-    }
-    if (t == _i43.EnumDefaultPersist) {
-      return _i43.EnumDefaultPersist.fromJson(data) as T;
-    }
-    if (t == _i44.ByIndexEnum) {
-      return _i44.ByIndexEnum.fromJson(data) as T;
-    }
-    if (t == _i45.ByNameEnum) {
-      return _i45.ByNameEnum.fromJson(data) as T;
-    }
-    if (t == _i46.DefaultValueEnum) {
-      return _i46.DefaultValueEnum.fromJson(data) as T;
-    }
-    if (t == _i47.DefaultException) {
-      return _i47.DefaultException.fromJson(data) as T;
-    }
-    if (t == _i48.IntDefault) {
-      return _i48.IntDefault.fromJson(data) as T;
-    }
-    if (t == _i49.IntDefaultMix) {
-      return _i49.IntDefaultMix.fromJson(data) as T;
-    }
-    if (t == _i50.IntDefaultModel) {
-      return _i50.IntDefaultModel.fromJson(data) as T;
-    }
-    if (t == _i51.IntDefaultPersist) {
-      return _i51.IntDefaultPersist.fromJson(data) as T;
-    }
-    if (t == _i52.StringDefault) {
-      return _i52.StringDefault.fromJson(data) as T;
-    }
-    if (t == _i53.StringDefaultMix) {
-      return _i53.StringDefaultMix.fromJson(data) as T;
-    }
-    if (t == _i54.StringDefaultModel) {
-      return _i54.StringDefaultModel.fromJson(data) as T;
-    }
-    if (t == _i55.StringDefaultPersist) {
-      return _i55.StringDefaultPersist.fromJson(data) as T;
-    }
-    if (t == _i56.UriDefault) {
-      return _i56.UriDefault.fromJson(data) as T;
-    }
-    if (t == _i57.UriDefaultMix) {
-      return _i57.UriDefaultMix.fromJson(data) as T;
-    }
-    if (t == _i58.UriDefaultModel) {
-      return _i58.UriDefaultModel.fromJson(data) as T;
-    }
-    if (t == _i59.UriDefaultPersist) {
-      return _i59.UriDefaultPersist.fromJson(data) as T;
-    }
-    if (t == _i60.UuidDefault) {
-      return _i60.UuidDefault.fromJson(data) as T;
-    }
-    if (t == _i61.UuidDefaultMix) {
-      return _i61.UuidDefaultMix.fromJson(data) as T;
-    }
-    if (t == _i62.UuidDefaultModel) {
-      return _i62.UuidDefaultModel.fromJson(data) as T;
-    }
-    if (t == _i63.UuidDefaultPersist) {
-      return _i63.UuidDefaultPersist.fromJson(data) as T;
-    }
-    if (t == _i64.EmptyModel) {
-      return _i64.EmptyModel.fromJson(data) as T;
-    }
-    if (t == _i65.EmptyModelRelationItem) {
-      return _i65.EmptyModelRelationItem.fromJson(data) as T;
-    }
-    if (t == _i66.EmptyModelWithTable) {
-      return _i66.EmptyModelWithTable.fromJson(data) as T;
-    }
-    if (t == _i67.RelationEmptyModel) {
-      return _i67.RelationEmptyModel.fromJson(data) as T;
-    }
-    if (t == _i68.ChildClassExplicitColumn) {
-      return _i68.ChildClassExplicitColumn.fromJson(data) as T;
-    }
-    if (t == _i69.NonTableParentClass) {
-      return _i69.NonTableParentClass.fromJson(data) as T;
-    }
-    if (t == _i70.ModifiedColumnName) {
-      return _i70.ModifiedColumnName.fromJson(data) as T;
-    }
-    if (t == _i71.Department) {
-      return _i71.Department.fromJson(data) as T;
-    }
-    if (t == _i72.Employee) {
-      return _i72.Employee.fromJson(data) as T;
-    }
-    if (t == _i73.Contractor) {
-      return _i73.Contractor.fromJson(data) as T;
-    }
-    if (t == _i74.Service) {
-      return _i74.Service.fromJson(data) as T;
-    }
-    if (t == _i75.TableWithExplicitColumnName) {
-      return _i75.TableWithExplicitColumnName.fromJson(data) as T;
-    }
-    if (t == _i76.SealedGrandChild) {
-      return _i76.SealedGrandChild.fromJson(data) as T;
-    }
-    if (t == _i76.SealedChild) {
-      return _i76.SealedChild.fromJson(data) as T;
-    }
-    if (t == _i76.SealedOtherChild) {
-      return _i76.SealedOtherChild.fromJson(data) as T;
-    }
-    if (t == _i77.CityWithLongTableName) {
-      return _i77.CityWithLongTableName.fromJson(data) as T;
-    }
-    if (t == _i78.OrganizationWithLongTableName) {
-      return _i78.OrganizationWithLongTableName.fromJson(data) as T;
-    }
-    if (t == _i79.PersonWithLongTableName) {
-      return _i79.PersonWithLongTableName.fromJson(data) as T;
-    }
-    if (t == _i80.MaxFieldName) {
-      return _i80.MaxFieldName.fromJson(data) as T;
-    }
-    if (t == _i81.LongImplicitIdField) {
-      return _i81.LongImplicitIdField.fromJson(data) as T;
-    }
-    if (t == _i82.LongImplicitIdFieldCollection) {
-      return _i82.LongImplicitIdFieldCollection.fromJson(data) as T;
-    }
-    if (t == _i83.RelationToMultipleMaxFieldName) {
-      return _i83.RelationToMultipleMaxFieldName.fromJson(data) as T;
-    }
-    if (t == _i84.UserNote) {
-      return _i84.UserNote.fromJson(data) as T;
-    }
-    if (t == _i85.UserNoteCollection) {
-      return _i85.UserNoteCollection.fromJson(data) as T;
-    }
-    if (t == _i86.UserNoteCollectionWithALongName) {
-      return _i86.UserNoteCollectionWithALongName.fromJson(data) as T;
-    }
-    if (t == _i87.UserNoteWithALongName) {
-      return _i87.UserNoteWithALongName.fromJson(data) as T;
-    }
-    if (t == _i88.MultipleMaxFieldName) {
-      return _i88.MultipleMaxFieldName.fromJson(data) as T;
-    }
-    if (t == _i89.City) {
-      return _i89.City.fromJson(data) as T;
-    }
-    if (t == _i90.Organization) {
-      return _i90.Organization.fromJson(data) as T;
-    }
-    if (t == _i91.Person) {
-      return _i91.Person.fromJson(data) as T;
-    }
-    if (t == _i92.Course) {
-      return _i92.Course.fromJson(data) as T;
-    }
-    if (t == _i93.Enrollment) {
-      return _i93.Enrollment.fromJson(data) as T;
-    }
-    if (t == _i94.Student) {
-      return _i94.Student.fromJson(data) as T;
-    }
-    if (t == _i95.Arena) {
-      return _i95.Arena.fromJson(data) as T;
-    }
-    if (t == _i96.Player) {
-      return _i96.Player.fromJson(data) as T;
-    }
-    if (t == _i97.Team) {
-      return _i97.Team.fromJson(data) as T;
-    }
-    if (t == _i98.Comment) {
-      return _i98.Comment.fromJson(data) as T;
-    }
-    if (t == _i99.Customer) {
-      return _i99.Customer.fromJson(data) as T;
-    }
-    if (t == _i100.Book) {
-      return _i100.Book.fromJson(data) as T;
-    }
-    if (t == _i101.Chapter) {
-      return _i101.Chapter.fromJson(data) as T;
-    }
-    if (t == _i102.Order) {
-      return _i102.Order.fromJson(data) as T;
-    }
-    if (t == _i103.Address) {
-      return _i103.Address.fromJson(data) as T;
-    }
-    if (t == _i104.Citizen) {
-      return _i104.Citizen.fromJson(data) as T;
-    }
-    if (t == _i105.Company) {
-      return _i105.Company.fromJson(data) as T;
-    }
-    if (t == _i106.Town) {
-      return _i106.Town.fromJson(data) as T;
-    }
-    if (t == _i107.Blocking) {
-      return _i107.Blocking.fromJson(data) as T;
-    }
-    if (t == _i108.Member) {
-      return _i108.Member.fromJson(data) as T;
-    }
-    if (t == _i109.Cat) {
-      return _i109.Cat.fromJson(data) as T;
-    }
-    if (t == _i110.Post) {
-      return _i110.Post.fromJson(data) as T;
-    }
-    if (t == _i111.NullsDistinctData) {
-      return _i111.NullsDistinctData.fromJson(data) as T;
-    }
-    if (t == _i112.ObjectFieldPersist) {
-      return _i112.ObjectFieldPersist.fromJson(data) as T;
-    }
-    if (t == _i113.ObjectFieldScopes) {
-      return _i113.ObjectFieldScopes.fromJson(data) as T;
-    }
-    if (t == _i114.ObjectWithBit) {
-      return _i114.ObjectWithBit.fromJson(data) as T;
-    }
-    if (t == _i115.ObjectWithByteData) {
-      return _i115.ObjectWithByteData.fromJson(data) as T;
-    }
-    if (t == _i116.ObjectWithDuration) {
-      return _i116.ObjectWithDuration.fromJson(data) as T;
-    }
-    if (t == _i117.ObjectWithDynamic) {
-      return _i117.ObjectWithDynamic.fromJson(data) as T;
-    }
-    if (t == _i118.ObjectWithEnum) {
-      return _i118.ObjectWithEnum.fromJson(data) as T;
-    }
-    if (t == _i119.ObjectWithEnumEnhanced) {
-      return _i119.ObjectWithEnumEnhanced.fromJson(data) as T;
-    }
-    if (t == _i120.ObjectWithHalfVector) {
-      return _i120.ObjectWithHalfVector.fromJson(data) as T;
-    }
-    if (t == _i121.ObjectWithIndex) {
-      return _i121.ObjectWithIndex.fromJson(data) as T;
-    }
-    if (t == _i122.ObjectWithJsonb) {
-      return _i122.ObjectWithJsonb.fromJson(data) as T;
-    }
-    if (t == _i123.ObjectWithJsonbClassLevel) {
-      return _i123.ObjectWithJsonbClassLevel.fromJson(data) as T;
-    }
-    if (t == _i124.ObjectWithMaps) {
-      return _i124.ObjectWithMaps.fromJson(data) as T;
-    }
-    if (t == _i125.ObjectWithObject) {
-      return _i125.ObjectWithObject.fromJson(data) as T;
-    }
-    if (t == _i126.ObjectWithParent) {
-      return _i126.ObjectWithParent.fromJson(data) as T;
-    }
-    if (t == _i127.ObjectWithSealedClass) {
-      return _i127.ObjectWithSealedClass.fromJson(data) as T;
-    }
-    if (t == _i128.ObjectWithSelfParent) {
-      return _i128.ObjectWithSelfParent.fromJson(data) as T;
-    }
-    if (t == _i129.ObjectWithSparseVector) {
-      return _i129.ObjectWithSparseVector.fromJson(data) as T;
-    }
-    if (t == _i130.ObjectWithUuid) {
-      return _i130.ObjectWithUuid.fromJson(data) as T;
-    }
-    if (t == _i131.ObjectWithVector) {
-      return _i131.ObjectWithVector.fromJson(data) as T;
-    }
-    if (t == _i132.RelatedUniqueData) {
-      return _i132.RelatedUniqueData.fromJson(data) as T;
-    }
-    if (t == _i133.ModelWithRequiredField) {
-      return _i133.ModelWithRequiredField.fromJson(data) as T;
-    }
-    if (t == _i134.SimpleData) {
-      return _i134.SimpleData.fromJson(data) as T;
-    }
-    if (t == _i135.SimpleDateTime) {
-      return _i135.SimpleDateTime.fromJson(data) as T;
-    }
-    if (t == _i136.TestEnum) {
-      return _i136.TestEnum.fromJson(data) as T;
-    }
-    if (t == _i137.TestEnumDefaultSerialization) {
-      return _i137.TestEnumDefaultSerialization.fromJson(data) as T;
-    }
-    if (t == _i138.TestEnumEnhanced) {
-      return _i138.TestEnumEnhanced.fromJson(data) as T;
-    }
-    if (t == _i139.TestEnumEnhancedByName) {
-      return _i139.TestEnumEnhancedByName.fromJson(data) as T;
-    }
-    if (t == _i140.TestEnumStringified) {
-      return _i140.TestEnumStringified.fromJson(data) as T;
-    }
-    if (t == _i141.Types) {
-      return _i141.Types.fromJson(data) as T;
-    }
-    if (t == _i142.UniqueData) {
-      return _i142.UniqueData.fromJson(data) as T;
-    }
-    if (t == _i143.UniqueDataWithNonPersist) {
-      return _i143.UniqueDataWithNonPersist.fromJson(data) as T;
-    }
-    if (t == _i144.UpsertTestModel) {
-      return _i144.UpsertTestModel.fromJson(data) as T;
-    }
-    if (t == _i145.getType<_i6.CourseUuid?>()) {
-      return (data != null ? _i6.CourseUuid.fromJson(data) : null) as T;
-    }
-    if (t == _i145.getType<_i7.EnrollmentInt?>()) {
-      return (data != null ? _i7.EnrollmentInt.fromJson(data) : null) as T;
-    }
-    if (t == _i145.getType<_i8.StudentUuid?>()) {
-      return (data != null ? _i8.StudentUuid.fromJson(data) : null) as T;
-    }
-    if (t == _i145.getType<_i9.ArenaUuid?>()) {
-      return (data != null ? _i9.ArenaUuid.fromJson(data) : null) as T;
-    }
-    if (t == _i145.getType<_i10.PlayerUuid?>()) {
-      return (data != null ? _i10.PlayerUuid.fromJson(data) : null) as T;
-    }
-    if (t == _i145.getType<_i11.TeamInt?>()) {
-      return (data != null ? _i11.TeamInt.fromJson(data) : null) as T;
-    }
-    if (t == _i145.getType<_i12.CommentInt?>()) {
-      return (data != null ? _i12.CommentInt.fromJson(data) : null) as T;
-    }
-    if (t == _i145.getType<_i13.CustomerInt?>()) {
-      return (data != null ? _i13.CustomerInt.fromJson(data) : null) as T;
-    }
-    if (t == _i145.getType<_i14.OrderUuid?>()) {
-      return (data != null ? _i14.OrderUuid.fromJson(data) : null) as T;
-    }
-    if (t == _i145.getType<_i15.AddressUuid?>()) {
-      return (data != null ? _i15.AddressUuid.fromJson(data) : null) as T;
-    }
-    if (t == _i145.getType<_i16.CitizenInt?>()) {
-      return (data != null ? _i16.CitizenInt.fromJson(data) : null) as T;
-    }
-    if (t == _i145.getType<_i17.CompanyUuid?>()) {
-      return (data != null ? _i17.CompanyUuid.fromJson(data) : null) as T;
-    }
-    if (t == _i145.getType<_i18.TownInt?>()) {
-      return (data != null ? _i18.TownInt.fromJson(data) : null) as T;
-    }
-    if (t == _i145.getType<_i19.ChangedIdTypeSelf?>()) {
-      return (data != null ? _i19.ChangedIdTypeSelf.fromJson(data) : null) as T;
-    }
-    if (t == _i145.getType<_i20.BigIntDefault?>()) {
-      return (data != null ? _i20.BigIntDefault.fromJson(data) : null) as T;
-    }
-    if (t == _i145.getType<_i21.BigIntDefaultMix?>()) {
-      return (data != null ? _i21.BigIntDefaultMix.fromJson(data) : null) as T;
-    }
-    if (t == _i145.getType<_i22.BigIntDefaultModel?>()) {
-      return (data != null ? _i22.BigIntDefaultModel.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i145.getType<_i23.BigIntDefaultPersist?>()) {
-      return (data != null ? _i23.BigIntDefaultPersist.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i145.getType<_i24.BoolDefault?>()) {
-      return (data != null ? _i24.BoolDefault.fromJson(data) : null) as T;
-    }
-    if (t == _i145.getType<_i25.BoolDefaultMix?>()) {
-      return (data != null ? _i25.BoolDefaultMix.fromJson(data) : null) as T;
-    }
-    if (t == _i145.getType<_i26.BoolDefaultModel?>()) {
-      return (data != null ? _i26.BoolDefaultModel.fromJson(data) : null) as T;
-    }
-    if (t == _i145.getType<_i27.BoolDefaultPersist?>()) {
-      return (data != null ? _i27.BoolDefaultPersist.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i145.getType<_i28.DateTimeDefault?>()) {
-      return (data != null ? _i28.DateTimeDefault.fromJson(data) : null) as T;
-    }
-    if (t == _i145.getType<_i29.DateTimeDefaultMix?>()) {
-      return (data != null ? _i29.DateTimeDefaultMix.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i145.getType<_i30.DateTimeDefaultModel?>()) {
-      return (data != null ? _i30.DateTimeDefaultModel.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i145.getType<_i31.DateTimeDefaultPersist?>()) {
-      return (data != null ? _i31.DateTimeDefaultPersist.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i145.getType<_i32.DoubleDefault?>()) {
-      return (data != null ? _i32.DoubleDefault.fromJson(data) : null) as T;
-    }
-    if (t == _i145.getType<_i33.DoubleDefaultMix?>()) {
-      return (data != null ? _i33.DoubleDefaultMix.fromJson(data) : null) as T;
-    }
-    if (t == _i145.getType<_i34.DoubleDefaultModel?>()) {
-      return (data != null ? _i34.DoubleDefaultModel.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i145.getType<_i35.DoubleDefaultPersist?>()) {
-      return (data != null ? _i35.DoubleDefaultPersist.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i145.getType<_i36.DurationDefault?>()) {
-      return (data != null ? _i36.DurationDefault.fromJson(data) : null) as T;
-    }
-    if (t == _i145.getType<_i37.DurationDefaultMix?>()) {
-      return (data != null ? _i37.DurationDefaultMix.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i145.getType<_i38.DurationDefaultModel?>()) {
-      return (data != null ? _i38.DurationDefaultModel.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i145.getType<_i39.DurationDefaultPersist?>()) {
-      return (data != null ? _i39.DurationDefaultPersist.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i145.getType<_i40.EnumDefault?>()) {
-      return (data != null ? _i40.EnumDefault.fromJson(data) : null) as T;
-    }
-    if (t == _i145.getType<_i41.EnumDefaultMix?>()) {
-      return (data != null ? _i41.EnumDefaultMix.fromJson(data) : null) as T;
-    }
-    if (t == _i145.getType<_i42.EnumDefaultModel?>()) {
-      return (data != null ? _i42.EnumDefaultModel.fromJson(data) : null) as T;
-    }
-    if (t == _i145.getType<_i43.EnumDefaultPersist?>()) {
-      return (data != null ? _i43.EnumDefaultPersist.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i145.getType<_i44.ByIndexEnum?>()) {
-      return (data != null ? _i44.ByIndexEnum.fromJson(data) : null) as T;
-    }
-    if (t == _i145.getType<_i45.ByNameEnum?>()) {
-      return (data != null ? _i45.ByNameEnum.fromJson(data) : null) as T;
-    }
-    if (t == _i145.getType<_i46.DefaultValueEnum?>()) {
-      return (data != null ? _i46.DefaultValueEnum.fromJson(data) : null) as T;
-    }
-    if (t == _i145.getType<_i47.DefaultException?>()) {
-      return (data != null ? _i47.DefaultException.fromJson(data) : null) as T;
-    }
-    if (t == _i145.getType<_i48.IntDefault?>()) {
-      return (data != null ? _i48.IntDefault.fromJson(data) : null) as T;
-    }
-    if (t == _i145.getType<_i49.IntDefaultMix?>()) {
-      return (data != null ? _i49.IntDefaultMix.fromJson(data) : null) as T;
-    }
-    if (t == _i145.getType<_i50.IntDefaultModel?>()) {
-      return (data != null ? _i50.IntDefaultModel.fromJson(data) : null) as T;
-    }
-    if (t == _i145.getType<_i51.IntDefaultPersist?>()) {
-      return (data != null ? _i51.IntDefaultPersist.fromJson(data) : null) as T;
-    }
-    if (t == _i145.getType<_i52.StringDefault?>()) {
-      return (data != null ? _i52.StringDefault.fromJson(data) : null) as T;
-    }
-    if (t == _i145.getType<_i53.StringDefaultMix?>()) {
-      return (data != null ? _i53.StringDefaultMix.fromJson(data) : null) as T;
-    }
-    if (t == _i145.getType<_i54.StringDefaultModel?>()) {
-      return (data != null ? _i54.StringDefaultModel.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i145.getType<_i55.StringDefaultPersist?>()) {
-      return (data != null ? _i55.StringDefaultPersist.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i145.getType<_i56.UriDefault?>()) {
-      return (data != null ? _i56.UriDefault.fromJson(data) : null) as T;
-    }
-    if (t == _i145.getType<_i57.UriDefaultMix?>()) {
-      return (data != null ? _i57.UriDefaultMix.fromJson(data) : null) as T;
-    }
-    if (t == _i145.getType<_i58.UriDefaultModel?>()) {
-      return (data != null ? _i58.UriDefaultModel.fromJson(data) : null) as T;
-    }
-    if (t == _i145.getType<_i59.UriDefaultPersist?>()) {
-      return (data != null ? _i59.UriDefaultPersist.fromJson(data) : null) as T;
-    }
-    if (t == _i145.getType<_i60.UuidDefault?>()) {
-      return (data != null ? _i60.UuidDefault.fromJson(data) : null) as T;
-    }
-    if (t == _i145.getType<_i61.UuidDefaultMix?>()) {
-      return (data != null ? _i61.UuidDefaultMix.fromJson(data) : null) as T;
-    }
-    if (t == _i145.getType<_i62.UuidDefaultModel?>()) {
-      return (data != null ? _i62.UuidDefaultModel.fromJson(data) : null) as T;
-    }
-    if (t == _i145.getType<_i63.UuidDefaultPersist?>()) {
-      return (data != null ? _i63.UuidDefaultPersist.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i145.getType<_i64.EmptyModel?>()) {
-      return (data != null ? _i64.EmptyModel.fromJson(data) : null) as T;
-    }
-    if (t == _i145.getType<_i65.EmptyModelRelationItem?>()) {
-      return (data != null ? _i65.EmptyModelRelationItem.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i145.getType<_i66.EmptyModelWithTable?>()) {
-      return (data != null ? _i66.EmptyModelWithTable.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i145.getType<_i67.RelationEmptyModel?>()) {
-      return (data != null ? _i67.RelationEmptyModel.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i145.getType<_i68.ChildClassExplicitColumn?>()) {
-      return (data != null
-              ? _i68.ChildClassExplicitColumn.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i145.getType<_i69.NonTableParentClass?>()) {
-      return (data != null ? _i69.NonTableParentClass.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i145.getType<_i70.ModifiedColumnName?>()) {
-      return (data != null ? _i70.ModifiedColumnName.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i145.getType<_i71.Department?>()) {
-      return (data != null ? _i71.Department.fromJson(data) : null) as T;
-    }
-    if (t == _i145.getType<_i72.Employee?>()) {
-      return (data != null ? _i72.Employee.fromJson(data) : null) as T;
-    }
-    if (t == _i145.getType<_i73.Contractor?>()) {
-      return (data != null ? _i73.Contractor.fromJson(data) : null) as T;
-    }
-    if (t == _i145.getType<_i74.Service?>()) {
-      return (data != null ? _i74.Service.fromJson(data) : null) as T;
-    }
-    if (t == _i145.getType<_i75.TableWithExplicitColumnName?>()) {
-      return (data != null
-              ? _i75.TableWithExplicitColumnName.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i145.getType<_i76.SealedGrandChild?>()) {
-      return (data != null ? _i76.SealedGrandChild.fromJson(data) : null) as T;
-    }
-    if (t == _i145.getType<_i76.SealedChild?>()) {
-      return (data != null ? _i76.SealedChild.fromJson(data) : null) as T;
-    }
-    if (t == _i145.getType<_i76.SealedOtherChild?>()) {
-      return (data != null ? _i76.SealedOtherChild.fromJson(data) : null) as T;
-    }
-    if (t == _i145.getType<_i77.CityWithLongTableName?>()) {
-      return (data != null ? _i77.CityWithLongTableName.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i145.getType<_i78.OrganizationWithLongTableName?>()) {
-      return (data != null
-              ? _i78.OrganizationWithLongTableName.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i145.getType<_i79.PersonWithLongTableName?>()) {
-      return (data != null ? _i79.PersonWithLongTableName.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i145.getType<_i80.MaxFieldName?>()) {
-      return (data != null ? _i80.MaxFieldName.fromJson(data) : null) as T;
-    }
-    if (t == _i145.getType<_i81.LongImplicitIdField?>()) {
-      return (data != null ? _i81.LongImplicitIdField.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i145.getType<_i82.LongImplicitIdFieldCollection?>()) {
-      return (data != null
-              ? _i82.LongImplicitIdFieldCollection.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i145.getType<_i83.RelationToMultipleMaxFieldName?>()) {
-      return (data != null
-              ? _i83.RelationToMultipleMaxFieldName.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i145.getType<_i84.UserNote?>()) {
-      return (data != null ? _i84.UserNote.fromJson(data) : null) as T;
-    }
-    if (t == _i145.getType<_i85.UserNoteCollection?>()) {
-      return (data != null ? _i85.UserNoteCollection.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i145.getType<_i86.UserNoteCollectionWithALongName?>()) {
-      return (data != null
-              ? _i86.UserNoteCollectionWithALongName.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i145.getType<_i87.UserNoteWithALongName?>()) {
-      return (data != null ? _i87.UserNoteWithALongName.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i145.getType<_i88.MultipleMaxFieldName?>()) {
-      return (data != null ? _i88.MultipleMaxFieldName.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i145.getType<_i89.City?>()) {
-      return (data != null ? _i89.City.fromJson(data) : null) as T;
-    }
-    if (t == _i145.getType<_i90.Organization?>()) {
-      return (data != null ? _i90.Organization.fromJson(data) : null) as T;
-    }
-    if (t == _i145.getType<_i91.Person?>()) {
-      return (data != null ? _i91.Person.fromJson(data) : null) as T;
-    }
-    if (t == _i145.getType<_i92.Course?>()) {
-      return (data != null ? _i92.Course.fromJson(data) : null) as T;
-    }
-    if (t == _i145.getType<_i93.Enrollment?>()) {
-      return (data != null ? _i93.Enrollment.fromJson(data) : null) as T;
-    }
-    if (t == _i145.getType<_i94.Student?>()) {
-      return (data != null ? _i94.Student.fromJson(data) : null) as T;
-    }
-    if (t == _i145.getType<_i95.Arena?>()) {
-      return (data != null ? _i95.Arena.fromJson(data) : null) as T;
-    }
-    if (t == _i145.getType<_i96.Player?>()) {
-      return (data != null ? _i96.Player.fromJson(data) : null) as T;
-    }
-    if (t == _i145.getType<_i97.Team?>()) {
-      return (data != null ? _i97.Team.fromJson(data) : null) as T;
-    }
-    if (t == _i145.getType<_i98.Comment?>()) {
-      return (data != null ? _i98.Comment.fromJson(data) : null) as T;
-    }
-    if (t == _i145.getType<_i99.Customer?>()) {
-      return (data != null ? _i99.Customer.fromJson(data) : null) as T;
-    }
-    if (t == _i145.getType<_i100.Book?>()) {
-      return (data != null ? _i100.Book.fromJson(data) : null) as T;
-    }
-    if (t == _i145.getType<_i101.Chapter?>()) {
-      return (data != null ? _i101.Chapter.fromJson(data) : null) as T;
-    }
-    if (t == _i145.getType<_i102.Order?>()) {
-      return (data != null ? _i102.Order.fromJson(data) : null) as T;
-    }
-    if (t == _i145.getType<_i103.Address?>()) {
-      return (data != null ? _i103.Address.fromJson(data) : null) as T;
-    }
-    if (t == _i145.getType<_i104.Citizen?>()) {
-      return (data != null ? _i104.Citizen.fromJson(data) : null) as T;
-    }
-    if (t == _i145.getType<_i105.Company?>()) {
-      return (data != null ? _i105.Company.fromJson(data) : null) as T;
-    }
-    if (t == _i145.getType<_i106.Town?>()) {
-      return (data != null ? _i106.Town.fromJson(data) : null) as T;
-    }
-    if (t == _i145.getType<_i107.Blocking?>()) {
-      return (data != null ? _i107.Blocking.fromJson(data) : null) as T;
-    }
-    if (t == _i145.getType<_i108.Member?>()) {
-      return (data != null ? _i108.Member.fromJson(data) : null) as T;
-    }
-    if (t == _i145.getType<_i109.Cat?>()) {
-      return (data != null ? _i109.Cat.fromJson(data) : null) as T;
-    }
-    if (t == _i145.getType<_i110.Post?>()) {
-      return (data != null ? _i110.Post.fromJson(data) : null) as T;
-    }
-    if (t == _i145.getType<_i111.NullsDistinctData?>()) {
-      return (data != null ? _i111.NullsDistinctData.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i145.getType<_i112.ObjectFieldPersist?>()) {
-      return (data != null ? _i112.ObjectFieldPersist.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i145.getType<_i113.ObjectFieldScopes?>()) {
-      return (data != null ? _i113.ObjectFieldScopes.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i145.getType<_i114.ObjectWithBit?>()) {
-      return (data != null ? _i114.ObjectWithBit.fromJson(data) : null) as T;
-    }
-    if (t == _i145.getType<_i115.ObjectWithByteData?>()) {
-      return (data != null ? _i115.ObjectWithByteData.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i145.getType<_i116.ObjectWithDuration?>()) {
-      return (data != null ? _i116.ObjectWithDuration.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i145.getType<_i117.ObjectWithDynamic?>()) {
-      return (data != null ? _i117.ObjectWithDynamic.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i145.getType<_i118.ObjectWithEnum?>()) {
-      return (data != null ? _i118.ObjectWithEnum.fromJson(data) : null) as T;
-    }
-    if (t == _i145.getType<_i119.ObjectWithEnumEnhanced?>()) {
-      return (data != null ? _i119.ObjectWithEnumEnhanced.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i145.getType<_i120.ObjectWithHalfVector?>()) {
-      return (data != null ? _i120.ObjectWithHalfVector.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i145.getType<_i121.ObjectWithIndex?>()) {
-      return (data != null ? _i121.ObjectWithIndex.fromJson(data) : null) as T;
-    }
-    if (t == _i145.getType<_i122.ObjectWithJsonb?>()) {
-      return (data != null ? _i122.ObjectWithJsonb.fromJson(data) : null) as T;
-    }
-    if (t == _i145.getType<_i123.ObjectWithJsonbClassLevel?>()) {
-      return (data != null
-              ? _i123.ObjectWithJsonbClassLevel.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i145.getType<_i124.ObjectWithMaps?>()) {
-      return (data != null ? _i124.ObjectWithMaps.fromJson(data) : null) as T;
-    }
-    if (t == _i145.getType<_i125.ObjectWithObject?>()) {
-      return (data != null ? _i125.ObjectWithObject.fromJson(data) : null) as T;
-    }
-    if (t == _i145.getType<_i126.ObjectWithParent?>()) {
-      return (data != null ? _i126.ObjectWithParent.fromJson(data) : null) as T;
-    }
-    if (t == _i145.getType<_i127.ObjectWithSealedClass?>()) {
-      return (data != null ? _i127.ObjectWithSealedClass.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i145.getType<_i128.ObjectWithSelfParent?>()) {
-      return (data != null ? _i128.ObjectWithSelfParent.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i145.getType<_i129.ObjectWithSparseVector?>()) {
-      return (data != null ? _i129.ObjectWithSparseVector.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i145.getType<_i130.ObjectWithUuid?>()) {
-      return (data != null ? _i130.ObjectWithUuid.fromJson(data) : null) as T;
-    }
-    if (t == _i145.getType<_i131.ObjectWithVector?>()) {
-      return (data != null ? _i131.ObjectWithVector.fromJson(data) : null) as T;
-    }
-    if (t == _i145.getType<_i132.RelatedUniqueData?>()) {
-      return (data != null ? _i132.RelatedUniqueData.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i145.getType<_i133.ModelWithRequiredField?>()) {
-      return (data != null ? _i133.ModelWithRequiredField.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i145.getType<_i134.SimpleData?>()) {
-      return (data != null ? _i134.SimpleData.fromJson(data) : null) as T;
-    }
-    if (t == _i145.getType<_i135.SimpleDateTime?>()) {
-      return (data != null ? _i135.SimpleDateTime.fromJson(data) : null) as T;
-    }
-    if (t == _i145.getType<_i136.TestEnum?>()) {
-      return (data != null ? _i136.TestEnum.fromJson(data) : null) as T;
-    }
-    if (t == _i145.getType<_i137.TestEnumDefaultSerialization?>()) {
-      return (data != null
-              ? _i137.TestEnumDefaultSerialization.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i145.getType<_i138.TestEnumEnhanced?>()) {
-      return (data != null ? _i138.TestEnumEnhanced.fromJson(data) : null) as T;
-    }
-    if (t == _i145.getType<_i139.TestEnumEnhancedByName?>()) {
-      return (data != null ? _i139.TestEnumEnhancedByName.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i145.getType<_i140.TestEnumStringified?>()) {
-      return (data != null ? _i140.TestEnumStringified.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i145.getType<_i141.Types?>()) {
-      return (data != null ? _i141.Types.fromJson(data) : null) as T;
-    }
-    if (t == _i145.getType<_i142.UniqueData?>()) {
-      return (data != null ? _i142.UniqueData.fromJson(data) : null) as T;
-    }
-    if (t == _i145.getType<_i143.UniqueDataWithNonPersist?>()) {
-      return (data != null
-              ? _i143.UniqueDataWithNonPersist.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i145.getType<_i144.UpsertTestModel?>()) {
-      return (data != null ? _i144.UpsertTestModel.fromJson(data) : null) as T;
-    }
-    if (t == List<_i7.EnrollmentInt>) {
-      return (data as List)
-              .map((e) => deserialize<_i7.EnrollmentInt>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i145.getType<List<_i7.EnrollmentInt>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i7.EnrollmentInt>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i10.PlayerUuid>) {
-      return (data as List).map((e) => deserialize<_i10.PlayerUuid>(e)).toList()
-          as T;
-    }
-    if (t == _i145.getType<List<_i10.PlayerUuid>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i10.PlayerUuid>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i14.OrderUuid>) {
-      return (data as List).map((e) => deserialize<_i14.OrderUuid>(e)).toList()
-          as T;
-    }
-    if (t == _i145.getType<List<_i14.OrderUuid>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i14.OrderUuid>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i12.CommentInt>) {
-      return (data as List).map((e) => deserialize<_i12.CommentInt>(e)).toList()
-          as T;
-    }
-    if (t == _i145.getType<List<_i12.CommentInt>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i12.CommentInt>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i19.ChangedIdTypeSelf>) {
-      return (data as List)
-              .map((e) => deserialize<_i19.ChangedIdTypeSelf>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i145.getType<List<_i19.ChangedIdTypeSelf>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i19.ChangedIdTypeSelf>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i65.EmptyModelRelationItem>) {
-      return (data as List)
-              .map((e) => deserialize<_i65.EmptyModelRelationItem>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i145.getType<List<_i65.EmptyModelRelationItem>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i65.EmptyModelRelationItem>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i72.Employee>) {
-      return (data as List).map((e) => deserialize<_i72.Employee>(e)).toList()
-          as T;
-    }
-    if (t == _i145.getType<List<_i72.Employee>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i72.Employee>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i79.PersonWithLongTableName>) {
-      return (data as List)
-              .map((e) => deserialize<_i79.PersonWithLongTableName>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i145.getType<List<_i79.PersonWithLongTableName>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i79.PersonWithLongTableName>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i78.OrganizationWithLongTableName>) {
-      return (data as List)
-              .map((e) => deserialize<_i78.OrganizationWithLongTableName>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i145.getType<List<_i78.OrganizationWithLongTableName>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map(
-                      (e) => deserialize<_i78.OrganizationWithLongTableName>(e),
-                    )
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i81.LongImplicitIdField>) {
-      return (data as List)
-              .map((e) => deserialize<_i81.LongImplicitIdField>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i145.getType<List<_i81.LongImplicitIdField>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i81.LongImplicitIdField>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i88.MultipleMaxFieldName>) {
-      return (data as List)
-              .map((e) => deserialize<_i88.MultipleMaxFieldName>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i145.getType<List<_i88.MultipleMaxFieldName>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i88.MultipleMaxFieldName>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i84.UserNote>) {
-      return (data as List).map((e) => deserialize<_i84.UserNote>(e)).toList()
-          as T;
-    }
-    if (t == _i145.getType<List<_i84.UserNote>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i84.UserNote>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i87.UserNoteWithALongName>) {
-      return (data as List)
-              .map((e) => deserialize<_i87.UserNoteWithALongName>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i145.getType<List<_i87.UserNoteWithALongName>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i87.UserNoteWithALongName>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i91.Person>) {
-      return (data as List).map((e) => deserialize<_i91.Person>(e)).toList()
-          as T;
-    }
-    if (t == _i145.getType<List<_i91.Person>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<_i91.Person>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i90.Organization>) {
-      return (data as List)
-              .map((e) => deserialize<_i90.Organization>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i145.getType<List<_i90.Organization>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i90.Organization>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i93.Enrollment>) {
-      return (data as List).map((e) => deserialize<_i93.Enrollment>(e)).toList()
-          as T;
-    }
-    if (t == _i145.getType<List<_i93.Enrollment>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i93.Enrollment>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i96.Player>) {
-      return (data as List).map((e) => deserialize<_i96.Player>(e)).toList()
-          as T;
-    }
-    if (t == _i145.getType<List<_i96.Player>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<_i96.Player>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i102.Order>) {
-      return (data as List).map((e) => deserialize<_i102.Order>(e)).toList()
-          as T;
-    }
-    if (t == _i145.getType<List<_i102.Order>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<_i102.Order>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i101.Chapter>) {
-      return (data as List).map((e) => deserialize<_i101.Chapter>(e)).toList()
-          as T;
-    }
-    if (t == _i145.getType<List<_i101.Chapter>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i101.Chapter>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i98.Comment>) {
-      return (data as List).map((e) => deserialize<_i98.Comment>(e)).toList()
-          as T;
-    }
-    if (t == _i145.getType<List<_i98.Comment>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<_i98.Comment>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i107.Blocking>) {
-      return (data as List).map((e) => deserialize<_i107.Blocking>(e)).toList()
-          as T;
-    }
-    if (t == _i145.getType<List<_i107.Blocking>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i107.Blocking>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i109.Cat>) {
-      return (data as List).map((e) => deserialize<_i109.Cat>(e)).toList() as T;
-    }
-    if (t == _i145.getType<List<_i109.Cat>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<_i109.Cat>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == dynamic) {
-      return deserializeDynamicFieldValue(data) as T;
-    }
-    if (t == List<dynamic>) {
-      return (data as List).map((e) => deserialize<dynamic>(e)).toList() as T;
-    }
-    if (t == Map<String, dynamic>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(deserialize<String>(k), deserialize<dynamic>(v)),
-          )
-          as T;
-    }
-    if (t == Set<dynamic>) {
-      return (data as List).map((e) => deserialize<dynamic>(e)).toSet() as T;
-    }
-    if (t == Map<dynamic, dynamic>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) => MapEntry(
-                deserialize<dynamic>(e['k']),
-                deserialize<dynamic>(e['v']),
-              ),
-            ),
-          )
-          as T;
-    }
-    if (t == List<_i136.TestEnum>) {
-      return (data as List).map((e) => deserialize<_i136.TestEnum>(e)).toList()
-          as T;
-    }
-    if (t == List<_i136.TestEnum?>) {
-      return (data as List).map((e) => deserialize<_i136.TestEnum?>(e)).toList()
-          as T;
-    }
-    if (t == List<List<_i136.TestEnum>>) {
-      return (data as List)
-              .map((e) => deserialize<List<_i136.TestEnum>>(e))
-              .toList()
-          as T;
-    }
-    if (t == List<_i138.TestEnumEnhanced>) {
-      return (data as List)
-              .map((e) => deserialize<_i138.TestEnumEnhanced>(e))
-              .toList()
-          as T;
-    }
-    if (t == List<_i139.TestEnumEnhancedByName>) {
-      return (data as List)
-              .map((e) => deserialize<_i139.TestEnumEnhancedByName>(e))
-              .toList()
-          as T;
-    }
-    if (t == List<String>) {
-      return (data as List).map((e) => deserialize<String>(e)).toList() as T;
-    }
-    if (t == Map<String, String>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(deserialize<String>(k), deserialize<String>(v)),
-          )
-          as T;
-    }
-    if (t == _i145.getType<List<String>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<String>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == Map<String, _i134.SimpleData>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<_i134.SimpleData>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == Map<String, int>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(deserialize<String>(k), deserialize<int>(v)),
-          )
-          as T;
-    }
-    if (t == Map<String, DateTime>) {
-      return (data as Map).map(
-            (k, v) =>
-                MapEntry(deserialize<String>(k), deserialize<DateTime>(v)),
-          )
-          as T;
-    }
-    if (t == Map<String, _i146.ByteData>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<_i146.ByteData>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == Map<String, Duration>) {
-      return (data as Map).map(
-            (k, v) =>
-                MapEntry(deserialize<String>(k), deserialize<Duration>(v)),
-          )
-          as T;
-    }
-    if (t == Map<String, _i145.UuidValue>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<_i145.UuidValue>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == Map<String, _i134.SimpleData?>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<_i134.SimpleData?>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == Map<String, int?>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(deserialize<String>(k), deserialize<int?>(v)),
-          )
-          as T;
-    }
-    if (t == Map<String, String?>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(deserialize<String>(k), deserialize<String?>(v)),
-          )
-          as T;
-    }
-    if (t == Map<String, DateTime?>) {
-      return (data as Map).map(
-            (k, v) =>
-                MapEntry(deserialize<String>(k), deserialize<DateTime?>(v)),
-          )
-          as T;
-    }
-    if (t == Map<String, _i146.ByteData?>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<_i146.ByteData?>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == Map<String, Duration?>) {
-      return (data as Map).map(
-            (k, v) =>
-                MapEntry(deserialize<String>(k), deserialize<Duration?>(v)),
-          )
-          as T;
-    }
-    if (t == Map<String, _i145.UuidValue?>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<_i145.UuidValue?>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == Map<int, int>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) =>
-                  MapEntry(deserialize<int>(e['k']), deserialize<int>(e['v'])),
-            ),
-          )
-          as T;
-    }
-    if (t == List<_i134.SimpleData>) {
-      return (data as List)
-              .map((e) => deserialize<_i134.SimpleData>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i145.getType<List<_i134.SimpleData>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i134.SimpleData>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i134.SimpleData?>) {
-      return (data as List)
-              .map((e) => deserialize<_i134.SimpleData?>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i145.getType<List<_i134.SimpleData?>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i134.SimpleData?>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<List<_i134.SimpleData>>) {
-      return (data as List)
-              .map((e) => deserialize<List<_i134.SimpleData>>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i145.getType<List<List<_i134.SimpleData>>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<List<_i134.SimpleData>>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == Map<String, List<List<Map<int, _i134.SimpleData>>?>>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<List<List<Map<int, _i134.SimpleData>>?>>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == List<List<Map<int, _i134.SimpleData>>?>) {
-      return (data as List)
-              .map((e) => deserialize<List<Map<int, _i134.SimpleData>>?>(e))
-              .toList()
-          as T;
-    }
-    if (t == List<Map<int, _i134.SimpleData>>) {
-      return (data as List)
-              .map((e) => deserialize<Map<int, _i134.SimpleData>>(e))
-              .toList()
-          as T;
-    }
-    if (t == Map<int, _i134.SimpleData>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) => MapEntry(
-                deserialize<int>(e['k']),
-                deserialize<_i134.SimpleData>(e['v']),
-              ),
-            ),
-          )
-          as T;
-    }
-    if (t == _i145.getType<List<Map<int, _i134.SimpleData>>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<Map<int, _i134.SimpleData>>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t ==
-        _i145
-            .getType<Map<String, List<List<Map<int, _i134.SimpleData>>?>>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) => MapEntry(
-                    deserialize<String>(k),
-                    deserialize<List<List<Map<int, _i134.SimpleData>>?>>(v),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == _i145.getType<List<Map<int, _i134.SimpleData>>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<Map<int, _i134.SimpleData>>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == Map<String, Map<int, _i134.SimpleData>>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<Map<int, _i134.SimpleData>>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == _i145.getType<Map<String, Map<int, _i134.SimpleData>>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) => MapEntry(
-                    deserialize<String>(k),
-                    deserialize<Map<int, _i134.SimpleData>>(v),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == List<_i76.SealedParent>) {
-      return (data as List)
-              .map((e) => deserialize<_i76.SealedParent>(e))
-              .toList()
-          as T;
-    }
-    if (t == List<int>) {
-      return (data as List).map((e) => deserialize<int>(e)).toList() as T;
-    }
-    if (t == _i145.getType<List<int>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<int>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == _i145.getType<Map<int, int>?>()) {
-      return (data != null
-              ? Map.fromEntries(
-                  (data as List).map(
-                    (e) => MapEntry(
-                      deserialize<int>(e['k']),
-                      deserialize<int>(e['v']),
-                    ),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == Set<int>) {
-      return (data as List).map((e) => deserialize<int>(e)).toSet() as T;
-    }
-    if (t == _i145.getType<Set<int>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<int>(e)).toSet()
-              : null)
-          as T;
-    }
-    if (t == _i145.getType<(String, {Uri? optionalUri})?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<String>(((data as Map)['p'] as List)[0]),
-                  optionalUri: ((data)['n'] as Map)['optionalUri'] == null
-                      ? null
-                      : deserialize<Uri>(data['n']['optionalUri']),
-                )
-                as T;
-    }
-    if (t == List<_i147.SimpleData>) {
-      return (data as List)
-              .map((e) => deserialize<_i147.SimpleData>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i145.getType<(String, {Uri? optionalUri})?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<String>(((data as Map)['p'] as List)[0]),
-                  optionalUri: ((data)['n'] as Map)['optionalUri'] == null
-                      ? null
-                      : deserialize<Uri>(data['n']['optionalUri']),
-                )
-                as T;
+    final fn = _deserializers[t];
+    if (fn != null) {
+      return fn(data, this) as T;
     }
     try {
       return _i2.Protocol().deserialize<T>(data, t);
-    } on _i145.DeserializationTypeNotFoundException catch (_) {}
+    } on _i6.DeserializationTypeNotFoundException catch (_) {}
     try {
       return _i3.Protocol().deserialize<T>(data, t);
-    } on _i145.DeserializationTypeNotFoundException catch (_) {}
+    } on _i6.DeserializationTypeNotFoundException catch (_) {}
     try {
       return _i4.Protocol().deserialize<T>(data, t);
-    } on _i145.DeserializationTypeNotFoundException catch (_) {}
+    } on _i6.DeserializationTypeNotFoundException catch (_) {}
     try {
       return _i5.Protocol().deserialize<T>(data, t);
-    } on _i145.DeserializationTypeNotFoundException catch (_) {}
+    } on _i6.DeserializationTypeNotFoundException catch (_) {}
     try {
-      return _i148.Protocol().deserialize<T>(data, t);
-    } on _i145.DeserializationTypeNotFoundException catch (_) {}
+      return _i7.Protocol().deserialize<T>(data, t);
+    } on _i6.DeserializationTypeNotFoundException catch (_) {}
     return super.deserialize<T>(data, t);
   }
 
   static String? getClassNameForType(Type type) {
     return switch (type) {
-      _i6.CourseUuid => 'CourseUuid',
-      _i7.EnrollmentInt => 'EnrollmentInt',
-      _i8.StudentUuid => 'StudentUuid',
-      _i9.ArenaUuid => 'ArenaUuid',
-      _i10.PlayerUuid => 'PlayerUuid',
-      _i11.TeamInt => 'TeamInt',
-      _i12.CommentInt => 'CommentInt',
-      _i13.CustomerInt => 'CustomerInt',
-      _i14.OrderUuid => 'OrderUuid',
-      _i15.AddressUuid => 'AddressUuid',
-      _i16.CitizenInt => 'CitizenInt',
-      _i17.CompanyUuid => 'CompanyUuid',
-      _i18.TownInt => 'TownInt',
-      _i19.ChangedIdTypeSelf => 'ChangedIdTypeSelf',
-      _i20.BigIntDefault => 'BigIntDefault',
-      _i21.BigIntDefaultMix => 'BigIntDefaultMix',
-      _i22.BigIntDefaultModel => 'BigIntDefaultModel',
-      _i23.BigIntDefaultPersist => 'BigIntDefaultPersist',
-      _i24.BoolDefault => 'BoolDefault',
-      _i25.BoolDefaultMix => 'BoolDefaultMix',
-      _i26.BoolDefaultModel => 'BoolDefaultModel',
-      _i27.BoolDefaultPersist => 'BoolDefaultPersist',
-      _i28.DateTimeDefault => 'DateTimeDefault',
-      _i29.DateTimeDefaultMix => 'DateTimeDefaultMix',
-      _i30.DateTimeDefaultModel => 'DateTimeDefaultModel',
-      _i31.DateTimeDefaultPersist => 'DateTimeDefaultPersist',
-      _i32.DoubleDefault => 'DoubleDefault',
-      _i33.DoubleDefaultMix => 'DoubleDefaultMix',
-      _i34.DoubleDefaultModel => 'DoubleDefaultModel',
-      _i35.DoubleDefaultPersist => 'DoubleDefaultPersist',
-      _i36.DurationDefault => 'DurationDefault',
-      _i37.DurationDefaultMix => 'DurationDefaultMix',
-      _i38.DurationDefaultModel => 'DurationDefaultModel',
-      _i39.DurationDefaultPersist => 'DurationDefaultPersist',
-      _i40.EnumDefault => 'EnumDefault',
-      _i41.EnumDefaultMix => 'EnumDefaultMix',
-      _i42.EnumDefaultModel => 'EnumDefaultModel',
-      _i43.EnumDefaultPersist => 'EnumDefaultPersist',
-      _i44.ByIndexEnum => 'ByIndexEnum',
-      _i45.ByNameEnum => 'ByNameEnum',
-      _i46.DefaultValueEnum => 'DefaultValueEnum',
-      _i47.DefaultException => 'DefaultException',
-      _i48.IntDefault => 'IntDefault',
-      _i49.IntDefaultMix => 'IntDefaultMix',
-      _i50.IntDefaultModel => 'IntDefaultModel',
-      _i51.IntDefaultPersist => 'IntDefaultPersist',
-      _i52.StringDefault => 'StringDefault',
-      _i53.StringDefaultMix => 'StringDefaultMix',
-      _i54.StringDefaultModel => 'StringDefaultModel',
-      _i55.StringDefaultPersist => 'StringDefaultPersist',
-      _i56.UriDefault => 'UriDefault',
-      _i57.UriDefaultMix => 'UriDefaultMix',
-      _i58.UriDefaultModel => 'UriDefaultModel',
-      _i59.UriDefaultPersist => 'UriDefaultPersist',
-      _i60.UuidDefault => 'UuidDefault',
-      _i61.UuidDefaultMix => 'UuidDefaultMix',
-      _i62.UuidDefaultModel => 'UuidDefaultModel',
-      _i63.UuidDefaultPersist => 'UuidDefaultPersist',
-      _i64.EmptyModel => 'EmptyModel',
-      _i65.EmptyModelRelationItem => 'EmptyModelRelationItem',
-      _i66.EmptyModelWithTable => 'EmptyModelWithTable',
-      _i67.RelationEmptyModel => 'RelationEmptyModel',
-      _i68.ChildClassExplicitColumn => 'ChildClassExplicitColumn',
-      _i69.NonTableParentClass => 'NonTableParentClass',
-      _i70.ModifiedColumnName => 'ModifiedColumnName',
-      _i71.Department => 'Department',
-      _i72.Employee => 'Employee',
-      _i73.Contractor => 'Contractor',
-      _i74.Service => 'Service',
-      _i75.TableWithExplicitColumnName => 'TableWithExplicitColumnName',
-      _i76.SealedGrandChild => 'SealedGrandChild',
-      _i76.SealedChild => 'SealedChild',
-      _i76.SealedOtherChild => 'SealedOtherChild',
-      _i77.CityWithLongTableName => 'CityWithLongTableName',
-      _i78.OrganizationWithLongTableName => 'OrganizationWithLongTableName',
-      _i79.PersonWithLongTableName => 'PersonWithLongTableName',
-      _i80.MaxFieldName => 'MaxFieldName',
-      _i81.LongImplicitIdField => 'LongImplicitIdField',
-      _i82.LongImplicitIdFieldCollection => 'LongImplicitIdFieldCollection',
-      _i83.RelationToMultipleMaxFieldName => 'RelationToMultipleMaxFieldName',
-      _i84.UserNote => 'UserNote',
-      _i85.UserNoteCollection => 'UserNoteCollection',
-      _i86.UserNoteCollectionWithALongName => 'UserNoteCollectionWithALongName',
-      _i87.UserNoteWithALongName => 'UserNoteWithALongName',
-      _i88.MultipleMaxFieldName => 'MultipleMaxFieldName',
-      _i89.City => 'City',
-      _i90.Organization => 'Organization',
-      _i91.Person => 'Person',
-      _i92.Course => 'Course',
-      _i93.Enrollment => 'Enrollment',
-      _i94.Student => 'Student',
-      _i95.Arena => 'Arena',
-      _i96.Player => 'Player',
-      _i97.Team => 'Team',
-      _i98.Comment => 'Comment',
-      _i99.Customer => 'Customer',
-      _i100.Book => 'Book',
-      _i101.Chapter => 'Chapter',
-      _i102.Order => 'Order',
-      _i103.Address => 'Address',
-      _i104.Citizen => 'Citizen',
-      _i105.Company => 'Company',
-      _i106.Town => 'Town',
-      _i107.Blocking => 'Blocking',
-      _i108.Member => 'Member',
-      _i109.Cat => 'Cat',
-      _i110.Post => 'Post',
-      _i111.NullsDistinctData => 'NullsDistinctData',
-      _i112.ObjectFieldPersist => 'ObjectFieldPersist',
-      _i113.ObjectFieldScopes => 'ObjectFieldScopes',
-      _i114.ObjectWithBit => 'ObjectWithBit',
-      _i115.ObjectWithByteData => 'ObjectWithByteData',
-      _i116.ObjectWithDuration => 'ObjectWithDuration',
-      _i117.ObjectWithDynamic => 'ObjectWithDynamic',
-      _i118.ObjectWithEnum => 'ObjectWithEnum',
-      _i119.ObjectWithEnumEnhanced => 'ObjectWithEnumEnhanced',
-      _i120.ObjectWithHalfVector => 'ObjectWithHalfVector',
-      _i121.ObjectWithIndex => 'ObjectWithIndex',
-      _i122.ObjectWithJsonb => 'ObjectWithJsonb',
-      _i123.ObjectWithJsonbClassLevel => 'ObjectWithJsonbClassLevel',
-      _i124.ObjectWithMaps => 'ObjectWithMaps',
-      _i125.ObjectWithObject => 'ObjectWithObject',
-      _i126.ObjectWithParent => 'ObjectWithParent',
-      _i127.ObjectWithSealedClass => 'ObjectWithSealedClass',
-      _i128.ObjectWithSelfParent => 'ObjectWithSelfParent',
-      _i129.ObjectWithSparseVector => 'ObjectWithSparseVector',
-      _i130.ObjectWithUuid => 'ObjectWithUuid',
-      _i131.ObjectWithVector => 'ObjectWithVector',
-      _i132.RelatedUniqueData => 'RelatedUniqueData',
-      _i133.ModelWithRequiredField => 'ModelWithRequiredField',
-      _i134.SimpleData => 'SimpleData',
-      _i135.SimpleDateTime => 'SimpleDateTime',
-      _i136.TestEnum => 'TestEnum',
-      _i137.TestEnumDefaultSerialization => 'TestEnumDefaultSerialization',
-      _i138.TestEnumEnhanced => 'TestEnumEnhanced',
-      _i139.TestEnumEnhancedByName => 'TestEnumEnhancedByName',
-      _i140.TestEnumStringified => 'TestEnumStringified',
-      _i141.Types => 'Types',
-      _i142.UniqueData => 'UniqueData',
-      _i143.UniqueDataWithNonPersist => 'UniqueDataWithNonPersist',
-      _i144.UpsertTestModel => 'UpsertTestModel',
+      _i8.CourseUuid => 'CourseUuid',
+      _i9.EnrollmentInt => 'EnrollmentInt',
+      _i10.StudentUuid => 'StudentUuid',
+      _i11.ArenaUuid => 'ArenaUuid',
+      _i12.PlayerUuid => 'PlayerUuid',
+      _i13.TeamInt => 'TeamInt',
+      _i14.CommentInt => 'CommentInt',
+      _i15.CustomerInt => 'CustomerInt',
+      _i16.OrderUuid => 'OrderUuid',
+      _i17.AddressUuid => 'AddressUuid',
+      _i18.CitizenInt => 'CitizenInt',
+      _i19.CompanyUuid => 'CompanyUuid',
+      _i20.TownInt => 'TownInt',
+      _i21.ChangedIdTypeSelf => 'ChangedIdTypeSelf',
+      _i22.BigIntDefault => 'BigIntDefault',
+      _i23.BigIntDefaultMix => 'BigIntDefaultMix',
+      _i24.BigIntDefaultModel => 'BigIntDefaultModel',
+      _i25.BigIntDefaultPersist => 'BigIntDefaultPersist',
+      _i26.BoolDefault => 'BoolDefault',
+      _i27.BoolDefaultMix => 'BoolDefaultMix',
+      _i28.BoolDefaultModel => 'BoolDefaultModel',
+      _i29.BoolDefaultPersist => 'BoolDefaultPersist',
+      _i30.DateTimeDefault => 'DateTimeDefault',
+      _i31.DateTimeDefaultMix => 'DateTimeDefaultMix',
+      _i32.DateTimeDefaultModel => 'DateTimeDefaultModel',
+      _i33.DateTimeDefaultPersist => 'DateTimeDefaultPersist',
+      _i34.DoubleDefault => 'DoubleDefault',
+      _i35.DoubleDefaultMix => 'DoubleDefaultMix',
+      _i36.DoubleDefaultModel => 'DoubleDefaultModel',
+      _i37.DoubleDefaultPersist => 'DoubleDefaultPersist',
+      _i38.DurationDefault => 'DurationDefault',
+      _i39.DurationDefaultMix => 'DurationDefaultMix',
+      _i40.DurationDefaultModel => 'DurationDefaultModel',
+      _i41.DurationDefaultPersist => 'DurationDefaultPersist',
+      _i42.EnumDefault => 'EnumDefault',
+      _i43.EnumDefaultMix => 'EnumDefaultMix',
+      _i44.EnumDefaultModel => 'EnumDefaultModel',
+      _i45.EnumDefaultPersist => 'EnumDefaultPersist',
+      _i46.ByIndexEnum => 'ByIndexEnum',
+      _i47.ByNameEnum => 'ByNameEnum',
+      _i48.DefaultValueEnum => 'DefaultValueEnum',
+      _i49.DefaultException => 'DefaultException',
+      _i50.IntDefault => 'IntDefault',
+      _i51.IntDefaultMix => 'IntDefaultMix',
+      _i52.IntDefaultModel => 'IntDefaultModel',
+      _i53.IntDefaultPersist => 'IntDefaultPersist',
+      _i54.StringDefault => 'StringDefault',
+      _i55.StringDefaultMix => 'StringDefaultMix',
+      _i56.StringDefaultModel => 'StringDefaultModel',
+      _i57.StringDefaultPersist => 'StringDefaultPersist',
+      _i58.UriDefault => 'UriDefault',
+      _i59.UriDefaultMix => 'UriDefaultMix',
+      _i60.UriDefaultModel => 'UriDefaultModel',
+      _i61.UriDefaultPersist => 'UriDefaultPersist',
+      _i62.UuidDefault => 'UuidDefault',
+      _i63.UuidDefaultMix => 'UuidDefaultMix',
+      _i64.UuidDefaultModel => 'UuidDefaultModel',
+      _i65.UuidDefaultPersist => 'UuidDefaultPersist',
+      _i66.EmptyModel => 'EmptyModel',
+      _i67.EmptyModelRelationItem => 'EmptyModelRelationItem',
+      _i68.EmptyModelWithTable => 'EmptyModelWithTable',
+      _i69.RelationEmptyModel => 'RelationEmptyModel',
+      _i70.ChildClassExplicitColumn => 'ChildClassExplicitColumn',
+      _i71.NonTableParentClass => 'NonTableParentClass',
+      _i72.ModifiedColumnName => 'ModifiedColumnName',
+      _i73.Department => 'Department',
+      _i74.Employee => 'Employee',
+      _i75.Contractor => 'Contractor',
+      _i76.Service => 'Service',
+      _i77.TableWithExplicitColumnName => 'TableWithExplicitColumnName',
+      _i78.SealedGrandChild => 'SealedGrandChild',
+      _i78.SealedChild => 'SealedChild',
+      _i78.SealedOtherChild => 'SealedOtherChild',
+      _i79.CityWithLongTableName => 'CityWithLongTableName',
+      _i80.OrganizationWithLongTableName => 'OrganizationWithLongTableName',
+      _i81.PersonWithLongTableName => 'PersonWithLongTableName',
+      _i82.MaxFieldName => 'MaxFieldName',
+      _i83.LongImplicitIdField => 'LongImplicitIdField',
+      _i84.LongImplicitIdFieldCollection => 'LongImplicitIdFieldCollection',
+      _i85.RelationToMultipleMaxFieldName => 'RelationToMultipleMaxFieldName',
+      _i86.UserNote => 'UserNote',
+      _i87.UserNoteCollection => 'UserNoteCollection',
+      _i88.UserNoteCollectionWithALongName => 'UserNoteCollectionWithALongName',
+      _i89.UserNoteWithALongName => 'UserNoteWithALongName',
+      _i90.MultipleMaxFieldName => 'MultipleMaxFieldName',
+      _i91.City => 'City',
+      _i92.Organization => 'Organization',
+      _i93.Person => 'Person',
+      _i94.Course => 'Course',
+      _i95.Enrollment => 'Enrollment',
+      _i96.Student => 'Student',
+      _i97.Arena => 'Arena',
+      _i98.Player => 'Player',
+      _i99.Team => 'Team',
+      _i100.Comment => 'Comment',
+      _i101.Customer => 'Customer',
+      _i102.Book => 'Book',
+      _i103.Chapter => 'Chapter',
+      _i104.Order => 'Order',
+      _i105.Address => 'Address',
+      _i106.Citizen => 'Citizen',
+      _i107.Company => 'Company',
+      _i108.Town => 'Town',
+      _i109.Blocking => 'Blocking',
+      _i110.Member => 'Member',
+      _i111.Cat => 'Cat',
+      _i112.Post => 'Post',
+      _i113.NullsDistinctData => 'NullsDistinctData',
+      _i114.ObjectFieldPersist => 'ObjectFieldPersist',
+      _i115.ObjectFieldScopes => 'ObjectFieldScopes',
+      _i116.ObjectWithBit => 'ObjectWithBit',
+      _i117.ObjectWithByteData => 'ObjectWithByteData',
+      _i118.ObjectWithDuration => 'ObjectWithDuration',
+      _i119.ObjectWithDynamic => 'ObjectWithDynamic',
+      _i120.ObjectWithEnum => 'ObjectWithEnum',
+      _i121.ObjectWithEnumEnhanced => 'ObjectWithEnumEnhanced',
+      _i122.ObjectWithHalfVector => 'ObjectWithHalfVector',
+      _i123.ObjectWithIndex => 'ObjectWithIndex',
+      _i124.ObjectWithJsonb => 'ObjectWithJsonb',
+      _i125.ObjectWithJsonbClassLevel => 'ObjectWithJsonbClassLevel',
+      _i126.ObjectWithMaps => 'ObjectWithMaps',
+      _i127.ObjectWithObject => 'ObjectWithObject',
+      _i128.ObjectWithParent => 'ObjectWithParent',
+      _i129.ObjectWithSealedClass => 'ObjectWithSealedClass',
+      _i130.ObjectWithSelfParent => 'ObjectWithSelfParent',
+      _i131.ObjectWithSparseVector => 'ObjectWithSparseVector',
+      _i132.ObjectWithUuid => 'ObjectWithUuid',
+      _i133.ObjectWithVector => 'ObjectWithVector',
+      _i134.RelatedUniqueData => 'RelatedUniqueData',
+      _i135.ModelWithRequiredField => 'ModelWithRequiredField',
+      _i136.SimpleData => 'SimpleData',
+      _i137.SimpleDateTime => 'SimpleDateTime',
+      _i138.TestEnum => 'TestEnum',
+      _i139.TestEnumDefaultSerialization => 'TestEnumDefaultSerialization',
+      _i140.TestEnumEnhanced => 'TestEnumEnhanced',
+      _i141.TestEnumEnhancedByName => 'TestEnumEnhancedByName',
+      _i142.TestEnumStringified => 'TestEnumStringified',
+      _i143.Types => 'Types',
+      _i144.UniqueData => 'UniqueData',
+      _i145.UniqueDataWithNonPersist => 'UniqueDataWithNonPersist',
+      _i146.UpsertTestModel => 'UpsertTestModel',
       _ => null,
     };
   }
@@ -3550,287 +2005,287 @@ class Protocol extends _i1.DatabaseSerializationManager {
     }
 
     switch (data) {
-      case _i6.CourseUuid():
+      case _i8.CourseUuid():
         return 'CourseUuid';
-      case _i7.EnrollmentInt():
+      case _i9.EnrollmentInt():
         return 'EnrollmentInt';
-      case _i8.StudentUuid():
+      case _i10.StudentUuid():
         return 'StudentUuid';
-      case _i9.ArenaUuid():
+      case _i11.ArenaUuid():
         return 'ArenaUuid';
-      case _i10.PlayerUuid():
+      case _i12.PlayerUuid():
         return 'PlayerUuid';
-      case _i11.TeamInt():
+      case _i13.TeamInt():
         return 'TeamInt';
-      case _i12.CommentInt():
+      case _i14.CommentInt():
         return 'CommentInt';
-      case _i13.CustomerInt():
+      case _i15.CustomerInt():
         return 'CustomerInt';
-      case _i14.OrderUuid():
+      case _i16.OrderUuid():
         return 'OrderUuid';
-      case _i15.AddressUuid():
+      case _i17.AddressUuid():
         return 'AddressUuid';
-      case _i16.CitizenInt():
+      case _i18.CitizenInt():
         return 'CitizenInt';
-      case _i17.CompanyUuid():
+      case _i19.CompanyUuid():
         return 'CompanyUuid';
-      case _i18.TownInt():
+      case _i20.TownInt():
         return 'TownInt';
-      case _i19.ChangedIdTypeSelf():
+      case _i21.ChangedIdTypeSelf():
         return 'ChangedIdTypeSelf';
-      case _i20.BigIntDefault():
+      case _i22.BigIntDefault():
         return 'BigIntDefault';
-      case _i21.BigIntDefaultMix():
+      case _i23.BigIntDefaultMix():
         return 'BigIntDefaultMix';
-      case _i22.BigIntDefaultModel():
+      case _i24.BigIntDefaultModel():
         return 'BigIntDefaultModel';
-      case _i23.BigIntDefaultPersist():
+      case _i25.BigIntDefaultPersist():
         return 'BigIntDefaultPersist';
-      case _i24.BoolDefault():
+      case _i26.BoolDefault():
         return 'BoolDefault';
-      case _i25.BoolDefaultMix():
+      case _i27.BoolDefaultMix():
         return 'BoolDefaultMix';
-      case _i26.BoolDefaultModel():
+      case _i28.BoolDefaultModel():
         return 'BoolDefaultModel';
-      case _i27.BoolDefaultPersist():
+      case _i29.BoolDefaultPersist():
         return 'BoolDefaultPersist';
-      case _i28.DateTimeDefault():
+      case _i30.DateTimeDefault():
         return 'DateTimeDefault';
-      case _i29.DateTimeDefaultMix():
+      case _i31.DateTimeDefaultMix():
         return 'DateTimeDefaultMix';
-      case _i30.DateTimeDefaultModel():
+      case _i32.DateTimeDefaultModel():
         return 'DateTimeDefaultModel';
-      case _i31.DateTimeDefaultPersist():
+      case _i33.DateTimeDefaultPersist():
         return 'DateTimeDefaultPersist';
-      case _i32.DoubleDefault():
+      case _i34.DoubleDefault():
         return 'DoubleDefault';
-      case _i33.DoubleDefaultMix():
+      case _i35.DoubleDefaultMix():
         return 'DoubleDefaultMix';
-      case _i34.DoubleDefaultModel():
+      case _i36.DoubleDefaultModel():
         return 'DoubleDefaultModel';
-      case _i35.DoubleDefaultPersist():
+      case _i37.DoubleDefaultPersist():
         return 'DoubleDefaultPersist';
-      case _i36.DurationDefault():
+      case _i38.DurationDefault():
         return 'DurationDefault';
-      case _i37.DurationDefaultMix():
+      case _i39.DurationDefaultMix():
         return 'DurationDefaultMix';
-      case _i38.DurationDefaultModel():
+      case _i40.DurationDefaultModel():
         return 'DurationDefaultModel';
-      case _i39.DurationDefaultPersist():
+      case _i41.DurationDefaultPersist():
         return 'DurationDefaultPersist';
-      case _i40.EnumDefault():
+      case _i42.EnumDefault():
         return 'EnumDefault';
-      case _i41.EnumDefaultMix():
+      case _i43.EnumDefaultMix():
         return 'EnumDefaultMix';
-      case _i42.EnumDefaultModel():
+      case _i44.EnumDefaultModel():
         return 'EnumDefaultModel';
-      case _i43.EnumDefaultPersist():
+      case _i45.EnumDefaultPersist():
         return 'EnumDefaultPersist';
-      case _i44.ByIndexEnum():
+      case _i46.ByIndexEnum():
         return 'ByIndexEnum';
-      case _i45.ByNameEnum():
+      case _i47.ByNameEnum():
         return 'ByNameEnum';
-      case _i46.DefaultValueEnum():
+      case _i48.DefaultValueEnum():
         return 'DefaultValueEnum';
-      case _i47.DefaultException():
+      case _i49.DefaultException():
         return 'DefaultException';
-      case _i48.IntDefault():
+      case _i50.IntDefault():
         return 'IntDefault';
-      case _i49.IntDefaultMix():
+      case _i51.IntDefaultMix():
         return 'IntDefaultMix';
-      case _i50.IntDefaultModel():
+      case _i52.IntDefaultModel():
         return 'IntDefaultModel';
-      case _i51.IntDefaultPersist():
+      case _i53.IntDefaultPersist():
         return 'IntDefaultPersist';
-      case _i52.StringDefault():
+      case _i54.StringDefault():
         return 'StringDefault';
-      case _i53.StringDefaultMix():
+      case _i55.StringDefaultMix():
         return 'StringDefaultMix';
-      case _i54.StringDefaultModel():
+      case _i56.StringDefaultModel():
         return 'StringDefaultModel';
-      case _i55.StringDefaultPersist():
+      case _i57.StringDefaultPersist():
         return 'StringDefaultPersist';
-      case _i56.UriDefault():
+      case _i58.UriDefault():
         return 'UriDefault';
-      case _i57.UriDefaultMix():
+      case _i59.UriDefaultMix():
         return 'UriDefaultMix';
-      case _i58.UriDefaultModel():
+      case _i60.UriDefaultModel():
         return 'UriDefaultModel';
-      case _i59.UriDefaultPersist():
+      case _i61.UriDefaultPersist():
         return 'UriDefaultPersist';
-      case _i60.UuidDefault():
+      case _i62.UuidDefault():
         return 'UuidDefault';
-      case _i61.UuidDefaultMix():
+      case _i63.UuidDefaultMix():
         return 'UuidDefaultMix';
-      case _i62.UuidDefaultModel():
+      case _i64.UuidDefaultModel():
         return 'UuidDefaultModel';
-      case _i63.UuidDefaultPersist():
+      case _i65.UuidDefaultPersist():
         return 'UuidDefaultPersist';
-      case _i64.EmptyModel():
+      case _i66.EmptyModel():
         return 'EmptyModel';
-      case _i65.EmptyModelRelationItem():
+      case _i67.EmptyModelRelationItem():
         return 'EmptyModelRelationItem';
-      case _i66.EmptyModelWithTable():
+      case _i68.EmptyModelWithTable():
         return 'EmptyModelWithTable';
-      case _i67.RelationEmptyModel():
+      case _i69.RelationEmptyModel():
         return 'RelationEmptyModel';
-      case _i68.ChildClassExplicitColumn():
+      case _i70.ChildClassExplicitColumn():
         return 'ChildClassExplicitColumn';
-      case _i69.NonTableParentClass():
+      case _i71.NonTableParentClass():
         return 'NonTableParentClass';
-      case _i70.ModifiedColumnName():
+      case _i72.ModifiedColumnName():
         return 'ModifiedColumnName';
-      case _i71.Department():
+      case _i73.Department():
         return 'Department';
-      case _i72.Employee():
+      case _i74.Employee():
         return 'Employee';
-      case _i73.Contractor():
+      case _i75.Contractor():
         return 'Contractor';
-      case _i74.Service():
+      case _i76.Service():
         return 'Service';
-      case _i75.TableWithExplicitColumnName():
+      case _i77.TableWithExplicitColumnName():
         return 'TableWithExplicitColumnName';
-      case _i76.SealedGrandChild():
+      case _i78.SealedGrandChild():
         return 'SealedGrandChild';
-      case _i76.SealedChild():
+      case _i78.SealedChild():
         return 'SealedChild';
-      case _i76.SealedOtherChild():
+      case _i78.SealedOtherChild():
         return 'SealedOtherChild';
-      case _i77.CityWithLongTableName():
+      case _i79.CityWithLongTableName():
         return 'CityWithLongTableName';
-      case _i78.OrganizationWithLongTableName():
+      case _i80.OrganizationWithLongTableName():
         return 'OrganizationWithLongTableName';
-      case _i79.PersonWithLongTableName():
+      case _i81.PersonWithLongTableName():
         return 'PersonWithLongTableName';
-      case _i80.MaxFieldName():
+      case _i82.MaxFieldName():
         return 'MaxFieldName';
-      case _i81.LongImplicitIdField():
+      case _i83.LongImplicitIdField():
         return 'LongImplicitIdField';
-      case _i82.LongImplicitIdFieldCollection():
+      case _i84.LongImplicitIdFieldCollection():
         return 'LongImplicitIdFieldCollection';
-      case _i83.RelationToMultipleMaxFieldName():
+      case _i85.RelationToMultipleMaxFieldName():
         return 'RelationToMultipleMaxFieldName';
-      case _i84.UserNote():
+      case _i86.UserNote():
         return 'UserNote';
-      case _i85.UserNoteCollection():
+      case _i87.UserNoteCollection():
         return 'UserNoteCollection';
-      case _i86.UserNoteCollectionWithALongName():
+      case _i88.UserNoteCollectionWithALongName():
         return 'UserNoteCollectionWithALongName';
-      case _i87.UserNoteWithALongName():
+      case _i89.UserNoteWithALongName():
         return 'UserNoteWithALongName';
-      case _i88.MultipleMaxFieldName():
+      case _i90.MultipleMaxFieldName():
         return 'MultipleMaxFieldName';
-      case _i89.City():
+      case _i91.City():
         return 'City';
-      case _i90.Organization():
+      case _i92.Organization():
         return 'Organization';
-      case _i91.Person():
+      case _i93.Person():
         return 'Person';
-      case _i92.Course():
+      case _i94.Course():
         return 'Course';
-      case _i93.Enrollment():
+      case _i95.Enrollment():
         return 'Enrollment';
-      case _i94.Student():
+      case _i96.Student():
         return 'Student';
-      case _i95.Arena():
+      case _i97.Arena():
         return 'Arena';
-      case _i96.Player():
+      case _i98.Player():
         return 'Player';
-      case _i97.Team():
+      case _i99.Team():
         return 'Team';
-      case _i98.Comment():
+      case _i100.Comment():
         return 'Comment';
-      case _i99.Customer():
+      case _i101.Customer():
         return 'Customer';
-      case _i100.Book():
+      case _i102.Book():
         return 'Book';
-      case _i101.Chapter():
+      case _i103.Chapter():
         return 'Chapter';
-      case _i102.Order():
+      case _i104.Order():
         return 'Order';
-      case _i103.Address():
+      case _i105.Address():
         return 'Address';
-      case _i104.Citizen():
+      case _i106.Citizen():
         return 'Citizen';
-      case _i105.Company():
+      case _i107.Company():
         return 'Company';
-      case _i106.Town():
+      case _i108.Town():
         return 'Town';
-      case _i107.Blocking():
+      case _i109.Blocking():
         return 'Blocking';
-      case _i108.Member():
+      case _i110.Member():
         return 'Member';
-      case _i109.Cat():
+      case _i111.Cat():
         return 'Cat';
-      case _i110.Post():
+      case _i112.Post():
         return 'Post';
-      case _i111.NullsDistinctData():
+      case _i113.NullsDistinctData():
         return 'NullsDistinctData';
-      case _i112.ObjectFieldPersist():
+      case _i114.ObjectFieldPersist():
         return 'ObjectFieldPersist';
-      case _i113.ObjectFieldScopes():
+      case _i115.ObjectFieldScopes():
         return 'ObjectFieldScopes';
-      case _i114.ObjectWithBit():
+      case _i116.ObjectWithBit():
         return 'ObjectWithBit';
-      case _i115.ObjectWithByteData():
+      case _i117.ObjectWithByteData():
         return 'ObjectWithByteData';
-      case _i116.ObjectWithDuration():
+      case _i118.ObjectWithDuration():
         return 'ObjectWithDuration';
-      case _i117.ObjectWithDynamic():
+      case _i119.ObjectWithDynamic():
         return 'ObjectWithDynamic';
-      case _i118.ObjectWithEnum():
+      case _i120.ObjectWithEnum():
         return 'ObjectWithEnum';
-      case _i119.ObjectWithEnumEnhanced():
+      case _i121.ObjectWithEnumEnhanced():
         return 'ObjectWithEnumEnhanced';
-      case _i120.ObjectWithHalfVector():
+      case _i122.ObjectWithHalfVector():
         return 'ObjectWithHalfVector';
-      case _i121.ObjectWithIndex():
+      case _i123.ObjectWithIndex():
         return 'ObjectWithIndex';
-      case _i122.ObjectWithJsonb():
+      case _i124.ObjectWithJsonb():
         return 'ObjectWithJsonb';
-      case _i123.ObjectWithJsonbClassLevel():
+      case _i125.ObjectWithJsonbClassLevel():
         return 'ObjectWithJsonbClassLevel';
-      case _i124.ObjectWithMaps():
+      case _i126.ObjectWithMaps():
         return 'ObjectWithMaps';
-      case _i125.ObjectWithObject():
+      case _i127.ObjectWithObject():
         return 'ObjectWithObject';
-      case _i126.ObjectWithParent():
+      case _i128.ObjectWithParent():
         return 'ObjectWithParent';
-      case _i127.ObjectWithSealedClass():
+      case _i129.ObjectWithSealedClass():
         return 'ObjectWithSealedClass';
-      case _i128.ObjectWithSelfParent():
+      case _i130.ObjectWithSelfParent():
         return 'ObjectWithSelfParent';
-      case _i129.ObjectWithSparseVector():
+      case _i131.ObjectWithSparseVector():
         return 'ObjectWithSparseVector';
-      case _i130.ObjectWithUuid():
+      case _i132.ObjectWithUuid():
         return 'ObjectWithUuid';
-      case _i131.ObjectWithVector():
+      case _i133.ObjectWithVector():
         return 'ObjectWithVector';
-      case _i132.RelatedUniqueData():
+      case _i134.RelatedUniqueData():
         return 'RelatedUniqueData';
-      case _i133.ModelWithRequiredField():
+      case _i135.ModelWithRequiredField():
         return 'ModelWithRequiredField';
-      case _i134.SimpleData():
+      case _i136.SimpleData():
         return 'SimpleData';
-      case _i135.SimpleDateTime():
+      case _i137.SimpleDateTime():
         return 'SimpleDateTime';
-      case _i136.TestEnum():
+      case _i138.TestEnum():
         return 'TestEnum';
-      case _i137.TestEnumDefaultSerialization():
+      case _i139.TestEnumDefaultSerialization():
         return 'TestEnumDefaultSerialization';
-      case _i138.TestEnumEnhanced():
+      case _i140.TestEnumEnhanced():
         return 'TestEnumEnhanced';
-      case _i139.TestEnumEnhancedByName():
+      case _i141.TestEnumEnhancedByName():
         return 'TestEnumEnhancedByName';
-      case _i140.TestEnumStringified():
+      case _i142.TestEnumStringified():
         return 'TestEnumStringified';
-      case _i141.Types():
+      case _i143.Types():
         return 'Types';
-      case _i142.UniqueData():
+      case _i144.UniqueData():
         return 'UniqueData';
-      case _i143.UniqueDataWithNonPersist():
+      case _i145.UniqueDataWithNonPersist():
         return 'UniqueDataWithNonPersist';
-      case _i144.UpsertTestModel():
+      case _i146.UpsertTestModel():
         return 'UpsertTestModel';
     }
     className = _i2.Protocol().getClassNameForObject(data);
@@ -3867,427 +2322,427 @@ class Protocol extends _i1.DatabaseSerializationManager {
       return super.deserializeByClassName(data);
     }
     if (dataClassName == 'CourseUuid') {
-      return deserialize<_i6.CourseUuid>(data['data']);
+      return deserialize<_i8.CourseUuid>(data['data']);
     }
     if (dataClassName == 'EnrollmentInt') {
-      return deserialize<_i7.EnrollmentInt>(data['data']);
+      return deserialize<_i9.EnrollmentInt>(data['data']);
     }
     if (dataClassName == 'StudentUuid') {
-      return deserialize<_i8.StudentUuid>(data['data']);
+      return deserialize<_i10.StudentUuid>(data['data']);
     }
     if (dataClassName == 'ArenaUuid') {
-      return deserialize<_i9.ArenaUuid>(data['data']);
+      return deserialize<_i11.ArenaUuid>(data['data']);
     }
     if (dataClassName == 'PlayerUuid') {
-      return deserialize<_i10.PlayerUuid>(data['data']);
+      return deserialize<_i12.PlayerUuid>(data['data']);
     }
     if (dataClassName == 'TeamInt') {
-      return deserialize<_i11.TeamInt>(data['data']);
+      return deserialize<_i13.TeamInt>(data['data']);
     }
     if (dataClassName == 'CommentInt') {
-      return deserialize<_i12.CommentInt>(data['data']);
+      return deserialize<_i14.CommentInt>(data['data']);
     }
     if (dataClassName == 'CustomerInt') {
-      return deserialize<_i13.CustomerInt>(data['data']);
+      return deserialize<_i15.CustomerInt>(data['data']);
     }
     if (dataClassName == 'OrderUuid') {
-      return deserialize<_i14.OrderUuid>(data['data']);
+      return deserialize<_i16.OrderUuid>(data['data']);
     }
     if (dataClassName == 'AddressUuid') {
-      return deserialize<_i15.AddressUuid>(data['data']);
+      return deserialize<_i17.AddressUuid>(data['data']);
     }
     if (dataClassName == 'CitizenInt') {
-      return deserialize<_i16.CitizenInt>(data['data']);
+      return deserialize<_i18.CitizenInt>(data['data']);
     }
     if (dataClassName == 'CompanyUuid') {
-      return deserialize<_i17.CompanyUuid>(data['data']);
+      return deserialize<_i19.CompanyUuid>(data['data']);
     }
     if (dataClassName == 'TownInt') {
-      return deserialize<_i18.TownInt>(data['data']);
+      return deserialize<_i20.TownInt>(data['data']);
     }
     if (dataClassName == 'ChangedIdTypeSelf') {
-      return deserialize<_i19.ChangedIdTypeSelf>(data['data']);
+      return deserialize<_i21.ChangedIdTypeSelf>(data['data']);
     }
     if (dataClassName == 'BigIntDefault') {
-      return deserialize<_i20.BigIntDefault>(data['data']);
+      return deserialize<_i22.BigIntDefault>(data['data']);
     }
     if (dataClassName == 'BigIntDefaultMix') {
-      return deserialize<_i21.BigIntDefaultMix>(data['data']);
+      return deserialize<_i23.BigIntDefaultMix>(data['data']);
     }
     if (dataClassName == 'BigIntDefaultModel') {
-      return deserialize<_i22.BigIntDefaultModel>(data['data']);
+      return deserialize<_i24.BigIntDefaultModel>(data['data']);
     }
     if (dataClassName == 'BigIntDefaultPersist') {
-      return deserialize<_i23.BigIntDefaultPersist>(data['data']);
+      return deserialize<_i25.BigIntDefaultPersist>(data['data']);
     }
     if (dataClassName == 'BoolDefault') {
-      return deserialize<_i24.BoolDefault>(data['data']);
+      return deserialize<_i26.BoolDefault>(data['data']);
     }
     if (dataClassName == 'BoolDefaultMix') {
-      return deserialize<_i25.BoolDefaultMix>(data['data']);
+      return deserialize<_i27.BoolDefaultMix>(data['data']);
     }
     if (dataClassName == 'BoolDefaultModel') {
-      return deserialize<_i26.BoolDefaultModel>(data['data']);
+      return deserialize<_i28.BoolDefaultModel>(data['data']);
     }
     if (dataClassName == 'BoolDefaultPersist') {
-      return deserialize<_i27.BoolDefaultPersist>(data['data']);
+      return deserialize<_i29.BoolDefaultPersist>(data['data']);
     }
     if (dataClassName == 'DateTimeDefault') {
-      return deserialize<_i28.DateTimeDefault>(data['data']);
+      return deserialize<_i30.DateTimeDefault>(data['data']);
     }
     if (dataClassName == 'DateTimeDefaultMix') {
-      return deserialize<_i29.DateTimeDefaultMix>(data['data']);
+      return deserialize<_i31.DateTimeDefaultMix>(data['data']);
     }
     if (dataClassName == 'DateTimeDefaultModel') {
-      return deserialize<_i30.DateTimeDefaultModel>(data['data']);
+      return deserialize<_i32.DateTimeDefaultModel>(data['data']);
     }
     if (dataClassName == 'DateTimeDefaultPersist') {
-      return deserialize<_i31.DateTimeDefaultPersist>(data['data']);
+      return deserialize<_i33.DateTimeDefaultPersist>(data['data']);
     }
     if (dataClassName == 'DoubleDefault') {
-      return deserialize<_i32.DoubleDefault>(data['data']);
+      return deserialize<_i34.DoubleDefault>(data['data']);
     }
     if (dataClassName == 'DoubleDefaultMix') {
-      return deserialize<_i33.DoubleDefaultMix>(data['data']);
+      return deserialize<_i35.DoubleDefaultMix>(data['data']);
     }
     if (dataClassName == 'DoubleDefaultModel') {
-      return deserialize<_i34.DoubleDefaultModel>(data['data']);
+      return deserialize<_i36.DoubleDefaultModel>(data['data']);
     }
     if (dataClassName == 'DoubleDefaultPersist') {
-      return deserialize<_i35.DoubleDefaultPersist>(data['data']);
+      return deserialize<_i37.DoubleDefaultPersist>(data['data']);
     }
     if (dataClassName == 'DurationDefault') {
-      return deserialize<_i36.DurationDefault>(data['data']);
+      return deserialize<_i38.DurationDefault>(data['data']);
     }
     if (dataClassName == 'DurationDefaultMix') {
-      return deserialize<_i37.DurationDefaultMix>(data['data']);
+      return deserialize<_i39.DurationDefaultMix>(data['data']);
     }
     if (dataClassName == 'DurationDefaultModel') {
-      return deserialize<_i38.DurationDefaultModel>(data['data']);
+      return deserialize<_i40.DurationDefaultModel>(data['data']);
     }
     if (dataClassName == 'DurationDefaultPersist') {
-      return deserialize<_i39.DurationDefaultPersist>(data['data']);
+      return deserialize<_i41.DurationDefaultPersist>(data['data']);
     }
     if (dataClassName == 'EnumDefault') {
-      return deserialize<_i40.EnumDefault>(data['data']);
+      return deserialize<_i42.EnumDefault>(data['data']);
     }
     if (dataClassName == 'EnumDefaultMix') {
-      return deserialize<_i41.EnumDefaultMix>(data['data']);
+      return deserialize<_i43.EnumDefaultMix>(data['data']);
     }
     if (dataClassName == 'EnumDefaultModel') {
-      return deserialize<_i42.EnumDefaultModel>(data['data']);
+      return deserialize<_i44.EnumDefaultModel>(data['data']);
     }
     if (dataClassName == 'EnumDefaultPersist') {
-      return deserialize<_i43.EnumDefaultPersist>(data['data']);
+      return deserialize<_i45.EnumDefaultPersist>(data['data']);
     }
     if (dataClassName == 'ByIndexEnum') {
-      return deserialize<_i44.ByIndexEnum>(data['data']);
+      return deserialize<_i46.ByIndexEnum>(data['data']);
     }
     if (dataClassName == 'ByNameEnum') {
-      return deserialize<_i45.ByNameEnum>(data['data']);
+      return deserialize<_i47.ByNameEnum>(data['data']);
     }
     if (dataClassName == 'DefaultValueEnum') {
-      return deserialize<_i46.DefaultValueEnum>(data['data']);
+      return deserialize<_i48.DefaultValueEnum>(data['data']);
     }
     if (dataClassName == 'DefaultException') {
-      return deserialize<_i47.DefaultException>(data['data']);
+      return deserialize<_i49.DefaultException>(data['data']);
     }
     if (dataClassName == 'IntDefault') {
-      return deserialize<_i48.IntDefault>(data['data']);
+      return deserialize<_i50.IntDefault>(data['data']);
     }
     if (dataClassName == 'IntDefaultMix') {
-      return deserialize<_i49.IntDefaultMix>(data['data']);
+      return deserialize<_i51.IntDefaultMix>(data['data']);
     }
     if (dataClassName == 'IntDefaultModel') {
-      return deserialize<_i50.IntDefaultModel>(data['data']);
+      return deserialize<_i52.IntDefaultModel>(data['data']);
     }
     if (dataClassName == 'IntDefaultPersist') {
-      return deserialize<_i51.IntDefaultPersist>(data['data']);
+      return deserialize<_i53.IntDefaultPersist>(data['data']);
     }
     if (dataClassName == 'StringDefault') {
-      return deserialize<_i52.StringDefault>(data['data']);
+      return deserialize<_i54.StringDefault>(data['data']);
     }
     if (dataClassName == 'StringDefaultMix') {
-      return deserialize<_i53.StringDefaultMix>(data['data']);
+      return deserialize<_i55.StringDefaultMix>(data['data']);
     }
     if (dataClassName == 'StringDefaultModel') {
-      return deserialize<_i54.StringDefaultModel>(data['data']);
+      return deserialize<_i56.StringDefaultModel>(data['data']);
     }
     if (dataClassName == 'StringDefaultPersist') {
-      return deserialize<_i55.StringDefaultPersist>(data['data']);
+      return deserialize<_i57.StringDefaultPersist>(data['data']);
     }
     if (dataClassName == 'UriDefault') {
-      return deserialize<_i56.UriDefault>(data['data']);
+      return deserialize<_i58.UriDefault>(data['data']);
     }
     if (dataClassName == 'UriDefaultMix') {
-      return deserialize<_i57.UriDefaultMix>(data['data']);
+      return deserialize<_i59.UriDefaultMix>(data['data']);
     }
     if (dataClassName == 'UriDefaultModel') {
-      return deserialize<_i58.UriDefaultModel>(data['data']);
+      return deserialize<_i60.UriDefaultModel>(data['data']);
     }
     if (dataClassName == 'UriDefaultPersist') {
-      return deserialize<_i59.UriDefaultPersist>(data['data']);
+      return deserialize<_i61.UriDefaultPersist>(data['data']);
     }
     if (dataClassName == 'UuidDefault') {
-      return deserialize<_i60.UuidDefault>(data['data']);
+      return deserialize<_i62.UuidDefault>(data['data']);
     }
     if (dataClassName == 'UuidDefaultMix') {
-      return deserialize<_i61.UuidDefaultMix>(data['data']);
+      return deserialize<_i63.UuidDefaultMix>(data['data']);
     }
     if (dataClassName == 'UuidDefaultModel') {
-      return deserialize<_i62.UuidDefaultModel>(data['data']);
+      return deserialize<_i64.UuidDefaultModel>(data['data']);
     }
     if (dataClassName == 'UuidDefaultPersist') {
-      return deserialize<_i63.UuidDefaultPersist>(data['data']);
+      return deserialize<_i65.UuidDefaultPersist>(data['data']);
     }
     if (dataClassName == 'EmptyModel') {
-      return deserialize<_i64.EmptyModel>(data['data']);
+      return deserialize<_i66.EmptyModel>(data['data']);
     }
     if (dataClassName == 'EmptyModelRelationItem') {
-      return deserialize<_i65.EmptyModelRelationItem>(data['data']);
+      return deserialize<_i67.EmptyModelRelationItem>(data['data']);
     }
     if (dataClassName == 'EmptyModelWithTable') {
-      return deserialize<_i66.EmptyModelWithTable>(data['data']);
+      return deserialize<_i68.EmptyModelWithTable>(data['data']);
     }
     if (dataClassName == 'RelationEmptyModel') {
-      return deserialize<_i67.RelationEmptyModel>(data['data']);
+      return deserialize<_i69.RelationEmptyModel>(data['data']);
     }
     if (dataClassName == 'ChildClassExplicitColumn') {
-      return deserialize<_i68.ChildClassExplicitColumn>(data['data']);
+      return deserialize<_i70.ChildClassExplicitColumn>(data['data']);
     }
     if (dataClassName == 'NonTableParentClass') {
-      return deserialize<_i69.NonTableParentClass>(data['data']);
+      return deserialize<_i71.NonTableParentClass>(data['data']);
     }
     if (dataClassName == 'ModifiedColumnName') {
-      return deserialize<_i70.ModifiedColumnName>(data['data']);
+      return deserialize<_i72.ModifiedColumnName>(data['data']);
     }
     if (dataClassName == 'Department') {
-      return deserialize<_i71.Department>(data['data']);
+      return deserialize<_i73.Department>(data['data']);
     }
     if (dataClassName == 'Employee') {
-      return deserialize<_i72.Employee>(data['data']);
+      return deserialize<_i74.Employee>(data['data']);
     }
     if (dataClassName == 'Contractor') {
-      return deserialize<_i73.Contractor>(data['data']);
+      return deserialize<_i75.Contractor>(data['data']);
     }
     if (dataClassName == 'Service') {
-      return deserialize<_i74.Service>(data['data']);
+      return deserialize<_i76.Service>(data['data']);
     }
     if (dataClassName == 'TableWithExplicitColumnName') {
-      return deserialize<_i75.TableWithExplicitColumnName>(data['data']);
+      return deserialize<_i77.TableWithExplicitColumnName>(data['data']);
     }
     if (dataClassName == 'SealedGrandChild') {
-      return deserialize<_i76.SealedGrandChild>(data['data']);
+      return deserialize<_i78.SealedGrandChild>(data['data']);
     }
     if (dataClassName == 'SealedChild') {
-      return deserialize<_i76.SealedChild>(data['data']);
+      return deserialize<_i78.SealedChild>(data['data']);
     }
     if (dataClassName == 'SealedOtherChild') {
-      return deserialize<_i76.SealedOtherChild>(data['data']);
+      return deserialize<_i78.SealedOtherChild>(data['data']);
     }
     if (dataClassName == 'CityWithLongTableName') {
-      return deserialize<_i77.CityWithLongTableName>(data['data']);
+      return deserialize<_i79.CityWithLongTableName>(data['data']);
     }
     if (dataClassName == 'OrganizationWithLongTableName') {
-      return deserialize<_i78.OrganizationWithLongTableName>(data['data']);
+      return deserialize<_i80.OrganizationWithLongTableName>(data['data']);
     }
     if (dataClassName == 'PersonWithLongTableName') {
-      return deserialize<_i79.PersonWithLongTableName>(data['data']);
+      return deserialize<_i81.PersonWithLongTableName>(data['data']);
     }
     if (dataClassName == 'MaxFieldName') {
-      return deserialize<_i80.MaxFieldName>(data['data']);
+      return deserialize<_i82.MaxFieldName>(data['data']);
     }
     if (dataClassName == 'LongImplicitIdField') {
-      return deserialize<_i81.LongImplicitIdField>(data['data']);
+      return deserialize<_i83.LongImplicitIdField>(data['data']);
     }
     if (dataClassName == 'LongImplicitIdFieldCollection') {
-      return deserialize<_i82.LongImplicitIdFieldCollection>(data['data']);
+      return deserialize<_i84.LongImplicitIdFieldCollection>(data['data']);
     }
     if (dataClassName == 'RelationToMultipleMaxFieldName') {
-      return deserialize<_i83.RelationToMultipleMaxFieldName>(data['data']);
+      return deserialize<_i85.RelationToMultipleMaxFieldName>(data['data']);
     }
     if (dataClassName == 'UserNote') {
-      return deserialize<_i84.UserNote>(data['data']);
+      return deserialize<_i86.UserNote>(data['data']);
     }
     if (dataClassName == 'UserNoteCollection') {
-      return deserialize<_i85.UserNoteCollection>(data['data']);
+      return deserialize<_i87.UserNoteCollection>(data['data']);
     }
     if (dataClassName == 'UserNoteCollectionWithALongName') {
-      return deserialize<_i86.UserNoteCollectionWithALongName>(data['data']);
+      return deserialize<_i88.UserNoteCollectionWithALongName>(data['data']);
     }
     if (dataClassName == 'UserNoteWithALongName') {
-      return deserialize<_i87.UserNoteWithALongName>(data['data']);
+      return deserialize<_i89.UserNoteWithALongName>(data['data']);
     }
     if (dataClassName == 'MultipleMaxFieldName') {
-      return deserialize<_i88.MultipleMaxFieldName>(data['data']);
+      return deserialize<_i90.MultipleMaxFieldName>(data['data']);
     }
     if (dataClassName == 'City') {
-      return deserialize<_i89.City>(data['data']);
+      return deserialize<_i91.City>(data['data']);
     }
     if (dataClassName == 'Organization') {
-      return deserialize<_i90.Organization>(data['data']);
+      return deserialize<_i92.Organization>(data['data']);
     }
     if (dataClassName == 'Person') {
-      return deserialize<_i91.Person>(data['data']);
+      return deserialize<_i93.Person>(data['data']);
     }
     if (dataClassName == 'Course') {
-      return deserialize<_i92.Course>(data['data']);
+      return deserialize<_i94.Course>(data['data']);
     }
     if (dataClassName == 'Enrollment') {
-      return deserialize<_i93.Enrollment>(data['data']);
+      return deserialize<_i95.Enrollment>(data['data']);
     }
     if (dataClassName == 'Student') {
-      return deserialize<_i94.Student>(data['data']);
+      return deserialize<_i96.Student>(data['data']);
     }
     if (dataClassName == 'Arena') {
-      return deserialize<_i95.Arena>(data['data']);
+      return deserialize<_i97.Arena>(data['data']);
     }
     if (dataClassName == 'Player') {
-      return deserialize<_i96.Player>(data['data']);
+      return deserialize<_i98.Player>(data['data']);
     }
     if (dataClassName == 'Team') {
-      return deserialize<_i97.Team>(data['data']);
+      return deserialize<_i99.Team>(data['data']);
     }
     if (dataClassName == 'Comment') {
-      return deserialize<_i98.Comment>(data['data']);
+      return deserialize<_i100.Comment>(data['data']);
     }
     if (dataClassName == 'Customer') {
-      return deserialize<_i99.Customer>(data['data']);
+      return deserialize<_i101.Customer>(data['data']);
     }
     if (dataClassName == 'Book') {
-      return deserialize<_i100.Book>(data['data']);
+      return deserialize<_i102.Book>(data['data']);
     }
     if (dataClassName == 'Chapter') {
-      return deserialize<_i101.Chapter>(data['data']);
+      return deserialize<_i103.Chapter>(data['data']);
     }
     if (dataClassName == 'Order') {
-      return deserialize<_i102.Order>(data['data']);
+      return deserialize<_i104.Order>(data['data']);
     }
     if (dataClassName == 'Address') {
-      return deserialize<_i103.Address>(data['data']);
+      return deserialize<_i105.Address>(data['data']);
     }
     if (dataClassName == 'Citizen') {
-      return deserialize<_i104.Citizen>(data['data']);
+      return deserialize<_i106.Citizen>(data['data']);
     }
     if (dataClassName == 'Company') {
-      return deserialize<_i105.Company>(data['data']);
+      return deserialize<_i107.Company>(data['data']);
     }
     if (dataClassName == 'Town') {
-      return deserialize<_i106.Town>(data['data']);
+      return deserialize<_i108.Town>(data['data']);
     }
     if (dataClassName == 'Blocking') {
-      return deserialize<_i107.Blocking>(data['data']);
+      return deserialize<_i109.Blocking>(data['data']);
     }
     if (dataClassName == 'Member') {
-      return deserialize<_i108.Member>(data['data']);
+      return deserialize<_i110.Member>(data['data']);
     }
     if (dataClassName == 'Cat') {
-      return deserialize<_i109.Cat>(data['data']);
+      return deserialize<_i111.Cat>(data['data']);
     }
     if (dataClassName == 'Post') {
-      return deserialize<_i110.Post>(data['data']);
+      return deserialize<_i112.Post>(data['data']);
     }
     if (dataClassName == 'NullsDistinctData') {
-      return deserialize<_i111.NullsDistinctData>(data['data']);
+      return deserialize<_i113.NullsDistinctData>(data['data']);
     }
     if (dataClassName == 'ObjectFieldPersist') {
-      return deserialize<_i112.ObjectFieldPersist>(data['data']);
+      return deserialize<_i114.ObjectFieldPersist>(data['data']);
     }
     if (dataClassName == 'ObjectFieldScopes') {
-      return deserialize<_i113.ObjectFieldScopes>(data['data']);
+      return deserialize<_i115.ObjectFieldScopes>(data['data']);
     }
     if (dataClassName == 'ObjectWithBit') {
-      return deserialize<_i114.ObjectWithBit>(data['data']);
+      return deserialize<_i116.ObjectWithBit>(data['data']);
     }
     if (dataClassName == 'ObjectWithByteData') {
-      return deserialize<_i115.ObjectWithByteData>(data['data']);
+      return deserialize<_i117.ObjectWithByteData>(data['data']);
     }
     if (dataClassName == 'ObjectWithDuration') {
-      return deserialize<_i116.ObjectWithDuration>(data['data']);
+      return deserialize<_i118.ObjectWithDuration>(data['data']);
     }
     if (dataClassName == 'ObjectWithDynamic') {
-      return deserialize<_i117.ObjectWithDynamic>(data['data']);
+      return deserialize<_i119.ObjectWithDynamic>(data['data']);
     }
     if (dataClassName == 'ObjectWithEnum') {
-      return deserialize<_i118.ObjectWithEnum>(data['data']);
+      return deserialize<_i120.ObjectWithEnum>(data['data']);
     }
     if (dataClassName == 'ObjectWithEnumEnhanced') {
-      return deserialize<_i119.ObjectWithEnumEnhanced>(data['data']);
+      return deserialize<_i121.ObjectWithEnumEnhanced>(data['data']);
     }
     if (dataClassName == 'ObjectWithHalfVector') {
-      return deserialize<_i120.ObjectWithHalfVector>(data['data']);
+      return deserialize<_i122.ObjectWithHalfVector>(data['data']);
     }
     if (dataClassName == 'ObjectWithIndex') {
-      return deserialize<_i121.ObjectWithIndex>(data['data']);
+      return deserialize<_i123.ObjectWithIndex>(data['data']);
     }
     if (dataClassName == 'ObjectWithJsonb') {
-      return deserialize<_i122.ObjectWithJsonb>(data['data']);
+      return deserialize<_i124.ObjectWithJsonb>(data['data']);
     }
     if (dataClassName == 'ObjectWithJsonbClassLevel') {
-      return deserialize<_i123.ObjectWithJsonbClassLevel>(data['data']);
+      return deserialize<_i125.ObjectWithJsonbClassLevel>(data['data']);
     }
     if (dataClassName == 'ObjectWithMaps') {
-      return deserialize<_i124.ObjectWithMaps>(data['data']);
+      return deserialize<_i126.ObjectWithMaps>(data['data']);
     }
     if (dataClassName == 'ObjectWithObject') {
-      return deserialize<_i125.ObjectWithObject>(data['data']);
+      return deserialize<_i127.ObjectWithObject>(data['data']);
     }
     if (dataClassName == 'ObjectWithParent') {
-      return deserialize<_i126.ObjectWithParent>(data['data']);
+      return deserialize<_i128.ObjectWithParent>(data['data']);
     }
     if (dataClassName == 'ObjectWithSealedClass') {
-      return deserialize<_i127.ObjectWithSealedClass>(data['data']);
+      return deserialize<_i129.ObjectWithSealedClass>(data['data']);
     }
     if (dataClassName == 'ObjectWithSelfParent') {
-      return deserialize<_i128.ObjectWithSelfParent>(data['data']);
+      return deserialize<_i130.ObjectWithSelfParent>(data['data']);
     }
     if (dataClassName == 'ObjectWithSparseVector') {
-      return deserialize<_i129.ObjectWithSparseVector>(data['data']);
+      return deserialize<_i131.ObjectWithSparseVector>(data['data']);
     }
     if (dataClassName == 'ObjectWithUuid') {
-      return deserialize<_i130.ObjectWithUuid>(data['data']);
+      return deserialize<_i132.ObjectWithUuid>(data['data']);
     }
     if (dataClassName == 'ObjectWithVector') {
-      return deserialize<_i131.ObjectWithVector>(data['data']);
+      return deserialize<_i133.ObjectWithVector>(data['data']);
     }
     if (dataClassName == 'RelatedUniqueData') {
-      return deserialize<_i132.RelatedUniqueData>(data['data']);
+      return deserialize<_i134.RelatedUniqueData>(data['data']);
     }
     if (dataClassName == 'ModelWithRequiredField') {
-      return deserialize<_i133.ModelWithRequiredField>(data['data']);
+      return deserialize<_i135.ModelWithRequiredField>(data['data']);
     }
     if (dataClassName == 'SimpleData') {
-      return deserialize<_i134.SimpleData>(data['data']);
+      return deserialize<_i136.SimpleData>(data['data']);
     }
     if (dataClassName == 'SimpleDateTime') {
-      return deserialize<_i135.SimpleDateTime>(data['data']);
+      return deserialize<_i137.SimpleDateTime>(data['data']);
     }
     if (dataClassName == 'TestEnum') {
-      return deserialize<_i136.TestEnum>(data['data']);
+      return deserialize<_i138.TestEnum>(data['data']);
     }
     if (dataClassName == 'TestEnumDefaultSerialization') {
-      return deserialize<_i137.TestEnumDefaultSerialization>(data['data']);
+      return deserialize<_i139.TestEnumDefaultSerialization>(data['data']);
     }
     if (dataClassName == 'TestEnumEnhanced') {
-      return deserialize<_i138.TestEnumEnhanced>(data['data']);
+      return deserialize<_i140.TestEnumEnhanced>(data['data']);
     }
     if (dataClassName == 'TestEnumEnhancedByName') {
-      return deserialize<_i139.TestEnumEnhancedByName>(data['data']);
+      return deserialize<_i141.TestEnumEnhancedByName>(data['data']);
     }
     if (dataClassName == 'TestEnumStringified') {
-      return deserialize<_i140.TestEnumStringified>(data['data']);
+      return deserialize<_i142.TestEnumStringified>(data['data']);
     }
     if (dataClassName == 'Types') {
-      return deserialize<_i141.Types>(data['data']);
+      return deserialize<_i143.Types>(data['data']);
     }
     if (dataClassName == 'UniqueData') {
-      return deserialize<_i142.UniqueData>(data['data']);
+      return deserialize<_i144.UniqueData>(data['data']);
     }
     if (dataClassName == 'UniqueDataWithNonPersist') {
-      return deserialize<_i143.UniqueDataWithNonPersist>(data['data']);
+      return deserialize<_i145.UniqueDataWithNonPersist>(data['data']);
     }
     if (dataClassName == 'UpsertTestModel') {
-      return deserialize<_i144.UpsertTestModel>(data['data']);
+      return deserialize<_i146.UpsertTestModel>(data['data']);
     }
     if (dataClassName.startsWith('serverpod_auth_core.')) {
       data['className'] = dataClassName.substring(20);
@@ -4354,74 +2809,74 @@ class Protocol extends _i1.DatabaseSerializationManager {
       }
     }
     switch (t) {
-      case _i65.EmptyModelRelationItem:
-        return _i65.EmptyModelRelationItem.t;
-      case _i66.EmptyModelWithTable:
-        return _i66.EmptyModelWithTable.t;
-      case _i67.RelationEmptyModel:
-        return _i67.RelationEmptyModel.t;
-      case _i89.City:
-        return _i89.City.t;
-      case _i90.Organization:
-        return _i90.Organization.t;
-      case _i91.Person:
-        return _i91.Person.t;
-      case _i92.Course:
-        return _i92.Course.t;
-      case _i93.Enrollment:
-        return _i93.Enrollment.t;
-      case _i94.Student:
-        return _i94.Student.t;
-      case _i95.Arena:
-        return _i95.Arena.t;
-      case _i96.Player:
-        return _i96.Player.t;
-      case _i97.Team:
-        return _i97.Team.t;
-      case _i98.Comment:
-        return _i98.Comment.t;
-      case _i99.Customer:
-        return _i99.Customer.t;
-      case _i100.Book:
-        return _i100.Book.t;
-      case _i101.Chapter:
-        return _i101.Chapter.t;
-      case _i102.Order:
-        return _i102.Order.t;
-      case _i103.Address:
-        return _i103.Address.t;
-      case _i104.Citizen:
-        return _i104.Citizen.t;
-      case _i105.Company:
-        return _i105.Company.t;
-      case _i106.Town:
-        return _i106.Town.t;
-      case _i107.Blocking:
-        return _i107.Blocking.t;
-      case _i108.Member:
-        return _i108.Member.t;
-      case _i109.Cat:
-        return _i109.Cat.t;
-      case _i110.Post:
-        return _i110.Post.t;
-      case _i111.NullsDistinctData:
-        return _i111.NullsDistinctData.t;
-      case _i112.ObjectFieldPersist:
-        return _i112.ObjectFieldPersist.t;
-      case _i132.RelatedUniqueData:
-        return _i132.RelatedUniqueData.t;
-      case _i133.ModelWithRequiredField:
-        return _i133.ModelWithRequiredField.t;
-      case _i134.SimpleData:
-        return _i134.SimpleData.t;
-      case _i135.SimpleDateTime:
-        return _i135.SimpleDateTime.t;
-      case _i141.Types:
-        return _i141.Types.t;
-      case _i142.UniqueData:
-        return _i142.UniqueData.t;
-      case _i143.UniqueDataWithNonPersist:
-        return _i143.UniqueDataWithNonPersist.t;
+      case _i67.EmptyModelRelationItem:
+        return _i67.EmptyModelRelationItem.t;
+      case _i68.EmptyModelWithTable:
+        return _i68.EmptyModelWithTable.t;
+      case _i69.RelationEmptyModel:
+        return _i69.RelationEmptyModel.t;
+      case _i91.City:
+        return _i91.City.t;
+      case _i92.Organization:
+        return _i92.Organization.t;
+      case _i93.Person:
+        return _i93.Person.t;
+      case _i94.Course:
+        return _i94.Course.t;
+      case _i95.Enrollment:
+        return _i95.Enrollment.t;
+      case _i96.Student:
+        return _i96.Student.t;
+      case _i97.Arena:
+        return _i97.Arena.t;
+      case _i98.Player:
+        return _i98.Player.t;
+      case _i99.Team:
+        return _i99.Team.t;
+      case _i100.Comment:
+        return _i100.Comment.t;
+      case _i101.Customer:
+        return _i101.Customer.t;
+      case _i102.Book:
+        return _i102.Book.t;
+      case _i103.Chapter:
+        return _i103.Chapter.t;
+      case _i104.Order:
+        return _i104.Order.t;
+      case _i105.Address:
+        return _i105.Address.t;
+      case _i106.Citizen:
+        return _i106.Citizen.t;
+      case _i107.Company:
+        return _i107.Company.t;
+      case _i108.Town:
+        return _i108.Town.t;
+      case _i109.Blocking:
+        return _i109.Blocking.t;
+      case _i110.Member:
+        return _i110.Member.t;
+      case _i111.Cat:
+        return _i111.Cat.t;
+      case _i112.Post:
+        return _i112.Post.t;
+      case _i113.NullsDistinctData:
+        return _i113.NullsDistinctData.t;
+      case _i114.ObjectFieldPersist:
+        return _i114.ObjectFieldPersist.t;
+      case _i134.RelatedUniqueData:
+        return _i134.RelatedUniqueData.t;
+      case _i135.ModelWithRequiredField:
+        return _i135.ModelWithRequiredField.t;
+      case _i136.SimpleData:
+        return _i136.SimpleData.t;
+      case _i137.SimpleDateTime:
+        return _i137.SimpleDateTime.t;
+      case _i143.Types:
+        return _i143.Types.t;
+      case _i144.UniqueData:
+        return _i144.UniqueData.t;
+      case _i145.UniqueDataWithNonPersist:
+        return _i145.UniqueDataWithNonPersist.t;
     }
     return null;
   }
@@ -4514,5 +2969,1080 @@ class Protocol extends _i1.DatabaseSerializationManager {
     }
 
     return obj;
+  }
+
+  static Map<Type, dynamic Function(dynamic, Protocol)> _buildDeserializers() {
+    final map = <Type, dynamic Function(dynamic, Protocol)>{};
+    map[_i8.CourseUuid] = (data, protocol) => _i8.CourseUuid.fromJson(data);
+    map[_i9.EnrollmentInt] = (data, protocol) =>
+        _i9.EnrollmentInt.fromJson(data);
+    map[_i10.StudentUuid] = (data, protocol) => _i10.StudentUuid.fromJson(data);
+    map[_i11.ArenaUuid] = (data, protocol) => _i11.ArenaUuid.fromJson(data);
+    map[_i12.PlayerUuid] = (data, protocol) => _i12.PlayerUuid.fromJson(data);
+    map[_i13.TeamInt] = (data, protocol) => _i13.TeamInt.fromJson(data);
+    map[_i14.CommentInt] = (data, protocol) => _i14.CommentInt.fromJson(data);
+    map[_i15.CustomerInt] = (data, protocol) => _i15.CustomerInt.fromJson(data);
+    map[_i16.OrderUuid] = (data, protocol) => _i16.OrderUuid.fromJson(data);
+    map[_i17.AddressUuid] = (data, protocol) => _i17.AddressUuid.fromJson(data);
+    map[_i18.CitizenInt] = (data, protocol) => _i18.CitizenInt.fromJson(data);
+    map[_i19.CompanyUuid] = (data, protocol) => _i19.CompanyUuid.fromJson(data);
+    map[_i20.TownInt] = (data, protocol) => _i20.TownInt.fromJson(data);
+    map[_i21.ChangedIdTypeSelf] = (data, protocol) =>
+        _i21.ChangedIdTypeSelf.fromJson(data);
+    map[_i22.BigIntDefault] = (data, protocol) =>
+        _i22.BigIntDefault.fromJson(data);
+    map[_i23.BigIntDefaultMix] = (data, protocol) =>
+        _i23.BigIntDefaultMix.fromJson(data);
+    map[_i24.BigIntDefaultModel] = (data, protocol) =>
+        _i24.BigIntDefaultModel.fromJson(data);
+    map[_i25.BigIntDefaultPersist] = (data, protocol) =>
+        _i25.BigIntDefaultPersist.fromJson(data);
+    map[_i26.BoolDefault] = (data, protocol) => _i26.BoolDefault.fromJson(data);
+    map[_i27.BoolDefaultMix] = (data, protocol) =>
+        _i27.BoolDefaultMix.fromJson(data);
+    map[_i28.BoolDefaultModel] = (data, protocol) =>
+        _i28.BoolDefaultModel.fromJson(data);
+    map[_i29.BoolDefaultPersist] = (data, protocol) =>
+        _i29.BoolDefaultPersist.fromJson(data);
+    map[_i30.DateTimeDefault] = (data, protocol) =>
+        _i30.DateTimeDefault.fromJson(data);
+    map[_i31.DateTimeDefaultMix] = (data, protocol) =>
+        _i31.DateTimeDefaultMix.fromJson(data);
+    map[_i32.DateTimeDefaultModel] = (data, protocol) =>
+        _i32.DateTimeDefaultModel.fromJson(data);
+    map[_i33.DateTimeDefaultPersist] = (data, protocol) =>
+        _i33.DateTimeDefaultPersist.fromJson(data);
+    map[_i34.DoubleDefault] = (data, protocol) =>
+        _i34.DoubleDefault.fromJson(data);
+    map[_i35.DoubleDefaultMix] = (data, protocol) =>
+        _i35.DoubleDefaultMix.fromJson(data);
+    map[_i36.DoubleDefaultModel] = (data, protocol) =>
+        _i36.DoubleDefaultModel.fromJson(data);
+    map[_i37.DoubleDefaultPersist] = (data, protocol) =>
+        _i37.DoubleDefaultPersist.fromJson(data);
+    map[_i38.DurationDefault] = (data, protocol) =>
+        _i38.DurationDefault.fromJson(data);
+    map[_i39.DurationDefaultMix] = (data, protocol) =>
+        _i39.DurationDefaultMix.fromJson(data);
+    map[_i40.DurationDefaultModel] = (data, protocol) =>
+        _i40.DurationDefaultModel.fromJson(data);
+    map[_i41.DurationDefaultPersist] = (data, protocol) =>
+        _i41.DurationDefaultPersist.fromJson(data);
+    map[_i42.EnumDefault] = (data, protocol) => _i42.EnumDefault.fromJson(data);
+    map[_i43.EnumDefaultMix] = (data, protocol) =>
+        _i43.EnumDefaultMix.fromJson(data);
+    map[_i44.EnumDefaultModel] = (data, protocol) =>
+        _i44.EnumDefaultModel.fromJson(data);
+    map[_i45.EnumDefaultPersist] = (data, protocol) =>
+        _i45.EnumDefaultPersist.fromJson(data);
+    map[_i46.ByIndexEnum] = (data, protocol) => _i46.ByIndexEnum.fromJson(data);
+    map[_i47.ByNameEnum] = (data, protocol) => _i47.ByNameEnum.fromJson(data);
+    map[_i48.DefaultValueEnum] = (data, protocol) =>
+        _i48.DefaultValueEnum.fromJson(data);
+    map[_i49.DefaultException] = (data, protocol) =>
+        _i49.DefaultException.fromJson(data);
+    map[_i50.IntDefault] = (data, protocol) => _i50.IntDefault.fromJson(data);
+    map[_i51.IntDefaultMix] = (data, protocol) =>
+        _i51.IntDefaultMix.fromJson(data);
+    map[_i52.IntDefaultModel] = (data, protocol) =>
+        _i52.IntDefaultModel.fromJson(data);
+    map[_i53.IntDefaultPersist] = (data, protocol) =>
+        _i53.IntDefaultPersist.fromJson(data);
+    map[_i54.StringDefault] = (data, protocol) =>
+        _i54.StringDefault.fromJson(data);
+    map[_i55.StringDefaultMix] = (data, protocol) =>
+        _i55.StringDefaultMix.fromJson(data);
+    map[_i56.StringDefaultModel] = (data, protocol) =>
+        _i56.StringDefaultModel.fromJson(data);
+    map[_i57.StringDefaultPersist] = (data, protocol) =>
+        _i57.StringDefaultPersist.fromJson(data);
+    map[_i58.UriDefault] = (data, protocol) => _i58.UriDefault.fromJson(data);
+    map[_i59.UriDefaultMix] = (data, protocol) =>
+        _i59.UriDefaultMix.fromJson(data);
+    map[_i60.UriDefaultModel] = (data, protocol) =>
+        _i60.UriDefaultModel.fromJson(data);
+    map[_i61.UriDefaultPersist] = (data, protocol) =>
+        _i61.UriDefaultPersist.fromJson(data);
+    map[_i62.UuidDefault] = (data, protocol) => _i62.UuidDefault.fromJson(data);
+    map[_i63.UuidDefaultMix] = (data, protocol) =>
+        _i63.UuidDefaultMix.fromJson(data);
+    map[_i64.UuidDefaultModel] = (data, protocol) =>
+        _i64.UuidDefaultModel.fromJson(data);
+    map[_i65.UuidDefaultPersist] = (data, protocol) =>
+        _i65.UuidDefaultPersist.fromJson(data);
+    map[_i66.EmptyModel] = (data, protocol) => _i66.EmptyModel.fromJson(data);
+    map[_i67.EmptyModelRelationItem] = (data, protocol) =>
+        _i67.EmptyModelRelationItem.fromJson(data);
+    map[_i68.EmptyModelWithTable] = (data, protocol) =>
+        _i68.EmptyModelWithTable.fromJson(data);
+    map[_i69.RelationEmptyModel] = (data, protocol) =>
+        _i69.RelationEmptyModel.fromJson(data);
+    map[_i70.ChildClassExplicitColumn] = (data, protocol) =>
+        _i70.ChildClassExplicitColumn.fromJson(data);
+    map[_i71.NonTableParentClass] = (data, protocol) =>
+        _i71.NonTableParentClass.fromJson(data);
+    map[_i72.ModifiedColumnName] = (data, protocol) =>
+        _i72.ModifiedColumnName.fromJson(data);
+    map[_i73.Department] = (data, protocol) => _i73.Department.fromJson(data);
+    map[_i74.Employee] = (data, protocol) => _i74.Employee.fromJson(data);
+    map[_i75.Contractor] = (data, protocol) => _i75.Contractor.fromJson(data);
+    map[_i76.Service] = (data, protocol) => _i76.Service.fromJson(data);
+    map[_i77.TableWithExplicitColumnName] = (data, protocol) =>
+        _i77.TableWithExplicitColumnName.fromJson(data);
+    map[_i78.SealedGrandChild] = (data, protocol) =>
+        _i78.SealedGrandChild.fromJson(data);
+    map[_i78.SealedChild] = (data, protocol) => _i78.SealedChild.fromJson(data);
+    map[_i78.SealedOtherChild] = (data, protocol) =>
+        _i78.SealedOtherChild.fromJson(data);
+    map[_i79.CityWithLongTableName] = (data, protocol) =>
+        _i79.CityWithLongTableName.fromJson(data);
+    map[_i80.OrganizationWithLongTableName] = (data, protocol) =>
+        _i80.OrganizationWithLongTableName.fromJson(data);
+    map[_i81.PersonWithLongTableName] = (data, protocol) =>
+        _i81.PersonWithLongTableName.fromJson(data);
+    map[_i82.MaxFieldName] = (data, protocol) =>
+        _i82.MaxFieldName.fromJson(data);
+    map[_i83.LongImplicitIdField] = (data, protocol) =>
+        _i83.LongImplicitIdField.fromJson(data);
+    map[_i84.LongImplicitIdFieldCollection] = (data, protocol) =>
+        _i84.LongImplicitIdFieldCollection.fromJson(data);
+    map[_i85.RelationToMultipleMaxFieldName] = (data, protocol) =>
+        _i85.RelationToMultipleMaxFieldName.fromJson(data);
+    map[_i86.UserNote] = (data, protocol) => _i86.UserNote.fromJson(data);
+    map[_i87.UserNoteCollection] = (data, protocol) =>
+        _i87.UserNoteCollection.fromJson(data);
+    map[_i88.UserNoteCollectionWithALongName] = (data, protocol) =>
+        _i88.UserNoteCollectionWithALongName.fromJson(data);
+    map[_i89.UserNoteWithALongName] = (data, protocol) =>
+        _i89.UserNoteWithALongName.fromJson(data);
+    map[_i90.MultipleMaxFieldName] = (data, protocol) =>
+        _i90.MultipleMaxFieldName.fromJson(data);
+    map[_i91.City] = (data, protocol) => _i91.City.fromJson(data);
+    map[_i92.Organization] = (data, protocol) =>
+        _i92.Organization.fromJson(data);
+    map[_i93.Person] = (data, protocol) => _i93.Person.fromJson(data);
+    map[_i94.Course] = (data, protocol) => _i94.Course.fromJson(data);
+    map[_i95.Enrollment] = (data, protocol) => _i95.Enrollment.fromJson(data);
+    map[_i96.Student] = (data, protocol) => _i96.Student.fromJson(data);
+    map[_i97.Arena] = (data, protocol) => _i97.Arena.fromJson(data);
+    map[_i98.Player] = (data, protocol) => _i98.Player.fromJson(data);
+    map[_i99.Team] = (data, protocol) => _i99.Team.fromJson(data);
+    map[_i100.Comment] = (data, protocol) => _i100.Comment.fromJson(data);
+    map[_i101.Customer] = (data, protocol) => _i101.Customer.fromJson(data);
+    map[_i102.Book] = (data, protocol) => _i102.Book.fromJson(data);
+    map[_i103.Chapter] = (data, protocol) => _i103.Chapter.fromJson(data);
+    map[_i104.Order] = (data, protocol) => _i104.Order.fromJson(data);
+    map[_i105.Address] = (data, protocol) => _i105.Address.fromJson(data);
+    map[_i106.Citizen] = (data, protocol) => _i106.Citizen.fromJson(data);
+    map[_i107.Company] = (data, protocol) => _i107.Company.fromJson(data);
+    map[_i108.Town] = (data, protocol) => _i108.Town.fromJson(data);
+    map[_i109.Blocking] = (data, protocol) => _i109.Blocking.fromJson(data);
+    map[_i110.Member] = (data, protocol) => _i110.Member.fromJson(data);
+    map[_i111.Cat] = (data, protocol) => _i111.Cat.fromJson(data);
+    map[_i112.Post] = (data, protocol) => _i112.Post.fromJson(data);
+    map[_i113.NullsDistinctData] = (data, protocol) =>
+        _i113.NullsDistinctData.fromJson(data);
+    map[_i114.ObjectFieldPersist] = (data, protocol) =>
+        _i114.ObjectFieldPersist.fromJson(data);
+    map[_i115.ObjectFieldScopes] = (data, protocol) =>
+        _i115.ObjectFieldScopes.fromJson(data);
+    map[_i116.ObjectWithBit] = (data, protocol) =>
+        _i116.ObjectWithBit.fromJson(data);
+    map[_i117.ObjectWithByteData] = (data, protocol) =>
+        _i117.ObjectWithByteData.fromJson(data);
+    map[_i118.ObjectWithDuration] = (data, protocol) =>
+        _i118.ObjectWithDuration.fromJson(data);
+    map[_i119.ObjectWithDynamic] = (data, protocol) =>
+        _i119.ObjectWithDynamic.fromJson(data);
+    map[_i120.ObjectWithEnum] = (data, protocol) =>
+        _i120.ObjectWithEnum.fromJson(data);
+    map[_i121.ObjectWithEnumEnhanced] = (data, protocol) =>
+        _i121.ObjectWithEnumEnhanced.fromJson(data);
+    map[_i122.ObjectWithHalfVector] = (data, protocol) =>
+        _i122.ObjectWithHalfVector.fromJson(data);
+    map[_i123.ObjectWithIndex] = (data, protocol) =>
+        _i123.ObjectWithIndex.fromJson(data);
+    map[_i124.ObjectWithJsonb] = (data, protocol) =>
+        _i124.ObjectWithJsonb.fromJson(data);
+    map[_i125.ObjectWithJsonbClassLevel] = (data, protocol) =>
+        _i125.ObjectWithJsonbClassLevel.fromJson(data);
+    map[_i126.ObjectWithMaps] = (data, protocol) =>
+        _i126.ObjectWithMaps.fromJson(data);
+    map[_i127.ObjectWithObject] = (data, protocol) =>
+        _i127.ObjectWithObject.fromJson(data);
+    map[_i128.ObjectWithParent] = (data, protocol) =>
+        _i128.ObjectWithParent.fromJson(data);
+    map[_i129.ObjectWithSealedClass] = (data, protocol) =>
+        _i129.ObjectWithSealedClass.fromJson(data);
+    map[_i130.ObjectWithSelfParent] = (data, protocol) =>
+        _i130.ObjectWithSelfParent.fromJson(data);
+    map[_i131.ObjectWithSparseVector] = (data, protocol) =>
+        _i131.ObjectWithSparseVector.fromJson(data);
+    map[_i132.ObjectWithUuid] = (data, protocol) =>
+        _i132.ObjectWithUuid.fromJson(data);
+    map[_i133.ObjectWithVector] = (data, protocol) =>
+        _i133.ObjectWithVector.fromJson(data);
+    map[_i134.RelatedUniqueData] = (data, protocol) =>
+        _i134.RelatedUniqueData.fromJson(data);
+    map[_i135.ModelWithRequiredField] = (data, protocol) =>
+        _i135.ModelWithRequiredField.fromJson(data);
+    map[_i136.SimpleData] = (data, protocol) => _i136.SimpleData.fromJson(data);
+    map[_i137.SimpleDateTime] = (data, protocol) =>
+        _i137.SimpleDateTime.fromJson(data);
+    map[_i138.TestEnum] = (data, protocol) => _i138.TestEnum.fromJson(data);
+    map[_i139.TestEnumDefaultSerialization] = (data, protocol) =>
+        _i139.TestEnumDefaultSerialization.fromJson(data);
+    map[_i140.TestEnumEnhanced] = (data, protocol) =>
+        _i140.TestEnumEnhanced.fromJson(data);
+    map[_i141.TestEnumEnhancedByName] = (data, protocol) =>
+        _i141.TestEnumEnhancedByName.fromJson(data);
+    map[_i142.TestEnumStringified] = (data, protocol) =>
+        _i142.TestEnumStringified.fromJson(data);
+    map[_i143.Types] = (data, protocol) => _i143.Types.fromJson(data);
+    map[_i144.UniqueData] = (data, protocol) => _i144.UniqueData.fromJson(data);
+    map[_i145.UniqueDataWithNonPersist] = (data, protocol) =>
+        _i145.UniqueDataWithNonPersist.fromJson(data);
+    map[_i146.UpsertTestModel] = (data, protocol) =>
+        _i146.UpsertTestModel.fromJson(data);
+    map[_i6.getType<_i8.CourseUuid?>()] = (data, protocol) =>
+        (data != null ? _i8.CourseUuid.fromJson(data) : null);
+    map[_i6.getType<_i9.EnrollmentInt?>()] = (data, protocol) =>
+        (data != null ? _i9.EnrollmentInt.fromJson(data) : null);
+    map[_i6.getType<_i10.StudentUuid?>()] = (data, protocol) =>
+        (data != null ? _i10.StudentUuid.fromJson(data) : null);
+    map[_i6.getType<_i11.ArenaUuid?>()] = (data, protocol) =>
+        (data != null ? _i11.ArenaUuid.fromJson(data) : null);
+    map[_i6.getType<_i12.PlayerUuid?>()] = (data, protocol) =>
+        (data != null ? _i12.PlayerUuid.fromJson(data) : null);
+    map[_i6.getType<_i13.TeamInt?>()] = (data, protocol) =>
+        (data != null ? _i13.TeamInt.fromJson(data) : null);
+    map[_i6.getType<_i14.CommentInt?>()] = (data, protocol) =>
+        (data != null ? _i14.CommentInt.fromJson(data) : null);
+    map[_i6.getType<_i15.CustomerInt?>()] = (data, protocol) =>
+        (data != null ? _i15.CustomerInt.fromJson(data) : null);
+    map[_i6.getType<_i16.OrderUuid?>()] = (data, protocol) =>
+        (data != null ? _i16.OrderUuid.fromJson(data) : null);
+    map[_i6.getType<_i17.AddressUuid?>()] = (data, protocol) =>
+        (data != null ? _i17.AddressUuid.fromJson(data) : null);
+    map[_i6.getType<_i18.CitizenInt?>()] = (data, protocol) =>
+        (data != null ? _i18.CitizenInt.fromJson(data) : null);
+    map[_i6.getType<_i19.CompanyUuid?>()] = (data, protocol) =>
+        (data != null ? _i19.CompanyUuid.fromJson(data) : null);
+    map[_i6.getType<_i20.TownInt?>()] = (data, protocol) =>
+        (data != null ? _i20.TownInt.fromJson(data) : null);
+    map[_i6.getType<_i21.ChangedIdTypeSelf?>()] = (data, protocol) =>
+        (data != null ? _i21.ChangedIdTypeSelf.fromJson(data) : null);
+    map[_i6.getType<_i22.BigIntDefault?>()] = (data, protocol) =>
+        (data != null ? _i22.BigIntDefault.fromJson(data) : null);
+    map[_i6.getType<_i23.BigIntDefaultMix?>()] = (data, protocol) =>
+        (data != null ? _i23.BigIntDefaultMix.fromJson(data) : null);
+    map[_i6.getType<_i24.BigIntDefaultModel?>()] = (data, protocol) =>
+        (data != null ? _i24.BigIntDefaultModel.fromJson(data) : null);
+    map[_i6.getType<_i25.BigIntDefaultPersist?>()] = (data, protocol) =>
+        (data != null ? _i25.BigIntDefaultPersist.fromJson(data) : null);
+    map[_i6.getType<_i26.BoolDefault?>()] = (data, protocol) =>
+        (data != null ? _i26.BoolDefault.fromJson(data) : null);
+    map[_i6.getType<_i27.BoolDefaultMix?>()] = (data, protocol) =>
+        (data != null ? _i27.BoolDefaultMix.fromJson(data) : null);
+    map[_i6.getType<_i28.BoolDefaultModel?>()] = (data, protocol) =>
+        (data != null ? _i28.BoolDefaultModel.fromJson(data) : null);
+    map[_i6.getType<_i29.BoolDefaultPersist?>()] = (data, protocol) =>
+        (data != null ? _i29.BoolDefaultPersist.fromJson(data) : null);
+    map[_i6.getType<_i30.DateTimeDefault?>()] = (data, protocol) =>
+        (data != null ? _i30.DateTimeDefault.fromJson(data) : null);
+    map[_i6.getType<_i31.DateTimeDefaultMix?>()] = (data, protocol) =>
+        (data != null ? _i31.DateTimeDefaultMix.fromJson(data) : null);
+    map[_i6.getType<_i32.DateTimeDefaultModel?>()] = (data, protocol) =>
+        (data != null ? _i32.DateTimeDefaultModel.fromJson(data) : null);
+    map[_i6.getType<_i33.DateTimeDefaultPersist?>()] = (data, protocol) =>
+        (data != null ? _i33.DateTimeDefaultPersist.fromJson(data) : null);
+    map[_i6.getType<_i34.DoubleDefault?>()] = (data, protocol) =>
+        (data != null ? _i34.DoubleDefault.fromJson(data) : null);
+    map[_i6.getType<_i35.DoubleDefaultMix?>()] = (data, protocol) =>
+        (data != null ? _i35.DoubleDefaultMix.fromJson(data) : null);
+    map[_i6.getType<_i36.DoubleDefaultModel?>()] = (data, protocol) =>
+        (data != null ? _i36.DoubleDefaultModel.fromJson(data) : null);
+    map[_i6.getType<_i37.DoubleDefaultPersist?>()] = (data, protocol) =>
+        (data != null ? _i37.DoubleDefaultPersist.fromJson(data) : null);
+    map[_i6.getType<_i38.DurationDefault?>()] = (data, protocol) =>
+        (data != null ? _i38.DurationDefault.fromJson(data) : null);
+    map[_i6.getType<_i39.DurationDefaultMix?>()] = (data, protocol) =>
+        (data != null ? _i39.DurationDefaultMix.fromJson(data) : null);
+    map[_i6.getType<_i40.DurationDefaultModel?>()] = (data, protocol) =>
+        (data != null ? _i40.DurationDefaultModel.fromJson(data) : null);
+    map[_i6.getType<_i41.DurationDefaultPersist?>()] = (data, protocol) =>
+        (data != null ? _i41.DurationDefaultPersist.fromJson(data) : null);
+    map[_i6.getType<_i42.EnumDefault?>()] = (data, protocol) =>
+        (data != null ? _i42.EnumDefault.fromJson(data) : null);
+    map[_i6.getType<_i43.EnumDefaultMix?>()] = (data, protocol) =>
+        (data != null ? _i43.EnumDefaultMix.fromJson(data) : null);
+    map[_i6.getType<_i44.EnumDefaultModel?>()] = (data, protocol) =>
+        (data != null ? _i44.EnumDefaultModel.fromJson(data) : null);
+    map[_i6.getType<_i45.EnumDefaultPersist?>()] = (data, protocol) =>
+        (data != null ? _i45.EnumDefaultPersist.fromJson(data) : null);
+    map[_i6.getType<_i46.ByIndexEnum?>()] = (data, protocol) =>
+        (data != null ? _i46.ByIndexEnum.fromJson(data) : null);
+    map[_i6.getType<_i47.ByNameEnum?>()] = (data, protocol) =>
+        (data != null ? _i47.ByNameEnum.fromJson(data) : null);
+    map[_i6.getType<_i48.DefaultValueEnum?>()] = (data, protocol) =>
+        (data != null ? _i48.DefaultValueEnum.fromJson(data) : null);
+    map[_i6.getType<_i49.DefaultException?>()] = (data, protocol) =>
+        (data != null ? _i49.DefaultException.fromJson(data) : null);
+    map[_i6.getType<_i50.IntDefault?>()] = (data, protocol) =>
+        (data != null ? _i50.IntDefault.fromJson(data) : null);
+    map[_i6.getType<_i51.IntDefaultMix?>()] = (data, protocol) =>
+        (data != null ? _i51.IntDefaultMix.fromJson(data) : null);
+    map[_i6.getType<_i52.IntDefaultModel?>()] = (data, protocol) =>
+        (data != null ? _i52.IntDefaultModel.fromJson(data) : null);
+    map[_i6.getType<_i53.IntDefaultPersist?>()] = (data, protocol) =>
+        (data != null ? _i53.IntDefaultPersist.fromJson(data) : null);
+    map[_i6.getType<_i54.StringDefault?>()] = (data, protocol) =>
+        (data != null ? _i54.StringDefault.fromJson(data) : null);
+    map[_i6.getType<_i55.StringDefaultMix?>()] = (data, protocol) =>
+        (data != null ? _i55.StringDefaultMix.fromJson(data) : null);
+    map[_i6.getType<_i56.StringDefaultModel?>()] = (data, protocol) =>
+        (data != null ? _i56.StringDefaultModel.fromJson(data) : null);
+    map[_i6.getType<_i57.StringDefaultPersist?>()] = (data, protocol) =>
+        (data != null ? _i57.StringDefaultPersist.fromJson(data) : null);
+    map[_i6.getType<_i58.UriDefault?>()] = (data, protocol) =>
+        (data != null ? _i58.UriDefault.fromJson(data) : null);
+    map[_i6.getType<_i59.UriDefaultMix?>()] = (data, protocol) =>
+        (data != null ? _i59.UriDefaultMix.fromJson(data) : null);
+    map[_i6.getType<_i60.UriDefaultModel?>()] = (data, protocol) =>
+        (data != null ? _i60.UriDefaultModel.fromJson(data) : null);
+    map[_i6.getType<_i61.UriDefaultPersist?>()] = (data, protocol) =>
+        (data != null ? _i61.UriDefaultPersist.fromJson(data) : null);
+    map[_i6.getType<_i62.UuidDefault?>()] = (data, protocol) =>
+        (data != null ? _i62.UuidDefault.fromJson(data) : null);
+    map[_i6.getType<_i63.UuidDefaultMix?>()] = (data, protocol) =>
+        (data != null ? _i63.UuidDefaultMix.fromJson(data) : null);
+    map[_i6.getType<_i64.UuidDefaultModel?>()] = (data, protocol) =>
+        (data != null ? _i64.UuidDefaultModel.fromJson(data) : null);
+    map[_i6.getType<_i65.UuidDefaultPersist?>()] = (data, protocol) =>
+        (data != null ? _i65.UuidDefaultPersist.fromJson(data) : null);
+    map[_i6.getType<_i66.EmptyModel?>()] = (data, protocol) =>
+        (data != null ? _i66.EmptyModel.fromJson(data) : null);
+    map[_i6.getType<_i67.EmptyModelRelationItem?>()] = (data, protocol) =>
+        (data != null ? _i67.EmptyModelRelationItem.fromJson(data) : null);
+    map[_i6.getType<_i68.EmptyModelWithTable?>()] = (data, protocol) =>
+        (data != null ? _i68.EmptyModelWithTable.fromJson(data) : null);
+    map[_i6.getType<_i69.RelationEmptyModel?>()] = (data, protocol) =>
+        (data != null ? _i69.RelationEmptyModel.fromJson(data) : null);
+    map[_i6.getType<_i70.ChildClassExplicitColumn?>()] = (data, protocol) =>
+        (data != null ? _i70.ChildClassExplicitColumn.fromJson(data) : null);
+    map[_i6.getType<_i71.NonTableParentClass?>()] = (data, protocol) =>
+        (data != null ? _i71.NonTableParentClass.fromJson(data) : null);
+    map[_i6.getType<_i72.ModifiedColumnName?>()] = (data, protocol) =>
+        (data != null ? _i72.ModifiedColumnName.fromJson(data) : null);
+    map[_i6.getType<_i73.Department?>()] = (data, protocol) =>
+        (data != null ? _i73.Department.fromJson(data) : null);
+    map[_i6.getType<_i74.Employee?>()] = (data, protocol) =>
+        (data != null ? _i74.Employee.fromJson(data) : null);
+    map[_i6.getType<_i75.Contractor?>()] = (data, protocol) =>
+        (data != null ? _i75.Contractor.fromJson(data) : null);
+    map[_i6.getType<_i76.Service?>()] = (data, protocol) =>
+        (data != null ? _i76.Service.fromJson(data) : null);
+    map[_i6.getType<_i77.TableWithExplicitColumnName?>()] = (data, protocol) =>
+        (data != null ? _i77.TableWithExplicitColumnName.fromJson(data) : null);
+    map[_i6.getType<_i78.SealedGrandChild?>()] = (data, protocol) =>
+        (data != null ? _i78.SealedGrandChild.fromJson(data) : null);
+    map[_i6.getType<_i78.SealedChild?>()] = (data, protocol) =>
+        (data != null ? _i78.SealedChild.fromJson(data) : null);
+    map[_i6.getType<_i78.SealedOtherChild?>()] = (data, protocol) =>
+        (data != null ? _i78.SealedOtherChild.fromJson(data) : null);
+    map[_i6.getType<_i79.CityWithLongTableName?>()] = (data, protocol) =>
+        (data != null ? _i79.CityWithLongTableName.fromJson(data) : null);
+    map[_i6
+        .getType<_i80.OrganizationWithLongTableName?>()] = (data, protocol) =>
+        (data != null
+        ? _i80.OrganizationWithLongTableName.fromJson(data)
+        : null);
+    map[_i6.getType<_i81.PersonWithLongTableName?>()] = (data, protocol) =>
+        (data != null ? _i81.PersonWithLongTableName.fromJson(data) : null);
+    map[_i6.getType<_i82.MaxFieldName?>()] = (data, protocol) =>
+        (data != null ? _i82.MaxFieldName.fromJson(data) : null);
+    map[_i6.getType<_i83.LongImplicitIdField?>()] = (data, protocol) =>
+        (data != null ? _i83.LongImplicitIdField.fromJson(data) : null);
+    map[_i6
+        .getType<_i84.LongImplicitIdFieldCollection?>()] = (data, protocol) =>
+        (data != null
+        ? _i84.LongImplicitIdFieldCollection.fromJson(data)
+        : null);
+    map[_i6
+        .getType<_i85.RelationToMultipleMaxFieldName?>()] = (data, protocol) =>
+        (data != null
+        ? _i85.RelationToMultipleMaxFieldName.fromJson(data)
+        : null);
+    map[_i6.getType<_i86.UserNote?>()] = (data, protocol) =>
+        (data != null ? _i86.UserNote.fromJson(data) : null);
+    map[_i6.getType<_i87.UserNoteCollection?>()] = (data, protocol) =>
+        (data != null ? _i87.UserNoteCollection.fromJson(data) : null);
+    map[_i6
+        .getType<_i88.UserNoteCollectionWithALongName?>()] = (data, protocol) =>
+        (data != null
+        ? _i88.UserNoteCollectionWithALongName.fromJson(data)
+        : null);
+    map[_i6.getType<_i89.UserNoteWithALongName?>()] = (data, protocol) =>
+        (data != null ? _i89.UserNoteWithALongName.fromJson(data) : null);
+    map[_i6.getType<_i90.MultipleMaxFieldName?>()] = (data, protocol) =>
+        (data != null ? _i90.MultipleMaxFieldName.fromJson(data) : null);
+    map[_i6.getType<_i91.City?>()] = (data, protocol) =>
+        (data != null ? _i91.City.fromJson(data) : null);
+    map[_i6.getType<_i92.Organization?>()] = (data, protocol) =>
+        (data != null ? _i92.Organization.fromJson(data) : null);
+    map[_i6.getType<_i93.Person?>()] = (data, protocol) =>
+        (data != null ? _i93.Person.fromJson(data) : null);
+    map[_i6.getType<_i94.Course?>()] = (data, protocol) =>
+        (data != null ? _i94.Course.fromJson(data) : null);
+    map[_i6.getType<_i95.Enrollment?>()] = (data, protocol) =>
+        (data != null ? _i95.Enrollment.fromJson(data) : null);
+    map[_i6.getType<_i96.Student?>()] = (data, protocol) =>
+        (data != null ? _i96.Student.fromJson(data) : null);
+    map[_i6.getType<_i97.Arena?>()] = (data, protocol) =>
+        (data != null ? _i97.Arena.fromJson(data) : null);
+    map[_i6.getType<_i98.Player?>()] = (data, protocol) =>
+        (data != null ? _i98.Player.fromJson(data) : null);
+    map[_i6.getType<_i99.Team?>()] = (data, protocol) =>
+        (data != null ? _i99.Team.fromJson(data) : null);
+    map[_i6.getType<_i100.Comment?>()] = (data, protocol) =>
+        (data != null ? _i100.Comment.fromJson(data) : null);
+    map[_i6.getType<_i101.Customer?>()] = (data, protocol) =>
+        (data != null ? _i101.Customer.fromJson(data) : null);
+    map[_i6.getType<_i102.Book?>()] = (data, protocol) =>
+        (data != null ? _i102.Book.fromJson(data) : null);
+    map[_i6.getType<_i103.Chapter?>()] = (data, protocol) =>
+        (data != null ? _i103.Chapter.fromJson(data) : null);
+    map[_i6.getType<_i104.Order?>()] = (data, protocol) =>
+        (data != null ? _i104.Order.fromJson(data) : null);
+    map[_i6.getType<_i105.Address?>()] = (data, protocol) =>
+        (data != null ? _i105.Address.fromJson(data) : null);
+    map[_i6.getType<_i106.Citizen?>()] = (data, protocol) =>
+        (data != null ? _i106.Citizen.fromJson(data) : null);
+    map[_i6.getType<_i107.Company?>()] = (data, protocol) =>
+        (data != null ? _i107.Company.fromJson(data) : null);
+    map[_i6.getType<_i108.Town?>()] = (data, protocol) =>
+        (data != null ? _i108.Town.fromJson(data) : null);
+    map[_i6.getType<_i109.Blocking?>()] = (data, protocol) =>
+        (data != null ? _i109.Blocking.fromJson(data) : null);
+    map[_i6.getType<_i110.Member?>()] = (data, protocol) =>
+        (data != null ? _i110.Member.fromJson(data) : null);
+    map[_i6.getType<_i111.Cat?>()] = (data, protocol) =>
+        (data != null ? _i111.Cat.fromJson(data) : null);
+    map[_i6.getType<_i112.Post?>()] = (data, protocol) =>
+        (data != null ? _i112.Post.fromJson(data) : null);
+    map[_i6.getType<_i113.NullsDistinctData?>()] = (data, protocol) =>
+        (data != null ? _i113.NullsDistinctData.fromJson(data) : null);
+    map[_i6.getType<_i114.ObjectFieldPersist?>()] = (data, protocol) =>
+        (data != null ? _i114.ObjectFieldPersist.fromJson(data) : null);
+    map[_i6.getType<_i115.ObjectFieldScopes?>()] = (data, protocol) =>
+        (data != null ? _i115.ObjectFieldScopes.fromJson(data) : null);
+    map[_i6.getType<_i116.ObjectWithBit?>()] = (data, protocol) =>
+        (data != null ? _i116.ObjectWithBit.fromJson(data) : null);
+    map[_i6.getType<_i117.ObjectWithByteData?>()] = (data, protocol) =>
+        (data != null ? _i117.ObjectWithByteData.fromJson(data) : null);
+    map[_i6.getType<_i118.ObjectWithDuration?>()] = (data, protocol) =>
+        (data != null ? _i118.ObjectWithDuration.fromJson(data) : null);
+    map[_i6.getType<_i119.ObjectWithDynamic?>()] = (data, protocol) =>
+        (data != null ? _i119.ObjectWithDynamic.fromJson(data) : null);
+    map[_i6.getType<_i120.ObjectWithEnum?>()] = (data, protocol) =>
+        (data != null ? _i120.ObjectWithEnum.fromJson(data) : null);
+    map[_i6.getType<_i121.ObjectWithEnumEnhanced?>()] = (data, protocol) =>
+        (data != null ? _i121.ObjectWithEnumEnhanced.fromJson(data) : null);
+    map[_i6.getType<_i122.ObjectWithHalfVector?>()] = (data, protocol) =>
+        (data != null ? _i122.ObjectWithHalfVector.fromJson(data) : null);
+    map[_i6.getType<_i123.ObjectWithIndex?>()] = (data, protocol) =>
+        (data != null ? _i123.ObjectWithIndex.fromJson(data) : null);
+    map[_i6.getType<_i124.ObjectWithJsonb?>()] = (data, protocol) =>
+        (data != null ? _i124.ObjectWithJsonb.fromJson(data) : null);
+    map[_i6.getType<_i125.ObjectWithJsonbClassLevel?>()] = (data, protocol) =>
+        (data != null ? _i125.ObjectWithJsonbClassLevel.fromJson(data) : null);
+    map[_i6.getType<_i126.ObjectWithMaps?>()] = (data, protocol) =>
+        (data != null ? _i126.ObjectWithMaps.fromJson(data) : null);
+    map[_i6.getType<_i127.ObjectWithObject?>()] = (data, protocol) =>
+        (data != null ? _i127.ObjectWithObject.fromJson(data) : null);
+    map[_i6.getType<_i128.ObjectWithParent?>()] = (data, protocol) =>
+        (data != null ? _i128.ObjectWithParent.fromJson(data) : null);
+    map[_i6.getType<_i129.ObjectWithSealedClass?>()] = (data, protocol) =>
+        (data != null ? _i129.ObjectWithSealedClass.fromJson(data) : null);
+    map[_i6.getType<_i130.ObjectWithSelfParent?>()] = (data, protocol) =>
+        (data != null ? _i130.ObjectWithSelfParent.fromJson(data) : null);
+    map[_i6.getType<_i131.ObjectWithSparseVector?>()] = (data, protocol) =>
+        (data != null ? _i131.ObjectWithSparseVector.fromJson(data) : null);
+    map[_i6.getType<_i132.ObjectWithUuid?>()] = (data, protocol) =>
+        (data != null ? _i132.ObjectWithUuid.fromJson(data) : null);
+    map[_i6.getType<_i133.ObjectWithVector?>()] = (data, protocol) =>
+        (data != null ? _i133.ObjectWithVector.fromJson(data) : null);
+    map[_i6.getType<_i134.RelatedUniqueData?>()] = (data, protocol) =>
+        (data != null ? _i134.RelatedUniqueData.fromJson(data) : null);
+    map[_i6.getType<_i135.ModelWithRequiredField?>()] = (data, protocol) =>
+        (data != null ? _i135.ModelWithRequiredField.fromJson(data) : null);
+    map[_i6.getType<_i136.SimpleData?>()] = (data, protocol) =>
+        (data != null ? _i136.SimpleData.fromJson(data) : null);
+    map[_i6.getType<_i137.SimpleDateTime?>()] = (data, protocol) =>
+        (data != null ? _i137.SimpleDateTime.fromJson(data) : null);
+    map[_i6.getType<_i138.TestEnum?>()] = (data, protocol) =>
+        (data != null ? _i138.TestEnum.fromJson(data) : null);
+    map[_i6
+        .getType<_i139.TestEnumDefaultSerialization?>()] = (data, protocol) =>
+        (data != null
+        ? _i139.TestEnumDefaultSerialization.fromJson(data)
+        : null);
+    map[_i6.getType<_i140.TestEnumEnhanced?>()] = (data, protocol) =>
+        (data != null ? _i140.TestEnumEnhanced.fromJson(data) : null);
+    map[_i6.getType<_i141.TestEnumEnhancedByName?>()] = (data, protocol) =>
+        (data != null ? _i141.TestEnumEnhancedByName.fromJson(data) : null);
+    map[_i6.getType<_i142.TestEnumStringified?>()] = (data, protocol) =>
+        (data != null ? _i142.TestEnumStringified.fromJson(data) : null);
+    map[_i6.getType<_i143.Types?>()] = (data, protocol) =>
+        (data != null ? _i143.Types.fromJson(data) : null);
+    map[_i6.getType<_i144.UniqueData?>()] = (data, protocol) =>
+        (data != null ? _i144.UniqueData.fromJson(data) : null);
+    map[_i6.getType<_i145.UniqueDataWithNonPersist?>()] = (data, protocol) =>
+        (data != null ? _i145.UniqueDataWithNonPersist.fromJson(data) : null);
+    map[_i6.getType<_i146.UpsertTestModel?>()] = (data, protocol) =>
+        (data != null ? _i146.UpsertTestModel.fromJson(data) : null);
+    map[List<_i9.EnrollmentInt>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i9.EnrollmentInt>(e))
+        .toList();
+    map[_i6.getType<List<_i9.EnrollmentInt>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i9.EnrollmentInt>(e))
+              .toList()
+        : null);
+    map[List<_i12.PlayerUuid>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i12.PlayerUuid>(e))
+        .toList();
+    map[_i6.getType<List<_i12.PlayerUuid>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i12.PlayerUuid>(e))
+              .toList()
+        : null);
+    map[List<_i16.OrderUuid>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i16.OrderUuid>(e))
+        .toList();
+    map[_i6.getType<List<_i16.OrderUuid>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i16.OrderUuid>(e))
+              .toList()
+        : null);
+    map[List<_i14.CommentInt>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i14.CommentInt>(e))
+        .toList();
+    map[_i6.getType<List<_i14.CommentInt>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i14.CommentInt>(e))
+              .toList()
+        : null);
+    map[List<_i21.ChangedIdTypeSelf>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i21.ChangedIdTypeSelf>(e))
+        .toList();
+    map[_i6.getType<List<_i21.ChangedIdTypeSelf>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i21.ChangedIdTypeSelf>(e))
+              .toList()
+        : null);
+    map[List<_i67.EmptyModelRelationItem>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i67.EmptyModelRelationItem>(e))
+        .toList();
+    map[_i6.getType<List<_i67.EmptyModelRelationItem>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i67.EmptyModelRelationItem>(e))
+              .toList()
+        : null);
+    map[List<_i74.Employee>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i74.Employee>(e))
+        .toList();
+    map[_i6.getType<List<_i74.Employee>?>()] = (data, protocol) => (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i74.Employee>(e))
+              .toList()
+        : null);
+    map[List<_i81.PersonWithLongTableName>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i81.PersonWithLongTableName>(e))
+        .toList();
+    map[_i6.getType<List<_i81.PersonWithLongTableName>?>()] =
+        (data, protocol) => (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i81.PersonWithLongTableName>(e))
+              .toList()
+        : null);
+    map[List<_i80.OrganizationWithLongTableName>] = (data, protocol) =>
+        (data as List)
+            .map(
+              (e) =>
+                  protocol.deserialize<_i80.OrganizationWithLongTableName>(e),
+            )
+            .toList();
+    map[_i6.getType<List<_i80.OrganizationWithLongTableName>?>()] =
+        (data, protocol) => (data != null
+        ? (data as List)
+              .map(
+                (e) =>
+                    protocol.deserialize<_i80.OrganizationWithLongTableName>(e),
+              )
+              .toList()
+        : null);
+    map[List<_i83.LongImplicitIdField>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i83.LongImplicitIdField>(e))
+        .toList();
+    map[_i6.getType<List<_i83.LongImplicitIdField>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i83.LongImplicitIdField>(e))
+              .toList()
+        : null);
+    map[List<_i90.MultipleMaxFieldName>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i90.MultipleMaxFieldName>(e))
+        .toList();
+    map[_i6.getType<List<_i90.MultipleMaxFieldName>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i90.MultipleMaxFieldName>(e))
+              .toList()
+        : null);
+    map[List<_i86.UserNote>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i86.UserNote>(e))
+        .toList();
+    map[_i6.getType<List<_i86.UserNote>?>()] = (data, protocol) => (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i86.UserNote>(e))
+              .toList()
+        : null);
+    map[List<_i89.UserNoteWithALongName>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i89.UserNoteWithALongName>(e))
+        .toList();
+    map[_i6.getType<List<_i89.UserNoteWithALongName>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i89.UserNoteWithALongName>(e))
+              .toList()
+        : null);
+    map[List<_i93.Person>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i93.Person>(e))
+        .toList();
+    map[_i6.getType<List<_i93.Person>?>()] = (data, protocol) => (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i93.Person>(e))
+              .toList()
+        : null);
+    map[List<_i92.Organization>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i92.Organization>(e))
+        .toList();
+    map[_i6.getType<List<_i92.Organization>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i92.Organization>(e))
+              .toList()
+        : null);
+    map[List<_i95.Enrollment>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i95.Enrollment>(e))
+        .toList();
+    map[_i6.getType<List<_i95.Enrollment>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i95.Enrollment>(e))
+              .toList()
+        : null);
+    map[List<_i98.Player>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i98.Player>(e))
+        .toList();
+    map[_i6.getType<List<_i98.Player>?>()] = (data, protocol) => (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i98.Player>(e))
+              .toList()
+        : null);
+    map[List<_i104.Order>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i104.Order>(e))
+        .toList();
+    map[_i6.getType<List<_i104.Order>?>()] = (data, protocol) => (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i104.Order>(e))
+              .toList()
+        : null);
+    map[List<_i103.Chapter>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i103.Chapter>(e))
+        .toList();
+    map[_i6.getType<List<_i103.Chapter>?>()] = (data, protocol) => (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i103.Chapter>(e))
+              .toList()
+        : null);
+    map[List<_i100.Comment>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i100.Comment>(e))
+        .toList();
+    map[_i6.getType<List<_i100.Comment>?>()] = (data, protocol) => (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i100.Comment>(e))
+              .toList()
+        : null);
+    map[List<_i109.Blocking>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i109.Blocking>(e))
+        .toList();
+    map[_i6.getType<List<_i109.Blocking>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i109.Blocking>(e))
+              .toList()
+        : null);
+    map[List<_i111.Cat>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<_i111.Cat>(e)).toList();
+    map[_i6.getType<List<_i111.Cat>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<_i111.Cat>(e)).toList()
+        : null);
+    map[dynamic] = (data, protocol) =>
+        protocol.deserializeDynamicFieldValue(data);
+    map[List<dynamic>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<dynamic>(e)).toList();
+    map[dynamic] = (data, protocol) =>
+        protocol.deserializeDynamicFieldValue(data);
+    map[Map<String, dynamic>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<dynamic>(v),
+      ),
+    );
+    map[dynamic] = (data, protocol) =>
+        protocol.deserializeDynamicFieldValue(data);
+    map[Set<dynamic>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<dynamic>(e)).toSet();
+    map[dynamic] = (data, protocol) =>
+        protocol.deserializeDynamicFieldValue(data);
+    map[Map<dynamic, dynamic>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<dynamic>(e['k']),
+          protocol.deserialize<dynamic>(e['v']),
+        ),
+      ),
+    );
+    map[dynamic] = (data, protocol) =>
+        protocol.deserializeDynamicFieldValue(data);
+    map[dynamic] = (data, protocol) =>
+        protocol.deserializeDynamicFieldValue(data);
+    map[List<_i138.TestEnum>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i138.TestEnum>(e))
+        .toList();
+    map[List<_i138.TestEnum?>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i138.TestEnum?>(e))
+        .toList();
+    map[List<List<_i138.TestEnum>>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<List<_i138.TestEnum>>(e))
+        .toList();
+    map[List<_i138.TestEnum>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i138.TestEnum>(e))
+        .toList();
+    map[List<_i140.TestEnumEnhanced>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i140.TestEnumEnhanced>(e))
+        .toList();
+    map[List<_i141.TestEnumEnhancedByName>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i141.TestEnumEnhancedByName>(e))
+        .toList();
+    map[List<String>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<String>(e)).toList();
+    map[Map<String, String>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<String>(v),
+      ),
+    );
+    map[List<String>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<String>(e)).toList();
+    map[_i6.getType<List<String>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<String>(e)).toList()
+        : null);
+    map[Map<String, _i136.SimpleData>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i136.SimpleData>(v),
+      ),
+    );
+    map[Map<String, int>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<int>(v),
+      ),
+    );
+    map[Map<String, DateTime>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<DateTime>(v),
+      ),
+    );
+    map[Map<String, _i147.ByteData>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i147.ByteData>(v),
+      ),
+    );
+    map[Map<String, Duration>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<Duration>(v),
+      ),
+    );
+    map[Map<String, _i6.UuidValue>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i6.UuidValue>(v),
+      ),
+    );
+    map[Map<String, _i136.SimpleData?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i136.SimpleData?>(v),
+      ),
+    );
+    map[Map<String, int?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<int?>(v),
+      ),
+    );
+    map[Map<String, String?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<String?>(v),
+      ),
+    );
+    map[Map<String, DateTime?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<DateTime?>(v),
+      ),
+    );
+    map[Map<String, _i147.ByteData?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i147.ByteData?>(v),
+      ),
+    );
+    map[Map<String, Duration?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<Duration?>(v),
+      ),
+    );
+    map[Map<String, _i6.UuidValue?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i6.UuidValue?>(v),
+      ),
+    );
+    map[Map<int, int>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<int>(e['k']),
+          protocol.deserialize<int>(e['v']),
+        ),
+      ),
+    );
+    map[List<_i136.SimpleData>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i136.SimpleData>(e))
+        .toList();
+    map[List<_i136.SimpleData>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i136.SimpleData>(e))
+        .toList();
+    map[_i6.getType<List<_i136.SimpleData>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i136.SimpleData>(e))
+              .toList()
+        : null);
+    map[List<_i136.SimpleData?>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i136.SimpleData?>(e))
+        .toList();
+    map[List<_i136.SimpleData?>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i136.SimpleData?>(e))
+        .toList();
+    map[_i6.getType<List<_i136.SimpleData?>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i136.SimpleData?>(e))
+              .toList()
+        : null);
+    map[List<List<_i136.SimpleData>>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<List<_i136.SimpleData>>(e))
+        .toList();
+    map[List<_i136.SimpleData>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i136.SimpleData>(e))
+        .toList();
+    map[_i6.getType<List<List<_i136.SimpleData>>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<List<_i136.SimpleData>>(e))
+              .toList()
+        : null);
+    map[List<_i136.SimpleData>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i136.SimpleData>(e))
+        .toList();
+    map[Map<String, List<List<Map<int, _i136.SimpleData>>?>>] =
+        (data, protocol) => (data as Map).map(
+          (k, v) => MapEntry(
+            protocol.deserialize<String>(k),
+            protocol.deserialize<List<List<Map<int, _i136.SimpleData>>?>>(v),
+          ),
+        );
+    map[List<List<Map<int, _i136.SimpleData>>?>] = (data, protocol) =>
+        (data as List)
+            .map(
+              (e) => protocol.deserialize<List<Map<int, _i136.SimpleData>>?>(e),
+            )
+            .toList();
+    map[List<Map<int, _i136.SimpleData>>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<Map<int, _i136.SimpleData>>(e))
+        .toList();
+    map[Map<int, _i136.SimpleData>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<int>(e['k']),
+          protocol.deserialize<_i136.SimpleData>(e['v']),
+        ),
+      ),
+    );
+    map[_i6.getType<List<Map<int, _i136.SimpleData>>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<Map<int, _i136.SimpleData>>(e))
+              .toList()
+        : null);
+    map[Map<int, _i136.SimpleData>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<int>(e['k']),
+          protocol.deserialize<_i136.SimpleData>(e['v']),
+        ),
+      ),
+    );
+    map[_i6.getType<Map<String, List<List<Map<int, _i136.SimpleData>>?>>?>()] =
+        (data, protocol) => (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<List<List<Map<int, _i136.SimpleData>>?>>(v),
+            ),
+          )
+        : null);
+    map[List<List<Map<int, _i136.SimpleData>>?>] = (data, protocol) =>
+        (data as List)
+            .map(
+              (e) => protocol.deserialize<List<Map<int, _i136.SimpleData>>?>(e),
+            )
+            .toList();
+    map[List<Map<int, _i136.SimpleData>>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<Map<int, _i136.SimpleData>>(e))
+        .toList();
+    map[Map<int, _i136.SimpleData>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<int>(e['k']),
+          protocol.deserialize<_i136.SimpleData>(e['v']),
+        ),
+      ),
+    );
+    map[_i6.getType<List<Map<int, _i136.SimpleData>>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<Map<int, _i136.SimpleData>>(e))
+              .toList()
+        : null);
+    map[Map<int, _i136.SimpleData>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<int>(e['k']),
+          protocol.deserialize<_i136.SimpleData>(e['v']),
+        ),
+      ),
+    );
+    map[Map<String, Map<int, _i136.SimpleData>>] = (data, protocol) =>
+        (data as Map).map(
+          (k, v) => MapEntry(
+            protocol.deserialize<String>(k),
+            protocol.deserialize<Map<int, _i136.SimpleData>>(v),
+          ),
+        );
+    map[Map<int, _i136.SimpleData>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<int>(e['k']),
+          protocol.deserialize<_i136.SimpleData>(e['v']),
+        ),
+      ),
+    );
+    map[_i6.getType<Map<String, Map<int, _i136.SimpleData>>?>()] =
+        (data, protocol) => (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<Map<int, _i136.SimpleData>>(v),
+            ),
+          )
+        : null);
+    map[Map<int, _i136.SimpleData>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<int>(e['k']),
+          protocol.deserialize<_i136.SimpleData>(e['v']),
+        ),
+      ),
+    );
+    map[List<_i78.SealedParent>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i78.SealedParent>(e))
+        .toList();
+    map[List<int>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int>(e)).toList();
+    map[_i6.getType<List<int>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<int>(e)).toList()
+        : null);
+    map[Map<int, int>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<int>(e['k']),
+          protocol.deserialize<int>(e['v']),
+        ),
+      ),
+    );
+    map[_i6.getType<Map<int, int>?>()] = (data, protocol) => (data != null
+        ? Map.fromEntries(
+            (data as List).map(
+              (e) => MapEntry(
+                protocol.deserialize<int>(e['k']),
+                protocol.deserialize<int>(e['v']),
+              ),
+            ),
+          )
+        : null);
+    map[Set<int>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int>(e)).toSet();
+    map[_i6.getType<Set<int>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<int>(e)).toSet()
+        : null);
+    map[_i6.getType<(String, {Uri? optionalUri})?>()] = (data, protocol) =>
+        (data == null)
+        ? null
+        : (
+            protocol.deserialize<String>(((data as Map)['p'] as List)[0]),
+            optionalUri: ((data)['n'] as Map)['optionalUri'] == null
+                ? null
+                : protocol.deserialize<Uri>(data['n']['optionalUri']),
+          );
+    map[List<_i148.SimpleData>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i148.SimpleData>(e))
+        .toList();
+    map[_i6.getType<(String, {Uri? optionalUri})?>()] = (data, protocol) =>
+        (data == null)
+        ? null
+        : (
+            protocol.deserialize<String>(((data as Map)['p'] as List)[0]),
+            optionalUri: ((data)['n'] as Map)['optionalUri'] == null
+                ? null
+                : protocol.deserialize<Uri>(data['n']['optionalUri']),
+          );
+    return map;
   }
 }

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/protocol.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/protocol.dart
@@ -5615,6 +5615,1081 @@ class Protocol extends _i1.DatabaseSerializationManager {
     ..._i2.Protocol.targetTableDefinitions,
   ];
 
+  static final Map<Type, dynamic Function(dynamic, Protocol)> _deserializers =
+      _buildDeserializers();
+
+  static Map<Type, dynamic Function(dynamic, Protocol)> _buildDeserializers() {
+    final map = <Type, dynamic Function(dynamic, Protocol)>{};
+    map[_i3.CourseUuid] = (data, protocol) => _i3.CourseUuid.fromJson(data);
+    map[_i4.EnrollmentInt] = (data, protocol) =>
+        _i4.EnrollmentInt.fromJson(data);
+    map[_i5.StudentUuid] = (data, protocol) => _i5.StudentUuid.fromJson(data);
+    map[_i6.ArenaUuid] = (data, protocol) => _i6.ArenaUuid.fromJson(data);
+    map[_i7.PlayerUuid] = (data, protocol) => _i7.PlayerUuid.fromJson(data);
+    map[_i8.TeamInt] = (data, protocol) => _i8.TeamInt.fromJson(data);
+    map[_i9.CommentInt] = (data, protocol) => _i9.CommentInt.fromJson(data);
+    map[_i10.CustomerInt] = (data, protocol) => _i10.CustomerInt.fromJson(data);
+    map[_i11.OrderUuid] = (data, protocol) => _i11.OrderUuid.fromJson(data);
+    map[_i12.AddressUuid] = (data, protocol) => _i12.AddressUuid.fromJson(data);
+    map[_i13.CitizenInt] = (data, protocol) => _i13.CitizenInt.fromJson(data);
+    map[_i14.CompanyUuid] = (data, protocol) => _i14.CompanyUuid.fromJson(data);
+    map[_i15.TownInt] = (data, protocol) => _i15.TownInt.fromJson(data);
+    map[_i16.ChangedIdTypeSelf] = (data, protocol) =>
+        _i16.ChangedIdTypeSelf.fromJson(data);
+    map[_i17.ServerOnlyChangedIdFieldClass] = (data, protocol) =>
+        _i17.ServerOnlyChangedIdFieldClass.fromJson(data);
+    map[_i18.BigIntDefault] = (data, protocol) =>
+        _i18.BigIntDefault.fromJson(data);
+    map[_i19.BigIntDefaultMix] = (data, protocol) =>
+        _i19.BigIntDefaultMix.fromJson(data);
+    map[_i20.BigIntDefaultModel] = (data, protocol) =>
+        _i20.BigIntDefaultModel.fromJson(data);
+    map[_i21.BigIntDefaultPersist] = (data, protocol) =>
+        _i21.BigIntDefaultPersist.fromJson(data);
+    map[_i22.BoolDefault] = (data, protocol) => _i22.BoolDefault.fromJson(data);
+    map[_i23.BoolDefaultMix] = (data, protocol) =>
+        _i23.BoolDefaultMix.fromJson(data);
+    map[_i24.BoolDefaultModel] = (data, protocol) =>
+        _i24.BoolDefaultModel.fromJson(data);
+    map[_i25.BoolDefaultPersist] = (data, protocol) =>
+        _i25.BoolDefaultPersist.fromJson(data);
+    map[_i26.DateTimeDefault] = (data, protocol) =>
+        _i26.DateTimeDefault.fromJson(data);
+    map[_i27.DateTimeDefaultMix] = (data, protocol) =>
+        _i27.DateTimeDefaultMix.fromJson(data);
+    map[_i28.DateTimeDefaultModel] = (data, protocol) =>
+        _i28.DateTimeDefaultModel.fromJson(data);
+    map[_i29.DateTimeDefaultPersist] = (data, protocol) =>
+        _i29.DateTimeDefaultPersist.fromJson(data);
+    map[_i30.DoubleDefault] = (data, protocol) =>
+        _i30.DoubleDefault.fromJson(data);
+    map[_i31.DoubleDefaultMix] = (data, protocol) =>
+        _i31.DoubleDefaultMix.fromJson(data);
+    map[_i32.DoubleDefaultModel] = (data, protocol) =>
+        _i32.DoubleDefaultModel.fromJson(data);
+    map[_i33.DoubleDefaultPersist] = (data, protocol) =>
+        _i33.DoubleDefaultPersist.fromJson(data);
+    map[_i34.DurationDefault] = (data, protocol) =>
+        _i34.DurationDefault.fromJson(data);
+    map[_i35.DurationDefaultMix] = (data, protocol) =>
+        _i35.DurationDefaultMix.fromJson(data);
+    map[_i36.DurationDefaultModel] = (data, protocol) =>
+        _i36.DurationDefaultModel.fromJson(data);
+    map[_i37.DurationDefaultPersist] = (data, protocol) =>
+        _i37.DurationDefaultPersist.fromJson(data);
+    map[_i38.EnumDefault] = (data, protocol) => _i38.EnumDefault.fromJson(data);
+    map[_i39.EnumDefaultMix] = (data, protocol) =>
+        _i39.EnumDefaultMix.fromJson(data);
+    map[_i40.EnumDefaultModel] = (data, protocol) =>
+        _i40.EnumDefaultModel.fromJson(data);
+    map[_i41.EnumDefaultPersist] = (data, protocol) =>
+        _i41.EnumDefaultPersist.fromJson(data);
+    map[_i42.ByIndexEnum] = (data, protocol) => _i42.ByIndexEnum.fromJson(data);
+    map[_i43.ByNameEnum] = (data, protocol) => _i43.ByNameEnum.fromJson(data);
+    map[_i44.DefaultValueEnum] = (data, protocol) =>
+        _i44.DefaultValueEnum.fromJson(data);
+    map[_i45.DefaultException] = (data, protocol) =>
+        _i45.DefaultException.fromJson(data);
+    map[_i46.IntDefault] = (data, protocol) => _i46.IntDefault.fromJson(data);
+    map[_i47.IntDefaultMix] = (data, protocol) =>
+        _i47.IntDefaultMix.fromJson(data);
+    map[_i48.IntDefaultModel] = (data, protocol) =>
+        _i48.IntDefaultModel.fromJson(data);
+    map[_i49.IntDefaultPersist] = (data, protocol) =>
+        _i49.IntDefaultPersist.fromJson(data);
+    map[_i50.StringDefault] = (data, protocol) =>
+        _i50.StringDefault.fromJson(data);
+    map[_i51.StringDefaultMix] = (data, protocol) =>
+        _i51.StringDefaultMix.fromJson(data);
+    map[_i52.StringDefaultModel] = (data, protocol) =>
+        _i52.StringDefaultModel.fromJson(data);
+    map[_i53.StringDefaultPersist] = (data, protocol) =>
+        _i53.StringDefaultPersist.fromJson(data);
+    map[_i54.UriDefault] = (data, protocol) => _i54.UriDefault.fromJson(data);
+    map[_i55.UriDefaultMix] = (data, protocol) =>
+        _i55.UriDefaultMix.fromJson(data);
+    map[_i56.UriDefaultModel] = (data, protocol) =>
+        _i56.UriDefaultModel.fromJson(data);
+    map[_i57.UriDefaultPersist] = (data, protocol) =>
+        _i57.UriDefaultPersist.fromJson(data);
+    map[_i58.UuidDefault] = (data, protocol) => _i58.UuidDefault.fromJson(data);
+    map[_i59.UuidDefaultMix] = (data, protocol) =>
+        _i59.UuidDefaultMix.fromJson(data);
+    map[_i60.UuidDefaultModel] = (data, protocol) =>
+        _i60.UuidDefaultModel.fromJson(data);
+    map[_i61.UuidDefaultPersist] = (data, protocol) =>
+        _i61.UuidDefaultPersist.fromJson(data);
+    map[_i62.EmptyModel] = (data, protocol) => _i62.EmptyModel.fromJson(data);
+    map[_i63.EmptyModelRelationItem] = (data, protocol) =>
+        _i63.EmptyModelRelationItem.fromJson(data);
+    map[_i64.EmptyModelWithTable] = (data, protocol) =>
+        _i64.EmptyModelWithTable.fromJson(data);
+    map[_i65.RelationEmptyModel] = (data, protocol) =>
+        _i65.RelationEmptyModel.fromJson(data);
+    map[_i66.ChildClassExplicitColumn] = (data, protocol) =>
+        _i66.ChildClassExplicitColumn.fromJson(data);
+    map[_i67.NonTableParentClass] = (data, protocol) =>
+        _i67.NonTableParentClass.fromJson(data);
+    map[_i68.ModifiedColumnName] = (data, protocol) =>
+        _i68.ModifiedColumnName.fromJson(data);
+    map[_i69.Department] = (data, protocol) => _i69.Department.fromJson(data);
+    map[_i70.Employee] = (data, protocol) => _i70.Employee.fromJson(data);
+    map[_i71.Contractor] = (data, protocol) => _i71.Contractor.fromJson(data);
+    map[_i72.Service] = (data, protocol) => _i72.Service.fromJson(data);
+    map[_i73.TableWithExplicitColumnName] = (data, protocol) =>
+        _i73.TableWithExplicitColumnName.fromJson(data);
+    map[_i74.SealedGrandChild] = (data, protocol) =>
+        _i74.SealedGrandChild.fromJson(data);
+    map[_i74.SealedChild] = (data, protocol) => _i74.SealedChild.fromJson(data);
+    map[_i74.SealedOtherChild] = (data, protocol) =>
+        _i74.SealedOtherChild.fromJson(data);
+    map[_i75.CityWithLongTableName] = (data, protocol) =>
+        _i75.CityWithLongTableName.fromJson(data);
+    map[_i76.OrganizationWithLongTableName] = (data, protocol) =>
+        _i76.OrganizationWithLongTableName.fromJson(data);
+    map[_i77.PersonWithLongTableName] = (data, protocol) =>
+        _i77.PersonWithLongTableName.fromJson(data);
+    map[_i78.MaxFieldName] = (data, protocol) =>
+        _i78.MaxFieldName.fromJson(data);
+    map[_i79.LongImplicitIdField] = (data, protocol) =>
+        _i79.LongImplicitIdField.fromJson(data);
+    map[_i80.LongImplicitIdFieldCollection] = (data, protocol) =>
+        _i80.LongImplicitIdFieldCollection.fromJson(data);
+    map[_i81.RelationToMultipleMaxFieldName] = (data, protocol) =>
+        _i81.RelationToMultipleMaxFieldName.fromJson(data);
+    map[_i82.UserNote] = (data, protocol) => _i82.UserNote.fromJson(data);
+    map[_i83.UserNoteCollection] = (data, protocol) =>
+        _i83.UserNoteCollection.fromJson(data);
+    map[_i84.UserNoteCollectionWithALongName] = (data, protocol) =>
+        _i84.UserNoteCollectionWithALongName.fromJson(data);
+    map[_i85.UserNoteWithALongName] = (data, protocol) =>
+        _i85.UserNoteWithALongName.fromJson(data);
+    map[_i86.MultipleMaxFieldName] = (data, protocol) =>
+        _i86.MultipleMaxFieldName.fromJson(data);
+    map[_i87.City] = (data, protocol) => _i87.City.fromJson(data);
+    map[_i88.Organization] = (data, protocol) =>
+        _i88.Organization.fromJson(data);
+    map[_i89.Person] = (data, protocol) => _i89.Person.fromJson(data);
+    map[_i90.Course] = (data, protocol) => _i90.Course.fromJson(data);
+    map[_i91.Enrollment] = (data, protocol) => _i91.Enrollment.fromJson(data);
+    map[_i92.Student] = (data, protocol) => _i92.Student.fromJson(data);
+    map[_i93.Arena] = (data, protocol) => _i93.Arena.fromJson(data);
+    map[_i94.Player] = (data, protocol) => _i94.Player.fromJson(data);
+    map[_i95.Team] = (data, protocol) => _i95.Team.fromJson(data);
+    map[_i96.Comment] = (data, protocol) => _i96.Comment.fromJson(data);
+    map[_i97.Customer] = (data, protocol) => _i97.Customer.fromJson(data);
+    map[_i98.Book] = (data, protocol) => _i98.Book.fromJson(data);
+    map[_i99.Chapter] = (data, protocol) => _i99.Chapter.fromJson(data);
+    map[_i100.Order] = (data, protocol) => _i100.Order.fromJson(data);
+    map[_i101.Address] = (data, protocol) => _i101.Address.fromJson(data);
+    map[_i102.Citizen] = (data, protocol) => _i102.Citizen.fromJson(data);
+    map[_i103.Company] = (data, protocol) => _i103.Company.fromJson(data);
+    map[_i104.Town] = (data, protocol) => _i104.Town.fromJson(data);
+    map[_i105.Blocking] = (data, protocol) => _i105.Blocking.fromJson(data);
+    map[_i106.Member] = (data, protocol) => _i106.Member.fromJson(data);
+    map[_i107.Cat] = (data, protocol) => _i107.Cat.fromJson(data);
+    map[_i108.Post] = (data, protocol) => _i108.Post.fromJson(data);
+    map[_i109.ObjectFieldPersist] = (data, protocol) =>
+        _i109.ObjectFieldPersist.fromJson(data);
+    map[_i110.ObjectFieldScopes] = (data, protocol) =>
+        _i110.ObjectFieldScopes.fromJson(data);
+    map[_i111.ObjectWithBit] = (data, protocol) =>
+        _i111.ObjectWithBit.fromJson(data);
+    map[_i112.ObjectWithByteData] = (data, protocol) =>
+        _i112.ObjectWithByteData.fromJson(data);
+    map[_i113.ObjectWithDuration] = (data, protocol) =>
+        _i113.ObjectWithDuration.fromJson(data);
+    map[_i114.ObjectWithDynamic] = (data, protocol) =>
+        _i114.ObjectWithDynamic.fromJson(data);
+    map[_i115.ObjectWithEnum] = (data, protocol) =>
+        _i115.ObjectWithEnum.fromJson(data);
+    map[_i116.ObjectWithEnumEnhanced] = (data, protocol) =>
+        _i116.ObjectWithEnumEnhanced.fromJson(data);
+    map[_i117.ObjectWithHalfVector] = (data, protocol) =>
+        _i117.ObjectWithHalfVector.fromJson(data);
+    map[_i118.ObjectWithIndex] = (data, protocol) =>
+        _i118.ObjectWithIndex.fromJson(data);
+    map[_i119.ObjectWithJsonb] = (data, protocol) =>
+        _i119.ObjectWithJsonb.fromJson(data);
+    map[_i120.ObjectWithJsonbClassLevel] = (data, protocol) =>
+        _i120.ObjectWithJsonbClassLevel.fromJson(data);
+    map[_i121.ObjectWithMaps] = (data, protocol) =>
+        _i121.ObjectWithMaps.fromJson(data);
+    map[_i122.ObjectWithObject] = (data, protocol) =>
+        _i122.ObjectWithObject.fromJson(data);
+    map[_i123.ObjectWithParent] = (data, protocol) =>
+        _i123.ObjectWithParent.fromJson(data);
+    map[_i124.ObjectWithSealedClass] = (data, protocol) =>
+        _i124.ObjectWithSealedClass.fromJson(data);
+    map[_i125.ObjectWithSelfParent] = (data, protocol) =>
+        _i125.ObjectWithSelfParent.fromJson(data);
+    map[_i126.ObjectWithSparseVector] = (data, protocol) =>
+        _i126.ObjectWithSparseVector.fromJson(data);
+    map[_i127.ObjectWithUuid] = (data, protocol) =>
+        _i127.ObjectWithUuid.fromJson(data);
+    map[_i128.ObjectWithVector] = (data, protocol) =>
+        _i128.ObjectWithVector.fromJson(data);
+    map[_i129.RelatedUniqueData] = (data, protocol) =>
+        _i129.RelatedUniqueData.fromJson(data);
+    map[_i130.ModelWithRequiredField] = (data, protocol) =>
+        _i130.ModelWithRequiredField.fromJson(data);
+    map[_i131.SimpleData] = (data, protocol) => _i131.SimpleData.fromJson(data);
+    map[_i132.SimpleDateTime] = (data, protocol) =>
+        _i132.SimpleDateTime.fromJson(data);
+    map[_i133.TestEnum] = (data, protocol) => _i133.TestEnum.fromJson(data);
+    map[_i134.TestEnumDefaultSerialization] = (data, protocol) =>
+        _i134.TestEnumDefaultSerialization.fromJson(data);
+    map[_i135.TestEnumEnhanced] = (data, protocol) =>
+        _i135.TestEnumEnhanced.fromJson(data);
+    map[_i136.TestEnumEnhancedByName] = (data, protocol) =>
+        _i136.TestEnumEnhancedByName.fromJson(data);
+    map[_i137.TestEnumStringified] = (data, protocol) =>
+        _i137.TestEnumStringified.fromJson(data);
+    map[_i138.Types] = (data, protocol) => _i138.Types.fromJson(data);
+    map[_i139.UniqueData] = (data, protocol) => _i139.UniqueData.fromJson(data);
+    map[_i140.UniqueDataWithNonPersist] = (data, protocol) =>
+        _i140.UniqueDataWithNonPersist.fromJson(data);
+    map[_i141.UpsertTestModel] = (data, protocol) =>
+        _i141.UpsertTestModel.fromJson(data);
+    map[_i1.getType<_i3.CourseUuid?>()] = (data, protocol) =>
+        (data != null ? _i3.CourseUuid.fromJson(data) : null);
+    map[_i1.getType<_i4.EnrollmentInt?>()] = (data, protocol) =>
+        (data != null ? _i4.EnrollmentInt.fromJson(data) : null);
+    map[_i1.getType<_i5.StudentUuid?>()] = (data, protocol) =>
+        (data != null ? _i5.StudentUuid.fromJson(data) : null);
+    map[_i1.getType<_i6.ArenaUuid?>()] = (data, protocol) =>
+        (data != null ? _i6.ArenaUuid.fromJson(data) : null);
+    map[_i1.getType<_i7.PlayerUuid?>()] = (data, protocol) =>
+        (data != null ? _i7.PlayerUuid.fromJson(data) : null);
+    map[_i1.getType<_i8.TeamInt?>()] = (data, protocol) =>
+        (data != null ? _i8.TeamInt.fromJson(data) : null);
+    map[_i1.getType<_i9.CommentInt?>()] = (data, protocol) =>
+        (data != null ? _i9.CommentInt.fromJson(data) : null);
+    map[_i1.getType<_i10.CustomerInt?>()] = (data, protocol) =>
+        (data != null ? _i10.CustomerInt.fromJson(data) : null);
+    map[_i1.getType<_i11.OrderUuid?>()] = (data, protocol) =>
+        (data != null ? _i11.OrderUuid.fromJson(data) : null);
+    map[_i1.getType<_i12.AddressUuid?>()] = (data, protocol) =>
+        (data != null ? _i12.AddressUuid.fromJson(data) : null);
+    map[_i1.getType<_i13.CitizenInt?>()] = (data, protocol) =>
+        (data != null ? _i13.CitizenInt.fromJson(data) : null);
+    map[_i1.getType<_i14.CompanyUuid?>()] = (data, protocol) =>
+        (data != null ? _i14.CompanyUuid.fromJson(data) : null);
+    map[_i1.getType<_i15.TownInt?>()] = (data, protocol) =>
+        (data != null ? _i15.TownInt.fromJson(data) : null);
+    map[_i1.getType<_i16.ChangedIdTypeSelf?>()] = (data, protocol) =>
+        (data != null ? _i16.ChangedIdTypeSelf.fromJson(data) : null);
+    map[_i1
+        .getType<_i17.ServerOnlyChangedIdFieldClass?>()] = (data, protocol) =>
+        (data != null
+        ? _i17.ServerOnlyChangedIdFieldClass.fromJson(data)
+        : null);
+    map[_i1.getType<_i18.BigIntDefault?>()] = (data, protocol) =>
+        (data != null ? _i18.BigIntDefault.fromJson(data) : null);
+    map[_i1.getType<_i19.BigIntDefaultMix?>()] = (data, protocol) =>
+        (data != null ? _i19.BigIntDefaultMix.fromJson(data) : null);
+    map[_i1.getType<_i20.BigIntDefaultModel?>()] = (data, protocol) =>
+        (data != null ? _i20.BigIntDefaultModel.fromJson(data) : null);
+    map[_i1.getType<_i21.BigIntDefaultPersist?>()] = (data, protocol) =>
+        (data != null ? _i21.BigIntDefaultPersist.fromJson(data) : null);
+    map[_i1.getType<_i22.BoolDefault?>()] = (data, protocol) =>
+        (data != null ? _i22.BoolDefault.fromJson(data) : null);
+    map[_i1.getType<_i23.BoolDefaultMix?>()] = (data, protocol) =>
+        (data != null ? _i23.BoolDefaultMix.fromJson(data) : null);
+    map[_i1.getType<_i24.BoolDefaultModel?>()] = (data, protocol) =>
+        (data != null ? _i24.BoolDefaultModel.fromJson(data) : null);
+    map[_i1.getType<_i25.BoolDefaultPersist?>()] = (data, protocol) =>
+        (data != null ? _i25.BoolDefaultPersist.fromJson(data) : null);
+    map[_i1.getType<_i26.DateTimeDefault?>()] = (data, protocol) =>
+        (data != null ? _i26.DateTimeDefault.fromJson(data) : null);
+    map[_i1.getType<_i27.DateTimeDefaultMix?>()] = (data, protocol) =>
+        (data != null ? _i27.DateTimeDefaultMix.fromJson(data) : null);
+    map[_i1.getType<_i28.DateTimeDefaultModel?>()] = (data, protocol) =>
+        (data != null ? _i28.DateTimeDefaultModel.fromJson(data) : null);
+    map[_i1.getType<_i29.DateTimeDefaultPersist?>()] = (data, protocol) =>
+        (data != null ? _i29.DateTimeDefaultPersist.fromJson(data) : null);
+    map[_i1.getType<_i30.DoubleDefault?>()] = (data, protocol) =>
+        (data != null ? _i30.DoubleDefault.fromJson(data) : null);
+    map[_i1.getType<_i31.DoubleDefaultMix?>()] = (data, protocol) =>
+        (data != null ? _i31.DoubleDefaultMix.fromJson(data) : null);
+    map[_i1.getType<_i32.DoubleDefaultModel?>()] = (data, protocol) =>
+        (data != null ? _i32.DoubleDefaultModel.fromJson(data) : null);
+    map[_i1.getType<_i33.DoubleDefaultPersist?>()] = (data, protocol) =>
+        (data != null ? _i33.DoubleDefaultPersist.fromJson(data) : null);
+    map[_i1.getType<_i34.DurationDefault?>()] = (data, protocol) =>
+        (data != null ? _i34.DurationDefault.fromJson(data) : null);
+    map[_i1.getType<_i35.DurationDefaultMix?>()] = (data, protocol) =>
+        (data != null ? _i35.DurationDefaultMix.fromJson(data) : null);
+    map[_i1.getType<_i36.DurationDefaultModel?>()] = (data, protocol) =>
+        (data != null ? _i36.DurationDefaultModel.fromJson(data) : null);
+    map[_i1.getType<_i37.DurationDefaultPersist?>()] = (data, protocol) =>
+        (data != null ? _i37.DurationDefaultPersist.fromJson(data) : null);
+    map[_i1.getType<_i38.EnumDefault?>()] = (data, protocol) =>
+        (data != null ? _i38.EnumDefault.fromJson(data) : null);
+    map[_i1.getType<_i39.EnumDefaultMix?>()] = (data, protocol) =>
+        (data != null ? _i39.EnumDefaultMix.fromJson(data) : null);
+    map[_i1.getType<_i40.EnumDefaultModel?>()] = (data, protocol) =>
+        (data != null ? _i40.EnumDefaultModel.fromJson(data) : null);
+    map[_i1.getType<_i41.EnumDefaultPersist?>()] = (data, protocol) =>
+        (data != null ? _i41.EnumDefaultPersist.fromJson(data) : null);
+    map[_i1.getType<_i42.ByIndexEnum?>()] = (data, protocol) =>
+        (data != null ? _i42.ByIndexEnum.fromJson(data) : null);
+    map[_i1.getType<_i43.ByNameEnum?>()] = (data, protocol) =>
+        (data != null ? _i43.ByNameEnum.fromJson(data) : null);
+    map[_i1.getType<_i44.DefaultValueEnum?>()] = (data, protocol) =>
+        (data != null ? _i44.DefaultValueEnum.fromJson(data) : null);
+    map[_i1.getType<_i45.DefaultException?>()] = (data, protocol) =>
+        (data != null ? _i45.DefaultException.fromJson(data) : null);
+    map[_i1.getType<_i46.IntDefault?>()] = (data, protocol) =>
+        (data != null ? _i46.IntDefault.fromJson(data) : null);
+    map[_i1.getType<_i47.IntDefaultMix?>()] = (data, protocol) =>
+        (data != null ? _i47.IntDefaultMix.fromJson(data) : null);
+    map[_i1.getType<_i48.IntDefaultModel?>()] = (data, protocol) =>
+        (data != null ? _i48.IntDefaultModel.fromJson(data) : null);
+    map[_i1.getType<_i49.IntDefaultPersist?>()] = (data, protocol) =>
+        (data != null ? _i49.IntDefaultPersist.fromJson(data) : null);
+    map[_i1.getType<_i50.StringDefault?>()] = (data, protocol) =>
+        (data != null ? _i50.StringDefault.fromJson(data) : null);
+    map[_i1.getType<_i51.StringDefaultMix?>()] = (data, protocol) =>
+        (data != null ? _i51.StringDefaultMix.fromJson(data) : null);
+    map[_i1.getType<_i52.StringDefaultModel?>()] = (data, protocol) =>
+        (data != null ? _i52.StringDefaultModel.fromJson(data) : null);
+    map[_i1.getType<_i53.StringDefaultPersist?>()] = (data, protocol) =>
+        (data != null ? _i53.StringDefaultPersist.fromJson(data) : null);
+    map[_i1.getType<_i54.UriDefault?>()] = (data, protocol) =>
+        (data != null ? _i54.UriDefault.fromJson(data) : null);
+    map[_i1.getType<_i55.UriDefaultMix?>()] = (data, protocol) =>
+        (data != null ? _i55.UriDefaultMix.fromJson(data) : null);
+    map[_i1.getType<_i56.UriDefaultModel?>()] = (data, protocol) =>
+        (data != null ? _i56.UriDefaultModel.fromJson(data) : null);
+    map[_i1.getType<_i57.UriDefaultPersist?>()] = (data, protocol) =>
+        (data != null ? _i57.UriDefaultPersist.fromJson(data) : null);
+    map[_i1.getType<_i58.UuidDefault?>()] = (data, protocol) =>
+        (data != null ? _i58.UuidDefault.fromJson(data) : null);
+    map[_i1.getType<_i59.UuidDefaultMix?>()] = (data, protocol) =>
+        (data != null ? _i59.UuidDefaultMix.fromJson(data) : null);
+    map[_i1.getType<_i60.UuidDefaultModel?>()] = (data, protocol) =>
+        (data != null ? _i60.UuidDefaultModel.fromJson(data) : null);
+    map[_i1.getType<_i61.UuidDefaultPersist?>()] = (data, protocol) =>
+        (data != null ? _i61.UuidDefaultPersist.fromJson(data) : null);
+    map[_i1.getType<_i62.EmptyModel?>()] = (data, protocol) =>
+        (data != null ? _i62.EmptyModel.fromJson(data) : null);
+    map[_i1.getType<_i63.EmptyModelRelationItem?>()] = (data, protocol) =>
+        (data != null ? _i63.EmptyModelRelationItem.fromJson(data) : null);
+    map[_i1.getType<_i64.EmptyModelWithTable?>()] = (data, protocol) =>
+        (data != null ? _i64.EmptyModelWithTable.fromJson(data) : null);
+    map[_i1.getType<_i65.RelationEmptyModel?>()] = (data, protocol) =>
+        (data != null ? _i65.RelationEmptyModel.fromJson(data) : null);
+    map[_i1.getType<_i66.ChildClassExplicitColumn?>()] = (data, protocol) =>
+        (data != null ? _i66.ChildClassExplicitColumn.fromJson(data) : null);
+    map[_i1.getType<_i67.NonTableParentClass?>()] = (data, protocol) =>
+        (data != null ? _i67.NonTableParentClass.fromJson(data) : null);
+    map[_i1.getType<_i68.ModifiedColumnName?>()] = (data, protocol) =>
+        (data != null ? _i68.ModifiedColumnName.fromJson(data) : null);
+    map[_i1.getType<_i69.Department?>()] = (data, protocol) =>
+        (data != null ? _i69.Department.fromJson(data) : null);
+    map[_i1.getType<_i70.Employee?>()] = (data, protocol) =>
+        (data != null ? _i70.Employee.fromJson(data) : null);
+    map[_i1.getType<_i71.Contractor?>()] = (data, protocol) =>
+        (data != null ? _i71.Contractor.fromJson(data) : null);
+    map[_i1.getType<_i72.Service?>()] = (data, protocol) =>
+        (data != null ? _i72.Service.fromJson(data) : null);
+    map[_i1.getType<_i73.TableWithExplicitColumnName?>()] = (data, protocol) =>
+        (data != null ? _i73.TableWithExplicitColumnName.fromJson(data) : null);
+    map[_i1.getType<_i74.SealedGrandChild?>()] = (data, protocol) =>
+        (data != null ? _i74.SealedGrandChild.fromJson(data) : null);
+    map[_i1.getType<_i74.SealedChild?>()] = (data, protocol) =>
+        (data != null ? _i74.SealedChild.fromJson(data) : null);
+    map[_i1.getType<_i74.SealedOtherChild?>()] = (data, protocol) =>
+        (data != null ? _i74.SealedOtherChild.fromJson(data) : null);
+    map[_i1.getType<_i75.CityWithLongTableName?>()] = (data, protocol) =>
+        (data != null ? _i75.CityWithLongTableName.fromJson(data) : null);
+    map[_i1
+        .getType<_i76.OrganizationWithLongTableName?>()] = (data, protocol) =>
+        (data != null
+        ? _i76.OrganizationWithLongTableName.fromJson(data)
+        : null);
+    map[_i1.getType<_i77.PersonWithLongTableName?>()] = (data, protocol) =>
+        (data != null ? _i77.PersonWithLongTableName.fromJson(data) : null);
+    map[_i1.getType<_i78.MaxFieldName?>()] = (data, protocol) =>
+        (data != null ? _i78.MaxFieldName.fromJson(data) : null);
+    map[_i1.getType<_i79.LongImplicitIdField?>()] = (data, protocol) =>
+        (data != null ? _i79.LongImplicitIdField.fromJson(data) : null);
+    map[_i1
+        .getType<_i80.LongImplicitIdFieldCollection?>()] = (data, protocol) =>
+        (data != null
+        ? _i80.LongImplicitIdFieldCollection.fromJson(data)
+        : null);
+    map[_i1
+        .getType<_i81.RelationToMultipleMaxFieldName?>()] = (data, protocol) =>
+        (data != null
+        ? _i81.RelationToMultipleMaxFieldName.fromJson(data)
+        : null);
+    map[_i1.getType<_i82.UserNote?>()] = (data, protocol) =>
+        (data != null ? _i82.UserNote.fromJson(data) : null);
+    map[_i1.getType<_i83.UserNoteCollection?>()] = (data, protocol) =>
+        (data != null ? _i83.UserNoteCollection.fromJson(data) : null);
+    map[_i1
+        .getType<_i84.UserNoteCollectionWithALongName?>()] = (data, protocol) =>
+        (data != null
+        ? _i84.UserNoteCollectionWithALongName.fromJson(data)
+        : null);
+    map[_i1.getType<_i85.UserNoteWithALongName?>()] = (data, protocol) =>
+        (data != null ? _i85.UserNoteWithALongName.fromJson(data) : null);
+    map[_i1.getType<_i86.MultipleMaxFieldName?>()] = (data, protocol) =>
+        (data != null ? _i86.MultipleMaxFieldName.fromJson(data) : null);
+    map[_i1.getType<_i87.City?>()] = (data, protocol) =>
+        (data != null ? _i87.City.fromJson(data) : null);
+    map[_i1.getType<_i88.Organization?>()] = (data, protocol) =>
+        (data != null ? _i88.Organization.fromJson(data) : null);
+    map[_i1.getType<_i89.Person?>()] = (data, protocol) =>
+        (data != null ? _i89.Person.fromJson(data) : null);
+    map[_i1.getType<_i90.Course?>()] = (data, protocol) =>
+        (data != null ? _i90.Course.fromJson(data) : null);
+    map[_i1.getType<_i91.Enrollment?>()] = (data, protocol) =>
+        (data != null ? _i91.Enrollment.fromJson(data) : null);
+    map[_i1.getType<_i92.Student?>()] = (data, protocol) =>
+        (data != null ? _i92.Student.fromJson(data) : null);
+    map[_i1.getType<_i93.Arena?>()] = (data, protocol) =>
+        (data != null ? _i93.Arena.fromJson(data) : null);
+    map[_i1.getType<_i94.Player?>()] = (data, protocol) =>
+        (data != null ? _i94.Player.fromJson(data) : null);
+    map[_i1.getType<_i95.Team?>()] = (data, protocol) =>
+        (data != null ? _i95.Team.fromJson(data) : null);
+    map[_i1.getType<_i96.Comment?>()] = (data, protocol) =>
+        (data != null ? _i96.Comment.fromJson(data) : null);
+    map[_i1.getType<_i97.Customer?>()] = (data, protocol) =>
+        (data != null ? _i97.Customer.fromJson(data) : null);
+    map[_i1.getType<_i98.Book?>()] = (data, protocol) =>
+        (data != null ? _i98.Book.fromJson(data) : null);
+    map[_i1.getType<_i99.Chapter?>()] = (data, protocol) =>
+        (data != null ? _i99.Chapter.fromJson(data) : null);
+    map[_i1.getType<_i100.Order?>()] = (data, protocol) =>
+        (data != null ? _i100.Order.fromJson(data) : null);
+    map[_i1.getType<_i101.Address?>()] = (data, protocol) =>
+        (data != null ? _i101.Address.fromJson(data) : null);
+    map[_i1.getType<_i102.Citizen?>()] = (data, protocol) =>
+        (data != null ? _i102.Citizen.fromJson(data) : null);
+    map[_i1.getType<_i103.Company?>()] = (data, protocol) =>
+        (data != null ? _i103.Company.fromJson(data) : null);
+    map[_i1.getType<_i104.Town?>()] = (data, protocol) =>
+        (data != null ? _i104.Town.fromJson(data) : null);
+    map[_i1.getType<_i105.Blocking?>()] = (data, protocol) =>
+        (data != null ? _i105.Blocking.fromJson(data) : null);
+    map[_i1.getType<_i106.Member?>()] = (data, protocol) =>
+        (data != null ? _i106.Member.fromJson(data) : null);
+    map[_i1.getType<_i107.Cat?>()] = (data, protocol) =>
+        (data != null ? _i107.Cat.fromJson(data) : null);
+    map[_i1.getType<_i108.Post?>()] = (data, protocol) =>
+        (data != null ? _i108.Post.fromJson(data) : null);
+    map[_i1.getType<_i109.ObjectFieldPersist?>()] = (data, protocol) =>
+        (data != null ? _i109.ObjectFieldPersist.fromJson(data) : null);
+    map[_i1.getType<_i110.ObjectFieldScopes?>()] = (data, protocol) =>
+        (data != null ? _i110.ObjectFieldScopes.fromJson(data) : null);
+    map[_i1.getType<_i111.ObjectWithBit?>()] = (data, protocol) =>
+        (data != null ? _i111.ObjectWithBit.fromJson(data) : null);
+    map[_i1.getType<_i112.ObjectWithByteData?>()] = (data, protocol) =>
+        (data != null ? _i112.ObjectWithByteData.fromJson(data) : null);
+    map[_i1.getType<_i113.ObjectWithDuration?>()] = (data, protocol) =>
+        (data != null ? _i113.ObjectWithDuration.fromJson(data) : null);
+    map[_i1.getType<_i114.ObjectWithDynamic?>()] = (data, protocol) =>
+        (data != null ? _i114.ObjectWithDynamic.fromJson(data) : null);
+    map[_i1.getType<_i115.ObjectWithEnum?>()] = (data, protocol) =>
+        (data != null ? _i115.ObjectWithEnum.fromJson(data) : null);
+    map[_i1.getType<_i116.ObjectWithEnumEnhanced?>()] = (data, protocol) =>
+        (data != null ? _i116.ObjectWithEnumEnhanced.fromJson(data) : null);
+    map[_i1.getType<_i117.ObjectWithHalfVector?>()] = (data, protocol) =>
+        (data != null ? _i117.ObjectWithHalfVector.fromJson(data) : null);
+    map[_i1.getType<_i118.ObjectWithIndex?>()] = (data, protocol) =>
+        (data != null ? _i118.ObjectWithIndex.fromJson(data) : null);
+    map[_i1.getType<_i119.ObjectWithJsonb?>()] = (data, protocol) =>
+        (data != null ? _i119.ObjectWithJsonb.fromJson(data) : null);
+    map[_i1.getType<_i120.ObjectWithJsonbClassLevel?>()] = (data, protocol) =>
+        (data != null ? _i120.ObjectWithJsonbClassLevel.fromJson(data) : null);
+    map[_i1.getType<_i121.ObjectWithMaps?>()] = (data, protocol) =>
+        (data != null ? _i121.ObjectWithMaps.fromJson(data) : null);
+    map[_i1.getType<_i122.ObjectWithObject?>()] = (data, protocol) =>
+        (data != null ? _i122.ObjectWithObject.fromJson(data) : null);
+    map[_i1.getType<_i123.ObjectWithParent?>()] = (data, protocol) =>
+        (data != null ? _i123.ObjectWithParent.fromJson(data) : null);
+    map[_i1.getType<_i124.ObjectWithSealedClass?>()] = (data, protocol) =>
+        (data != null ? _i124.ObjectWithSealedClass.fromJson(data) : null);
+    map[_i1.getType<_i125.ObjectWithSelfParent?>()] = (data, protocol) =>
+        (data != null ? _i125.ObjectWithSelfParent.fromJson(data) : null);
+    map[_i1.getType<_i126.ObjectWithSparseVector?>()] = (data, protocol) =>
+        (data != null ? _i126.ObjectWithSparseVector.fromJson(data) : null);
+    map[_i1.getType<_i127.ObjectWithUuid?>()] = (data, protocol) =>
+        (data != null ? _i127.ObjectWithUuid.fromJson(data) : null);
+    map[_i1.getType<_i128.ObjectWithVector?>()] = (data, protocol) =>
+        (data != null ? _i128.ObjectWithVector.fromJson(data) : null);
+    map[_i1.getType<_i129.RelatedUniqueData?>()] = (data, protocol) =>
+        (data != null ? _i129.RelatedUniqueData.fromJson(data) : null);
+    map[_i1.getType<_i130.ModelWithRequiredField?>()] = (data, protocol) =>
+        (data != null ? _i130.ModelWithRequiredField.fromJson(data) : null);
+    map[_i1.getType<_i131.SimpleData?>()] = (data, protocol) =>
+        (data != null ? _i131.SimpleData.fromJson(data) : null);
+    map[_i1.getType<_i132.SimpleDateTime?>()] = (data, protocol) =>
+        (data != null ? _i132.SimpleDateTime.fromJson(data) : null);
+    map[_i1.getType<_i133.TestEnum?>()] = (data, protocol) =>
+        (data != null ? _i133.TestEnum.fromJson(data) : null);
+    map[_i1
+        .getType<_i134.TestEnumDefaultSerialization?>()] = (data, protocol) =>
+        (data != null
+        ? _i134.TestEnumDefaultSerialization.fromJson(data)
+        : null);
+    map[_i1.getType<_i135.TestEnumEnhanced?>()] = (data, protocol) =>
+        (data != null ? _i135.TestEnumEnhanced.fromJson(data) : null);
+    map[_i1.getType<_i136.TestEnumEnhancedByName?>()] = (data, protocol) =>
+        (data != null ? _i136.TestEnumEnhancedByName.fromJson(data) : null);
+    map[_i1.getType<_i137.TestEnumStringified?>()] = (data, protocol) =>
+        (data != null ? _i137.TestEnumStringified.fromJson(data) : null);
+    map[_i1.getType<_i138.Types?>()] = (data, protocol) =>
+        (data != null ? _i138.Types.fromJson(data) : null);
+    map[_i1.getType<_i139.UniqueData?>()] = (data, protocol) =>
+        (data != null ? _i139.UniqueData.fromJson(data) : null);
+    map[_i1.getType<_i140.UniqueDataWithNonPersist?>()] = (data, protocol) =>
+        (data != null ? _i140.UniqueDataWithNonPersist.fromJson(data) : null);
+    map[_i1.getType<_i141.UpsertTestModel?>()] = (data, protocol) =>
+        (data != null ? _i141.UpsertTestModel.fromJson(data) : null);
+    map[List<_i4.EnrollmentInt>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i4.EnrollmentInt>(e))
+        .toList();
+    map[_i1.getType<List<_i4.EnrollmentInt>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i4.EnrollmentInt>(e))
+              .toList()
+        : null);
+    map[List<_i7.PlayerUuid>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i7.PlayerUuid>(e))
+        .toList();
+    map[_i1.getType<List<_i7.PlayerUuid>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i7.PlayerUuid>(e))
+              .toList()
+        : null);
+    map[List<_i11.OrderUuid>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i11.OrderUuid>(e))
+        .toList();
+    map[_i1.getType<List<_i11.OrderUuid>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i11.OrderUuid>(e))
+              .toList()
+        : null);
+    map[List<_i9.CommentInt>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i9.CommentInt>(e))
+        .toList();
+    map[_i1.getType<List<_i9.CommentInt>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i9.CommentInt>(e))
+              .toList()
+        : null);
+    map[List<_i16.ChangedIdTypeSelf>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i16.ChangedIdTypeSelf>(e))
+        .toList();
+    map[_i1.getType<List<_i16.ChangedIdTypeSelf>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i16.ChangedIdTypeSelf>(e))
+              .toList()
+        : null);
+    map[List<_i63.EmptyModelRelationItem>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i63.EmptyModelRelationItem>(e))
+        .toList();
+    map[_i1.getType<List<_i63.EmptyModelRelationItem>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i63.EmptyModelRelationItem>(e))
+              .toList()
+        : null);
+    map[List<_i70.Employee>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i70.Employee>(e))
+        .toList();
+    map[_i1.getType<List<_i70.Employee>?>()] = (data, protocol) => (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i70.Employee>(e))
+              .toList()
+        : null);
+    map[List<_i77.PersonWithLongTableName>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i77.PersonWithLongTableName>(e))
+        .toList();
+    map[_i1.getType<List<_i77.PersonWithLongTableName>?>()] =
+        (data, protocol) => (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i77.PersonWithLongTableName>(e))
+              .toList()
+        : null);
+    map[List<_i76.OrganizationWithLongTableName>] = (data, protocol) =>
+        (data as List)
+            .map(
+              (e) =>
+                  protocol.deserialize<_i76.OrganizationWithLongTableName>(e),
+            )
+            .toList();
+    map[_i1.getType<List<_i76.OrganizationWithLongTableName>?>()] =
+        (data, protocol) => (data != null
+        ? (data as List)
+              .map(
+                (e) =>
+                    protocol.deserialize<_i76.OrganizationWithLongTableName>(e),
+              )
+              .toList()
+        : null);
+    map[List<_i79.LongImplicitIdField>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i79.LongImplicitIdField>(e))
+        .toList();
+    map[_i1.getType<List<_i79.LongImplicitIdField>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i79.LongImplicitIdField>(e))
+              .toList()
+        : null);
+    map[List<_i86.MultipleMaxFieldName>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i86.MultipleMaxFieldName>(e))
+        .toList();
+    map[_i1.getType<List<_i86.MultipleMaxFieldName>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i86.MultipleMaxFieldName>(e))
+              .toList()
+        : null);
+    map[List<_i82.UserNote>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i82.UserNote>(e))
+        .toList();
+    map[_i1.getType<List<_i82.UserNote>?>()] = (data, protocol) => (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i82.UserNote>(e))
+              .toList()
+        : null);
+    map[List<_i85.UserNoteWithALongName>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i85.UserNoteWithALongName>(e))
+        .toList();
+    map[_i1.getType<List<_i85.UserNoteWithALongName>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i85.UserNoteWithALongName>(e))
+              .toList()
+        : null);
+    map[List<_i89.Person>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i89.Person>(e))
+        .toList();
+    map[_i1.getType<List<_i89.Person>?>()] = (data, protocol) => (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i89.Person>(e))
+              .toList()
+        : null);
+    map[List<_i88.Organization>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i88.Organization>(e))
+        .toList();
+    map[_i1.getType<List<_i88.Organization>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i88.Organization>(e))
+              .toList()
+        : null);
+    map[List<_i91.Enrollment>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i91.Enrollment>(e))
+        .toList();
+    map[_i1.getType<List<_i91.Enrollment>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i91.Enrollment>(e))
+              .toList()
+        : null);
+    map[List<_i94.Player>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i94.Player>(e))
+        .toList();
+    map[_i1.getType<List<_i94.Player>?>()] = (data, protocol) => (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i94.Player>(e))
+              .toList()
+        : null);
+    map[List<_i100.Order>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i100.Order>(e))
+        .toList();
+    map[_i1.getType<List<_i100.Order>?>()] = (data, protocol) => (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i100.Order>(e))
+              .toList()
+        : null);
+    map[List<_i99.Chapter>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i99.Chapter>(e))
+        .toList();
+    map[_i1.getType<List<_i99.Chapter>?>()] = (data, protocol) => (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i99.Chapter>(e))
+              .toList()
+        : null);
+    map[List<_i96.Comment>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i96.Comment>(e))
+        .toList();
+    map[_i1.getType<List<_i96.Comment>?>()] = (data, protocol) => (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i96.Comment>(e))
+              .toList()
+        : null);
+    map[List<_i105.Blocking>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i105.Blocking>(e))
+        .toList();
+    map[_i1.getType<List<_i105.Blocking>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i105.Blocking>(e))
+              .toList()
+        : null);
+    map[List<_i107.Cat>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<_i107.Cat>(e)).toList();
+    map[_i1.getType<List<_i107.Cat>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<_i107.Cat>(e)).toList()
+        : null);
+    map[dynamic] = (data, protocol) => deserializeDynamicFieldValue(data) as T;
+    map[List<dynamic>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<dynamic>(e)).toList();
+    map[dynamic] = (data, protocol) => deserializeDynamicFieldValue(data) as T;
+    map[Map<String, dynamic>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<dynamic>(v),
+      ),
+    );
+    map[dynamic] = (data, protocol) => deserializeDynamicFieldValue(data) as T;
+    map[Set<dynamic>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<dynamic>(e)).toSet();
+    map[dynamic] = (data, protocol) => deserializeDynamicFieldValue(data) as T;
+    map[Map<dynamic, dynamic>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<dynamic>(e['k']),
+          protocol.deserialize<dynamic>(e['v']),
+        ),
+      ),
+    );
+    map[dynamic] = (data, protocol) => deserializeDynamicFieldValue(data) as T;
+    map[dynamic] = (data, protocol) => deserializeDynamicFieldValue(data) as T;
+    map[List<_i133.TestEnum>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i133.TestEnum>(e))
+        .toList();
+    map[List<_i133.TestEnum?>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i133.TestEnum?>(e))
+        .toList();
+    map[List<List<_i133.TestEnum>>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<List<_i133.TestEnum>>(e))
+        .toList();
+    map[List<_i133.TestEnum>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i133.TestEnum>(e))
+        .toList();
+    map[List<_i135.TestEnumEnhanced>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i135.TestEnumEnhanced>(e))
+        .toList();
+    map[List<_i136.TestEnumEnhancedByName>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i136.TestEnumEnhancedByName>(e))
+        .toList();
+    map[List<String>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<String>(e)).toList();
+    map[Map<String, String>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<String>(v),
+      ),
+    );
+    map[List<String>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<String>(e)).toList();
+    map[_i1.getType<List<String>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<String>(e)).toList()
+        : null);
+    map[Map<String, _i131.SimpleData>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i131.SimpleData>(v),
+      ),
+    );
+    map[Map<String, int>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<int>(v),
+      ),
+    );
+    map[Map<String, DateTime>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<DateTime>(v),
+      ),
+    );
+    map[Map<String, _i142.ByteData>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i142.ByteData>(v),
+      ),
+    );
+    map[Map<String, Duration>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<Duration>(v),
+      ),
+    );
+    map[Map<String, _i1.UuidValue>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i1.UuidValue>(v),
+      ),
+    );
+    map[Map<String, _i131.SimpleData?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i131.SimpleData?>(v),
+      ),
+    );
+    map[Map<String, int?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<int?>(v),
+      ),
+    );
+    map[Map<String, String?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<String?>(v),
+      ),
+    );
+    map[Map<String, DateTime?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<DateTime?>(v),
+      ),
+    );
+    map[Map<String, _i142.ByteData?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i142.ByteData?>(v),
+      ),
+    );
+    map[Map<String, Duration?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<Duration?>(v),
+      ),
+    );
+    map[Map<String, _i1.UuidValue?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i1.UuidValue?>(v),
+      ),
+    );
+    map[Map<int, int>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<int>(e['k']),
+          protocol.deserialize<int>(e['v']),
+        ),
+      ),
+    );
+    map[List<_i131.SimpleData>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i131.SimpleData>(e))
+        .toList();
+    map[List<_i131.SimpleData>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i131.SimpleData>(e))
+        .toList();
+    map[_i1.getType<List<_i131.SimpleData>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i131.SimpleData>(e))
+              .toList()
+        : null);
+    map[List<_i131.SimpleData?>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i131.SimpleData?>(e))
+        .toList();
+    map[List<_i131.SimpleData?>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i131.SimpleData?>(e))
+        .toList();
+    map[_i1.getType<List<_i131.SimpleData?>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i131.SimpleData?>(e))
+              .toList()
+        : null);
+    map[List<List<_i131.SimpleData>>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<List<_i131.SimpleData>>(e))
+        .toList();
+    map[List<_i131.SimpleData>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i131.SimpleData>(e))
+        .toList();
+    map[_i1.getType<List<List<_i131.SimpleData>>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<List<_i131.SimpleData>>(e))
+              .toList()
+        : null);
+    map[List<_i131.SimpleData>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i131.SimpleData>(e))
+        .toList();
+    map[Map<String, List<List<Map<int, _i131.SimpleData>>?>>] =
+        (data, protocol) => (data as Map).map(
+          (k, v) => MapEntry(
+            protocol.deserialize<String>(k),
+            protocol.deserialize<List<List<Map<int, _i131.SimpleData>>?>>(v),
+          ),
+        );
+    map[List<List<Map<int, _i131.SimpleData>>?>] = (data, protocol) =>
+        (data as List)
+            .map(
+              (e) => protocol.deserialize<List<Map<int, _i131.SimpleData>>?>(e),
+            )
+            .toList();
+    map[List<Map<int, _i131.SimpleData>>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<Map<int, _i131.SimpleData>>(e))
+        .toList();
+    map[Map<int, _i131.SimpleData>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<int>(e['k']),
+          protocol.deserialize<_i131.SimpleData>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<List<Map<int, _i131.SimpleData>>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<Map<int, _i131.SimpleData>>(e))
+              .toList()
+        : null);
+    map[Map<int, _i131.SimpleData>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<int>(e['k']),
+          protocol.deserialize<_i131.SimpleData>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<Map<String, List<List<Map<int, _i131.SimpleData>>?>>?>()] =
+        (data, protocol) => (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<List<List<Map<int, _i131.SimpleData>>?>>(v),
+            ),
+          )
+        : null);
+    map[List<List<Map<int, _i131.SimpleData>>?>] = (data, protocol) =>
+        (data as List)
+            .map(
+              (e) => protocol.deserialize<List<Map<int, _i131.SimpleData>>?>(e),
+            )
+            .toList();
+    map[List<Map<int, _i131.SimpleData>>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<Map<int, _i131.SimpleData>>(e))
+        .toList();
+    map[Map<int, _i131.SimpleData>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<int>(e['k']),
+          protocol.deserialize<_i131.SimpleData>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<List<Map<int, _i131.SimpleData>>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<Map<int, _i131.SimpleData>>(e))
+              .toList()
+        : null);
+    map[Map<int, _i131.SimpleData>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<int>(e['k']),
+          protocol.deserialize<_i131.SimpleData>(e['v']),
+        ),
+      ),
+    );
+    map[Map<String, Map<int, _i131.SimpleData>>] = (data, protocol) =>
+        (data as Map).map(
+          (k, v) => MapEntry(
+            protocol.deserialize<String>(k),
+            protocol.deserialize<Map<int, _i131.SimpleData>>(v),
+          ),
+        );
+    map[Map<int, _i131.SimpleData>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<int>(e['k']),
+          protocol.deserialize<_i131.SimpleData>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<Map<String, Map<int, _i131.SimpleData>>?>()] =
+        (data, protocol) => (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<Map<int, _i131.SimpleData>>(v),
+            ),
+          )
+        : null);
+    map[Map<int, _i131.SimpleData>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<int>(e['k']),
+          protocol.deserialize<_i131.SimpleData>(e['v']),
+        ),
+      ),
+    );
+    map[List<_i74.SealedParent>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i74.SealedParent>(e))
+        .toList();
+    map[List<int>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int>(e)).toList();
+    map[_i1.getType<List<int>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<int>(e)).toList()
+        : null);
+    map[Map<int, int>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<int>(e['k']),
+          protocol.deserialize<int>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<Map<int, int>?>()] = (data, protocol) => (data != null
+        ? Map.fromEntries(
+            (data as List).map(
+              (e) => MapEntry(
+                protocol.deserialize<int>(e['k']),
+                protocol.deserialize<int>(e['v']),
+              ),
+            ),
+          )
+        : null);
+    map[Set<int>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int>(e)).toSet();
+    map[_i1.getType<Set<int>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<int>(e)).toSet()
+        : null);
+    map[_i1.getType<(String, {Uri? optionalUri})?>()] = (data, protocol) =>
+        (data == null)
+        ? null
+        : (
+            protocol.deserialize<String>(((data as Map)['p'] as List)[0]),
+            optionalUri: ((data)['n'] as Map)['optionalUri'] == null
+                ? null
+                : protocol.deserialize<Uri>(data['n']['optionalUri']),
+          );
+    map[List<_i143.SimpleData>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i143.SimpleData>(e))
+        .toList();
+    map[_i1.getType<(String, {Uri? optionalUri})?>()] = (data, protocol) =>
+        (data == null)
+        ? null
+        : (
+            protocol.deserialize<String>(((data as Map)['p'] as List)[0]),
+            optionalUri: ((data)['n'] as Map)['optionalUri'] == null
+                ? null
+                : protocol.deserialize<Uri>(data['n']['optionalUri']),
+          );
+    return map;
+  }
+
   static String? getClassNameFromObjectJson(dynamic data) {
     if (data is! Map) return null;
     final className = data['__className__'] as String?;
@@ -5642,1553 +6717,9 @@ class Protocol extends _i1.DatabaseSerializationManager {
       }
     }
 
-    if (t == _i3.CourseUuid) {
-      return _i3.CourseUuid.fromJson(data) as T;
-    }
-    if (t == _i4.EnrollmentInt) {
-      return _i4.EnrollmentInt.fromJson(data) as T;
-    }
-    if (t == _i5.StudentUuid) {
-      return _i5.StudentUuid.fromJson(data) as T;
-    }
-    if (t == _i6.ArenaUuid) {
-      return _i6.ArenaUuid.fromJson(data) as T;
-    }
-    if (t == _i7.PlayerUuid) {
-      return _i7.PlayerUuid.fromJson(data) as T;
-    }
-    if (t == _i8.TeamInt) {
-      return _i8.TeamInt.fromJson(data) as T;
-    }
-    if (t == _i9.CommentInt) {
-      return _i9.CommentInt.fromJson(data) as T;
-    }
-    if (t == _i10.CustomerInt) {
-      return _i10.CustomerInt.fromJson(data) as T;
-    }
-    if (t == _i11.OrderUuid) {
-      return _i11.OrderUuid.fromJson(data) as T;
-    }
-    if (t == _i12.AddressUuid) {
-      return _i12.AddressUuid.fromJson(data) as T;
-    }
-    if (t == _i13.CitizenInt) {
-      return _i13.CitizenInt.fromJson(data) as T;
-    }
-    if (t == _i14.CompanyUuid) {
-      return _i14.CompanyUuid.fromJson(data) as T;
-    }
-    if (t == _i15.TownInt) {
-      return _i15.TownInt.fromJson(data) as T;
-    }
-    if (t == _i16.ChangedIdTypeSelf) {
-      return _i16.ChangedIdTypeSelf.fromJson(data) as T;
-    }
-    if (t == _i17.ServerOnlyChangedIdFieldClass) {
-      return _i17.ServerOnlyChangedIdFieldClass.fromJson(data) as T;
-    }
-    if (t == _i18.BigIntDefault) {
-      return _i18.BigIntDefault.fromJson(data) as T;
-    }
-    if (t == _i19.BigIntDefaultMix) {
-      return _i19.BigIntDefaultMix.fromJson(data) as T;
-    }
-    if (t == _i20.BigIntDefaultModel) {
-      return _i20.BigIntDefaultModel.fromJson(data) as T;
-    }
-    if (t == _i21.BigIntDefaultPersist) {
-      return _i21.BigIntDefaultPersist.fromJson(data) as T;
-    }
-    if (t == _i22.BoolDefault) {
-      return _i22.BoolDefault.fromJson(data) as T;
-    }
-    if (t == _i23.BoolDefaultMix) {
-      return _i23.BoolDefaultMix.fromJson(data) as T;
-    }
-    if (t == _i24.BoolDefaultModel) {
-      return _i24.BoolDefaultModel.fromJson(data) as T;
-    }
-    if (t == _i25.BoolDefaultPersist) {
-      return _i25.BoolDefaultPersist.fromJson(data) as T;
-    }
-    if (t == _i26.DateTimeDefault) {
-      return _i26.DateTimeDefault.fromJson(data) as T;
-    }
-    if (t == _i27.DateTimeDefaultMix) {
-      return _i27.DateTimeDefaultMix.fromJson(data) as T;
-    }
-    if (t == _i28.DateTimeDefaultModel) {
-      return _i28.DateTimeDefaultModel.fromJson(data) as T;
-    }
-    if (t == _i29.DateTimeDefaultPersist) {
-      return _i29.DateTimeDefaultPersist.fromJson(data) as T;
-    }
-    if (t == _i30.DoubleDefault) {
-      return _i30.DoubleDefault.fromJson(data) as T;
-    }
-    if (t == _i31.DoubleDefaultMix) {
-      return _i31.DoubleDefaultMix.fromJson(data) as T;
-    }
-    if (t == _i32.DoubleDefaultModel) {
-      return _i32.DoubleDefaultModel.fromJson(data) as T;
-    }
-    if (t == _i33.DoubleDefaultPersist) {
-      return _i33.DoubleDefaultPersist.fromJson(data) as T;
-    }
-    if (t == _i34.DurationDefault) {
-      return _i34.DurationDefault.fromJson(data) as T;
-    }
-    if (t == _i35.DurationDefaultMix) {
-      return _i35.DurationDefaultMix.fromJson(data) as T;
-    }
-    if (t == _i36.DurationDefaultModel) {
-      return _i36.DurationDefaultModel.fromJson(data) as T;
-    }
-    if (t == _i37.DurationDefaultPersist) {
-      return _i37.DurationDefaultPersist.fromJson(data) as T;
-    }
-    if (t == _i38.EnumDefault) {
-      return _i38.EnumDefault.fromJson(data) as T;
-    }
-    if (t == _i39.EnumDefaultMix) {
-      return _i39.EnumDefaultMix.fromJson(data) as T;
-    }
-    if (t == _i40.EnumDefaultModel) {
-      return _i40.EnumDefaultModel.fromJson(data) as T;
-    }
-    if (t == _i41.EnumDefaultPersist) {
-      return _i41.EnumDefaultPersist.fromJson(data) as T;
-    }
-    if (t == _i42.ByIndexEnum) {
-      return _i42.ByIndexEnum.fromJson(data) as T;
-    }
-    if (t == _i43.ByNameEnum) {
-      return _i43.ByNameEnum.fromJson(data) as T;
-    }
-    if (t == _i44.DefaultValueEnum) {
-      return _i44.DefaultValueEnum.fromJson(data) as T;
-    }
-    if (t == _i45.DefaultException) {
-      return _i45.DefaultException.fromJson(data) as T;
-    }
-    if (t == _i46.IntDefault) {
-      return _i46.IntDefault.fromJson(data) as T;
-    }
-    if (t == _i47.IntDefaultMix) {
-      return _i47.IntDefaultMix.fromJson(data) as T;
-    }
-    if (t == _i48.IntDefaultModel) {
-      return _i48.IntDefaultModel.fromJson(data) as T;
-    }
-    if (t == _i49.IntDefaultPersist) {
-      return _i49.IntDefaultPersist.fromJson(data) as T;
-    }
-    if (t == _i50.StringDefault) {
-      return _i50.StringDefault.fromJson(data) as T;
-    }
-    if (t == _i51.StringDefaultMix) {
-      return _i51.StringDefaultMix.fromJson(data) as T;
-    }
-    if (t == _i52.StringDefaultModel) {
-      return _i52.StringDefaultModel.fromJson(data) as T;
-    }
-    if (t == _i53.StringDefaultPersist) {
-      return _i53.StringDefaultPersist.fromJson(data) as T;
-    }
-    if (t == _i54.UriDefault) {
-      return _i54.UriDefault.fromJson(data) as T;
-    }
-    if (t == _i55.UriDefaultMix) {
-      return _i55.UriDefaultMix.fromJson(data) as T;
-    }
-    if (t == _i56.UriDefaultModel) {
-      return _i56.UriDefaultModel.fromJson(data) as T;
-    }
-    if (t == _i57.UriDefaultPersist) {
-      return _i57.UriDefaultPersist.fromJson(data) as T;
-    }
-    if (t == _i58.UuidDefault) {
-      return _i58.UuidDefault.fromJson(data) as T;
-    }
-    if (t == _i59.UuidDefaultMix) {
-      return _i59.UuidDefaultMix.fromJson(data) as T;
-    }
-    if (t == _i60.UuidDefaultModel) {
-      return _i60.UuidDefaultModel.fromJson(data) as T;
-    }
-    if (t == _i61.UuidDefaultPersist) {
-      return _i61.UuidDefaultPersist.fromJson(data) as T;
-    }
-    if (t == _i62.EmptyModel) {
-      return _i62.EmptyModel.fromJson(data) as T;
-    }
-    if (t == _i63.EmptyModelRelationItem) {
-      return _i63.EmptyModelRelationItem.fromJson(data) as T;
-    }
-    if (t == _i64.EmptyModelWithTable) {
-      return _i64.EmptyModelWithTable.fromJson(data) as T;
-    }
-    if (t == _i65.RelationEmptyModel) {
-      return _i65.RelationEmptyModel.fromJson(data) as T;
-    }
-    if (t == _i66.ChildClassExplicitColumn) {
-      return _i66.ChildClassExplicitColumn.fromJson(data) as T;
-    }
-    if (t == _i67.NonTableParentClass) {
-      return _i67.NonTableParentClass.fromJson(data) as T;
-    }
-    if (t == _i68.ModifiedColumnName) {
-      return _i68.ModifiedColumnName.fromJson(data) as T;
-    }
-    if (t == _i69.Department) {
-      return _i69.Department.fromJson(data) as T;
-    }
-    if (t == _i70.Employee) {
-      return _i70.Employee.fromJson(data) as T;
-    }
-    if (t == _i71.Contractor) {
-      return _i71.Contractor.fromJson(data) as T;
-    }
-    if (t == _i72.Service) {
-      return _i72.Service.fromJson(data) as T;
-    }
-    if (t == _i73.TableWithExplicitColumnName) {
-      return _i73.TableWithExplicitColumnName.fromJson(data) as T;
-    }
-    if (t == _i74.SealedGrandChild) {
-      return _i74.SealedGrandChild.fromJson(data) as T;
-    }
-    if (t == _i74.SealedChild) {
-      return _i74.SealedChild.fromJson(data) as T;
-    }
-    if (t == _i74.SealedOtherChild) {
-      return _i74.SealedOtherChild.fromJson(data) as T;
-    }
-    if (t == _i75.CityWithLongTableName) {
-      return _i75.CityWithLongTableName.fromJson(data) as T;
-    }
-    if (t == _i76.OrganizationWithLongTableName) {
-      return _i76.OrganizationWithLongTableName.fromJson(data) as T;
-    }
-    if (t == _i77.PersonWithLongTableName) {
-      return _i77.PersonWithLongTableName.fromJson(data) as T;
-    }
-    if (t == _i78.MaxFieldName) {
-      return _i78.MaxFieldName.fromJson(data) as T;
-    }
-    if (t == _i79.LongImplicitIdField) {
-      return _i79.LongImplicitIdField.fromJson(data) as T;
-    }
-    if (t == _i80.LongImplicitIdFieldCollection) {
-      return _i80.LongImplicitIdFieldCollection.fromJson(data) as T;
-    }
-    if (t == _i81.RelationToMultipleMaxFieldName) {
-      return _i81.RelationToMultipleMaxFieldName.fromJson(data) as T;
-    }
-    if (t == _i82.UserNote) {
-      return _i82.UserNote.fromJson(data) as T;
-    }
-    if (t == _i83.UserNoteCollection) {
-      return _i83.UserNoteCollection.fromJson(data) as T;
-    }
-    if (t == _i84.UserNoteCollectionWithALongName) {
-      return _i84.UserNoteCollectionWithALongName.fromJson(data) as T;
-    }
-    if (t == _i85.UserNoteWithALongName) {
-      return _i85.UserNoteWithALongName.fromJson(data) as T;
-    }
-    if (t == _i86.MultipleMaxFieldName) {
-      return _i86.MultipleMaxFieldName.fromJson(data) as T;
-    }
-    if (t == _i87.City) {
-      return _i87.City.fromJson(data) as T;
-    }
-    if (t == _i88.Organization) {
-      return _i88.Organization.fromJson(data) as T;
-    }
-    if (t == _i89.Person) {
-      return _i89.Person.fromJson(data) as T;
-    }
-    if (t == _i90.Course) {
-      return _i90.Course.fromJson(data) as T;
-    }
-    if (t == _i91.Enrollment) {
-      return _i91.Enrollment.fromJson(data) as T;
-    }
-    if (t == _i92.Student) {
-      return _i92.Student.fromJson(data) as T;
-    }
-    if (t == _i93.Arena) {
-      return _i93.Arena.fromJson(data) as T;
-    }
-    if (t == _i94.Player) {
-      return _i94.Player.fromJson(data) as T;
-    }
-    if (t == _i95.Team) {
-      return _i95.Team.fromJson(data) as T;
-    }
-    if (t == _i96.Comment) {
-      return _i96.Comment.fromJson(data) as T;
-    }
-    if (t == _i97.Customer) {
-      return _i97.Customer.fromJson(data) as T;
-    }
-    if (t == _i98.Book) {
-      return _i98.Book.fromJson(data) as T;
-    }
-    if (t == _i99.Chapter) {
-      return _i99.Chapter.fromJson(data) as T;
-    }
-    if (t == _i100.Order) {
-      return _i100.Order.fromJson(data) as T;
-    }
-    if (t == _i101.Address) {
-      return _i101.Address.fromJson(data) as T;
-    }
-    if (t == _i102.Citizen) {
-      return _i102.Citizen.fromJson(data) as T;
-    }
-    if (t == _i103.Company) {
-      return _i103.Company.fromJson(data) as T;
-    }
-    if (t == _i104.Town) {
-      return _i104.Town.fromJson(data) as T;
-    }
-    if (t == _i105.Blocking) {
-      return _i105.Blocking.fromJson(data) as T;
-    }
-    if (t == _i106.Member) {
-      return _i106.Member.fromJson(data) as T;
-    }
-    if (t == _i107.Cat) {
-      return _i107.Cat.fromJson(data) as T;
-    }
-    if (t == _i108.Post) {
-      return _i108.Post.fromJson(data) as T;
-    }
-    if (t == _i109.ObjectFieldPersist) {
-      return _i109.ObjectFieldPersist.fromJson(data) as T;
-    }
-    if (t == _i110.ObjectFieldScopes) {
-      return _i110.ObjectFieldScopes.fromJson(data) as T;
-    }
-    if (t == _i111.ObjectWithBit) {
-      return _i111.ObjectWithBit.fromJson(data) as T;
-    }
-    if (t == _i112.ObjectWithByteData) {
-      return _i112.ObjectWithByteData.fromJson(data) as T;
-    }
-    if (t == _i113.ObjectWithDuration) {
-      return _i113.ObjectWithDuration.fromJson(data) as T;
-    }
-    if (t == _i114.ObjectWithDynamic) {
-      return _i114.ObjectWithDynamic.fromJson(data) as T;
-    }
-    if (t == _i115.ObjectWithEnum) {
-      return _i115.ObjectWithEnum.fromJson(data) as T;
-    }
-    if (t == _i116.ObjectWithEnumEnhanced) {
-      return _i116.ObjectWithEnumEnhanced.fromJson(data) as T;
-    }
-    if (t == _i117.ObjectWithHalfVector) {
-      return _i117.ObjectWithHalfVector.fromJson(data) as T;
-    }
-    if (t == _i118.ObjectWithIndex) {
-      return _i118.ObjectWithIndex.fromJson(data) as T;
-    }
-    if (t == _i119.ObjectWithJsonb) {
-      return _i119.ObjectWithJsonb.fromJson(data) as T;
-    }
-    if (t == _i120.ObjectWithJsonbClassLevel) {
-      return _i120.ObjectWithJsonbClassLevel.fromJson(data) as T;
-    }
-    if (t == _i121.ObjectWithMaps) {
-      return _i121.ObjectWithMaps.fromJson(data) as T;
-    }
-    if (t == _i122.ObjectWithObject) {
-      return _i122.ObjectWithObject.fromJson(data) as T;
-    }
-    if (t == _i123.ObjectWithParent) {
-      return _i123.ObjectWithParent.fromJson(data) as T;
-    }
-    if (t == _i124.ObjectWithSealedClass) {
-      return _i124.ObjectWithSealedClass.fromJson(data) as T;
-    }
-    if (t == _i125.ObjectWithSelfParent) {
-      return _i125.ObjectWithSelfParent.fromJson(data) as T;
-    }
-    if (t == _i126.ObjectWithSparseVector) {
-      return _i126.ObjectWithSparseVector.fromJson(data) as T;
-    }
-    if (t == _i127.ObjectWithUuid) {
-      return _i127.ObjectWithUuid.fromJson(data) as T;
-    }
-    if (t == _i128.ObjectWithVector) {
-      return _i128.ObjectWithVector.fromJson(data) as T;
-    }
-    if (t == _i129.RelatedUniqueData) {
-      return _i129.RelatedUniqueData.fromJson(data) as T;
-    }
-    if (t == _i130.ModelWithRequiredField) {
-      return _i130.ModelWithRequiredField.fromJson(data) as T;
-    }
-    if (t == _i131.SimpleData) {
-      return _i131.SimpleData.fromJson(data) as T;
-    }
-    if (t == _i132.SimpleDateTime) {
-      return _i132.SimpleDateTime.fromJson(data) as T;
-    }
-    if (t == _i133.TestEnum) {
-      return _i133.TestEnum.fromJson(data) as T;
-    }
-    if (t == _i134.TestEnumDefaultSerialization) {
-      return _i134.TestEnumDefaultSerialization.fromJson(data) as T;
-    }
-    if (t == _i135.TestEnumEnhanced) {
-      return _i135.TestEnumEnhanced.fromJson(data) as T;
-    }
-    if (t == _i136.TestEnumEnhancedByName) {
-      return _i136.TestEnumEnhancedByName.fromJson(data) as T;
-    }
-    if (t == _i137.TestEnumStringified) {
-      return _i137.TestEnumStringified.fromJson(data) as T;
-    }
-    if (t == _i138.Types) {
-      return _i138.Types.fromJson(data) as T;
-    }
-    if (t == _i139.UniqueData) {
-      return _i139.UniqueData.fromJson(data) as T;
-    }
-    if (t == _i140.UniqueDataWithNonPersist) {
-      return _i140.UniqueDataWithNonPersist.fromJson(data) as T;
-    }
-    if (t == _i141.UpsertTestModel) {
-      return _i141.UpsertTestModel.fromJson(data) as T;
-    }
-    if (t == _i1.getType<_i3.CourseUuid?>()) {
-      return (data != null ? _i3.CourseUuid.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i4.EnrollmentInt?>()) {
-      return (data != null ? _i4.EnrollmentInt.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i5.StudentUuid?>()) {
-      return (data != null ? _i5.StudentUuid.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i6.ArenaUuid?>()) {
-      return (data != null ? _i6.ArenaUuid.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i7.PlayerUuid?>()) {
-      return (data != null ? _i7.PlayerUuid.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i8.TeamInt?>()) {
-      return (data != null ? _i8.TeamInt.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i9.CommentInt?>()) {
-      return (data != null ? _i9.CommentInt.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i10.CustomerInt?>()) {
-      return (data != null ? _i10.CustomerInt.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i11.OrderUuid?>()) {
-      return (data != null ? _i11.OrderUuid.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i12.AddressUuid?>()) {
-      return (data != null ? _i12.AddressUuid.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i13.CitizenInt?>()) {
-      return (data != null ? _i13.CitizenInt.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i14.CompanyUuid?>()) {
-      return (data != null ? _i14.CompanyUuid.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i15.TownInt?>()) {
-      return (data != null ? _i15.TownInt.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i16.ChangedIdTypeSelf?>()) {
-      return (data != null ? _i16.ChangedIdTypeSelf.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i17.ServerOnlyChangedIdFieldClass?>()) {
-      return (data != null
-              ? _i17.ServerOnlyChangedIdFieldClass.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i18.BigIntDefault?>()) {
-      return (data != null ? _i18.BigIntDefault.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i19.BigIntDefaultMix?>()) {
-      return (data != null ? _i19.BigIntDefaultMix.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i20.BigIntDefaultModel?>()) {
-      return (data != null ? _i20.BigIntDefaultModel.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i21.BigIntDefaultPersist?>()) {
-      return (data != null ? _i21.BigIntDefaultPersist.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i22.BoolDefault?>()) {
-      return (data != null ? _i22.BoolDefault.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i23.BoolDefaultMix?>()) {
-      return (data != null ? _i23.BoolDefaultMix.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i24.BoolDefaultModel?>()) {
-      return (data != null ? _i24.BoolDefaultModel.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i25.BoolDefaultPersist?>()) {
-      return (data != null ? _i25.BoolDefaultPersist.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i26.DateTimeDefault?>()) {
-      return (data != null ? _i26.DateTimeDefault.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i27.DateTimeDefaultMix?>()) {
-      return (data != null ? _i27.DateTimeDefaultMix.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i28.DateTimeDefaultModel?>()) {
-      return (data != null ? _i28.DateTimeDefaultModel.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i29.DateTimeDefaultPersist?>()) {
-      return (data != null ? _i29.DateTimeDefaultPersist.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i30.DoubleDefault?>()) {
-      return (data != null ? _i30.DoubleDefault.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i31.DoubleDefaultMix?>()) {
-      return (data != null ? _i31.DoubleDefaultMix.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i32.DoubleDefaultModel?>()) {
-      return (data != null ? _i32.DoubleDefaultModel.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i33.DoubleDefaultPersist?>()) {
-      return (data != null ? _i33.DoubleDefaultPersist.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i34.DurationDefault?>()) {
-      return (data != null ? _i34.DurationDefault.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i35.DurationDefaultMix?>()) {
-      return (data != null ? _i35.DurationDefaultMix.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i36.DurationDefaultModel?>()) {
-      return (data != null ? _i36.DurationDefaultModel.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i37.DurationDefaultPersist?>()) {
-      return (data != null ? _i37.DurationDefaultPersist.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i38.EnumDefault?>()) {
-      return (data != null ? _i38.EnumDefault.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i39.EnumDefaultMix?>()) {
-      return (data != null ? _i39.EnumDefaultMix.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i40.EnumDefaultModel?>()) {
-      return (data != null ? _i40.EnumDefaultModel.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i41.EnumDefaultPersist?>()) {
-      return (data != null ? _i41.EnumDefaultPersist.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i42.ByIndexEnum?>()) {
-      return (data != null ? _i42.ByIndexEnum.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i43.ByNameEnum?>()) {
-      return (data != null ? _i43.ByNameEnum.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i44.DefaultValueEnum?>()) {
-      return (data != null ? _i44.DefaultValueEnum.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i45.DefaultException?>()) {
-      return (data != null ? _i45.DefaultException.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i46.IntDefault?>()) {
-      return (data != null ? _i46.IntDefault.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i47.IntDefaultMix?>()) {
-      return (data != null ? _i47.IntDefaultMix.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i48.IntDefaultModel?>()) {
-      return (data != null ? _i48.IntDefaultModel.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i49.IntDefaultPersist?>()) {
-      return (data != null ? _i49.IntDefaultPersist.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i50.StringDefault?>()) {
-      return (data != null ? _i50.StringDefault.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i51.StringDefaultMix?>()) {
-      return (data != null ? _i51.StringDefaultMix.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i52.StringDefaultModel?>()) {
-      return (data != null ? _i52.StringDefaultModel.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i53.StringDefaultPersist?>()) {
-      return (data != null ? _i53.StringDefaultPersist.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i54.UriDefault?>()) {
-      return (data != null ? _i54.UriDefault.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i55.UriDefaultMix?>()) {
-      return (data != null ? _i55.UriDefaultMix.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i56.UriDefaultModel?>()) {
-      return (data != null ? _i56.UriDefaultModel.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i57.UriDefaultPersist?>()) {
-      return (data != null ? _i57.UriDefaultPersist.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i58.UuidDefault?>()) {
-      return (data != null ? _i58.UuidDefault.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i59.UuidDefaultMix?>()) {
-      return (data != null ? _i59.UuidDefaultMix.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i60.UuidDefaultModel?>()) {
-      return (data != null ? _i60.UuidDefaultModel.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i61.UuidDefaultPersist?>()) {
-      return (data != null ? _i61.UuidDefaultPersist.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i62.EmptyModel?>()) {
-      return (data != null ? _i62.EmptyModel.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i63.EmptyModelRelationItem?>()) {
-      return (data != null ? _i63.EmptyModelRelationItem.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i64.EmptyModelWithTable?>()) {
-      return (data != null ? _i64.EmptyModelWithTable.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i65.RelationEmptyModel?>()) {
-      return (data != null ? _i65.RelationEmptyModel.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i66.ChildClassExplicitColumn?>()) {
-      return (data != null
-              ? _i66.ChildClassExplicitColumn.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i67.NonTableParentClass?>()) {
-      return (data != null ? _i67.NonTableParentClass.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i68.ModifiedColumnName?>()) {
-      return (data != null ? _i68.ModifiedColumnName.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i69.Department?>()) {
-      return (data != null ? _i69.Department.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i70.Employee?>()) {
-      return (data != null ? _i70.Employee.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i71.Contractor?>()) {
-      return (data != null ? _i71.Contractor.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i72.Service?>()) {
-      return (data != null ? _i72.Service.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i73.TableWithExplicitColumnName?>()) {
-      return (data != null
-              ? _i73.TableWithExplicitColumnName.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i74.SealedGrandChild?>()) {
-      return (data != null ? _i74.SealedGrandChild.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i74.SealedChild?>()) {
-      return (data != null ? _i74.SealedChild.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i74.SealedOtherChild?>()) {
-      return (data != null ? _i74.SealedOtherChild.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i75.CityWithLongTableName?>()) {
-      return (data != null ? _i75.CityWithLongTableName.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i76.OrganizationWithLongTableName?>()) {
-      return (data != null
-              ? _i76.OrganizationWithLongTableName.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i77.PersonWithLongTableName?>()) {
-      return (data != null ? _i77.PersonWithLongTableName.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i78.MaxFieldName?>()) {
-      return (data != null ? _i78.MaxFieldName.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i79.LongImplicitIdField?>()) {
-      return (data != null ? _i79.LongImplicitIdField.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i80.LongImplicitIdFieldCollection?>()) {
-      return (data != null
-              ? _i80.LongImplicitIdFieldCollection.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i81.RelationToMultipleMaxFieldName?>()) {
-      return (data != null
-              ? _i81.RelationToMultipleMaxFieldName.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i82.UserNote?>()) {
-      return (data != null ? _i82.UserNote.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i83.UserNoteCollection?>()) {
-      return (data != null ? _i83.UserNoteCollection.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i84.UserNoteCollectionWithALongName?>()) {
-      return (data != null
-              ? _i84.UserNoteCollectionWithALongName.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i85.UserNoteWithALongName?>()) {
-      return (data != null ? _i85.UserNoteWithALongName.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i86.MultipleMaxFieldName?>()) {
-      return (data != null ? _i86.MultipleMaxFieldName.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i87.City?>()) {
-      return (data != null ? _i87.City.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i88.Organization?>()) {
-      return (data != null ? _i88.Organization.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i89.Person?>()) {
-      return (data != null ? _i89.Person.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i90.Course?>()) {
-      return (data != null ? _i90.Course.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i91.Enrollment?>()) {
-      return (data != null ? _i91.Enrollment.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i92.Student?>()) {
-      return (data != null ? _i92.Student.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i93.Arena?>()) {
-      return (data != null ? _i93.Arena.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i94.Player?>()) {
-      return (data != null ? _i94.Player.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i95.Team?>()) {
-      return (data != null ? _i95.Team.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i96.Comment?>()) {
-      return (data != null ? _i96.Comment.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i97.Customer?>()) {
-      return (data != null ? _i97.Customer.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i98.Book?>()) {
-      return (data != null ? _i98.Book.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i99.Chapter?>()) {
-      return (data != null ? _i99.Chapter.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i100.Order?>()) {
-      return (data != null ? _i100.Order.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i101.Address?>()) {
-      return (data != null ? _i101.Address.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i102.Citizen?>()) {
-      return (data != null ? _i102.Citizen.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i103.Company?>()) {
-      return (data != null ? _i103.Company.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i104.Town?>()) {
-      return (data != null ? _i104.Town.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i105.Blocking?>()) {
-      return (data != null ? _i105.Blocking.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i106.Member?>()) {
-      return (data != null ? _i106.Member.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i107.Cat?>()) {
-      return (data != null ? _i107.Cat.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i108.Post?>()) {
-      return (data != null ? _i108.Post.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i109.ObjectFieldPersist?>()) {
-      return (data != null ? _i109.ObjectFieldPersist.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i110.ObjectFieldScopes?>()) {
-      return (data != null ? _i110.ObjectFieldScopes.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i111.ObjectWithBit?>()) {
-      return (data != null ? _i111.ObjectWithBit.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i112.ObjectWithByteData?>()) {
-      return (data != null ? _i112.ObjectWithByteData.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i113.ObjectWithDuration?>()) {
-      return (data != null ? _i113.ObjectWithDuration.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i114.ObjectWithDynamic?>()) {
-      return (data != null ? _i114.ObjectWithDynamic.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i115.ObjectWithEnum?>()) {
-      return (data != null ? _i115.ObjectWithEnum.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i116.ObjectWithEnumEnhanced?>()) {
-      return (data != null ? _i116.ObjectWithEnumEnhanced.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i117.ObjectWithHalfVector?>()) {
-      return (data != null ? _i117.ObjectWithHalfVector.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i118.ObjectWithIndex?>()) {
-      return (data != null ? _i118.ObjectWithIndex.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i119.ObjectWithJsonb?>()) {
-      return (data != null ? _i119.ObjectWithJsonb.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i120.ObjectWithJsonbClassLevel?>()) {
-      return (data != null
-              ? _i120.ObjectWithJsonbClassLevel.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i121.ObjectWithMaps?>()) {
-      return (data != null ? _i121.ObjectWithMaps.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i122.ObjectWithObject?>()) {
-      return (data != null ? _i122.ObjectWithObject.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i123.ObjectWithParent?>()) {
-      return (data != null ? _i123.ObjectWithParent.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i124.ObjectWithSealedClass?>()) {
-      return (data != null ? _i124.ObjectWithSealedClass.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i125.ObjectWithSelfParent?>()) {
-      return (data != null ? _i125.ObjectWithSelfParent.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i126.ObjectWithSparseVector?>()) {
-      return (data != null ? _i126.ObjectWithSparseVector.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i127.ObjectWithUuid?>()) {
-      return (data != null ? _i127.ObjectWithUuid.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i128.ObjectWithVector?>()) {
-      return (data != null ? _i128.ObjectWithVector.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i129.RelatedUniqueData?>()) {
-      return (data != null ? _i129.RelatedUniqueData.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i130.ModelWithRequiredField?>()) {
-      return (data != null ? _i130.ModelWithRequiredField.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i131.SimpleData?>()) {
-      return (data != null ? _i131.SimpleData.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i132.SimpleDateTime?>()) {
-      return (data != null ? _i132.SimpleDateTime.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i133.TestEnum?>()) {
-      return (data != null ? _i133.TestEnum.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i134.TestEnumDefaultSerialization?>()) {
-      return (data != null
-              ? _i134.TestEnumDefaultSerialization.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i135.TestEnumEnhanced?>()) {
-      return (data != null ? _i135.TestEnumEnhanced.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i136.TestEnumEnhancedByName?>()) {
-      return (data != null ? _i136.TestEnumEnhancedByName.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i137.TestEnumStringified?>()) {
-      return (data != null ? _i137.TestEnumStringified.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i138.Types?>()) {
-      return (data != null ? _i138.Types.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i139.UniqueData?>()) {
-      return (data != null ? _i139.UniqueData.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i140.UniqueDataWithNonPersist?>()) {
-      return (data != null
-              ? _i140.UniqueDataWithNonPersist.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i141.UpsertTestModel?>()) {
-      return (data != null ? _i141.UpsertTestModel.fromJson(data) : null) as T;
-    }
-    if (t == List<_i4.EnrollmentInt>) {
-      return (data as List)
-              .map((e) => deserialize<_i4.EnrollmentInt>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i4.EnrollmentInt>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i4.EnrollmentInt>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i7.PlayerUuid>) {
-      return (data as List).map((e) => deserialize<_i7.PlayerUuid>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i7.PlayerUuid>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i7.PlayerUuid>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i11.OrderUuid>) {
-      return (data as List).map((e) => deserialize<_i11.OrderUuid>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i11.OrderUuid>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i11.OrderUuid>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i9.CommentInt>) {
-      return (data as List).map((e) => deserialize<_i9.CommentInt>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i9.CommentInt>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i9.CommentInt>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i16.ChangedIdTypeSelf>) {
-      return (data as List)
-              .map((e) => deserialize<_i16.ChangedIdTypeSelf>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i16.ChangedIdTypeSelf>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i16.ChangedIdTypeSelf>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i63.EmptyModelRelationItem>) {
-      return (data as List)
-              .map((e) => deserialize<_i63.EmptyModelRelationItem>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i63.EmptyModelRelationItem>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i63.EmptyModelRelationItem>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i70.Employee>) {
-      return (data as List).map((e) => deserialize<_i70.Employee>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i70.Employee>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i70.Employee>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i77.PersonWithLongTableName>) {
-      return (data as List)
-              .map((e) => deserialize<_i77.PersonWithLongTableName>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i77.PersonWithLongTableName>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i77.PersonWithLongTableName>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i76.OrganizationWithLongTableName>) {
-      return (data as List)
-              .map((e) => deserialize<_i76.OrganizationWithLongTableName>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i76.OrganizationWithLongTableName>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map(
-                      (e) => deserialize<_i76.OrganizationWithLongTableName>(e),
-                    )
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i79.LongImplicitIdField>) {
-      return (data as List)
-              .map((e) => deserialize<_i79.LongImplicitIdField>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i79.LongImplicitIdField>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i79.LongImplicitIdField>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i86.MultipleMaxFieldName>) {
-      return (data as List)
-              .map((e) => deserialize<_i86.MultipleMaxFieldName>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i86.MultipleMaxFieldName>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i86.MultipleMaxFieldName>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i82.UserNote>) {
-      return (data as List).map((e) => deserialize<_i82.UserNote>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i82.UserNote>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i82.UserNote>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i85.UserNoteWithALongName>) {
-      return (data as List)
-              .map((e) => deserialize<_i85.UserNoteWithALongName>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i85.UserNoteWithALongName>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i85.UserNoteWithALongName>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i89.Person>) {
-      return (data as List).map((e) => deserialize<_i89.Person>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i89.Person>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<_i89.Person>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i88.Organization>) {
-      return (data as List)
-              .map((e) => deserialize<_i88.Organization>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i88.Organization>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i88.Organization>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i91.Enrollment>) {
-      return (data as List).map((e) => deserialize<_i91.Enrollment>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i91.Enrollment>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i91.Enrollment>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i94.Player>) {
-      return (data as List).map((e) => deserialize<_i94.Player>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i94.Player>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<_i94.Player>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i100.Order>) {
-      return (data as List).map((e) => deserialize<_i100.Order>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i100.Order>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<_i100.Order>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i99.Chapter>) {
-      return (data as List).map((e) => deserialize<_i99.Chapter>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i99.Chapter>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<_i99.Chapter>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i96.Comment>) {
-      return (data as List).map((e) => deserialize<_i96.Comment>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i96.Comment>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<_i96.Comment>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i105.Blocking>) {
-      return (data as List).map((e) => deserialize<_i105.Blocking>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i105.Blocking>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i105.Blocking>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i107.Cat>) {
-      return (data as List).map((e) => deserialize<_i107.Cat>(e)).toList() as T;
-    }
-    if (t == _i1.getType<List<_i107.Cat>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<_i107.Cat>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == dynamic) {
-      return deserializeDynamicFieldValue(data) as T;
-    }
-    if (t == List<dynamic>) {
-      return (data as List).map((e) => deserialize<dynamic>(e)).toList() as T;
-    }
-    if (t == Map<String, dynamic>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(deserialize<String>(k), deserialize<dynamic>(v)),
-          )
-          as T;
-    }
-    if (t == Set<dynamic>) {
-      return (data as List).map((e) => deserialize<dynamic>(e)).toSet() as T;
-    }
-    if (t == Map<dynamic, dynamic>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) => MapEntry(
-                deserialize<dynamic>(e['k']),
-                deserialize<dynamic>(e['v']),
-              ),
-            ),
-          )
-          as T;
-    }
-    if (t == List<_i133.TestEnum>) {
-      return (data as List).map((e) => deserialize<_i133.TestEnum>(e)).toList()
-          as T;
-    }
-    if (t == List<_i133.TestEnum?>) {
-      return (data as List).map((e) => deserialize<_i133.TestEnum?>(e)).toList()
-          as T;
-    }
-    if (t == List<List<_i133.TestEnum>>) {
-      return (data as List)
-              .map((e) => deserialize<List<_i133.TestEnum>>(e))
-              .toList()
-          as T;
-    }
-    if (t == List<_i135.TestEnumEnhanced>) {
-      return (data as List)
-              .map((e) => deserialize<_i135.TestEnumEnhanced>(e))
-              .toList()
-          as T;
-    }
-    if (t == List<_i136.TestEnumEnhancedByName>) {
-      return (data as List)
-              .map((e) => deserialize<_i136.TestEnumEnhancedByName>(e))
-              .toList()
-          as T;
-    }
-    if (t == List<String>) {
-      return (data as List).map((e) => deserialize<String>(e)).toList() as T;
-    }
-    if (t == Map<String, String>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(deserialize<String>(k), deserialize<String>(v)),
-          )
-          as T;
-    }
-    if (t == _i1.getType<List<String>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<String>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == Map<String, _i131.SimpleData>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<_i131.SimpleData>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == Map<String, int>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(deserialize<String>(k), deserialize<int>(v)),
-          )
-          as T;
-    }
-    if (t == Map<String, DateTime>) {
-      return (data as Map).map(
-            (k, v) =>
-                MapEntry(deserialize<String>(k), deserialize<DateTime>(v)),
-          )
-          as T;
-    }
-    if (t == Map<String, _i142.ByteData>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<_i142.ByteData>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == Map<String, Duration>) {
-      return (data as Map).map(
-            (k, v) =>
-                MapEntry(deserialize<String>(k), deserialize<Duration>(v)),
-          )
-          as T;
-    }
-    if (t == Map<String, _i1.UuidValue>) {
-      return (data as Map).map(
-            (k, v) =>
-                MapEntry(deserialize<String>(k), deserialize<_i1.UuidValue>(v)),
-          )
-          as T;
-    }
-    if (t == Map<String, _i131.SimpleData?>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<_i131.SimpleData?>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == Map<String, int?>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(deserialize<String>(k), deserialize<int?>(v)),
-          )
-          as T;
-    }
-    if (t == Map<String, String?>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(deserialize<String>(k), deserialize<String?>(v)),
-          )
-          as T;
-    }
-    if (t == Map<String, DateTime?>) {
-      return (data as Map).map(
-            (k, v) =>
-                MapEntry(deserialize<String>(k), deserialize<DateTime?>(v)),
-          )
-          as T;
-    }
-    if (t == Map<String, _i142.ByteData?>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<_i142.ByteData?>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == Map<String, Duration?>) {
-      return (data as Map).map(
-            (k, v) =>
-                MapEntry(deserialize<String>(k), deserialize<Duration?>(v)),
-          )
-          as T;
-    }
-    if (t == Map<String, _i1.UuidValue?>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<_i1.UuidValue?>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == Map<int, int>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) =>
-                  MapEntry(deserialize<int>(e['k']), deserialize<int>(e['v'])),
-            ),
-          )
-          as T;
-    }
-    if (t == List<_i131.SimpleData>) {
-      return (data as List)
-              .map((e) => deserialize<_i131.SimpleData>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i131.SimpleData>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i131.SimpleData>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i131.SimpleData?>) {
-      return (data as List)
-              .map((e) => deserialize<_i131.SimpleData?>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i131.SimpleData?>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i131.SimpleData?>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<List<_i131.SimpleData>>) {
-      return (data as List)
-              .map((e) => deserialize<List<_i131.SimpleData>>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<List<_i131.SimpleData>>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<List<_i131.SimpleData>>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == Map<String, List<List<Map<int, _i131.SimpleData>>?>>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<List<List<Map<int, _i131.SimpleData>>?>>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == List<List<Map<int, _i131.SimpleData>>?>) {
-      return (data as List)
-              .map((e) => deserialize<List<Map<int, _i131.SimpleData>>?>(e))
-              .toList()
-          as T;
-    }
-    if (t == List<Map<int, _i131.SimpleData>>) {
-      return (data as List)
-              .map((e) => deserialize<Map<int, _i131.SimpleData>>(e))
-              .toList()
-          as T;
-    }
-    if (t == Map<int, _i131.SimpleData>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) => MapEntry(
-                deserialize<int>(e['k']),
-                deserialize<_i131.SimpleData>(e['v']),
-              ),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<List<Map<int, _i131.SimpleData>>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<Map<int, _i131.SimpleData>>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t ==
-        _i1.getType<Map<String, List<List<Map<int, _i131.SimpleData>>?>>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) => MapEntry(
-                    deserialize<String>(k),
-                    deserialize<List<List<Map<int, _i131.SimpleData>>?>>(v),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<List<Map<int, _i131.SimpleData>>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<Map<int, _i131.SimpleData>>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == Map<String, Map<int, _i131.SimpleData>>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<Map<int, _i131.SimpleData>>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<String, Map<int, _i131.SimpleData>>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) => MapEntry(
-                    deserialize<String>(k),
-                    deserialize<Map<int, _i131.SimpleData>>(v),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == List<_i74.SealedParent>) {
-      return (data as List)
-              .map((e) => deserialize<_i74.SealedParent>(e))
-              .toList()
-          as T;
-    }
-    if (t == List<int>) {
-      return (data as List).map((e) => deserialize<int>(e)).toList() as T;
-    }
-    if (t == _i1.getType<List<int>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<int>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<Map<int, int>?>()) {
-      return (data != null
-              ? Map.fromEntries(
-                  (data as List).map(
-                    (e) => MapEntry(
-                      deserialize<int>(e['k']),
-                      deserialize<int>(e['v']),
-                    ),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == Set<int>) {
-      return (data as List).map((e) => deserialize<int>(e)).toSet() as T;
-    }
-    if (t == _i1.getType<Set<int>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<int>(e)).toSet()
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(String, {Uri? optionalUri})?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<String>(((data as Map)['p'] as List)[0]),
-                  optionalUri: ((data)['n'] as Map)['optionalUri'] == null
-                      ? null
-                      : deserialize<Uri>(data['n']['optionalUri']),
-                )
-                as T;
-    }
-    if (t == List<_i143.SimpleData>) {
-      return (data as List)
-              .map((e) => deserialize<_i143.SimpleData>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<(String, {Uri? optionalUri})?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<String>(((data as Map)['p'] as List)[0]),
-                  optionalUri: ((data)['n'] as Map)['optionalUri'] == null
-                      ? null
-                      : deserialize<Uri>(data['n']['optionalUri']),
-                )
-                as T;
+    final fn = _deserializers[t];
+    if (fn != null) {
+      return fn(data, this) as T;
     }
     try {
       return _i2.Protocol().deserialize<T>(data, t);

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/protocol.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/protocol.dart
@@ -322,6 +322,9 @@ class Protocol extends _i1.DatabaseSerializationManager {
 
   static final Protocol _instance = Protocol._().._registerHostProtocols();
 
+  static final Map<Type, dynamic Function(dynamic, Protocol)> _deserializers =
+      _buildDeserializers();
+
   static List<_i2.TableDefinition> get targetTableDefinitions => [
     _i2.TableDefinition(
       name: 'address',
@@ -5743,1564 +5746,9 @@ class Protocol extends _i1.DatabaseSerializationManager {
       }
     }
 
-    if (t == _i7.CourseUuid) {
-      return _i7.CourseUuid.fromJson(data) as T;
-    }
-    if (t == _i8.EnrollmentInt) {
-      return _i8.EnrollmentInt.fromJson(data) as T;
-    }
-    if (t == _i9.StudentUuid) {
-      return _i9.StudentUuid.fromJson(data) as T;
-    }
-    if (t == _i10.ArenaUuid) {
-      return _i10.ArenaUuid.fromJson(data) as T;
-    }
-    if (t == _i11.PlayerUuid) {
-      return _i11.PlayerUuid.fromJson(data) as T;
-    }
-    if (t == _i12.TeamInt) {
-      return _i12.TeamInt.fromJson(data) as T;
-    }
-    if (t == _i13.CommentInt) {
-      return _i13.CommentInt.fromJson(data) as T;
-    }
-    if (t == _i14.CustomerInt) {
-      return _i14.CustomerInt.fromJson(data) as T;
-    }
-    if (t == _i15.OrderUuid) {
-      return _i15.OrderUuid.fromJson(data) as T;
-    }
-    if (t == _i16.AddressUuid) {
-      return _i16.AddressUuid.fromJson(data) as T;
-    }
-    if (t == _i17.CitizenInt) {
-      return _i17.CitizenInt.fromJson(data) as T;
-    }
-    if (t == _i18.CompanyUuid) {
-      return _i18.CompanyUuid.fromJson(data) as T;
-    }
-    if (t == _i19.TownInt) {
-      return _i19.TownInt.fromJson(data) as T;
-    }
-    if (t == _i20.ChangedIdTypeSelf) {
-      return _i20.ChangedIdTypeSelf.fromJson(data) as T;
-    }
-    if (t == _i21.ServerOnlyChangedIdFieldClass) {
-      return _i21.ServerOnlyChangedIdFieldClass.fromJson(data) as T;
-    }
-    if (t == _i22.BigIntDefault) {
-      return _i22.BigIntDefault.fromJson(data) as T;
-    }
-    if (t == _i23.BigIntDefaultMix) {
-      return _i23.BigIntDefaultMix.fromJson(data) as T;
-    }
-    if (t == _i24.BigIntDefaultModel) {
-      return _i24.BigIntDefaultModel.fromJson(data) as T;
-    }
-    if (t == _i25.BigIntDefaultPersist) {
-      return _i25.BigIntDefaultPersist.fromJson(data) as T;
-    }
-    if (t == _i26.BoolDefault) {
-      return _i26.BoolDefault.fromJson(data) as T;
-    }
-    if (t == _i27.BoolDefaultMix) {
-      return _i27.BoolDefaultMix.fromJson(data) as T;
-    }
-    if (t == _i28.BoolDefaultModel) {
-      return _i28.BoolDefaultModel.fromJson(data) as T;
-    }
-    if (t == _i29.BoolDefaultPersist) {
-      return _i29.BoolDefaultPersist.fromJson(data) as T;
-    }
-    if (t == _i30.DateTimeDefault) {
-      return _i30.DateTimeDefault.fromJson(data) as T;
-    }
-    if (t == _i31.DateTimeDefaultMix) {
-      return _i31.DateTimeDefaultMix.fromJson(data) as T;
-    }
-    if (t == _i32.DateTimeDefaultModel) {
-      return _i32.DateTimeDefaultModel.fromJson(data) as T;
-    }
-    if (t == _i33.DateTimeDefaultPersist) {
-      return _i33.DateTimeDefaultPersist.fromJson(data) as T;
-    }
-    if (t == _i34.DoubleDefault) {
-      return _i34.DoubleDefault.fromJson(data) as T;
-    }
-    if (t == _i35.DoubleDefaultMix) {
-      return _i35.DoubleDefaultMix.fromJson(data) as T;
-    }
-    if (t == _i36.DoubleDefaultModel) {
-      return _i36.DoubleDefaultModel.fromJson(data) as T;
-    }
-    if (t == _i37.DoubleDefaultPersist) {
-      return _i37.DoubleDefaultPersist.fromJson(data) as T;
-    }
-    if (t == _i38.DurationDefault) {
-      return _i38.DurationDefault.fromJson(data) as T;
-    }
-    if (t == _i39.DurationDefaultMix) {
-      return _i39.DurationDefaultMix.fromJson(data) as T;
-    }
-    if (t == _i40.DurationDefaultModel) {
-      return _i40.DurationDefaultModel.fromJson(data) as T;
-    }
-    if (t == _i41.DurationDefaultPersist) {
-      return _i41.DurationDefaultPersist.fromJson(data) as T;
-    }
-    if (t == _i42.EnumDefault) {
-      return _i42.EnumDefault.fromJson(data) as T;
-    }
-    if (t == _i43.EnumDefaultMix) {
-      return _i43.EnumDefaultMix.fromJson(data) as T;
-    }
-    if (t == _i44.EnumDefaultModel) {
-      return _i44.EnumDefaultModel.fromJson(data) as T;
-    }
-    if (t == _i45.EnumDefaultPersist) {
-      return _i45.EnumDefaultPersist.fromJson(data) as T;
-    }
-    if (t == _i46.ByIndexEnum) {
-      return _i46.ByIndexEnum.fromJson(data) as T;
-    }
-    if (t == _i47.ByNameEnum) {
-      return _i47.ByNameEnum.fromJson(data) as T;
-    }
-    if (t == _i48.DefaultValueEnum) {
-      return _i48.DefaultValueEnum.fromJson(data) as T;
-    }
-    if (t == _i49.DefaultException) {
-      return _i49.DefaultException.fromJson(data) as T;
-    }
-    if (t == _i50.IntDefault) {
-      return _i50.IntDefault.fromJson(data) as T;
-    }
-    if (t == _i51.IntDefaultMix) {
-      return _i51.IntDefaultMix.fromJson(data) as T;
-    }
-    if (t == _i52.IntDefaultModel) {
-      return _i52.IntDefaultModel.fromJson(data) as T;
-    }
-    if (t == _i53.IntDefaultPersist) {
-      return _i53.IntDefaultPersist.fromJson(data) as T;
-    }
-    if (t == _i54.StringDefault) {
-      return _i54.StringDefault.fromJson(data) as T;
-    }
-    if (t == _i55.StringDefaultMix) {
-      return _i55.StringDefaultMix.fromJson(data) as T;
-    }
-    if (t == _i56.StringDefaultModel) {
-      return _i56.StringDefaultModel.fromJson(data) as T;
-    }
-    if (t == _i57.StringDefaultPersist) {
-      return _i57.StringDefaultPersist.fromJson(data) as T;
-    }
-    if (t == _i58.UriDefault) {
-      return _i58.UriDefault.fromJson(data) as T;
-    }
-    if (t == _i59.UriDefaultMix) {
-      return _i59.UriDefaultMix.fromJson(data) as T;
-    }
-    if (t == _i60.UriDefaultModel) {
-      return _i60.UriDefaultModel.fromJson(data) as T;
-    }
-    if (t == _i61.UriDefaultPersist) {
-      return _i61.UriDefaultPersist.fromJson(data) as T;
-    }
-    if (t == _i62.UuidDefault) {
-      return _i62.UuidDefault.fromJson(data) as T;
-    }
-    if (t == _i63.UuidDefaultMix) {
-      return _i63.UuidDefaultMix.fromJson(data) as T;
-    }
-    if (t == _i64.UuidDefaultModel) {
-      return _i64.UuidDefaultModel.fromJson(data) as T;
-    }
-    if (t == _i65.UuidDefaultPersist) {
-      return _i65.UuidDefaultPersist.fromJson(data) as T;
-    }
-    if (t == _i66.EmptyModel) {
-      return _i66.EmptyModel.fromJson(data) as T;
-    }
-    if (t == _i67.EmptyModelRelationItem) {
-      return _i67.EmptyModelRelationItem.fromJson(data) as T;
-    }
-    if (t == _i68.EmptyModelWithTable) {
-      return _i68.EmptyModelWithTable.fromJson(data) as T;
-    }
-    if (t == _i69.RelationEmptyModel) {
-      return _i69.RelationEmptyModel.fromJson(data) as T;
-    }
-    if (t == _i70.ChildClassExplicitColumn) {
-      return _i70.ChildClassExplicitColumn.fromJson(data) as T;
-    }
-    if (t == _i71.NonTableParentClass) {
-      return _i71.NonTableParentClass.fromJson(data) as T;
-    }
-    if (t == _i72.ModifiedColumnName) {
-      return _i72.ModifiedColumnName.fromJson(data) as T;
-    }
-    if (t == _i73.Department) {
-      return _i73.Department.fromJson(data) as T;
-    }
-    if (t == _i74.Employee) {
-      return _i74.Employee.fromJson(data) as T;
-    }
-    if (t == _i75.Contractor) {
-      return _i75.Contractor.fromJson(data) as T;
-    }
-    if (t == _i76.Service) {
-      return _i76.Service.fromJson(data) as T;
-    }
-    if (t == _i77.TableWithExplicitColumnName) {
-      return _i77.TableWithExplicitColumnName.fromJson(data) as T;
-    }
-    if (t == _i78.SealedGrandChild) {
-      return _i78.SealedGrandChild.fromJson(data) as T;
-    }
-    if (t == _i78.SealedChild) {
-      return _i78.SealedChild.fromJson(data) as T;
-    }
-    if (t == _i78.SealedOtherChild) {
-      return _i78.SealedOtherChild.fromJson(data) as T;
-    }
-    if (t == _i79.CityWithLongTableName) {
-      return _i79.CityWithLongTableName.fromJson(data) as T;
-    }
-    if (t == _i80.OrganizationWithLongTableName) {
-      return _i80.OrganizationWithLongTableName.fromJson(data) as T;
-    }
-    if (t == _i81.PersonWithLongTableName) {
-      return _i81.PersonWithLongTableName.fromJson(data) as T;
-    }
-    if (t == _i82.MaxFieldName) {
-      return _i82.MaxFieldName.fromJson(data) as T;
-    }
-    if (t == _i83.LongImplicitIdField) {
-      return _i83.LongImplicitIdField.fromJson(data) as T;
-    }
-    if (t == _i84.LongImplicitIdFieldCollection) {
-      return _i84.LongImplicitIdFieldCollection.fromJson(data) as T;
-    }
-    if (t == _i85.RelationToMultipleMaxFieldName) {
-      return _i85.RelationToMultipleMaxFieldName.fromJson(data) as T;
-    }
-    if (t == _i86.UserNote) {
-      return _i86.UserNote.fromJson(data) as T;
-    }
-    if (t == _i87.UserNoteCollection) {
-      return _i87.UserNoteCollection.fromJson(data) as T;
-    }
-    if (t == _i88.UserNoteCollectionWithALongName) {
-      return _i88.UserNoteCollectionWithALongName.fromJson(data) as T;
-    }
-    if (t == _i89.UserNoteWithALongName) {
-      return _i89.UserNoteWithALongName.fromJson(data) as T;
-    }
-    if (t == _i90.MultipleMaxFieldName) {
-      return _i90.MultipleMaxFieldName.fromJson(data) as T;
-    }
-    if (t == _i91.City) {
-      return _i91.City.fromJson(data) as T;
-    }
-    if (t == _i92.Organization) {
-      return _i92.Organization.fromJson(data) as T;
-    }
-    if (t == _i93.Person) {
-      return _i93.Person.fromJson(data) as T;
-    }
-    if (t == _i94.Course) {
-      return _i94.Course.fromJson(data) as T;
-    }
-    if (t == _i95.Enrollment) {
-      return _i95.Enrollment.fromJson(data) as T;
-    }
-    if (t == _i96.Student) {
-      return _i96.Student.fromJson(data) as T;
-    }
-    if (t == _i97.Arena) {
-      return _i97.Arena.fromJson(data) as T;
-    }
-    if (t == _i98.Player) {
-      return _i98.Player.fromJson(data) as T;
-    }
-    if (t == _i99.Team) {
-      return _i99.Team.fromJson(data) as T;
-    }
-    if (t == _i100.Comment) {
-      return _i100.Comment.fromJson(data) as T;
-    }
-    if (t == _i101.Customer) {
-      return _i101.Customer.fromJson(data) as T;
-    }
-    if (t == _i102.Book) {
-      return _i102.Book.fromJson(data) as T;
-    }
-    if (t == _i103.Chapter) {
-      return _i103.Chapter.fromJson(data) as T;
-    }
-    if (t == _i104.Order) {
-      return _i104.Order.fromJson(data) as T;
-    }
-    if (t == _i105.Address) {
-      return _i105.Address.fromJson(data) as T;
-    }
-    if (t == _i106.Citizen) {
-      return _i106.Citizen.fromJson(data) as T;
-    }
-    if (t == _i107.Company) {
-      return _i107.Company.fromJson(data) as T;
-    }
-    if (t == _i108.Town) {
-      return _i108.Town.fromJson(data) as T;
-    }
-    if (t == _i109.Blocking) {
-      return _i109.Blocking.fromJson(data) as T;
-    }
-    if (t == _i110.Member) {
-      return _i110.Member.fromJson(data) as T;
-    }
-    if (t == _i111.Cat) {
-      return _i111.Cat.fromJson(data) as T;
-    }
-    if (t == _i112.Post) {
-      return _i112.Post.fromJson(data) as T;
-    }
-    if (t == _i113.NullsDistinctData) {
-      return _i113.NullsDistinctData.fromJson(data) as T;
-    }
-    if (t == _i114.ObjectFieldPersist) {
-      return _i114.ObjectFieldPersist.fromJson(data) as T;
-    }
-    if (t == _i115.ObjectFieldScopes) {
-      return _i115.ObjectFieldScopes.fromJson(data) as T;
-    }
-    if (t == _i116.ObjectWithBit) {
-      return _i116.ObjectWithBit.fromJson(data) as T;
-    }
-    if (t == _i117.ObjectWithByteData) {
-      return _i117.ObjectWithByteData.fromJson(data) as T;
-    }
-    if (t == _i118.ObjectWithDuration) {
-      return _i118.ObjectWithDuration.fromJson(data) as T;
-    }
-    if (t == _i119.ObjectWithDynamic) {
-      return _i119.ObjectWithDynamic.fromJson(data) as T;
-    }
-    if (t == _i120.ObjectWithEnum) {
-      return _i120.ObjectWithEnum.fromJson(data) as T;
-    }
-    if (t == _i121.ObjectWithEnumEnhanced) {
-      return _i121.ObjectWithEnumEnhanced.fromJson(data) as T;
-    }
-    if (t == _i122.ObjectWithHalfVector) {
-      return _i122.ObjectWithHalfVector.fromJson(data) as T;
-    }
-    if (t == _i123.ObjectWithIndex) {
-      return _i123.ObjectWithIndex.fromJson(data) as T;
-    }
-    if (t == _i124.ObjectWithJsonb) {
-      return _i124.ObjectWithJsonb.fromJson(data) as T;
-    }
-    if (t == _i125.ObjectWithJsonbClassLevel) {
-      return _i125.ObjectWithJsonbClassLevel.fromJson(data) as T;
-    }
-    if (t == _i126.ObjectWithMaps) {
-      return _i126.ObjectWithMaps.fromJson(data) as T;
-    }
-    if (t == _i127.ObjectWithObject) {
-      return _i127.ObjectWithObject.fromJson(data) as T;
-    }
-    if (t == _i128.ObjectWithParent) {
-      return _i128.ObjectWithParent.fromJson(data) as T;
-    }
-    if (t == _i129.ObjectWithSealedClass) {
-      return _i129.ObjectWithSealedClass.fromJson(data) as T;
-    }
-    if (t == _i130.ObjectWithSelfParent) {
-      return _i130.ObjectWithSelfParent.fromJson(data) as T;
-    }
-    if (t == _i131.ObjectWithSparseVector) {
-      return _i131.ObjectWithSparseVector.fromJson(data) as T;
-    }
-    if (t == _i132.ObjectWithUuid) {
-      return _i132.ObjectWithUuid.fromJson(data) as T;
-    }
-    if (t == _i133.ObjectWithVector) {
-      return _i133.ObjectWithVector.fromJson(data) as T;
-    }
-    if (t == _i134.RelatedUniqueData) {
-      return _i134.RelatedUniqueData.fromJson(data) as T;
-    }
-    if (t == _i135.ModelWithRequiredField) {
-      return _i135.ModelWithRequiredField.fromJson(data) as T;
-    }
-    if (t == _i136.SimpleData) {
-      return _i136.SimpleData.fromJson(data) as T;
-    }
-    if (t == _i137.SimpleDateTime) {
-      return _i137.SimpleDateTime.fromJson(data) as T;
-    }
-    if (t == _i138.TestEnum) {
-      return _i138.TestEnum.fromJson(data) as T;
-    }
-    if (t == _i139.TestEnumDefaultSerialization) {
-      return _i139.TestEnumDefaultSerialization.fromJson(data) as T;
-    }
-    if (t == _i140.TestEnumEnhanced) {
-      return _i140.TestEnumEnhanced.fromJson(data) as T;
-    }
-    if (t == _i141.TestEnumEnhancedByName) {
-      return _i141.TestEnumEnhancedByName.fromJson(data) as T;
-    }
-    if (t == _i142.TestEnumStringified) {
-      return _i142.TestEnumStringified.fromJson(data) as T;
-    }
-    if (t == _i143.Types) {
-      return _i143.Types.fromJson(data) as T;
-    }
-    if (t == _i144.UniqueData) {
-      return _i144.UniqueData.fromJson(data) as T;
-    }
-    if (t == _i145.UniqueDataWithNonPersist) {
-      return _i145.UniqueDataWithNonPersist.fromJson(data) as T;
-    }
-    if (t == _i146.UpsertTestModel) {
-      return _i146.UpsertTestModel.fromJson(data) as T;
-    }
-    if (t == _i1.getType<_i7.CourseUuid?>()) {
-      return (data != null ? _i7.CourseUuid.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i8.EnrollmentInt?>()) {
-      return (data != null ? _i8.EnrollmentInt.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i9.StudentUuid?>()) {
-      return (data != null ? _i9.StudentUuid.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i10.ArenaUuid?>()) {
-      return (data != null ? _i10.ArenaUuid.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i11.PlayerUuid?>()) {
-      return (data != null ? _i11.PlayerUuid.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i12.TeamInt?>()) {
-      return (data != null ? _i12.TeamInt.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i13.CommentInt?>()) {
-      return (data != null ? _i13.CommentInt.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i14.CustomerInt?>()) {
-      return (data != null ? _i14.CustomerInt.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i15.OrderUuid?>()) {
-      return (data != null ? _i15.OrderUuid.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i16.AddressUuid?>()) {
-      return (data != null ? _i16.AddressUuid.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i17.CitizenInt?>()) {
-      return (data != null ? _i17.CitizenInt.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i18.CompanyUuid?>()) {
-      return (data != null ? _i18.CompanyUuid.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i19.TownInt?>()) {
-      return (data != null ? _i19.TownInt.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i20.ChangedIdTypeSelf?>()) {
-      return (data != null ? _i20.ChangedIdTypeSelf.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i21.ServerOnlyChangedIdFieldClass?>()) {
-      return (data != null
-              ? _i21.ServerOnlyChangedIdFieldClass.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i22.BigIntDefault?>()) {
-      return (data != null ? _i22.BigIntDefault.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i23.BigIntDefaultMix?>()) {
-      return (data != null ? _i23.BigIntDefaultMix.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i24.BigIntDefaultModel?>()) {
-      return (data != null ? _i24.BigIntDefaultModel.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i25.BigIntDefaultPersist?>()) {
-      return (data != null ? _i25.BigIntDefaultPersist.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i26.BoolDefault?>()) {
-      return (data != null ? _i26.BoolDefault.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i27.BoolDefaultMix?>()) {
-      return (data != null ? _i27.BoolDefaultMix.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i28.BoolDefaultModel?>()) {
-      return (data != null ? _i28.BoolDefaultModel.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i29.BoolDefaultPersist?>()) {
-      return (data != null ? _i29.BoolDefaultPersist.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i30.DateTimeDefault?>()) {
-      return (data != null ? _i30.DateTimeDefault.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i31.DateTimeDefaultMix?>()) {
-      return (data != null ? _i31.DateTimeDefaultMix.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i32.DateTimeDefaultModel?>()) {
-      return (data != null ? _i32.DateTimeDefaultModel.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i33.DateTimeDefaultPersist?>()) {
-      return (data != null ? _i33.DateTimeDefaultPersist.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i34.DoubleDefault?>()) {
-      return (data != null ? _i34.DoubleDefault.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i35.DoubleDefaultMix?>()) {
-      return (data != null ? _i35.DoubleDefaultMix.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i36.DoubleDefaultModel?>()) {
-      return (data != null ? _i36.DoubleDefaultModel.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i37.DoubleDefaultPersist?>()) {
-      return (data != null ? _i37.DoubleDefaultPersist.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i38.DurationDefault?>()) {
-      return (data != null ? _i38.DurationDefault.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i39.DurationDefaultMix?>()) {
-      return (data != null ? _i39.DurationDefaultMix.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i40.DurationDefaultModel?>()) {
-      return (data != null ? _i40.DurationDefaultModel.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i41.DurationDefaultPersist?>()) {
-      return (data != null ? _i41.DurationDefaultPersist.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i42.EnumDefault?>()) {
-      return (data != null ? _i42.EnumDefault.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i43.EnumDefaultMix?>()) {
-      return (data != null ? _i43.EnumDefaultMix.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i44.EnumDefaultModel?>()) {
-      return (data != null ? _i44.EnumDefaultModel.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i45.EnumDefaultPersist?>()) {
-      return (data != null ? _i45.EnumDefaultPersist.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i46.ByIndexEnum?>()) {
-      return (data != null ? _i46.ByIndexEnum.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i47.ByNameEnum?>()) {
-      return (data != null ? _i47.ByNameEnum.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i48.DefaultValueEnum?>()) {
-      return (data != null ? _i48.DefaultValueEnum.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i49.DefaultException?>()) {
-      return (data != null ? _i49.DefaultException.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i50.IntDefault?>()) {
-      return (data != null ? _i50.IntDefault.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i51.IntDefaultMix?>()) {
-      return (data != null ? _i51.IntDefaultMix.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i52.IntDefaultModel?>()) {
-      return (data != null ? _i52.IntDefaultModel.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i53.IntDefaultPersist?>()) {
-      return (data != null ? _i53.IntDefaultPersist.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i54.StringDefault?>()) {
-      return (data != null ? _i54.StringDefault.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i55.StringDefaultMix?>()) {
-      return (data != null ? _i55.StringDefaultMix.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i56.StringDefaultModel?>()) {
-      return (data != null ? _i56.StringDefaultModel.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i57.StringDefaultPersist?>()) {
-      return (data != null ? _i57.StringDefaultPersist.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i58.UriDefault?>()) {
-      return (data != null ? _i58.UriDefault.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i59.UriDefaultMix?>()) {
-      return (data != null ? _i59.UriDefaultMix.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i60.UriDefaultModel?>()) {
-      return (data != null ? _i60.UriDefaultModel.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i61.UriDefaultPersist?>()) {
-      return (data != null ? _i61.UriDefaultPersist.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i62.UuidDefault?>()) {
-      return (data != null ? _i62.UuidDefault.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i63.UuidDefaultMix?>()) {
-      return (data != null ? _i63.UuidDefaultMix.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i64.UuidDefaultModel?>()) {
-      return (data != null ? _i64.UuidDefaultModel.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i65.UuidDefaultPersist?>()) {
-      return (data != null ? _i65.UuidDefaultPersist.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i66.EmptyModel?>()) {
-      return (data != null ? _i66.EmptyModel.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i67.EmptyModelRelationItem?>()) {
-      return (data != null ? _i67.EmptyModelRelationItem.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i68.EmptyModelWithTable?>()) {
-      return (data != null ? _i68.EmptyModelWithTable.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i69.RelationEmptyModel?>()) {
-      return (data != null ? _i69.RelationEmptyModel.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i70.ChildClassExplicitColumn?>()) {
-      return (data != null
-              ? _i70.ChildClassExplicitColumn.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i71.NonTableParentClass?>()) {
-      return (data != null ? _i71.NonTableParentClass.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i72.ModifiedColumnName?>()) {
-      return (data != null ? _i72.ModifiedColumnName.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i73.Department?>()) {
-      return (data != null ? _i73.Department.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i74.Employee?>()) {
-      return (data != null ? _i74.Employee.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i75.Contractor?>()) {
-      return (data != null ? _i75.Contractor.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i76.Service?>()) {
-      return (data != null ? _i76.Service.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i77.TableWithExplicitColumnName?>()) {
-      return (data != null
-              ? _i77.TableWithExplicitColumnName.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i78.SealedGrandChild?>()) {
-      return (data != null ? _i78.SealedGrandChild.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i78.SealedChild?>()) {
-      return (data != null ? _i78.SealedChild.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i78.SealedOtherChild?>()) {
-      return (data != null ? _i78.SealedOtherChild.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i79.CityWithLongTableName?>()) {
-      return (data != null ? _i79.CityWithLongTableName.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i80.OrganizationWithLongTableName?>()) {
-      return (data != null
-              ? _i80.OrganizationWithLongTableName.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i81.PersonWithLongTableName?>()) {
-      return (data != null ? _i81.PersonWithLongTableName.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i82.MaxFieldName?>()) {
-      return (data != null ? _i82.MaxFieldName.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i83.LongImplicitIdField?>()) {
-      return (data != null ? _i83.LongImplicitIdField.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i84.LongImplicitIdFieldCollection?>()) {
-      return (data != null
-              ? _i84.LongImplicitIdFieldCollection.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i85.RelationToMultipleMaxFieldName?>()) {
-      return (data != null
-              ? _i85.RelationToMultipleMaxFieldName.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i86.UserNote?>()) {
-      return (data != null ? _i86.UserNote.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i87.UserNoteCollection?>()) {
-      return (data != null ? _i87.UserNoteCollection.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i88.UserNoteCollectionWithALongName?>()) {
-      return (data != null
-              ? _i88.UserNoteCollectionWithALongName.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i89.UserNoteWithALongName?>()) {
-      return (data != null ? _i89.UserNoteWithALongName.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i90.MultipleMaxFieldName?>()) {
-      return (data != null ? _i90.MultipleMaxFieldName.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i91.City?>()) {
-      return (data != null ? _i91.City.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i92.Organization?>()) {
-      return (data != null ? _i92.Organization.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i93.Person?>()) {
-      return (data != null ? _i93.Person.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i94.Course?>()) {
-      return (data != null ? _i94.Course.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i95.Enrollment?>()) {
-      return (data != null ? _i95.Enrollment.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i96.Student?>()) {
-      return (data != null ? _i96.Student.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i97.Arena?>()) {
-      return (data != null ? _i97.Arena.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i98.Player?>()) {
-      return (data != null ? _i98.Player.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i99.Team?>()) {
-      return (data != null ? _i99.Team.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i100.Comment?>()) {
-      return (data != null ? _i100.Comment.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i101.Customer?>()) {
-      return (data != null ? _i101.Customer.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i102.Book?>()) {
-      return (data != null ? _i102.Book.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i103.Chapter?>()) {
-      return (data != null ? _i103.Chapter.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i104.Order?>()) {
-      return (data != null ? _i104.Order.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i105.Address?>()) {
-      return (data != null ? _i105.Address.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i106.Citizen?>()) {
-      return (data != null ? _i106.Citizen.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i107.Company?>()) {
-      return (data != null ? _i107.Company.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i108.Town?>()) {
-      return (data != null ? _i108.Town.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i109.Blocking?>()) {
-      return (data != null ? _i109.Blocking.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i110.Member?>()) {
-      return (data != null ? _i110.Member.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i111.Cat?>()) {
-      return (data != null ? _i111.Cat.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i112.Post?>()) {
-      return (data != null ? _i112.Post.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i113.NullsDistinctData?>()) {
-      return (data != null ? _i113.NullsDistinctData.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i114.ObjectFieldPersist?>()) {
-      return (data != null ? _i114.ObjectFieldPersist.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i115.ObjectFieldScopes?>()) {
-      return (data != null ? _i115.ObjectFieldScopes.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i116.ObjectWithBit?>()) {
-      return (data != null ? _i116.ObjectWithBit.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i117.ObjectWithByteData?>()) {
-      return (data != null ? _i117.ObjectWithByteData.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i118.ObjectWithDuration?>()) {
-      return (data != null ? _i118.ObjectWithDuration.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i119.ObjectWithDynamic?>()) {
-      return (data != null ? _i119.ObjectWithDynamic.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i120.ObjectWithEnum?>()) {
-      return (data != null ? _i120.ObjectWithEnum.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i121.ObjectWithEnumEnhanced?>()) {
-      return (data != null ? _i121.ObjectWithEnumEnhanced.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i122.ObjectWithHalfVector?>()) {
-      return (data != null ? _i122.ObjectWithHalfVector.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i123.ObjectWithIndex?>()) {
-      return (data != null ? _i123.ObjectWithIndex.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i124.ObjectWithJsonb?>()) {
-      return (data != null ? _i124.ObjectWithJsonb.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i125.ObjectWithJsonbClassLevel?>()) {
-      return (data != null
-              ? _i125.ObjectWithJsonbClassLevel.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i126.ObjectWithMaps?>()) {
-      return (data != null ? _i126.ObjectWithMaps.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i127.ObjectWithObject?>()) {
-      return (data != null ? _i127.ObjectWithObject.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i128.ObjectWithParent?>()) {
-      return (data != null ? _i128.ObjectWithParent.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i129.ObjectWithSealedClass?>()) {
-      return (data != null ? _i129.ObjectWithSealedClass.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i130.ObjectWithSelfParent?>()) {
-      return (data != null ? _i130.ObjectWithSelfParent.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i131.ObjectWithSparseVector?>()) {
-      return (data != null ? _i131.ObjectWithSparseVector.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i132.ObjectWithUuid?>()) {
-      return (data != null ? _i132.ObjectWithUuid.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i133.ObjectWithVector?>()) {
-      return (data != null ? _i133.ObjectWithVector.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i134.RelatedUniqueData?>()) {
-      return (data != null ? _i134.RelatedUniqueData.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i135.ModelWithRequiredField?>()) {
-      return (data != null ? _i135.ModelWithRequiredField.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i136.SimpleData?>()) {
-      return (data != null ? _i136.SimpleData.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i137.SimpleDateTime?>()) {
-      return (data != null ? _i137.SimpleDateTime.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i138.TestEnum?>()) {
-      return (data != null ? _i138.TestEnum.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i139.TestEnumDefaultSerialization?>()) {
-      return (data != null
-              ? _i139.TestEnumDefaultSerialization.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i140.TestEnumEnhanced?>()) {
-      return (data != null ? _i140.TestEnumEnhanced.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i141.TestEnumEnhancedByName?>()) {
-      return (data != null ? _i141.TestEnumEnhancedByName.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i142.TestEnumStringified?>()) {
-      return (data != null ? _i142.TestEnumStringified.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i143.Types?>()) {
-      return (data != null ? _i143.Types.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i144.UniqueData?>()) {
-      return (data != null ? _i144.UniqueData.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i145.UniqueDataWithNonPersist?>()) {
-      return (data != null
-              ? _i145.UniqueDataWithNonPersist.fromJson(data)
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<_i146.UpsertTestModel?>()) {
-      return (data != null ? _i146.UpsertTestModel.fromJson(data) : null) as T;
-    }
-    if (t == List<_i8.EnrollmentInt>) {
-      return (data as List)
-              .map((e) => deserialize<_i8.EnrollmentInt>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i8.EnrollmentInt>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i8.EnrollmentInt>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i11.PlayerUuid>) {
-      return (data as List).map((e) => deserialize<_i11.PlayerUuid>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i11.PlayerUuid>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i11.PlayerUuid>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i15.OrderUuid>) {
-      return (data as List).map((e) => deserialize<_i15.OrderUuid>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i15.OrderUuid>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i15.OrderUuid>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i13.CommentInt>) {
-      return (data as List).map((e) => deserialize<_i13.CommentInt>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i13.CommentInt>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i13.CommentInt>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i20.ChangedIdTypeSelf>) {
-      return (data as List)
-              .map((e) => deserialize<_i20.ChangedIdTypeSelf>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i20.ChangedIdTypeSelf>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i20.ChangedIdTypeSelf>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i67.EmptyModelRelationItem>) {
-      return (data as List)
-              .map((e) => deserialize<_i67.EmptyModelRelationItem>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i67.EmptyModelRelationItem>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i67.EmptyModelRelationItem>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i74.Employee>) {
-      return (data as List).map((e) => deserialize<_i74.Employee>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i74.Employee>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i74.Employee>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i81.PersonWithLongTableName>) {
-      return (data as List)
-              .map((e) => deserialize<_i81.PersonWithLongTableName>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i81.PersonWithLongTableName>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i81.PersonWithLongTableName>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i80.OrganizationWithLongTableName>) {
-      return (data as List)
-              .map((e) => deserialize<_i80.OrganizationWithLongTableName>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i80.OrganizationWithLongTableName>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map(
-                      (e) => deserialize<_i80.OrganizationWithLongTableName>(e),
-                    )
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i83.LongImplicitIdField>) {
-      return (data as List)
-              .map((e) => deserialize<_i83.LongImplicitIdField>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i83.LongImplicitIdField>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i83.LongImplicitIdField>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i90.MultipleMaxFieldName>) {
-      return (data as List)
-              .map((e) => deserialize<_i90.MultipleMaxFieldName>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i90.MultipleMaxFieldName>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i90.MultipleMaxFieldName>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i86.UserNote>) {
-      return (data as List).map((e) => deserialize<_i86.UserNote>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i86.UserNote>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i86.UserNote>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i89.UserNoteWithALongName>) {
-      return (data as List)
-              .map((e) => deserialize<_i89.UserNoteWithALongName>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i89.UserNoteWithALongName>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i89.UserNoteWithALongName>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i93.Person>) {
-      return (data as List).map((e) => deserialize<_i93.Person>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i93.Person>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<_i93.Person>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i92.Organization>) {
-      return (data as List)
-              .map((e) => deserialize<_i92.Organization>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i92.Organization>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i92.Organization>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i95.Enrollment>) {
-      return (data as List).map((e) => deserialize<_i95.Enrollment>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i95.Enrollment>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i95.Enrollment>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i98.Player>) {
-      return (data as List).map((e) => deserialize<_i98.Player>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i98.Player>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<_i98.Player>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i104.Order>) {
-      return (data as List).map((e) => deserialize<_i104.Order>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i104.Order>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<_i104.Order>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i103.Chapter>) {
-      return (data as List).map((e) => deserialize<_i103.Chapter>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i103.Chapter>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i103.Chapter>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i100.Comment>) {
-      return (data as List).map((e) => deserialize<_i100.Comment>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i100.Comment>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i100.Comment>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i109.Blocking>) {
-      return (data as List).map((e) => deserialize<_i109.Blocking>(e)).toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i109.Blocking>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i109.Blocking>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i111.Cat>) {
-      return (data as List).map((e) => deserialize<_i111.Cat>(e)).toList() as T;
-    }
-    if (t == _i1.getType<List<_i111.Cat>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<_i111.Cat>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == dynamic) {
-      return deserializeDynamicFieldValue(data) as T;
-    }
-    if (t == List<dynamic>) {
-      return (data as List).map((e) => deserialize<dynamic>(e)).toList() as T;
-    }
-    if (t == Map<String, dynamic>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(deserialize<String>(k), deserialize<dynamic>(v)),
-          )
-          as T;
-    }
-    if (t == Set<dynamic>) {
-      return (data as List).map((e) => deserialize<dynamic>(e)).toSet() as T;
-    }
-    if (t == Map<dynamic, dynamic>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) => MapEntry(
-                deserialize<dynamic>(e['k']),
-                deserialize<dynamic>(e['v']),
-              ),
-            ),
-          )
-          as T;
-    }
-    if (t == List<_i138.TestEnum>) {
-      return (data as List).map((e) => deserialize<_i138.TestEnum>(e)).toList()
-          as T;
-    }
-    if (t == List<_i138.TestEnum?>) {
-      return (data as List).map((e) => deserialize<_i138.TestEnum?>(e)).toList()
-          as T;
-    }
-    if (t == List<List<_i138.TestEnum>>) {
-      return (data as List)
-              .map((e) => deserialize<List<_i138.TestEnum>>(e))
-              .toList()
-          as T;
-    }
-    if (t == List<_i140.TestEnumEnhanced>) {
-      return (data as List)
-              .map((e) => deserialize<_i140.TestEnumEnhanced>(e))
-              .toList()
-          as T;
-    }
-    if (t == List<_i141.TestEnumEnhancedByName>) {
-      return (data as List)
-              .map((e) => deserialize<_i141.TestEnumEnhancedByName>(e))
-              .toList()
-          as T;
-    }
-    if (t == List<String>) {
-      return (data as List).map((e) => deserialize<String>(e)).toList() as T;
-    }
-    if (t == Map<String, String>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(deserialize<String>(k), deserialize<String>(v)),
-          )
-          as T;
-    }
-    if (t == _i1.getType<List<String>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<String>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == Map<String, _i136.SimpleData>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<_i136.SimpleData>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == Map<String, int>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(deserialize<String>(k), deserialize<int>(v)),
-          )
-          as T;
-    }
-    if (t == Map<String, DateTime>) {
-      return (data as Map).map(
-            (k, v) =>
-                MapEntry(deserialize<String>(k), deserialize<DateTime>(v)),
-          )
-          as T;
-    }
-    if (t == Map<String, _i147.ByteData>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<_i147.ByteData>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == Map<String, Duration>) {
-      return (data as Map).map(
-            (k, v) =>
-                MapEntry(deserialize<String>(k), deserialize<Duration>(v)),
-          )
-          as T;
-    }
-    if (t == Map<String, _i1.UuidValue>) {
-      return (data as Map).map(
-            (k, v) =>
-                MapEntry(deserialize<String>(k), deserialize<_i1.UuidValue>(v)),
-          )
-          as T;
-    }
-    if (t == Map<String, _i136.SimpleData?>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<_i136.SimpleData?>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == Map<String, int?>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(deserialize<String>(k), deserialize<int?>(v)),
-          )
-          as T;
-    }
-    if (t == Map<String, String?>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(deserialize<String>(k), deserialize<String?>(v)),
-          )
-          as T;
-    }
-    if (t == Map<String, DateTime?>) {
-      return (data as Map).map(
-            (k, v) =>
-                MapEntry(deserialize<String>(k), deserialize<DateTime?>(v)),
-          )
-          as T;
-    }
-    if (t == Map<String, _i147.ByteData?>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<_i147.ByteData?>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == Map<String, Duration?>) {
-      return (data as Map).map(
-            (k, v) =>
-                MapEntry(deserialize<String>(k), deserialize<Duration?>(v)),
-          )
-          as T;
-    }
-    if (t == Map<String, _i1.UuidValue?>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<_i1.UuidValue?>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == Map<int, int>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) =>
-                  MapEntry(deserialize<int>(e['k']), deserialize<int>(e['v'])),
-            ),
-          )
-          as T;
-    }
-    if (t == List<_i136.SimpleData>) {
-      return (data as List)
-              .map((e) => deserialize<_i136.SimpleData>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i136.SimpleData>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i136.SimpleData>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<_i136.SimpleData?>) {
-      return (data as List)
-              .map((e) => deserialize<_i136.SimpleData?>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<_i136.SimpleData?>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<_i136.SimpleData?>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == List<List<_i136.SimpleData>>) {
-      return (data as List)
-              .map((e) => deserialize<List<_i136.SimpleData>>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<List<List<_i136.SimpleData>>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<List<_i136.SimpleData>>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == Map<String, List<List<Map<int, _i136.SimpleData>>?>>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<List<List<Map<int, _i136.SimpleData>>?>>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == List<List<Map<int, _i136.SimpleData>>?>) {
-      return (data as List)
-              .map((e) => deserialize<List<Map<int, _i136.SimpleData>>?>(e))
-              .toList()
-          as T;
-    }
-    if (t == List<Map<int, _i136.SimpleData>>) {
-      return (data as List)
-              .map((e) => deserialize<Map<int, _i136.SimpleData>>(e))
-              .toList()
-          as T;
-    }
-    if (t == Map<int, _i136.SimpleData>) {
-      return Map.fromEntries(
-            (data as List).map(
-              (e) => MapEntry(
-                deserialize<int>(e['k']),
-                deserialize<_i136.SimpleData>(e['v']),
-              ),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<List<Map<int, _i136.SimpleData>>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<Map<int, _i136.SimpleData>>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t ==
-        _i1.getType<Map<String, List<List<Map<int, _i136.SimpleData>>?>>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) => MapEntry(
-                    deserialize<String>(k),
-                    deserialize<List<List<Map<int, _i136.SimpleData>>?>>(v),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<List<Map<int, _i136.SimpleData>>?>()) {
-      return (data != null
-              ? (data as List)
-                    .map((e) => deserialize<Map<int, _i136.SimpleData>>(e))
-                    .toList()
-              : null)
-          as T;
-    }
-    if (t == Map<String, Map<int, _i136.SimpleData>>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(
-              deserialize<String>(k),
-              deserialize<Map<int, _i136.SimpleData>>(v),
-            ),
-          )
-          as T;
-    }
-    if (t == _i1.getType<Map<String, Map<int, _i136.SimpleData>>?>()) {
-      return (data != null
-              ? (data as Map).map(
-                  (k, v) => MapEntry(
-                    deserialize<String>(k),
-                    deserialize<Map<int, _i136.SimpleData>>(v),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == List<_i78.SealedParent>) {
-      return (data as List)
-              .map((e) => deserialize<_i78.SealedParent>(e))
-              .toList()
-          as T;
-    }
-    if (t == List<int>) {
-      return (data as List).map((e) => deserialize<int>(e)).toList() as T;
-    }
-    if (t == _i1.getType<List<int>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<int>(e)).toList()
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<Map<int, int>?>()) {
-      return (data != null
-              ? Map.fromEntries(
-                  (data as List).map(
-                    (e) => MapEntry(
-                      deserialize<int>(e['k']),
-                      deserialize<int>(e['v']),
-                    ),
-                  ),
-                )
-              : null)
-          as T;
-    }
-    if (t == Set<int>) {
-      return (data as List).map((e) => deserialize<int>(e)).toSet() as T;
-    }
-    if (t == _i1.getType<Set<int>?>()) {
-      return (data != null
-              ? (data as List).map((e) => deserialize<int>(e)).toSet()
-              : null)
-          as T;
-    }
-    if (t == _i1.getType<(String, {Uri? optionalUri})?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<String>(((data as Map)['p'] as List)[0]),
-                  optionalUri: ((data)['n'] as Map)['optionalUri'] == null
-                      ? null
-                      : deserialize<Uri>(data['n']['optionalUri']),
-                )
-                as T;
-    }
-    if (t == List<_i148.SimpleData>) {
-      return (data as List)
-              .map((e) => deserialize<_i148.SimpleData>(e))
-              .toList()
-          as T;
-    }
-    if (t == _i1.getType<(String, {Uri? optionalUri})?>()) {
-      return (data == null)
-          ? null as T
-          : (
-                  deserialize<String>(((data as Map)['p'] as List)[0]),
-                  optionalUri: ((data)['n'] as Map)['optionalUri'] == null
-                      ? null
-                      : deserialize<Uri>(data['n']['optionalUri']),
-                )
-                as T;
+    final fn = _deserializers[t];
+    if (fn != null) {
+      return fn(data, this) as T;
     }
     try {
       return _i3.Protocol().deserialize<T>(data, t);
@@ -8639,5 +7087,1087 @@ class Protocol extends _i1.DatabaseSerializationManager {
     }
 
     return obj;
+  }
+
+  static Map<Type, dynamic Function(dynamic, Protocol)> _buildDeserializers() {
+    final map = <Type, dynamic Function(dynamic, Protocol)>{};
+    map[_i7.CourseUuid] = (data, protocol) => _i7.CourseUuid.fromJson(data);
+    map[_i8.EnrollmentInt] = (data, protocol) =>
+        _i8.EnrollmentInt.fromJson(data);
+    map[_i9.StudentUuid] = (data, protocol) => _i9.StudentUuid.fromJson(data);
+    map[_i10.ArenaUuid] = (data, protocol) => _i10.ArenaUuid.fromJson(data);
+    map[_i11.PlayerUuid] = (data, protocol) => _i11.PlayerUuid.fromJson(data);
+    map[_i12.TeamInt] = (data, protocol) => _i12.TeamInt.fromJson(data);
+    map[_i13.CommentInt] = (data, protocol) => _i13.CommentInt.fromJson(data);
+    map[_i14.CustomerInt] = (data, protocol) => _i14.CustomerInt.fromJson(data);
+    map[_i15.OrderUuid] = (data, protocol) => _i15.OrderUuid.fromJson(data);
+    map[_i16.AddressUuid] = (data, protocol) => _i16.AddressUuid.fromJson(data);
+    map[_i17.CitizenInt] = (data, protocol) => _i17.CitizenInt.fromJson(data);
+    map[_i18.CompanyUuid] = (data, protocol) => _i18.CompanyUuid.fromJson(data);
+    map[_i19.TownInt] = (data, protocol) => _i19.TownInt.fromJson(data);
+    map[_i20.ChangedIdTypeSelf] = (data, protocol) =>
+        _i20.ChangedIdTypeSelf.fromJson(data);
+    map[_i21.ServerOnlyChangedIdFieldClass] = (data, protocol) =>
+        _i21.ServerOnlyChangedIdFieldClass.fromJson(data);
+    map[_i22.BigIntDefault] = (data, protocol) =>
+        _i22.BigIntDefault.fromJson(data);
+    map[_i23.BigIntDefaultMix] = (data, protocol) =>
+        _i23.BigIntDefaultMix.fromJson(data);
+    map[_i24.BigIntDefaultModel] = (data, protocol) =>
+        _i24.BigIntDefaultModel.fromJson(data);
+    map[_i25.BigIntDefaultPersist] = (data, protocol) =>
+        _i25.BigIntDefaultPersist.fromJson(data);
+    map[_i26.BoolDefault] = (data, protocol) => _i26.BoolDefault.fromJson(data);
+    map[_i27.BoolDefaultMix] = (data, protocol) =>
+        _i27.BoolDefaultMix.fromJson(data);
+    map[_i28.BoolDefaultModel] = (data, protocol) =>
+        _i28.BoolDefaultModel.fromJson(data);
+    map[_i29.BoolDefaultPersist] = (data, protocol) =>
+        _i29.BoolDefaultPersist.fromJson(data);
+    map[_i30.DateTimeDefault] = (data, protocol) =>
+        _i30.DateTimeDefault.fromJson(data);
+    map[_i31.DateTimeDefaultMix] = (data, protocol) =>
+        _i31.DateTimeDefaultMix.fromJson(data);
+    map[_i32.DateTimeDefaultModel] = (data, protocol) =>
+        _i32.DateTimeDefaultModel.fromJson(data);
+    map[_i33.DateTimeDefaultPersist] = (data, protocol) =>
+        _i33.DateTimeDefaultPersist.fromJson(data);
+    map[_i34.DoubleDefault] = (data, protocol) =>
+        _i34.DoubleDefault.fromJson(data);
+    map[_i35.DoubleDefaultMix] = (data, protocol) =>
+        _i35.DoubleDefaultMix.fromJson(data);
+    map[_i36.DoubleDefaultModel] = (data, protocol) =>
+        _i36.DoubleDefaultModel.fromJson(data);
+    map[_i37.DoubleDefaultPersist] = (data, protocol) =>
+        _i37.DoubleDefaultPersist.fromJson(data);
+    map[_i38.DurationDefault] = (data, protocol) =>
+        _i38.DurationDefault.fromJson(data);
+    map[_i39.DurationDefaultMix] = (data, protocol) =>
+        _i39.DurationDefaultMix.fromJson(data);
+    map[_i40.DurationDefaultModel] = (data, protocol) =>
+        _i40.DurationDefaultModel.fromJson(data);
+    map[_i41.DurationDefaultPersist] = (data, protocol) =>
+        _i41.DurationDefaultPersist.fromJson(data);
+    map[_i42.EnumDefault] = (data, protocol) => _i42.EnumDefault.fromJson(data);
+    map[_i43.EnumDefaultMix] = (data, protocol) =>
+        _i43.EnumDefaultMix.fromJson(data);
+    map[_i44.EnumDefaultModel] = (data, protocol) =>
+        _i44.EnumDefaultModel.fromJson(data);
+    map[_i45.EnumDefaultPersist] = (data, protocol) =>
+        _i45.EnumDefaultPersist.fromJson(data);
+    map[_i46.ByIndexEnum] = (data, protocol) => _i46.ByIndexEnum.fromJson(data);
+    map[_i47.ByNameEnum] = (data, protocol) => _i47.ByNameEnum.fromJson(data);
+    map[_i48.DefaultValueEnum] = (data, protocol) =>
+        _i48.DefaultValueEnum.fromJson(data);
+    map[_i49.DefaultException] = (data, protocol) =>
+        _i49.DefaultException.fromJson(data);
+    map[_i50.IntDefault] = (data, protocol) => _i50.IntDefault.fromJson(data);
+    map[_i51.IntDefaultMix] = (data, protocol) =>
+        _i51.IntDefaultMix.fromJson(data);
+    map[_i52.IntDefaultModel] = (data, protocol) =>
+        _i52.IntDefaultModel.fromJson(data);
+    map[_i53.IntDefaultPersist] = (data, protocol) =>
+        _i53.IntDefaultPersist.fromJson(data);
+    map[_i54.StringDefault] = (data, protocol) =>
+        _i54.StringDefault.fromJson(data);
+    map[_i55.StringDefaultMix] = (data, protocol) =>
+        _i55.StringDefaultMix.fromJson(data);
+    map[_i56.StringDefaultModel] = (data, protocol) =>
+        _i56.StringDefaultModel.fromJson(data);
+    map[_i57.StringDefaultPersist] = (data, protocol) =>
+        _i57.StringDefaultPersist.fromJson(data);
+    map[_i58.UriDefault] = (data, protocol) => _i58.UriDefault.fromJson(data);
+    map[_i59.UriDefaultMix] = (data, protocol) =>
+        _i59.UriDefaultMix.fromJson(data);
+    map[_i60.UriDefaultModel] = (data, protocol) =>
+        _i60.UriDefaultModel.fromJson(data);
+    map[_i61.UriDefaultPersist] = (data, protocol) =>
+        _i61.UriDefaultPersist.fromJson(data);
+    map[_i62.UuidDefault] = (data, protocol) => _i62.UuidDefault.fromJson(data);
+    map[_i63.UuidDefaultMix] = (data, protocol) =>
+        _i63.UuidDefaultMix.fromJson(data);
+    map[_i64.UuidDefaultModel] = (data, protocol) =>
+        _i64.UuidDefaultModel.fromJson(data);
+    map[_i65.UuidDefaultPersist] = (data, protocol) =>
+        _i65.UuidDefaultPersist.fromJson(data);
+    map[_i66.EmptyModel] = (data, protocol) => _i66.EmptyModel.fromJson(data);
+    map[_i67.EmptyModelRelationItem] = (data, protocol) =>
+        _i67.EmptyModelRelationItem.fromJson(data);
+    map[_i68.EmptyModelWithTable] = (data, protocol) =>
+        _i68.EmptyModelWithTable.fromJson(data);
+    map[_i69.RelationEmptyModel] = (data, protocol) =>
+        _i69.RelationEmptyModel.fromJson(data);
+    map[_i70.ChildClassExplicitColumn] = (data, protocol) =>
+        _i70.ChildClassExplicitColumn.fromJson(data);
+    map[_i71.NonTableParentClass] = (data, protocol) =>
+        _i71.NonTableParentClass.fromJson(data);
+    map[_i72.ModifiedColumnName] = (data, protocol) =>
+        _i72.ModifiedColumnName.fromJson(data);
+    map[_i73.Department] = (data, protocol) => _i73.Department.fromJson(data);
+    map[_i74.Employee] = (data, protocol) => _i74.Employee.fromJson(data);
+    map[_i75.Contractor] = (data, protocol) => _i75.Contractor.fromJson(data);
+    map[_i76.Service] = (data, protocol) => _i76.Service.fromJson(data);
+    map[_i77.TableWithExplicitColumnName] = (data, protocol) =>
+        _i77.TableWithExplicitColumnName.fromJson(data);
+    map[_i78.SealedGrandChild] = (data, protocol) =>
+        _i78.SealedGrandChild.fromJson(data);
+    map[_i78.SealedChild] = (data, protocol) => _i78.SealedChild.fromJson(data);
+    map[_i78.SealedOtherChild] = (data, protocol) =>
+        _i78.SealedOtherChild.fromJson(data);
+    map[_i79.CityWithLongTableName] = (data, protocol) =>
+        _i79.CityWithLongTableName.fromJson(data);
+    map[_i80.OrganizationWithLongTableName] = (data, protocol) =>
+        _i80.OrganizationWithLongTableName.fromJson(data);
+    map[_i81.PersonWithLongTableName] = (data, protocol) =>
+        _i81.PersonWithLongTableName.fromJson(data);
+    map[_i82.MaxFieldName] = (data, protocol) =>
+        _i82.MaxFieldName.fromJson(data);
+    map[_i83.LongImplicitIdField] = (data, protocol) =>
+        _i83.LongImplicitIdField.fromJson(data);
+    map[_i84.LongImplicitIdFieldCollection] = (data, protocol) =>
+        _i84.LongImplicitIdFieldCollection.fromJson(data);
+    map[_i85.RelationToMultipleMaxFieldName] = (data, protocol) =>
+        _i85.RelationToMultipleMaxFieldName.fromJson(data);
+    map[_i86.UserNote] = (data, protocol) => _i86.UserNote.fromJson(data);
+    map[_i87.UserNoteCollection] = (data, protocol) =>
+        _i87.UserNoteCollection.fromJson(data);
+    map[_i88.UserNoteCollectionWithALongName] = (data, protocol) =>
+        _i88.UserNoteCollectionWithALongName.fromJson(data);
+    map[_i89.UserNoteWithALongName] = (data, protocol) =>
+        _i89.UserNoteWithALongName.fromJson(data);
+    map[_i90.MultipleMaxFieldName] = (data, protocol) =>
+        _i90.MultipleMaxFieldName.fromJson(data);
+    map[_i91.City] = (data, protocol) => _i91.City.fromJson(data);
+    map[_i92.Organization] = (data, protocol) =>
+        _i92.Organization.fromJson(data);
+    map[_i93.Person] = (data, protocol) => _i93.Person.fromJson(data);
+    map[_i94.Course] = (data, protocol) => _i94.Course.fromJson(data);
+    map[_i95.Enrollment] = (data, protocol) => _i95.Enrollment.fromJson(data);
+    map[_i96.Student] = (data, protocol) => _i96.Student.fromJson(data);
+    map[_i97.Arena] = (data, protocol) => _i97.Arena.fromJson(data);
+    map[_i98.Player] = (data, protocol) => _i98.Player.fromJson(data);
+    map[_i99.Team] = (data, protocol) => _i99.Team.fromJson(data);
+    map[_i100.Comment] = (data, protocol) => _i100.Comment.fromJson(data);
+    map[_i101.Customer] = (data, protocol) => _i101.Customer.fromJson(data);
+    map[_i102.Book] = (data, protocol) => _i102.Book.fromJson(data);
+    map[_i103.Chapter] = (data, protocol) => _i103.Chapter.fromJson(data);
+    map[_i104.Order] = (data, protocol) => _i104.Order.fromJson(data);
+    map[_i105.Address] = (data, protocol) => _i105.Address.fromJson(data);
+    map[_i106.Citizen] = (data, protocol) => _i106.Citizen.fromJson(data);
+    map[_i107.Company] = (data, protocol) => _i107.Company.fromJson(data);
+    map[_i108.Town] = (data, protocol) => _i108.Town.fromJson(data);
+    map[_i109.Blocking] = (data, protocol) => _i109.Blocking.fromJson(data);
+    map[_i110.Member] = (data, protocol) => _i110.Member.fromJson(data);
+    map[_i111.Cat] = (data, protocol) => _i111.Cat.fromJson(data);
+    map[_i112.Post] = (data, protocol) => _i112.Post.fromJson(data);
+    map[_i113.NullsDistinctData] = (data, protocol) =>
+        _i113.NullsDistinctData.fromJson(data);
+    map[_i114.ObjectFieldPersist] = (data, protocol) =>
+        _i114.ObjectFieldPersist.fromJson(data);
+    map[_i115.ObjectFieldScopes] = (data, protocol) =>
+        _i115.ObjectFieldScopes.fromJson(data);
+    map[_i116.ObjectWithBit] = (data, protocol) =>
+        _i116.ObjectWithBit.fromJson(data);
+    map[_i117.ObjectWithByteData] = (data, protocol) =>
+        _i117.ObjectWithByteData.fromJson(data);
+    map[_i118.ObjectWithDuration] = (data, protocol) =>
+        _i118.ObjectWithDuration.fromJson(data);
+    map[_i119.ObjectWithDynamic] = (data, protocol) =>
+        _i119.ObjectWithDynamic.fromJson(data);
+    map[_i120.ObjectWithEnum] = (data, protocol) =>
+        _i120.ObjectWithEnum.fromJson(data);
+    map[_i121.ObjectWithEnumEnhanced] = (data, protocol) =>
+        _i121.ObjectWithEnumEnhanced.fromJson(data);
+    map[_i122.ObjectWithHalfVector] = (data, protocol) =>
+        _i122.ObjectWithHalfVector.fromJson(data);
+    map[_i123.ObjectWithIndex] = (data, protocol) =>
+        _i123.ObjectWithIndex.fromJson(data);
+    map[_i124.ObjectWithJsonb] = (data, protocol) =>
+        _i124.ObjectWithJsonb.fromJson(data);
+    map[_i125.ObjectWithJsonbClassLevel] = (data, protocol) =>
+        _i125.ObjectWithJsonbClassLevel.fromJson(data);
+    map[_i126.ObjectWithMaps] = (data, protocol) =>
+        _i126.ObjectWithMaps.fromJson(data);
+    map[_i127.ObjectWithObject] = (data, protocol) =>
+        _i127.ObjectWithObject.fromJson(data);
+    map[_i128.ObjectWithParent] = (data, protocol) =>
+        _i128.ObjectWithParent.fromJson(data);
+    map[_i129.ObjectWithSealedClass] = (data, protocol) =>
+        _i129.ObjectWithSealedClass.fromJson(data);
+    map[_i130.ObjectWithSelfParent] = (data, protocol) =>
+        _i130.ObjectWithSelfParent.fromJson(data);
+    map[_i131.ObjectWithSparseVector] = (data, protocol) =>
+        _i131.ObjectWithSparseVector.fromJson(data);
+    map[_i132.ObjectWithUuid] = (data, protocol) =>
+        _i132.ObjectWithUuid.fromJson(data);
+    map[_i133.ObjectWithVector] = (data, protocol) =>
+        _i133.ObjectWithVector.fromJson(data);
+    map[_i134.RelatedUniqueData] = (data, protocol) =>
+        _i134.RelatedUniqueData.fromJson(data);
+    map[_i135.ModelWithRequiredField] = (data, protocol) =>
+        _i135.ModelWithRequiredField.fromJson(data);
+    map[_i136.SimpleData] = (data, protocol) => _i136.SimpleData.fromJson(data);
+    map[_i137.SimpleDateTime] = (data, protocol) =>
+        _i137.SimpleDateTime.fromJson(data);
+    map[_i138.TestEnum] = (data, protocol) => _i138.TestEnum.fromJson(data);
+    map[_i139.TestEnumDefaultSerialization] = (data, protocol) =>
+        _i139.TestEnumDefaultSerialization.fromJson(data);
+    map[_i140.TestEnumEnhanced] = (data, protocol) =>
+        _i140.TestEnumEnhanced.fromJson(data);
+    map[_i141.TestEnumEnhancedByName] = (data, protocol) =>
+        _i141.TestEnumEnhancedByName.fromJson(data);
+    map[_i142.TestEnumStringified] = (data, protocol) =>
+        _i142.TestEnumStringified.fromJson(data);
+    map[_i143.Types] = (data, protocol) => _i143.Types.fromJson(data);
+    map[_i144.UniqueData] = (data, protocol) => _i144.UniqueData.fromJson(data);
+    map[_i145.UniqueDataWithNonPersist] = (data, protocol) =>
+        _i145.UniqueDataWithNonPersist.fromJson(data);
+    map[_i146.UpsertTestModel] = (data, protocol) =>
+        _i146.UpsertTestModel.fromJson(data);
+    map[_i1.getType<_i7.CourseUuid?>()] = (data, protocol) =>
+        (data != null ? _i7.CourseUuid.fromJson(data) : null);
+    map[_i1.getType<_i8.EnrollmentInt?>()] = (data, protocol) =>
+        (data != null ? _i8.EnrollmentInt.fromJson(data) : null);
+    map[_i1.getType<_i9.StudentUuid?>()] = (data, protocol) =>
+        (data != null ? _i9.StudentUuid.fromJson(data) : null);
+    map[_i1.getType<_i10.ArenaUuid?>()] = (data, protocol) =>
+        (data != null ? _i10.ArenaUuid.fromJson(data) : null);
+    map[_i1.getType<_i11.PlayerUuid?>()] = (data, protocol) =>
+        (data != null ? _i11.PlayerUuid.fromJson(data) : null);
+    map[_i1.getType<_i12.TeamInt?>()] = (data, protocol) =>
+        (data != null ? _i12.TeamInt.fromJson(data) : null);
+    map[_i1.getType<_i13.CommentInt?>()] = (data, protocol) =>
+        (data != null ? _i13.CommentInt.fromJson(data) : null);
+    map[_i1.getType<_i14.CustomerInt?>()] = (data, protocol) =>
+        (data != null ? _i14.CustomerInt.fromJson(data) : null);
+    map[_i1.getType<_i15.OrderUuid?>()] = (data, protocol) =>
+        (data != null ? _i15.OrderUuid.fromJson(data) : null);
+    map[_i1.getType<_i16.AddressUuid?>()] = (data, protocol) =>
+        (data != null ? _i16.AddressUuid.fromJson(data) : null);
+    map[_i1.getType<_i17.CitizenInt?>()] = (data, protocol) =>
+        (data != null ? _i17.CitizenInt.fromJson(data) : null);
+    map[_i1.getType<_i18.CompanyUuid?>()] = (data, protocol) =>
+        (data != null ? _i18.CompanyUuid.fromJson(data) : null);
+    map[_i1.getType<_i19.TownInt?>()] = (data, protocol) =>
+        (data != null ? _i19.TownInt.fromJson(data) : null);
+    map[_i1.getType<_i20.ChangedIdTypeSelf?>()] = (data, protocol) =>
+        (data != null ? _i20.ChangedIdTypeSelf.fromJson(data) : null);
+    map[_i1
+        .getType<_i21.ServerOnlyChangedIdFieldClass?>()] = (data, protocol) =>
+        (data != null
+        ? _i21.ServerOnlyChangedIdFieldClass.fromJson(data)
+        : null);
+    map[_i1.getType<_i22.BigIntDefault?>()] = (data, protocol) =>
+        (data != null ? _i22.BigIntDefault.fromJson(data) : null);
+    map[_i1.getType<_i23.BigIntDefaultMix?>()] = (data, protocol) =>
+        (data != null ? _i23.BigIntDefaultMix.fromJson(data) : null);
+    map[_i1.getType<_i24.BigIntDefaultModel?>()] = (data, protocol) =>
+        (data != null ? _i24.BigIntDefaultModel.fromJson(data) : null);
+    map[_i1.getType<_i25.BigIntDefaultPersist?>()] = (data, protocol) =>
+        (data != null ? _i25.BigIntDefaultPersist.fromJson(data) : null);
+    map[_i1.getType<_i26.BoolDefault?>()] = (data, protocol) =>
+        (data != null ? _i26.BoolDefault.fromJson(data) : null);
+    map[_i1.getType<_i27.BoolDefaultMix?>()] = (data, protocol) =>
+        (data != null ? _i27.BoolDefaultMix.fromJson(data) : null);
+    map[_i1.getType<_i28.BoolDefaultModel?>()] = (data, protocol) =>
+        (data != null ? _i28.BoolDefaultModel.fromJson(data) : null);
+    map[_i1.getType<_i29.BoolDefaultPersist?>()] = (data, protocol) =>
+        (data != null ? _i29.BoolDefaultPersist.fromJson(data) : null);
+    map[_i1.getType<_i30.DateTimeDefault?>()] = (data, protocol) =>
+        (data != null ? _i30.DateTimeDefault.fromJson(data) : null);
+    map[_i1.getType<_i31.DateTimeDefaultMix?>()] = (data, protocol) =>
+        (data != null ? _i31.DateTimeDefaultMix.fromJson(data) : null);
+    map[_i1.getType<_i32.DateTimeDefaultModel?>()] = (data, protocol) =>
+        (data != null ? _i32.DateTimeDefaultModel.fromJson(data) : null);
+    map[_i1.getType<_i33.DateTimeDefaultPersist?>()] = (data, protocol) =>
+        (data != null ? _i33.DateTimeDefaultPersist.fromJson(data) : null);
+    map[_i1.getType<_i34.DoubleDefault?>()] = (data, protocol) =>
+        (data != null ? _i34.DoubleDefault.fromJson(data) : null);
+    map[_i1.getType<_i35.DoubleDefaultMix?>()] = (data, protocol) =>
+        (data != null ? _i35.DoubleDefaultMix.fromJson(data) : null);
+    map[_i1.getType<_i36.DoubleDefaultModel?>()] = (data, protocol) =>
+        (data != null ? _i36.DoubleDefaultModel.fromJson(data) : null);
+    map[_i1.getType<_i37.DoubleDefaultPersist?>()] = (data, protocol) =>
+        (data != null ? _i37.DoubleDefaultPersist.fromJson(data) : null);
+    map[_i1.getType<_i38.DurationDefault?>()] = (data, protocol) =>
+        (data != null ? _i38.DurationDefault.fromJson(data) : null);
+    map[_i1.getType<_i39.DurationDefaultMix?>()] = (data, protocol) =>
+        (data != null ? _i39.DurationDefaultMix.fromJson(data) : null);
+    map[_i1.getType<_i40.DurationDefaultModel?>()] = (data, protocol) =>
+        (data != null ? _i40.DurationDefaultModel.fromJson(data) : null);
+    map[_i1.getType<_i41.DurationDefaultPersist?>()] = (data, protocol) =>
+        (data != null ? _i41.DurationDefaultPersist.fromJson(data) : null);
+    map[_i1.getType<_i42.EnumDefault?>()] = (data, protocol) =>
+        (data != null ? _i42.EnumDefault.fromJson(data) : null);
+    map[_i1.getType<_i43.EnumDefaultMix?>()] = (data, protocol) =>
+        (data != null ? _i43.EnumDefaultMix.fromJson(data) : null);
+    map[_i1.getType<_i44.EnumDefaultModel?>()] = (data, protocol) =>
+        (data != null ? _i44.EnumDefaultModel.fromJson(data) : null);
+    map[_i1.getType<_i45.EnumDefaultPersist?>()] = (data, protocol) =>
+        (data != null ? _i45.EnumDefaultPersist.fromJson(data) : null);
+    map[_i1.getType<_i46.ByIndexEnum?>()] = (data, protocol) =>
+        (data != null ? _i46.ByIndexEnum.fromJson(data) : null);
+    map[_i1.getType<_i47.ByNameEnum?>()] = (data, protocol) =>
+        (data != null ? _i47.ByNameEnum.fromJson(data) : null);
+    map[_i1.getType<_i48.DefaultValueEnum?>()] = (data, protocol) =>
+        (data != null ? _i48.DefaultValueEnum.fromJson(data) : null);
+    map[_i1.getType<_i49.DefaultException?>()] = (data, protocol) =>
+        (data != null ? _i49.DefaultException.fromJson(data) : null);
+    map[_i1.getType<_i50.IntDefault?>()] = (data, protocol) =>
+        (data != null ? _i50.IntDefault.fromJson(data) : null);
+    map[_i1.getType<_i51.IntDefaultMix?>()] = (data, protocol) =>
+        (data != null ? _i51.IntDefaultMix.fromJson(data) : null);
+    map[_i1.getType<_i52.IntDefaultModel?>()] = (data, protocol) =>
+        (data != null ? _i52.IntDefaultModel.fromJson(data) : null);
+    map[_i1.getType<_i53.IntDefaultPersist?>()] = (data, protocol) =>
+        (data != null ? _i53.IntDefaultPersist.fromJson(data) : null);
+    map[_i1.getType<_i54.StringDefault?>()] = (data, protocol) =>
+        (data != null ? _i54.StringDefault.fromJson(data) : null);
+    map[_i1.getType<_i55.StringDefaultMix?>()] = (data, protocol) =>
+        (data != null ? _i55.StringDefaultMix.fromJson(data) : null);
+    map[_i1.getType<_i56.StringDefaultModel?>()] = (data, protocol) =>
+        (data != null ? _i56.StringDefaultModel.fromJson(data) : null);
+    map[_i1.getType<_i57.StringDefaultPersist?>()] = (data, protocol) =>
+        (data != null ? _i57.StringDefaultPersist.fromJson(data) : null);
+    map[_i1.getType<_i58.UriDefault?>()] = (data, protocol) =>
+        (data != null ? _i58.UriDefault.fromJson(data) : null);
+    map[_i1.getType<_i59.UriDefaultMix?>()] = (data, protocol) =>
+        (data != null ? _i59.UriDefaultMix.fromJson(data) : null);
+    map[_i1.getType<_i60.UriDefaultModel?>()] = (data, protocol) =>
+        (data != null ? _i60.UriDefaultModel.fromJson(data) : null);
+    map[_i1.getType<_i61.UriDefaultPersist?>()] = (data, protocol) =>
+        (data != null ? _i61.UriDefaultPersist.fromJson(data) : null);
+    map[_i1.getType<_i62.UuidDefault?>()] = (data, protocol) =>
+        (data != null ? _i62.UuidDefault.fromJson(data) : null);
+    map[_i1.getType<_i63.UuidDefaultMix?>()] = (data, protocol) =>
+        (data != null ? _i63.UuidDefaultMix.fromJson(data) : null);
+    map[_i1.getType<_i64.UuidDefaultModel?>()] = (data, protocol) =>
+        (data != null ? _i64.UuidDefaultModel.fromJson(data) : null);
+    map[_i1.getType<_i65.UuidDefaultPersist?>()] = (data, protocol) =>
+        (data != null ? _i65.UuidDefaultPersist.fromJson(data) : null);
+    map[_i1.getType<_i66.EmptyModel?>()] = (data, protocol) =>
+        (data != null ? _i66.EmptyModel.fromJson(data) : null);
+    map[_i1.getType<_i67.EmptyModelRelationItem?>()] = (data, protocol) =>
+        (data != null ? _i67.EmptyModelRelationItem.fromJson(data) : null);
+    map[_i1.getType<_i68.EmptyModelWithTable?>()] = (data, protocol) =>
+        (data != null ? _i68.EmptyModelWithTable.fromJson(data) : null);
+    map[_i1.getType<_i69.RelationEmptyModel?>()] = (data, protocol) =>
+        (data != null ? _i69.RelationEmptyModel.fromJson(data) : null);
+    map[_i1.getType<_i70.ChildClassExplicitColumn?>()] = (data, protocol) =>
+        (data != null ? _i70.ChildClassExplicitColumn.fromJson(data) : null);
+    map[_i1.getType<_i71.NonTableParentClass?>()] = (data, protocol) =>
+        (data != null ? _i71.NonTableParentClass.fromJson(data) : null);
+    map[_i1.getType<_i72.ModifiedColumnName?>()] = (data, protocol) =>
+        (data != null ? _i72.ModifiedColumnName.fromJson(data) : null);
+    map[_i1.getType<_i73.Department?>()] = (data, protocol) =>
+        (data != null ? _i73.Department.fromJson(data) : null);
+    map[_i1.getType<_i74.Employee?>()] = (data, protocol) =>
+        (data != null ? _i74.Employee.fromJson(data) : null);
+    map[_i1.getType<_i75.Contractor?>()] = (data, protocol) =>
+        (data != null ? _i75.Contractor.fromJson(data) : null);
+    map[_i1.getType<_i76.Service?>()] = (data, protocol) =>
+        (data != null ? _i76.Service.fromJson(data) : null);
+    map[_i1.getType<_i77.TableWithExplicitColumnName?>()] = (data, protocol) =>
+        (data != null ? _i77.TableWithExplicitColumnName.fromJson(data) : null);
+    map[_i1.getType<_i78.SealedGrandChild?>()] = (data, protocol) =>
+        (data != null ? _i78.SealedGrandChild.fromJson(data) : null);
+    map[_i1.getType<_i78.SealedChild?>()] = (data, protocol) =>
+        (data != null ? _i78.SealedChild.fromJson(data) : null);
+    map[_i1.getType<_i78.SealedOtherChild?>()] = (data, protocol) =>
+        (data != null ? _i78.SealedOtherChild.fromJson(data) : null);
+    map[_i1.getType<_i79.CityWithLongTableName?>()] = (data, protocol) =>
+        (data != null ? _i79.CityWithLongTableName.fromJson(data) : null);
+    map[_i1
+        .getType<_i80.OrganizationWithLongTableName?>()] = (data, protocol) =>
+        (data != null
+        ? _i80.OrganizationWithLongTableName.fromJson(data)
+        : null);
+    map[_i1.getType<_i81.PersonWithLongTableName?>()] = (data, protocol) =>
+        (data != null ? _i81.PersonWithLongTableName.fromJson(data) : null);
+    map[_i1.getType<_i82.MaxFieldName?>()] = (data, protocol) =>
+        (data != null ? _i82.MaxFieldName.fromJson(data) : null);
+    map[_i1.getType<_i83.LongImplicitIdField?>()] = (data, protocol) =>
+        (data != null ? _i83.LongImplicitIdField.fromJson(data) : null);
+    map[_i1
+        .getType<_i84.LongImplicitIdFieldCollection?>()] = (data, protocol) =>
+        (data != null
+        ? _i84.LongImplicitIdFieldCollection.fromJson(data)
+        : null);
+    map[_i1
+        .getType<_i85.RelationToMultipleMaxFieldName?>()] = (data, protocol) =>
+        (data != null
+        ? _i85.RelationToMultipleMaxFieldName.fromJson(data)
+        : null);
+    map[_i1.getType<_i86.UserNote?>()] = (data, protocol) =>
+        (data != null ? _i86.UserNote.fromJson(data) : null);
+    map[_i1.getType<_i87.UserNoteCollection?>()] = (data, protocol) =>
+        (data != null ? _i87.UserNoteCollection.fromJson(data) : null);
+    map[_i1
+        .getType<_i88.UserNoteCollectionWithALongName?>()] = (data, protocol) =>
+        (data != null
+        ? _i88.UserNoteCollectionWithALongName.fromJson(data)
+        : null);
+    map[_i1.getType<_i89.UserNoteWithALongName?>()] = (data, protocol) =>
+        (data != null ? _i89.UserNoteWithALongName.fromJson(data) : null);
+    map[_i1.getType<_i90.MultipleMaxFieldName?>()] = (data, protocol) =>
+        (data != null ? _i90.MultipleMaxFieldName.fromJson(data) : null);
+    map[_i1.getType<_i91.City?>()] = (data, protocol) =>
+        (data != null ? _i91.City.fromJson(data) : null);
+    map[_i1.getType<_i92.Organization?>()] = (data, protocol) =>
+        (data != null ? _i92.Organization.fromJson(data) : null);
+    map[_i1.getType<_i93.Person?>()] = (data, protocol) =>
+        (data != null ? _i93.Person.fromJson(data) : null);
+    map[_i1.getType<_i94.Course?>()] = (data, protocol) =>
+        (data != null ? _i94.Course.fromJson(data) : null);
+    map[_i1.getType<_i95.Enrollment?>()] = (data, protocol) =>
+        (data != null ? _i95.Enrollment.fromJson(data) : null);
+    map[_i1.getType<_i96.Student?>()] = (data, protocol) =>
+        (data != null ? _i96.Student.fromJson(data) : null);
+    map[_i1.getType<_i97.Arena?>()] = (data, protocol) =>
+        (data != null ? _i97.Arena.fromJson(data) : null);
+    map[_i1.getType<_i98.Player?>()] = (data, protocol) =>
+        (data != null ? _i98.Player.fromJson(data) : null);
+    map[_i1.getType<_i99.Team?>()] = (data, protocol) =>
+        (data != null ? _i99.Team.fromJson(data) : null);
+    map[_i1.getType<_i100.Comment?>()] = (data, protocol) =>
+        (data != null ? _i100.Comment.fromJson(data) : null);
+    map[_i1.getType<_i101.Customer?>()] = (data, protocol) =>
+        (data != null ? _i101.Customer.fromJson(data) : null);
+    map[_i1.getType<_i102.Book?>()] = (data, protocol) =>
+        (data != null ? _i102.Book.fromJson(data) : null);
+    map[_i1.getType<_i103.Chapter?>()] = (data, protocol) =>
+        (data != null ? _i103.Chapter.fromJson(data) : null);
+    map[_i1.getType<_i104.Order?>()] = (data, protocol) =>
+        (data != null ? _i104.Order.fromJson(data) : null);
+    map[_i1.getType<_i105.Address?>()] = (data, protocol) =>
+        (data != null ? _i105.Address.fromJson(data) : null);
+    map[_i1.getType<_i106.Citizen?>()] = (data, protocol) =>
+        (data != null ? _i106.Citizen.fromJson(data) : null);
+    map[_i1.getType<_i107.Company?>()] = (data, protocol) =>
+        (data != null ? _i107.Company.fromJson(data) : null);
+    map[_i1.getType<_i108.Town?>()] = (data, protocol) =>
+        (data != null ? _i108.Town.fromJson(data) : null);
+    map[_i1.getType<_i109.Blocking?>()] = (data, protocol) =>
+        (data != null ? _i109.Blocking.fromJson(data) : null);
+    map[_i1.getType<_i110.Member?>()] = (data, protocol) =>
+        (data != null ? _i110.Member.fromJson(data) : null);
+    map[_i1.getType<_i111.Cat?>()] = (data, protocol) =>
+        (data != null ? _i111.Cat.fromJson(data) : null);
+    map[_i1.getType<_i112.Post?>()] = (data, protocol) =>
+        (data != null ? _i112.Post.fromJson(data) : null);
+    map[_i1.getType<_i113.NullsDistinctData?>()] = (data, protocol) =>
+        (data != null ? _i113.NullsDistinctData.fromJson(data) : null);
+    map[_i1.getType<_i114.ObjectFieldPersist?>()] = (data, protocol) =>
+        (data != null ? _i114.ObjectFieldPersist.fromJson(data) : null);
+    map[_i1.getType<_i115.ObjectFieldScopes?>()] = (data, protocol) =>
+        (data != null ? _i115.ObjectFieldScopes.fromJson(data) : null);
+    map[_i1.getType<_i116.ObjectWithBit?>()] = (data, protocol) =>
+        (data != null ? _i116.ObjectWithBit.fromJson(data) : null);
+    map[_i1.getType<_i117.ObjectWithByteData?>()] = (data, protocol) =>
+        (data != null ? _i117.ObjectWithByteData.fromJson(data) : null);
+    map[_i1.getType<_i118.ObjectWithDuration?>()] = (data, protocol) =>
+        (data != null ? _i118.ObjectWithDuration.fromJson(data) : null);
+    map[_i1.getType<_i119.ObjectWithDynamic?>()] = (data, protocol) =>
+        (data != null ? _i119.ObjectWithDynamic.fromJson(data) : null);
+    map[_i1.getType<_i120.ObjectWithEnum?>()] = (data, protocol) =>
+        (data != null ? _i120.ObjectWithEnum.fromJson(data) : null);
+    map[_i1.getType<_i121.ObjectWithEnumEnhanced?>()] = (data, protocol) =>
+        (data != null ? _i121.ObjectWithEnumEnhanced.fromJson(data) : null);
+    map[_i1.getType<_i122.ObjectWithHalfVector?>()] = (data, protocol) =>
+        (data != null ? _i122.ObjectWithHalfVector.fromJson(data) : null);
+    map[_i1.getType<_i123.ObjectWithIndex?>()] = (data, protocol) =>
+        (data != null ? _i123.ObjectWithIndex.fromJson(data) : null);
+    map[_i1.getType<_i124.ObjectWithJsonb?>()] = (data, protocol) =>
+        (data != null ? _i124.ObjectWithJsonb.fromJson(data) : null);
+    map[_i1.getType<_i125.ObjectWithJsonbClassLevel?>()] = (data, protocol) =>
+        (data != null ? _i125.ObjectWithJsonbClassLevel.fromJson(data) : null);
+    map[_i1.getType<_i126.ObjectWithMaps?>()] = (data, protocol) =>
+        (data != null ? _i126.ObjectWithMaps.fromJson(data) : null);
+    map[_i1.getType<_i127.ObjectWithObject?>()] = (data, protocol) =>
+        (data != null ? _i127.ObjectWithObject.fromJson(data) : null);
+    map[_i1.getType<_i128.ObjectWithParent?>()] = (data, protocol) =>
+        (data != null ? _i128.ObjectWithParent.fromJson(data) : null);
+    map[_i1.getType<_i129.ObjectWithSealedClass?>()] = (data, protocol) =>
+        (data != null ? _i129.ObjectWithSealedClass.fromJson(data) : null);
+    map[_i1.getType<_i130.ObjectWithSelfParent?>()] = (data, protocol) =>
+        (data != null ? _i130.ObjectWithSelfParent.fromJson(data) : null);
+    map[_i1.getType<_i131.ObjectWithSparseVector?>()] = (data, protocol) =>
+        (data != null ? _i131.ObjectWithSparseVector.fromJson(data) : null);
+    map[_i1.getType<_i132.ObjectWithUuid?>()] = (data, protocol) =>
+        (data != null ? _i132.ObjectWithUuid.fromJson(data) : null);
+    map[_i1.getType<_i133.ObjectWithVector?>()] = (data, protocol) =>
+        (data != null ? _i133.ObjectWithVector.fromJson(data) : null);
+    map[_i1.getType<_i134.RelatedUniqueData?>()] = (data, protocol) =>
+        (data != null ? _i134.RelatedUniqueData.fromJson(data) : null);
+    map[_i1.getType<_i135.ModelWithRequiredField?>()] = (data, protocol) =>
+        (data != null ? _i135.ModelWithRequiredField.fromJson(data) : null);
+    map[_i1.getType<_i136.SimpleData?>()] = (data, protocol) =>
+        (data != null ? _i136.SimpleData.fromJson(data) : null);
+    map[_i1.getType<_i137.SimpleDateTime?>()] = (data, protocol) =>
+        (data != null ? _i137.SimpleDateTime.fromJson(data) : null);
+    map[_i1.getType<_i138.TestEnum?>()] = (data, protocol) =>
+        (data != null ? _i138.TestEnum.fromJson(data) : null);
+    map[_i1
+        .getType<_i139.TestEnumDefaultSerialization?>()] = (data, protocol) =>
+        (data != null
+        ? _i139.TestEnumDefaultSerialization.fromJson(data)
+        : null);
+    map[_i1.getType<_i140.TestEnumEnhanced?>()] = (data, protocol) =>
+        (data != null ? _i140.TestEnumEnhanced.fromJson(data) : null);
+    map[_i1.getType<_i141.TestEnumEnhancedByName?>()] = (data, protocol) =>
+        (data != null ? _i141.TestEnumEnhancedByName.fromJson(data) : null);
+    map[_i1.getType<_i142.TestEnumStringified?>()] = (data, protocol) =>
+        (data != null ? _i142.TestEnumStringified.fromJson(data) : null);
+    map[_i1.getType<_i143.Types?>()] = (data, protocol) =>
+        (data != null ? _i143.Types.fromJson(data) : null);
+    map[_i1.getType<_i144.UniqueData?>()] = (data, protocol) =>
+        (data != null ? _i144.UniqueData.fromJson(data) : null);
+    map[_i1.getType<_i145.UniqueDataWithNonPersist?>()] = (data, protocol) =>
+        (data != null ? _i145.UniqueDataWithNonPersist.fromJson(data) : null);
+    map[_i1.getType<_i146.UpsertTestModel?>()] = (data, protocol) =>
+        (data != null ? _i146.UpsertTestModel.fromJson(data) : null);
+    map[List<_i8.EnrollmentInt>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i8.EnrollmentInt>(e))
+        .toList();
+    map[_i1.getType<List<_i8.EnrollmentInt>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i8.EnrollmentInt>(e))
+              .toList()
+        : null);
+    map[List<_i11.PlayerUuid>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i11.PlayerUuid>(e))
+        .toList();
+    map[_i1.getType<List<_i11.PlayerUuid>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i11.PlayerUuid>(e))
+              .toList()
+        : null);
+    map[List<_i15.OrderUuid>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i15.OrderUuid>(e))
+        .toList();
+    map[_i1.getType<List<_i15.OrderUuid>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i15.OrderUuid>(e))
+              .toList()
+        : null);
+    map[List<_i13.CommentInt>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i13.CommentInt>(e))
+        .toList();
+    map[_i1.getType<List<_i13.CommentInt>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i13.CommentInt>(e))
+              .toList()
+        : null);
+    map[List<_i20.ChangedIdTypeSelf>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i20.ChangedIdTypeSelf>(e))
+        .toList();
+    map[_i1.getType<List<_i20.ChangedIdTypeSelf>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i20.ChangedIdTypeSelf>(e))
+              .toList()
+        : null);
+    map[List<_i67.EmptyModelRelationItem>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i67.EmptyModelRelationItem>(e))
+        .toList();
+    map[_i1.getType<List<_i67.EmptyModelRelationItem>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i67.EmptyModelRelationItem>(e))
+              .toList()
+        : null);
+    map[List<_i74.Employee>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i74.Employee>(e))
+        .toList();
+    map[_i1.getType<List<_i74.Employee>?>()] = (data, protocol) => (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i74.Employee>(e))
+              .toList()
+        : null);
+    map[List<_i81.PersonWithLongTableName>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i81.PersonWithLongTableName>(e))
+        .toList();
+    map[_i1.getType<List<_i81.PersonWithLongTableName>?>()] =
+        (data, protocol) => (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i81.PersonWithLongTableName>(e))
+              .toList()
+        : null);
+    map[List<_i80.OrganizationWithLongTableName>] = (data, protocol) =>
+        (data as List)
+            .map(
+              (e) =>
+                  protocol.deserialize<_i80.OrganizationWithLongTableName>(e),
+            )
+            .toList();
+    map[_i1.getType<List<_i80.OrganizationWithLongTableName>?>()] =
+        (data, protocol) => (data != null
+        ? (data as List)
+              .map(
+                (e) =>
+                    protocol.deserialize<_i80.OrganizationWithLongTableName>(e),
+              )
+              .toList()
+        : null);
+    map[List<_i83.LongImplicitIdField>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i83.LongImplicitIdField>(e))
+        .toList();
+    map[_i1.getType<List<_i83.LongImplicitIdField>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i83.LongImplicitIdField>(e))
+              .toList()
+        : null);
+    map[List<_i90.MultipleMaxFieldName>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i90.MultipleMaxFieldName>(e))
+        .toList();
+    map[_i1.getType<List<_i90.MultipleMaxFieldName>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i90.MultipleMaxFieldName>(e))
+              .toList()
+        : null);
+    map[List<_i86.UserNote>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i86.UserNote>(e))
+        .toList();
+    map[_i1.getType<List<_i86.UserNote>?>()] = (data, protocol) => (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i86.UserNote>(e))
+              .toList()
+        : null);
+    map[List<_i89.UserNoteWithALongName>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i89.UserNoteWithALongName>(e))
+        .toList();
+    map[_i1.getType<List<_i89.UserNoteWithALongName>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i89.UserNoteWithALongName>(e))
+              .toList()
+        : null);
+    map[List<_i93.Person>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i93.Person>(e))
+        .toList();
+    map[_i1.getType<List<_i93.Person>?>()] = (data, protocol) => (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i93.Person>(e))
+              .toList()
+        : null);
+    map[List<_i92.Organization>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i92.Organization>(e))
+        .toList();
+    map[_i1.getType<List<_i92.Organization>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i92.Organization>(e))
+              .toList()
+        : null);
+    map[List<_i95.Enrollment>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i95.Enrollment>(e))
+        .toList();
+    map[_i1.getType<List<_i95.Enrollment>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i95.Enrollment>(e))
+              .toList()
+        : null);
+    map[List<_i98.Player>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i98.Player>(e))
+        .toList();
+    map[_i1.getType<List<_i98.Player>?>()] = (data, protocol) => (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i98.Player>(e))
+              .toList()
+        : null);
+    map[List<_i104.Order>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i104.Order>(e))
+        .toList();
+    map[_i1.getType<List<_i104.Order>?>()] = (data, protocol) => (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i104.Order>(e))
+              .toList()
+        : null);
+    map[List<_i103.Chapter>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i103.Chapter>(e))
+        .toList();
+    map[_i1.getType<List<_i103.Chapter>?>()] = (data, protocol) => (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i103.Chapter>(e))
+              .toList()
+        : null);
+    map[List<_i100.Comment>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i100.Comment>(e))
+        .toList();
+    map[_i1.getType<List<_i100.Comment>?>()] = (data, protocol) => (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i100.Comment>(e))
+              .toList()
+        : null);
+    map[List<_i109.Blocking>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i109.Blocking>(e))
+        .toList();
+    map[_i1.getType<List<_i109.Blocking>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i109.Blocking>(e))
+              .toList()
+        : null);
+    map[List<_i111.Cat>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<_i111.Cat>(e)).toList();
+    map[_i1.getType<List<_i111.Cat>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<_i111.Cat>(e)).toList()
+        : null);
+    map[dynamic] = (data, protocol) =>
+        protocol.deserializeDynamicFieldValue(data);
+    map[List<dynamic>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<dynamic>(e)).toList();
+    map[dynamic] = (data, protocol) =>
+        protocol.deserializeDynamicFieldValue(data);
+    map[Map<String, dynamic>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<dynamic>(v),
+      ),
+    );
+    map[dynamic] = (data, protocol) =>
+        protocol.deserializeDynamicFieldValue(data);
+    map[Set<dynamic>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<dynamic>(e)).toSet();
+    map[dynamic] = (data, protocol) =>
+        protocol.deserializeDynamicFieldValue(data);
+    map[Map<dynamic, dynamic>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<dynamic>(e['k']),
+          protocol.deserialize<dynamic>(e['v']),
+        ),
+      ),
+    );
+    map[dynamic] = (data, protocol) =>
+        protocol.deserializeDynamicFieldValue(data);
+    map[dynamic] = (data, protocol) =>
+        protocol.deserializeDynamicFieldValue(data);
+    map[List<_i138.TestEnum>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i138.TestEnum>(e))
+        .toList();
+    map[List<_i138.TestEnum?>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i138.TestEnum?>(e))
+        .toList();
+    map[List<List<_i138.TestEnum>>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<List<_i138.TestEnum>>(e))
+        .toList();
+    map[List<_i138.TestEnum>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i138.TestEnum>(e))
+        .toList();
+    map[List<_i140.TestEnumEnhanced>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i140.TestEnumEnhanced>(e))
+        .toList();
+    map[List<_i141.TestEnumEnhancedByName>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i141.TestEnumEnhancedByName>(e))
+        .toList();
+    map[List<String>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<String>(e)).toList();
+    map[Map<String, String>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<String>(v),
+      ),
+    );
+    map[List<String>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<String>(e)).toList();
+    map[_i1.getType<List<String>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<String>(e)).toList()
+        : null);
+    map[Map<String, _i136.SimpleData>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i136.SimpleData>(v),
+      ),
+    );
+    map[Map<String, int>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<int>(v),
+      ),
+    );
+    map[Map<String, DateTime>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<DateTime>(v),
+      ),
+    );
+    map[Map<String, _i147.ByteData>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i147.ByteData>(v),
+      ),
+    );
+    map[Map<String, Duration>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<Duration>(v),
+      ),
+    );
+    map[Map<String, _i1.UuidValue>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i1.UuidValue>(v),
+      ),
+    );
+    map[Map<String, _i136.SimpleData?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i136.SimpleData?>(v),
+      ),
+    );
+    map[Map<String, int?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<int?>(v),
+      ),
+    );
+    map[Map<String, String?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<String?>(v),
+      ),
+    );
+    map[Map<String, DateTime?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<DateTime?>(v),
+      ),
+    );
+    map[Map<String, _i147.ByteData?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i147.ByteData?>(v),
+      ),
+    );
+    map[Map<String, Duration?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<Duration?>(v),
+      ),
+    );
+    map[Map<String, _i1.UuidValue?>] = (data, protocol) => (data as Map).map(
+      (k, v) => MapEntry(
+        protocol.deserialize<String>(k),
+        protocol.deserialize<_i1.UuidValue?>(v),
+      ),
+    );
+    map[Map<int, int>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<int>(e['k']),
+          protocol.deserialize<int>(e['v']),
+        ),
+      ),
+    );
+    map[List<_i136.SimpleData>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i136.SimpleData>(e))
+        .toList();
+    map[List<_i136.SimpleData>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i136.SimpleData>(e))
+        .toList();
+    map[_i1.getType<List<_i136.SimpleData>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i136.SimpleData>(e))
+              .toList()
+        : null);
+    map[List<_i136.SimpleData?>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i136.SimpleData?>(e))
+        .toList();
+    map[List<_i136.SimpleData?>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i136.SimpleData?>(e))
+        .toList();
+    map[_i1.getType<List<_i136.SimpleData?>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<_i136.SimpleData?>(e))
+              .toList()
+        : null);
+    map[List<List<_i136.SimpleData>>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<List<_i136.SimpleData>>(e))
+        .toList();
+    map[List<_i136.SimpleData>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i136.SimpleData>(e))
+        .toList();
+    map[_i1.getType<List<List<_i136.SimpleData>>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<List<_i136.SimpleData>>(e))
+              .toList()
+        : null);
+    map[List<_i136.SimpleData>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i136.SimpleData>(e))
+        .toList();
+    map[Map<String, List<List<Map<int, _i136.SimpleData>>?>>] =
+        (data, protocol) => (data as Map).map(
+          (k, v) => MapEntry(
+            protocol.deserialize<String>(k),
+            protocol.deserialize<List<List<Map<int, _i136.SimpleData>>?>>(v),
+          ),
+        );
+    map[List<List<Map<int, _i136.SimpleData>>?>] = (data, protocol) =>
+        (data as List)
+            .map(
+              (e) => protocol.deserialize<List<Map<int, _i136.SimpleData>>?>(e),
+            )
+            .toList();
+    map[List<Map<int, _i136.SimpleData>>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<Map<int, _i136.SimpleData>>(e))
+        .toList();
+    map[Map<int, _i136.SimpleData>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<int>(e['k']),
+          protocol.deserialize<_i136.SimpleData>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<List<Map<int, _i136.SimpleData>>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<Map<int, _i136.SimpleData>>(e))
+              .toList()
+        : null);
+    map[Map<int, _i136.SimpleData>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<int>(e['k']),
+          protocol.deserialize<_i136.SimpleData>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<Map<String, List<List<Map<int, _i136.SimpleData>>?>>?>()] =
+        (data, protocol) => (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<List<List<Map<int, _i136.SimpleData>>?>>(v),
+            ),
+          )
+        : null);
+    map[List<List<Map<int, _i136.SimpleData>>?>] = (data, protocol) =>
+        (data as List)
+            .map(
+              (e) => protocol.deserialize<List<Map<int, _i136.SimpleData>>?>(e),
+            )
+            .toList();
+    map[List<Map<int, _i136.SimpleData>>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<Map<int, _i136.SimpleData>>(e))
+        .toList();
+    map[Map<int, _i136.SimpleData>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<int>(e['k']),
+          protocol.deserialize<_i136.SimpleData>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<List<Map<int, _i136.SimpleData>>?>()] = (data, protocol) =>
+        (data != null
+        ? (data as List)
+              .map((e) => protocol.deserialize<Map<int, _i136.SimpleData>>(e))
+              .toList()
+        : null);
+    map[Map<int, _i136.SimpleData>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<int>(e['k']),
+          protocol.deserialize<_i136.SimpleData>(e['v']),
+        ),
+      ),
+    );
+    map[Map<String, Map<int, _i136.SimpleData>>] = (data, protocol) =>
+        (data as Map).map(
+          (k, v) => MapEntry(
+            protocol.deserialize<String>(k),
+            protocol.deserialize<Map<int, _i136.SimpleData>>(v),
+          ),
+        );
+    map[Map<int, _i136.SimpleData>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<int>(e['k']),
+          protocol.deserialize<_i136.SimpleData>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<Map<String, Map<int, _i136.SimpleData>>?>()] =
+        (data, protocol) => (data != null
+        ? (data as Map).map(
+            (k, v) => MapEntry(
+              protocol.deserialize<String>(k),
+              protocol.deserialize<Map<int, _i136.SimpleData>>(v),
+            ),
+          )
+        : null);
+    map[Map<int, _i136.SimpleData>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<int>(e['k']),
+          protocol.deserialize<_i136.SimpleData>(e['v']),
+        ),
+      ),
+    );
+    map[List<_i78.SealedParent>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i78.SealedParent>(e))
+        .toList();
+    map[List<int>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int>(e)).toList();
+    map[_i1.getType<List<int>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<int>(e)).toList()
+        : null);
+    map[Map<int, int>] = (data, protocol) => Map.fromEntries(
+      (data as List).map(
+        (e) => MapEntry(
+          protocol.deserialize<int>(e['k']),
+          protocol.deserialize<int>(e['v']),
+        ),
+      ),
+    );
+    map[_i1.getType<Map<int, int>?>()] = (data, protocol) => (data != null
+        ? Map.fromEntries(
+            (data as List).map(
+              (e) => MapEntry(
+                protocol.deserialize<int>(e['k']),
+                protocol.deserialize<int>(e['v']),
+              ),
+            ),
+          )
+        : null);
+    map[Set<int>] = (data, protocol) =>
+        (data as List).map((e) => protocol.deserialize<int>(e)).toSet();
+    map[_i1.getType<Set<int>?>()] = (data, protocol) => (data != null
+        ? (data as List).map((e) => protocol.deserialize<int>(e)).toSet()
+        : null);
+    map[_i1.getType<(String, {Uri? optionalUri})?>()] = (data, protocol) =>
+        (data == null)
+        ? null
+        : (
+            protocol.deserialize<String>(((data as Map)['p'] as List)[0]),
+            optionalUri: ((data)['n'] as Map)['optionalUri'] == null
+                ? null
+                : protocol.deserialize<Uri>(data['n']['optionalUri']),
+          );
+    map[List<_i148.SimpleData>] = (data, protocol) => (data as List)
+        .map((e) => protocol.deserialize<_i148.SimpleData>(e))
+        .toList();
+    map[_i1.getType<(String, {Uri? optionalUri})?>()] = (data, protocol) =>
+        (data == null)
+        ? null
+        : (
+            protocol.deserialize<String>(((data as Map)['p'] as List)[0]),
+            optionalUri: ((data)['n'] as Map)['optionalUri'] == null
+                ? null
+                : protocol.deserialize<Uri>(data['n']['optionalUri']),
+          );
+    return map;
   }
 }

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_shared/lib/src/generated/protocol.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_shared/lib/src/generated/protocol.dart
@@ -13,11 +13,11 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_database/serverpod_database.dart' as _i1;
 import 'package:serverpod_serialization/serverpod_serialization.dart' as _i2;
-import 'shared/enum.dart' as _i3;
-import 'shared/subclass.dart' as _i4;
-import 'shared/model.dart' as _i5;
-import 'shared/shared_table_record.dart' as _i6;
-import 'package:serverpod_database/serverpod_database.dart' as _i7;
+import 'package:serverpod_database/serverpod_database.dart' as _i3;
+import 'shared/enum.dart' as _i4;
+import 'shared/subclass.dart' as _i5;
+import 'shared/model.dart' as _i6;
+import 'shared/shared_table_record.dart' as _i7;
 export 'shared/enum.dart';
 export 'shared/subclass.dart';
 export 'shared/model.dart';
@@ -31,6 +31,9 @@ class Protocol extends _i1.DatabaseSerializationManager {
   static final Protocol _instance = Protocol._();
 
   final Set<_i2.SerializationManager> _hostProtocols = {};
+
+  static final Map<Type, dynamic Function(dynamic, Protocol)> _deserializers =
+      _buildDeserializers();
 
   static List<_i1.TableDefinition> get targetTableDefinitions => [
     _i1.TableDefinition(
@@ -112,42 +115,22 @@ class Protocol extends _i1.DatabaseSerializationManager {
       }
     }
 
-    if (t == _i3.SharedEnum) {
-      return _i3.SharedEnum.fromJson(data) as T;
-    }
-    if (t == _i4.SharedSubclass) {
-      return _i4.SharedSubclass.fromJson(data) as T;
-    }
-    if (t == _i5.SharedModel) {
-      return _i5.SharedModel.fromJson(data) as T;
-    }
-    if (t == _i6.SharedTableRecord) {
-      return _i6.SharedTableRecord.fromJson(data) as T;
-    }
-    if (t == _i2.getType<_i3.SharedEnum?>()) {
-      return (data != null ? _i3.SharedEnum.fromJson(data) : null) as T;
-    }
-    if (t == _i2.getType<_i4.SharedSubclass?>()) {
-      return (data != null ? _i4.SharedSubclass.fromJson(data) : null) as T;
-    }
-    if (t == _i2.getType<_i5.SharedModel?>()) {
-      return (data != null ? _i5.SharedModel.fromJson(data) : null) as T;
-    }
-    if (t == _i2.getType<_i6.SharedTableRecord?>()) {
-      return (data != null ? _i6.SharedTableRecord.fromJson(data) : null) as T;
+    final fn = _deserializers[t];
+    if (fn != null) {
+      return fn(data, this) as T;
     }
     try {
-      return _i7.Protocol().deserialize<T>(data, t);
+      return _i3.Protocol().deserialize<T>(data, t);
     } on _i2.DeserializationTypeNotFoundException catch (_) {}
     return super.deserialize<T>(data, t);
   }
 
   static String? getClassNameForType(Type type) {
     return switch (type) {
-      _i3.SharedEnum => 'SharedEnum',
-      _i4.SharedSubclass => 'SharedSubclass',
-      _i5.SharedModel => 'SharedModel',
-      _i6.SharedTableRecord => 'SharedTableRecord',
+      _i4.SharedEnum => 'SharedEnum',
+      _i5.SharedSubclass => 'SharedSubclass',
+      _i6.SharedModel => 'SharedModel',
+      _i7.SharedTableRecord => 'SharedTableRecord',
       _ => null,
     };
   }
@@ -165,13 +148,13 @@ class Protocol extends _i1.DatabaseSerializationManager {
     }
 
     switch (data) {
-      case _i3.SharedEnum():
+      case _i4.SharedEnum():
         return 'SharedEnum';
-      case _i4.SharedSubclass():
+      case _i5.SharedSubclass():
         return 'SharedSubclass';
-      case _i5.SharedModel():
+      case _i6.SharedModel():
         return 'SharedModel';
-      case _i6.SharedTableRecord():
+      case _i7.SharedTableRecord():
         return 'SharedTableRecord';
     }
     return null;
@@ -184,16 +167,16 @@ class Protocol extends _i1.DatabaseSerializationManager {
       return super.deserializeByClassName(data);
     }
     if (dataClassName == 'SharedEnum') {
-      return deserialize<_i3.SharedEnum>(data['data']);
+      return deserialize<_i4.SharedEnum>(data['data']);
     }
     if (dataClassName == 'SharedSubclass') {
-      return deserialize<_i4.SharedSubclass>(data['data']);
+      return deserialize<_i5.SharedSubclass>(data['data']);
     }
     if (dataClassName == 'SharedModel') {
-      return deserialize<_i5.SharedModel>(data['data']);
+      return deserialize<_i6.SharedModel>(data['data']);
     }
     if (dataClassName == 'SharedTableRecord') {
-      return deserialize<_i6.SharedTableRecord>(data['data']);
+      return deserialize<_i7.SharedTableRecord>(data['data']);
     }
     return super.deserializeByClassName(data);
   }
@@ -260,8 +243,8 @@ class Protocol extends _i1.DatabaseSerializationManager {
   @override
   _i1.Table? getTableForType(Type t) {
     switch (t) {
-      case _i6.SharedTableRecord:
-        return _i6.SharedTableRecord.t;
+      case _i7.SharedTableRecord:
+        return _i7.SharedTableRecord.t;
     }
     return null;
   }
@@ -283,8 +266,27 @@ class Protocol extends _i1.DatabaseSerializationManager {
       return null;
     }
     try {
-      return _i7.Protocol().mapRecordToJson(record);
+      return _i3.Protocol().mapRecordToJson(record);
     } catch (_) {}
     throw Exception('Unsupported record type ${record.runtimeType}');
+  }
+
+  static Map<Type, dynamic Function(dynamic, Protocol)> _buildDeserializers() {
+    final map = <Type, dynamic Function(dynamic, Protocol)>{};
+    map[_i4.SharedEnum] = (data, protocol) => _i4.SharedEnum.fromJson(data);
+    map[_i5.SharedSubclass] = (data, protocol) =>
+        _i5.SharedSubclass.fromJson(data);
+    map[_i6.SharedModel] = (data, protocol) => _i6.SharedModel.fromJson(data);
+    map[_i7.SharedTableRecord] = (data, protocol) =>
+        _i7.SharedTableRecord.fromJson(data);
+    map[_i2.getType<_i4.SharedEnum?>()] = (data, protocol) =>
+        (data != null ? _i4.SharedEnum.fromJson(data) : null);
+    map[_i2.getType<_i5.SharedSubclass?>()] = (data, protocol) =>
+        (data != null ? _i5.SharedSubclass.fromJson(data) : null);
+    map[_i2.getType<_i6.SharedModel?>()] = (data, protocol) =>
+        (data != null ? _i6.SharedModel.fromJson(data) : null);
+    map[_i2.getType<_i7.SharedTableRecord?>()] = (data, protocol) =>
+        (data != null ? _i7.SharedTableRecord.fromJson(data) : null);
+    return map;
   }
 }

--- a/tools/serverpod_cli/lib/src/generator/dart/library_generators/library_generator.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart/library_generators/library_generator.dart
@@ -211,6 +211,103 @@ class LibraryGenerator {
         .where((f) => f.shouldIncludeField(serverCode))
         .distinct();
 
+    // Per-type deserializer entries used by deserialize<T>.
+    //
+    // Emitted as a static `Map<Type, _DeserializerFn>` populated by
+    // `_buildDeserializers`. Replacing the previous if-chain — one method
+    // with a branch per registered type — with a map lookup dramatically cuts
+    // AOT compile time (`gen_snapshot` per-function passes degrade
+    // non-linearly on huge methods); each branch is now a tiny closure of
+    // its own. Population is done in a function body rather than a map
+    // literal so that duplicate `Type` keys (same Dart class imported under
+    // multiple module aliases) don't trigger the `equal_keys_in_map`
+    // analyzer warning — last-write-wins is harmless since duplicates have
+    // identical bodies. See https://github.com/serverpod/serverpod/issues/5000.
+    final deserializerEntries = <MapEntry<Expression, Code>>[
+      for (var classInfo in unsealedModels)
+        MapEntry(
+          refer(classInfo.className, TypeDefinition.getRef(classInfo)),
+          Code.scope(
+            (a) =>
+                '${a(refer(classInfo.className, TypeDefinition.getRef(classInfo)))}'
+                '.fromJson(data)',
+          ),
+        ),
+      for (var classInfo in unsealedModels)
+        MapEntry(
+          refer('getType', serverpodUrl(serverCode)).call([], {}, [
+            TypeReference(
+              (b) => b
+                ..symbol = classInfo.className
+                ..url = TypeDefinition.getRef(classInfo)
+                ..isNullable = true,
+            ),
+          ]),
+          Code.scope(
+            (a) =>
+                '(data!=null?'
+                '${a(refer(classInfo.className, TypeDefinition.getRef(classInfo)))}'
+                '.fromJson(data) :null)',
+          ),
+        ),
+      for (var field in allFieldsToGenerateSerialization)
+        ...field.type.generateDeserialization(serverCode, config: config),
+      for (var type in allTypesToDeserialize)
+        ...type.generateDeserialization(serverCode, config: config),
+      for (var extraClass in config.extraClasses)
+        ...extraClass.generateDeserialization(serverCode, config: config),
+      for (var extraClass in config.extraClasses)
+        ...extraClass.asNullable.generateDeserialization(
+          serverCode,
+          config: config,
+        ),
+      for (var type in nonModelStreamTypes)
+        ...type.generateDeserialization(serverCode, config: config),
+    ];
+
+    final deserializerFnTypeRef = refer(
+      'dynamic Function(dynamic, Protocol)',
+    );
+    final deserializerMapTypeRef = TypeReference(
+      (t) => t
+        ..symbol = 'Map'
+        ..types.addAll([refer('Type'), deserializerFnTypeRef]),
+    );
+
+    protocol.fields.add(
+      Field(
+        (f) => f
+          ..name = '_deserializers'
+          ..static = true
+          ..modifier = FieldModifier.final$
+          ..type = deserializerMapTypeRef
+          ..assignment = const Code('_buildDeserializers()'),
+      ),
+    );
+
+    protocol.methods.add(
+      Method(
+        (m) => m
+          ..static = true
+          ..name = '_buildDeserializers'
+          ..returns = deserializerMapTypeRef
+          ..body = Block.of([
+            const Code(
+              'final map = <Type, dynamic Function(dynamic, Protocol)>{};',
+            ),
+            for (final entry in deserializerEntries)
+              Block.of([
+                const Code('map['),
+                entry.key.code,
+                const Code('] = (data, protocol) => '),
+                entry.value,
+                const Code(';'),
+              ]),
+            const Code('return map;'),
+          ]),
+      ),
+    );
+
     protocol.methods.addAll([
       if (_supportsHostProtocols) ..._buildModuleHostProtocolMethods(),
       Method(
@@ -278,68 +375,10 @@ class LibraryGenerator {
               }
             }
           '''),
-            ...(<Expression, Code>{
-                  for (var classInfo in unsealedModels)
-                    refer(
-                      classInfo.className,
-                      TypeDefinition.getRef(classInfo),
-                    ): Code.scope(
-                      (a) =>
-                          '${a(refer(classInfo.className, TypeDefinition.getRef(classInfo)))}'
-                          '.fromJson(data) as T',
-                    ),
-                  for (var classInfo in unsealedModels)
-                    refer('getType', serverpodUrl(serverCode)).call([], {}, [
-                      TypeReference(
-                        (b) => b
-                          ..symbol = classInfo.className
-                          ..url = TypeDefinition.getRef(classInfo)
-                          ..isNullable = true,
-                      ),
-                    ]): Code.scope(
-                      (a) =>
-                          '(data!=null?'
-                          '${a(refer(classInfo.className, TypeDefinition.getRef(classInfo)))}'
-                          '.fromJson(data) :null) as T',
-                    ),
-                }..addEntries([
-                  // Generate deserialization for fields of models.
-                  for (var field in allFieldsToGenerateSerialization)
-                    ...field.type.generateDeserialization(
-                      serverCode,
-                      config: config,
-                    ),
-                  for (var type in allTypesToDeserialize)
-                    ...type.generateDeserialization(
-                      serverCode,
-                      config: config,
-                    ),
-                  // Generate deserialization for extra classes.
-                  for (var extraClass in config.extraClasses)
-                    ...extraClass.generateDeserialization(
-                      serverCode,
-                      config: config,
-                    ),
-                  // Generate deserialization for extra classes as nullables.
-                  for (var extraClass in config.extraClasses)
-                    ...extraClass.asNullable.generateDeserialization(
-                      serverCode,
-                      config: config,
-                    ),
-                  // Generate deserialization for containers used in streams
-                  for (var type in nonModelStreamTypes)
-                    ...type.generateDeserialization(serverCode, config: config),
-                ]))
-                .entries
-                .map(
-                  (e) => Block.of([
-                    const Code('if(t=='),
-                    e.key.code,
-                    const Code('){return '),
-                    e.value,
-                    const Code(';}'),
-                  ]),
-                ),
+            const Code(
+              'final fn = _deserializers[t];'
+              'if (fn != null) { return fn(data, this) as T; }',
+            ),
             for (var module in config.modules)
               Code.scope(
                 (a) =>

--- a/tools/serverpod_cli/lib/src/generator/dart/library_generators/library_generator.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart/library_generators/library_generator.dart
@@ -176,6 +176,69 @@ class LibraryGenerator {
         .where((f) => f.shouldIncludeField(serverCode))
         .distinct();
 
+    // Per-type deserializer entries used by deserialize<T>.
+    //
+    // Emitted as a static `Map<Type, _DeserializerFn>` populated by
+    // `_buildDeserializers`. Replacing the previous if-chain — one method
+    // with a branch per registered type — with a map lookup dramatically cuts
+    // AOT compile time (`gen_snapshot` per-function passes degrade
+    // non-linearly on huge methods); each branch is now a tiny closure of
+    // its own. Population is done in a function body rather than a map
+    // literal so that duplicate `Type` keys (same Dart class imported under
+    // multiple module aliases) don't trigger the `equal_keys_in_map`
+    // analyzer warning — last-write-wins is harmless since duplicates have
+    // identical bodies. See https://github.com/serverpod/serverpod/issues/5000.
+    final deserializerEntries = <MapEntry<Expression, Code>>[
+      for (var classInfo in unsealedModels)
+        MapEntry(
+          refer(classInfo.className, TypeDefinition.getRef(classInfo)),
+          Code.scope(
+            (a) =>
+                '${a(refer(classInfo.className, TypeDefinition.getRef(classInfo)))}'
+                '.fromJson(data)',
+          ),
+        ),
+      for (var classInfo in unsealedModels)
+        MapEntry(
+          refer('getType', serverpodUrl(serverCode)).call([], {}, [
+            TypeReference(
+              (b) => b
+                ..symbol = classInfo.className
+                ..url = TypeDefinition.getRef(classInfo)
+                ..isNullable = true,
+            ),
+          ]),
+          Code.scope(
+            (a) =>
+                '(data!=null?'
+                '${a(refer(classInfo.className, TypeDefinition.getRef(classInfo)))}'
+                '.fromJson(data) :null)',
+          ),
+        ),
+      for (var field in allFieldsToGenerateSerialization)
+        ...field.type.generateDeserialization(serverCode, config: config),
+      for (var type in allTypesToDeserialize)
+        ...type.generateDeserialization(serverCode, config: config),
+      for (var extraClass in config.extraClasses)
+        ...extraClass.generateDeserialization(serverCode, config: config),
+      for (var extraClass in config.extraClasses)
+        ...extraClass.asNullable.generateDeserialization(
+          serverCode,
+          config: config,
+        ),
+      for (var type in nonModelStreamTypes)
+        ...type.generateDeserialization(serverCode, config: config),
+    ];
+
+    final deserializerFnTypeRef = refer(
+      'dynamic Function(dynamic, Protocol)',
+    );
+    final deserializerMapTypeRef = TypeReference(
+      (t) => t
+        ..symbol = 'Map'
+        ..types.addAll([refer('Type'), deserializerFnTypeRef]),
+    );
+
     protocol.methods.addAll([
       if (shouldExtendDatabaseSerializationManager)
         Method(
@@ -300,68 +363,10 @@ class LibraryGenerator {
               }
             }
           '''),
-            ...(<Expression, Code>{
-                  for (var classInfo in unsealedModels)
-                    refer(
-                      classInfo.className,
-                      TypeDefinition.getRef(classInfo),
-                    ): Code.scope(
-                      (a) =>
-                          '${a(refer(classInfo.className, TypeDefinition.getRef(classInfo)))}'
-                          '.fromJson(data) as T',
-                    ),
-                  for (var classInfo in unsealedModels)
-                    refer('getType', serverpodUrl(serverCode)).call([], {}, [
-                      TypeReference(
-                        (b) => b
-                          ..symbol = classInfo.className
-                          ..url = TypeDefinition.getRef(classInfo)
-                          ..isNullable = true,
-                      ),
-                    ]): Code.scope(
-                      (a) =>
-                          '(data!=null?'
-                          '${a(refer(classInfo.className, TypeDefinition.getRef(classInfo)))}'
-                          '.fromJson(data) :null) as T',
-                    ),
-                }..addEntries([
-                  // Generate deserialization for fields of models.
-                  for (var field in allFieldsToGenerateSerialization)
-                    ...field.type.generateDeserialization(
-                      serverCode,
-                      config: config,
-                    ),
-                  for (var type in allTypesToDeserialize)
-                    ...type.generateDeserialization(
-                      serverCode,
-                      config: config,
-                    ),
-                  // Generate deserialization for extra classes.
-                  for (var extraClass in config.extraClasses)
-                    ...extraClass.generateDeserialization(
-                      serverCode,
-                      config: config,
-                    ),
-                  // Generate deserialization for extra classes as nullables.
-                  for (var extraClass in config.extraClasses)
-                    ...extraClass.asNullable.generateDeserialization(
-                      serverCode,
-                      config: config,
-                    ),
-                  // Generate deserialization for containers used in streams
-                  for (var type in nonModelStreamTypes)
-                    ...type.generateDeserialization(serverCode, config: config),
-                ]))
-                .entries
-                .map(
-                  (e) => Block.of([
-                    const Code('if(t=='),
-                    e.key.code,
-                    const Code('){return '),
-                    e.value,
-                    const Code(';}'),
-                  ]),
-                ),
+            const Code(
+              'final fn = _deserializers[t];'
+              'if (fn != null) { return fn(data, this) as T; }',
+            ),
             for (var module in config.modules)
               Code.scope(
                 (a) =>
@@ -680,6 +685,40 @@ class LibraryGenerator {
           allTypesToDeserialize.any((type) => type.containsNonStringKeyedMap))
         _mapContainerToJsonMethod(),
     ]);
+
+    protocol.fields.add(
+      Field(
+        (f) => f
+          ..name = '_deserializers'
+          ..static = true
+          ..modifier = FieldModifier.final$
+          ..type = deserializerMapTypeRef
+          ..assignment = const Code('_buildDeserializers()'),
+      ),
+    );
+
+    protocol.methods.add(
+      Method(
+        (m) => m
+          ..static = true
+          ..name = '_buildDeserializers'
+          ..returns = deserializerMapTypeRef
+          ..body = Block.of([
+            const Code(
+              'final map = <Type, dynamic Function(dynamic, Protocol)>{};',
+            ),
+            for (final entry in deserializerEntries)
+              Block.of([
+                const Code('map['),
+                entry.key.code,
+                const Code('] = (data, protocol) => '),
+                entry.value,
+                const Code(';'),
+              ]),
+            const Code('return map;'),
+          ]),
+      ),
+    );
 
     library.body.add(protocol.build());
 

--- a/tools/serverpod_cli/lib/src/generator/types.dart
+++ b/tools/serverpod_cli/lib/src/generator/types.dart
@@ -520,7 +520,11 @@ class TypeDefinition {
     return genericType;
   }
 
-  /// Generates the constructors for List and Map types
+  /// Generates value expressions used as bodies of `(data, protocol) => ...`
+  /// closures in `Protocol._deserializers`. Recursive `deserialize<X>` calls
+  /// route through `protocol.deserialize<X>` because the closure has no
+  /// access to `this`; the trailing `as T` cast is added once by the caller
+  /// on the result of the map lookup.
   List<MapEntry<Expression, Code>> generateDeserialization(
     bool serverCode, {
     required GeneratorConfig config,
@@ -534,7 +538,7 @@ class TypeDefinition {
           ).call([], {}, [reference(serverCode, config: config)]),
           Block.of(
             [
-              if (nullable) const Code(' (data == null) ? null as T : '),
+              if (nullable) const Code(' (data == null) ? null : '),
               const Code('('),
               for (final (i, positionalField)
                   in positionalRecordFields.indexed) ...[
@@ -542,7 +546,7 @@ class TypeDefinition {
                   Code(
                     "((data ${i == 0 ? 'as Map' : ''})['p'] as List)[$i] == null ? null : ",
                   ),
-                const Code('deserialize<'),
+                const Code('protocol.deserialize<'),
                 positionalField
                     .reference(serverCode, config: config, nullable: false)
                     .code,
@@ -562,7 +566,7 @@ class TypeDefinition {
                     Code(
                       "((data ${i == 0 && positionalRecordFields.isEmpty ? 'as Map' : ''})['n'] as Map)['${namedField.recordFieldName!}'] == null ? null : ",
                     ),
-                  const Code('deserialize<'),
+                  const Code('protocol.deserialize<'),
                   namedField
                       .reference(serverCode, config: config, nullable: false)
                       .code,
@@ -579,7 +583,7 @@ class TypeDefinition {
                   const Code(','),
                 ],
               ],
-              const Code(') as T'),
+              const Code(')'),
             ],
           ),
         ),
@@ -607,22 +611,22 @@ class TypeDefinition {
                     const Code(
                       '(data!=null?'
                       '(data as List).map((e) =>'
-                      'deserialize<',
+                      'protocol.deserialize<',
                     ),
                     generics.first.reference(serverCode, config: config).code,
                     Code(
                       '>(e))${className == 'Set' ? '.toSet()' : '.toList()'}'
-                      ':null) as T',
+                      ':null)',
                     ),
                   ])
                 : Block.of([
                     const Code(
                       '(data as List).map((e) =>'
-                      'deserialize<',
+                      'protocol.deserialize<',
                     ),
                     generics.first.reference(serverCode, config: config).code,
                     Code(
-                      '>(e))${className == 'Set' ? '.toSet()' : '.toList()'} as T',
+                      '>(e))${className == 'Set' ? '.toSet()' : '.toList()'}',
                     ),
                   ]),
           ]),
@@ -651,34 +655,34 @@ class TypeDefinition {
                           const Code(
                             '(data!=null?'
                             '(data as Map).map((k,v) =>'
-                            'MapEntry(deserialize<',
+                            'MapEntry(protocol.deserialize<',
                           ),
                           generics.first
                               .reference(serverCode, config: config)
                               .code,
-                          const Code('>(k),deserialize<'),
+                          const Code('>(k),protocol.deserialize<'),
                           generics[1]
                               .reference(serverCode, config: config)
                               .code,
                           const Code(
                             '>(v)))'
-                            ':null) as T',
+                            ':null)',
                           ),
                         ])
                       : Block.of([
                           // using Code.scope only sets the generic to List
                           const Code(
                             '(data as Map).map((k,v) =>'
-                            'MapEntry(deserialize<',
+                            'MapEntry(protocol.deserialize<',
                           ),
                           generics.first
                               .reference(serverCode, config: config)
                               .code,
-                          const Code('>(k),deserialize<'),
+                          const Code('>(k),protocol.deserialize<'),
                           generics[1]
                               .reference(serverCode, config: config)
                               .code,
-                          const Code('>(v))) as T'),
+                          const Code('>(v)))'),
                         ])
                 : // Key is not String -> stored as list of map entries
                   nullable
@@ -687,26 +691,26 @@ class TypeDefinition {
                     const Code(
                       '(data!=null?'
                       'Map.fromEntries((data as List).map((e) =>'
-                      'MapEntry(deserialize<',
+                      'MapEntry(protocol.deserialize<',
                     ),
                     generics.first.reference(serverCode, config: config).code,
-                    const Code('>(e[\'k\']),deserialize<'),
+                    const Code('>(e[\'k\']),protocol.deserialize<'),
                     generics[1].reference(serverCode, config: config).code,
                     const Code(
                       '>(e[\'v\']))))'
-                      ':null) as T',
+                      ':null)',
                     ),
                   ])
                 : Block.of([
                     // using Code.scope only sets the generic to List
                     const Code(
                       'Map.fromEntries((data as List).map((e) =>'
-                      'MapEntry(deserialize<',
+                      'MapEntry(protocol.deserialize<',
                     ),
                     generics.first.reference(serverCode, config: config).code,
-                    const Code('>(e[\'k\']),deserialize<'),
+                    const Code('>(e[\'k\']),protocol.deserialize<'),
                     generics[1].reference(serverCode, config: config).code,
-                    const Code('>(e[\'v\'])))) as T'),
+                    const Code('>(e[\'v\']))))'),
                   ]),
           ]),
         ),
@@ -739,9 +743,9 @@ class TypeDefinition {
             (a) => nullable
                 ? '(data!=null?'
                       '${a(reference(serverCode, config: config))}'
-                      '.fromJson(data):null)as T'
+                      '.fromJson(data):null)'
                 : '${a(reference(serverCode, config: config))}'
-                      '.fromJson(data) as T',
+                      '.fromJson(data)',
           ),
         ),
       ];

--- a/tools/serverpod_cli/lib/src/generator/types.dart
+++ b/tools/serverpod_cli/lib/src/generator/types.dart
@@ -583,7 +583,11 @@ class TypeDefinition {
     return genericType;
   }
 
-  /// Generates the constructors for List and Map types
+  /// Generates value expressions used as bodies of `(data, protocol) => ...`
+  /// closures in `Protocol._deserializers`. Recursive `deserialize<X>` calls
+  /// route through `protocol.deserialize<X>` because the closure has no
+  /// access to `this`; the trailing `as T` cast is added once by the caller
+  /// on the result of the map lookup.
   List<MapEntry<Expression, Code>> generateDeserialization(
     bool serverCode, {
     required GeneratorConfig config,
@@ -597,7 +601,7 @@ class TypeDefinition {
           ).call([], {}, [reference(serverCode, config: config)]),
           Block.of(
             [
-              if (nullable) const Code(' (data == null) ? null as T : '),
+              if (nullable) const Code(' (data == null) ? null : '),
               const Code('('),
               for (final (i, positionalField)
                   in positionalRecordFields.indexed) ...[
@@ -605,7 +609,7 @@ class TypeDefinition {
                   Code(
                     "((data ${i == 0 ? 'as Map' : ''})['p'] as List)[$i] == null ? null : ",
                   ),
-                const Code('deserialize<'),
+                const Code('protocol.deserialize<'),
                 positionalField
                     .reference(serverCode, config: config, nullable: false)
                     .code,
@@ -625,7 +629,7 @@ class TypeDefinition {
                     Code(
                       "((data ${i == 0 && positionalRecordFields.isEmpty ? 'as Map' : ''})['n'] as Map)['${namedField.recordFieldName!}'] == null ? null : ",
                     ),
-                  const Code('deserialize<'),
+                  const Code('protocol.deserialize<'),
                   namedField
                       .reference(serverCode, config: config, nullable: false)
                       .code,
@@ -642,7 +646,7 @@ class TypeDefinition {
                   const Code(','),
                 ],
               ],
-              const Code(') as T'),
+              const Code(')'),
             ],
           ),
         ),
@@ -670,22 +674,22 @@ class TypeDefinition {
                     const Code(
                       '(data!=null?'
                       '(data as List).map((e) =>'
-                      'deserialize<',
+                      'protocol.deserialize<',
                     ),
                     generics.first.reference(serverCode, config: config).code,
                     Code(
                       '>(e))${className == 'Set' ? '.toSet()' : '.toList()'}'
-                      ':null) as T',
+                      ':null)',
                     ),
                   ])
                 : Block.of([
                     const Code(
                       '(data as List).map((e) =>'
-                      'deserialize<',
+                      'protocol.deserialize<',
                     ),
                     generics.first.reference(serverCode, config: config).code,
                     Code(
-                      '>(e))${className == 'Set' ? '.toSet()' : '.toList()'} as T',
+                      '>(e))${className == 'Set' ? '.toSet()' : '.toList()'}',
                     ),
                   ]),
           ]),
@@ -714,34 +718,34 @@ class TypeDefinition {
                           const Code(
                             '(data!=null?'
                             '(data as Map).map((k,v) =>'
-                            'MapEntry(deserialize<',
+                            'MapEntry(protocol.deserialize<',
                           ),
                           generics.first
                               .reference(serverCode, config: config)
                               .code,
-                          const Code('>(k),deserialize<'),
+                          const Code('>(k),protocol.deserialize<'),
                           generics[1]
                               .reference(serverCode, config: config)
                               .code,
                           const Code(
                             '>(v)))'
-                            ':null) as T',
+                            ':null)',
                           ),
                         ])
                       : Block.of([
                           // using Code.scope only sets the generic to List
                           const Code(
                             '(data as Map).map((k,v) =>'
-                            'MapEntry(deserialize<',
+                            'MapEntry(protocol.deserialize<',
                           ),
                           generics.first
                               .reference(serverCode, config: config)
                               .code,
-                          const Code('>(k),deserialize<'),
+                          const Code('>(k),protocol.deserialize<'),
                           generics[1]
                               .reference(serverCode, config: config)
                               .code,
-                          const Code('>(v))) as T'),
+                          const Code('>(v)))'),
                         ])
                 : // Key is not String -> stored as list of map entries
                   nullable
@@ -750,26 +754,26 @@ class TypeDefinition {
                     const Code(
                       '(data!=null?'
                       'Map.fromEntries((data as List).map((e) =>'
-                      'MapEntry(deserialize<',
+                      'MapEntry(protocol.deserialize<',
                     ),
                     generics.first.reference(serverCode, config: config).code,
-                    const Code('>(e[\'k\']),deserialize<'),
+                    const Code('>(e[\'k\']),protocol.deserialize<'),
                     generics[1].reference(serverCode, config: config).code,
                     const Code(
                       '>(e[\'v\']))))'
-                      ':null) as T',
+                      ':null)',
                     ),
                   ])
                 : Block.of([
                     // using Code.scope only sets the generic to List
                     const Code(
                       'Map.fromEntries((data as List).map((e) =>'
-                      'MapEntry(deserialize<',
+                      'MapEntry(protocol.deserialize<',
                     ),
                     generics.first.reference(serverCode, config: config).code,
-                    const Code('>(e[\'k\']),deserialize<'),
+                    const Code('>(e[\'k\']),protocol.deserialize<'),
                     generics[1].reference(serverCode, config: config).code,
-                    const Code('>(e[\'v\'])))) as T'),
+                    const Code('>(e[\'v\']))))'),
                   ]),
           ]),
         ),
@@ -780,7 +784,7 @@ class TypeDefinition {
       return [
         MapEntry(
           refer('dynamic'),
-          const Code('deserializeDynamicFieldValue(data) as T'),
+          const Code('protocol.deserializeDynamicFieldValue(data)'),
         ),
       ];
     } else if (customClass) {
@@ -802,9 +806,9 @@ class TypeDefinition {
             (a) => nullable
                 ? '(data!=null?'
                       '${a(reference(serverCode, config: config))}'
-                      '.fromJson(data):null)as T'
+                      '.fromJson(data):null)'
                 : '${a(reference(serverCode, config: config))}'
-                      '.fromJson(data) as T',
+                      '.fromJson(data)',
           ),
         ),
       ];

--- a/tools/serverpod_cli/test/generator/dart/client_code_generator/protocol/inheritance_exception_protocol_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/client_code_generator/protocol/inheritance_exception_protocol_test.dart
@@ -166,10 +166,10 @@ void main() {
           });
 
           test(
-            'that does NOT return $parentClassName.fromJson.',
+            'that does NOT reference $parentClassName.fromJson.',
             () {
               expect(
-                deserializeMethod!.toSource().contains(
+                protocolClass.toSource().contains(
                   '$parentClassName.fromJson',
                 ),
                 isFalse,
@@ -177,18 +177,18 @@ void main() {
             },
           );
 
-          test('that returns $childClassName.fromJson.', () {
+          test('that calls $childClassName.fromJson.', () {
             expect(
-              deserializeMethod!.toSource().contains(
+              protocolClass.toSource().contains(
                 '$childClassName.fromJson',
               ),
               isTrue,
             );
           });
 
-          test('that returns $grandchildClassName.fromJson.', () {
+          test('that calls $grandchildClassName.fromJson.', () {
             expect(
-              deserializeMethod!.toSource().contains(
+              protocolClass.toSource().contains(
                 '$grandchildClassName.fromJson',
               ),
               isTrue,

--- a/tools/serverpod_cli/test/generator/dart/client_code_generator/protocol/inheritance_protocol_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/client_code_generator/protocol/inheritance_protocol_test.dart
@@ -184,21 +184,21 @@ void main() {
             expect(deserializeMethod, isNotNull);
           });
 
-          test('that does NOT return $parentClassName.fromJson', () {
+          test('that does NOT reference $parentClassName.fromJson', () {
             expect(
-              deserializeMethod!.toSource().contains(
-                'return _i3.$parentClassName.fromJson',
+              protocolClass.toSource().contains(
+                '_i3.$parentClassName.fromJson',
               ),
               isFalse,
             );
           });
 
           test(
-            'that returns $childClassName.fromJson with the top nodes alias',
+            'that calls $childClassName.fromJson with the top nodes alias',
             () {
               expect(
-                deserializeMethod!.toSource().contains(
-                  'return _i2.$childClassName.fromJson',
+                protocolClass.toSource().contains(
+                  '_i2.$childClassName.fromJson',
                 ),
                 isTrue,
               );
@@ -206,11 +206,11 @@ void main() {
           );
 
           test(
-            'that does return $grandchildClassName.fromJson with the top nodes alias',
+            'that calls $grandchildClassName.fromJson with the top nodes alias',
             () {
               expect(
-                deserializeMethod!.toSource().contains(
-                  'return _i2.$grandchildClassName.fromJson',
+                protocolClass.toSource().contains(
+                  '_i2.$grandchildClassName.fromJson',
                 ),
                 isTrue,
               );

--- a/tools/serverpod_cli/test/generator/dart/server_code_generator/protocol/inheritance_exception_protocol_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/server_code_generator/protocol/inheritance_exception_protocol_test.dart
@@ -164,10 +164,10 @@ void main() {
           });
 
           test(
-            'that does NOT return $parentClassName.fromJson.',
+            'that does NOT reference $parentClassName.fromJson.',
             () {
               expect(
-                deserializeMethod!.toSource().contains(
+                protocolClass.toSource().contains(
                   '$parentClassName.fromJson',
                 ),
                 isFalse,
@@ -175,18 +175,18 @@ void main() {
             },
           );
 
-          test('that returns $childClassName.fromJson.', () {
+          test('that calls $childClassName.fromJson.', () {
             expect(
-              deserializeMethod!.toSource().contains(
+              protocolClass.toSource().contains(
                 '$childClassName.fromJson',
               ),
               isTrue,
             );
           });
 
-          test('that returns $grandchildClassName.fromJson.', () {
+          test('that calls $grandchildClassName.fromJson.', () {
             expect(
-              deserializeMethod!.toSource().contains(
+              protocolClass.toSource().contains(
                 '$grandchildClassName.fromJson',
               ),
               isTrue,

--- a/tools/serverpod_cli/test/generator/dart/server_code_generator/protocol/inheritance_protocol_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/server_code_generator/protocol/inheritance_protocol_test.dart
@@ -182,21 +182,21 @@ void main() {
             expect(deserializeMethod, isNotNull);
           });
 
-          test('that does NOT return $parentClassName.fromJson', () {
+          test('that does NOT reference $parentClassName.fromJson', () {
             expect(
-              deserializeMethod!.toSource().contains(
-                'return _i3.$parentClassName.fromJson',
+              protocolClass.toSource().contains(
+                '_i3.$parentClassName.fromJson',
               ),
               isFalse,
             );
           });
 
           test(
-            'that returns $childClassName.fromJson with the top nodes alias',
+            'that calls $childClassName.fromJson with the top nodes alias',
             () {
               expect(
-                deserializeMethod!.toSource().contains(
-                  'return _i3.$childClassName.fromJson',
+                protocolClass.toSource().contains(
+                  '_i3.$childClassName.fromJson',
                 ),
                 isTrue,
               );
@@ -204,11 +204,11 @@ void main() {
           );
 
           test(
-            'that does return $grandchildClassName.fromJson with the top nodes alias',
+            'that calls $grandchildClassName.fromJson with the top nodes alias',
             () {
               expect(
-                deserializeMethod!.toSource().contains(
-                  'return _i3.$grandchildClassName.fromJson',
+                protocolClass.toSource().contains(
+                  '_i3.$grandchildClassName.fromJson',
                 ),
                 isTrue,
               );

--- a/tools/serverpod_cli/test/generator/dart/server_code_generator/protocol/protocol_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/server_code_generator/protocol/protocol_test.dart
@@ -924,11 +924,11 @@ void main() {
         () {
           var protocolContent = codeMap[expectedFileName]!;
 
-          // Count occurrences of List<Person>? type check
-          // This should appear only once even though it's referenced in multiple models
-          // Pattern matches: getType<List<Person>?>() or similar variations
+          // Count occurrences of `map[...List<Person>?...] =` deserializer
+          // entries. This should appear only once even though Person is
+          // referenced in multiple models.
           var listPersonPattern = RegExp(
-            r'if\s*\(\s*t\s*==\s*[^)]*List<[^>]*Person[^>]*>\?[^)]*\)',
+            r'map\[[^\]]*List<[^>]*Person[^>]*>\?[^\]]*\]\s*=',
             multiLine: true,
           );
 

--- a/tools/serverpod_cli/test/generator/dart/server_code_generator/protocol/protocol_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/server_code_generator/protocol/protocol_test.dart
@@ -938,11 +938,11 @@ void main() {
         () {
           var protocolContent = codeMap[expectedFileName]!;
 
-          // Count occurrences of List<Person>? type check
-          // This should appear only once even though it's referenced in multiple models
-          // Pattern matches: getType<List<Person>?>() or similar variations
+          // Count occurrences of `map[...List<Person>?...] =` deserializer
+          // entries. This should appear only once even though Person is
+          // referenced in multiple models.
           var listPersonPattern = RegExp(
-            r'if\s*\(\s*t\s*==\s*[^)]*List<[^>]*Person[^>]*>\?[^)]*\)',
+            r'map\[[^\]]*List<[^>]*Person[^>]*>\?[^\]]*\]\s*=',
             multiLine: true,
           );
 

--- a/tools/serverpod_cli/test/generator/dart/shared_code_generator/protocol/inheritance_exception_protocol_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/shared_code_generator/protocol/inheritance_exception_protocol_test.dart
@@ -170,21 +170,21 @@ void main() {
             expect(deserializeMethod, isNotNull);
           });
 
-          test('that does NOT return $parentClassName.fromJson', () {
+          test('that does NOT reference $parentClassName.fromJson', () {
             expect(
-              deserializeMethod!.toSource().contains(
-                'return _i3.$parentClassName.fromJson',
+              protocolClass!.toSource().contains(
+                '_i3.$parentClassName.fromJson',
               ),
               isFalse,
             );
           });
 
           test(
-            'that returns $childClassName.fromJson with the top nodes alias',
+            'that calls $childClassName.fromJson with the top nodes alias',
             () {
               expect(
-                deserializeMethod!.toSource().contains(
-                  'return _i2.$childClassName.fromJson',
+                protocolClass!.toSource().contains(
+                  '_i2.$childClassName.fromJson',
                 ),
                 isTrue,
               );
@@ -192,11 +192,11 @@ void main() {
           );
 
           test(
-            'that does return $grandchildClassName.fromJson with the top nodes alias',
+            'that calls $grandchildClassName.fromJson with the top nodes alias',
             () {
               expect(
-                deserializeMethod!.toSource().contains(
-                  'return _i2.$grandchildClassName.fromJson',
+                protocolClass!.toSource().contains(
+                  '_i2.$grandchildClassName.fromJson',
                 ),
                 isTrue,
               );

--- a/tools/serverpod_cli/test/generator/dart/shared_code_generator/protocol/inheritance_protocol_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/shared_code_generator/protocol/inheritance_protocol_test.dart
@@ -170,21 +170,21 @@ void main() {
             expect(deserializeMethod, isNotNull);
           });
 
-          test('that does NOT return $parentClassName.fromJson', () {
+          test('that does NOT reference $parentClassName.fromJson', () {
             expect(
-              deserializeMethod!.toSource().contains(
-                'return _i3.$parentClassName.fromJson',
+              protocolClass!.toSource().contains(
+                '_i3.$parentClassName.fromJson',
               ),
               isFalse,
             );
           });
 
           test(
-            'that returns $childClassName.fromJson with the top nodes alias',
+            'that calls $childClassName.fromJson with the top nodes alias',
             () {
               expect(
-                deserializeMethod!.toSource().contains(
-                  'return _i2.$childClassName.fromJson',
+                protocolClass!.toSource().contains(
+                  '_i2.$childClassName.fromJson',
                 ),
                 isTrue,
               );
@@ -192,11 +192,11 @@ void main() {
           );
 
           test(
-            'that does return $grandchildClassName.fromJson with the top nodes alias',
+            'that calls $grandchildClassName.fromJson with the top nodes alias',
             () {
               expect(
-                deserializeMethod!.toSource().contains(
-                  'return _i2.$grandchildClassName.fromJson',
+                protocolClass!.toSource().contains(
+                  '_i2.$grandchildClassName.fromJson',
                 ),
                 isTrue,
               );


### PR DESCRIPTION
Replaces the `Protocol.deserialize<T>` if-chain with a static `Map<Type, dynamic Function(dynamic, Protocol)> _deserializers` lookup. Each former branch becomes its own closure, so dispatch is O(1) and the compiler no longer has to optimize one method holding thousands of `Type`-equality comparisons.

Fixes #5000.

## Why the if-chain is expensive to compile

The cost is not method size. In the same generated `protocol.dart`, compiled into the same snapshot:

| Method | Shape | Size | `gen_snapshot` cost |
|---|---|---:|---|
| `deserialize` | if-chain over `Type` constants | 4,342 branches | 2,122 s |
| `deserializeByClassName` | if-chain over `String` constants | 5,971 lines, ~1,850 branches | negligible |
| `getClassNameForType` | `switch` expression over `Type` | 1,854 arms | negligible |

A 5,971-line if-chain compiles fine; 4,342 `t == <Type constant>` comparisons do not. 73% of the time goes to `TypePropagation`.

A `switch` is not an alternative here: 1,907 of the 4,342 keys (43.9%) are `getType<X?>()` calls, and `case` patterns require constant expressions. Nullable types cannot be written as type literals in Dart, which is what that helper exists for. Converting only the const-expressible keys would leave ~1,907 comparisons in the chain.

## Measured impact

Apple M5 Max, Dart 3.12.2 (Flutter 3.44.6 SDK), a 4,367-entry project protocol. AOT built as `gen_kernel` + `gen_snapshot` so pass timings are visible; runtime measured with `dartaotruntime`.

### Compile

Minimal probe — Serverpod + Database + the project protocol, no endpoints:

| | Before | After |
|---|---:|---:|
| `gen_kernel` real | 15.34 s | 53.45 s |
| `gen_snapshot` real | 2,122.67 s | 12.61 s |
| └ `TypePropagation` | 1,551.09 s | 0.53 s |
| └ `ConstantPropagation` | 277.84 s | 0.24 s |
| └ `OptimizeBranches` | 274.95 s | 0.21 s |
| **total AOT** | **2,138.0 s** | **66.1 s** |

`gen_kernel` gets slower — 4,387 closures are more work for the front end — and that is included in the total above.

### Runtime

Enum models deserialized at spread positions of the chain; enums keep `fromJson` trivial so the measurement reflects dispatch. 300k iterations per case after 20k warmup.

| Position in chain | Before | After |
|---:|---:|---:|
| 1 | 17.4 ns | 18.1 ns |
| 464 | 976.2 ns | 17.8 ns |
| 918 | 1,883.7 ns | 17.7 ns |
| 1,389 | 2,974.9 ns | 17.0 ns |
| 1,832 | 4,943.4 ns | 17.6 ns |
| 4,108 (`List<T>` variant) | 39,887.7 ns | 73.2 ns |
| round-robin across all of the above | 8,704.8 ns | 29.7 ns |

Dispatch becomes flat in position. The chain is faster only for the type that happens to sit first, by 0.7 ns.

For models with many fields the relative gain is smaller, since `fromJson` dominates; the absolute saving per call is unchanged.

### Memory and startup

| | Before | After |
|---|---:|---:|
| first `deserialize` call | 13 µs | 2,617 µs |
| RSS after first call | 29.8 MB | 33.2 MB |
| snapshot `Total(HeapSize)` | 11.28 MB | 12.99 MB |
| snapshot `Total(CodeSize)` | 13.25 MB | 13.61 MB |

The map is built lazily on the first `deserialize`, not at process start, and pays for itself after roughly 300 calls.

## Implementation notes

* Map population uses a function body (`map[K] = (data, protocol) => ...;`) rather than a map literal so that duplicate `Type` keys — caused by the same Dart class being imported under multiple module aliases — do not trigger the `equal_keys_in_map` analyzer warning. Last-write-wins is harmless because duplicates have identical bodies.
* Closures have no access to `this`, so everything a body used to reach through the enclosing instance method is routed through the closure's `protocol` parameter: recursive `deserialize<X>` calls inside container types (`List<X>`, `Map<K,V>`, `Set<X>`, nullable variants, records), and `protocol.deserializeDynamicFieldValue(data)` for `dynamic` fields. The single `as T` cast is applied once at the call site in `deserialize<T>` rather than in each body.
* `deserialize<T>` is now a lookup followed by the same module-fallback chain, so module composition semantics are preserved.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else.
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

## Breaking changes

No semantic breaking changes. The generated `protocol.dart` shape changes — the if-chain in `Protocol.deserialize<T>` becomes a static `_deserializers` map with a `_buildDeserializers()` method — but this is internal generated code, not a stable API.

CLI test updates come with it:

* One `protocol_test.dart` case matched a regex against the `if (t == ... List<Person>?...)` shape; it now matches `map[...] = ...`.
* `inheritance_protocol_test.dart` and `inheritance_exception_protocol_test.dart` (server / client / shared each) inspected `deserializeMethod.toSource()` for `X.fromJson` to verify top-node alias resolution. Those calls now live in `_buildDeserializers`, so the tests target the protocol class instead — the same check, independent of which method holds the call, and it makes the negative assertion about sealed parents meaningful rather than vacuous.
