### PR TITLE
test: Avoid withServerpod doing work on test declare time

### DIFF
--- a/packages/serverpod/skills/serverpod-testing/SKILL.md
+++ b/packages/serverpod/skills/serverpod-testing/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: serverpod-testing
-description: Test Serverpod endpoints and business logic — withServerpod, sessionBuilder, authentication, DB seeding, rollback, streams, running tests. Use when writing server tests or working with serverpod_test.
+description: Test Serverpod endpoints and business logic - withServerpod, sessionBuilder, authentication, DB seeding, rollback, streams, running tests. Use when writing server tests or working with serverpod_test.
 ---
 
 # Serverpod Testing
 
-Generated test tools let you call endpoints in tests with full server context (DB, caching, etc.). Import the **generated** test tools file, not `serverpod_test` directly — it re-exports everything needed. The import path comes from `config/generator.yaml` (`server_test_tools_path`); the examples below use the common `test_tools/serverpod_test_tools.dart` output.
+Generated test tools let you call endpoints in tests with full server context (DB, caching, etc.). Import the **generated** test tools file, not `serverpod_test` directly - it re-exports everything needed. The import path comes from `config/generator.yaml` (`server_test_tools_path`); the examples below use the common `test_tools/serverpod_test_tools.dart` output.
 
 Prefer Given/when/then descriptions. Across nested groups plus the test name, there should be one clear Given, one when, and one then that can explain a failure without reading the code.
 
@@ -31,6 +31,8 @@ Start required services before running tests. In default Docker/PostgreSQL proje
 
 Use `sessionBuilder.copyWith(...)` to create modified sessions. Call `sessionBuilder.build()` to get a `Session` for DB operations or passing to helpers.
 
+> **Important:** Both `sessionBuilder.build()` and `sessionBuilder.copyWith()` only work after the framework's `setUpAll` has run. Calling them at the top of the `withServerpod` closure body (declaration time) throws `LateInitializationError` and prevents the test file from loading. Always defer them into `setUp`, `setUpAll`, `tearDown`, or the test body.
+
 ### Authenticated tests
 
 ```dart
@@ -38,9 +40,12 @@ withServerpod('Given AuthEndpoint', (sessionBuilder, endpoints) {
   final userId = '550e8400-e29b-41d4-a716-446655440000';
 
   group('when authenticated', () {
-    var authed = sessionBuilder.copyWith(
-      authentication: AuthenticationOverride.authenticationInfo(userId, {Scope('user')}),
-    );
+    late TestSessionBuilder authed;
+    setUp(() {
+      authed = sessionBuilder.copyWith(
+        authentication: AuthenticationOverride.authenticationInfo(userId, {Scope('user')}),
+      );
+    });
 
     test('then hello succeeds', () async {
       final greeting = await endpoints.authExample.hello(authed, 'Michael');
@@ -49,9 +54,12 @@ withServerpod('Given AuthEndpoint', (sessionBuilder, endpoints) {
   });
 
   group('when unauthenticated', () {
-    var unauthed = sessionBuilder.copyWith(
-      authentication: AuthenticationOverride.unauthenticated(),
-    );
+    late TestSessionBuilder unauthed;
+    setUp(() {
+      unauthed = sessionBuilder.copyWith(
+        authentication: AuthenticationOverride.unauthenticated(),
+      );
+    });
 
     test('then hello throws', () async {
       await expectLater(
@@ -67,7 +75,8 @@ withServerpod('Given AuthEndpoint', (sessionBuilder, endpoints) {
 
 ```dart
 withServerpod('Given Products endpoint', (sessionBuilder, endpoints) {
-  var session = sessionBuilder.build();
+  late Session session;
+  setUp(() => session = sessionBuilder.build());
 
   setUp(() async {
     await Product.db.insert(session, [
@@ -83,14 +92,14 @@ withServerpod('Given Products endpoint', (sessionBuilder, endpoints) {
 });
 ```
 
-No manual tearDown needed — by default each test runs in a transaction that is rolled back.
+No manual tearDown needed - by default each test runs in a transaction that is rolled back.
 
 ## Rollback behavior
 
-Default: `RollbackDatabase.afterEach` — each test in a rolled-back transaction.
+Default: `RollbackDatabase.afterEach` - each test in a rolled-back transaction.
 
-- `afterAll` — roll back after all tests in the group. Useful for scenario tests where consecutive tests depend on each other and setup is expensive.
-- `disabled` — no automatic rollback. Required when endpoint code uses concurrent `session.db.transaction(...)` calls (nested transactions would throw `InvalidConfigurationException`). Clean up manually in `tearDownAll`; consider `--concurrency=1`.
+- `afterAll` - roll back after all tests in the group. Useful for scenario tests where consecutive tests depend on each other and setup is expensive.
+- `disabled` - no automatic rollback. Required when endpoint code uses concurrent `session.db.transaction(...)` calls (nested transactions would throw `InvalidConfigurationException`). Clean up manually in `tearDownAll`; consider `--concurrency=1`.
 
 ```dart
 withServerpod(
@@ -115,7 +124,8 @@ If logic lives outside endpoints but needs a `Session`, use `withServerpod` and 
 
 ```dart
 withServerpod('Given product quantity is zero', (sessionBuilder, _) {
-  var session = sessionBuilder.build();
+  late Session session;
+  setUp(() => session = sessionBuilder.build());
 
   setUp(() async {
     await Product.db.insertRow(session, Product(id: 123, name: 'Apple', quantity: 0));
@@ -136,10 +146,14 @@ Use `flushEventQueue()` to ensure a generator executes up to its `yield` before 
 
 ```dart
 withServerpod('Given shared stream', (sessionBuilder, endpoints) {
-  final user1 = sessionBuilder.copyWith(
-    authentication: AuthenticationOverride.authenticationInfo('user-1', {}));
-  final user2 = sessionBuilder.copyWith(
-    authentication: AuthenticationOverride.authenticationInfo('user-2', {}));
+  late TestSessionBuilder user1;
+  late TestSessionBuilder user2;
+  setUp(() {
+    user1 = sessionBuilder.copyWith(
+      authentication: AuthenticationOverride.authenticationInfo('user-1', {}));
+    user2 = sessionBuilder.copyWith(
+      authentication: AuthenticationOverride.authenticationInfo('user-2', {}));
+  });
 
   test('when posting numbers then listener receives them', () async {
     var stream = endpoints.comm.listenForNumbers(user1);
@@ -158,7 +172,7 @@ withServerpod('Given shared stream', (sessionBuilder, endpoints) {
 | Option | Default | Description |
 | ------ | ------- | ----------- |
 | `applyMigrations` | `true` | Apply pending migrations on start |
-| `configOverride` | — | Override loaded server config for tests |
+| `configOverride` | - | Override loaded server config for tests |
 | `enableSessionLogging` | `false` | Enable session logging |
 | `experimentalFeatures` | `null` | Experimental features to enable for the tests |
 | `rollbackDatabase` | `afterEach` | When to rollback (afterEach, afterAll, disabled) |
@@ -179,23 +193,34 @@ dart test -x integration      # Only unit tests
 dart test -t integration --concurrency=1  # Sequential (for rollback disabled)
 ```
 
+## Test exceptions
+
+Exported from generated test tools:
+
+- `ServerpodUnauthenticatedException` - endpoint called without auth
+- `ServerpodInsufficientAccessException` - auth key lacks required scope
+- `ConnectionClosedException` - stream connection closed with error
+- `InvalidConfigurationException` - invalid config (e.g. nested transactions with rollback enabled)
+
 ## DB connection limits
 
-Each `withServerpod` lazily creates a Serverpod instance on first `sessionBuilder.build()`. With many concurrent tests, DB connections can exceed limits. Fix: raise the DB limit, or defer `build()` to `setUpAll`:
+`sessionBuilder.build()` always runs inside `setUp`/`setUpAll`/`test` (see Session builder section). For shared connections across tests in a group, prefer `setUpAll` over per-test `setUp`:
 
 ```dart
 withServerpod('Given example', (sessionBuilder, endpoints) {
   late Session session;
-  setUpAll(() { session = sessionBuilder.build(); });
+  setUpAll(() => session = sessionBuilder.build());
   // ...
 });
 ```
+
+Trade-off: `setUpAll` creates one shared `Session` for the group (saves connections); `setUp` creates one per test (better isolation). Both share the underlying transaction manager, so DB visibility is identical.
 
 ## Project structure
 
 Keep tests organized:
 
-- `test/unit/` — unit tests (no Serverpod dependency)
-- `test/integration/` — tests using `withServerpod`
+- `test/unit/` - unit tests (no Serverpod dependency)
+- `test/integration/` - tests using `withServerpod`
 
-Always call endpoints via the `endpoints` parameter, not by instantiating endpoint classes directly — the test tools handle lifecycle and validation to match production behavior.
+Always call endpoints via the `endpoints` parameter, not by instantiating endpoint classes directly - the test tools handle lifecycle and validation to match production behavior.

--- a/packages/serverpod/skills/serverpod-testing/SKILL.md
+++ b/packages/serverpod/skills/serverpod-testing/SKILL.md
@@ -29,6 +29,8 @@ void main() {
 
 Use `sessionBuilder.copyWith(...)` to create modified sessions. Call `sessionBuilder.build()` to get a `Session` for DB operations or passing to helpers.
 
+> **Important:** `sessionBuilder.build()` and `copyWith()` only work after the framework's `setUpAll` has run - calling them at declaration time throws `LateInitializationError` and stops the test file from loading. Defer them into `setUp`, `setUpAll`, `tearDown`, or the test body. When a hook already seeds data, build the session at the top of that hook instead of registering a second one.
+
 ### Authenticated tests
 
 ```dart
@@ -36,9 +38,12 @@ withServerpod('Given AuthEndpoint', (sessionBuilder, endpoints) {
   final userId = '550e8400-e29b-41d4-a716-446655440000';
 
   group('when authenticated', () {
-    var authed = sessionBuilder.copyWith(
-      authentication: AuthenticationOverride.authenticationInfo(userId, {Scope('user')}),
-    );
+    late TestSessionBuilder authed;
+    setUp(() {
+      authed = sessionBuilder.copyWith(
+        authentication: AuthenticationOverride.authenticationInfo(userId, {Scope('user')}),
+      );
+    });
 
     test('then hello succeeds', () async {
       final greeting = await endpoints.authExample.hello(authed, 'Michael');
@@ -47,9 +52,12 @@ withServerpod('Given AuthEndpoint', (sessionBuilder, endpoints) {
   });
 
   group('when unauthenticated', () {
-    var unauthed = sessionBuilder.copyWith(
-      authentication: AuthenticationOverride.unauthenticated(),
-    );
+    late TestSessionBuilder unauthed;
+    setUp(() {
+      unauthed = sessionBuilder.copyWith(
+        authentication: AuthenticationOverride.unauthenticated(),
+      );
+    });
 
     test('then hello throws', () async {
       await expectLater(
@@ -65,9 +73,9 @@ withServerpod('Given AuthEndpoint', (sessionBuilder, endpoints) {
 
 ```dart
 withServerpod('Given Products endpoint', (sessionBuilder, endpoints) {
-  var session = sessionBuilder.build();
-
+  late Session session;
   setUp(() async {
+    session = sessionBuilder.build();
     await Product.db.insert(session, [
       Product(name: 'Apple', price: 10),
       Product(name: 'Banana', price: 10),
@@ -108,9 +116,9 @@ If logic lives outside endpoints but needs a `Session`, use `withServerpod` and 
 
 ```dart
 withServerpod('Given product quantity is zero', (sessionBuilder, _) {
-  var session = sessionBuilder.build();
-
+  late Session session;
   setUp(() async {
+    session = sessionBuilder.build();
     await Product.db.insertRow(session, Product(id: 123, name: 'Apple', quantity: 0));
   });
 
@@ -129,10 +137,14 @@ Use `flushEventQueue()` to ensure a generator executes up to its `yield` before 
 
 ```dart
 withServerpod('Given shared stream', (sessionBuilder, endpoints) {
-  final user1 = sessionBuilder.copyWith(
-    authentication: AuthenticationOverride.authenticationInfo('user-1', {}));
-  final user2 = sessionBuilder.copyWith(
-    authentication: AuthenticationOverride.authenticationInfo('user-2', {}));
+  late TestSessionBuilder user1;
+  late TestSessionBuilder user2;
+  setUp(() {
+    user1 = sessionBuilder.copyWith(
+      authentication: AuthenticationOverride.authenticationInfo('user-1', {}));
+    user2 = sessionBuilder.copyWith(
+      authentication: AuthenticationOverride.authenticationInfo('user-2', {}));
+  });
 
   test('when posting numbers then listener receives them', () async {
     var stream = endpoints.comm.listenForNumbers(user1);
@@ -168,6 +180,29 @@ dart test -x integration      # Only unit tests
 **Nothing has to be started first — do NOT run `docker compose up`.** `withServerpod` boots the server in the `test` run mode, and the test database comes with it: projects created by `serverpod create` use an embedded PostgreSQL that Serverpod launches and manages, or a SQLite file. A generated `docker-compose.yaml` is present even in those projects, so seeing that file is not a reason to start Docker.
 
 Only when a run actually fails to reach the database is it worth opening `config/test.yaml`: a `database` section with `host`/`port` and no `dataPath` points at an external database, which does have to be running (`docker compose up -d` starts the one the project ships). With `dataPath` or `filePath` set, fix the configuration or runtime instead — starting Docker will not help.
+
+## Test exceptions
+
+Exported from generated test tools:
+
+- `ServerpodUnauthenticatedException` - endpoint called without auth
+- `ServerpodInsufficientAccessException` - auth key lacks required scope
+- `ConnectionClosedException` - stream connection closed with error
+- `InvalidConfigurationException` - invalid config (e.g. nested transactions with rollback enabled)
+
+## DB connection limits
+
+`sessionBuilder.build()` always runs inside `setUp`/`setUpAll`/`test` (see Session builder section). For shared connections across tests in a group, prefer `setUpAll` over per-test `setUp`:
+
+```dart
+withServerpod('Given example', (sessionBuilder, endpoints) {
+  late Session session;
+  setUpAll(() => session = sessionBuilder.build());
+  // ...
+});
+```
+
+Trade-off: `setUpAll` creates one shared `Session` for the group (saves connections); `setUp` creates one per test (better isolation). Both share the underlying transaction manager, so DB visibility is identical.
 
 ## Project structure
 

--- a/packages/serverpod_test/lib/src/test_serverpod.dart
+++ b/packages/serverpod_test/lib/src/test_serverpod.dart
@@ -111,6 +111,8 @@ class TestServerpod<T extends InternalTestEndpoints> {
   final TestServerOutputMode testServerOutputMode;
 
   /// Creates a new test serverpod instance.
+  ///
+  /// Endpoint wrappers are not initialized until the first [createSession] or [start] call.
   TestServerpod({
     required bool? applyMigrations,
     required EndpointDispatch endpoints,
@@ -145,12 +147,12 @@ class TestServerpod<T extends InternalTestEndpoints> {
           runtimeParametersBuilder: runtimeParametersBuilder,
         );
         endpoints.initializeEndpoints(serverpod.server);
+        testEndpoints.initialize(serializationManager, endpoints);
         return serverpod;
       },
       stdout: () => NullStdOut(),
       stderr: () => NullStdOut(),
     );
-    testEndpoints.initialize(serializationManager, endpoints);
   }
 
   /// Executes a callback with output suppression based on the configured mode.

--- a/packages/serverpod_test/lib/src/test_serverpod.dart
+++ b/packages/serverpod_test/lib/src/test_serverpod.dart
@@ -252,19 +252,7 @@ class TestServerpod<T extends InternalTestEndpoints> {
           );
         }
 
-        try {
-          await _serverpod.start(runInGuardedZone: false);
-        } catch (_) {
-          // A failed start skips shutdown(), so drop this group's database
-          // here. Best-effort, preserving the original start failure.
-          try {
-            await _serverpod.shutdown(exitProcess: false);
-          } catch (_) {}
-          try {
-            await _ephemeralDatabase?.drop();
-          } catch (_) {}
-          rethrow;
-        }
+        await _serverpod.start(runInGuardedZone: false);
       });
     } on InitializationException {
       // Already a descriptive failure (e.g. database setup); surface it as-is.
@@ -284,11 +272,19 @@ class TestServerpod<T extends InternalTestEndpoints> {
   /// database (a PostgreSQL `DROP DATABASE`, or deleting the SQLite file). The
   /// shared embedded postmaster is intentionally left running; it is reclaimed
   /// when the test process exits.
+  ///
+  /// `withServerpod` calls this from `tearDownAll` even when [start] failed, so
+  /// this is the only place that needs to clean up after a failed start.
   Future<void> shutdown() async {
     try {
       await _withOutputMode(() async {
-        await _serverpod.shutdown(exitProcess: false);
-        await _ephemeralDatabase?.drop();
+        try {
+          await _serverpod.shutdown(exitProcess: false);
+        } finally {
+          // Drop even if the shutdown failed, or a group that never finished
+          // starting leaves its database behind in the shared postmaster.
+          await _ephemeralDatabase?.drop();
+        }
       });
     } catch (e, stackTrace) {
       throw InitializationException(

--- a/packages/serverpod_test/lib/src/test_serverpod.dart
+++ b/packages/serverpod_test/lib/src/test_serverpod.dart
@@ -130,6 +130,8 @@ class TestServerpod<T extends InternalTestEndpoints> {
   final TestServerOutputMode testServerOutputMode;
 
   /// Creates a new test serverpod instance.
+  ///
+  /// Endpoint wrappers are not initialized until the first [createSession] or [start] call.
   TestServerpod({
     required bool? applyMigrations,
     required EndpointDispatch endpoints,
@@ -155,9 +157,7 @@ class TestServerpod<T extends InternalTestEndpoints> {
        _databaseInterceptor = databaseInterceptor,
        _configOverride = configOverride,
        testServerOutputMode =
-           testServerOutputMode ?? TestServerOutputMode.normal {
-    testEndpoints.initialize(serializationManager, endpoints);
-  }
+           testServerOutputMode ?? TestServerOutputMode.normal;
 
   /// Constructs a [Serverpod] whose configured database is this group's own: a
   /// PostgreSQL database named [_targetDatabaseName], or a SQLite file derived
@@ -201,6 +201,7 @@ class TestServerpod<T extends InternalTestEndpoints> {
           databaseInterceptor: _databaseInterceptor,
         );
         _endpoints.initializeEndpoints(serverpod.server);
+        testEndpoints.initialize(_serializationManager, _endpoints);
         return serverpod;
       },
       stdout: () => NullStdOut(),

--- a/packages/serverpod_test/lib/src/test_session_builder.dart
+++ b/packages/serverpod_test/lib/src/test_session_builder.dart
@@ -23,45 +23,46 @@ abstract class AuthenticationOverride {
 
 /// Internal test session that contains implementation details that should
 /// only be used internally by the test tools.
+///
+/// Construct, then call [bind] before any other method. Methods called
+/// before [bind] throw [LateInitializationError].
 class InternalTestSessionBuilder extends TestSessionBuilder {
-  final List<InternalServerpodSession> _allTestSessions;
-  final TestServerpod _testServerpod;
-  final AuthenticationOverride? _authenticationOverride;
-  final bool _enableLogging;
-  final InternalServerpodSession _mainServerpodSession;
+  late final List<InternalServerpodSession> _allTestSessions;
+  late final TestServerpod _testServerpod;
+  late final AuthenticationOverride? _authenticationOverride;
+  late final bool _enableLogging;
+  late final InternalServerpodSession _mainServerpodSession;
 
-  /// Creates a new internal test session.
-  InternalTestSessionBuilder(
-    TestServerpod testServerpod, {
-    AuthenticationOverride? authenticationOverride,
-    InternalTestSessionBuilder? sessionWithDatabaseConnection,
-    required bool enableLogging,
+  /// Populates the builder's state. Can only be called once.
+  void bind({
+    required TestServerpod testServerpod,
     required List<InternalServerpodSession> allTestSessions,
     required InternalServerpodSession mainServerpodSession,
-  }) : _allTestSessions = allTestSessions,
-       _authenticationOverride = authenticationOverride,
-       _testServerpod = testServerpod,
-       _enableLogging = enableLogging,
-       _mainServerpodSession = mainServerpodSession;
+    required bool enableLogging,
+    AuthenticationOverride? authenticationOverride,
+  }) {
+    _testServerpod = testServerpod;
+    _allTestSessions = allTestSessions;
+    _mainServerpodSession = mainServerpodSession;
+    _enableLogging = enableLogging;
+    _authenticationOverride = authenticationOverride;
+  }
 
   @override
-  Session build() {
-    return internalBuild();
-  }
+  Session build() => internalBuild();
 
   @override
   TestSessionBuilder copyWith({
     AuthenticationOverride? authentication,
     bool? enableLogging,
-  }) {
-    return InternalTestSessionBuilder(
-      _testServerpod,
+  }) => InternalTestSessionBuilder()
+    ..bind(
+      testServerpod: _testServerpod,
       allTestSessions: _allTestSessions,
-      authenticationOverride: authentication ?? _authenticationOverride,
-      enableLogging: enableLogging ?? _enableLogging,
       mainServerpodSession: _mainServerpodSession,
+      enableLogging: enableLogging ?? _enableLogging,
+      authenticationOverride: authentication ?? _authenticationOverride,
     );
-  }
 
   /// Creates a new Serverpod session with the specified [endpoint] and [method].
   /// Should only be used by generated code.

--- a/packages/serverpod_test/lib/src/with_serverpod.dart
+++ b/packages/serverpod_test/lib/src/with_serverpod.dart
@@ -72,9 +72,13 @@ typedef TestClosure<T> =
 /// The default integration test tag used by `withServerpod`.
 const String defaultIntegrationTestTag = 'integration';
 
-/// Builds the `withServerpod` test helper.
-/// Used by the generated code.
-/// Note: The [testGroupName] parameter is needed to enable IDE support.
+/// Builds the `withServerpod` test helper. Used by generated code.
+///
+/// Registers a `group` with `setUpAll`, `tearDown`, and `tearDownAll`
+/// hooks and nothing else. Session, transaction manager, endpoint
+/// wrappers, and Serverpod construction are all deferred into
+/// `setUpAll`, so test-tree enumeration stays cheap and sendable
+/// across isolates.
 void Function(TestClosure<T>)
 buildWithServerpod<T extends InternalTestEndpoints>(
   String testGroupName,
@@ -95,41 +99,7 @@ buildWithServerpod<T extends InternalTestEndpoints>(
   }
 
   var startTimeout = maybeServerpodStartTimeout ?? const Duration(seconds: 30);
-
-  var mainServerpodSession = testServerpod.createSession(
-    rollbackDatabase: rollbackDatabase,
-  );
-
-  TransactionManager? transactionManager;
-  if (testServerpod.isDatabaseEnabled) {
-    transactionManager = mainServerpodSession.transactionManager;
-    if (transactionManager == null) {
-      throw InitializationException(
-        'The transaction manager is null but database is enabled.',
-      );
-    }
-  }
-
-  TransactionManager getTransactionManager() {
-    var localTransactionManager = transactionManager;
-    if (localTransactionManager == null) {
-      throw StateError(
-        'The transaction manager is null.',
-      );
-    }
-
-    return localTransactionManager;
-  }
-
-  List<InternalServerpodSession> allTestSessions = [];
-
-  InternalTestSessionBuilder mainTestSessionBuilder =
-      InternalTestSessionBuilder(
-        testServerpod,
-        allTestSessions: allTestSessions,
-        enableLogging: maybeEnableSessionLogging ?? false,
-        mainServerpodSession: mainServerpodSession,
-      );
+  var enableLogging = maybeEnableSessionLogging ?? false;
 
   bool startServerpodFailed = false;
 
@@ -139,6 +109,22 @@ buildWithServerpod<T extends InternalTestEndpoints>(
     group(
       testGroupName,
       () {
+        final sessionBuilder = InternalTestSessionBuilder();
+        late final InternalServerpodSession mainServerpodSession;
+        late final List<InternalServerpodSession> allTestSessions;
+        TransactionManager? transactionManager;
+
+        TransactionManager getTransactionManager() {
+          var localTransactionManager = transactionManager;
+          if (localTransactionManager == null) {
+            throw StateError(
+              'The transaction manager is null.',
+            );
+          }
+
+          return localTransactionManager;
+        }
+
         setUpAll(() async {
           try {
             await testServerpod.start().timeout(
@@ -155,6 +141,25 @@ buildWithServerpod<T extends InternalTestEndpoints>(
             startServerpodFailed = true;
             rethrow;
           }
+
+          mainServerpodSession = testServerpod.createSession(
+            rollbackDatabase: rollbackDatabase,
+          );
+          if (testServerpod.isDatabaseEnabled) {
+            transactionManager = mainServerpodSession.transactionManager;
+            if (transactionManager == null) {
+              throw InitializationException(
+                'The transaction manager is null but database is enabled.',
+              );
+            }
+          }
+          allTestSessions = <InternalServerpodSession>[];
+          sessionBuilder.bind(
+            testServerpod: testServerpod,
+            allTestSessions: allTestSessions,
+            mainServerpodSession: mainServerpodSession,
+            enableLogging: enableLogging,
+          );
 
           if (rollbackDatabase == RollbackDatabase.afterAll ||
               rollbackDatabase == RollbackDatabase.afterEach) {
@@ -202,7 +207,7 @@ buildWithServerpod<T extends InternalTestEndpoints>(
           await testServerpod.shutdown();
         });
 
-        testClosure(mainTestSessionBuilder, testServerpod.testEndpoints);
+        testClosure(sessionBuilder, testServerpod.testEndpoints);
       },
       tags: maybeTestGroupTagsOverride ?? [defaultIntegrationTestTag],
     );

--- a/packages/serverpod_test/lib/src/with_serverpod.dart
+++ b/packages/serverpod_test/lib/src/with_serverpod.dart
@@ -101,8 +101,6 @@ buildWithServerpod<T extends InternalTestEndpoints>(
   var startTimeout = maybeServerpodStartTimeout ?? const Duration(seconds: 30);
   var enableLogging = maybeEnableSessionLogging ?? false;
 
-  bool startServerpodFailed = false;
-
   return (
     TestClosure<T> testClosure,
   ) {
@@ -126,21 +124,16 @@ buildWithServerpod<T extends InternalTestEndpoints>(
         }
 
         setUpAll(() async {
-          try {
-            await testServerpod.start().timeout(
-              startTimeout,
-              onTimeout: () {
-                throw InitializationException(
-                  'Serverpod did not start within the timeout of $startTimeout. '
-                  'This might indicate that Serverpod cannot connect to the database. '
-                  'Ensure that you have run `docker compose up` and check the logs for more information.',
-                );
-              },
-            );
-          } catch (_) {
-            startServerpodFailed = true;
-            rethrow;
-          }
+          await testServerpod.start().timeout(
+            startTimeout,
+            onTimeout: () {
+              throw InitializationException(
+                'Serverpod did not start within the timeout of $startTimeout. '
+                'This might indicate that Serverpod cannot connect to the database. '
+                'Ensure that you have run `docker compose up` and check the logs for more information.',
+              );
+            },
+          );
 
           mainServerpodSession = testServerpod.createSession(
             rollbackDatabase: rollbackDatabase,
@@ -164,46 +157,71 @@ buildWithServerpod<T extends InternalTestEndpoints>(
           if (rollbackDatabase == RollbackDatabase.afterAll ||
               rollbackDatabase == RollbackDatabase.afterEach) {
             var localTransactionManager = getTransactionManager();
-
-            await localTransactionManager.createTransaction();
-            await localTransactionManager.addSavepoint();
+            try {
+              await localTransactionManager.createTransaction();
+              await localTransactionManager.addSavepoint();
+            } catch (_) {
+              // A throw here can leave the transaction stack locked or a
+              // half-created transaction behind. That state persists across
+              // test groups because the TransactionManager is retained on
+              // mainServerpodSession. Reset so the next group starts clean.
+              await localTransactionManager.ensureTransactionIsUnlocked();
+              rethrow;
+            }
           }
         });
 
         tearDown(() async {
-          if (startServerpodFailed) {
-            return;
-          }
-
           if (rollbackDatabase == RollbackDatabase.afterEach) {
             var localTransactionManager = getTransactionManager();
-
-            await localTransactionManager.rollbackToPreviousSavepoint();
-            await localTransactionManager.addSavepoint();
+            try {
+              await localTransactionManager.rollbackToPreviousSavepoint();
+              await localTransactionManager.addSavepoint();
+            } catch (_) {
+              // Unlock so the next test in the group doesn't inherit a locked
+              // stack from a failed rollback/addSavepoint pair.
+              await localTransactionManager.ensureTransactionIsUnlocked();
+              rethrow;
+            }
           }
 
-          await mainServerpodSession.caches.clear();
-
-          await GlobalStreamManager.closeAllStreams();
+          await (
+            mainServerpodSession.caches.clear(),
+            GlobalStreamManager.closeAllStreams(),
+          ).wait;
         });
 
         tearDownAll(() async {
-          if (startServerpodFailed) {
-            return;
+          // DB-touching cleanup runs first, in parallel. They may return
+          // connections to the pool via rollback / session close.
+          Future<void> cancelTransactionIfNeeded() async {
+            if (rollbackDatabase == RollbackDatabase.afterAll ||
+                rollbackDatabase == RollbackDatabase.afterEach) {
+              var localTransactionManager = getTransactionManager();
+              await localTransactionManager.cancelTransaction();
+            }
           }
 
-          if (rollbackDatabase == RollbackDatabase.afterAll ||
-              rollbackDatabase == RollbackDatabase.afterEach) {
-            var localTransactionManager = getTransactionManager();
-
-            await localTransactionManager.cancelTransaction();
+          Future<void> closeAllTestSessions() async {
+            await [
+              for (var testSession in allTestSessions) testSession.close(),
+            ].wait;
+            allTestSessions.clear();
           }
 
-          for (var testSession in allTestSessions) {
-            await testSession.close();
+          try {
+            await (cancelTransactionIfNeeded(), closeAllTestSessions()).wait;
+          } catch (_) {
+            // Partial state from a broken setUpAll can make these fail.
+            // Not fatal - we still need shutdown to drain the pool.
           }
-          allTestSessions.clear();
 
+          // Shutdown must be sequentially last. pg.Pool.close() skips
+          // connections still marked _isInUse; they dangle until returned.
+          // Running shutdown in parallel with the DB cleanup above means
+          // an in-flight ROLLBACK can race pool.close() and leak its
+          // connection across test files, eventually hitting Postgres'
+          // max_connections cap.
           await testServerpod.shutdown();
         });
 

--- a/packages/serverpod_test/lib/src/with_serverpod.dart
+++ b/packages/serverpod_test/lib/src/with_serverpod.dart
@@ -72,9 +72,13 @@ typedef TestClosure<T> =
 /// The default integration test tag used by `withServerpod`.
 const String defaultIntegrationTestTag = 'integration';
 
-/// Builds the `withServerpod` test helper.
-/// Used by the generated code.
-/// Note: The [testGroupName] parameter is needed to enable IDE support.
+/// Builds the `withServerpod` test helper. Used by generated code.
+///
+/// Registers a `group` with `setUpAll`, `tearDown`, and `tearDownAll`
+/// hooks and nothing else. Session, transaction manager, endpoint
+/// wrappers, and Serverpod construction are all deferred into
+/// `setUpAll`, so test-tree enumeration stays cheap and sendable
+/// across isolates.
 void Function(TestClosure<T>)
 buildWithServerpod<T extends InternalTestEndpoints>(
   String testGroupName,
@@ -99,41 +103,7 @@ buildWithServerpod<T extends InternalTestEndpoints>(
   }
 
   var startTimeout = maybeServerpodStartTimeout ?? const Duration(seconds: 120);
-
-  var mainServerpodSession = testServerpod.createSession(
-    rollbackDatabase: rollbackDatabase,
-  );
-
-  TransactionManager? transactionManager;
-  if (testServerpod.isDatabaseEnabled) {
-    transactionManager = mainServerpodSession.transactionManager;
-    if (transactionManager == null) {
-      throw InitializationException(
-        'The transaction manager is null but database is enabled.',
-      );
-    }
-  }
-
-  TransactionManager getTransactionManager() {
-    var localTransactionManager = transactionManager;
-    if (localTransactionManager == null) {
-      throw StateError(
-        'The transaction manager is null.',
-      );
-    }
-
-    return localTransactionManager;
-  }
-
-  List<InternalServerpodSession> allTestSessions = [];
-
-  InternalTestSessionBuilder mainTestSessionBuilder =
-      InternalTestSessionBuilder(
-        testServerpod,
-        allTestSessions: allTestSessions,
-        enableLogging: maybeEnableSessionLogging ?? false,
-        mainServerpodSession: mainServerpodSession,
-      );
+  var enableLogging = maybeEnableSessionLogging ?? false;
 
   bool startServerpodFailed = false;
 
@@ -143,6 +113,22 @@ buildWithServerpod<T extends InternalTestEndpoints>(
     group(
       testGroupName,
       () {
+        final sessionBuilder = InternalTestSessionBuilder();
+        late final InternalServerpodSession mainServerpodSession;
+        late final List<InternalServerpodSession> allTestSessions;
+        TransactionManager? transactionManager;
+
+        TransactionManager getTransactionManager() {
+          var localTransactionManager = transactionManager;
+          if (localTransactionManager == null) {
+            throw StateError(
+              'The transaction manager is null.',
+            );
+          }
+
+          return localTransactionManager;
+        }
+
         setUpAll(() async {
           try {
             await testServerpod.start().timeout(
@@ -158,6 +144,25 @@ buildWithServerpod<T extends InternalTestEndpoints>(
             startServerpodFailed = true;
             rethrow;
           }
+
+          mainServerpodSession = testServerpod.createSession(
+            rollbackDatabase: rollbackDatabase,
+          );
+          if (testServerpod.isDatabaseEnabled) {
+            transactionManager = mainServerpodSession.transactionManager;
+            if (transactionManager == null) {
+              throw InitializationException(
+                'The transaction manager is null but database is enabled.',
+              );
+            }
+          }
+          allTestSessions = <InternalServerpodSession>[];
+          sessionBuilder.bind(
+            testServerpod: testServerpod,
+            allTestSessions: allTestSessions,
+            mainServerpodSession: mainServerpodSession,
+            enableLogging: enableLogging,
+          );
 
           if (rollbackDatabase == RollbackDatabase.afterAll ||
               rollbackDatabase == RollbackDatabase.afterEach) {
@@ -205,7 +210,7 @@ buildWithServerpod<T extends InternalTestEndpoints>(
           await testServerpod.shutdown();
         });
 
-        testClosure(mainTestSessionBuilder, testServerpod.testEndpoints);
+        testClosure(sessionBuilder, testServerpod.testEndpoints);
       },
       tags: maybeTestGroupTagsOverride ?? [defaultIntegrationTestTag],
     );

--- a/packages/serverpod_test/lib/src/with_serverpod.dart
+++ b/packages/serverpod_test/lib/src/with_serverpod.dart
@@ -105,8 +105,6 @@ buildWithServerpod<T extends InternalTestEndpoints>(
   var startTimeout = maybeServerpodStartTimeout ?? const Duration(seconds: 120);
   var enableLogging = maybeEnableSessionLogging ?? false;
 
-  bool startServerpodFailed = false;
-
   return (
     TestClosure<T> testClosure,
   ) {
@@ -116,45 +114,33 @@ buildWithServerpod<T extends InternalTestEndpoints>(
         final sessionBuilder = InternalTestSessionBuilder();
         late final InternalServerpodSession mainServerpodSession;
         late final List<InternalServerpodSession> allTestSessions;
-        TransactionManager? transactionManager;
-
-        TransactionManager getTransactionManager() {
-          var localTransactionManager = transactionManager;
-          if (localTransactionManager == null) {
-            throw StateError(
-              'The transaction manager is null.',
-            );
-          }
-
-          return localTransactionManager;
-        }
+        // Assigned in setUpAll whenever the database is enabled, which
+        // `rollbacksEnabled` already guarantees for every read below.
+        late final TransactionManager transactionManager;
 
         setUpAll(() async {
-          try {
-            await testServerpod.start().timeout(
-              startTimeout,
-              onTimeout: () {
-                throw InitializationException(
-                  'Serverpod did not start within the timeout of $startTimeout. '
-                  'This might indicate that Serverpod cannot connect to the database.',
-                );
-              },
-            );
-          } catch (_) {
-            startServerpodFailed = true;
-            rethrow;
-          }
+          await testServerpod.start().timeout(
+            startTimeout,
+            onTimeout: () {
+              throw InitializationException(
+                'Serverpod did not start within the timeout of $startTimeout. '
+                'This might indicate that Serverpod cannot connect to the database.',
+              );
+            },
+          );
 
           mainServerpodSession = testServerpod.createSession(
             rollbackDatabase: rollbackDatabase,
           );
           if (testServerpod.isDatabaseEnabled) {
-            transactionManager = mainServerpodSession.transactionManager;
-            if (transactionManager == null) {
+            var localTransactionManager =
+                mainServerpodSession.transactionManager;
+            if (localTransactionManager == null) {
               throw InitializationException(
                 'The transaction manager is null but database is enabled.',
               );
             }
+            transactionManager = localTransactionManager;
           }
           allTestSessions = <InternalServerpodSession>[];
           sessionBuilder.bind(
@@ -164,49 +150,61 @@ buildWithServerpod<T extends InternalTestEndpoints>(
             enableLogging: enableLogging,
           );
 
-          if (rollbackDatabase == RollbackDatabase.afterAll ||
-              rollbackDatabase == RollbackDatabase.afterEach) {
-            var localTransactionManager = getTransactionManager();
-
-            await localTransactionManager.createTransaction();
-            await localTransactionManager.addSavepoint();
+          // A throw here skips the group's tests, but tearDownAll still runs
+          // and drops the database. No unlock needed - this TransactionManager
+          // dies with the group's session.
+          if (rollbacksEnabled) {
+            await transactionManager.createTransaction();
+            await transactionManager.addSavepoint();
           }
         });
 
         tearDown(() async {
-          if (startServerpodFailed) {
-            return;
-          }
-
           if (rollbackDatabase == RollbackDatabase.afterEach) {
-            var localTransactionManager = getTransactionManager();
-
-            await localTransactionManager.rollbackToPreviousSavepoint();
-            await localTransactionManager.addSavepoint();
+            try {
+              await transactionManager.rollbackToPreviousSavepoint();
+              await transactionManager.addSavepoint();
+            } catch (_) {
+              // A half-applied pair leaves the stack locked, failing every
+              // later addSavepoint with ConcurrentTransactionsException.
+              await transactionManager.ensureTransactionIsUnlocked();
+              rethrow;
+            }
           }
 
-          await mainServerpodSession.caches.clear();
-
-          await GlobalStreamManager.closeAllStreams();
+          await (
+            mainServerpodSession.caches.clear(),
+            GlobalStreamManager.closeAllStreams(),
+          ).wait;
         });
 
         tearDownAll(() async {
-          if (startServerpodFailed) {
-            return;
+          // DB-touching cleanup runs first, in parallel; both return
+          // connections to the pool.
+          Future<void> cancelTransactionIfNeeded() async {
+            if (rollbacksEnabled) {
+              await transactionManager.cancelTransaction();
+            }
           }
 
-          if (rollbackDatabase == RollbackDatabase.afterAll ||
-              rollbackDatabase == RollbackDatabase.afterEach) {
-            var localTransactionManager = getTransactionManager();
-
-            await localTransactionManager.cancelTransaction();
+          Future<void> closeAllTestSessions() async {
+            await [
+              for (var testSession in allTestSessions) testSession.close(),
+            ].wait;
+            allTestSessions.clear();
           }
 
-          for (var testSession in allTestSessions) {
-            await testSession.close();
+          try {
+            await (cancelTransactionIfNeeded(), closeAllTestSessions()).wait;
+          } catch (_) {
+            // Swallowed rather than `finally`: a broken setUpAll leaves this
+            // state half-built, and rethrowing would report the resulting
+            // cascade as a second failure on top of the real one.
           }
-          allTestSessions.clear();
 
+          // Must run after, not alongside, the cleanup above: pg.Pool.close()
+          // skips connections still marked _isInUse, so a racing in-flight
+          // ROLLBACK leaks its connection until max_connections is hit.
           await testServerpod.shutdown();
         });
 

--- a/tests/serverpod_auth_test/serverpod_auth_test_server/test/integration/legacy_client_support_test.dart
+++ b/tests/serverpod_auth_test/serverpod_auth_test_server/test/integration/legacy_client_support_test.dart
@@ -1,4 +1,5 @@
 import 'package:serverpod/serverpod.dart';
+import 'package:serverpod/src/server/server.dart' show ServerInternalMethods;
 import 'package:serverpod_auth_bridge_server/serverpod_auth_bridge_server.dart';
 import 'package:serverpod_auth_client/serverpod_auth_client.dart'
     as legacy_auth;
@@ -23,673 +24,644 @@ void main() {
   });
 
   withServerpod(
-    'Given a migrated legacy user,',
+    'Given legacy client support is enabled,',
     testGroupTagsOverride: TestTags.concurrencyOneTestTags,
     rollbackDatabase: RollbackDatabase.disabled,
     (final sessionBuilder, final endpoints) {
-      // Must run before withServerpod boots the server so legacy middleware is
-      // active for all requests in this group.
-      _configurePublicLegacySupport(sessionBuilder);
+      setUpAll(() => _configurePublicLegacySupport(sessionBuilder));
 
-      const email = 'legacy-client-test@serverpod.dev';
-      const password = 'LegacyPass123!';
+      group('Given a migrated legacy user,', () {
+        const email = 'legacy-client-test@serverpod.dev';
+        const password = 'LegacyPass123!';
 
-      setUp(() async {
-        const config = EmailIdpConfig(secretHashPepper: 'test');
-        AuthServices.set(
-          identityProviderBuilders: [config],
-          tokenManagerBuilders: [
-            tokenManagerConfig,
-            const LegacySessionTokenManager(),
-          ],
+        setUp(() async {
+          const config = EmailIdpConfig(secretHashPepper: 'test');
+          AuthServices.set(
+            identityProviderBuilders: [config],
+            tokenManagerBuilders: [
+              tokenManagerConfig,
+              const LegacySessionTokenManager(),
+            ],
+          );
+
+          final legacyUserId = await endpoints
+              .emailAccountBackwardsCompatibilityTest
+              .createLegacyUser(
+                sessionBuilder,
+                email: email,
+                password: password,
+              );
+
+          await endpoints.emailAccountBackwardsCompatibilityTest.migrateUser(
+            sessionBuilder,
+            legacyUserId: legacyUserId,
+          );
+        });
+
+        tearDown(() async {
+          await _cleanUpDatabase(sessionBuilder.build());
+        });
+
+        test(
+          'when authenticating with correct credentials then returns success with session key.',
+          () async {
+            final legacyClient = _createLegacyClient(sessionBuilder);
+            final result =
+                await legacy_auth.Caller(
+                  legacyClient,
+                ).email.authenticate(
+                  email,
+                  password,
+                );
+
+            expect(result.success, isTrue);
+            expect(result.key, isNotNull);
+            expect(result.keyId, isNotNull);
+            expect(result.userInfo, isNotNull);
+            expect(result.userInfo!.id, isA<int>());
+            expect(result.userInfo!.email, equals(email));
+          },
         );
 
-        final legacyUserId = await endpoints
-            .emailAccountBackwardsCompatibilityTest
-            .createLegacyUser(
-              sessionBuilder,
-              email: email,
-              password: password,
+        test(
+          'when authenticating with wrong password then returns invalidCredentials.',
+          () async {
+            final legacyClient = _createLegacyClient(sessionBuilder);
+            final result =
+                await legacy_auth.Caller(
+                  legacyClient,
+                ).email.authenticate(
+                  email,
+                  'wrong-password',
+                );
+
+            expect(result.success, isFalse);
+            expect(
+              result.failReason,
+              equals(
+                legacy_auth.AuthenticationFailReason.invalidCredentials,
+              ),
+            );
+          },
+        );
+
+        test(
+          'when authenticating with non-existent email then returns invalidCredentials.',
+          () async {
+            final legacyClient = _createLegacyClient(sessionBuilder);
+            final result =
+                await legacy_auth.Caller(
+                  legacyClient,
+                ).email.authenticate(
+                  'nobody@serverpod.dev',
+                  password,
+                );
+
+            expect(result.success, isFalse);
+            expect(
+              result.failReason,
+              equals(
+                legacy_auth.AuthenticationFailReason.invalidCredentials,
+              ),
+            );
+          },
+        );
+      });
+
+      group(
+        'Given a migrated legacy user and a successful legacy authentication,',
+        () {
+          const email = 'legacy-session-test@serverpod.dev';
+          const password = 'LegacyPass123!';
+
+          late UuidValue authUserId;
+
+          setUp(() async {
+            const config = EmailIdpConfig(secretHashPepper: 'test');
+            AuthServices.set(
+              identityProviderBuilders: [config],
+              tokenManagerBuilders: [
+                tokenManagerConfig,
+                const LegacySessionTokenManager(),
+              ],
             );
 
-        await endpoints.emailAccountBackwardsCompatibilityTest.migrateUser(
-          sessionBuilder,
-          legacyUserId: legacyUserId,
-        );
-      });
+            final legacyUserId = await endpoints
+                .emailAccountBackwardsCompatibilityTest
+                .createLegacyUser(
+                  sessionBuilder,
+                  email: email,
+                  password: password,
+                );
 
-      tearDown(() async {
-        await _cleanUpDatabase(sessionBuilder.build());
-      });
+            await endpoints.emailAccountBackwardsCompatibilityTest.migrateUser(
+              sessionBuilder,
+              legacyUserId: legacyUserId,
+            );
 
-      test(
-        'when authenticating with correct credentials then returns success with session key.',
-        () async {
-          final legacyClient = _createLegacyClient(sessionBuilder);
-          final result =
+            final newAuthUserIdResult = await endpoints
+                .emailAccountBackwardsCompatibilityTest
+                .getNewAuthUserId(sessionBuilder, userId: legacyUserId);
+            authUserId = newAuthUserIdResult!;
+          });
+
+          tearDown(() async {
+            await _cleanUpDatabase(sessionBuilder.build());
+          });
+
+          test(
+            'when validating the legacy session token then it is valid.',
+            () async {
+              final authKeyProvider = MutableAuthKeyProvider();
+              final legacyClient = _createLegacyClient(
+                sessionBuilder,
+                authKeyProvider: authKeyProvider,
+              );
+              final authResult = await legacy_auth.Caller(legacyClient).email
+                  .authenticate(
+                    email,
+                    password,
+                  );
+              authKeyProvider.setToken('${authResult.keyId}:${authResult.key}');
+
+              final isValid = await legacyClient.modules.auth.status
+                  .isSignedIn();
+
+              expect(isValid, isTrue);
+            },
+          );
+
+          test(
+            'when validating the token then the user identifier matches.',
+            () async {
+              final authKeyProvider = MutableAuthKeyProvider();
+              final legacyClient = _createLegacyClient(
+                sessionBuilder,
+                authKeyProvider: authKeyProvider,
+              );
+              final authResult = await legacy_auth.Caller(legacyClient).email
+                  .authenticate(
+                    email,
+                    password,
+                  );
+              authKeyProvider.setToken('${authResult.keyId}:${authResult.key}');
+
+              final userInfo = await legacyClient.modules.auth.status
+                  .getUserInfo();
+
+              expect(userInfo?.userIdentifier, equals(authUserId.toString()));
+            },
+          );
+
+          test(
+            'when changing full name via legacy user endpoint then it is updated.',
+            () async {
+              final authKeyProvider = MutableAuthKeyProvider();
+              final legacyClient = _createLegacyClient(
+                sessionBuilder,
+                authKeyProvider: authKeyProvider,
+              );
+              final authResult = await legacy_auth.Caller(legacyClient).email
+                  .authenticate(
+                    email,
+                    password,
+                  );
+              authKeyProvider.setToken('${authResult.keyId}:${authResult.key}');
+
+              final changed = await legacyClient.modules.auth.user
+                  .changeFullName(
+                    'Legacy Full Name',
+                  );
+              final updatedUserInfo = await legacyClient.modules.auth.status
+                  .getUserInfo();
+
+              expect(changed, isTrue);
+              expect(updatedUserInfo?.fullName, equals('Legacy Full Name'));
+            },
+          );
+
+          test(
+            'when revoking the token then it becomes invalid.',
+            () async {
+              final authKeyProvider = MutableAuthKeyProvider();
+              final legacyClient = _createLegacyClient(
+                sessionBuilder,
+                authKeyProvider: authKeyProvider,
+              );
+              final authResult = await legacy_auth.Caller(legacyClient).email
+                  .authenticate(
+                    email,
+                    password,
+                  );
+              authKeyProvider.setToken('${authResult.keyId}:${authResult.key}');
+
+              await legacy_auth.Caller(legacyClient).status.signOutDevice();
+
+              final isValid = await legacyClient.modules.auth.status
+                  .isSignedIn();
+
+              expect(isValid, isFalse);
+            },
+          );
+        },
+      );
+
+      group('Given a migrated user with multiple legacy sessions,', () {
+        const email = 'legacy-multi-session@serverpod.dev';
+        const password = 'LegacyPass123!';
+
+        late MutableAuthKeyProvider authKeyProvider1;
+        late MutableAuthKeyProvider authKeyProvider2;
+        late _LegacyClient legacyClient1;
+        late _LegacyClient legacyClient2;
+
+        setUp(() async {
+          const config = EmailIdpConfig(secretHashPepper: 'test');
+          AuthServices.set(
+            identityProviderBuilders: [config],
+            tokenManagerBuilders: [
+              tokenManagerConfig,
+              const LegacySessionTokenManager(),
+            ],
+          );
+
+          final legacyUserId = await endpoints
+              .emailAccountBackwardsCompatibilityTest
+              .createLegacyUser(
+                sessionBuilder,
+                email: email,
+                password: password,
+              );
+
+          await endpoints.emailAccountBackwardsCompatibilityTest.migrateUser(
+            sessionBuilder,
+            legacyUserId: legacyUserId,
+          );
+
+          authKeyProvider1 = MutableAuthKeyProvider();
+          authKeyProvider2 = MutableAuthKeyProvider();
+          legacyClient1 = _createLegacyClient(
+            sessionBuilder,
+            authKeyProvider: authKeyProvider1,
+          );
+          legacyClient2 = _createLegacyClient(
+            sessionBuilder,
+            authKeyProvider: authKeyProvider2,
+          );
+
+          final result1 =
               await legacy_auth.Caller(
-                legacyClient,
+                legacyClient1,
               ).email.authenticate(
                 email,
                 password,
               );
+          authKeyProvider1.setToken('${result1.keyId}:${result1.key}');
 
-          expect(result.success, isTrue);
-          expect(result.key, isNotNull);
-          expect(result.keyId, isNotNull);
-          expect(result.userInfo, isNotNull);
-          expect(result.userInfo!.id, isA<int>());
-          expect(result.userInfo!.email, equals(email));
-        },
-      );
-
-      test(
-        'when authenticating with wrong password then returns invalidCredentials.',
-        () async {
-          final legacyClient = _createLegacyClient(sessionBuilder);
-          final result =
+          final result2 =
               await legacy_auth.Caller(
-                legacyClient,
+                legacyClient2,
               ).email.authenticate(
                 email,
-                'wrong-password',
-              );
-
-          expect(result.success, isFalse);
-          expect(
-            result.failReason,
-            equals(
-              legacy_auth.AuthenticationFailReason.invalidCredentials,
-            ),
-          );
-        },
-      );
-
-      test(
-        'when authenticating with non-existent email then returns invalidCredentials.',
-        () async {
-          final legacyClient = _createLegacyClient(sessionBuilder);
-          final result =
-              await legacy_auth.Caller(
-                legacyClient,
-              ).email.authenticate(
-                'nobody@serverpod.dev',
                 password,
               );
+          authKeyProvider2.setToken('${result2.keyId}:${result2.key}');
+        });
 
-          expect(result.success, isFalse);
-          expect(
-            result.failReason,
-            equals(
-              legacy_auth.AuthenticationFailReason.invalidCredentials,
-            ),
-          );
-        },
-      );
-    },
-  );
+        tearDown(() async {
+          await _cleanUpDatabase(sessionBuilder.build());
+        });
 
-  withServerpod(
-    'Given a migrated legacy user and a successful legacy authentication,',
-    testGroupTagsOverride: TestTags.concurrencyOneTestTags,
-    rollbackDatabase: RollbackDatabase.disabled,
-    (final sessionBuilder, final endpoints) {
-      _configurePublicLegacySupport(sessionBuilder);
+        test(
+          'when revoking all tokens then all become invalid.',
+          () async {
+            await legacy_auth.Caller(legacyClient1).status.signOutAllDevices();
 
-      const email = 'legacy-session-test@serverpod.dev';
-      const password = 'LegacyPass123!';
-
-      late UuidValue authUserId;
-
-      setUp(() async {
-        const config = EmailIdpConfig(secretHashPepper: 'test');
-        AuthServices.set(
-          identityProviderBuilders: [config],
-          tokenManagerBuilders: [
-            tokenManagerConfig,
-            const LegacySessionTokenManager(),
-          ],
-        );
-
-        final legacyUserId = await endpoints
-            .emailAccountBackwardsCompatibilityTest
-            .createLegacyUser(
-              sessionBuilder,
-              email: email,
-              password: password,
-            );
-
-        await endpoints.emailAccountBackwardsCompatibilityTest.migrateUser(
-          sessionBuilder,
-          legacyUserId: legacyUserId,
-        );
-
-        final newAuthUserIdResult = await endpoints
-            .emailAccountBackwardsCompatibilityTest
-            .getNewAuthUserId(sessionBuilder, userId: legacyUserId);
-        authUserId = newAuthUserIdResult!;
-      });
-
-      tearDown(() async {
-        await _cleanUpDatabase(sessionBuilder.build());
-      });
-
-      test(
-        'when validating the legacy session token then it is valid.',
-        () async {
-          final authKeyProvider = MutableAuthKeyProvider();
-          final legacyClient = _createLegacyClient(
-            sessionBuilder,
-            authKeyProvider: authKeyProvider,
-          );
-          final authResult = await legacy_auth.Caller(legacyClient).email
-              .authenticate(
-                email,
-                password,
-              );
-          authKeyProvider.setToken('${authResult.keyId}:${authResult.key}');
-
-          final isValid = await legacyClient.modules.auth.status.isSignedIn();
-
-          expect(isValid, isTrue);
-        },
-      );
-
-      test(
-        'when validating the token then the user identifier matches.',
-        () async {
-          final authKeyProvider = MutableAuthKeyProvider();
-          final legacyClient = _createLegacyClient(
-            sessionBuilder,
-            authKeyProvider: authKeyProvider,
-          );
-          final authResult = await legacy_auth.Caller(legacyClient).email
-              .authenticate(
-                email,
-                password,
-              );
-          authKeyProvider.setToken('${authResult.keyId}:${authResult.key}');
-
-          final userInfo = await legacyClient.modules.auth.status.getUserInfo();
-
-          expect(userInfo?.userIdentifier, equals(authUserId.toString()));
-        },
-      );
-
-      test(
-        'when changing full name via legacy user endpoint then it is updated.',
-        () async {
-          final authKeyProvider = MutableAuthKeyProvider();
-          final legacyClient = _createLegacyClient(
-            sessionBuilder,
-            authKeyProvider: authKeyProvider,
-          );
-          final authResult = await legacy_auth.Caller(legacyClient).email
-              .authenticate(
-                email,
-                password,
-              );
-          authKeyProvider.setToken('${authResult.keyId}:${authResult.key}');
-
-          final changed = await legacyClient.modules.auth.user.changeFullName(
-            'Legacy Full Name',
-          );
-          final updatedUserInfo = await legacyClient.modules.auth.status
-              .getUserInfo();
-
-          expect(changed, isTrue);
-          expect(updatedUserInfo?.fullName, equals('Legacy Full Name'));
-        },
-      );
-
-      test(
-        'when revoking the token then it becomes invalid.',
-        () async {
-          final authKeyProvider = MutableAuthKeyProvider();
-          final legacyClient = _createLegacyClient(
-            sessionBuilder,
-            authKeyProvider: authKeyProvider,
-          );
-          final authResult = await legacy_auth.Caller(legacyClient).email
-              .authenticate(
-                email,
-                password,
-              );
-          authKeyProvider.setToken('${authResult.keyId}:${authResult.key}');
-
-          await legacy_auth.Caller(legacyClient).status.signOutDevice();
-
-          final isValid = await legacyClient.modules.auth.status.isSignedIn();
-
-          expect(isValid, isFalse);
-        },
-      );
-    },
-  );
-
-  withServerpod(
-    'Given a migrated user with multiple legacy sessions,',
-    testGroupTagsOverride: TestTags.concurrencyOneTestTags,
-    rollbackDatabase: RollbackDatabase.disabled,
-    (final sessionBuilder, final endpoints) {
-      _configurePublicLegacySupport(sessionBuilder);
-
-      const email = 'legacy-multi-session@serverpod.dev';
-      const password = 'LegacyPass123!';
-
-      late MutableAuthKeyProvider authKeyProvider1;
-      late MutableAuthKeyProvider authKeyProvider2;
-      late _LegacyClient legacyClient1;
-      late _LegacyClient legacyClient2;
-
-      setUp(() async {
-        const config = EmailIdpConfig(secretHashPepper: 'test');
-        AuthServices.set(
-          identityProviderBuilders: [config],
-          tokenManagerBuilders: [
-            tokenManagerConfig,
-            const LegacySessionTokenManager(),
-          ],
-        );
-
-        final legacyUserId = await endpoints
-            .emailAccountBackwardsCompatibilityTest
-            .createLegacyUser(
-              sessionBuilder,
-              email: email,
-              password: password,
-            );
-
-        await endpoints.emailAccountBackwardsCompatibilityTest.migrateUser(
-          sessionBuilder,
-          legacyUserId: legacyUserId,
-        );
-
-        authKeyProvider1 = MutableAuthKeyProvider();
-        authKeyProvider2 = MutableAuthKeyProvider();
-        legacyClient1 = _createLegacyClient(
-          sessionBuilder,
-          authKeyProvider: authKeyProvider1,
-        );
-        legacyClient2 = _createLegacyClient(
-          sessionBuilder,
-          authKeyProvider: authKeyProvider2,
-        );
-
-        final result1 =
-            await legacy_auth.Caller(
+            final isValid1 = await legacy_auth.Caller(
               legacyClient1,
-            ).email.authenticate(
-              email,
-              password,
-            );
-        authKeyProvider1.setToken('${result1.keyId}:${result1.key}');
-
-        final result2 =
-            await legacy_auth.Caller(
+            ).status.isSignedIn();
+            final isValid2 = await legacy_auth.Caller(
               legacyClient2,
-            ).email.authenticate(
-              email,
-              password,
+            ).status.isSignedIn();
+
+            expect(isValid1, isFalse);
+            expect(isValid2, isFalse);
+          },
+        );
+      });
+
+      group('Given a post-migration user (no legacy record),', () {
+        const email = 'post-migration@serverpod.dev';
+        const password = 'NewPass123!';
+
+        setUp(() async {
+          String? receivedVerificationCode;
+          final config = EmailIdpConfig(
+            secretHashPepper: 'test',
+            sendRegistrationVerificationCode:
+                (
+                  final session, {
+                  required final email,
+                  required final accountRequestId,
+                  required final transaction,
+                  required final verificationCode,
+                }) {
+                  receivedVerificationCode = verificationCode;
+                },
+          );
+          AuthServices.set(
+            identityProviderBuilders: [config],
+            tokenManagerBuilders: [
+              tokenManagerConfig,
+              const LegacySessionTokenManager(),
+            ],
+          );
+
+          final requestId = await endpoints.emailAccount.startRegistration(
+            sessionBuilder,
+            email: email,
+          );
+
+          final registrationToken = await endpoints.emailAccount
+              .verifyRegistrationCode(
+                sessionBuilder,
+                accountRequestId: requestId,
+                verificationCode: receivedVerificationCode!,
+              );
+
+          await endpoints.emailAccount.finishRegistration(
+            sessionBuilder,
+            registrationToken: registrationToken,
+            password: password,
+          );
+        });
+
+        tearDown(() async {
+          await _cleanUpDatabase(sessionBuilder.build());
+        });
+
+        test(
+          'when authenticating via legacy endpoint then returns internalError.',
+          () async {
+            final legacyClient = _createLegacyClient(sessionBuilder);
+            final result =
+                await legacy_auth.Caller(
+                  legacyClient,
+                ).email.authenticate(
+                  email,
+                  password,
+                );
+
+            expect(result.success, isFalse);
+            expect(
+              result.failReason,
+              equals(legacy_auth.AuthenticationFailReason.internalError),
             );
-        authKeyProvider2.setToken('${result2.keyId}:${result2.key}');
+          },
+        );
       });
 
-      tearDown(() async {
-        await _cleanUpDatabase(sessionBuilder.build());
+      group('Given unsupported legacy email methods,', () {
+        test(
+          'when calling createAccountRequest then returns false.',
+          () async {
+            final legacyClient = _createLegacyClient(sessionBuilder);
+            final result = await legacy_auth.Caller(legacyClient).email
+                .createAccountRequest(
+                  'test',
+                  'test@test.com',
+                  'pass',
+                );
+
+            expect(result, isFalse);
+          },
+        );
+
+        test(
+          'when calling changePassword then returns false.',
+          () async {
+            final legacyClient = _createLegacyClient(sessionBuilder);
+            final result = await legacyClient.modules.auth.email.changePassword(
+              'old',
+              'new',
+            );
+
+            expect(result, isFalse);
+          },
+        );
+
+        test(
+          'when calling initiatePasswordReset then returns false.',
+          () async {
+            final legacyClient = _createLegacyClient(sessionBuilder);
+            final result = await legacy_auth.Caller(legacyClient).email
+                .initiatePasswordReset(
+                  'test@test.com',
+                );
+
+            expect(result, isFalse);
+          },
+        );
       });
 
-      test(
-        'when revoking all tokens then all become invalid.',
-        () async {
-          await legacy_auth.Caller(legacyClient1).status.signOutAllDevices();
-
-          final isValid1 = await legacy_auth.Caller(
-            legacyClient1,
-          ).status.isSignedIn();
-          final isValid2 = await legacy_auth.Caller(
-            legacyClient2,
-          ).status.isSignedIn();
-
-          expect(isValid1, isFalse);
-          expect(isValid2, isFalse);
-        },
-      );
-    },
-  );
-
-  withServerpod(
-    'Given a post-migration user (no legacy record),',
-    testGroupTagsOverride: TestTags.concurrencyOneTestTags,
-    rollbackDatabase: RollbackDatabase.disabled,
-    (final sessionBuilder, final endpoints) {
-      _configurePublicLegacySupport(sessionBuilder);
-
-      const email = 'post-migration@serverpod.dev';
-      const password = 'NewPass123!';
-
-      setUp(() async {
-        String? receivedVerificationCode;
-        final config = EmailIdpConfig(
-          secretHashPepper: 'test',
-          sendRegistrationVerificationCode:
-              (
-                final session, {
-                required final email,
-                required final accountRequestId,
-                required final transaction,
-                required final verificationCode,
-              }) {
-                receivedVerificationCode = verificationCode;
-              },
-        );
-        AuthServices.set(
-          identityProviderBuilders: [config],
-          tokenManagerBuilders: [
-            tokenManagerConfig,
-            const LegacySessionTokenManager(),
-          ],
+      group('Given legacy endpoints outside the forwarding allowlist,', () {
+        test(
+          'when calling Google authenticate then it is handled by non-legacy endpoint.',
+          () async {
+            final legacyClient = _createLegacyClient(sessionBuilder);
+            await expectLater(
+              legacy_auth.Caller(legacyClient).google.authenticateWithIdToken(
+                'fake-token',
+              ),
+              throwsA(isA<legacy_auth.ServerpodClientInternalServerError>()),
+            );
+          },
         );
 
-        final requestId = await endpoints.emailAccount.startRegistration(
-          sessionBuilder,
-          email: email,
+        test(
+          'when calling Firebase authenticate then it is handled by non-legacy endpoint.',
+          () async {
+            final legacyClient = _createLegacyClient(sessionBuilder);
+            final result = await legacyClient.modules.auth.firebase
+                .authenticate(
+                  'fake-token',
+                );
+
+            expect(result.success, isFalse);
+            expect(
+              result.failReason,
+              equals(legacy_auth.AuthenticationFailReason.internalError),
+            );
+          },
         );
 
-        final registrationToken = await endpoints.emailAccount
-            .verifyRegistrationCode(
+        test(
+          'when calling Admin getUserInfo then it is handled by non-legacy endpoint.',
+          () async {
+            final legacyClient = _createLegacyClient(sessionBuilder);
+            await expectLater(
+              legacy_auth.Caller(legacyClient).admin.getUserInfo(1),
+              throwsA(isA<legacy_auth.ServerpodClientUnauthorized>()),
+            );
+          },
+        );
+      });
+
+      group(
+        'Given migrated legacy users and an authenticated admin session,',
+        () {
+          const adminEmail = 'legacy-admin@serverpod.dev';
+          const targetEmail = 'legacy-user@serverpod.dev';
+          const password = 'LegacyPass123!';
+
+          late int targetLegacyUserId;
+          late MutableAuthKeyProvider adminAuthKeyProvider;
+          late Client adminClient;
+          late _LegacyClient adminLegacyClient;
+
+          setUp(() async {
+            const config = EmailIdpConfig(secretHashPepper: 'test');
+            AuthServices.set(
+              identityProviderBuilders: [config],
+              tokenManagerBuilders: [
+                tokenManagerConfig,
+                const LegacySessionTokenManager(),
+              ],
+            );
+
+            final adminLegacyUserId = await endpoints
+                .emailAccountBackwardsCompatibilityTest
+                .createLegacyUser(
+                  sessionBuilder,
+                  email: adminEmail,
+                  password: password,
+                );
+            targetLegacyUserId = await endpoints
+                .emailAccountBackwardsCompatibilityTest
+                .createLegacyUser(
+                  sessionBuilder,
+                  email: targetEmail,
+                  password: password,
+                );
+
+            await endpoints.emailAccountBackwardsCompatibilityTest.migrateUser(
               sessionBuilder,
-              accountRequestId: requestId,
-              verificationCode: receivedVerificationCode!,
+              legacyUserId: adminLegacyUserId,
             );
-
-        await endpoints.emailAccount.finishRegistration(
-          sessionBuilder,
-          registrationToken: registrationToken,
-          password: password,
-        );
-      });
-
-      tearDown(() async {
-        await _cleanUpDatabase(sessionBuilder.build());
-      });
-
-      test(
-        'when authenticating via legacy endpoint then returns internalError.',
-        () async {
-          final legacyClient = _createLegacyClient(sessionBuilder);
-          final result =
-              await legacy_auth.Caller(
-                legacyClient,
-              ).email.authenticate(
-                email,
-                password,
-              );
-
-          expect(result.success, isFalse);
-          expect(
-            result.failReason,
-            equals(legacy_auth.AuthenticationFailReason.internalError),
-          );
-        },
-      );
-    },
-  );
-
-  withServerpod(
-    'Given unsupported legacy email methods,',
-    testGroupTagsOverride: TestTags.concurrencyOneTestTags,
-    rollbackDatabase: RollbackDatabase.disabled,
-    (final sessionBuilder, final endpoints) {
-      _configurePublicLegacySupport(sessionBuilder);
-
-      test(
-        'when calling createAccountRequest then returns false.',
-        () async {
-          final legacyClient = _createLegacyClient(sessionBuilder);
-          final result = await legacy_auth.Caller(legacyClient).email
-              .createAccountRequest(
-                'test',
-                'test@test.com',
-                'pass',
-              );
-
-          expect(result, isFalse);
-        },
-      );
-
-      test(
-        'when calling changePassword then returns false.',
-        () async {
-          final legacyClient = _createLegacyClient(sessionBuilder);
-          final result = await legacyClient.modules.auth.email.changePassword(
-            'old',
-            'new',
-          );
-
-          expect(result, isFalse);
-        },
-      );
-
-      test(
-        'when calling initiatePasswordReset then returns false.',
-        () async {
-          final legacyClient = _createLegacyClient(sessionBuilder);
-          final result = await legacy_auth.Caller(legacyClient).email
-              .initiatePasswordReset(
-                'test@test.com',
-              );
-
-          expect(result, isFalse);
-        },
-      );
-    },
-  );
-
-  withServerpod(
-    'Given legacy endpoints outside the forwarding allowlist,',
-    testGroupTagsOverride: TestTags.concurrencyOneTestTags,
-    rollbackDatabase: RollbackDatabase.disabled,
-    (final sessionBuilder, final endpoints) {
-      _configurePublicLegacySupport(sessionBuilder);
-
-      test(
-        'when calling Google authenticate then it is handled by non-legacy endpoint.',
-        () async {
-          final legacyClient = _createLegacyClient(sessionBuilder);
-          await expectLater(
-            legacy_auth.Caller(legacyClient).google.authenticateWithIdToken(
-              'fake-token',
-            ),
-            throwsA(isA<legacy_auth.ServerpodClientInternalServerError>()),
-          );
-        },
-      );
-
-      test(
-        'when calling Firebase authenticate then it is handled by non-legacy endpoint.',
-        () async {
-          final legacyClient = _createLegacyClient(sessionBuilder);
-          final result = await legacyClient.modules.auth.firebase.authenticate(
-            'fake-token',
-          );
-
-          expect(result.success, isFalse);
-          expect(
-            result.failReason,
-            equals(legacy_auth.AuthenticationFailReason.internalError),
-          );
-        },
-      );
-
-      test(
-        'when calling Admin getUserInfo then it is handled by non-legacy endpoint.',
-        () async {
-          final legacyClient = _createLegacyClient(sessionBuilder);
-          await expectLater(
-            legacy_auth.Caller(legacyClient).admin.getUserInfo(1),
-            throwsA(isA<legacy_auth.ServerpodClientUnauthorized>()),
-          );
-        },
-      );
-    },
-  );
-
-  withServerpod(
-    'Given migrated legacy users and an authenticated admin session,',
-    testGroupTagsOverride: TestTags.concurrencyOneTestTags,
-    rollbackDatabase: RollbackDatabase.disabled,
-    (final sessionBuilder, final endpoints) {
-      _configurePublicLegacySupport(sessionBuilder);
-
-      const adminEmail = 'legacy-admin@serverpod.dev';
-      const targetEmail = 'legacy-user@serverpod.dev';
-      const password = 'LegacyPass123!';
-
-      late int targetLegacyUserId;
-      late MutableAuthKeyProvider adminAuthKeyProvider;
-      late Client adminClient;
-      late _LegacyClient adminLegacyClient;
-
-      setUp(() async {
-        const config = EmailIdpConfig(secretHashPepper: 'test');
-        AuthServices.set(
-          identityProviderBuilders: [config],
-          tokenManagerBuilders: [
-            tokenManagerConfig,
-            const LegacySessionTokenManager(),
-          ],
-        );
-
-        final adminLegacyUserId = await endpoints
-            .emailAccountBackwardsCompatibilityTest
-            .createLegacyUser(
+            await endpoints.emailAccountBackwardsCompatibilityTest.migrateUser(
               sessionBuilder,
-              email: adminEmail,
-              password: password,
+              legacyUserId: targetLegacyUserId,
             );
-        targetLegacyUserId = await endpoints
-            .emailAccountBackwardsCompatibilityTest
-            .createLegacyUser(
+
+            final adminAuthUserId = await endpoints
+                .emailAccountBackwardsCompatibilityTest
+                .getNewAuthUserId(sessionBuilder, userId: adminLegacyUserId);
+
+            final session = sessionBuilder.build();
+            final adminAuthUser = await AuthServices.instance.authUsers.get(
+              session,
+              authUserId: adminAuthUserId!,
+            );
+            await AuthServices.instance.authUsers.update(
+              session,
+              authUserId: adminAuthUserId,
+              scopes: {...adminAuthUser.scopes, Scope.admin},
+            );
+
+            adminAuthKeyProvider = MutableAuthKeyProvider();
+            adminClient = _createClient(
               sessionBuilder,
-              email: targetEmail,
-              password: password,
+              authKeyProvider: adminAuthKeyProvider,
             );
+            adminLegacyClient = _createLegacyClient(
+              sessionBuilder,
+              authKeyProvider: adminAuthKeyProvider,
+            );
+            final adminAuthResult = await legacy_auth.Caller(
+              adminLegacyClient,
+            ).email.authenticate(adminEmail, password);
+            adminAuthKeyProvider.setToken(
+              '${adminAuthResult.keyId}:${adminAuthResult.key}',
+            );
+          });
 
-        await endpoints.emailAccountBackwardsCompatibilityTest.migrateUser(
-          sessionBuilder,
-          legacyUserId: adminLegacyUserId,
-        );
-        await endpoints.emailAccountBackwardsCompatibilityTest.migrateUser(
-          sessionBuilder,
-          legacyUserId: targetLegacyUserId,
-        );
+          tearDown(() async {
+            await _cleanUpDatabase(sessionBuilder.build());
+          });
 
-        final adminAuthUserId = await endpoints
-            .emailAccountBackwardsCompatibilityTest
-            .getNewAuthUserId(sessionBuilder, userId: adminLegacyUserId);
+          test(
+            'when calling getUserInfo then it returns mapped user data.',
+            () async {
+              final userInfo = await adminClient
+                  .modules
+                  .serverpod_auth_bridge
+                  .legacyAdmin
+                  .getUserInfo(targetLegacyUserId);
 
-        final session = sessionBuilder.build();
-        final adminAuthUser = await AuthServices.instance.authUsers.get(
-          session,
-          authUserId: adminAuthUserId!,
-        );
-        await AuthServices.instance.authUsers.update(
-          session,
-          authUserId: adminAuthUserId,
-          scopes: {...adminAuthUser.scopes, Scope.admin},
-        );
-
-        adminAuthKeyProvider = MutableAuthKeyProvider();
-        adminClient = _createClient(
-          sessionBuilder,
-          authKeyProvider: adminAuthKeyProvider,
-        );
-        adminLegacyClient = _createLegacyClient(
-          sessionBuilder,
-          authKeyProvider: adminAuthKeyProvider,
-        );
-        final adminAuthResult = await legacy_auth.Caller(
-          adminLegacyClient,
-        ).email.authenticate(adminEmail, password);
-        adminAuthKeyProvider.setToken(
-          '${adminAuthResult.keyId}:${adminAuthResult.key}',
-        );
-      });
-
-      tearDown(() async {
-        await _cleanUpDatabase(sessionBuilder.build());
-      });
-
-      test(
-        'when calling getUserInfo then it returns mapped user data.',
-        () async {
-          final userInfo = await adminClient
-              .modules
-              .serverpod_auth_bridge
-              .legacyAdmin
-              .getUserInfo(targetLegacyUserId);
-
-          expect(userInfo, isNotNull);
-          expect(userInfo!.id, equals(targetLegacyUserId));
-          expect(userInfo.email, equals(targetEmail));
-          expect(userInfo.blocked, isFalse);
-        },
-      );
-
-      test(
-        'when blocking a user then authentication fails with blocked.',
-        () async {
-          await adminClient.modules.serverpod_auth_bridge.legacyAdmin.blockUser(
-            targetLegacyUserId,
+              expect(userInfo, isNotNull);
+              expect(userInfo!.id, equals(targetLegacyUserId));
+              expect(userInfo.email, equals(targetEmail));
+              expect(userInfo.blocked, isFalse);
+            },
           );
 
-          final blockedInfo = await adminClient
-              .modules
-              .serverpod_auth_bridge
-              .legacyAdmin
-              .getUserInfo(targetLegacyUserId);
-          expect(blockedInfo!.blocked, isTrue);
+          test(
+            'when blocking a user then authentication fails with blocked.',
+            () async {
+              await adminClient.modules.serverpod_auth_bridge.legacyAdmin
+                  .blockUser(
+                    targetLegacyUserId,
+                  );
 
-          final targetLegacyClient = _createLegacyClient(sessionBuilder);
-          final authResult = await targetLegacyClient.modules.auth.email
-              .authenticate(
-                targetEmail,
-                password,
+              final blockedInfo = await adminClient
+                  .modules
+                  .serverpod_auth_bridge
+                  .legacyAdmin
+                  .getUserInfo(targetLegacyUserId);
+              expect(blockedInfo!.blocked, isTrue);
+
+              final targetLegacyClient = _createLegacyClient(sessionBuilder);
+              final authResult = await targetLegacyClient.modules.auth.email
+                  .authenticate(
+                    targetEmail,
+                    password,
+                  );
+
+              expect(authResult.success, isFalse);
+              expect(
+                authResult.failReason,
+                equals(legacy_auth.AuthenticationFailReason.blocked),
               );
-
-          expect(authResult.success, isFalse);
-          expect(
-            authResult.failReason,
-            equals(legacy_auth.AuthenticationFailReason.blocked),
+            },
           );
-        },
-      );
 
-      test(
-        'when unblocking a user then authentication succeeds again.',
-        () async {
-          await adminClient.modules.serverpod_auth_bridge.legacyAdmin.blockUser(
-            targetLegacyUserId,
+          test(
+            'when unblocking a user then authentication succeeds again.',
+            () async {
+              await adminClient.modules.serverpod_auth_bridge.legacyAdmin
+                  .blockUser(
+                    targetLegacyUserId,
+                  );
+              await adminClient.modules.serverpod_auth_bridge.legacyAdmin
+                  .unblockUser(
+                    targetLegacyUserId,
+                  );
+
+              final unblockedInfo = await adminClient
+                  .modules
+                  .serverpod_auth_bridge
+                  .legacyAdmin
+                  .getUserInfo(targetLegacyUserId);
+              expect(unblockedInfo!.blocked, isFalse);
+
+              final targetLegacyClient = _createLegacyClient(sessionBuilder);
+              final authResult = await legacy_auth.Caller(
+                targetLegacyClient,
+              ).email.authenticate(targetEmail, password);
+
+              expect(authResult.success, isTrue);
+            },
           );
-          await adminClient.modules.serverpod_auth_bridge.legacyAdmin
-              .unblockUser(
-                targetLegacyUserId,
-              );
-
-          final unblockedInfo = await adminClient
-              .modules
-              .serverpod_auth_bridge
-              .legacyAdmin
-              .getUserInfo(targetLegacyUserId);
-          expect(unblockedInfo!.blocked, isFalse);
-
-          final targetLegacyClient = _createLegacyClient(sessionBuilder);
-          final authResult = await legacy_auth.Caller(
-            targetLegacyClient,
-          ).email.authenticate(targetEmail, password);
-
-          expect(authResult.success, isTrue);
         },
       );
     },
@@ -745,10 +717,14 @@ Client _createClient(
 }
 
 void _configurePublicLegacySupport(final TestSessionBuilder sessionBuilder) {
-  final pod = sessionBuilder.build().server.serverpod;
-  pod.authenticationHandler = (final session, final authKey) =>
-      AuthServices.instance.authenticationHandler(session, authKey);
-  pod.enableLegacyClientSupport();
+  final server = sessionBuilder.build().server;
+  // The auth handler is captured by `Server.start()`, so post-start mutation
+  // of `pod.authenticationHandler` is ignored. Use the test-only hot-swap.
+  server.setAuthenticationHandlerForTesting(
+    (final session, final authKey) =>
+        AuthServices.instance.authenticationHandler(session, authKey),
+  );
+  server.serverpod.enableLegacyClientSupport();
 }
 
 class MutableAuthKeyProvider implements ClientAuthKeyProvider {

--- a/tests/serverpod_auth_test/serverpod_auth_test_server/test/integration/legacy_client_support_test.dart
+++ b/tests/serverpod_auth_test/serverpod_auth_test_server/test/integration/legacy_client_support_test.dart
@@ -1,4 +1,5 @@
 import 'package:serverpod/serverpod.dart';
+import 'package:serverpod/src/server/server.dart' show ServerInternalMethods;
 import 'package:serverpod_auth_bridge_server/serverpod_auth_bridge_server.dart';
 import 'package:serverpod_auth_client/serverpod_auth_client.dart'
     as legacy_auth;
@@ -22,459 +23,638 @@ void main() {
   });
 
   withServerpod(
-    'Given a migrated legacy user,',
+    'Given legacy client support is enabled,',
     rollbackDatabase: RollbackDatabase.disabled,
     (final sessionBuilder, final endpoints) {
-      // Must run before withServerpod boots the server so legacy middleware is
-      // active for all requests in this group.
-      _configurePublicLegacySupport(sessionBuilder);
+      setUpAll(() => _configurePublicLegacySupport(sessionBuilder));
 
-      const email = 'legacy-client-test@serverpod.dev';
-      const password = 'LegacyPass123!';
+      group('Given a migrated legacy user,', () {
+        const email = 'legacy-client-test@serverpod.dev';
+        const password = 'LegacyPass123!';
 
-      setUp(() async {
-        const config = EmailIdpConfig(secretHashPepper: 'test');
-        AuthServices.set(
-          identityProviderBuilders: [config],
-          tokenManagerBuilders: [
-            tokenManagerConfig,
-            const LegacySessionTokenManager(),
-          ],
+        setUp(() async {
+          const config = EmailIdpConfig(secretHashPepper: 'test');
+          AuthServices.set(
+            identityProviderBuilders: [config],
+            tokenManagerBuilders: [
+              tokenManagerConfig,
+              const LegacySessionTokenManager(),
+            ],
+          );
+
+          final legacyUserId = await endpoints
+              .emailAccountBackwardsCompatibilityTest
+              .createLegacyUser(
+                sessionBuilder,
+                email: email,
+                password: password,
+              );
+
+          await endpoints.emailAccountBackwardsCompatibilityTest.migrateUser(
+            sessionBuilder,
+            legacyUserId: legacyUserId,
+          );
+        });
+
+        tearDown(() async {
+          await _cleanUpDatabase(sessionBuilder.build());
+        });
+
+        test(
+          'when authenticating with correct credentials then returns success with session key.',
+          () async {
+            final legacyClient = _createLegacyClient(sessionBuilder);
+            final result =
+                await legacy_auth.Caller(
+                  legacyClient,
+                ).email.authenticate(
+                  email,
+                  password,
+                );
+
+            expect(result.success, isTrue);
+            expect(result.key, isNotNull);
+            expect(result.keyId, isNotNull);
+            expect(result.userInfo, isNotNull);
+            expect(result.userInfo!.id, isA<int>());
+            expect(result.userInfo!.email, equals(email));
+          },
         );
 
-        final legacyUserId = await endpoints
-            .emailAccountBackwardsCompatibilityTest
-            .createLegacyUser(
-              sessionBuilder,
-              email: email,
-              password: password,
+        test(
+          'when authenticating with wrong password then returns invalidCredentials.',
+          () async {
+            final legacyClient = _createLegacyClient(sessionBuilder);
+            final result =
+                await legacy_auth.Caller(
+                  legacyClient,
+                ).email.authenticate(
+                  email,
+                  'wrong-password',
+                );
+
+            expect(result.success, isFalse);
+            expect(
+              result.failReason,
+              equals(
+                legacy_auth.AuthenticationFailReason.invalidCredentials,
+              ),
+            );
+          },
+        );
+
+        test(
+          'when authenticating with non-existent email then returns invalidCredentials.',
+          () async {
+            final legacyClient = _createLegacyClient(sessionBuilder);
+            final result =
+                await legacy_auth.Caller(
+                  legacyClient,
+                ).email.authenticate(
+                  'nobody@serverpod.dev',
+                  password,
+                );
+
+            expect(result.success, isFalse);
+            expect(
+              result.failReason,
+              equals(
+                legacy_auth.AuthenticationFailReason.invalidCredentials,
+              ),
+            );
+          },
+        );
+      });
+
+      group(
+        'Given a migrated legacy user and a successful legacy authentication,',
+        () {
+          const email = 'legacy-session-test@serverpod.dev';
+          const password = 'LegacyPass123!';
+
+          late UuidValue authUserId;
+
+          setUp(() async {
+            const config = EmailIdpConfig(secretHashPepper: 'test');
+            AuthServices.set(
+              identityProviderBuilders: [config],
+              tokenManagerBuilders: [
+                tokenManagerConfig,
+                const LegacySessionTokenManager(),
+              ],
             );
 
-        await endpoints.emailAccountBackwardsCompatibilityTest.migrateUser(
-          sessionBuilder,
-          legacyUserId: legacyUserId,
-        );
-      });
+            final legacyUserId = await endpoints
+                .emailAccountBackwardsCompatibilityTest
+                .createLegacyUser(
+                  sessionBuilder,
+                  email: email,
+                  password: password,
+                );
 
-      tearDown(() async {
-        await _cleanUpDatabase(sessionBuilder.build());
-      });
+            await endpoints.emailAccountBackwardsCompatibilityTest.migrateUser(
+              sessionBuilder,
+              legacyUserId: legacyUserId,
+            );
 
-      test(
-        'when authenticating with correct credentials then returns success with session key.',
-        () async {
-          final legacyClient = _createLegacyClient(sessionBuilder);
-          final result =
+            final newAuthUserIdResult = await endpoints
+                .emailAccountBackwardsCompatibilityTest
+                .getNewAuthUserId(sessionBuilder, userId: legacyUserId);
+            authUserId = newAuthUserIdResult!;
+          });
+
+          tearDown(() async {
+            await _cleanUpDatabase(sessionBuilder.build());
+          });
+
+          test(
+            'when validating the legacy session token then it is valid.',
+            () async {
+              final authKeyProvider = MutableAuthKeyProvider();
+              final legacyClient = _createLegacyClient(
+                sessionBuilder,
+                authKeyProvider: authKeyProvider,
+              );
+              final authResult = await legacy_auth.Caller(legacyClient).email
+                  .authenticate(
+                    email,
+                    password,
+                  );
+              authKeyProvider.setToken('${authResult.keyId}:${authResult.key}');
+
+              final isValid = await legacyClient.modules.auth.status
+                  .isSignedIn();
+
+              expect(isValid, isTrue);
+            },
+          );
+
+          test(
+            'when validating the token then the user identifier matches.',
+            () async {
+              final authKeyProvider = MutableAuthKeyProvider();
+              final legacyClient = _createLegacyClient(
+                sessionBuilder,
+                authKeyProvider: authKeyProvider,
+              );
+              final authResult = await legacy_auth.Caller(legacyClient).email
+                  .authenticate(
+                    email,
+                    password,
+                  );
+              authKeyProvider.setToken('${authResult.keyId}:${authResult.key}');
+
+              final userInfo = await legacyClient.modules.auth.status
+                  .getUserInfo();
+
+              expect(userInfo?.userIdentifier, equals(authUserId.toString()));
+            },
+          );
+
+          test(
+            'when changing full name via legacy user endpoint then it is updated.',
+            () async {
+              final authKeyProvider = MutableAuthKeyProvider();
+              final legacyClient = _createLegacyClient(
+                sessionBuilder,
+                authKeyProvider: authKeyProvider,
+              );
+              final authResult = await legacy_auth.Caller(legacyClient).email
+                  .authenticate(
+                    email,
+                    password,
+                  );
+              authKeyProvider.setToken('${authResult.keyId}:${authResult.key}');
+
+              final changed = await legacyClient.modules.auth.user
+                  .changeFullName(
+                    'Legacy Full Name',
+                  );
+              final updatedUserInfo = await legacyClient.modules.auth.status
+                  .getUserInfo();
+
+              expect(changed, isTrue);
+              expect(updatedUserInfo?.fullName, equals('Legacy Full Name'));
+            },
+          );
+
+          test(
+            'when revoking the token then it becomes invalid.',
+            () async {
+              final authKeyProvider = MutableAuthKeyProvider();
+              final legacyClient = _createLegacyClient(
+                sessionBuilder,
+                authKeyProvider: authKeyProvider,
+              );
+              final authResult = await legacy_auth.Caller(legacyClient).email
+                  .authenticate(
+                    email,
+                    password,
+                  );
+              authKeyProvider.setToken('${authResult.keyId}:${authResult.key}');
+
+              await legacy_auth.Caller(legacyClient).status.signOutDevice();
+
+              final isValid = await legacyClient.modules.auth.status
+                  .isSignedIn();
+
+              expect(isValid, isFalse);
+            },
+          );
+        },
+      );
+
+      group('Given a migrated user with multiple legacy sessions,', () {
+        const email = 'legacy-multi-session@serverpod.dev';
+        const password = 'LegacyPass123!';
+
+        late MutableAuthKeyProvider authKeyProvider1;
+        late MutableAuthKeyProvider authKeyProvider2;
+        late _LegacyClient legacyClient1;
+        late _LegacyClient legacyClient2;
+
+        setUp(() async {
+          const config = EmailIdpConfig(secretHashPepper: 'test');
+          AuthServices.set(
+            identityProviderBuilders: [config],
+            tokenManagerBuilders: [
+              tokenManagerConfig,
+              const LegacySessionTokenManager(),
+            ],
+          );
+
+          final legacyUserId = await endpoints
+              .emailAccountBackwardsCompatibilityTest
+              .createLegacyUser(
+                sessionBuilder,
+                email: email,
+                password: password,
+              );
+
+          await endpoints.emailAccountBackwardsCompatibilityTest.migrateUser(
+            sessionBuilder,
+            legacyUserId: legacyUserId,
+          );
+
+          authKeyProvider1 = MutableAuthKeyProvider();
+          authKeyProvider2 = MutableAuthKeyProvider();
+          legacyClient1 = _createLegacyClient(
+            sessionBuilder,
+            authKeyProvider: authKeyProvider1,
+          );
+          legacyClient2 = _createLegacyClient(
+            sessionBuilder,
+            authKeyProvider: authKeyProvider2,
+          );
+
+          final result1 =
               await legacy_auth.Caller(
-                legacyClient,
+                legacyClient1,
               ).email.authenticate(
                 email,
                 password,
               );
+          authKeyProvider1.setToken('${result1.keyId}:${result1.key}');
 
-          expect(result.success, isTrue);
-          expect(result.key, isNotNull);
-          expect(result.keyId, isNotNull);
-          expect(result.userInfo, isNotNull);
-          expect(result.userInfo!.id, isA<int>());
-          expect(result.userInfo!.email, equals(email));
-        },
-      );
-
-      test(
-        'when authenticating with wrong password then returns invalidCredentials.',
-        () async {
-          final legacyClient = _createLegacyClient(sessionBuilder);
-          final result =
+          final result2 =
               await legacy_auth.Caller(
-                legacyClient,
+                legacyClient2,
               ).email.authenticate(
                 email,
-                'wrong-password',
-              );
-
-          expect(result.success, isFalse);
-          expect(
-            result.failReason,
-            equals(
-              legacy_auth.AuthenticationFailReason.invalidCredentials,
-            ),
-          );
-        },
-      );
-
-      test(
-        'when authenticating with non-existent email then returns invalidCredentials.',
-        () async {
-          final legacyClient = _createLegacyClient(sessionBuilder);
-          final result =
-              await legacy_auth.Caller(
-                legacyClient,
-              ).email.authenticate(
-                'nobody@serverpod.dev',
                 password,
               );
+          authKeyProvider2.setToken('${result2.keyId}:${result2.key}');
+        });
 
-          expect(result.success, isFalse);
-          expect(
-            result.failReason,
-            equals(
-              legacy_auth.AuthenticationFailReason.invalidCredentials,
-            ),
-          );
-        },
-      );
-    },
-  );
+        tearDown(() async {
+          await _cleanUpDatabase(sessionBuilder.build());
+        });
 
-  withServerpod(
-    'Given a migrated legacy user and a successful legacy authentication,',
-    rollbackDatabase: RollbackDatabase.disabled,
-    (final sessionBuilder, final endpoints) {
-      _configurePublicLegacySupport(sessionBuilder);
+        test(
+          'when revoking all tokens then all become invalid.',
+          () async {
+            await legacy_auth.Caller(legacyClient1).status.signOutAllDevices();
 
-      const email = 'legacy-session-test@serverpod.dev';
-      const password = 'LegacyPass123!';
-
-      late UuidValue authUserId;
-
-      setUp(() async {
-        const config = EmailIdpConfig(secretHashPepper: 'test');
-        AuthServices.set(
-          identityProviderBuilders: [config],
-          tokenManagerBuilders: [
-            tokenManagerConfig,
-            const LegacySessionTokenManager(),
-          ],
-        );
-
-        final legacyUserId = await endpoints
-            .emailAccountBackwardsCompatibilityTest
-            .createLegacyUser(
-              sessionBuilder,
-              email: email,
-              password: password,
-            );
-
-        await endpoints.emailAccountBackwardsCompatibilityTest.migrateUser(
-          sessionBuilder,
-          legacyUserId: legacyUserId,
-        );
-
-        final newAuthUserIdResult = await endpoints
-            .emailAccountBackwardsCompatibilityTest
-            .getNewAuthUserId(sessionBuilder, userId: legacyUserId);
-        authUserId = newAuthUserIdResult!;
-      });
-
-      tearDown(() async {
-        await _cleanUpDatabase(sessionBuilder.build());
-      });
-
-      test(
-        'when validating the legacy session token then it is valid.',
-        () async {
-          final authKeyProvider = MutableAuthKeyProvider();
-          final legacyClient = _createLegacyClient(
-            sessionBuilder,
-            authKeyProvider: authKeyProvider,
-          );
-          final authResult = await legacy_auth.Caller(legacyClient).email
-              .authenticate(
-                email,
-                password,
-              );
-          authKeyProvider.setToken('${authResult.keyId}:${authResult.key}');
-
-          final isValid = await legacyClient.modules.auth.status.isSignedIn();
-
-          expect(isValid, isTrue);
-        },
-      );
-
-      test(
-        'when validating the token then the user identifier matches.',
-        () async {
-          final authKeyProvider = MutableAuthKeyProvider();
-          final legacyClient = _createLegacyClient(
-            sessionBuilder,
-            authKeyProvider: authKeyProvider,
-          );
-          final authResult = await legacy_auth.Caller(legacyClient).email
-              .authenticate(
-                email,
-                password,
-              );
-          authKeyProvider.setToken('${authResult.keyId}:${authResult.key}');
-
-          final userInfo = await legacyClient.modules.auth.status.getUserInfo();
-
-          expect(userInfo?.userIdentifier, equals(authUserId.toString()));
-        },
-      );
-
-      test(
-        'when changing full name via legacy user endpoint then it is updated.',
-        () async {
-          final authKeyProvider = MutableAuthKeyProvider();
-          final legacyClient = _createLegacyClient(
-            sessionBuilder,
-            authKeyProvider: authKeyProvider,
-          );
-          final authResult = await legacy_auth.Caller(legacyClient).email
-              .authenticate(
-                email,
-                password,
-              );
-          authKeyProvider.setToken('${authResult.keyId}:${authResult.key}');
-
-          final changed = await legacyClient.modules.auth.user.changeFullName(
-            'Legacy Full Name',
-          );
-          final updatedUserInfo = await legacyClient.modules.auth.status
-              .getUserInfo();
-
-          expect(changed, isTrue);
-          expect(updatedUserInfo?.fullName, equals('Legacy Full Name'));
-        },
-      );
-
-      test(
-        'when revoking the token then it becomes invalid.',
-        () async {
-          final authKeyProvider = MutableAuthKeyProvider();
-          final legacyClient = _createLegacyClient(
-            sessionBuilder,
-            authKeyProvider: authKeyProvider,
-          );
-          final authResult = await legacy_auth.Caller(legacyClient).email
-              .authenticate(
-                email,
-                password,
-              );
-          authKeyProvider.setToken('${authResult.keyId}:${authResult.key}');
-
-          await legacy_auth.Caller(legacyClient).status.signOutDevice();
-
-          final isValid = await legacyClient.modules.auth.status.isSignedIn();
-
-          expect(isValid, isFalse);
-        },
-      );
-    },
-  );
-
-  withServerpod(
-    'Given a migrated user with multiple legacy sessions,',
-    rollbackDatabase: RollbackDatabase.disabled,
-    (final sessionBuilder, final endpoints) {
-      _configurePublicLegacySupport(sessionBuilder);
-
-      const email = 'legacy-multi-session@serverpod.dev';
-      const password = 'LegacyPass123!';
-
-      late MutableAuthKeyProvider authKeyProvider1;
-      late MutableAuthKeyProvider authKeyProvider2;
-      late _LegacyClient legacyClient1;
-      late _LegacyClient legacyClient2;
-
-      setUp(() async {
-        const config = EmailIdpConfig(secretHashPepper: 'test');
-        AuthServices.set(
-          identityProviderBuilders: [config],
-          tokenManagerBuilders: [
-            tokenManagerConfig,
-            const LegacySessionTokenManager(),
-          ],
-        );
-
-        final legacyUserId = await endpoints
-            .emailAccountBackwardsCompatibilityTest
-            .createLegacyUser(
-              sessionBuilder,
-              email: email,
-              password: password,
-            );
-
-        await endpoints.emailAccountBackwardsCompatibilityTest.migrateUser(
-          sessionBuilder,
-          legacyUserId: legacyUserId,
-        );
-
-        authKeyProvider1 = MutableAuthKeyProvider();
-        authKeyProvider2 = MutableAuthKeyProvider();
-        legacyClient1 = _createLegacyClient(
-          sessionBuilder,
-          authKeyProvider: authKeyProvider1,
-        );
-        legacyClient2 = _createLegacyClient(
-          sessionBuilder,
-          authKeyProvider: authKeyProvider2,
-        );
-
-        final result1 =
-            await legacy_auth.Caller(
+            final isValid1 = await legacy_auth.Caller(
               legacyClient1,
-            ).email.authenticate(
-              email,
-              password,
-            );
-        authKeyProvider1.setToken('${result1.keyId}:${result1.key}');
-
-        final result2 =
-            await legacy_auth.Caller(
+            ).status.isSignedIn();
+            final isValid2 = await legacy_auth.Caller(
               legacyClient2,
-            ).email.authenticate(
-              email,
-              password,
+            ).status.isSignedIn();
+
+            expect(isValid1, isFalse);
+            expect(isValid2, isFalse);
+          },
+        );
+      });
+
+      group('Given a post-migration user (no legacy record),', () {
+        const email = 'post-migration@serverpod.dev';
+        const password = 'NewPass123!';
+
+        setUp(() async {
+          String? receivedVerificationCode;
+          final config = EmailIdpConfig(
+            secretHashPepper: 'test',
+            sendRegistrationVerificationCode:
+                (
+                  final session, {
+                  required final email,
+                  required final accountRequestId,
+                  required final transaction,
+                  required final verificationCode,
+                }) {
+                  receivedVerificationCode = verificationCode;
+                },
+          );
+          AuthServices.set(
+            identityProviderBuilders: [config],
+            tokenManagerBuilders: [
+              tokenManagerConfig,
+              const LegacySessionTokenManager(),
+            ],
+          );
+
+          final requestId = await endpoints.emailAccount.startRegistration(
+            sessionBuilder,
+            email: email,
+          );
+
+          final registrationToken = await endpoints.emailAccount
+              .verifyRegistrationCode(
+                sessionBuilder,
+                accountRequestId: requestId,
+                verificationCode: receivedVerificationCode!,
+              );
+
+          await endpoints.emailAccount.finishRegistration(
+            sessionBuilder,
+            registrationToken: registrationToken,
+            password: password,
+          );
+        });
+
+        tearDown(() async {
+          await _cleanUpDatabase(sessionBuilder.build());
+        });
+
+        test(
+          'when authenticating via legacy endpoint then returns internalError.',
+          () async {
+            final legacyClient = _createLegacyClient(sessionBuilder);
+            final result =
+                await legacy_auth.Caller(
+                  legacyClient,
+                ).email.authenticate(
+                  email,
+                  password,
+                );
+
+            expect(result.success, isFalse);
+            expect(
+              result.failReason,
+              equals(legacy_auth.AuthenticationFailReason.internalError),
             );
-        authKeyProvider2.setToken('${result2.keyId}:${result2.key}');
+          },
+        );
       });
 
-      tearDown(() async {
-        await _cleanUpDatabase(sessionBuilder.build());
-      });
+      group('Given unsupported legacy email methods,', () {
+        test(
+          'when calling createAccountRequest then returns false.',
+          () async {
+            final legacyClient = _createLegacyClient(sessionBuilder);
+            final result = await legacy_auth.Caller(legacyClient).email
+                .createAccountRequest(
+                  'test',
+                  'test@test.com',
+                  'pass',
+                );
 
-      test(
-        'when revoking all tokens then all become invalid.',
-        () async {
-          await legacy_auth.Caller(legacyClient1).status.signOutAllDevices();
-
-          final isValid1 = await legacy_auth.Caller(
-            legacyClient1,
-          ).status.isSignedIn();
-          final isValid2 = await legacy_auth.Caller(
-            legacyClient2,
-          ).status.isSignedIn();
-
-          expect(isValid1, isFalse);
-          expect(isValid2, isFalse);
-        },
-      );
-    },
-  );
-
-  withServerpod(
-    'Given a post-migration user (no legacy record),',
-    rollbackDatabase: RollbackDatabase.disabled,
-    (final sessionBuilder, final endpoints) {
-      _configurePublicLegacySupport(sessionBuilder);
-
-      const email = 'post-migration@serverpod.dev';
-      const password = 'NewPass123!';
-
-      setUp(() async {
-        String? receivedVerificationCode;
-        final config = EmailIdpConfig(
-          secretHashPepper: 'test',
-          sendRegistrationVerificationCode:
-              (
-                final session, {
-                required final email,
-                required final accountRequestId,
-                required final transaction,
-                required final verificationCode,
-              }) {
-                receivedVerificationCode = verificationCode;
-              },
-        );
-        AuthServices.set(
-          identityProviderBuilders: [config],
-          tokenManagerBuilders: [
-            tokenManagerConfig,
-            const LegacySessionTokenManager(),
-          ],
+            expect(result, isFalse);
+          },
         );
 
-        final requestId = await endpoints.emailAccount.startRegistration(
-          sessionBuilder,
-          email: email,
-        );
-
-        final registrationToken = await endpoints.emailAccount
-            .verifyRegistrationCode(
-              sessionBuilder,
-              accountRequestId: requestId,
-              verificationCode: receivedVerificationCode!,
+        test(
+          'when calling changePassword then returns false.',
+          () async {
+            final legacyClient = _createLegacyClient(sessionBuilder);
+            final result = await legacyClient.modules.auth.email.changePassword(
+              'old',
+              'new',
             );
 
-        await endpoints.emailAccount.finishRegistration(
-          sessionBuilder,
-          registrationToken: registrationToken,
-          password: password,
+            expect(result, isFalse);
+          },
+        );
+
+        test(
+          'when calling initiatePasswordReset then returns false.',
+          () async {
+            final legacyClient = _createLegacyClient(sessionBuilder);
+            final result = await legacy_auth.Caller(legacyClient).email
+                .initiatePasswordReset(
+                  'test@test.com',
+                );
+
+            expect(result, isFalse);
+          },
         );
       });
 
-      tearDown(() async {
-        await _cleanUpDatabase(sessionBuilder.build());
-      });
+      group(
+        'Given legacy auth endpoints the bridge cannot forward, '
+        'with blocking off,',
+        () {
+          test(
+            'when calling Firebase authenticate, '
+            'then the legacy endpoint serves it.',
+            () async {
+              final legacyClient = _createLegacyClient(sessionBuilder);
+              final result = await legacyClient.modules.auth.firebase
+                  .authenticate('fake-token');
 
-      test(
-        'when authenticating via legacy endpoint then returns internalError.',
-        () async {
-          final legacyClient = _createLegacyClient(sessionBuilder);
-          final result =
-              await legacy_auth.Caller(
+              expect(
+                result.failReason,
+                equals(legacy_auth.AuthenticationFailReason.internalError),
+                reason: 'Reaching the endpoint is the point, not the failure.',
+              );
+            },
+          );
+
+          test(
+            'when calling the email endpoint, then it is still forwarded.',
+            () async {
+              final legacyClient = _createLegacyClient(sessionBuilder);
+              final result = await legacy_auth.Caller(
                 legacyClient,
-              ).email.authenticate(
-                email,
-                password,
-              );
+              ).email.authenticate('nobody@serverpod.dev', 'wrong-password');
 
-          expect(result.success, isFalse);
-          expect(
-            result.failReason,
-            equals(legacy_auth.AuthenticationFailReason.internalError),
+              expect(
+                result.success,
+                isFalse,
+                reason: 'Turning off blocking must not turn off forwarding.',
+              );
+            },
           );
         },
       );
-    },
-  );
 
-  withServerpod(
-    'Given unsupported legacy email methods,',
-    rollbackDatabase: RollbackDatabase.disabled,
-    (final sessionBuilder, final endpoints) {
-      _configurePublicLegacySupport(sessionBuilder);
+      group(
+        'Given migrated legacy users and an authenticated admin session,',
+        () {
+          const adminEmail = 'legacy-admin@serverpod.dev';
+          const targetEmail = 'legacy-user@serverpod.dev';
+          const password = 'LegacyPass123!';
 
-      test(
-        'when calling createAccountRequest then returns false.',
-        () async {
-          final legacyClient = _createLegacyClient(sessionBuilder);
-          final result = await legacy_auth.Caller(legacyClient).email
-              .createAccountRequest(
-                'test',
-                'test@test.com',
-                'pass',
-              );
+          late int targetLegacyUserId;
+          late MutableAuthKeyProvider adminAuthKeyProvider;
+          late Client adminClient;
+          late _LegacyClient adminLegacyClient;
 
-          expect(result, isFalse);
-        },
-      );
+          setUp(() async {
+            const config = EmailIdpConfig(secretHashPepper: 'test');
+            AuthServices.set(
+              identityProviderBuilders: [config],
+              tokenManagerBuilders: [
+                tokenManagerConfig,
+                const LegacySessionTokenManager(),
+              ],
+            );
 
-      test(
-        'when calling changePassword then returns false.',
-        () async {
-          final legacyClient = _createLegacyClient(sessionBuilder);
-          final result = await legacyClient.modules.auth.email.changePassword(
-            'old',
-            'new',
+            final adminLegacyUserId = await endpoints
+                .emailAccountBackwardsCompatibilityTest
+                .createLegacyUser(
+                  sessionBuilder,
+                  email: adminEmail,
+                  password: password,
+                );
+            targetLegacyUserId = await endpoints
+                .emailAccountBackwardsCompatibilityTest
+                .createLegacyUser(
+                  sessionBuilder,
+                  email: targetEmail,
+                  password: password,
+                );
+
+            await endpoints.emailAccountBackwardsCompatibilityTest.migrateUser(
+              sessionBuilder,
+              legacyUserId: adminLegacyUserId,
+            );
+            await endpoints.emailAccountBackwardsCompatibilityTest.migrateUser(
+              sessionBuilder,
+              legacyUserId: targetLegacyUserId,
+            );
+
+            final adminAuthUserId = await endpoints
+                .emailAccountBackwardsCompatibilityTest
+                .getNewAuthUserId(sessionBuilder, userId: adminLegacyUserId);
+
+            final session = sessionBuilder.build();
+            final adminAuthUser = await AuthServices.instance.authUsers.get(
+              session,
+              authUserId: adminAuthUserId!,
+            );
+            await AuthServices.instance.authUsers.update(
+              session,
+              authUserId: adminAuthUserId,
+              scopes: {...adminAuthUser.scopes, Scope.admin},
+            );
+
+            adminAuthKeyProvider = MutableAuthKeyProvider();
+            adminClient = _createClient(
+              sessionBuilder,
+              authKeyProvider: adminAuthKeyProvider,
+            );
+            adminLegacyClient = _createLegacyClient(
+              sessionBuilder,
+              authKeyProvider: adminAuthKeyProvider,
+            );
+            final adminAuthResult = await legacy_auth.Caller(
+              adminLegacyClient,
+            ).email.authenticate(adminEmail, password);
+            adminAuthKeyProvider.setToken(
+              '${adminAuthResult.keyId}:${adminAuthResult.key}',
+            );
+          });
+
+          tearDown(() async {
+            await _cleanUpDatabase(sessionBuilder.build());
+          });
+
+          test(
+            'when calling getUserInfo then it returns mapped user data.',
+            () async {
+              final userInfo = await adminClient
+                  .modules
+                  .serverpod_auth_bridge
+                  .legacyAdmin
+                  .getUserInfo(targetLegacyUserId);
+
+              expect(userInfo, isNotNull);
+              expect(userInfo!.id, equals(targetLegacyUserId));
+              expect(userInfo.email, equals(targetEmail));
+              expect(userInfo.blocked, isFalse);
+            },
           );
 
-          expect(result, isFalse);
-        },
-      );
+          test(
+            'when blocking a user then authentication fails with blocked.',
+            () async {
+              await adminClient.modules.serverpod_auth_bridge.legacyAdmin
+                  .blockUser(
+                    targetLegacyUserId,
+                  );
 
-      test(
-        'when calling initiatePasswordReset then returns false.',
-        () async {
-          final legacyClient = _createLegacyClient(sessionBuilder);
-          final result = await legacy_auth.Caller(legacyClient).email
-              .initiatePasswordReset(
-                'test@test.com',
+              final blockedInfo = await adminClient
+                  .modules
+                  .serverpod_auth_bridge
+                  .legacyAdmin
+                  .getUserInfo(targetLegacyUserId);
+              expect(blockedInfo!.blocked, isTrue);
+
+              final targetLegacyClient = _createLegacyClient(sessionBuilder);
+              final authResult = await targetLegacyClient.modules.auth.email
+                  .authenticate(
+                    targetEmail,
+                    password,
+                  );
+
+              expect(authResult.success, isFalse);
+              expect(
+                authResult.failReason,
+                equals(legacy_auth.AuthenticationFailReason.blocked),
               );
+            },
+          );
 
-          expect(result, isFalse);
+          test(
+            'when unblocking a user then authentication succeeds again.',
+            () async {
+              await adminClient.modules.serverpod_auth_bridge.legacyAdmin
+                  .blockUser(
+                    targetLegacyUserId,
+                  );
+              await adminClient.modules.serverpod_auth_bridge.legacyAdmin
+                  .unblockUser(
+                    targetLegacyUserId,
+                  );
+
+              final unblockedInfo = await adminClient
+                  .modules
+                  .serverpod_auth_bridge
+                  .legacyAdmin
+                  .getUserInfo(targetLegacyUserId);
+              expect(unblockedInfo!.blocked, isFalse);
+
+              final targetLegacyClient = _createLegacyClient(sessionBuilder);
+              final authResult = await legacy_auth.Caller(
+                targetLegacyClient,
+              ).email.authenticate(targetEmail, password);
+
+              expect(authResult.success, isTrue);
+            },
+          );
         },
       );
     },
@@ -482,12 +662,15 @@ void main() {
 
   // A migrated deployment must not keep answering out of the legacy tables.
   withServerpod(
-    'Given legacy auth endpoints the bridge cannot forward, with blocking on,',
+    'Given legacy auth endpoints the bridge cannot forward, '
+    'with blocking on,',
     rollbackDatabase: RollbackDatabase.disabled,
     (final sessionBuilder, final endpoints) {
-      _configurePublicLegacySupport(
-        sessionBuilder,
-        blockUnbridgedAuthEndpoints: true,
+      setUpAll(
+        () => _configurePublicLegacySupport(
+          sessionBuilder,
+          blockUnbridgedAuthEndpoints: true,
+        ),
       );
 
       test('when calling Google authenticate, then it is refused.', () async {
@@ -515,209 +698,6 @@ void main() {
           throwsA(isA<legacy_auth.ServerpodClientNotFound>()),
         );
       });
-    },
-  );
-
-  withServerpod(
-    'Given legacy auth endpoints the bridge cannot forward, with blocking off,',
-    rollbackDatabase: RollbackDatabase.disabled,
-    (final sessionBuilder, final endpoints) {
-      _configurePublicLegacySupport(
-        sessionBuilder,
-        blockUnbridgedAuthEndpoints: false,
-      );
-
-      test(
-        'when calling Firebase authenticate, '
-        'then the legacy endpoint serves it.',
-        () async {
-          final legacyClient = _createLegacyClient(sessionBuilder);
-          final result = await legacyClient.modules.auth.firebase.authenticate(
-            'fake-token',
-          );
-
-          expect(
-            result.failReason,
-            equals(legacy_auth.AuthenticationFailReason.internalError),
-            reason: 'Reaching the endpoint is the point, not the failure.',
-          );
-        },
-      );
-
-      test(
-        'when calling the email endpoint, then it is still forwarded.',
-        () async {
-          final legacyClient = _createLegacyClient(sessionBuilder);
-          final result = await legacy_auth.Caller(
-            legacyClient,
-          ).email.authenticate('nobody@serverpod.dev', 'wrong-password');
-
-          expect(
-            result.success,
-            isFalse,
-            reason: 'Turning off blocking must not turn off forwarding.',
-          );
-        },
-      );
-    },
-  );
-
-  withServerpod(
-    'Given migrated legacy users and an authenticated admin session,',
-    rollbackDatabase: RollbackDatabase.disabled,
-    (final sessionBuilder, final endpoints) {
-      _configurePublicLegacySupport(sessionBuilder);
-
-      const adminEmail = 'legacy-admin@serverpod.dev';
-      const targetEmail = 'legacy-user@serverpod.dev';
-      const password = 'LegacyPass123!';
-
-      late int targetLegacyUserId;
-      late MutableAuthKeyProvider adminAuthKeyProvider;
-      late Client adminClient;
-      late _LegacyClient adminLegacyClient;
-
-      setUp(() async {
-        const config = EmailIdpConfig(secretHashPepper: 'test');
-        AuthServices.set(
-          identityProviderBuilders: [config],
-          tokenManagerBuilders: [
-            tokenManagerConfig,
-            const LegacySessionTokenManager(),
-          ],
-        );
-
-        final adminLegacyUserId = await endpoints
-            .emailAccountBackwardsCompatibilityTest
-            .createLegacyUser(
-              sessionBuilder,
-              email: adminEmail,
-              password: password,
-            );
-        targetLegacyUserId = await endpoints
-            .emailAccountBackwardsCompatibilityTest
-            .createLegacyUser(
-              sessionBuilder,
-              email: targetEmail,
-              password: password,
-            );
-
-        await endpoints.emailAccountBackwardsCompatibilityTest.migrateUser(
-          sessionBuilder,
-          legacyUserId: adminLegacyUserId,
-        );
-        await endpoints.emailAccountBackwardsCompatibilityTest.migrateUser(
-          sessionBuilder,
-          legacyUserId: targetLegacyUserId,
-        );
-
-        final adminAuthUserId = await endpoints
-            .emailAccountBackwardsCompatibilityTest
-            .getNewAuthUserId(sessionBuilder, userId: adminLegacyUserId);
-
-        final session = sessionBuilder.build();
-        final adminAuthUser = await AuthServices.instance.authUsers.get(
-          session,
-          authUserId: adminAuthUserId!,
-        );
-        await AuthServices.instance.authUsers.update(
-          session,
-          authUserId: adminAuthUserId,
-          scopes: {...adminAuthUser.scopes, Scope.admin},
-        );
-
-        adminAuthKeyProvider = MutableAuthKeyProvider();
-        adminClient = _createClient(
-          sessionBuilder,
-          authKeyProvider: adminAuthKeyProvider,
-        );
-        adminLegacyClient = _createLegacyClient(
-          sessionBuilder,
-          authKeyProvider: adminAuthKeyProvider,
-        );
-        final adminAuthResult = await legacy_auth.Caller(
-          adminLegacyClient,
-        ).email.authenticate(adminEmail, password);
-        adminAuthKeyProvider.setToken(
-          '${adminAuthResult.keyId}:${adminAuthResult.key}',
-        );
-      });
-
-      tearDown(() async {
-        await _cleanUpDatabase(sessionBuilder.build());
-      });
-
-      test(
-        'when calling getUserInfo then it returns mapped user data.',
-        () async {
-          final userInfo = await adminClient
-              .modules
-              .serverpod_auth_bridge
-              .legacyAdmin
-              .getUserInfo(targetLegacyUserId);
-
-          expect(userInfo, isNotNull);
-          expect(userInfo!.id, equals(targetLegacyUserId));
-          expect(userInfo.email, equals(targetEmail));
-          expect(userInfo.blocked, isFalse);
-        },
-      );
-
-      test(
-        'when blocking a user then authentication fails with blocked.',
-        () async {
-          await adminClient.modules.serverpod_auth_bridge.legacyAdmin.blockUser(
-            targetLegacyUserId,
-          );
-
-          final blockedInfo = await adminClient
-              .modules
-              .serverpod_auth_bridge
-              .legacyAdmin
-              .getUserInfo(targetLegacyUserId);
-          expect(blockedInfo!.blocked, isTrue);
-
-          final targetLegacyClient = _createLegacyClient(sessionBuilder);
-          final authResult = await targetLegacyClient.modules.auth.email
-              .authenticate(
-                targetEmail,
-                password,
-              );
-
-          expect(authResult.success, isFalse);
-          expect(
-            authResult.failReason,
-            equals(legacy_auth.AuthenticationFailReason.blocked),
-          );
-        },
-      );
-
-      test(
-        'when unblocking a user then authentication succeeds again.',
-        () async {
-          await adminClient.modules.serverpod_auth_bridge.legacyAdmin.blockUser(
-            targetLegacyUserId,
-          );
-          await adminClient.modules.serverpod_auth_bridge.legacyAdmin
-              .unblockUser(
-                targetLegacyUserId,
-              );
-
-          final unblockedInfo = await adminClient
-              .modules
-              .serverpod_auth_bridge
-              .legacyAdmin
-              .getUserInfo(targetLegacyUserId);
-          expect(unblockedInfo!.blocked, isFalse);
-
-          final targetLegacyClient = _createLegacyClient(sessionBuilder);
-          final authResult = await legacy_auth.Caller(
-            targetLegacyClient,
-          ).email.authenticate(targetEmail, password);
-
-          expect(authResult.success, isTrue);
-        },
-      );
     },
   );
 }
@@ -774,10 +754,14 @@ void _configurePublicLegacySupport(
   final TestSessionBuilder sessionBuilder, {
   final bool blockUnbridgedAuthEndpoints = false,
 }) {
-  final pod = sessionBuilder.build().server.serverpod;
-  pod.authenticationHandler = (final session, final authKey) =>
-      AuthServices.instance.authenticationHandler(session, authKey);
-  pod.enableLegacyClientSupport(
+  final server = sessionBuilder.build().server;
+  // The auth handler is captured by `Server.start()`, so post-start mutation
+  // of `pod.authenticationHandler` is ignored. Use the test-only hot-swap.
+  server.setAuthenticationHandlerForTesting(
+    (final session, final authKey) =>
+        AuthServices.instance.authenticationHandler(session, authKey),
+  );
+  server.serverpod.enableLegacyClientSupport(
     blockUnbridgedAuthEndpoints: blockUnbridgedAuthEndpoints,
   );
 }

--- a/tests/serverpod_test_server/test_integration/auth_module/email_auth_provider/account_request_test.dart
+++ b/tests/serverpod_test_server/test_integration/auth_module/email_auth_provider/account_request_test.dart
@@ -1,4 +1,4 @@
-import 'package:serverpod/database.dart';
+import 'package:serverpod/serverpod.dart';
 import 'package:serverpod_auth_server/module.dart';
 import 'package:test/test.dart';
 
@@ -9,7 +9,8 @@ void main() async {
     sessionBuilder,
     _,
   ) {
-    var session = sessionBuilder.build();
+    late Session session;
+    setUp(() => session = sessionBuilder.build());
 
     late UserInfo? response;
     setUp(
@@ -40,7 +41,8 @@ void main() async {
     sessionBuilder,
     _,
   ) {
-    var session = sessionBuilder.build();
+    late Session session;
+    setUp(() => session = sessionBuilder.build());
     var username = 'test';
     var password = 'password';
     var email = 'test@serverpod.dev';

--- a/tests/serverpod_test_server/test_integration/auth_module/email_auth_provider/custom_password_hash_test.dart
+++ b/tests/serverpod_test_server/test_integration/auth_module/email_auth_provider/custom_password_hash_test.dart
@@ -1,3 +1,4 @@
+import 'package:serverpod/serverpod.dart';
 import 'package:serverpod_auth_server/module.dart';
 import 'package:test/test.dart';
 
@@ -29,7 +30,8 @@ void main() async {
   withServerpod(
     'Given a custom non-hashing password hash generator and a create account request',
     (sessionBuilder, _) {
-      var session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
       var userName = 'test';
       var email = 'test8@serverpod.dev';
       var password = 'password';
@@ -66,7 +68,8 @@ void main() async {
   withServerpod(
     'Given a custom always true password hash validator and a created user',
     (sessionBuilder, _) {
-      var session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
       var userName = 'test';
       var email = 'test8@serverpod.dev';
       var password = 'password';
@@ -97,7 +100,8 @@ void main() async {
   withServerpod(
     'Given custom hash generator and a stored legacy password in the database',
     (sessionBuilder, _) {
-      var session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
       var userName = 'test';
       var email = 'test@serverpod.dev';
       var password = 'hunter2';

--- a/tests/serverpod_test_server/test_integration/auth_module/email_auth_provider/email_auth_provider_test.dart
+++ b/tests/serverpod_test_server/test_integration/auth_module/email_auth_provider/email_auth_provider_test.dart
@@ -1,3 +1,4 @@
+import 'package:serverpod/serverpod.dart';
 import 'package:serverpod_auth_server/module.dart';
 import 'package:test/test.dart';
 
@@ -15,7 +16,8 @@ void main() async {
   );
 
   withServerpod('Given create account request ', (sessionBuilder, _) {
-    var session = sessionBuilder.build();
+    late Session session;
+    setUp(() => session = sessionBuilder.build());
     var userName = 'test';
     var email = 'test@serverpod.dev';
     var password = 'password';
@@ -50,7 +52,8 @@ void main() async {
   });
 
   withServerpod('Given a created user', (sessionBuilder, _) {
-    var session = sessionBuilder.build();
+    late Session session;
+    setUp(() => session = sessionBuilder.build());
     var userName = 'test';
     var email = 'test@serverpod.dev';
     var password = 'password';
@@ -86,7 +89,8 @@ void main() async {
     sessionBuilder,
     _,
   ) {
-    var session = sessionBuilder.build();
+    late Session session;
+    setUp(() => session = sessionBuilder.build());
     var userName = 'test';
     var email = 'test@serverpod.dev';
     var password = 'hunter2';
@@ -140,7 +144,8 @@ void main() async {
     sessionBuilder,
     _,
   ) {
-    var session = sessionBuilder.build();
+    late Session session;
+    setUp(() => session = sessionBuilder.build());
 
     setUp(
       () async => await EmailAuth.db.insert(session, [
@@ -360,33 +365,36 @@ void main() async {
     });
   });
 
-  group('Given password not matching the hash when validating password', () {
-    // This is the hash from the password 'hunter4'
-    var hunter4PasswordHash =
-        '2ee3dc6432300eabf9630ac7827d6dd23fd23cc9120ec4cd58f8f66bd3ce2db9';
-    var notHunter4PasswordHash =
-        '1d24f0d21861e659c50c87ae03b679dc66ac7dd5fb1b03140e53f9331eeb0a31';
+  withServerpod(
+    'Given password not matching the hash when validating password',
+    (_, _) {
+      // This is the hash from the password 'hunter4'
+      var hunter4PasswordHash =
+          '2ee3dc6432300eabf9630ac7827d6dd23fd23cc9120ec4cd58f8f66bd3ce2db9';
+      var notHunter4PasswordHash =
+          '1d24f0d21861e659c50c87ae03b679dc66ac7dd5fb1b03140e53f9331eeb0a31';
 
-    test(
-      'then validation returns PasswordValidationFailed with generated and passed in hash.',
-      () async {
-        late String actualStoredHash;
-        late String actualPasswordHash;
-        final validationResponse = await Emails.validatePasswordHash(
-          'notHunter4',
-          'test7@serverpod.dev',
-          hunter4PasswordHash,
-        );
-        expect(validationResponse, isA<PasswordValidationFailed>());
+      test(
+        'then validation returns PasswordValidationFailed with generated and passed in hash.',
+        () async {
+          late String actualStoredHash;
+          late String actualPasswordHash;
+          final validationResponse = await Emails.validatePasswordHash(
+            'notHunter4',
+            'test7@serverpod.dev',
+            hunter4PasswordHash,
+          );
+          expect(validationResponse, isA<PasswordValidationFailed>());
 
-        if (validationResponse is PasswordValidationFailed) {
-          actualPasswordHash = validationResponse.passwordHash;
-          actualStoredHash = validationResponse.storedHash;
-        }
+          if (validationResponse is PasswordValidationFailed) {
+            actualPasswordHash = validationResponse.passwordHash;
+            actualStoredHash = validationResponse.storedHash;
+          }
 
-        expect(actualStoredHash, hunter4PasswordHash);
-        expect(actualPasswordHash, notHunter4PasswordHash);
-      },
-    );
-  });
+          expect(actualStoredHash, hunter4PasswordHash);
+          expect(actualPasswordHash, notHunter4PasswordHash);
+        },
+      );
+    },
+  );
 }

--- a/tests/serverpod_test_server/test_integration/auth_module/email_auth_provider/email_auth_provider_test.dart
+++ b/tests/serverpod_test_server/test_integration/auth_module/email_auth_provider/email_auth_provider_test.dart
@@ -145,10 +145,9 @@ void main() async {
     _,
   ) {
     late Session session;
-    setUp(() => session = sessionBuilder.build());
-
-    setUp(
-      () async => await EmailAuth.db.insert(session, [
+    setUp(() async {
+      session = sessionBuilder.build();
+      await EmailAuth.db.insert(session, [
         // These entries where generated using the hash algorithms.
         // The salt for all passwords is 'serverpod password salt'.
         EmailAuth(
@@ -200,8 +199,8 @@ void main() async {
           hash:
               r'$argon2id$c2VydmVycG9kIHBhc3N3b3JkIHNhbHQ=$lratTXSlVuxb6xwzHQzMu4Ra0pPVl1YLDdR8AwPY0gRlvF/5M7jxf6tODW9+KOgowfbP1tSGFHQebAjEOsmvL5NvAOrFDI3u0mD/414W8wR0Cni1KpATP7p5MHr5OZ2O4gEtOWfSJfgPTcq0X/uWZjRi1m4mc40TkyIFbMOfyO05JtoX0hi6r/4fTlIgIp1s7KgXEwF7B8IrmEb5zdnDgUs4qUifUM+SEH2S59fNBAt5CIviCOK7VreBztQw+L5S58ZHYSWWyB7bHJLcg1pDV9uiBb+q7qmXWJqDUBQjeJMH4nePzDmy7zarA04zQFhd6d5wIfZilJxJb8XXVGKZrQ==',
         ),
-      ]),
-    );
+      ]);
+    });
 
     test(
       'when migrating auth entries then updated rows matches legacy hashes stored.',

--- a/tests/serverpod_test_server/test_integration/auth_module/email_auth_provider/password_length_validation_test.dart
+++ b/tests/serverpod_test_server/test_integration/auth_module/email_auth_provider/password_length_validation_test.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:math';
 
+import 'package:serverpod/serverpod.dart';
 import 'package:serverpod_auth_server/serverpod_auth_server.dart';
 import 'package:test/test.dart';
 
@@ -31,7 +32,8 @@ void main() async {
   });
 
   withServerpod('Given an existing user ', (sessionBuilder, _) {
-    final session = sessionBuilder.build();
+    late Session session;
+    setUp(() => session = sessionBuilder.build());
 
     const userName = 'user-change';
     const email = 'user.change@serverpod.dev';
@@ -162,7 +164,8 @@ void main() async {
   });
 
   withServerpod('Given create account request ', (sessionBuilder, _) async {
-    var session = sessionBuilder.build();
+    late Session session;
+    setUp(() => session = sessionBuilder.build());
     var userName = 'test';
     var email = 'test@serverpod.dev';
 

--- a/tests/serverpod_test_server/test_integration/database_operations/crud/update_by_id_test.dart
+++ b/tests/serverpod_test_server/test_integration/database_operations/crud/update_by_id_test.dart
@@ -10,7 +10,8 @@ void main() {
   withServerpod(
     'Given a database entry with all basic fields',
     (sessionBuilder, endpoints) {
-      var session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
 
       const originalBool = true;
       const originalInt = 1;
@@ -164,7 +165,8 @@ void main() {
   withServerpod(
     'Given a database entry with non-null values',
     (sessionBuilder, endpoints) {
-      var session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
 
       const originalInt = 1;
       const originalString = 'original';
@@ -208,7 +210,8 @@ void main() {
   withServerpod(
     'Given a database entry with null values',
     (sessionBuilder, endpoints) {
-      var session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
 
       late Types existingEntry;
 
@@ -247,7 +250,8 @@ void main() {
   withServerpod(
     'Given a database entry with all supported data types',
     (sessionBuilder, endpoints) {
-      var session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
 
       late Types existingEntry;
 
@@ -501,7 +505,8 @@ void main() {
   withServerpod(
     'Given a non-existent database entry',
     (testSession, endpoints) {
-      var session = testSession.build();
+      late Session session;
+      setUp(() => session = testSession.build());
 
       test(
         'when updating by non-existent id then DatabaseUpdateRowException is thrown',

--- a/tests/serverpod_test_server/test_integration/database_operations/crud/update_by_id_test.dart
+++ b/tests/serverpod_test_server/test_integration/database_operations/crud/update_by_id_test.dart
@@ -10,7 +10,8 @@ void main() {
   withServerpod(
     'Given a database entry with all basic fields',
     (sessionBuilder, endpoints) {
-      var session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
 
       const originalBool = true;
       const originalInt = 1;
@@ -164,7 +165,8 @@ void main() {
   withServerpod(
     'Given a database entry with non-null values',
     (sessionBuilder, endpoints) {
-      var session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
 
       const originalInt = 1;
       const originalString = 'original';
@@ -208,7 +210,8 @@ void main() {
   withServerpod(
     'Given a database entry with null values',
     (sessionBuilder, endpoints) {
-      var session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
 
       late Types existingEntry;
 
@@ -247,7 +250,8 @@ void main() {
   withServerpod(
     'Given a database entry with all supported data types',
     (sessionBuilder, endpoints) {
-      var session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
 
       late Types existingEntry;
 
@@ -501,7 +505,8 @@ void main() {
   withServerpod(
     'Given a non-existent database entry',
     (testSession, endpoints) {
-      var session = testSession.build();
+      late Session session;
+      setUp(() => session = testSession.build());
 
       test(
         'when updating by non-existent id then an exception is thrown',

--- a/tests/serverpod_test_server/test_integration/database_operations/crud/update_where_test.dart
+++ b/tests/serverpod_test_server/test_integration/database_operations/crud/update_where_test.dart
@@ -10,7 +10,8 @@ void main() {
   withServerpod(
     'Given database entries with basic matching criteria',
     (sessionBuilder, endpoints) {
-      var session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
 
       setUp(() async {
         await Types.db.insert(
@@ -186,7 +187,8 @@ void main() {
   withServerpod(
     'Given database entries for transaction testing',
     (sessionBuilder, endpoints) {
-      var session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
 
       setUp(() async {
         await Types.db.insert(
@@ -238,7 +240,8 @@ void main() {
   withServerpod(
     'Given no matching database entries',
     (sessionBuilder, endpoints) {
-      var session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
 
       setUp(() async {
         await Types.db.insert(
@@ -267,7 +270,8 @@ void main() {
   withServerpod(
     'Given database entries with null values',
     (sessionBuilder, endpoints) {
-      var session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
 
       setUp(() async {
         await Types.db.insertRow(
@@ -320,7 +324,8 @@ void main() {
   withServerpod(
     'Given database entries with non-null values',
     (sessionBuilder, endpoints) {
-      var session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
 
       const originalInt = 1;
       const originalString = 'value';
@@ -388,7 +393,8 @@ void main() {
   withServerpod(
     'Given database entries for pagination operations',
     (sessionBuilder, endpoints) {
-      var session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
 
       const matchingInt = 100;
 
@@ -575,7 +581,8 @@ void main() {
   withServerpod(
     'Given database entries with all supported data types',
     (sessionBuilder, endpoints) {
-      var session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
 
       setUp(() async {
         await Types.db.insert(

--- a/tests/serverpod_test_server/test_integration/database_operations/crud/update_where_test.dart
+++ b/tests/serverpod_test_server/test_integration/database_operations/crud/update_where_test.dart
@@ -11,9 +11,8 @@ void main() {
     'Given database entries with basic matching criteria',
     (sessionBuilder, endpoints) {
       late Session session;
-      setUp(() => session = sessionBuilder.build());
-
       setUp(() async {
+        session = sessionBuilder.build();
         await Types.db.insert(
           session,
           [
@@ -188,9 +187,8 @@ void main() {
     'Given database entries for transaction testing',
     (sessionBuilder, endpoints) {
       late Session session;
-      setUp(() => session = sessionBuilder.build());
-
       setUp(() async {
+        session = sessionBuilder.build();
         await Types.db.insert(
           session,
           [
@@ -241,9 +239,8 @@ void main() {
     'Given no matching database entries',
     (sessionBuilder, endpoints) {
       late Session session;
-      setUp(() => session = sessionBuilder.build());
-
       setUp(() async {
+        session = sessionBuilder.build();
         await Types.db.insert(
           session,
           [
@@ -271,9 +268,8 @@ void main() {
     'Given database entries with null values',
     (sessionBuilder, endpoints) {
       late Session session;
-      setUp(() => session = sessionBuilder.build());
-
       setUp(() async {
+        session = sessionBuilder.build();
         await Types.db.insertRow(
           session,
           Types(
@@ -582,9 +578,8 @@ void main() {
     'Given database entries with all supported data types',
     (sessionBuilder, endpoints) {
       late Session session;
-      setUp(() => session = sessionBuilder.build());
-
       setUp(() async {
+        session = sessionBuilder.build();
         await Types.db.insert(
           session,
           [
@@ -895,9 +890,8 @@ void main() {
     'Given an inserted entry,',
     (sessionBuilder, endpoints) {
       late Session session;
-      setUp(() => session = sessionBuilder.build());
-
       setUp(() async {
+        session = sessionBuilder.build();
         await UniqueData.db.insert(session, [
           UniqueData(number: 1, email: 'a@serverpod.dev'),
         ]);

--- a/tests/serverpod_test_server/test_integration/database_operations/crud/update_where_test.dart
+++ b/tests/serverpod_test_server/test_integration/database_operations/crud/update_where_test.dart
@@ -10,7 +10,8 @@ void main() {
   withServerpod(
     'Given database entries with basic matching criteria',
     (sessionBuilder, endpoints) {
-      var session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
 
       setUp(() async {
         await Types.db.insert(
@@ -186,7 +187,8 @@ void main() {
   withServerpod(
     'Given database entries for transaction testing',
     (sessionBuilder, endpoints) {
-      var session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
 
       setUp(() async {
         await Types.db.insert(
@@ -238,7 +240,8 @@ void main() {
   withServerpod(
     'Given no matching database entries',
     (sessionBuilder, endpoints) {
-      var session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
 
       setUp(() async {
         await Types.db.insert(
@@ -267,7 +270,8 @@ void main() {
   withServerpod(
     'Given database entries with null values',
     (sessionBuilder, endpoints) {
-      var session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
 
       setUp(() async {
         await Types.db.insertRow(
@@ -320,7 +324,8 @@ void main() {
   withServerpod(
     'Given database entries with non-null values',
     (sessionBuilder, endpoints) {
-      var session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
 
       const originalInt = 1;
       const originalString = 'value';
@@ -388,7 +393,8 @@ void main() {
   withServerpod(
     'Given database entries for pagination operations',
     (sessionBuilder, endpoints) {
-      var session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
 
       const matchingInt = 100;
 
@@ -575,7 +581,8 @@ void main() {
   withServerpod(
     'Given database entries with all supported data types',
     (sessionBuilder, endpoints) {
-      var session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
 
       setUp(() async {
         await Types.db.insert(
@@ -887,7 +894,8 @@ void main() {
   withServerpod(
     'Given an inserted entry,',
     (sessionBuilder, endpoints) {
-      var session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
 
       setUp(() async {
         await UniqueData.db.insert(session, [

--- a/tests/serverpod_test_server/test_integration/database_operations/dynamic_roundtrip_test.dart
+++ b/tests/serverpod_test_server/test_integration/database_operations/dynamic_roundtrip_test.dart
@@ -70,9 +70,8 @@ void main() {
     'Given a table model with dynamic fields and an entry that has been inserted,',
     (sessionBuilder, endpoints) {
       late Session session;
-      setUp(() => session = sessionBuilder.build());
-
       setUp(() async {
+        session = sessionBuilder.build();
         await ObjectWithDynamic.db.insertRow(session, object);
       });
 

--- a/tests/serverpod_test_server/test_integration/database_operations/dynamic_roundtrip_test.dart
+++ b/tests/serverpod_test_server/test_integration/database_operations/dynamic_roundtrip_test.dart
@@ -1,3 +1,4 @@
+import 'package:serverpod/serverpod.dart';
 import 'package:serverpod_test_server/src/generated/protocol.dart';
 import 'package:test/test.dart';
 
@@ -43,7 +44,8 @@ void main() {
   withServerpod(
     'Given a table model with dynamic fields,',
     (sessionBuilder, endpoints) {
-      var session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
 
       group('when inserting the model with all dynamic fields ', () {
         late Future<ObjectWithDynamic> insert;
@@ -67,7 +69,8 @@ void main() {
   withServerpod(
     'Given a table model with dynamic fields and an entry that has been inserted,',
     (sessionBuilder, endpoints) {
-      var session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
 
       setUp(() async {
         await ObjectWithDynamic.db.insertRow(session, object);

--- a/tests/serverpod_test_server/test_integration/database_operations/entity_relations/one_to_many/update/update_row_test.dart
+++ b/tests/serverpod_test_server/test_integration/database_operations/entity_relations/one_to_many/update/update_row_test.dart
@@ -1,4 +1,5 @@
 import '../../../../test_tools/serverpod_test_tools.dart';
+import 'package:serverpod/serverpod.dart';
 import 'package:serverpod_test_server/src/generated/protocol.dart';
 import 'package:test/test.dart';
 
@@ -6,7 +7,8 @@ void main() async {
   withServerpod(
     'Given an entity with an implicit one-to-many relation',
     (sessionBuilder, _) {
-      var session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
 
       setUp(() async {
         var book = await Book.db.insertRow(

--- a/tests/serverpod_test_server/test_integration/database_operations/entity_relations/one_to_many/update/update_row_test.dart
+++ b/tests/serverpod_test_server/test_integration/database_operations/entity_relations/one_to_many/update/update_row_test.dart
@@ -8,9 +8,8 @@ void main() async {
     'Given an entity with an implicit one-to-many relation',
     (sessionBuilder, _) {
       late Session session;
-      setUp(() => session = sessionBuilder.build());
-
       setUp(() async {
+        session = sessionBuilder.build();
         var book = await Book.db.insertRow(
           session,
           Book(title: 'Book 1'),

--- a/tests/serverpod_test_server/test_integration/database_operations/explicit_column_name/crud_test.dart
+++ b/tests/serverpod_test_server/test_integration/database_operations/explicit_column_name/crud_test.dart
@@ -1,3 +1,4 @@
+import 'package:serverpod/serverpod.dart';
 import 'package:serverpod_test_server/src/generated/protocol.dart';
 import 'package:test/test.dart';
 
@@ -7,7 +8,8 @@ void main() {
   withServerpod(
     'Given a table with an explicit column name',
     (sessionBuilder, endpoints) {
-      var session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
 
       late TableWithExplicitColumnName data;
       late TableWithExplicitColumnNameRepository db;
@@ -31,7 +33,8 @@ void main() {
   withServerpod(
     'Given an entry in the database for a table with an explicit column name',
     (sessionBuilder, endpoints) {
-      var session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
 
       late TableWithExplicitColumnName data;
       late TableWithExplicitColumnName inserted;

--- a/tests/serverpod_test_server/test_integration/database_operations/explicit_column_name/crud_test_inheritance.dart
+++ b/tests/serverpod_test_server/test_integration/database_operations/explicit_column_name/crud_test_inheritance.dart
@@ -1,3 +1,4 @@
+import 'package:serverpod/serverpod.dart';
 import 'package:serverpod_test_server/src/generated/protocol.dart';
 import 'package:test/test.dart';
 
@@ -7,7 +8,8 @@ void main() {
   withServerpod(
     'Given a child class with explicit column name that extends another class',
     (sessionBuilder, endpoints) {
-      final session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
       const parentValue = 'parentValue';
       const childValue = 'childValue';
 

--- a/tests/serverpod_test_server/test_integration/database_operations/runtime_parameters/vector_query_test.dart
+++ b/tests/serverpod_test_server/test_integration/database_operations/runtime_parameters/vector_query_test.dart
@@ -13,12 +13,13 @@ void main() {
   withServerpod(
     'Given a large number of vectors with very similar distances',
     (sessionBuilder, _) {
-      final session = sessionBuilder.build();
+      late Session session;
       final queryVector = Vector(
         [0.5, 0.5] + List.filled(vectorDimension - 2, 0.0),
       );
 
       setUpAll(() async {
+        session = sessionBuilder.build();
         final random = math.Random(42);
         final zeroFilledVector = Vector(List.filled(vectorDimension, 0.0));
 

--- a/tests/serverpod_test_server/test_integration/database_operations/runtime_parameters/vector_query_test.dart
+++ b/tests/serverpod_test_server/test_integration/database_operations/runtime_parameters/vector_query_test.dart
@@ -25,12 +25,13 @@ void main() {
   withServerpod(
     'Given a large number of vectors with very similar distances',
     (sessionBuilder, _) {
-      final session = sessionBuilder.build();
+      late Session session;
       final queryVector = Vector(
         [0.5, 0.5] + List.filled(vectorDimension - 2, 0.0),
       );
 
       setUpAll(() async {
+        session = sessionBuilder.build();
         final random = math.Random(42);
         final zeroFilledVector = Vector(List.filled(vectorDimension, 0.0));
 

--- a/tests/serverpod_test_server/test_integration/database_operations/shared_module_table_test.dart
+++ b/tests/serverpod_test_server/test_integration/database_operations/shared_module_table_test.dart
@@ -1,3 +1,4 @@
+import 'package:serverpod/serverpod.dart';
 import 'package:serverpod_test_shared_module_server/serverpod_test_shared_module_server.dart';
 import 'package:test/test.dart';
 
@@ -8,7 +9,8 @@ void main() {
     rollbackDatabase: RollbackDatabase.disabled,
     'Given a table model declared in the shared package of a module,',
     (sessionBuilder, _) {
-      final session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
 
       test(
         'when inserting the table through the module server package, '

--- a/tests/serverpod_test_server/test_integration/database_operations/shared_table/shared_table_record_test.dart
+++ b/tests/serverpod_test_server/test_integration/database_operations/shared_table/shared_table_record_test.dart
@@ -1,3 +1,4 @@
+import 'package:serverpod/serverpod.dart';
 import 'package:serverpod_test_shared/serverpod_test_shared.dart';
 import 'package:test/test.dart';
 
@@ -7,7 +8,8 @@ void main() {
   withServerpod(
     'Given an empty database,',
     (sessionBuilder, endpoints) {
-      var session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
 
       test(
         'when inserting a shared table record, '
@@ -73,8 +75,10 @@ void main() {
     sessionBuilder,
     endpoints,
   ) {
-    var session = sessionBuilder.build();
+    late Session session;
     late SharedTableRecord inserted;
+
+    setUp(() => session = sessionBuilder.build());
 
     setUp(() async {
       inserted = await SharedTableRecord.db.insertRow(

--- a/tests/serverpod_test_server/test_integration/database_operations/shared_table/shared_table_record_test.dart
+++ b/tests/serverpod_test_server/test_integration/database_operations/shared_table/shared_table_record_test.dart
@@ -78,9 +78,8 @@ void main() {
     late Session session;
     late SharedTableRecord inserted;
 
-    setUp(() => session = sessionBuilder.build());
-
     setUp(() async {
+      session = sessionBuilder.build();
       inserted = await SharedTableRecord.db.insertRow(
         session,
         SharedTableRecord(

--- a/tests/serverpod_test_server/test_integration/database_operations/transactions/transaction_isolatation_level_test.dart
+++ b/tests/serverpod_test_server/test_integration/database_operations/transactions/transaction_isolatation_level_test.dart
@@ -13,7 +13,8 @@ void main() async {
     rollbackDatabase: RollbackDatabase.disabled,
     testGroupTagsOverride: [TestTags.concurrencyOneTestTag],
     (sessionBuilder, _) {
-      var session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
 
       tearDown(() async {
         await SimpleData.db.deleteWhere(
@@ -81,7 +82,8 @@ void main() async {
     rollbackDatabase: RollbackDatabase.disabled,
     testGroupTagsOverride: [TestTags.concurrencyOneTestTag],
     (sessionBuilder, _) {
-      var session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
 
       tearDown(() async {
         await SimpleData.db.deleteWhere(
@@ -207,7 +209,8 @@ void main() async {
     rollbackDatabase: RollbackDatabase.disabled,
     testGroupTagsOverride: [TestTags.concurrencyOneTestTag],
     (sessionBuilder, _) {
-      var session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
 
       tearDown(() async {
         await SimpleData.db.deleteWhere(

--- a/tests/serverpod_test_server/test_integration/database_operations/transactions/transaction_isolatation_level_test.dart
+++ b/tests/serverpod_test_server/test_integration/database_operations/transactions/transaction_isolatation_level_test.dart
@@ -11,7 +11,8 @@ void main() async {
     'Given read committed transaction isolation level and single row in database',
     rollbackDatabase: RollbackDatabase.disabled,
     (sessionBuilder, _) {
-      var session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
 
       tearDown(() async {
         await SimpleData.db.deleteWhere(
@@ -78,7 +79,8 @@ void main() async {
     'Given repeatable read transaction isolation level',
     rollbackDatabase: RollbackDatabase.disabled,
     (sessionBuilder, _) {
-      var session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
 
       tearDown(() async {
         await SimpleData.db.deleteWhere(
@@ -203,7 +205,8 @@ void main() async {
     'Given serializable transaction isolation level',
     rollbackDatabase: RollbackDatabase.disabled,
     (sessionBuilder, _) {
-      var session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
 
       tearDown(() async {
         await SimpleData.db.deleteWhere(

--- a/tests/serverpod_test_server/test_integration/nulls_distinct_index_test.dart
+++ b/tests/serverpod_test_server/test_integration/nulls_distinct_index_test.dart
@@ -1,4 +1,4 @@
-import 'package:serverpod_database/serverpod_database.dart';
+import 'package:serverpod/serverpod.dart';
 import 'package:serverpod_test_server/src/generated/protocol.dart';
 import 'package:test/test.dart';
 
@@ -12,7 +12,8 @@ void main() {
     sessionBuilder,
     endpoints,
   ) {
-    var session = sessionBuilder.build();
+    late Session session;
+    setUp(() => session = sessionBuilder.build());
 
     test(
       'when rows with the same null-distinct values and a null are inserted, '
@@ -149,7 +150,8 @@ void main() {
     sessionBuilder,
     endpoints,
   ) {
-    var session = sessionBuilder.build();
+    late Session session;
+    setUp(() => session = sessionBuilder.build());
 
     test(
       'when the PostgreSQL schema is analyzed, '

--- a/tests/serverpod_test_server/test_integration/test_tools/authentication_validation_test.dart
+++ b/tests/serverpod_test_server/test_integration/test_tools/authentication_validation_test.dart
@@ -126,16 +126,17 @@ void main() {
         late StreamController<int> inStream;
 
         var authenticatedUserId = '1';
-        var authenticatedSessionBuilder = sessionBuilder.copyWith(
-          authentication: AuthenticationOverride.authenticationInfo(
-            authenticatedUserId,
-            {Scope('user')},
-          ),
-        );
+        late TestSessionBuilder authenticatedSessionBuilder;
 
         late Session session;
 
         setUp(() async {
+          authenticatedSessionBuilder = sessionBuilder.copyWith(
+            authentication: AuthenticationOverride.authenticationInfo(
+              authenticatedUserId,
+              {Scope('user')},
+            ),
+          );
           session = authenticatedSessionBuilder.build();
           streamClosedCompleter = Completer<dynamic>();
           inStream = StreamController<int>();
@@ -224,16 +225,17 @@ void main() {
         late StreamController<int> inStream2;
 
         var authenticatedUserId = '1';
-        var authenticatedSessionBuilder = sessionBuilder.copyWith(
-          authentication: AuthenticationOverride.authenticationInfo(
-            authenticatedUserId,
-            {Scope('user')},
-          ),
-        );
+        late TestSessionBuilder authenticatedSessionBuilder;
 
         late Session session;
 
         setUp(() async {
+          authenticatedSessionBuilder = sessionBuilder.copyWith(
+            authentication: AuthenticationOverride.authenticationInfo(
+              authenticatedUserId,
+              {Scope('user')},
+            ),
+          );
           session = authenticatedSessionBuilder.build();
           streamClosedCompleter1 = Completer<dynamic>();
           inStream1 = StreamController<int>();

--- a/tests/serverpod_test_server/test_integration/test_tools/database_operations_test.dart
+++ b/tests/serverpod_test_server/test_integration/test_tools/database_operations_test.dart
@@ -9,7 +9,8 @@ void main() {
   withServerpod(
     'Given TestToolsEndpoint',
     (sessionBuilder, endpoints) {
-      var session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
 
       test(
         'when calling createSimpleData then creates a SimpleData in the database',
@@ -109,7 +110,8 @@ void main() {
   withServerpod(
     'Given TestToolsEndpoint and rollbackDatabase afterEach',
     (sessionBuilder, endpoints) {
-      var session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
       group('when calling createSimpleDatasInsideTransactions', () {
         setUpAll(() async {
           await endpoints.testTools.createSimpleDatasInsideTransactions(
@@ -195,7 +197,8 @@ void main() {
       withServerpod(
         '',
         (sessionBuilder, endpoints) {
-          var session = sessionBuilder.build();
+          late Session session;
+          setUp(() => session = sessionBuilder.build());
 
           setUpAll(() async {
             await endpoints.testTools.createSimpleDatasInsideTransactions(
@@ -228,7 +231,8 @@ void main() {
       withServerpod(
         'when fetching SimpleData in the next withServerpod',
         (sessionBuilder, endpoints) {
-          var session = sessionBuilder.build();
+          late Session session;
+          setUp(() => session = sessionBuilder.build());
           test('then should have been rolled back', () async {
             var simpleDatas = await SimpleData.db.find(session);
 
@@ -242,7 +246,8 @@ void main() {
       withServerpod(
         '',
         (sessionBuilder, endpoints) {
-          var session = sessionBuilder.build();
+          late Session session;
+          setUp(() => session = sessionBuilder.build());
 
           setUpAll(() async {
             try {
@@ -267,7 +272,8 @@ void main() {
       withServerpod(
         'when fetching SimpleData in the next withServerpod',
         (sessionBuilder, endpoints) {
-          var session = sessionBuilder.build();
+          late Session session;
+          setUp(() => session = sessionBuilder.build());
           test('then should have been rolled back', () async {
             var simpleDatas = await SimpleData.db.find(session);
 
@@ -306,7 +312,8 @@ void main() {
       withServerpod(
         'when fetching SimpleData in the next withServerpod',
         (sessionBuilder, endpoints) {
-          var session = sessionBuilder.build();
+          late Session session;
+          setUp(() => session = sessionBuilder.build());
 
           test('then should have been rolled back', () async {
             var simpleDatas = await SimpleData.db.find(session);
@@ -323,7 +330,8 @@ void main() {
       withServerpod(
         '',
         (sessionBuilder, endpoints) {
-          var session = sessionBuilder.build();
+          late Session session;
+          setUp(() => session = sessionBuilder.build());
           setUpAll(() async {
             await endpoints.testTools.createSimpleDatasInsideTransactions(
               sessionBuilder,
@@ -356,7 +364,8 @@ void main() {
       withServerpod(
         'when fetching SimpleData in the next withServerpod',
         (sessionBuilder, endpoints) {
-          var session = sessionBuilder.build();
+          late Session session;
+          setUp(() => session = sessionBuilder.build());
           tearDownAll(() async {
             await SimpleData.db.deleteWhere(
               session,
@@ -384,7 +393,8 @@ void main() {
       withServerpod(
         '',
         (sessionBuilder, endpoints) {
-          var session = sessionBuilder.build();
+          late Session session;
+          setUp(() => session = sessionBuilder.build());
           setUpAll(() async {
             try {
               await endpoints.testTools
@@ -409,7 +419,8 @@ void main() {
       withServerpod(
         'when fetching SimpleData in the next withServerpod',
         (sessionBuilder, endpoints) {
-          var session = sessionBuilder.build();
+          late Session session;
+          setUp(() => session = sessionBuilder.build());
 
           tearDownAll(() async {
             await SimpleData.db.deleteWhere(
@@ -432,7 +443,8 @@ void main() {
     withServerpod(
       'when calling createSimpleDatasInParallelTransactionCalls',
       (sessionBuilder, endpoints) {
-        var session = sessionBuilder.build();
+        late Session session;
+        setUp(() => session = sessionBuilder.build());
         setUpAll(() async {
           await endpoints.testTools.createSimpleDatasInParallelTransactionCalls(
             sessionBuilder,
@@ -461,7 +473,8 @@ void main() {
     'Given rollbackDatabase is not disabled (transaction active) ',
     rollbackDatabase: RollbackDatabase.afterEach,
     (sessionBuilder, _) {
-      var session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
 
       group('when creating UniqueData with the same unique value', () {
         late Future failingInsert;

--- a/tests/serverpod_test_server/test_integration/test_tools/database_operations_test.dart
+++ b/tests/serverpod_test_server/test_integration/test_tools/database_operations_test.dart
@@ -331,8 +331,8 @@ void main() {
         '',
         (sessionBuilder, endpoints) {
           late Session session;
-          setUp(() => session = sessionBuilder.build());
           setUpAll(() async {
+            session = sessionBuilder.build();
             await endpoints.testTools.createSimpleDatasInsideTransactions(
               sessionBuilder,
               123,

--- a/tests/serverpod_test_server/test_integration/test_tools/database_operations_test.dart
+++ b/tests/serverpod_test_server/test_integration/test_tools/database_operations_test.dart
@@ -197,9 +197,8 @@ void main() {
         '',
         (sessionBuilder, endpoints) {
           late Session session;
-          setUp(() => session = sessionBuilder.build());
-
           setUpAll(() async {
+            session = sessionBuilder.build();
             await endpoints.testTools.createSimpleDatasInsideTransactions(
               sessionBuilder,
               123,
@@ -246,9 +245,8 @@ void main() {
         '',
         (sessionBuilder, endpoints) {
           late Session session;
-          setUp(() => session = sessionBuilder.build());
-
           setUpAll(() async {
+            session = sessionBuilder.build();
             try {
               await endpoints.testTools
                   .createSimpleDataAndThrowInsideTransaction(
@@ -330,8 +328,8 @@ void main() {
         '',
         (sessionBuilder, endpoints) {
           late Session session;
-          setUp(() => session = sessionBuilder.build());
           setUpAll(() async {
+            session = sessionBuilder.build();
             await endpoints.testTools.createSimpleDatasInsideTransactions(
               sessionBuilder,
               123,
@@ -383,8 +381,8 @@ void main() {
         '',
         (sessionBuilder, endpoints) {
           late Session session;
-          setUp(() => session = sessionBuilder.build());
           setUpAll(() async {
+            session = sessionBuilder.build();
             try {
               await endpoints.testTools
                   .createSimpleDataAndThrowInsideTransaction(
@@ -427,8 +425,8 @@ void main() {
       'when calling createSimpleDatasInParallelTransactionCalls',
       (sessionBuilder, endpoints) {
         late Session session;
-        setUp(() => session = sessionBuilder.build());
         setUpAll(() async {
+          session = sessionBuilder.build();
           await endpoints.testTools.createSimpleDatasInParallelTransactionCalls(
             sessionBuilder,
           );

--- a/tests/serverpod_test_server/test_integration/test_tools/database_operations_test.dart
+++ b/tests/serverpod_test_server/test_integration/test_tools/database_operations_test.dart
@@ -8,7 +8,8 @@ void main() {
   withServerpod(
     'Given TestToolsEndpoint',
     (sessionBuilder, endpoints) {
-      var session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
 
       test(
         'when calling createSimpleData then creates a SimpleData in the database',
@@ -108,7 +109,8 @@ void main() {
   withServerpod(
     'Given TestToolsEndpoint and rollbackDatabase afterEach',
     (sessionBuilder, endpoints) {
-      var session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
       group('when calling createSimpleDatasInsideTransactions', () {
         setUpAll(() async {
           await endpoints.testTools.createSimpleDatasInsideTransactions(
@@ -194,7 +196,8 @@ void main() {
       withServerpod(
         '',
         (sessionBuilder, endpoints) {
-          var session = sessionBuilder.build();
+          late Session session;
+          setUp(() => session = sessionBuilder.build());
 
           setUpAll(() async {
             await endpoints.testTools.createSimpleDatasInsideTransactions(
@@ -227,7 +230,8 @@ void main() {
       withServerpod(
         'when fetching SimpleData in the next withServerpod',
         (sessionBuilder, endpoints) {
-          var session = sessionBuilder.build();
+          late Session session;
+          setUp(() => session = sessionBuilder.build());
           test('then should have been rolled back', () async {
             var simpleDatas = await SimpleData.db.find(session);
 
@@ -241,7 +245,8 @@ void main() {
       withServerpod(
         '',
         (sessionBuilder, endpoints) {
-          var session = sessionBuilder.build();
+          late Session session;
+          setUp(() => session = sessionBuilder.build());
 
           setUpAll(() async {
             try {
@@ -266,7 +271,8 @@ void main() {
       withServerpod(
         'when fetching SimpleData in the next withServerpod',
         (sessionBuilder, endpoints) {
-          var session = sessionBuilder.build();
+          late Session session;
+          setUp(() => session = sessionBuilder.build());
           test('then should have been rolled back', () async {
             var simpleDatas = await SimpleData.db.find(session);
 
@@ -305,7 +311,8 @@ void main() {
       withServerpod(
         'when fetching SimpleData in the next withServerpod',
         (sessionBuilder, endpoints) {
-          var session = sessionBuilder.build();
+          late Session session;
+          setUp(() => session = sessionBuilder.build());
 
           test('then should have been rolled back', () async {
             var simpleDatas = await SimpleData.db.find(session);
@@ -322,7 +329,8 @@ void main() {
       withServerpod(
         '',
         (sessionBuilder, endpoints) {
-          var session = sessionBuilder.build();
+          late Session session;
+          setUp(() => session = sessionBuilder.build());
           setUpAll(() async {
             await endpoints.testTools.createSimpleDatasInsideTransactions(
               sessionBuilder,
@@ -354,7 +362,8 @@ void main() {
       withServerpod(
         'when fetching SimpleData in the next withServerpod',
         (sessionBuilder, endpoints) {
-          var session = sessionBuilder.build();
+          late Session session;
+          setUp(() => session = sessionBuilder.build());
 
           test(
             'then there is no data because each group has its own database',
@@ -373,7 +382,8 @@ void main() {
       withServerpod(
         '',
         (sessionBuilder, endpoints) {
-          var session = sessionBuilder.build();
+          late Session session;
+          setUp(() => session = sessionBuilder.build());
           setUpAll(() async {
             try {
               await endpoints.testTools
@@ -397,7 +407,8 @@ void main() {
       withServerpod(
         'when fetching SimpleData in the next withServerpod',
         (sessionBuilder, endpoints) {
-          var session = sessionBuilder.build();
+          late Session session;
+          setUp(() => session = sessionBuilder.build());
 
           test(
             'then there is no data because each group has its own database',
@@ -415,7 +426,8 @@ void main() {
     withServerpod(
       'when calling createSimpleDatasInParallelTransactionCalls',
       (sessionBuilder, endpoints) {
-        var session = sessionBuilder.build();
+        late Session session;
+        setUp(() => session = sessionBuilder.build());
         setUpAll(() async {
           await endpoints.testTools.createSimpleDatasInParallelTransactionCalls(
             sessionBuilder,
@@ -443,7 +455,8 @@ void main() {
     'Given rollbackDatabase is not disabled (transaction active) ',
     rollbackDatabase: RollbackDatabase.afterEach,
     (sessionBuilder, _) {
-      var session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
 
       group('when creating UniqueData with the same unique value', () {
         late Future failingInsert;

--- a/tests/serverpod_test_server/test_integration/test_tools/rollback_database_test.dart
+++ b/tests/serverpod_test_server/test_integration/test_tools/rollback_database_test.dart
@@ -9,7 +9,8 @@ void main() {
   withServerpod(
     'Given no explicit rollbackDatabase configuration when having multiple test cases',
     (sessionBuilder, endpoints) {
-      var session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
 
       test(
         'then first test creates objects in the database that should be rolled back due to default rollbackDatabase.afterEach configuration',
@@ -45,8 +46,9 @@ void main() {
       withServerpod(
         '',
         (sessionBuilder, endpoints) {
-          var session = sessionBuilder.build();
+          late Session session;
           setUpAll(() async {
+            session = sessionBuilder.build();
             await SimpleData.db.insert(
               session,
               [
@@ -79,7 +81,8 @@ void main() {
       withServerpod(
         '',
         (sessionBuilder, endpoints) {
-          var session = sessionBuilder.build();
+          late Session session;
+          setUp(() => session = sessionBuilder.build());
 
           test(
             'then the database is rolled back after the first withServerpod',
@@ -97,7 +100,8 @@ void main() {
       withServerpod(
         '',
         (sessionBuilder, endpoints) {
-          var session = sessionBuilder.build();
+          late Session session;
+          setUp(() => session = sessionBuilder.build());
 
           setUp(() async {
             await SimpleData.db.insert(session, [
@@ -134,7 +138,8 @@ void main() {
       withServerpod(
         '',
         (sessionBuilder, endpoints) {
-          var session = sessionBuilder.build();
+          late Session session;
+          setUp(() => session = sessionBuilder.build());
 
           test(
             'then the database is rolled back after the first withServerpod',
@@ -151,9 +156,12 @@ void main() {
     withServerpod(
       'when creating a copy of the session builder and creating new objects in the database in setUp',
       (sessionBuilder, endpoints) {
-        var session = sessionBuilder.build();
-        var newSessionBuilder = sessionBuilder.copyWith();
-        var newSession = newSessionBuilder.build();
+        late Session session;
+        late Session newSession;
+        setUp(() {
+          session = sessionBuilder.build();
+          newSession = sessionBuilder.copyWith().build();
+        });
         setUp(() async {
           await SimpleData.db.insert(newSession, [
             SimpleData(num: 111),
@@ -200,8 +208,9 @@ void main() {
       withServerpod(
         '',
         (sessionBuilder, endpoints) {
-          var session = sessionBuilder.build();
+          late Session session;
           setUpAll(() async {
+            session = sessionBuilder.build();
             await SimpleData.db.insert(session, [
               SimpleData(num: 111),
               SimpleData(num: 222),
@@ -236,7 +245,8 @@ void main() {
       withServerpod(
         '',
         (sessionBuilder, endpoints) {
-          var session = sessionBuilder.build();
+          late Session session;
+          setUp(() => session = sessionBuilder.build());
           test(
             'then the database is rolled back after the first withServerpod',
             () async {
@@ -253,7 +263,8 @@ void main() {
       withServerpod(
         '',
         (sessionBuilder, endpoints) {
-          var session = sessionBuilder.build();
+          late Session session;
+          setUp(() => session = sessionBuilder.build());
           setUp(() async {
             await SimpleData.db.insert(session, [
               SimpleData(num: 111),
@@ -291,7 +302,8 @@ void main() {
       withServerpod(
         '',
         (sessionBuilder, endpoints) {
-          var session = sessionBuilder.build();
+          late Session session;
+          setUp(() => session = sessionBuilder.build());
 
           test(
             'then the database is rolled back after the first withServerpod',
@@ -311,7 +323,8 @@ void main() {
         withServerpod(
           '',
           (sessionBuilder, endpoints) {
-            var session = sessionBuilder.build();
+            late Session session;
+            setUp(() => session = sessionBuilder.build());
             test('then creates SimpleData in the first test', () async {
               await SimpleData.db.insert(session, [
                 SimpleData(num: 111),
@@ -336,7 +349,8 @@ void main() {
         withServerpod(
           '',
           (sessionBuilder, endpoints) {
-            var session = sessionBuilder.build();
+            late Session session;
+            setUp(() => session = sessionBuilder.build());
             test(
               'when fetching SimpleData after the first withServerpod then the database is rolled back',
               () async {
@@ -355,7 +369,8 @@ void main() {
     withServerpod(
       'when creating SimpleData in in one test and fetching it in the other',
       (sessionBuilder, endpoints) {
-        var session = sessionBuilder.build();
+        late Session session;
+        setUp(() => session = sessionBuilder.build());
         test('then creates SimpleData in the first test', () async {
           await SimpleData.db.insert(session, [
             SimpleData(num: 111),
@@ -381,7 +396,8 @@ void main() {
     withServerpod(
       'when fetching SimpleData after the first withServerpod',
       (sessionBuilder, endpoints) {
-        var session = sessionBuilder.build();
+        late Session session;
+        setUp(() => session = sessionBuilder.build());
 
         tearDownAll(() async {
           await SimpleData.db.deleteWhere(

--- a/tests/serverpod_test_server/test_integration/test_tools/rollback_database_test.dart
+++ b/tests/serverpod_test_server/test_integration/test_tools/rollback_database_test.dart
@@ -158,11 +158,9 @@ void main() {
       (sessionBuilder, endpoints) {
         late Session session;
         late Session newSession;
-        setUp(() {
+        setUp(() async {
           session = sessionBuilder.build();
           newSession = sessionBuilder.copyWith().build();
-        });
-        setUp(() async {
           await SimpleData.db.insert(newSession, [
             SimpleData(num: 111),
             SimpleData(num: 222),
@@ -264,8 +262,8 @@ void main() {
         '',
         (sessionBuilder, endpoints) {
           late Session session;
-          setUp(() => session = sessionBuilder.build());
           setUp(() async {
+            session = sessionBuilder.build();
             await SimpleData.db.insert(session, [
               SimpleData(num: 111),
               SimpleData(num: 222),

--- a/tests/serverpod_test_server/test_integration/test_tools/rollback_database_test.dart
+++ b/tests/serverpod_test_server/test_integration/test_tools/rollback_database_test.dart
@@ -1,3 +1,4 @@
+import 'package:serverpod/serverpod.dart';
 import 'package:serverpod_test_server/src/generated/protocol.dart';
 import 'package:test/test.dart';
 
@@ -7,7 +8,8 @@ void main() {
   withServerpod(
     'Given no explicit rollbackDatabase configuration when having multiple test cases',
     (sessionBuilder, endpoints) {
-      var session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
 
       test(
         'then first test creates objects in the database that should be rolled back due to default rollbackDatabase.afterEach configuration',
@@ -43,8 +45,9 @@ void main() {
       withServerpod(
         '',
         (sessionBuilder, endpoints) {
-          var session = sessionBuilder.build();
+          late Session session;
           setUpAll(() async {
+            session = sessionBuilder.build();
             await SimpleData.db.insert(
               session,
               [
@@ -77,7 +80,8 @@ void main() {
       withServerpod(
         '',
         (sessionBuilder, endpoints) {
-          var session = sessionBuilder.build();
+          late Session session;
+          setUp(() => session = sessionBuilder.build());
 
           test(
             'then the database is rolled back after the first withServerpod',
@@ -95,7 +99,8 @@ void main() {
       withServerpod(
         '',
         (sessionBuilder, endpoints) {
-          var session = sessionBuilder.build();
+          late Session session;
+          setUp(() => session = sessionBuilder.build());
 
           setUp(() async {
             await SimpleData.db.insert(session, [
@@ -132,7 +137,8 @@ void main() {
       withServerpod(
         '',
         (sessionBuilder, endpoints) {
-          var session = sessionBuilder.build();
+          late Session session;
+          setUp(() => session = sessionBuilder.build());
 
           test(
             'then the database is rolled back after the first withServerpod',
@@ -149,9 +155,12 @@ void main() {
     withServerpod(
       'when creating a copy of the session builder and creating new objects in the database in setUp',
       (sessionBuilder, endpoints) {
-        var session = sessionBuilder.build();
-        var newSessionBuilder = sessionBuilder.copyWith();
-        var newSession = newSessionBuilder.build();
+        late Session session;
+        late Session newSession;
+        setUp(() {
+          session = sessionBuilder.build();
+          newSession = sessionBuilder.copyWith().build();
+        });
         setUp(() async {
           await SimpleData.db.insert(newSession, [
             SimpleData(num: 111),
@@ -198,8 +207,9 @@ void main() {
       withServerpod(
         '',
         (sessionBuilder, endpoints) {
-          var session = sessionBuilder.build();
+          late Session session;
           setUpAll(() async {
+            session = sessionBuilder.build();
             await SimpleData.db.insert(session, [
               SimpleData(num: 111),
               SimpleData(num: 222),
@@ -234,7 +244,8 @@ void main() {
       withServerpod(
         '',
         (sessionBuilder, endpoints) {
-          var session = sessionBuilder.build();
+          late Session session;
+          setUp(() => session = sessionBuilder.build());
           test(
             'then the database is rolled back after the first withServerpod',
             () async {
@@ -251,7 +262,8 @@ void main() {
       withServerpod(
         '',
         (sessionBuilder, endpoints) {
-          var session = sessionBuilder.build();
+          late Session session;
+          setUp(() => session = sessionBuilder.build());
           setUp(() async {
             await SimpleData.db.insert(session, [
               SimpleData(num: 111),
@@ -289,7 +301,8 @@ void main() {
       withServerpod(
         '',
         (sessionBuilder, endpoints) {
-          var session = sessionBuilder.build();
+          late Session session;
+          setUp(() => session = sessionBuilder.build());
 
           test(
             'then the database is rolled back after the first withServerpod',
@@ -309,7 +322,8 @@ void main() {
         withServerpod(
           '',
           (sessionBuilder, endpoints) {
-            var session = sessionBuilder.build();
+            late Session session;
+            setUp(() => session = sessionBuilder.build());
             test('then creates SimpleData in the first test', () async {
               await SimpleData.db.insert(session, [
                 SimpleData(num: 111),
@@ -334,7 +348,8 @@ void main() {
         withServerpod(
           '',
           (sessionBuilder, endpoints) {
-            var session = sessionBuilder.build();
+            late Session session;
+            setUp(() => session = sessionBuilder.build());
             test(
               'when fetching SimpleData after the first withServerpod then the database is rolled back',
               () async {
@@ -353,7 +368,8 @@ void main() {
     withServerpod(
       'when creating SimpleData in in one test and fetching it in the other',
       (sessionBuilder, endpoints) {
-        var session = sessionBuilder.build();
+        late Session session;
+        setUp(() => session = sessionBuilder.build());
         test('then creates SimpleData in the first test', () async {
           await SimpleData.db.insert(session, [
             SimpleData(num: 111),
@@ -378,7 +394,8 @@ void main() {
     withServerpod(
       'when fetching SimpleData after the first withServerpod',
       (sessionBuilder, endpoints) {
-        var session = sessionBuilder.build();
+        late Session session;
+        setUp(() => session = sessionBuilder.build());
 
         test(
           'then there is no data because each group has its own database',

--- a/tests/serverpod_test_server/test_integration/test_tools/rollback_database_test.dart
+++ b/tests/serverpod_test_server/test_integration/test_tools/rollback_database_test.dart
@@ -100,9 +100,8 @@ void main() {
         '',
         (sessionBuilder, endpoints) {
           late Session session;
-          setUp(() => session = sessionBuilder.build());
-
           setUp(() async {
+            session = sessionBuilder.build();
             await SimpleData.db.insert(session, [
               SimpleData(num: 111),
               SimpleData(num: 222),
@@ -157,11 +156,9 @@ void main() {
       (sessionBuilder, endpoints) {
         late Session session;
         late Session newSession;
-        setUp(() {
+        setUp(() async {
           session = sessionBuilder.build();
           newSession = sessionBuilder.copyWith().build();
-        });
-        setUp(() async {
           await SimpleData.db.insert(newSession, [
             SimpleData(num: 111),
             SimpleData(num: 222),
@@ -263,8 +260,8 @@ void main() {
         '',
         (sessionBuilder, endpoints) {
           late Session session;
-          setUp(() => session = sessionBuilder.build());
           setUp(() async {
+            session = sessionBuilder.build();
             await SimpleData.db.insert(session, [
               SimpleData(num: 111),
               SimpleData(num: 222),

--- a/tests/serverpod_test_server/test_integration/test_tools/runtime_parameters_test.dart
+++ b/tests/serverpod_test_server/test_integration/test_tools/runtime_parameters_test.dart
@@ -1,4 +1,4 @@
-import 'package:serverpod/database.dart';
+import 'package:serverpod/serverpod.dart';
 import 'package:serverpod_test_server/test_util/test_tags.dart';
 import 'package:test/test.dart';
 
@@ -8,7 +8,8 @@ void main() {
   withServerpod(
     'Given withServerpod without runtimeParametersBuilder',
     (sessionBuilder, endpoints) {
-      var session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
 
       test('when querying runtime parameters globally '
           'then no database parameters are set.', () async {
@@ -73,7 +74,8 @@ void main() {
       ),
     ],
     (sessionBuilder, endpoints) {
-      var session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
 
       Future<void> validateParameters() async {
         var hnswCheckQuery = HnswIndexQueryOptions().buildCheckValues();
@@ -126,7 +128,8 @@ void main() {
       ),
     ],
     (sessionBuilder, endpoints) {
-      var session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
 
       test('then local parameters override global ones temporarily.', () async {
         await session.db.ensureVectorLoaded();

--- a/tests/serverpod_test_server/test_integration/test_tools/runtime_parameters_test.dart
+++ b/tests/serverpod_test_server/test_integration/test_tools/runtime_parameters_test.dart
@@ -1,4 +1,4 @@
-import 'package:serverpod/database.dart';
+import 'package:serverpod/serverpod.dart';
 import 'package:test/test.dart';
 
 import 'serverpod_test_tools.dart';
@@ -7,7 +7,8 @@ void main() {
   withServerpod(
     'Given withServerpod without runtimeParametersBuilder',
     (sessionBuilder, endpoints) {
-      var session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
 
       test('when querying runtime parameters globally '
           'then no database parameters are set.', () async {
@@ -71,7 +72,8 @@ void main() {
       ),
     ],
     (sessionBuilder, endpoints) {
-      var session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
 
       Future<void> validateParameters() async {
         var hnswCheckQuery = HnswIndexQueryOptions().buildCheckValues();
@@ -123,7 +125,8 @@ void main() {
       ),
     ],
     (sessionBuilder, endpoints) {
-      var session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
 
       test('then local parameters override global ones temporarily.', () async {
         await session.db.ensureVectorLoaded();

--- a/tests/serverpod_test_server/test_integration/test_tools/session_copy_with_test.dart
+++ b/tests/serverpod_test_server/test_integration/test_tools/session_copy_with_test.dart
@@ -9,12 +9,15 @@ void main() {
     'Given calling `copyWith` on the session builder',
     (sessionBuilder, endpoints) {
       group('when setting a new shared session builder on the group level', () {
-        TestSessionBuilder modifiedSessionBuilder = sessionBuilder.copyWith(
-          authentication: AuthenticationOverride.authenticationInfo(
-            '123',
-            {},
-          ),
-        );
+        late TestSessionBuilder modifiedSessionBuilder;
+        setUpAll(() {
+          modifiedSessionBuilder = sessionBuilder.copyWith(
+            authentication: AuthenticationOverride.authenticationInfo(
+              '123',
+              {},
+            ),
+          );
+        });
 
         test(
           'then the first test gets the modifiedSessionBuilder according to the group assignment',
@@ -46,9 +49,12 @@ void main() {
 
       group('when setting a new shared session builder on the group level '
           'and copying the session builder in the first test', () {
-        TestSessionBuilder modifiedSessionBuilder = sessionBuilder.copyWith(
-          authentication: AuthenticationOverride.unauthenticated(),
-        );
+        late TestSessionBuilder modifiedSessionBuilder;
+        setUpAll(() {
+          modifiedSessionBuilder = sessionBuilder.copyWith(
+            authentication: AuthenticationOverride.unauthenticated(),
+          );
+        });
 
         test('then the first test can change it', () {
           modifiedSessionBuilder = sessionBuilder.copyWith(

--- a/tests/serverpod_test_server/test_integration/test_tools/session_copy_with_test.dart
+++ b/tests/serverpod_test_server/test_integration/test_tools/session_copy_with_test.dart
@@ -9,12 +9,15 @@ void main() {
     'Given calling `copyWith` on the session builder',
     (sessionBuilder, endpoints) {
       group('when setting a new shared session builder on the group level', () {
-        TestSessionBuilder modifiedSessionBuilder = sessionBuilder.copyWith(
-          authentication: AuthenticationOverride.authenticationInfo(
-            '123',
-            {},
-          ),
-        );
+        late TestSessionBuilder modifiedSessionBuilder;
+        setUpAll(() {
+          modifiedSessionBuilder = sessionBuilder.copyWith(
+            authentication: AuthenticationOverride.authenticationInfo(
+              '123',
+              {},
+            ),
+          );
+        });
 
         test(
           'then the first test gets the modifiedSessionBuilder according to the group assignment',
@@ -44,33 +47,24 @@ void main() {
         );
       });
 
-      group('when setting a new shared session builder on the group level '
-          'and copying the session builder in the first test', () {
-        TestSessionBuilder modifiedSessionBuilder = sessionBuilder.copyWith(
-          authentication: AuthenticationOverride.unauthenticated(),
-        );
+      group(
+        'when setting a new shared session builder on the group level and copying the session builder in the first test',
+        () {
+          late TestSessionBuilder modifiedSessionBuilder;
+          setUpAll(() {
+            modifiedSessionBuilder = sessionBuilder.copyWith(
+              authentication: AuthenticationOverride.unauthenticated(),
+            );
+          });
 
-        test('then the first test can change it', () {
-          modifiedSessionBuilder = sessionBuilder.copyWith(
-            authentication: AuthenticationOverride.authenticationInfo(
-              '123',
-              {},
-            ),
-          );
+          test('then the first test can change it', () {
+            modifiedSessionBuilder = sessionBuilder.copyWith(
+              authentication: AuthenticationOverride.authenticationInfo(
+                '123',
+                {},
+              ),
+            );
 
-          expect(
-            modifiedSessionBuilder.build().authenticated,
-            isA<AuthenticationInfo>().having(
-              (a) => a.userId,
-              'userId',
-              123,
-            ),
-          );
-        });
-
-        test(
-          'then the second test gets the modifiedSessionBuilder according to the first test',
-          () {
             expect(
               modifiedSessionBuilder.build().authenticated,
               isA<AuthenticationInfo>().having(
@@ -79,9 +73,23 @@ void main() {
                 123,
               ),
             );
-          },
-        );
-      });
+          });
+
+          test(
+            'then the second test gets the modifiedSessionBuilder according to the first test',
+            () {
+              expect(
+                modifiedSessionBuilder.build().authenticated,
+                isA<AuthenticationInfo>().having(
+                  (a) => a.userId,
+                  'userId',
+                  123,
+                ),
+              );
+            },
+          );
+        },
+      );
     },
   );
 }

--- a/tests/serverpod_test_server/test_integration/test_tools/transaction_correctness_test.dart
+++ b/tests/serverpod_test_server/test_integration/test_tools/transaction_correctness_test.dart
@@ -12,7 +12,8 @@ void main() {
     'Given transaction call in test and rollbacks are enabled',
     rollbackDatabase: RollbackDatabase.afterEach,
     (sessionBuilder, endpoints) {
-      var session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
 
       test('when inserting an object '
           'then should be persisted if transaction completes', () async {
@@ -256,7 +257,8 @@ void main() {
     rollbackDatabase: RollbackDatabase.disabled,
     testGroupTagsOverride: [TestTags.concurrencyOneTestTag],
     (sessionBuilder, endpoints) {
-      var session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
 
       tearDown(() async {
         await SimpleData.db.deleteWhere(
@@ -332,7 +334,8 @@ void main() {
     withServerpod(
       'Given transaction call in test with database rollbacks enabled (default)',
       (sessionBuilder, endpoints) {
-        var session = sessionBuilder.build();
+        late Session session;
+        setUp(() => session = sessionBuilder.build());
         test(
           'when database exception occurs '
           'then transaction WILL NOT throw exception if it was caught in the transaction',
@@ -356,7 +359,8 @@ void main() {
     withServerpod(
       'Given transaction call in test with database rollbacks disabled',
       (sessionBuilder, endpoints) {
-        var session = sessionBuilder.build();
+        late Session session;
+        setUp(() => session = sessionBuilder.build());
 
         test(
           'when database exception occurs '

--- a/tests/serverpod_test_server/test_integration/test_tools/transaction_correctness_test.dart
+++ b/tests/serverpod_test_server/test_integration/test_tools/transaction_correctness_test.dart
@@ -11,7 +11,8 @@ void main() {
     'Given transaction call in test and rollbacks are enabled',
     rollbackDatabase: RollbackDatabase.afterEach,
     (sessionBuilder, endpoints) {
-      var session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
 
       test('when inserting an object '
           'then should be persisted if transaction completes', () async {
@@ -254,7 +255,8 @@ void main() {
     'Given transaction calls when rollbacks are disabled',
     rollbackDatabase: RollbackDatabase.disabled,
     (sessionBuilder, endpoints) {
-      var session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
 
       tearDown(() async {
         await SimpleData.db.deleteWhere(
@@ -330,7 +332,8 @@ void main() {
     withServerpod(
       'Given transaction call in test with database rollbacks enabled (default)',
       (sessionBuilder, endpoints) {
-        var session = sessionBuilder.build();
+        late Session session;
+        setUp(() => session = sessionBuilder.build());
         test(
           'when database exception occurs '
           'then transaction WILL NOT throw exception if it was caught in the transaction',
@@ -354,7 +357,8 @@ void main() {
     withServerpod(
       'Given transaction call in test with database rollbacks disabled',
       (sessionBuilder, endpoints) {
-        var session = sessionBuilder.build();
+        late Session session;
+        setUp(() => session = sessionBuilder.build());
 
         test(
           'when database exception occurs '

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/test_integration/database_operations/crud/update_by_id_test.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/test_integration/database_operations/crud/update_by_id_test.dart
@@ -10,7 +10,8 @@ void main() {
   withServerpod(
     'Given a database entry with all basic fields',
     (sessionBuilder, endpoints) {
-      var session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
 
       const originalBool = true;
       const originalInt = 1;
@@ -164,7 +165,8 @@ void main() {
   withServerpod(
     'Given a database entry with non-null values',
     (sessionBuilder, endpoints) {
-      var session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
 
       const originalInt = 1;
       const originalString = 'original';
@@ -208,7 +210,8 @@ void main() {
   withServerpod(
     'Given a database entry with null values',
     (sessionBuilder, endpoints) {
-      var session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
 
       late Types existingEntry;
 
@@ -247,7 +250,8 @@ void main() {
   withServerpod(
     'Given a database entry with all supported data types',
     (sessionBuilder, endpoints) {
-      var session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
 
       late Types existingEntry;
 
@@ -399,7 +403,8 @@ void main() {
   withServerpod(
     'Given a non-existent database entry',
     (testSession, endpoints) {
-      var session = testSession.build();
+      late Session session;
+      setUp(() => session = testSession.build());
 
       test(
         'when updating by non-existent id then DatabaseUpdateRowException is thrown',

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/test_integration/database_operations/crud/update_by_id_test.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/test_integration/database_operations/crud/update_by_id_test.dart
@@ -10,7 +10,8 @@ void main() {
   withServerpod(
     'Given a database entry with all basic fields',
     (sessionBuilder, endpoints) {
-      var session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
 
       const originalBool = true;
       const originalInt = 1;
@@ -164,7 +165,8 @@ void main() {
   withServerpod(
     'Given a database entry with non-null values',
     (sessionBuilder, endpoints) {
-      var session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
 
       const originalInt = 1;
       const originalString = 'original';
@@ -208,7 +210,8 @@ void main() {
   withServerpod(
     'Given a database entry with null values',
     (sessionBuilder, endpoints) {
-      var session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
 
       late Types existingEntry;
 
@@ -247,7 +250,8 @@ void main() {
   withServerpod(
     'Given a database entry with all supported data types',
     (sessionBuilder, endpoints) {
-      var session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
 
       late Types existingEntry;
 
@@ -399,7 +403,8 @@ void main() {
   withServerpod(
     'Given a non-existent database entry',
     (testSession, endpoints) {
-      var session = testSession.build();
+      late Session session;
+      setUp(() => session = testSession.build());
 
       test(
         'when updating by non-existent id then an exception is thrown',

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/test_integration/database_operations/crud/update_where_test.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/test_integration/database_operations/crud/update_where_test.dart
@@ -10,7 +10,8 @@ void main() {
   withServerpod(
     'Given database entries with basic matching criteria',
     (sessionBuilder, endpoints) {
-      var session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
 
       setUp(() async {
         await Types.db.insert(
@@ -186,7 +187,8 @@ void main() {
   withServerpod(
     'Given database entries for transaction testing',
     (sessionBuilder, endpoints) {
-      var session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
 
       setUp(() async {
         await Types.db.insert(
@@ -238,7 +240,8 @@ void main() {
   withServerpod(
     'Given no matching database entries',
     (sessionBuilder, endpoints) {
-      var session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
 
       setUp(() async {
         await Types.db.insert(
@@ -267,7 +270,8 @@ void main() {
   withServerpod(
     'Given database entries with null values',
     (sessionBuilder, endpoints) {
-      var session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
 
       setUp(() async {
         await Types.db.insertRow(
@@ -320,7 +324,8 @@ void main() {
   withServerpod(
     'Given database entries with non-null values',
     (sessionBuilder, endpoints) {
-      var session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
 
       const originalInt = 1;
       const originalString = 'value';
@@ -388,7 +393,8 @@ void main() {
   withServerpod(
     'Given database entries for pagination operations',
     (sessionBuilder, endpoints) {
-      var session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
 
       const matchingInt = 100;
 
@@ -575,7 +581,8 @@ void main() {
   withServerpod(
     'Given database entries with all supported data types',
     (sessionBuilder, endpoints) {
-      var session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
 
       setUp(() async {
         await Types.db.insert(

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/test_integration/database_operations/crud/update_where_test.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/test_integration/database_operations/crud/update_where_test.dart
@@ -11,9 +11,8 @@ void main() {
     'Given database entries with basic matching criteria',
     (sessionBuilder, endpoints) {
       late Session session;
-      setUp(() => session = sessionBuilder.build());
-
       setUp(() async {
+        session = sessionBuilder.build();
         await Types.db.insert(
           session,
           [
@@ -188,9 +187,8 @@ void main() {
     'Given database entries for transaction testing',
     (sessionBuilder, endpoints) {
       late Session session;
-      setUp(() => session = sessionBuilder.build());
-
       setUp(() async {
+        session = sessionBuilder.build();
         await Types.db.insert(
           session,
           [
@@ -241,9 +239,8 @@ void main() {
     'Given no matching database entries',
     (sessionBuilder, endpoints) {
       late Session session;
-      setUp(() => session = sessionBuilder.build());
-
       setUp(() async {
+        session = sessionBuilder.build();
         await Types.db.insert(
           session,
           [
@@ -271,9 +268,8 @@ void main() {
     'Given database entries with null values',
     (sessionBuilder, endpoints) {
       late Session session;
-      setUp(() => session = sessionBuilder.build());
-
       setUp(() async {
+        session = sessionBuilder.build();
         await Types.db.insertRow(
           session,
           Types(
@@ -582,9 +578,8 @@ void main() {
     'Given database entries with all supported data types',
     (sessionBuilder, endpoints) {
       late Session session;
-      setUp(() => session = sessionBuilder.build());
-
       setUp(() async {
+        session = sessionBuilder.build();
         await Types.db.insert(
           session,
           [
@@ -775,9 +770,8 @@ void main() {
     'Given an inserted entry,',
     (sessionBuilder, endpoints) {
       late Session session;
-      setUp(() => session = sessionBuilder.build());
-
       setUp(() async {
+        session = sessionBuilder.build();
         await UniqueData.db.insert(session, [
           UniqueData(number: 1, email: 'a@serverpod.dev'),
         ]);

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/test_integration/database_operations/crud/update_where_test.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/test_integration/database_operations/crud/update_where_test.dart
@@ -10,7 +10,8 @@ void main() {
   withServerpod(
     'Given database entries with basic matching criteria',
     (sessionBuilder, endpoints) {
-      var session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
 
       setUp(() async {
         await Types.db.insert(
@@ -186,7 +187,8 @@ void main() {
   withServerpod(
     'Given database entries for transaction testing',
     (sessionBuilder, endpoints) {
-      var session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
 
       setUp(() async {
         await Types.db.insert(
@@ -238,7 +240,8 @@ void main() {
   withServerpod(
     'Given no matching database entries',
     (sessionBuilder, endpoints) {
-      var session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
 
       setUp(() async {
         await Types.db.insert(
@@ -267,7 +270,8 @@ void main() {
   withServerpod(
     'Given database entries with null values',
     (sessionBuilder, endpoints) {
-      var session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
 
       setUp(() async {
         await Types.db.insertRow(
@@ -320,7 +324,8 @@ void main() {
   withServerpod(
     'Given database entries with non-null values',
     (sessionBuilder, endpoints) {
-      var session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
 
       const originalInt = 1;
       const originalString = 'value';
@@ -388,7 +393,8 @@ void main() {
   withServerpod(
     'Given database entries for pagination operations',
     (sessionBuilder, endpoints) {
-      var session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
 
       const matchingInt = 100;
 
@@ -575,7 +581,8 @@ void main() {
   withServerpod(
     'Given database entries with all supported data types',
     (sessionBuilder, endpoints) {
-      var session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
 
       setUp(() async {
         await Types.db.insert(
@@ -767,7 +774,8 @@ void main() {
   withServerpod(
     'Given an inserted entry,',
     (sessionBuilder, endpoints) {
-      var session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
 
       setUp(() async {
         await UniqueData.db.insert(session, [

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/test_integration/database_operations/dynamic_roundtrip_test.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/test_integration/database_operations/dynamic_roundtrip_test.dart
@@ -1,3 +1,4 @@
+import 'package:serverpod/serverpod.dart';
 import 'package:serverpod_test_sqlite_server/src/generated/protocol.dart';
 import 'package:test/test.dart';
 
@@ -43,7 +44,8 @@ void main() {
   withServerpod(
     'Given a table model with dynamic fields,',
     (sessionBuilder, endpoints) {
-      var session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
 
       group('when inserting the model with all dynamic fields ', () {
         late Future<ObjectWithDynamic> insert;
@@ -67,7 +69,8 @@ void main() {
   withServerpod(
     'Given a table model with dynamic fields and an entry that has been inserted,',
     (sessionBuilder, endpoints) {
-      var session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
 
       setUp(() async {
         await ObjectWithDynamic.db.insertRow(session, object);

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/test_integration/database_operations/dynamic_roundtrip_test.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/test_integration/database_operations/dynamic_roundtrip_test.dart
@@ -70,9 +70,8 @@ void main() {
     'Given a table model with dynamic fields and an entry that has been inserted,',
     (sessionBuilder, endpoints) {
       late Session session;
-      setUp(() => session = sessionBuilder.build());
-
       setUp(() async {
+        session = sessionBuilder.build();
         await ObjectWithDynamic.db.insertRow(session, object);
       });
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/test_integration/database_operations/entity_relations/one_to_many/update/update_row_test.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/test_integration/database_operations/entity_relations/one_to_many/update/update_row_test.dart
@@ -1,4 +1,5 @@
 import '../../../../test_tools/serverpod_test_tools.dart';
+import 'package:serverpod/serverpod.dart';
 import 'package:serverpod_test_sqlite_server/src/generated/protocol.dart';
 import 'package:test/test.dart';
 
@@ -6,7 +7,8 @@ void main() async {
   withServerpod(
     'Given an entity with an implicit one-to-many relation',
     (sessionBuilder, _) {
-      var session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
 
       setUp(() async {
         var book = await Book.db.insertRow(

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/test_integration/database_operations/entity_relations/one_to_many/update/update_row_test.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/test_integration/database_operations/entity_relations/one_to_many/update/update_row_test.dart
@@ -8,9 +8,8 @@ void main() async {
     'Given an entity with an implicit one-to-many relation',
     (sessionBuilder, _) {
       late Session session;
-      setUp(() => session = sessionBuilder.build());
-
       setUp(() async {
+        session = sessionBuilder.build();
         var book = await Book.db.insertRow(
           session,
           Book(title: 'Book 1'),

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/test_integration/database_operations/explicit_column_name/crud_test.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/test_integration/database_operations/explicit_column_name/crud_test.dart
@@ -1,3 +1,4 @@
+import 'package:serverpod/serverpod.dart';
 import 'package:serverpod_test_sqlite_server/src/generated/protocol.dart';
 import 'package:test/test.dart';
 
@@ -7,7 +8,8 @@ void main() {
   withServerpod(
     'Given a table with an explicit column name',
     (sessionBuilder, endpoints) {
-      var session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
 
       late TableWithExplicitColumnName data;
       late TableWithExplicitColumnNameRepository db;
@@ -31,7 +33,8 @@ void main() {
   withServerpod(
     'Given an entry in the database for a table with an explicit column name',
     (sessionBuilder, endpoints) {
-      var session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
 
       late TableWithExplicitColumnName data;
       late TableWithExplicitColumnName inserted;

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/test_integration/database_operations/explicit_column_name/crud_test_inheritance.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/test_integration/database_operations/explicit_column_name/crud_test_inheritance.dart
@@ -1,3 +1,4 @@
+import 'package:serverpod/serverpod.dart';
 import 'package:serverpod_test_sqlite_server/src/generated/protocol.dart';
 import 'package:test/test.dart';
 
@@ -7,7 +8,8 @@ void main() {
   withServerpod(
     'Given a child class with explicit column name that extends another class',
     (sessionBuilder, endpoints) {
-      final session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
       const parentValue = 'parentValue';
       const childValue = 'childValue';
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/test_integration/database_operations/shared_module_table_test.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/test_integration/database_operations/shared_module_table_test.dart
@@ -1,3 +1,4 @@
+import 'package:serverpod/serverpod.dart';
 import 'package:serverpod_test_shared_module_server/serverpod_test_shared_module_server.dart';
 import 'package:test/test.dart';
 
@@ -8,7 +9,8 @@ void main() {
     rollbackDatabase: RollbackDatabase.disabled,
     'Given a table model declared in the shared package of a module,',
     (sessionBuilder, _) {
-      final session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
 
       test(
         'when inserting the table through the module server package, '

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/test_integration/database_operations/shared_table/shared_table_record_test.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/test_integration/database_operations/shared_table/shared_table_record_test.dart
@@ -1,3 +1,4 @@
+import 'package:serverpod/serverpod.dart';
 import 'package:serverpod_test_sqlite_shared/serverpod_test_sqlite_shared.dart';
 import 'package:test/test.dart';
 
@@ -7,7 +8,8 @@ void main() {
   withServerpod(
     'Given an empty database,',
     (sessionBuilder, endpoints) {
-      var session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
 
       test(
         'when inserting a shared table record, '
@@ -73,8 +75,10 @@ void main() {
     sessionBuilder,
     endpoints,
   ) {
-    var session = sessionBuilder.build();
+    late Session session;
     late SharedTableRecord inserted;
+
+    setUp(() => session = sessionBuilder.build());
 
     setUp(() async {
       inserted = await SharedTableRecord.db.insertRow(

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/test_integration/database_operations/shared_table/shared_table_record_test.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/test_integration/database_operations/shared_table/shared_table_record_test.dart
@@ -78,9 +78,8 @@ void main() {
     late Session session;
     late SharedTableRecord inserted;
 
-    setUp(() => session = sessionBuilder.build());
-
     setUp(() async {
+      session = sessionBuilder.build();
       inserted = await SharedTableRecord.db.insertRow(
         session,
         SharedTableRecord(

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/test_integration/database_operations/transactions/transaction_concurrency_test.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/test_integration/database_operations/transactions/transaction_concurrency_test.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:serverpod/serverpod.dart';
 import 'package:serverpod_test_sqlite_server/src/generated/protocol.dart';
 import 'package:serverpod_test_server/test_util/test_tags.dart';
 import 'package:test/test.dart';
@@ -13,7 +14,8 @@ void main() {
     rollbackDatabase: RollbackDatabase.disabled,
     testGroupTagsOverride: [TestTags.concurrencyOneTestTag],
     (sessionBuilder, endpoints) {
-      var session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
 
       late Future<void> writeTransaction;
       late Completer<void> finishedWriting;

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/test_integration/database_operations/transactions/transaction_concurrency_test.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/test_integration/database_operations/transactions/transaction_concurrency_test.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:serverpod/serverpod.dart';
 import 'package:serverpod_test_sqlite_server/src/generated/protocol.dart';
 import 'package:test/test.dart';
 
@@ -11,7 +12,8 @@ void main() {
     // Rollbacks must be disabled or SQLite will have the test transaction.
     rollbackDatabase: RollbackDatabase.disabled,
     (sessionBuilder, endpoints) {
-      var session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
 
       late Future<void> writeTransaction;
       late Completer<void> finishedWriting;

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/test_integration/nulls_distinct_index_test.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/test_integration/nulls_distinct_index_test.dart
@@ -1,4 +1,4 @@
-import 'package:serverpod_database/serverpod_database.dart';
+import 'package:serverpod/serverpod.dart';
 import 'package:serverpod_test_sqlite_server/src/generated/protocol.dart';
 import 'package:test/test.dart';
 
@@ -9,7 +9,8 @@ void main() {
     sessionBuilder,
     endpoints,
   ) {
-    var session = sessionBuilder.build();
+    late Session session;
+    setUp(() => session = sessionBuilder.build());
 
     test(
       'when rows with the same indexed values and a null are inserted, '
@@ -77,7 +78,8 @@ void main() {
     sessionBuilder,
     endpoints,
   ) {
-    var session = sessionBuilder.build();
+    late Session session;
+    setUp(() => session = sessionBuilder.build());
 
     test(
       'when the SQLite schema is analyzed, '

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/test_integration/test_tools/database_operations_test.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/test_integration/test_tools/database_operations_test.dart
@@ -9,7 +9,8 @@ void main() {
   withServerpod(
     'Given TestToolsEndpoint',
     (sessionBuilder, endpoints) {
-      var session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
 
       test(
         'when calling createSimpleData then creates a SimpleData in the database',
@@ -109,7 +110,8 @@ void main() {
   withServerpod(
     'Given TestToolsEndpoint and rollbackDatabase afterEach',
     (sessionBuilder, endpoints) {
-      var session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
       group('when calling createSimpleDatasInsideTransactions', () {
         setUpAll(() async {
           await endpoints.testTools.createSimpleDatasInsideTransactions(
@@ -195,7 +197,8 @@ void main() {
       withServerpod(
         '',
         (sessionBuilder, endpoints) {
-          var session = sessionBuilder.build();
+          late Session session;
+          setUp(() => session = sessionBuilder.build());
 
           setUpAll(() async {
             await endpoints.testTools.createSimpleDatasInsideTransactions(
@@ -228,7 +231,8 @@ void main() {
       withServerpod(
         'when fetching SimpleData in the next withServerpod',
         (sessionBuilder, endpoints) {
-          var session = sessionBuilder.build();
+          late Session session;
+          setUp(() => session = sessionBuilder.build());
           test('then should have been rolled back', () async {
             var simpleDatas = await SimpleData.db.find(session);
 
@@ -242,7 +246,8 @@ void main() {
       withServerpod(
         '',
         (sessionBuilder, endpoints) {
-          var session = sessionBuilder.build();
+          late Session session;
+          setUp(() => session = sessionBuilder.build());
 
           setUpAll(() async {
             try {
@@ -270,7 +275,8 @@ void main() {
       withServerpod(
         'when fetching SimpleData in the next withServerpod',
         (sessionBuilder, endpoints) {
-          var session = sessionBuilder.build();
+          late Session session;
+          setUp(() => session = sessionBuilder.build());
           test('then should have been rolled back', () async {
             var simpleDatas = await SimpleData.db.find(session);
 
@@ -309,7 +315,8 @@ void main() {
       withServerpod(
         'when fetching SimpleData in the next withServerpod',
         (sessionBuilder, endpoints) {
-          var session = sessionBuilder.build();
+          late Session session;
+          setUp(() => session = sessionBuilder.build());
 
           test('then should have been rolled back', () async {
             var simpleDatas = await SimpleData.db.find(session);
@@ -326,7 +333,8 @@ void main() {
       withServerpod(
         '',
         (sessionBuilder, endpoints) {
-          var session = sessionBuilder.build();
+          late Session session;
+          setUp(() => session = sessionBuilder.build());
           setUpAll(() async {
             await endpoints.testTools.createSimpleDatasInsideTransactions(
               sessionBuilder,
@@ -359,7 +367,8 @@ void main() {
       withServerpod(
         'when fetching SimpleData in the next withServerpod',
         (sessionBuilder, endpoints) {
-          var session = sessionBuilder.build();
+          late Session session;
+          setUp(() => session = sessionBuilder.build());
           tearDownAll(() async {
             await SimpleData.db.deleteWhere(
               session,
@@ -387,7 +396,8 @@ void main() {
       withServerpod(
         '',
         (sessionBuilder, endpoints) {
-          var session = sessionBuilder.build();
+          late Session session;
+          setUp(() => session = sessionBuilder.build());
           setUpAll(() async {
             try {
               await endpoints.testTools
@@ -415,7 +425,8 @@ void main() {
       withServerpod(
         'when fetching SimpleData in the next withServerpod',
         (sessionBuilder, endpoints) {
-          var session = sessionBuilder.build();
+          late Session session;
+          setUp(() => session = sessionBuilder.build());
 
           tearDownAll(() async {
             await SimpleData.db.deleteWhere(
@@ -438,7 +449,8 @@ void main() {
     withServerpod(
       'when calling createSimpleDatasInParallelTransactionCalls',
       (sessionBuilder, endpoints) {
-        var session = sessionBuilder.build();
+        late Session session;
+        setUp(() => session = sessionBuilder.build());
 
         setUpAll(() async {
           await endpoints.testTools.createSimpleDatasInParallelTransactionCalls(
@@ -468,7 +480,8 @@ void main() {
     'Given rollbackDatabase is not disabled (transaction active) ',
     rollbackDatabase: RollbackDatabase.afterEach,
     (sessionBuilder, _) {
-      var session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
 
       group('when creating UniqueData with the same unique value', () {
         late Future<UniqueData> Function() failingInsert;

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/test_integration/test_tools/database_operations_test.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/test_integration/test_tools/database_operations_test.dart
@@ -197,9 +197,8 @@ void main() {
         '',
         (sessionBuilder, endpoints) {
           late Session session;
-          setUp(() => session = sessionBuilder.build());
-
           setUpAll(() async {
+            session = sessionBuilder.build();
             await endpoints.testTools.createSimpleDatasInsideTransactions(
               sessionBuilder,
               123,
@@ -246,9 +245,8 @@ void main() {
         '',
         (sessionBuilder, endpoints) {
           late Session session;
-          setUp(() => session = sessionBuilder.build());
-
           setUpAll(() async {
+            session = sessionBuilder.build();
             try {
               await endpoints.testTools
                   .createSimpleDataAndThrowInsideTransaction(
@@ -333,8 +331,8 @@ void main() {
         '',
         (sessionBuilder, endpoints) {
           late Session session;
-          setUp(() => session = sessionBuilder.build());
           setUpAll(() async {
+            session = sessionBuilder.build();
             await endpoints.testTools.createSimpleDatasInsideTransactions(
               sessionBuilder,
               123,
@@ -386,8 +384,8 @@ void main() {
         '',
         (sessionBuilder, endpoints) {
           late Session session;
-          setUp(() => session = sessionBuilder.build());
           setUpAll(() async {
+            session = sessionBuilder.build();
             try {
               await endpoints.testTools
                   .createSimpleDataAndThrowInsideTransaction(
@@ -433,9 +431,8 @@ void main() {
       'when calling createSimpleDatasInParallelTransactionCalls',
       (sessionBuilder, endpoints) {
         late Session session;
-        setUp(() => session = sessionBuilder.build());
-
         setUpAll(() async {
+          session = sessionBuilder.build();
           await endpoints.testTools.createSimpleDatasInParallelTransactionCalls(
             sessionBuilder,
           );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/test_integration/test_tools/database_operations_test.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/test_integration/test_tools/database_operations_test.dart
@@ -8,7 +8,8 @@ void main() {
   withServerpod(
     'Given TestToolsEndpoint',
     (sessionBuilder, endpoints) {
-      var session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
 
       test(
         'when calling createSimpleData then creates a SimpleData in the database',
@@ -108,7 +109,8 @@ void main() {
   withServerpod(
     'Given TestToolsEndpoint and rollbackDatabase afterEach',
     (sessionBuilder, endpoints) {
-      var session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
       group('when calling createSimpleDatasInsideTransactions', () {
         setUpAll(() async {
           await endpoints.testTools.createSimpleDatasInsideTransactions(
@@ -194,7 +196,8 @@ void main() {
       withServerpod(
         '',
         (sessionBuilder, endpoints) {
-          var session = sessionBuilder.build();
+          late Session session;
+          setUp(() => session = sessionBuilder.build());
 
           setUpAll(() async {
             await endpoints.testTools.createSimpleDatasInsideTransactions(
@@ -227,7 +230,8 @@ void main() {
       withServerpod(
         'when fetching SimpleData in the next withServerpod',
         (sessionBuilder, endpoints) {
-          var session = sessionBuilder.build();
+          late Session session;
+          setUp(() => session = sessionBuilder.build());
           test('then should have been rolled back', () async {
             var simpleDatas = await SimpleData.db.find(session);
 
@@ -241,7 +245,8 @@ void main() {
       withServerpod(
         '',
         (sessionBuilder, endpoints) {
-          var session = sessionBuilder.build();
+          late Session session;
+          setUp(() => session = sessionBuilder.build());
 
           setUpAll(() async {
             try {
@@ -269,7 +274,8 @@ void main() {
       withServerpod(
         'when fetching SimpleData in the next withServerpod',
         (sessionBuilder, endpoints) {
-          var session = sessionBuilder.build();
+          late Session session;
+          setUp(() => session = sessionBuilder.build());
           test('then should have been rolled back', () async {
             var simpleDatas = await SimpleData.db.find(session);
 
@@ -308,7 +314,8 @@ void main() {
       withServerpod(
         'when fetching SimpleData in the next withServerpod',
         (sessionBuilder, endpoints) {
-          var session = sessionBuilder.build();
+          late Session session;
+          setUp(() => session = sessionBuilder.build());
 
           test('then should have been rolled back', () async {
             var simpleDatas = await SimpleData.db.find(session);
@@ -325,7 +332,8 @@ void main() {
       withServerpod(
         '',
         (sessionBuilder, endpoints) {
-          var session = sessionBuilder.build();
+          late Session session;
+          setUp(() => session = sessionBuilder.build());
           setUpAll(() async {
             await endpoints.testTools.createSimpleDatasInsideTransactions(
               sessionBuilder,
@@ -357,7 +365,8 @@ void main() {
       withServerpod(
         'when fetching SimpleData in the next withServerpod',
         (sessionBuilder, endpoints) {
-          var session = sessionBuilder.build();
+          late Session session;
+          setUp(() => session = sessionBuilder.build());
 
           test(
             'then there is no data because each group has its own database',
@@ -376,7 +385,8 @@ void main() {
       withServerpod(
         '',
         (sessionBuilder, endpoints) {
-          var session = sessionBuilder.build();
+          late Session session;
+          setUp(() => session = sessionBuilder.build());
           setUpAll(() async {
             try {
               await endpoints.testTools
@@ -403,7 +413,8 @@ void main() {
       withServerpod(
         'when fetching SimpleData in the next withServerpod',
         (sessionBuilder, endpoints) {
-          var session = sessionBuilder.build();
+          late Session session;
+          setUp(() => session = sessionBuilder.build());
 
           test(
             'then there is no data because each group has its own database',
@@ -421,7 +432,8 @@ void main() {
     withServerpod(
       'when calling createSimpleDatasInParallelTransactionCalls',
       (sessionBuilder, endpoints) {
-        var session = sessionBuilder.build();
+        late Session session;
+        setUp(() => session = sessionBuilder.build());
 
         setUpAll(() async {
           await endpoints.testTools.createSimpleDatasInParallelTransactionCalls(
@@ -450,7 +462,8 @@ void main() {
     'Given rollbackDatabase is not disabled (transaction active) ',
     rollbackDatabase: RollbackDatabase.afterEach,
     (sessionBuilder, _) {
-      var session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
 
       group('when creating UniqueData with the same unique value', () {
         late Future<UniqueData> Function() failingInsert;

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/test_integration/test_tools/rollback_database_test.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/test_integration/test_tools/rollback_database_test.dart
@@ -9,7 +9,8 @@ void main() {
   withServerpod(
     'Given no explicit rollbackDatabase configuration when having multiple test cases',
     (sessionBuilder, endpoints) {
-      var session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
 
       test(
         'then first test creates objects in the database that should be rolled back due to default rollbackDatabase.afterEach configuration',
@@ -45,8 +46,9 @@ void main() {
       withServerpod(
         '',
         (sessionBuilder, endpoints) {
-          var session = sessionBuilder.build();
+          late Session session;
           setUpAll(() async {
+            session = sessionBuilder.build();
             await SimpleData.db.insert(
               session,
               [
@@ -79,7 +81,8 @@ void main() {
       withServerpod(
         '',
         (sessionBuilder, endpoints) {
-          var session = sessionBuilder.build();
+          late Session session;
+          setUp(() => session = sessionBuilder.build());
 
           test(
             'then the database is rolled back after the first withServerpod',
@@ -97,7 +100,8 @@ void main() {
       withServerpod(
         '',
         (sessionBuilder, endpoints) {
-          var session = sessionBuilder.build();
+          late Session session;
+          setUp(() => session = sessionBuilder.build());
 
           setUp(() async {
             await SimpleData.db.insert(session, [
@@ -134,7 +138,8 @@ void main() {
       withServerpod(
         '',
         (sessionBuilder, endpoints) {
-          var session = sessionBuilder.build();
+          late Session session;
+          setUp(() => session = sessionBuilder.build());
 
           test(
             'then the database is rolled back after the first withServerpod',
@@ -151,9 +156,12 @@ void main() {
     withServerpod(
       'when creating a copy of the session builder and creating new objects in the database in setUp',
       (sessionBuilder, endpoints) {
-        var session = sessionBuilder.build();
-        var newSessionBuilder = sessionBuilder.copyWith();
-        var newSession = newSessionBuilder.build();
+        late Session session;
+        late Session newSession;
+        setUp(() {
+          session = sessionBuilder.build();
+          newSession = sessionBuilder.copyWith().build();
+        });
         setUp(() async {
           await SimpleData.db.insert(newSession, [
             SimpleData(num: 111),
@@ -200,8 +208,9 @@ void main() {
       withServerpod(
         '',
         (sessionBuilder, endpoints) {
-          var session = sessionBuilder.build();
+          late Session session;
           setUpAll(() async {
+            session = sessionBuilder.build();
             await SimpleData.db.insert(session, [
               SimpleData(num: 111),
               SimpleData(num: 222),
@@ -236,7 +245,8 @@ void main() {
       withServerpod(
         '',
         (sessionBuilder, endpoints) {
-          var session = sessionBuilder.build();
+          late Session session;
+          setUp(() => session = sessionBuilder.build());
           test(
             'then the database is rolled back after the first withServerpod',
             () async {
@@ -253,7 +263,8 @@ void main() {
       withServerpod(
         '',
         (sessionBuilder, endpoints) {
-          var session = sessionBuilder.build();
+          late Session session;
+          setUp(() => session = sessionBuilder.build());
           setUp(() async {
             await SimpleData.db.insert(session, [
               SimpleData(num: 111),
@@ -291,7 +302,8 @@ void main() {
       withServerpod(
         '',
         (sessionBuilder, endpoints) {
-          var session = sessionBuilder.build();
+          late Session session;
+          setUp(() => session = sessionBuilder.build());
 
           test(
             'then the database is rolled back after the first withServerpod',
@@ -311,7 +323,8 @@ void main() {
         withServerpod(
           '',
           (sessionBuilder, endpoints) {
-            var session = sessionBuilder.build();
+            late Session session;
+            setUp(() => session = sessionBuilder.build());
             test('then creates SimpleData in the first test', () async {
               await SimpleData.db.insert(session, [
                 SimpleData(num: 111),
@@ -336,7 +349,8 @@ void main() {
         withServerpod(
           '',
           (sessionBuilder, endpoints) {
-            var session = sessionBuilder.build();
+            late Session session;
+            setUp(() => session = sessionBuilder.build());
             test(
               'when fetching SimpleData after the first withServerpod then the database is rolled back',
               () async {
@@ -355,7 +369,8 @@ void main() {
     withServerpod(
       'when creating SimpleData in in one test and fetching it in the other',
       (sessionBuilder, endpoints) {
-        var session = sessionBuilder.build();
+        late Session session;
+        setUp(() => session = sessionBuilder.build());
         test('then creates SimpleData in the first test', () async {
           await SimpleData.db.insert(session, [
             SimpleData(num: 111),
@@ -381,7 +396,8 @@ void main() {
     withServerpod(
       'when fetching SimpleData after the first withServerpod',
       (sessionBuilder, endpoints) {
-        var session = sessionBuilder.build();
+        late Session session;
+        setUp(() => session = sessionBuilder.build());
 
         tearDownAll(() async {
           await SimpleData.db.deleteWhere(

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/test_integration/test_tools/rollback_database_test.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/test_integration/test_tools/rollback_database_test.dart
@@ -100,9 +100,8 @@ void main() {
         '',
         (sessionBuilder, endpoints) {
           late Session session;
-          setUp(() => session = sessionBuilder.build());
-
           setUp(() async {
+            session = sessionBuilder.build();
             await SimpleData.db.insert(session, [
               SimpleData(num: 111),
               SimpleData(num: 222),
@@ -157,11 +156,9 @@ void main() {
       (sessionBuilder, endpoints) {
         late Session session;
         late Session newSession;
-        setUp(() {
+        setUp(() async {
           session = sessionBuilder.build();
           newSession = sessionBuilder.copyWith().build();
-        });
-        setUp(() async {
           await SimpleData.db.insert(newSession, [
             SimpleData(num: 111),
             SimpleData(num: 222),
@@ -263,8 +260,8 @@ void main() {
         '',
         (sessionBuilder, endpoints) {
           late Session session;
-          setUp(() => session = sessionBuilder.build());
           setUp(() async {
+            session = sessionBuilder.build();
             await SimpleData.db.insert(session, [
               SimpleData(num: 111),
               SimpleData(num: 222),

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/test_integration/test_tools/rollback_database_test.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/test_integration/test_tools/rollback_database_test.dart
@@ -1,3 +1,4 @@
+import 'package:serverpod/serverpod.dart';
 import 'package:serverpod_test_sqlite_server/src/generated/protocol.dart';
 import 'package:test/test.dart';
 
@@ -7,7 +8,8 @@ void main() {
   withServerpod(
     'Given no explicit rollbackDatabase configuration when having multiple test cases',
     (sessionBuilder, endpoints) {
-      var session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
 
       test(
         'then first test creates objects in the database that should be rolled back due to default rollbackDatabase.afterEach configuration',
@@ -43,8 +45,9 @@ void main() {
       withServerpod(
         '',
         (sessionBuilder, endpoints) {
-          var session = sessionBuilder.build();
+          late Session session;
           setUpAll(() async {
+            session = sessionBuilder.build();
             await SimpleData.db.insert(
               session,
               [
@@ -77,7 +80,8 @@ void main() {
       withServerpod(
         '',
         (sessionBuilder, endpoints) {
-          var session = sessionBuilder.build();
+          late Session session;
+          setUp(() => session = sessionBuilder.build());
 
           test(
             'then the database is rolled back after the first withServerpod',
@@ -95,7 +99,8 @@ void main() {
       withServerpod(
         '',
         (sessionBuilder, endpoints) {
-          var session = sessionBuilder.build();
+          late Session session;
+          setUp(() => session = sessionBuilder.build());
 
           setUp(() async {
             await SimpleData.db.insert(session, [
@@ -132,7 +137,8 @@ void main() {
       withServerpod(
         '',
         (sessionBuilder, endpoints) {
-          var session = sessionBuilder.build();
+          late Session session;
+          setUp(() => session = sessionBuilder.build());
 
           test(
             'then the database is rolled back after the first withServerpod',
@@ -149,9 +155,12 @@ void main() {
     withServerpod(
       'when creating a copy of the session builder and creating new objects in the database in setUp',
       (sessionBuilder, endpoints) {
-        var session = sessionBuilder.build();
-        var newSessionBuilder = sessionBuilder.copyWith();
-        var newSession = newSessionBuilder.build();
+        late Session session;
+        late Session newSession;
+        setUp(() {
+          session = sessionBuilder.build();
+          newSession = sessionBuilder.copyWith().build();
+        });
         setUp(() async {
           await SimpleData.db.insert(newSession, [
             SimpleData(num: 111),
@@ -198,8 +207,9 @@ void main() {
       withServerpod(
         '',
         (sessionBuilder, endpoints) {
-          var session = sessionBuilder.build();
+          late Session session;
           setUpAll(() async {
+            session = sessionBuilder.build();
             await SimpleData.db.insert(session, [
               SimpleData(num: 111),
               SimpleData(num: 222),
@@ -234,7 +244,8 @@ void main() {
       withServerpod(
         '',
         (sessionBuilder, endpoints) {
-          var session = sessionBuilder.build();
+          late Session session;
+          setUp(() => session = sessionBuilder.build());
           test(
             'then the database is rolled back after the first withServerpod',
             () async {
@@ -251,7 +262,8 @@ void main() {
       withServerpod(
         '',
         (sessionBuilder, endpoints) {
-          var session = sessionBuilder.build();
+          late Session session;
+          setUp(() => session = sessionBuilder.build());
           setUp(() async {
             await SimpleData.db.insert(session, [
               SimpleData(num: 111),
@@ -289,7 +301,8 @@ void main() {
       withServerpod(
         '',
         (sessionBuilder, endpoints) {
-          var session = sessionBuilder.build();
+          late Session session;
+          setUp(() => session = sessionBuilder.build());
 
           test(
             'then the database is rolled back after the first withServerpod',
@@ -309,7 +322,8 @@ void main() {
         withServerpod(
           '',
           (sessionBuilder, endpoints) {
-            var session = sessionBuilder.build();
+            late Session session;
+            setUp(() => session = sessionBuilder.build());
             test('then creates SimpleData in the first test', () async {
               await SimpleData.db.insert(session, [
                 SimpleData(num: 111),
@@ -334,7 +348,8 @@ void main() {
         withServerpod(
           '',
           (sessionBuilder, endpoints) {
-            var session = sessionBuilder.build();
+            late Session session;
+            setUp(() => session = sessionBuilder.build());
             test(
               'when fetching SimpleData after the first withServerpod then the database is rolled back',
               () async {
@@ -353,7 +368,8 @@ void main() {
     withServerpod(
       'when creating SimpleData in in one test and fetching it in the other',
       (sessionBuilder, endpoints) {
-        var session = sessionBuilder.build();
+        late Session session;
+        setUp(() => session = sessionBuilder.build());
         test('then creates SimpleData in the first test', () async {
           await SimpleData.db.insert(session, [
             SimpleData(num: 111),
@@ -378,7 +394,8 @@ void main() {
     withServerpod(
       'when fetching SimpleData after the first withServerpod',
       (sessionBuilder, endpoints) {
-        var session = sessionBuilder.build();
+        late Session session;
+        setUp(() => session = sessionBuilder.build());
 
         test(
           'then there is no data because each group has its own database',

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/test_integration/test_tools/transaction_correctness_test.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/test_integration/test_tools/transaction_correctness_test.dart
@@ -12,7 +12,8 @@ void main() {
     'Given transaction call in test and rollbacks are enabled',
     rollbackDatabase: RollbackDatabase.afterEach,
     (sessionBuilder, endpoints) {
-      var session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
 
       test('when inserting an object '
           'then should be persisted if transaction completes', () async {
@@ -256,7 +257,8 @@ void main() {
     rollbackDatabase: RollbackDatabase.disabled,
     testGroupTagsOverride: [TestTags.concurrencyOneTestTag],
     (sessionBuilder, endpoints) {
-      var session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
 
       tearDown(() async {
         await SimpleData.db.deleteWhere(
@@ -338,7 +340,8 @@ void main() {
   withServerpod(
     'Given transaction call in test with database rollbacks enabled (default)',
     (sessionBuilder, endpoints) {
-      var session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
       test(
         'when database exception occurs '
         'then transaction WILL NOT throw exception if it was caught in the transaction',
@@ -365,7 +368,8 @@ void main() {
     rollbackDatabase: RollbackDatabase.disabled,
     testGroupTagsOverride: [TestTags.concurrencyOneTestTag],
     (sessionBuilder, endpoints) {
-      var session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
 
       tearDown(() async {
         await UniqueData.db.deleteWhere(

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/test_integration/test_tools/transaction_correctness_test.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/test_integration/test_tools/transaction_correctness_test.dart
@@ -11,7 +11,8 @@ void main() {
     'Given transaction call in test and rollbacks are enabled',
     rollbackDatabase: RollbackDatabase.afterEach,
     (sessionBuilder, endpoints) {
-      var session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
 
       test('when inserting an object '
           'then should be persisted if transaction completes', () async {
@@ -254,7 +255,8 @@ void main() {
     'Given transaction calls when rollbacks are disabled',
     rollbackDatabase: RollbackDatabase.disabled,
     (sessionBuilder, endpoints) {
-      var session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
 
       tearDown(() async {
         await SimpleData.db.deleteWhere(
@@ -336,7 +338,8 @@ void main() {
   withServerpod(
     'Given transaction call in test with database rollbacks enabled (default)',
     (sessionBuilder, endpoints) {
-      var session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
       test(
         'when database exception occurs '
         'then transaction WILL NOT throw exception if it was caught in the transaction',
@@ -362,7 +365,8 @@ void main() {
     'Given transaction call in test with database rollbacks disabled',
     rollbackDatabase: RollbackDatabase.disabled,
     (sessionBuilder, endpoints) {
-      var session = sessionBuilder.build();
+      late Session session;
+      setUp(() => session = sessionBuilder.build());
 
       tearDown(() async {
         await UniqueData.db.deleteWhere(


### PR DESCRIPTION
This PR reworks `withServerpod` so that it defers setup. It is important in dart test to defer setup so that it doesn't happen during the _declare_ phase. This allows quick test discovery in the IDE, and select by pattern to work fast. 
