### PR TITLE
feat: Ensure serverpod start works with build hook deps

### DIFF
--- a/templates/pubspecs/tools/serverpod_cli/pubspec.yaml
+++ b/templates/pubspecs/tools/serverpod_cli/pubspec.yaml
@@ -45,7 +45,7 @@ dependencies:
   path: ^1.8.3
   pub_api_client: '>=2.4.0 <4.0.0'
   pub_semver: ^2.1.4
-  pubspec_parse: ^1.4.0
+  pubspec_parse: ^1.5.0
   recase: ^4.1.0
   serverpod_database: SERVERPOD_VERSION
   serverpod_serialization: SERVERPOD_VERSION

--- a/templates/pubspecs/tools/serverpod_cli/pubspec.yaml
+++ b/templates/pubspecs/tools/serverpod_cli/pubspec.yaml
@@ -16,6 +16,7 @@ dependencies:
   built_collection: ^5.1.1
   ci: ^0.1.0
   cli_tools: ^0.11.0
+  code_assets: ^1.0.0
   code_builder: ^4.5.0
   collection: ^1.18.0
   config: ^0.8.3
@@ -26,9 +27,17 @@ dependencies:
   # produce a different style than `dart format` and break the CI. For more
   # details, see: https://github.com/dart-lang/dart_style/issues/1785
   dart_style: 3.1.5
+  data_assets: '>=0.19.0 <0.20.0'
+  file: ^7.0.1
+  hooks: ^1.0.0
+  hooks_runner: ^1.2.1
   http: '>=1.1.0 <2.0.0'
   intl: '>=0.19.0 <0.21.0'
   json_rpc_2: ^4.0.0
+  # Bridge type only: hooks_runner's NativeAssetsBuildRunner requires a
+  # Logger argument. All log records are forwarded to the serverpod CLI
+  # logger; we never call package:logging methods directly.
+  logging: ^1.2.0
   lsp_server: ^0.4.0
   meta: ^1.15.0
   nocterm: ^0.6.0

--- a/tools/serverpod_cli/lib/src/commands/start.dart
+++ b/tools/serverpod_cli/lib/src/commands/start.dart
@@ -14,6 +14,7 @@ import 'package:serverpod_cli/src/commands/start/file_watcher.dart';
 import 'package:serverpod_cli/src/commands/start/kernel_compiler.dart';
 import 'package:serverpod_cli/src/commands/start/mcp_server.dart';
 import 'package:serverpod_cli/src/commands/start/mcp_socket.dart';
+import 'package:serverpod_cli/src/commands/start/native_assets_builder.dart';
 import 'package:serverpod_cli/src/commands/start/server_process.dart';
 import 'package:serverpod_cli/src/commands/start/tui/app.dart';
 import 'package:serverpod_cli/src/commands/start/tui/event_handler.dart';
@@ -251,6 +252,16 @@ class StartCommand extends ServerpodCommand<StartOption> {
       entryPoint: entryPoint,
       outputDill: dillPath,
     );
+
+    final nativeAssetsBuilder = _createNativeAssetsBuilder(
+      serverDir: serverDir,
+      serverpodToolDir: serverpodToolDir,
+      dartExecutable: compiler.dartExecutable,
+    );
+    if (!await _initialNativeAssetsBuild(nativeAssetsBuilder, compiler)) {
+      throw ExitException.error();
+    }
+
     await compiler.start();
 
     try {
@@ -272,6 +283,70 @@ class StartCommand extends ServerpodCommand<StartOption> {
     } finally {
       await compiler.dispose();
     }
+  }
+}
+
+/// Constructs a [NativeAssetsBuilder] for the server at [serverDir].
+NativeAssetsBuilder _createNativeAssetsBuilder({
+  required String serverDir,
+  required String serverpodToolDir,
+  required String dartExecutable,
+}) {
+  return NativeAssetsBuilder(
+    dartExecutable: dartExecutable,
+    serverDir: serverDir,
+    packageConfigPath: p.join(
+      serverDir,
+      '.dart_tool',
+      'package_config.json',
+    ),
+    outputDir: p.join(serverpodToolDir, 'native_assets'),
+  );
+}
+
+/// Runs build hooks for the initial compile and stores the resulting manifest
+/// path on the compiler. Caller invokes this *before* [KernelCompiler.start]
+/// so the FES picks up `--native-assets` on its first launch. Returns false on
+/// hook failure (an error has already been logged).
+Future<bool> _initialNativeAssetsBuild(
+  NativeAssetsBuilder builder,
+  KernelCompiler compiler,
+) async {
+  final outcome = await builder.build();
+  switch (outcome) {
+    case NativeAssetsBuildSkipped():
+      return true;
+    case NativeAssetsBuildFailed(:final message):
+      log.error(message);
+      return false;
+    case NativeAssetsBuildSuccess(:final manifestPath):
+      compiler.nativeAssetsPath = manifestPath;
+      return true;
+  }
+}
+
+/// Runs build hooks for an IDE-initiated reload. Restarts the FES if the
+/// manifest content changed. Returns false on hook failure.
+Future<bool> _applyNativeAssetsBuildForReload(
+  NativeAssetsBuilder builder,
+  KernelCompiler compiler,
+) async {
+  final outcome = await builder.build();
+  switch (outcome) {
+    case NativeAssetsBuildSkipped():
+      return true;
+    case NativeAssetsBuildFailed(:final message):
+      log.error(message);
+      return false;
+    case NativeAssetsBuildSuccess(
+      :final manifestPath,
+      :final manifestChanged,
+    ):
+      if (manifestChanged) {
+        compiler.nativeAssetsPath = manifestPath;
+        await compiler.restart();
+      }
+      return true;
   }
 }
 
@@ -426,6 +501,7 @@ Future<int> _startWatchSession({
   required bool noFes,
 }) async {
   KernelCompiler? compiler;
+  NativeAssetsBuilder? nativeAssetsBuilder;
   ServerProcessFactory? serverProcessFactory;
   ServerProcess initialServerProcess;
 
@@ -450,6 +526,16 @@ Future<int> _startWatchSession({
       entryPoint: entryPoint,
       outputDill: initialDill,
     );
+
+    final localBuilder = _createNativeAssetsBuilder(
+      serverDir: serverDir,
+      serverpodToolDir: serverpodToolDir,
+      dartExecutable: localCompiler.dartExecutable,
+    );
+    if (!await _initialNativeAssetsBuild(nativeAssetsBuilder, compiler)) {
+      return 1;
+    }
+
     await compiler.start();
 
     // Compile if the cached dill is stale. The FES starts in the background
@@ -461,9 +547,17 @@ Future<int> _startWatchSession({
       return 1;
     }
 
-    // IDE reload callback: compile incrementally and return the dill path.
+    // IDE reload callback: re-run native build hooks (manifest may have
+    // changed since the last cycle if the developer edited C source), then
+    // compile and return the dill path.
     Future<String?> onReloadRequested() async {
-      await compiler!.reset();
+      if (!await _applyNativeAssetsBuildForReload(
+        nativeAssetsBuilder!,
+        compiler!,
+      )) {
+        return null;
+      }
+      await localCompiler.reset();
       final result = await compileWithProgress(
         'Compiling server (IDE reload)',
         compiler,
@@ -497,6 +591,7 @@ Future<int> _startWatchSession({
 
   final session = WatchSession(
     compiler: compiler,
+    nativeAssetsBuilder: nativeAssetsBuilder,
     generate: generate,
     createServer: serverProcessFactory,
     initialServer: initialServerProcess,
@@ -740,6 +835,17 @@ Future<void> _runTuiBackend({
       entryPoint: entryPoint,
       outputDill: initialDill,
     );
+
+    final nativeAssetsBuilder = _createNativeAssetsBuilder(
+      serverDir: serverDir,
+      serverpodToolDir: serverpodToolDir,
+      dartExecutable: compiler.dartExecutable,
+    );
+    if (!await _initialNativeAssetsBuild(nativeAssetsBuilder, compiler)) {
+      onExitCode(1);
+      return;
+    }
+
     await compiler.start();
 
     if (!await compiler.compileIfNeeded(
@@ -756,8 +862,15 @@ Future<void> _runTuiBackend({
     final stdoutSink = TuiLogSink(holder);
     final stderrSink = TuiLogSink(holder);
 
-    // IDE reload callback.
+    // IDE reload callback. Re-runs build hooks first so manifest changes
+    // (e.g. edited C source) are picked up before recompiling.
     Future<String?> onReloadRequested() async {
+      if (!await _applyNativeAssetsBuildForReload(
+        nativeAssetsBuilder,
+        compiler,
+      )) {
+        return null;
+      }
       await compiler.reset();
       final result = await compileWithProgress(
         'Compiling server (IDE reload)',
@@ -810,6 +923,7 @@ Future<void> _runTuiBackend({
     // Create watch session.
     final session = WatchSession(
       compiler: compiler,
+      nativeAssetsBuilder: nativeAssetsBuilder,
       generate: (affectedPaths, requirements) async {
         return analyzeAndGenerate(
           analyzers: await analyzersFuture,

--- a/tools/serverpod_cli/lib/src/commands/start.dart
+++ b/tools/serverpod_cli/lib/src/commands/start.dart
@@ -286,7 +286,9 @@ class StartCommand extends ServerpodCommand<StartOption> {
   }
 }
 
-/// Constructs a [NativeAssetsBuilder] for the server at [serverDir].
+/// Constructs a [NativeAssetsBuilder] for the server at [serverDir]. The
+/// builder discovers `package_config.json` itself (walking up to a workspace
+/// root if needed).
 NativeAssetsBuilder _createNativeAssetsBuilder({
   required String serverDir,
   required String serverpodToolDir,
@@ -295,11 +297,6 @@ NativeAssetsBuilder _createNativeAssetsBuilder({
   return NativeAssetsBuilder(
     dartExecutable: dartExecutable,
     serverDir: serverDir,
-    packageConfigPath: p.join(
-      serverDir,
-      '.dart_tool',
-      'package_config.json',
-    ),
     outputDir: p.join(serverpodToolDir, 'native_assets'),
   );
 }

--- a/tools/serverpod_cli/lib/src/commands/start.dart
+++ b/tools/serverpod_cli/lib/src/commands/start.dart
@@ -258,7 +258,7 @@ class StartCommand extends ServerpodCommand<StartOption> {
       serverpodToolDir: serverpodToolDir,
       dartExecutable: compiler.dartExecutable,
     );
-    if (!await _initialNativeAssetsBuild(nativeAssetsBuilder, compiler)) {
+    if (!await _runHooksFor(nativeAssetsBuilder, compiler)) {
       throw ExitException.error();
     }
 
@@ -301,49 +301,24 @@ NativeAssetsBuilder _createNativeAssetsBuilder({
   );
 }
 
-/// Runs build hooks for the initial compile and stores the resulting manifest
-/// path on the compiler. Caller invokes this *before* [KernelCompiler.start]
-/// so the FES picks up `--native-assets` on its first launch. Returns false on
-/// hook failure (an error has already been logged).
-Future<bool> _initialNativeAssetsBuild(
+/// Runs build hooks via [builder] and applies the result to [compiler].
+/// Returns false on hook failure (an error has been logged).
+///
+/// Wraps [NativeAssetsBuilder.applyTo] for the start.dart paths that don't
+/// care about the restart-distinction (initial-build callers and the IDE
+/// reload callback). The watch-loop and migration paths switch on the
+/// outcome directly to read [NativeAssetsApplySuccess.restarted].
+Future<bool> _runHooksFor(
   NativeAssetsBuilder builder,
   KernelCompiler compiler,
 ) async {
-  final outcome = await builder.build();
+  final outcome = await builder.applyTo(compiler);
   switch (outcome) {
-    case NativeAssetsBuildSkipped():
+    case NativeAssetsApplySuccess():
       return true;
-    case NativeAssetsBuildFailed(:final message):
+    case NativeAssetsApplyFailure(:final message):
       log.error(message);
       return false;
-    case NativeAssetsBuildSuccess(:final manifestPath):
-      compiler.nativeAssetsPath = manifestPath;
-      return true;
-  }
-}
-
-/// Runs build hooks for an IDE-initiated reload. Restarts the FES if the
-/// manifest content changed. Returns false on hook failure.
-Future<bool> _applyNativeAssetsBuildForReload(
-  NativeAssetsBuilder builder,
-  KernelCompiler compiler,
-) async {
-  final outcome = await builder.build();
-  switch (outcome) {
-    case NativeAssetsBuildSkipped():
-      return true;
-    case NativeAssetsBuildFailed(:final message):
-      log.error(message);
-      return false;
-    case NativeAssetsBuildSuccess(
-      :final manifestPath,
-      :final manifestChanged,
-    ):
-      if (manifestChanged) {
-        compiler.nativeAssetsPath = manifestPath;
-        await compiler.restart();
-      }
-      return true;
   }
 }
 
@@ -529,7 +504,7 @@ Future<int> _startWatchSession({
       serverpodToolDir: serverpodToolDir,
       dartExecutable: localCompiler.dartExecutable,
     );
-    if (!await _initialNativeAssetsBuild(nativeAssetsBuilder, compiler)) {
+    if (!await _runHooksFor(localBuilder, localCompiler)) {
       return 1;
     }
 
@@ -548,7 +523,7 @@ Future<int> _startWatchSession({
     // changed since the last cycle if the developer edited C source), then
     // compile and return the dill path.
     Future<String?> onReloadRequested() async {
-      if (!await _applyNativeAssetsBuildForReload(
+      if (!await _runHooksFor(
         nativeAssetsBuilder!,
         compiler!,
       )) {
@@ -838,7 +813,7 @@ Future<void> _runTuiBackend({
       serverpodToolDir: serverpodToolDir,
       dartExecutable: compiler.dartExecutable,
     );
-    if (!await _initialNativeAssetsBuild(nativeAssetsBuilder, compiler)) {
+    if (!await _runHooksFor(nativeAssetsBuilder, compiler)) {
       onExitCode(1);
       return;
     }
@@ -862,7 +837,7 @@ Future<void> _runTuiBackend({
     // IDE reload callback. Re-runs build hooks first so manifest changes
     // (e.g. edited C source) are picked up before recompiling.
     Future<String?> onReloadRequested() async {
-      if (!await _applyNativeAssetsBuildForReload(
+      if (!await _runHooksFor(
         nativeAssetsBuilder,
         compiler,
       )) {

--- a/tools/serverpod_cli/lib/src/commands/start.dart
+++ b/tools/serverpod_cli/lib/src/commands/start.dart
@@ -494,7 +494,7 @@ Future<int> _startWatchSession({
     // Set up incremental compiler.
     final entryPoint = p.join(serverDir, 'bin', 'main.dart');
     final initialDill = p.join(serverpodToolDir, 'server.dill');
-    compiler = KernelCompiler(
+    final localCompiler = KernelCompiler(
       entryPoint: entryPoint,
       outputDill: initialDill,
     );
@@ -508,13 +508,13 @@ Future<int> _startWatchSession({
       return 1;
     }
 
-    await compiler.start();
+    await localCompiler.start();
 
     // Compile if the cached dill is stale. The FES starts in the background
     // (KernelCompiler gates compile/reset calls internally until start
     // completes), so if the dill is up to date we boot immediately.
-    if (!await compiler.compileIfNeeded(watcher.watchPaths)) {
-      await compiler.dispose();
+    if (!await localCompiler.compileIfNeeded(watcher.watchPaths)) {
+      await localCompiler.dispose();
       log.error('Initial compilation failed.');
       return 1;
     }
@@ -523,20 +523,17 @@ Future<int> _startWatchSession({
     // changed since the last cycle if the developer edited C source), then
     // compile and return the dill path.
     Future<String?> onReloadRequested() async {
-      if (!await _runHooksFor(
-        nativeAssetsBuilder!,
-        compiler!,
-      )) {
+      if (!await _runHooksFor(localBuilder, localCompiler)) {
         return null;
       }
       await localCompiler.reset();
       final result = await compileWithProgress(
         'Compiling server (IDE reload)',
-        compiler,
+        localCompiler,
         rejectOnFailure: true,
       );
       if (result == null) return null;
-      compiler.accept();
+      localCompiler.accept();
       return result.dillOutput ?? initialDill;
     }
 
@@ -548,7 +545,7 @@ Future<int> _startWatchSession({
           final serverProcess = ServerProcess(
             serverDir: serverDir,
             serverArgs: [...serverArgs, ...extraArgs],
-            dartExecutable: compiler!.dartExecutable,
+            dartExecutable: localCompiler.dartExecutable,
             enableVmService: true,
             vmServiceInfoFile: vmServiceInfoFile,
             onReloadRequested: onReloadRequested,
@@ -559,6 +556,8 @@ Future<int> _startWatchSession({
         };
 
     initialServerProcess = await serverProcessFactory(initialDill);
+    compiler = localCompiler;
+    nativeAssetsBuilder = localBuilder;
   }
 
   final session = WatchSession(

--- a/tools/serverpod_cli/lib/src/commands/start/kernel_compiler.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/kernel_compiler.dart
@@ -47,6 +47,9 @@ class KernelCompiler {
   /// The path to the `dart` executable from the SDK used by this compiler.
   String get dartExecutable => p.join(_sdkRoot, 'bin', 'dart');
 
+  /// Whether [start] has run.
+  bool get isStarted => _started;
+
   /// Start the Frontend Server process.
   ///
   /// This starts the server in resident mode, ready to receive compile

--- a/tools/serverpod_cli/lib/src/commands/start/kernel_compiler.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/kernel_compiler.dart
@@ -19,8 +19,19 @@ class KernelCompiler {
   final String outputDill;
   final String? packagesPath;
 
-  late final String _sdkRoot;
-  late final String _platformDill;
+  /// Native-assets manifest path forwarded as `--native-assets` to the
+  /// Frontend Server on [start]. Mutable so callers can swap the manifest
+  /// between Frontend Server restarts; the FES reads this only at startup,
+  /// so changes require a [restart] to take effect.
+  String? nativeAssetsPath;
+
+  late final String _sdkRoot = getSdkPath();
+  late final String _platformDill = p.join(
+    _sdkRoot,
+    'lib',
+    '_internal',
+    'vm_platform_strong.dill',
+  );
   late Future<FrontendServerClient> _client;
 
   bool _needsFullCompile = true;
@@ -30,6 +41,7 @@ class KernelCompiler {
     required this.entryPoint,
     this.outputDill = '.dart_tool/serverpod/server.dill',
     this.packagesPath,
+    this.nativeAssetsPath,
   });
 
   /// The path to the `dart` executable from the SDK used by this compiler.
@@ -42,14 +54,6 @@ class KernelCompiler {
   Future<void> start() async {
     if (_started) return;
 
-    _sdkRoot = getSdkPath();
-    _platformDill = p.join(
-      _sdkRoot,
-      'lib',
-      '_internal',
-      'vm_platform_strong.dill',
-    );
-
     _client = FrontendServerClient.start(
       entryPoint,
       outputDill,
@@ -57,6 +61,7 @@ class KernelCompiler {
       sdkRoot: _sdkRoot,
       target: 'vm',
       packagesJson: packagesPath,
+      nativeAssetsPath: nativeAssetsPath,
     );
     _started = true;
     _needsFullCompile = true;

--- a/tools/serverpod_cli/lib/src/commands/start/native_assets_builder.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/native_assets_builder.dart
@@ -11,6 +11,7 @@ import 'package:hooks_runner/hooks_runner.dart' as hr;
 import 'package:logging/logging.dart' show Level, Logger, LogRecord;
 import 'package:package_config/package_config.dart' as pc;
 import 'package:path/path.dart' as p;
+import 'package:pubspec_parse/pubspec_parse.dart';
 import 'package:serverpod_cli/src/util/serverpod_cli_logger.dart';
 import 'package:serverpod_cli/src/vendored/native_assets_bundling.dart';
 
@@ -67,16 +68,16 @@ class NativeAssetsBuilder {
   /// Path to the dart executable (used to compile and run individual hooks).
   final String dartExecutable;
 
-  /// The server directory (the package whose hooks we recurse from).
+  /// The server package directory. The package_config.json lives either here
+  /// (standalone) or in the workspace root above it; [_discoverPaths] walks
+  /// up to find it.
   final String serverDir;
-
-  /// Path to the `package_config.json` for the server's `.dart_tool` dir.
-  final String packageConfigPath;
 
   /// Output directory for the assets and the manifest yaml (typically
   /// `<serverDir>/.dart_tool/serverpod/native_assets/`).
   final String outputDir;
 
+  Future<_ResolvedPaths>? _pathsFuture;
   Future<hr.PackageLayout>? _packageLayoutFuture;
   Future<hr.NativeAssetsBuildRunner>? _runnerFuture;
   String? _lastManifestContent;
@@ -89,7 +90,6 @@ class NativeAssetsBuilder {
   NativeAssetsBuilder({
     required this.dartExecutable,
     required this.serverDir,
-    required this.packageConfigPath,
     required this.outputDir,
   });
 
@@ -97,24 +97,63 @@ class NativeAssetsBuilder {
   /// been written yet).
   String get manifestPath => p.join(outputDir, 'native_assets.yaml');
 
-  /// Drops the cached package layout / runner so the next [build] reloads
-  /// `package_config.json`. Call after a `pub get` or other change that
-  /// adds or removes packages with build hooks.
+  /// Drops every cache so the next [build] re-discovers the workspace,
+  /// reloads `package_config.json`, and treats the next manifest as freshly
+  /// generated. Call after a `pub get` or other change that adds or removes
+  /// packages with build hooks.
   void reset() {
+    _pathsFuture = null;
     _packageLayoutFuture = null;
     _runnerFuture = null;
     _lastManifestContent = null;
     _lastEncodedAssets = null;
   }
 
+  /// Walks up from [serverDir] to the first pubspec that is *not* a workspace
+  /// member (i.e. `resolution != 'workspace'`). That directory is either the
+  /// workspace root (when a workspace is in use) or the package itself (when
+  /// it isn't). Pub places `.dart_tool/` only at that root.
+  Future<_ResolvedPaths> _discoverPaths() async {
+    var dir = p.canonicalize(serverDir);
+    while (true) {
+      final pubspec = await _tryLoadPubspec(dir);
+      if (pubspec != null && pubspec.resolution != 'workspace') {
+        final cfg = p.join(dir, '.dart_tool', 'package_config.json');
+        final graph = p.join(dir, '.dart_tool', 'package_graph.json');
+        if (!await File(cfg).exists() || !await File(graph).exists()) {
+          throw StateError(
+            'Found project root at $dir but its .dart_tool is missing '
+            'package_config.json / package_graph.json. Run `dart pub get`.',
+          );
+        }
+        return _ResolvedPaths(
+          packageConfigPath: cfg,
+          workspacePubspecPath: p.join(dir, 'pubspec.yaml'),
+        );
+      }
+      final parent = p.dirname(dir);
+      if (parent == dir) {
+        throw StateError(
+          'No project root pubspec found walking up from $serverDir. '
+          'Server packages with `resolution: workspace` need a workspace '
+          'root pubspec above them.',
+        );
+      }
+      dir = parent;
+    }
+  }
+
   Future<hr.PackageLayout> _loadPackageLayout() async {
-    final pkgConfigUri = Uri.file(p.absolute(packageConfigPath));
+    final paths = await (_pathsFuture ??= _discoverPaths());
+    final pkgConfigUri = Uri.file(paths.packageConfigPath);
     final packageConfig = await pc.loadPackageConfigUri(pkgConfigUri);
 
-    // The server is the root package; we want to build hooks of the server
-    // and all its (non-dev) transitive dependencies.
-    final pubspecPath = p.join(serverDir, 'pubspec.yaml');
-    final pubspecName = await _readPubspecName(pubspecPath);
+    // The server is the package whose transitive (non-dev) deps we walk.
+    // It may be a workspace member, in which case the discovered config
+    // covers it along with its siblings.
+    final pubspecName = await _readPubspecName(
+      p.join(serverDir, 'pubspec.yaml'),
+    );
 
     return hr.PackageLayout.fromPackageConfig(
       _fileSystem,
@@ -127,13 +166,14 @@ class NativeAssetsBuilder {
 
   Future<hr.NativeAssetsBuildRunner> _createRunner() async {
     final layout = await (_packageLayoutFuture ??= _loadPackageLayout());
+    final paths = await (_pathsFuture ??= _discoverPaths());
     return hr.NativeAssetsBuildRunner(
       dartExecutable: Uri.file(dartExecutable),
       logger: _logger,
       fileSystem: _fileSystem,
       packageLayout: layout,
       userDefines: hr.UserDefines(
-        workspacePubspec: Uri.file(p.absolute(serverDir, 'pubspec.yaml')),
+        workspacePubspec: Uri.file(paths.workspacePubspecPath),
       ),
     );
   }
@@ -229,6 +269,15 @@ class NativeAssetsBuilder {
 /// floor as `dart run`.
 const _minMacOSVersion = 13;
 
+class _ResolvedPaths {
+  final String packageConfigPath;
+  final String workspacePubspecPath;
+  const _ResolvedPaths({
+    required this.packageConfigPath,
+    required this.workspacePubspecPath,
+  });
+}
+
 /// Routes a single `hooks_runner` log record into the serverpod CLI logger.
 void _forwardLogRecord(LogRecord rec) {
   final v = rec.level.value;
@@ -244,23 +293,19 @@ void _forwardLogRecord(LogRecord rec) {
 }
 
 Future<String> _readPubspecName(String pubspecPath) async {
-  final lines = await File(pubspecPath).readAsLines();
-  for (final line in lines) {
-    final trimmed = line.trim();
-    if (trimmed.startsWith('name:')) {
-      final value = trimmed.substring('name:'.length).trim();
-      // Strip optional surrounding quotes.
-      return value.replaceAll(
-        RegExp(
-          r'^["'
-          "'"
-          r']|["'
-          "'"
-          r']$',
-        ),
-        '',
-      );
-    }
+  final pubspec = await _tryLoadPubspec(p.dirname(pubspecPath));
+  if (pubspec == null) {
+    throw StateError('Could not parse pubspec at $pubspecPath');
   }
-  throw StateError('Could not find package name in $pubspecPath');
+  return pubspec.name;
+}
+
+Future<Pubspec?> _tryLoadPubspec(String dir) async {
+  final file = File(p.join(dir, 'pubspec.yaml'));
+  if (!await file.exists()) return null;
+  try {
+    return Pubspec.parse(await file.readAsString());
+  } on Exception {
+    return null;
+  }
 }

--- a/tools/serverpod_cli/lib/src/commands/start/native_assets_builder.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/native_assets_builder.dart
@@ -1,0 +1,266 @@
+import 'dart:io';
+
+import 'package:code_assets/code_assets.dart';
+import 'package:data_assets/data_assets.dart';
+import 'package:file/local.dart';
+import 'package:hooks/hooks.dart';
+// hooks_runner requires a `Logger` (from package:logging) on its constructor.
+// We import the type only to satisfy the API and route every record through
+// the serverpod CLI [log]; there are no log calls of our own against it.
+import 'package:hooks_runner/hooks_runner.dart' as hr;
+import 'package:logging/logging.dart' show Level, Logger, LogRecord;
+import 'package:package_config/package_config.dart' as pc;
+import 'package:path/path.dart' as p;
+import 'package:serverpod_cli/src/util/serverpod_cli_logger.dart';
+import 'package:serverpod_cli/src/vendored/native_assets_bundling.dart';
+
+const _fileSystem = LocalFileSystem();
+
+/// Outcome of a [NativeAssetsBuilder.build] invocation.
+sealed class NativeAssetsBuildOutcome {
+  const NativeAssetsBuildOutcome();
+}
+
+/// The project has no packages with native build hooks; nothing to do.
+class NativeAssetsBuildSkipped extends NativeAssetsBuildOutcome {
+  const NativeAssetsBuildSkipped();
+}
+
+/// The build ran (possibly cached). [manifestPath] is the path to the
+/// `native_assets.yaml` to pass to `frontend_server` via `--native-assets`,
+/// or `null` if the build produced no bundleable assets.
+///
+/// [manifestChanged] is `true` when the manifest content differs from the
+/// previous successful build (or this is the first build). Callers should
+/// restart `frontend_server` with the new manifest when this is `true`.
+class NativeAssetsBuildSuccess extends NativeAssetsBuildOutcome {
+  final String? manifestPath;
+  final bool manifestChanged;
+  final List<Uri> dependencies;
+
+  const NativeAssetsBuildSuccess({
+    required this.manifestPath,
+    required this.manifestChanged,
+    required this.dependencies,
+  });
+}
+
+/// The build failed. [message] contains a short, user-facing summary; full
+/// hook logs are emitted via the serverpod CLI logger as the build runs.
+class NativeAssetsBuildFailed extends NativeAssetsBuildOutcome {
+  final String message;
+  const NativeAssetsBuildFailed(this.message);
+}
+
+/// Orchestrates `package:hooks_runner` on behalf of `serverpod start`.
+///
+/// `dart compile` refuses to run build hooks, and `frontend_server` does not
+/// know how to find them - they live outside the kernel-compile pipeline.
+/// This class fills that gap: invoke [build] once before each
+/// `frontend_server` compile cycle, then feed [NativeAssetsBuildSuccess.manifestPath]
+/// to `frontend_server` via `--native-assets`.
+///
+/// Hook execution is internally cached by `hooks_runner` keyed on hook
+/// inputs/dependencies/environment, so re-invoking each watch cycle is cheap
+/// when nothing changed.
+class NativeAssetsBuilder {
+  /// Path to the dart executable (used to compile and run individual hooks).
+  final String dartExecutable;
+
+  /// The server directory (the package whose hooks we recurse from).
+  final String serverDir;
+
+  /// Path to the `package_config.json` for the server's `.dart_tool` dir.
+  final String packageConfigPath;
+
+  /// Output directory for the assets and the manifest yaml (typically
+  /// `<serverDir>/.dart_tool/serverpod/native_assets/`).
+  final String outputDir;
+
+  Future<hr.PackageLayout>? _packageLayoutFuture;
+  Future<hr.NativeAssetsBuildRunner>? _runnerFuture;
+  String? _lastManifestContent;
+
+  /// Bridges `hooks_runner`'s `Logger` records into the serverpod CLI [log].
+  /// Detached so it never escapes into the global `package:logging` hierarchy.
+  late final Logger _logger = Logger.detached('hooks_runner')
+    ..onRecord.listen(_forwardLogRecord);
+
+  NativeAssetsBuilder({
+    required this.dartExecutable,
+    required this.serverDir,
+    required this.packageConfigPath,
+    required this.outputDir,
+  });
+
+  /// Path of the manifest yaml this builder writes (whether or not it has
+  /// been written yet).
+  String get manifestPath => p.join(outputDir, 'native_assets.yaml');
+
+  /// Drops the cached package layout / runner so the next [build] reloads
+  /// `package_config.json`. Call after a `pub get` or other change that
+  /// adds or removes packages with build hooks.
+  void reset() {
+    _packageLayoutFuture = null;
+    _runnerFuture = null;
+    _lastManifestContent = null;
+    _lastEncodedAssets = null;
+  }
+
+  Future<hr.PackageLayout> _loadPackageLayout() async {
+    final pkgConfigUri = Uri.file(p.absolute(packageConfigPath));
+    final packageConfig = await pc.loadPackageConfigUri(pkgConfigUri);
+
+    // The server is the root package; we want to build hooks of the server
+    // and all its (non-dev) transitive dependencies.
+    final pubspecPath = p.join(serverDir, 'pubspec.yaml');
+    final pubspecName = await _readPubspecName(pubspecPath);
+
+    return hr.PackageLayout.fromPackageConfig(
+      _fileSystem,
+      packageConfig,
+      pkgConfigUri,
+      pubspecName,
+      includeDevDependencies: false,
+    );
+  }
+
+  Future<hr.NativeAssetsBuildRunner> _createRunner() async {
+    final layout = await (_packageLayoutFuture ??= _loadPackageLayout());
+    return hr.NativeAssetsBuildRunner(
+      dartExecutable: Uri.file(dartExecutable),
+      logger: _logger,
+      fileSystem: _fileSystem,
+      packageLayout: layout,
+      userDefines: hr.UserDefines(
+        workspacePubspec: Uri.file(p.absolute(serverDir, 'pubspec.yaml')),
+      ),
+    );
+  }
+
+  /// Runs build hooks for the server package and its transitive dependencies.
+  Future<NativeAssetsBuildOutcome> build() async {
+    final runner = await (_runnerFuture ??= _createRunner());
+
+    final hookPackages = await runner.packagesWithBuildHooks();
+    if (hookPackages.isEmpty) {
+      return const NativeAssetsBuildSkipped();
+    }
+
+    final target = hr.Target.current;
+    final extensions = <ProtocolExtension>[
+      CodeAssetExtension(
+        targetOS: target.os,
+        linkModePreference: LinkModePreference.dynamic,
+        targetArchitecture: target.architecture,
+        macOS: target.os == OS.macOS
+            ? MacOSCodeConfig(targetVersion: _minMacOSVersion)
+            : null,
+      ),
+      DataAssetsExtension(),
+    ];
+
+    final result = await runner.build(
+      extensions: extensions,
+      linkingEnabled: false,
+    );
+    if (result.isFailure) {
+      return NativeAssetsBuildFailed(
+        'Native build hooks failed for: ${hookPackages.join(', ')}',
+      );
+    }
+
+    final buildResult = result.success;
+    final encodedAssets = buildResult.encodedAssets;
+
+    // No bundleable assets -> no manifest needed. Tell the caller to ensure
+    // FES is running without a --native-assets argument.
+    if (encodedAssets.isEmpty) {
+      final changed = _lastManifestContent != null;
+      _lastManifestContent = null;
+      // Best-effort cleanup of a stale manifest from a prior run.
+      final stale = File(manifestPath);
+      if (await stale.exists()) await stale.delete();
+      return NativeAssetsBuildSuccess(
+        manifestPath: null,
+        manifestChanged: changed,
+        dependencies: buildResult.dependencies,
+      );
+    }
+
+    final outputUri = Directory(outputDir).uri;
+    await Directory(outputDir).create(recursive: true);
+
+    final kernelAssets = await bundleNativeAssets(
+      encodedAssets,
+      target,
+      outputUri,
+      relocatable: false,
+    );
+
+    // Render the manifest text (without writing it yet) so we can compare
+    // against the previously written one before bouncing FES.
+    const header =
+        '# Native assets mapping for host OS in JIT mode.\n'
+        '# Generated by serverpod_cli and package:hooks_runner.\n';
+    final body = kernelAssets.toNativeAssetsFile();
+    final newContent = '$header\n$body';
+
+    final manifestFile = File(manifestPath);
+    final exists = await manifestFile.exists();
+    final priorContent = exists ? await manifestFile.readAsString() : null;
+    final changed = priorContent != newContent;
+    if (changed) {
+      await manifestFile.create(recursive: true);
+      await manifestFile.writeAsString(newContent);
+    }
+    _lastManifestContent = newContent;
+
+    return NativeAssetsBuildSuccess(
+      manifestPath: manifestPath,
+      manifestChanged: changed,
+      dependencies: buildResult.dependencies,
+    );
+  }
+}
+
+/// Minimum macOS deployment target. Matches dartdev's default for hosts that
+/// only ever build for the current machine, so hooks compile against the same
+/// floor as `dart run`.
+const _minMacOSVersion = 13;
+
+/// Routes a single `hooks_runner` log record into the serverpod CLI logger.
+void _forwardLogRecord(LogRecord rec) {
+  final v = rec.level.value;
+  if (v >= Level.SEVERE.value) {
+    log.error(rec.message);
+  } else if (v >= Level.WARNING.value) {
+    log.warning(rec.message);
+  } else if (v >= Level.INFO.value) {
+    log.info(rec.message);
+  } else {
+    log.debug(rec.message);
+  }
+}
+
+Future<String> _readPubspecName(String pubspecPath) async {
+  final lines = await File(pubspecPath).readAsLines();
+  for (final line in lines) {
+    final trimmed = line.trim();
+    if (trimmed.startsWith('name:')) {
+      final value = trimmed.substring('name:'.length).trim();
+      // Strip optional surrounding quotes.
+      return value.replaceAll(
+        RegExp(
+          r'^["'
+          "'"
+          r']|["'
+          "'"
+          r']$',
+        ),
+        '',
+      );
+    }
+  }
+  throw StateError('Could not find package name in $pubspecPath');
+}

--- a/tools/serverpod_cli/lib/src/commands/start/native_assets_builder.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/native_assets_builder.dart
@@ -90,15 +90,15 @@ class NativeAssetsBuilder {
   final String dartExecutable;
 
   /// The server package directory. The package_config.json lives either here
-  /// (standalone) or in the workspace root above it; [discoverPaths] walks
-  /// up to find it.
+  /// (standalone) or in the workspace root above it; [discoverProjectRoot]
+  /// walks up to find it.
   final String serverDir;
 
   /// Output directory for the assets and the manifest yaml (typically
   /// `<serverDir>/.dart_tool/serverpod/native_assets/`).
   final String outputDir;
 
-  Future<ResolvedPaths>? _pathsFuture;
+  Future<String>? _projectRootFuture;
   Future<hr.PackageLayout>? _packageLayoutFuture;
   Future<hr.NativeAssetsBuildRunner>? _runnerFuture;
   String? _lastManifestContent;
@@ -124,7 +124,7 @@ class NativeAssetsBuilder {
   /// generated. Call after a `pub get` or other change that adds or removes
   /// packages with build hooks.
   void reset() {
-    _pathsFuture = null;
+    _projectRootFuture = null;
     _packageLayoutFuture = null;
     _runnerFuture = null;
     _lastManifestContent = null;
@@ -132,11 +132,15 @@ class NativeAssetsBuilder {
   }
 
   /// Walks up from [serverDir] to the first pubspec that is *not* a workspace
-  /// member (i.e. `resolution != 'workspace'`). That directory is either the
-  /// workspace root (when a workspace is in use) or the package itself (when
-  /// it isn't). Pub places `.dart_tool/` only at that root.
+  /// member (i.e. `resolution != 'workspace'`). The directory containing that
+  /// pubspec is either the workspace root (when a workspace is in use) or the
+  /// package itself (when it isn't); pub places `.dart_tool/` only there.
+  ///
+  /// Validates that `package_config.json` and `package_graph.json` exist
+  /// alongside the pubspec, so callers can trust the returned root without
+  /// re-checking.
   @visibleForTesting
-  Future<ResolvedPaths> discoverPaths() async {
+  Future<String> discoverProjectRoot() async {
     var dir = p.canonicalize(serverDir);
     while (true) {
       final pubspec = await tryParsePubspecAt(dir);
@@ -149,10 +153,7 @@ class NativeAssetsBuilder {
             'package_config.json / package_graph.json. Run `dart pub get`.',
           );
         }
-        return ResolvedPaths(
-          packageConfigPath: cfg,
-          workspacePubspecPath: p.join(dir, 'pubspec.yaml'),
-        );
+        return dir;
       }
       final parent = p.dirname(dir);
       if (parent == dir) {
@@ -167,8 +168,10 @@ class NativeAssetsBuilder {
   }
 
   Future<hr.PackageLayout> _loadPackageLayout() async {
-    final paths = await (_pathsFuture ??= discoverPaths());
-    final pkgConfigUri = Uri.file(paths.packageConfigPath);
+    final root = await (_projectRootFuture ??= discoverProjectRoot());
+    final pkgConfigUri = Uri.file(
+      p.join(root, '.dart_tool', 'package_config.json'),
+    );
 
     // Run the package_config load and the server pubspec read in parallel.
     final (packageConfig, serverPubspec) = await (
@@ -190,14 +193,14 @@ class NativeAssetsBuilder {
 
   Future<hr.NativeAssetsBuildRunner> _createRunner() async {
     final layout = await (_packageLayoutFuture ??= _loadPackageLayout());
-    final paths = await (_pathsFuture ??= discoverPaths());
+    final root = await (_projectRootFuture ??= discoverProjectRoot());
     return hr.NativeAssetsBuildRunner(
       dartExecutable: Uri.file(dartExecutable),
       logger: _logger,
       fileSystem: _fileSystem,
       packageLayout: layout,
       userDefines: hr.UserDefines(
-        workspacePubspec: Uri.file(paths.workspacePubspecPath),
+        workspacePubspec: Uri.file(p.join(root, 'pubspec.yaml')),
       ),
     );
   }
@@ -328,21 +331,6 @@ const _encodedAssetsEq = ListEquality<EncodedAsset>();
 /// only ever build for the current machine, so hooks compile against the same
 /// floor as `dart run`.
 const _minMacOSVersion = 13;
-
-/// Paths resolved by [NativeAssetsBuilder.discoverPaths].
-///
-/// [packageConfigPath] is the absolute path to `.dart_tool/package_config.json`
-/// (lives at the workspace root when a workspace is in use, or at the
-/// package itself otherwise). [workspacePubspecPath] is the absolute path to
-/// the `pubspec.yaml` next to it - the same directory.
-class ResolvedPaths {
-  final String packageConfigPath;
-  final String workspacePubspecPath;
-  const ResolvedPaths({
-    required this.packageConfigPath,
-    required this.workspacePubspecPath,
-  });
-}
 
 /// Routes a single `hooks_runner` log record into the serverpod CLI logger.
 ///

--- a/tools/serverpod_cli/lib/src/commands/start/native_assets_builder.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/native_assets_builder.dart
@@ -10,6 +10,7 @@ import 'package:hooks/hooks.dart';
 // the serverpod CLI [log]; there are no log calls of our own against it.
 import 'package:hooks_runner/hooks_runner.dart' as hr;
 import 'package:logging/logging.dart' show Level, Logger, LogRecord;
+import 'package:meta/meta.dart' show visibleForTesting;
 import 'package:package_config/package_config.dart' as pc;
 import 'package:path/path.dart' as p;
 import 'package:serverpod_cli/src/commands/start/kernel_compiler.dart';
@@ -89,7 +90,7 @@ class NativeAssetsBuilder {
   final String dartExecutable;
 
   /// The server package directory. The package_config.json lives either here
-  /// (standalone) or in the workspace root above it; [_discoverPaths] walks
+  /// (standalone) or in the workspace root above it; [discoverPaths] walks
   /// up to find it.
   final String serverDir;
 
@@ -97,7 +98,7 @@ class NativeAssetsBuilder {
   /// `<serverDir>/.dart_tool/serverpod/native_assets/`).
   final String outputDir;
 
-  Future<_ResolvedPaths>? _pathsFuture;
+  Future<ResolvedPaths>? _pathsFuture;
   Future<hr.PackageLayout>? _packageLayoutFuture;
   Future<hr.NativeAssetsBuildRunner>? _runnerFuture;
   String? _lastManifestContent;
@@ -134,7 +135,8 @@ class NativeAssetsBuilder {
   /// member (i.e. `resolution != 'workspace'`). That directory is either the
   /// workspace root (when a workspace is in use) or the package itself (when
   /// it isn't). Pub places `.dart_tool/` only at that root.
-  Future<_ResolvedPaths> _discoverPaths() async {
+  @visibleForTesting
+  Future<ResolvedPaths> discoverPaths() async {
     var dir = p.canonicalize(serverDir);
     while (true) {
       final pubspec = await tryParsePubspecAt(dir);
@@ -147,7 +149,7 @@ class NativeAssetsBuilder {
             'package_config.json / package_graph.json. Run `dart pub get`.',
           );
         }
-        return _ResolvedPaths(
+        return ResolvedPaths(
           packageConfigPath: cfg,
           workspacePubspecPath: p.join(dir, 'pubspec.yaml'),
         );
@@ -165,7 +167,7 @@ class NativeAssetsBuilder {
   }
 
   Future<hr.PackageLayout> _loadPackageLayout() async {
-    final paths = await (_pathsFuture ??= _discoverPaths());
+    final paths = await (_pathsFuture ??= discoverPaths());
     final pkgConfigUri = Uri.file(paths.packageConfigPath);
 
     // Run the package_config load and the server pubspec read in parallel.
@@ -188,7 +190,7 @@ class NativeAssetsBuilder {
 
   Future<hr.NativeAssetsBuildRunner> _createRunner() async {
     final layout = await (_packageLayoutFuture ??= _loadPackageLayout());
-    final paths = await (_pathsFuture ??= _discoverPaths());
+    final paths = await (_pathsFuture ??= discoverPaths());
     return hr.NativeAssetsBuildRunner(
       dartExecutable: Uri.file(dartExecutable),
       logger: _logger,
@@ -327,10 +329,16 @@ const _encodedAssetsEq = ListEquality<EncodedAsset>();
 /// floor as `dart run`.
 const _minMacOSVersion = 13;
 
-class _ResolvedPaths {
+/// Paths resolved by [NativeAssetsBuilder.discoverPaths].
+///
+/// [packageConfigPath] is the absolute path to `.dart_tool/package_config.json`
+/// (lives at the workspace root when a workspace is in use, or at the
+/// package itself otherwise). [workspacePubspecPath] is the absolute path to
+/// the `pubspec.yaml` next to it - the same directory.
+class ResolvedPaths {
   final String packageConfigPath;
   final String workspacePubspecPath;
-  const _ResolvedPaths({
+  const ResolvedPaths({
     required this.packageConfigPath,
     required this.workspacePubspecPath,
   });

--- a/tools/serverpod_cli/lib/src/commands/start/native_assets_builder.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/native_assets_builder.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:code_assets/code_assets.dart';
+import 'package:collection/collection.dart' show ListEquality;
 import 'package:data_assets/data_assets.dart';
 import 'package:file/local.dart';
 import 'package:hooks/hooks.dart';
@@ -11,7 +12,8 @@ import 'package:hooks_runner/hooks_runner.dart' as hr;
 import 'package:logging/logging.dart' show Level, Logger, LogRecord;
 import 'package:package_config/package_config.dart' as pc;
 import 'package:path/path.dart' as p;
-import 'package:pubspec_parse/pubspec_parse.dart';
+import 'package:serverpod_cli/src/commands/start/kernel_compiler.dart';
+import 'package:serverpod_cli/src/util/pubspec_helpers.dart';
 import 'package:serverpod_cli/src/util/serverpod_cli_logger.dart';
 import 'package:serverpod_cli/src/vendored/native_assets_bundling.dart';
 
@@ -37,12 +39,10 @@ class NativeAssetsBuildSkipped extends NativeAssetsBuildOutcome {
 class NativeAssetsBuildSuccess extends NativeAssetsBuildOutcome {
   final String? manifestPath;
   final bool manifestChanged;
-  final List<Uri> dependencies;
 
   const NativeAssetsBuildSuccess({
     required this.manifestPath,
     required this.manifestChanged,
-    required this.dependencies,
   });
 }
 
@@ -51,6 +51,26 @@ class NativeAssetsBuildSuccess extends NativeAssetsBuildOutcome {
 class NativeAssetsBuildFailed extends NativeAssetsBuildOutcome {
   final String message;
   const NativeAssetsBuildFailed(this.message);
+}
+
+/// Outcome of [NativeAssetsBuilder.applyTo].
+sealed class NativeAssetsApplyOutcome {
+  const NativeAssetsApplyOutcome();
+}
+
+/// Hooks ran (or were skipped) and the manifest is up to date on [compiler].
+/// [restarted] is `true` when the builder restarted [KernelCompiler] because
+/// the manifest changed; the caller should treat the next compile as a full
+/// one.
+class NativeAssetsApplySuccess extends NativeAssetsApplyOutcome {
+  final bool restarted;
+  const NativeAssetsApplySuccess({this.restarted = false});
+}
+
+/// Hooks failed; [message] is a short, user-facing summary.
+class NativeAssetsApplyFailure extends NativeAssetsApplyOutcome {
+  final String message;
+  const NativeAssetsApplyFailure(this.message);
 }
 
 /// Orchestrates `package:hooks_runner` on behalf of `serverpod start`.
@@ -81,6 +101,7 @@ class NativeAssetsBuilder {
   Future<hr.PackageLayout>? _packageLayoutFuture;
   Future<hr.NativeAssetsBuildRunner>? _runnerFuture;
   String? _lastManifestContent;
+  List<EncodedAsset>? _lastEncodedAssets;
 
   /// Bridges `hooks_runner`'s `Logger` records into the serverpod CLI [log].
   /// Detached so it never escapes into the global `package:logging` hierarchy.
@@ -116,7 +137,7 @@ class NativeAssetsBuilder {
   Future<_ResolvedPaths> _discoverPaths() async {
     var dir = p.canonicalize(serverDir);
     while (true) {
-      final pubspec = await _tryLoadPubspec(dir);
+      final pubspec = await tryParsePubspecAt(dir);
       if (pubspec != null && pubspec.resolution != 'workspace') {
         final cfg = p.join(dir, '.dart_tool', 'package_config.json');
         final graph = p.join(dir, '.dart_tool', 'package_graph.json');
@@ -146,20 +167,21 @@ class NativeAssetsBuilder {
   Future<hr.PackageLayout> _loadPackageLayout() async {
     final paths = await (_pathsFuture ??= _discoverPaths());
     final pkgConfigUri = Uri.file(paths.packageConfigPath);
-    final packageConfig = await pc.loadPackageConfigUri(pkgConfigUri);
 
-    // The server is the package whose transitive (non-dev) deps we walk.
-    // It may be a workspace member, in which case the discovered config
-    // covers it along with its siblings.
-    final pubspecName = await _readPubspecName(
-      p.join(serverDir, 'pubspec.yaml'),
-    );
+    // Run the package_config load and the server pubspec read in parallel.
+    final (packageConfig, serverPubspec) = await (
+      pc.loadPackageConfigUri(pkgConfigUri),
+      tryParsePubspecAt(serverDir),
+    ).wait;
+    if (serverPubspec == null) {
+      throw StateError('Could not parse pubspec.yaml in $serverDir');
+    }
 
     return hr.PackageLayout.fromPackageConfig(
       _fileSystem,
       packageConfig,
       pkgConfigUri,
-      pubspecName,
+      serverPubspec.name,
       includeDevDependencies: false,
     );
   }
@@ -210,59 +232,95 @@ class NativeAssetsBuilder {
       );
     }
 
-    final buildResult = result.success;
-    final encodedAssets = buildResult.encodedAssets;
+    final encodedAssets = result.success.encodedAssets;
 
     // No bundleable assets -> no manifest needed. Tell the caller to ensure
     // FES is running without a --native-assets argument.
     if (encodedAssets.isEmpty) {
       final changed = _lastManifestContent != null;
       _lastManifestContent = null;
-      // Best-effort cleanup of a stale manifest from a prior run.
-      final stale = File(manifestPath);
-      if (await stale.exists()) await stale.delete();
+      _lastEncodedAssets = const [];
+      // Best-effort cleanup of a stale manifest from a prior run. Avoid
+      // exists() + delete() (TOCTOU); just delete and ignore "not found".
+      try {
+        await File(manifestPath).delete();
+      } on PathNotFoundException {
+        // Already gone.
+      }
       return NativeAssetsBuildSuccess(
         manifestPath: null,
         manifestChanged: changed,
-        dependencies: buildResult.dependencies,
       );
     }
 
-    final outputUri = Directory(outputDir).uri;
-    await Directory(outputDir).create(recursive: true);
+    // hooks_runner caches build results internally, so the encoded asset list
+    // is the same object-graph when nothing changed. Skip the bundle step
+    // entirely in that case - it would otherwise re-copy dylibs and re-run
+    // install_name_tool / codesign on macOS for every reload cycle.
+    if (_lastEncodedAssets != null &&
+        _encodedAssetsEq.equals(_lastEncodedAssets!, encodedAssets)) {
+      return NativeAssetsBuildSuccess(
+        manifestPath: manifestPath,
+        manifestChanged: false,
+      );
+    }
 
+    await Directory(outputDir).create(recursive: true);
     final kernelAssets = await bundleNativeAssets(
       encodedAssets,
       target,
-      outputUri,
+      Directory(outputDir).uri,
       relocatable: false,
     );
 
-    // Render the manifest text (without writing it yet) so we can compare
-    // against the previously written one before bouncing FES.
     const header =
         '# Native assets mapping for host OS in JIT mode.\n'
         '# Generated by serverpod_cli and package:hooks_runner.\n';
-    final body = kernelAssets.toNativeAssetsFile();
-    final newContent = '$header\n$body';
+    final newContent = '$header\n${kernelAssets.toNativeAssetsFile()}';
 
-    final manifestFile = File(manifestPath);
-    final exists = await manifestFile.exists();
-    final priorContent = exists ? await manifestFile.readAsString() : null;
-    final changed = priorContent != newContent;
+    final changed = _lastManifestContent != newContent;
     if (changed) {
+      final manifestFile = File(manifestPath);
       await manifestFile.create(recursive: true);
       await manifestFile.writeAsString(newContent);
     }
     _lastManifestContent = newContent;
+    _lastEncodedAssets = List.unmodifiable(encodedAssets);
 
     return NativeAssetsBuildSuccess(
       manifestPath: manifestPath,
       manifestChanged: changed,
-      dependencies: buildResult.dependencies,
     );
   }
+
+  /// Runs build hooks and applies the result to [compiler]:
+  ///  - `nativeAssetsPath` is updated to the freshly built manifest (if any)
+  ///  - if the manifest content changed AND [compiler] has already started,
+  ///    restarts the FES so the new `--native-assets` value takes effect
+  ///
+  /// Centralises the "did we restart?" bookkeeping that callers in the watch
+  /// loop and migration path need to avoid double-restarting.
+  Future<NativeAssetsApplyOutcome> applyTo(KernelCompiler compiler) async {
+    final outcome = await build();
+    switch (outcome) {
+      case NativeAssetsBuildSkipped():
+        return const NativeAssetsApplySuccess();
+      case NativeAssetsBuildFailed(:final message):
+        return NativeAssetsApplyFailure(message);
+      case NativeAssetsBuildSuccess(
+        :final manifestPath,
+        :final manifestChanged,
+      ):
+        if (!manifestChanged) return const NativeAssetsApplySuccess();
+        compiler.nativeAssetsPath = manifestPath;
+        if (!compiler.isStarted) return const NativeAssetsApplySuccess();
+        await compiler.restart();
+        return const NativeAssetsApplySuccess(restarted: true);
+    }
+  }
 }
+
+const _encodedAssetsEq = ListEquality<EncodedAsset>();
 
 /// Minimum macOS deployment target. Matches dartdev's default for hosts that
 /// only ever build for the current machine, so hooks compile against the same
@@ -279,33 +337,18 @@ class _ResolvedPaths {
 }
 
 /// Routes a single `hooks_runner` log record into the serverpod CLI logger.
+///
+/// Demotes `INFO` to `debug`: hooks_runner emits the full input/output JSON
+/// for every hook invocation at INFO level (build_runner.dart:638, 991,
+/// 1031), which is too verbose for normal use. Real user-facing messages are
+/// emitted at WARNING/SEVERE.
 void _forwardLogRecord(LogRecord rec) {
   final v = rec.level.value;
   if (v >= Level.SEVERE.value) {
     log.error(rec.message);
   } else if (v >= Level.WARNING.value) {
     log.warning(rec.message);
-  } else if (v >= Level.INFO.value) {
-    log.info(rec.message);
   } else {
     log.debug(rec.message);
-  }
-}
-
-Future<String> _readPubspecName(String pubspecPath) async {
-  final pubspec = await _tryLoadPubspec(p.dirname(pubspecPath));
-  if (pubspec == null) {
-    throw StateError('Could not parse pubspec at $pubspecPath');
-  }
-  return pubspec.name;
-}
-
-Future<Pubspec?> _tryLoadPubspec(String dir) async {
-  final file = File(p.join(dir, 'pubspec.yaml'));
-  if (!await file.exists()) return null;
-  try {
-    return Pubspec.parse(await file.readAsString());
-  } on Exception {
-    return null;
   }
 }

--- a/tools/serverpod_cli/lib/src/commands/start/watch_session.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/watch_session.dart
@@ -272,26 +272,19 @@ class WatchSession {
     // 1. Run native build hooks (if configured). The hook runner caches on
     //    input hashes, so this is cheap when nothing changed. A manifest
     //    content change requires a fresh FES because `--native-assets` is
-    //    only read at startup; track that so we don't double-restart below.
+    //    only read at startup; the apply step restarts in that case and
+    //    reports back so we don't double-restart below.
     var compilerRestartedByHooks = false;
     final builder = _nativeAssetsBuilder;
     if (builder != null) {
       if (packageConfigChanged) builder.reset();
-      final outcome = await builder.build();
-      switch (outcome) {
-        case NativeAssetsBuildSkipped():
-          break;
-        case NativeAssetsBuildFailed(:final message):
+      switch (await builder.applyTo(compiler)) {
+        case NativeAssetsApplyFailure(:final message):
           log.error('$message Server not reloaded.');
           if (changedPaths.isNotEmpty) _pendingPaths.addAll(changedPaths);
           return;
-        case NativeAssetsBuildSuccess(
-          :final manifestPath,
-          :final manifestChanged,
-        ):
-          if (manifestChanged) {
-            compiler.nativeAssetsPath = manifestPath;
-            await compiler.restart();
+        case NativeAssetsApplySuccess(:final restarted):
+          if (restarted) {
             compilerRestartedByHooks = true;
             _pendingPaths.clear();
           }
@@ -440,21 +433,11 @@ class WatchSession {
       var restartedByHooks = false;
       final builder = _nativeAssetsBuilder;
       if (builder != null) {
-        final outcome = await builder.build();
-        switch (outcome) {
-          case NativeAssetsBuildSkipped():
-            break;
-          case NativeAssetsBuildFailed(:final message):
+        switch (await builder.applyTo(compiler)) {
+          case NativeAssetsApplyFailure(:final message):
             throw StateError('$message Migration not applied.');
-          case NativeAssetsBuildSuccess(
-            :final manifestPath,
-            :final manifestChanged,
-          ):
-            if (manifestChanged) {
-              compiler.nativeAssetsPath = manifestPath;
-              await compiler.restart();
-              restartedByHooks = true;
-            }
+          case NativeAssetsApplySuccess(:final restarted):
+            restartedByHooks = restarted;
         }
       }
 

--- a/tools/serverpod_cli/lib/src/commands/start/watch_session.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/watch_session.dart
@@ -6,6 +6,7 @@ import 'package:serverpod_cli/src/commands/generate.dart';
 import 'package:serverpod_cli/src/commands/messages.dart';
 import 'package:serverpod_cli/src/commands/start/file_watcher.dart';
 import 'package:serverpod_cli/src/commands/start/kernel_compiler.dart';
+import 'package:serverpod_cli/src/commands/start/native_assets_builder.dart';
 import 'package:serverpod_cli/src/commands/start/server_process.dart';
 import 'package:serverpod_cli/src/generator/analyzers.dart';
 import 'package:serverpod_cli/src/util/serverpod_cli_logger.dart';
@@ -95,6 +96,7 @@ final _endpointOrFutureCallRegex = RegExp(
 
 class WatchSession {
   final KernelCompiler? _compiler;
+  final NativeAssetsBuilder? _nativeAssetsBuilder;
   final GenerateAction _generate;
   final ServerProcessFactory? _createServer;
   final Set<String> _generatedDirPaths;
@@ -119,6 +121,7 @@ class WatchSession {
 
   WatchSession({
     KernelCompiler? compiler,
+    NativeAssetsBuilder? nativeAssetsBuilder,
     required GenerateAction generate,
     ServerProcessFactory? createServer,
     required ServerProcess initialServer,
@@ -126,6 +129,7 @@ class WatchSession {
     ProtocolChangeClassifier classifyProtocolChange =
         defaultProtocolChangeClassifier,
   }) : _compiler = compiler,
+       _nativeAssetsBuilder = nativeAssetsBuilder,
        _generate = generate,
        _createServer = createServer,
        _server = initialServer,
@@ -134,6 +138,10 @@ class WatchSession {
     assert(
       (compiler == null) == (createServer == null),
       'compiler and createServer must both be provided or both be null.',
+    );
+    assert(
+      nativeAssetsBuilder == null || compiler != null,
+      'nativeAssetsBuilder requires a compiler.',
     );
     _monitorExit(initialServer);
     _trackVmServiceUri(initialServer);
@@ -261,10 +269,40 @@ class WatchSession {
     // compiles so the FES re-invalidates them (reject rolls back its state).
     final changedPaths = {..._pendingPaths, ...dartFiles};
 
+    // 1. Run native build hooks (if configured). The hook runner caches on
+    //    input hashes, so this is cheap when nothing changed. A manifest
+    //    content change requires a fresh FES because `--native-assets` is
+    //    only read at startup; track that so we don't double-restart below.
+    var compilerRestartedByHooks = false;
+    final builder = _nativeAssetsBuilder;
+    if (builder != null) {
+      if (packageConfigChanged) builder.reset();
+      final outcome = await builder.build();
+      switch (outcome) {
+        case NativeAssetsBuildSkipped():
+          break;
+        case NativeAssetsBuildFailed(:final message):
+          log.error('$message Server not reloaded.');
+          if (changedPaths.isNotEmpty) _pendingPaths.addAll(changedPaths);
+          return;
+        case NativeAssetsBuildSuccess(
+          :final manifestPath,
+          :final manifestChanged,
+        ):
+          if (manifestChanged) {
+            compiler.nativeAssetsPath = manifestPath;
+            await compiler.restart();
+            compilerRestartedByHooks = true;
+            _pendingPaths.clear();
+          }
+      }
+    }
+
+    // 2. Bring the FES into the right state for this cycle.
     CompileResult? result;
     if (forceFullCompile) {
       _pendingPaths.clear();
-      await compiler.reset();
+      if (!compilerRestartedByHooks) await compiler.reset();
       result = await compileWithProgress(
         'Compiling server',
         compiler,
@@ -274,13 +312,13 @@ class WatchSession {
       // FES reads package_config.json only at startup - must restart it.
       // After restart the FES is in initial state, so we do a full compile.
       _pendingPaths.clear();
-      await compiler.restart();
+      if (!compilerRestartedByHooks) await compiler.restart();
       result = await compileWithProgress(
         'Compiling server',
         compiler,
         rejectOnFailure: true,
       );
-    } else if (changedPaths.isNotEmpty) {
+    } else if (changedPaths.isNotEmpty || compilerRestartedByHooks) {
       result = await compileWithProgress(
         'Compiling server',
         compiler,
@@ -397,8 +435,31 @@ class WatchSession {
 
     _state = SessionState.applyingMigration;
     try {
+      // Re-run native build hooks first; if the manifest changed the
+      // restart they trigger replaces the explicit reset() below.
+      var restartedByHooks = false;
+      final builder = _nativeAssetsBuilder;
+      if (builder != null) {
+        final outcome = await builder.build();
+        switch (outcome) {
+          case NativeAssetsBuildSkipped():
+            break;
+          case NativeAssetsBuildFailed(:final message):
+            throw StateError('$message Migration not applied.');
+          case NativeAssetsBuildSuccess(
+            :final manifestPath,
+            :final manifestChanged,
+          ):
+            if (manifestChanged) {
+              compiler.nativeAssetsPath = manifestPath;
+              await compiler.restart();
+              restartedByHooks = true;
+            }
+        }
+      }
+
       // Full compile so we have a complete kernel for the new process.
-      await compiler.reset();
+      if (!restartedByHooks) await compiler.reset();
       final result = await compileWithProgress(
         'Compiling server',
         compiler,

--- a/tools/serverpod_cli/lib/src/util/pubspec_helpers.dart
+++ b/tools/serverpod_cli/lib/src/util/pubspec_helpers.dart
@@ -19,6 +19,15 @@ Pubspec parsePubspec(File pubspecFile) {
   }
 }
 
+/// Returns the parsed `pubspec.yaml` at [dir], or `null` if the file is
+/// absent. Parse errors propagate so an unparseable pubspec is surfaced
+/// rather than masquerading as "no pubspec here" during ancestor walks.
+Future<Pubspec?> tryParsePubspecAt(String dir) async {
+  final file = File(p.join(dir, 'pubspec.yaml'));
+  if (!await file.exists()) return null;
+  return Pubspec.parse(await file.readAsString());
+}
+
 List<File> findPubspecsFiles(
   Directory dir, {
   List<String> ignorePaths = const [],

--- a/tools/serverpod_cli/lib/src/util/serverpod_cli_logger.dart
+++ b/tools/serverpod_cli/lib/src/util/serverpod_cli_logger.dart
@@ -41,6 +41,7 @@ class ServerpodCliLogger extends cli.Logger {
   @override
   set logLevel(cli.LogLevel level) {
     super.logLevel = level;
+    if (level == cli.LogLevel.nothing) return;
     _log.logLevel = _mapLogLevel(level);
   }
 
@@ -113,6 +114,7 @@ class ServerpodCliLogger extends cli.Logger {
     Future<bool> Function() runner, {
     bool newParagraph = false,
   }) {
+    if (_silent) return runner();
     return _log.progress(message, runner);
   }
 
@@ -120,6 +122,7 @@ class ServerpodCliLogger extends cli.Logger {
   Future<void> flush() async {}
 
   void _call(LogLevel level, String message, {cli.LogType? type}) {
+    if (_silent) return;
     _log(
       level,
       () => LogEntry(
@@ -131,6 +134,13 @@ class ServerpodCliLogger extends cli.Logger {
       ),
     );
   }
+
+  // serverpod_shared LogLevel has no "nothing" sentinel - its lowest-passing
+  // level is fatal, and the filter check is strict-`<` so fatal still leaks
+  // through. Progress / scope events bypass logLevel entirely. So when the
+  // caller sets cli.LogLevel.nothing we gate at the bridge instead of mapping
+  // through to _log.logLevel.
+  bool get _silent => super.logLevel == cli.LogLevel.nothing;
 
   static cli.LogLevel _mapLevel(LogLevel level) => switch (level) {
     LogLevel.debug => cli.LogLevel.debug,
@@ -144,7 +154,15 @@ class ServerpodCliLogger extends cli.Logger {
     cli.LogLevel.info => LogLevel.info,
     cli.LogLevel.warning => LogLevel.warning,
     cli.LogLevel.error => LogLevel.error,
-    cli.LogLevel.nothing => LogLevel.debug,
+    // The setter early-returns before reaching here, so this branch only
+    // fires from log() / write() being called with nothing as a message
+    // level - which is a programmer error worth surfacing.
+    cli.LogLevel.nothing => throw ArgumentError.value(
+      level,
+      'level',
+      'cli.LogLevel.nothing is a filter sentinel; it cannot be used as a '
+          'message level',
+    ),
   };
 }
 

--- a/tools/serverpod_cli/lib/src/vendored/frontend_server_client.dart
+++ b/tools/serverpod_cli/lib/src/vendored/frontend_server_client.dart
@@ -10,6 +10,9 @@
  * Modifications: Simplified to use sdkRoot to locate the dart executable and
  * frontend server snapshots. The upstream version uses
  * Platform.resolvedExecutable which breaks when running as an AOT binary.
+ * Added optional `nativeAssetsPath` parameter to forward the
+ * `--native-assets <path>` flag, used to feed `frontend_server` the manifest
+ * produced by `package:hooks_runner` so `@Native` lookups resolve correctly.
  *
  * Copyright 2020 The Dart Authors. All rights reserved.
  *
@@ -70,6 +73,7 @@ class FrontendServerClient {
     required String sdkRoot,
     String target = 'vm',
     String? packagesJson,
+    String? nativeAssetsPath,
     IOSink? errorSink,
   }) async {
     final entrypointUri = Uri.file(p.absolute(entrypoint));
@@ -82,6 +86,10 @@ class FrontendServerClient {
       outputDillPath,
       if (packagesJson != null)
         '--packages=${Uri.file(p.absolute(packagesJson))}',
+      if (nativeAssetsPath != null) ...[
+        '--native-assets',
+        p.absolute(nativeAssetsPath),
+      ],
       '--incremental',
     ];
     final exe = Platform.isWindows ? '.exe' : '';

--- a/tools/serverpod_cli/lib/src/vendored/native_assets_bundling.dart
+++ b/tools/serverpod_cli/lib/src/vendored/native_assets_bundling.dart
@@ -1,0 +1,210 @@
+/*
+ * This file is adapted from the original source in `pkg/dartdev` of the Dart
+ * SDK (`pkg/dartdev/lib/src/native_assets_bundling.dart`) and licensed under
+ * a BSD-style license.
+ * Source: https://github.com/dart-lang/sdk/tree/main/pkg/dartdev
+ *
+ * Vendored against Dart SDK 3.11.x (matches the version pinned in this
+ * package's pubspec). When re-syncing, diff against the upstream
+ * `pkg/dartdev/lib/src/native_assets_bundling.dart` at the SDK tag matching
+ * the `code_assets` / `hooks_runner` versions in pubspec.yaml.
+ *
+ * The scope of the below license ("Software") is limited to this file only,
+ * which is a derivative work of the original. The license does not apply to
+ * any other part of the codebase.
+ *
+ * Modifications: none, except for adjusting the import of the macOS install
+ * name rewriter to point at the vendored copy in this directory.
+ *
+ * Copyright 2024 The Dart project authors. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of Google LLC nor the names of its contributors may
+ *       be used to endorse or promote products derived from this software
+ *       without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import 'dart:io';
+
+import 'package:code_assets/code_assets.dart';
+import 'package:data_assets/data_assets.dart';
+import 'package:hooks/hooks.dart';
+import 'package:hooks_runner/hooks_runner.dart';
+import 'package:serverpod_cli/src/vendored/native_assets_macos.dart';
+
+final libOutputDirectoryUriFromBin = Uri.file(
+  '../',
+).resolveUri(libOutputDirectoryUri);
+final libOutputDirectoryUri = Uri.file('lib/');
+final dataOutputDirectoryUri = Uri.file('assets/');
+
+Future<KernelAssets> bundleNativeAssets(
+  Iterable<EncodedAsset> assets,
+  Target target,
+  Uri outputUri, {
+  required bool relocatable,
+  bool verbose = false,
+}) async {
+  final targetMapping = _targetMapping(assets, target, outputUri, relocatable);
+  await _copyAssets(targetMapping, target, outputUri, relocatable, verbose);
+  return KernelAssets(targetMapping.map((asset) => asset.target).toList());
+}
+
+Future<Uri> writeNativeAssetsYaml(
+  KernelAssets assets,
+  Uri outputUri, {
+  String? header,
+}) async {
+  final nativeAssetsYamlUri = outputUri.resolve('native_assets.yaml');
+  final nativeAssetsYamlFile = File(nativeAssetsYamlUri.toFilePath());
+  await nativeAssetsYamlFile.create(recursive: true);
+
+  var contents = assets.toNativeAssetsFile();
+  if (header != null) {
+    contents = '$header\n$contents';
+  }
+
+  await nativeAssetsYamlFile.writeAsString(contents);
+  return nativeAssetsYamlUri;
+}
+
+Future<void> _copyAssets(
+  List<({Object asset, KernelAsset target})> targetMapping,
+  Target target,
+  Uri outputUri,
+  bool relocatable,
+  bool verbose,
+) async {
+  final filesToCopy = <({String id, Uri src, Uri dest})>[];
+  final codeAssetUris = <Uri>[];
+
+  for (final (:asset, :target) in targetMapping) {
+    final targetPath = target.path;
+    if (targetPath
+        case KernelAssetRelativePath(:final uri) ||
+            KernelAssetAbsolutePath(:final uri)) {
+      final targetUri = outputUri.resolveUri(uri);
+
+      switch (asset) {
+        case CodeAsset(:final file!):
+          filesToCopy.add((id: asset.id, src: file, dest: targetUri));
+          codeAssetUris.add(targetUri);
+        case DataAsset(:final file):
+          filesToCopy.add((id: asset.id, src: file, dest: targetUri));
+        default:
+          throw UnimplementedError();
+      }
+    }
+  }
+
+  if (filesToCopy.isNotEmpty) {
+    if (verbose) {
+      stdout.writeln(
+        'Copying ${filesToCopy.length} build assets:\n'
+        '${filesToCopy.map((e) => e.id).join('\n')}',
+      );
+    }
+
+    // TODO(https://dartbug.com/59668): Cache copying and rewriting of install
+    // names.
+    await Future.wait(filesToCopy.map((file) => file.src.copyTo(file.dest)));
+
+    if (target.os == OS.macOS) {
+      await rewriteInstallNames(codeAssetUris, relocatable: relocatable);
+    }
+  }
+}
+
+List<({Object asset, KernelAsset target})> _targetMapping(
+  Iterable<EncodedAsset> assets,
+  Target target,
+  Uri outputUri,
+  bool relocatable,
+) {
+  final codeAssets = assets
+      .where((asset) => asset.isCodeAsset)
+      .map(CodeAsset.fromEncoded);
+  final dataAssets = assets
+      .where((asset) => asset.isDataAsset)
+      .map(DataAsset.fromEncoded);
+
+  return [
+    for (final asset in codeAssets)
+      (
+        asset: asset,
+        target: asset.targetLocation(target, outputUri, relocatable),
+      ),
+    for (final asset in dataAssets)
+      (
+        asset: asset,
+        target: asset.targetLocation(target, outputUri, relocatable),
+      ),
+  ];
+}
+
+extension on CodeAsset {
+  KernelAsset targetLocation(Target target, Uri outputUri, bool relocatable) {
+    final kernelAssetPath = switch (linkMode) {
+      DynamicLoadingSystem(:final uri) => KernelAssetSystemPath(uri),
+      LookupInExecutable() => KernelAssetInExecutable(),
+      LookupInProcess() => KernelAssetInProcess(),
+      DynamicLoadingBundled() => () {
+        final relativeUri = libOutputDirectoryUriFromBin.resolve(
+          file!.pathSegments.last,
+        );
+        return relocatable
+            ? KernelAssetRelativePath(relativeUri)
+            : KernelAssetAbsolutePath(outputUri.resolveUri(relativeUri));
+      }(),
+      _ => throw UnsupportedError(
+        'Unsupported NativeCodeAsset linkMode '
+        '${linkMode.runtimeType} in asset $this',
+      ),
+    };
+    return KernelAsset(id: id, target: target, path: kernelAssetPath);
+  }
+}
+
+extension on DataAsset {
+  KernelAsset targetLocation(Target target, Uri outputUri, bool relocatable) {
+    final relativeUri = dataOutputDirectoryUri.resolve(file.pathSegments.last);
+    return KernelAsset(
+      id: id,
+      target: target,
+      path: relocatable
+          ? KernelAssetRelativePath(relativeUri)
+          : KernelAssetAbsolutePath(outputUri.resolveUri(relativeUri)),
+    );
+  }
+}
+
+extension on Uri {
+  Future<void> copyTo(Uri targetUri) async {
+    var targetFile = File.fromUri(targetUri);
+    // File.copy truncates. So, first delete to ensure that if it was dlopened
+    // it doesn't get truncated on disk.
+    // https://github.com/dart-lang/sdk/issues/62361
+    if (await targetFile.exists()) await targetFile.delete();
+    await targetFile.create(recursive: true);
+    await File.fromUri(this).copy(targetUri.toFilePath());
+  }
+}

--- a/tools/serverpod_cli/lib/src/vendored/native_assets_macos.dart
+++ b/tools/serverpod_cli/lib/src/vendored/native_assets_macos.dart
@@ -1,0 +1,196 @@
+/*
+ * This file is adapted from the original source in `pkg/dartdev` of the Dart
+ * SDK (`pkg/dartdev/lib/src/native_assets_macos.dart`) and licensed under
+ * a BSD-style license.
+ * Source: https://github.com/dart-lang/sdk/tree/main/pkg/dartdev
+ *
+ * Vendored against Dart SDK 3.11.x (matches the version pinned in this
+ * package's pubspec). When re-syncing, diff against the upstream
+ * `pkg/dartdev/lib/src/native_assets_macos.dart` at the SDK tag matching
+ * the `code_assets` / `hooks_runner` versions in pubspec.yaml.
+ *
+ * The scope of the below license ("Software") is limited to this file only,
+ * which is a derivative work of the original. The license does not apply to
+ * any other part of the codebase.
+ *
+ * Modifications: none, except for adjusting the import of the bundling
+ * helpers to point at the vendored copy in this directory.
+ *
+ * Copyright 2024 The Dart project authors. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of Google LLC nor the names of its contributors may
+ *       be used to endorse or promote products derived from this software
+ *       without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import 'dart:io';
+
+import 'package:code_assets/code_assets.dart';
+import 'package:serverpod_cli/src/vendored/native_assets_bundling.dart';
+
+final _rpathUri = Uri.file('@rpath/');
+
+Future<void> rewriteInstallNames(
+  List<Uri> dylibs, {
+  required bool relocatable,
+}) async {
+  final oldToNewInstallNames = <String, String>{};
+  final dylibInfos = <(Uri, String)>[];
+
+  await Future.wait(
+    dylibs.map((dylib) async {
+      final newInstallName = relocatable
+          ? _rpathUri
+                .resolveUri(libOutputDirectoryUri)
+                .resolve(dylib.pathSegments.last)
+                .toFilePath()
+          : dylib.toFilePath();
+      final oldInstallName = await _getInstallName(dylib);
+      oldToNewInstallNames[oldInstallName] = newInstallName;
+      dylibInfos.add((dylib, newInstallName));
+    }),
+  );
+
+  await Future.wait(
+    dylibInfos.map((info) async {
+      final (dylib, newInstallName) = info;
+      await _setInstallNames(dylib, newInstallName, oldToNewInstallNames);
+      await _codeSignDylib(dylib);
+    }),
+  );
+}
+
+Future<String> _getInstallName(Uri dylib) async {
+  final otoolResult = await Process.run('otool', ['-D', dylib.toFilePath()]);
+  if (otoolResult.exitCode != 0) {
+    throw Exception(
+      'Failed to get install name for dylib $dylib: ${otoolResult.stderr}',
+    );
+  }
+  final architectureSections = parseOtoolArchitectureSections(
+    otoolResult.stdout as String,
+  );
+  if (architectureSections.length != 1) {
+    throw Exception(
+      'Expected a single architecture section in otool output: $otoolResult',
+    );
+  }
+  return architectureSections.values.first.single;
+}
+
+Future<void> _setInstallNames(
+  Uri dylib,
+  String newInstallName,
+  Map<String, String> oldToNewInstallNames,
+) async {
+  final installNameToolResult = await Process.run('install_name_tool', [
+    '-id',
+    newInstallName,
+    for (final entry in oldToNewInstallNames.entries) ...[
+      '-change',
+      entry.key,
+      entry.value,
+    ],
+    dylib.toFilePath(),
+  ]);
+  if (installNameToolResult.exitCode != 0) {
+    throw Exception(
+      'Failed to set install names for dylib $dylib:\n'
+      'id -> $newInstallName\n'
+      'dependencies -> $oldToNewInstallNames\n'
+      '${installNameToolResult.stderr}',
+    );
+  }
+}
+
+Future<void> _codeSignDylib(Uri dylib) async {
+  final codesignResult = await Process.run('codesign', [
+    '--force',
+    '--sign',
+    '-',
+    dylib.toFilePath(),
+  ]);
+  if (codesignResult.exitCode != 0) {
+    throw Exception(
+      'Failed to codesign dylib $dylib: ${codesignResult.stderr}',
+    );
+  }
+}
+
+Map<Architecture?, List<String>> parseOtoolArchitectureSections(String output) {
+  // The output of `otool -D`, for example, looks like below. For each
+  // architecture, there is a separate section.
+  //
+  // /build/native_assets/ios/buz.framework/buz (architecture x86_64):
+  // @rpath/libbuz.dylib
+  // /build/native_assets/ios/buz.framework/buz (architecture arm64):
+  // @rpath/libbuz.dylib
+  //
+  // Some versions of `otool` don't print the architecture name if the
+  // binary only has one architecture:
+  //
+  // /build/native_assets/ios/buz.framework/buz:
+  // @rpath/libbuz.dylib
+
+  const Map<String, Architecture> outputArchitectures = <String, Architecture>{
+    'arm': Architecture.arm,
+    'arm64': Architecture.arm64,
+    'x86_64': Architecture.x64,
+  };
+  final RegExp architectureHeaderPattern = RegExp(
+    r'^[^(]+( \(architecture (.+)\))?:$',
+  );
+  final Iterator<String> lines = output.trim().split('\n').iterator;
+  Architecture? currentArchitecture;
+  final Map<Architecture?, List<String>> architectureSections =
+      <Architecture?, List<String>>{};
+
+  while (lines.moveNext()) {
+    final String line = lines.current;
+    final Match? architectureHeader = architectureHeaderPattern.firstMatch(
+      line,
+    );
+    if (architectureHeader != null) {
+      if (architectureSections.containsKey(null)) {
+        throw Exception(
+          'Expected a single architecture section in otool output: $output',
+        );
+      }
+      final String? architectureString = architectureHeader[2];
+      if (architectureString != null) {
+        currentArchitecture = outputArchitectures[architectureString];
+        if (currentArchitecture == null) {
+          throw Exception(
+            'Unknown architecture in otool output: $architectureString',
+          );
+        }
+      }
+      architectureSections[currentArchitecture] = <String>[];
+      continue;
+    } else {
+      architectureSections[currentArchitecture]!.add(line.trim());
+    }
+  }
+
+  return architectureSections;
+}

--- a/tools/serverpod_cli/pubspec.yaml
+++ b/tools/serverpod_cli/pubspec.yaml
@@ -17,6 +17,7 @@ dependencies:
   built_collection: ^5.1.1
   ci: ^0.1.0
   cli_tools: ^0.11.0
+  code_assets: ^1.0.0
   code_builder: ^4.5.0
   collection: ^1.18.0
   config: ^0.8.3
@@ -27,9 +28,17 @@ dependencies:
   # produce a different style than `dart format` and break the CI. For more
   # details, see: https://github.com/dart-lang/dart_style/issues/1785
   dart_style: 3.1.5
+  data_assets: '>=0.19.0 <0.20.0'
+  file: ^7.0.1
+  hooks: ^1.0.0
+  hooks_runner: ^1.2.1
   http: '>=1.1.0 <2.0.0'
   intl: '>=0.19.0 <0.21.0'
   json_rpc_2: ^4.0.0
+  # Bridge type only: hooks_runner's NativeAssetsBuildRunner requires a
+  # Logger argument. All log records are forwarded to the serverpod CLI
+  # logger; we never call package:logging methods directly.
+  logging: ^1.2.0
   lsp_server: ^0.4.0
   meta: ^1.15.0
   nocterm: ^0.6.0

--- a/tools/serverpod_cli/pubspec.yaml
+++ b/tools/serverpod_cli/pubspec.yaml
@@ -46,7 +46,7 @@ dependencies:
   path: ^1.8.3
   pub_api_client: '>=2.4.0 <4.0.0'
   pub_semver: ^2.1.4
-  pubspec_parse: ^1.4.0
+  pubspec_parse: ^1.5.0
   recase: ^4.1.0
   serverpod_database: 3.5.0-beta.4
   serverpod_serialization: 3.5.0-beta.4

--- a/tools/serverpod_cli/test/commands/start/native_assets_builder_test.dart
+++ b/tools/serverpod_cli/test/commands/start/native_assets_builder_test.dart
@@ -88,11 +88,31 @@ void main() {
     });
 
     test(
-      'when build is called from the member dir, '
-      'then path discovery walks up to the workspace root',
+      'when discoverPaths is called from the member dir, '
+      'then it returns the workspace root pubspec and package_config',
       () async {
-        final outcome = await builder.build();
-        expect(outcome, isA<NativeAssetsBuildSkipped>());
+        final paths = await builder.discoverPaths();
+
+        expect(
+          p.equals(
+            paths.workspacePubspecPath,
+            p.join(tempDir.path, 'pubspec.yaml'),
+          ),
+          isTrue,
+          reason:
+              'workspacePubspecPath should be the root pubspec, not the '
+              'member pubspec. Got: ${paths.workspacePubspecPath}',
+        );
+        expect(
+          p.equals(
+            paths.packageConfigPath,
+            p.join(tempDir.path, '.dart_tool', 'package_config.json'),
+          ),
+          isTrue,
+          reason:
+              'packageConfigPath should be at the workspace root .dart_tool/. '
+              'Got: ${paths.packageConfigPath}',
+        );
       },
       timeout: const Timeout(Duration(seconds: 60)),
     );

--- a/tools/serverpod_cli/test/commands/start/native_assets_builder_test.dart
+++ b/tools/serverpod_cli/test/commands/start/native_assets_builder_test.dart
@@ -17,11 +17,6 @@ void main() {
       builder = NativeAssetsBuilder(
         dartExecutable: _dartExecutable(),
         serverDir: tempDir.path,
-        packageConfigPath: p.join(
-          tempDir.path,
-          '.dart_tool',
-          'package_config.json',
-        ),
         outputDir: p.join(tempDir.path, '.dart_tool', 'serverpod', 'na'),
       );
     });
@@ -64,6 +59,110 @@ void main() {
       timeout: const Timeout(Duration(seconds: 60)),
     );
   });
+
+  group('Given a workspace with the server as a member package', () {
+    late Directory tempDir;
+    late NativeAssetsBuilder builder;
+    late String serverDir;
+
+    setUp(() async {
+      tempDir = await Directory.systemTemp.createTemp(
+        'native_assets_builder_workspace_test_',
+      );
+      serverDir = p.join(tempDir.path, 'server');
+      await _createWorkspaceProject(
+        rootDir: tempDir.path,
+        memberDir: serverDir,
+      );
+      builder = NativeAssetsBuilder(
+        dartExecutable: _dartExecutable(),
+        serverDir: serverDir,
+        outputDir: p.join(serverDir, '.dart_tool', 'serverpod', 'na'),
+      );
+    });
+
+    tearDown(() async {
+      if (await tempDir.exists()) {
+        await tempDir.delete(recursive: true);
+      }
+    });
+
+    test(
+      'when build is called from the member dir, '
+      'then path discovery walks up to the workspace root',
+      () async {
+        final outcome = await builder.build();
+        expect(outcome, isA<NativeAssetsBuildSkipped>());
+      },
+      timeout: const Timeout(Duration(seconds: 60)),
+    );
+  });
+}
+
+/// Creates a Dart workspace at [rootDir] with one member at [memberDir].
+/// `.dart_tool/` lives only at the workspace root, matching real pub layout.
+Future<void> _createWorkspaceProject({
+  required String rootDir,
+  required String memberDir,
+}) async {
+  final relMember = p.relative(memberDir, from: rootDir);
+
+  await Directory('$rootDir/.dart_tool').create(recursive: true);
+  await Directory(memberDir).create(recursive: true);
+
+  await File('$rootDir/pubspec.yaml').writeAsString('''
+name: test_workspace
+environment:
+  sdk: ^3.8.0
+workspace:
+  - $relMember
+''');
+
+  await File('$memberDir/pubspec.yaml').writeAsString('''
+name: test_server
+environment:
+  sdk: ^3.8.0
+resolution: workspace
+''');
+
+  await File('$rootDir/.dart_tool/package_config.json').writeAsString('''
+{
+  "configVersion": 2,
+  "packages": [
+    {
+      "name": "test_workspace",
+      "rootUri": "..",
+      "packageUri": "lib/"
+    },
+    {
+      "name": "test_server",
+      "rootUri": "../$relMember",
+      "packageUri": "lib/"
+    }
+  ]
+}
+''');
+
+  await File('$rootDir/.dart_tool/package_graph.json').writeAsString('''
+{
+  "roots": ["test_workspace", "test_server"],
+  "packages": [
+    {
+      "name": "test_workspace",
+      "version": "1.0.0",
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "name": "test_server",
+      "version": "1.0.0",
+      "dependencies": [],
+      "devDependencies": []
+    }
+  ],
+  "configVersion": 1
+}
+''');
 }
 
 /// Creates a minimal Dart project with `pubspec.yaml` and a

--- a/tools/serverpod_cli/test/commands/start/native_assets_builder_test.dart
+++ b/tools/serverpod_cli/test/commands/start/native_assets_builder_test.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:package_config/package_config.dart' as pc;
 import 'package:path/path.dart' as p;
 import 'package:serverpod_cli/src/commands/start/native_assets_builder.dart';
 import 'package:test/test.dart';
@@ -117,6 +118,65 @@ void main() {
       timeout: const Timeout(Duration(seconds: 60)),
     );
   });
+
+  group('Given a project with a build hook that emits no assets', () {
+    late Directory tempDir;
+    late NativeAssetsBuilder builder;
+
+    setUp(() async {
+      tempDir = await Directory.systemTemp.createTemp(
+        'native_assets_builder_hook_test_',
+      );
+      await _createProjectWithBuildHook(
+        dir: tempDir.path,
+        hookBody: '// No assets emitted.',
+      );
+      builder = NativeAssetsBuilder(
+        dartExecutable: _dartExecutable(),
+        serverDir: tempDir.path,
+        outputDir: p.join(tempDir.path, '.dart_tool', 'serverpod', 'na'),
+      );
+    });
+
+    tearDown(() async {
+      if (await tempDir.exists()) {
+        await tempDir.delete(recursive: true);
+      }
+    });
+
+    test(
+      'when build is called, '
+      'then it returns NativeAssetsBuildSuccess with no manifest',
+      () async {
+        final outcome = await builder.build();
+
+        expect(outcome, isA<NativeAssetsBuildSuccess>());
+        final success = outcome as NativeAssetsBuildSuccess;
+        expect(
+          success.manifestPath,
+          isNull,
+          reason:
+              'A hook that emits no assets should produce no manifest yaml. '
+              'manifestChanged=${success.manifestChanged}',
+        );
+        expect(File(builder.manifestPath).existsSync(), isFalse);
+      },
+      timeout: const Timeout(Duration(minutes: 2)),
+    );
+
+    test(
+      'when build is called twice, '
+      'then the second call reports the manifest as unchanged',
+      () async {
+        await builder.build();
+        final second = await builder.build();
+
+        expect(second, isA<NativeAssetsBuildSuccess>());
+        expect((second as NativeAssetsBuildSuccess).manifestChanged, isFalse);
+      },
+      timeout: const Timeout(Duration(minutes: 2)),
+    );
+  });
 }
 
 /// Creates a Dart workspace at [rootDir] with one member at [memberDir].
@@ -225,6 +285,111 @@ environment:
   "configVersion": 1
 }
 ''');
+}
+
+/// Creates a Dart project at [dir] whose `hook/build.dart` calls
+/// `package:hooks` build with [hookBody] inserted into the closure.
+///
+/// Builds a `package_config.json` that points at `package:hooks` and its
+/// transitive dependencies via the host test runner's already-resolved
+/// package_config - which is the only way to compile the hook without
+/// shelling out to `dart pub get` (and without making the test depend on
+/// network access).
+Future<void> _createProjectWithBuildHook({
+  required String dir,
+  required String hookBody,
+}) async {
+  await Directory(p.join(dir, '.dart_tool')).create(recursive: true);
+  await Directory(p.join(dir, 'hook')).create(recursive: true);
+
+  await File(p.join(dir, 'pubspec.yaml')).writeAsString('''
+name: test_server
+environment:
+  sdk: ^3.10.0
+dependencies:
+  hooks: ^1.0.0
+''');
+
+  await File(p.join(dir, 'hook', 'build.dart')).writeAsString('''
+import 'package:hooks/hooks.dart';
+
+void main(List<String> args) async {
+  await build(args, (input, output) async {
+    $hookBody
+  });
+}
+''');
+
+  // Inherit every package from the test runner's own package_config.json so
+  // `package:hooks` and its full transitive dep tree (yaml, pub_semver,
+  // record_use, meta, ...) resolve without `dart pub get`. The hook only
+  // imports `package:hooks`; the extras are harmless on the lookup path.
+  final hostConfig = await pc.findPackageConfig(Directory.current);
+  if (hostConfig == null) {
+    throw StateError(
+      'Could not locate the host package_config.json from '
+      '${Directory.current.path}. Run `dart pub get` first.',
+    );
+  }
+
+  // Sanity-check that the host has hooks resolved. If this fails the test
+  // won't compile the hook, so a clear error here beats the kernel-compile
+  // mess downstream.
+  if (!hostConfig.packages.any((p) => p.name == 'hooks')) {
+    throw StateError(
+      'Host package_config.json does not include `hooks`; '
+      'run `dart pub get` in the serverpod_cli package.',
+    );
+  }
+
+  final entries = <Map<String, Object?>>[
+    {
+      'name': 'test_server',
+      'rootUri': '../',
+      'packageUri': 'lib/',
+      'languageVersion': '3.10',
+    },
+    for (final pkg in hostConfig.packages)
+      {
+        'name': pkg.name,
+        'rootUri': pkg.root.toString(),
+        'packageUri': 'lib/',
+        'languageVersion': pkg.languageVersion?.toString() ?? '3.0',
+      },
+  ];
+
+  await File(p.join(dir, '.dart_tool', 'package_config.json')).writeAsString(
+    '{\n'
+    '  "configVersion": 2,\n'
+    '  "packages": [\n'
+    '${entries.map(_encodeEntry).join(',\n')}\n'
+    '  ]\n'
+    '}\n',
+  );
+
+  // hooks_runner only requires that this file exists alongside
+  // package_config.json; the contents are not used to drive hook compilation.
+  await File(p.join(dir, '.dart_tool', 'package_graph.json')).writeAsString('''
+{
+  "roots": ["test_server"],
+  "packages": [
+    {
+      "name": "test_server",
+      "version": "1.0.0",
+      "dependencies": ["hooks"],
+      "devDependencies": []
+    }
+  ],
+  "configVersion": 1
+}
+''');
+}
+
+String _encodeEntry(Map<String, Object?> entry) {
+  final fields = entry.entries
+      .map((e) => '      "${e.key}": "${e.value}"')
+      .join(',\n');
+  return '    {\n$fields\n    }';
 }
 
 /// Resolves the dart executable from the SDK currently running these tests.

--- a/tools/serverpod_cli/test/commands/start/native_assets_builder_test.dart
+++ b/tools/serverpod_cli/test/commands/start/native_assets_builder_test.dart
@@ -104,62 +104,69 @@ void main() {
     );
   });
 
-  group('Given a project with a build hook that emits no assets', () {
-    late Directory tempDir;
-    late NativeAssetsBuilder builder;
+  group(
+    'Given a project with a build hook that emits no assets',
+    () {
+      late Directory tempDir;
+      late NativeAssetsBuilder builder;
 
-    setUp(() async {
-      tempDir = await Directory.systemTemp.createTemp(
-        'native_assets_builder_hook_test_',
-      );
-      await _createProjectWithBuildHook(
-        dir: tempDir.path,
-        hookBody: '// No assets emitted.',
-      );
-      builder = NativeAssetsBuilder(
-        dartExecutable: _dartExecutable(),
-        serverDir: tempDir.path,
-        outputDir: p.join(tempDir.path, '.dart_tool', 'serverpod', 'na'),
-      );
-    });
-
-    tearDown(() async {
-      await tempDir.deleteWithRetry(recursive: true);
-    });
-
-    test(
-      'when build is called, '
-      'then it returns NativeAssetsBuildSuccess with no manifest',
-      () async {
-        final outcome = await builder.build();
-
-        expect(outcome, isA<NativeAssetsBuildSuccess>());
-        final success = outcome as NativeAssetsBuildSuccess;
-        expect(
-          success.manifestPath,
-          isNull,
-          reason:
-              'A hook that emits no assets should produce no manifest yaml. '
-              'manifestChanged=${success.manifestChanged}',
+      setUp(() async {
+        tempDir = await Directory.systemTemp.createTemp(
+          'native_assets_builder_hook_test_',
         );
-        expect(File(builder.manifestPath).existsSync(), isFalse);
-      },
-      timeout: const Timeout(Duration(minutes: 2)),
-    );
+        await _createProjectWithBuildHook(
+          dir: tempDir.path,
+          hookBody: '// No assets emitted.',
+        );
+        builder = NativeAssetsBuilder(
+          dartExecutable: _dartExecutable(),
+          serverDir: tempDir.path,
+          outputDir: p.join(tempDir.path, '.dart_tool', 'serverpod', 'na'),
+        );
+      });
 
-    test(
-      'when build is called twice, '
-      'then the second call reports the manifest as unchanged',
-      () async {
-        await builder.build();
-        final second = await builder.build();
+      tearDown(() async {
+        await tempDir.deleteWithRetry(recursive: true);
+      });
 
-        expect(second, isA<NativeAssetsBuildSuccess>());
-        expect((second as NativeAssetsBuildSuccess).manifestChanged, isFalse);
-      },
-      timeout: const Timeout(Duration(minutes: 2)),
-    );
-  });
+      test(
+        'when build is called, '
+        'then it returns NativeAssetsBuildSuccess with no manifest',
+        () async {
+          final outcome = await builder.build();
+
+          expect(outcome, isA<NativeAssetsBuildSuccess>());
+          final success = outcome as NativeAssetsBuildSuccess;
+          expect(
+            success.manifestPath,
+            isNull,
+            reason:
+                'A hook that emits no assets should produce no manifest yaml. '
+                'manifestChanged=${success.manifestChanged}',
+          );
+          expect(File(builder.manifestPath).existsSync(), isFalse);
+        },
+        timeout: const Timeout(Duration(minutes: 2)),
+      );
+
+      test(
+        'when build is called twice, '
+        'then the second call reports the manifest as unchanged',
+        () async {
+          await builder.build();
+          final second = await builder.build();
+
+          expect(second, isA<NativeAssetsBuildSuccess>());
+          expect((second as NativeAssetsBuildSuccess).manifestChanged, isFalse);
+        },
+        timeout: const Timeout(Duration(minutes: 2)),
+      );
+    },
+    skip: Platform.isWindows
+        ? 'hooks_runner subprocesses keep .dart_tool handles open on Windows '
+              'long enough to race tearDown — see CI run 25155561001'
+        : null,
+  );
 }
 
 /// Creates a Dart workspace at [rootDir] with one member at [memberDir].

--- a/tools/serverpod_cli/test/commands/start/native_assets_builder_test.dart
+++ b/tools/serverpod_cli/test/commands/start/native_assets_builder_test.dart
@@ -5,6 +5,8 @@ import 'package:path/path.dart' as p;
 import 'package:serverpod_cli/src/commands/start/native_assets_builder.dart';
 import 'package:test/test.dart';
 
+import '../../test_util/file_system_entity_helpers.dart';
+
 void main() {
   group('Given a project with no packages that have build hooks', () {
     late Directory tempDir;
@@ -23,9 +25,7 @@ void main() {
     });
 
     tearDown(() async {
-      if (await tempDir.exists()) {
-        await tempDir.delete(recursive: true);
-      }
+      await tempDir.deleteWithRetry(recursive: true);
     });
 
     test(
@@ -83,9 +83,7 @@ void main() {
     });
 
     tearDown(() async {
-      if (await tempDir.exists()) {
-        await tempDir.delete(recursive: true);
-      }
+      await tempDir.deleteWithRetry(recursive: true);
     });
 
     test(
@@ -126,9 +124,7 @@ void main() {
     });
 
     tearDown(() async {
-      if (await tempDir.exists()) {
-        await tempDir.delete(recursive: true);
-      }
+      await tempDir.deleteWithRetry(recursive: true);
     });
 
     test(

--- a/tools/serverpod_cli/test/commands/start/native_assets_builder_test.dart
+++ b/tools/serverpod_cli/test/commands/start/native_assets_builder_test.dart
@@ -89,30 +89,17 @@ void main() {
     });
 
     test(
-      'when discoverPaths is called from the member dir, '
-      'then it returns the workspace root pubspec and package_config',
+      'when discoverProjectRoot is called from the member dir, '
+      'then it walks up to the workspace root',
       () async {
-        final paths = await builder.discoverPaths();
+        final root = await builder.discoverProjectRoot();
 
         expect(
-          p.equals(
-            paths.workspacePubspecPath,
-            p.join(tempDir.path, 'pubspec.yaml'),
-          ),
+          p.equals(root, tempDir.path),
           isTrue,
           reason:
-              'workspacePubspecPath should be the root pubspec, not the '
-              'member pubspec. Got: ${paths.workspacePubspecPath}',
-        );
-        expect(
-          p.equals(
-            paths.packageConfigPath,
-            p.join(tempDir.path, '.dart_tool', 'package_config.json'),
-          ),
-          isTrue,
-          reason:
-              'packageConfigPath should be at the workspace root .dart_tool/. '
-              'Got: ${paths.packageConfigPath}',
+              'Project root should be the workspace root, not the member '
+              'dir. Got: $root',
         );
       },
       timeout: const Timeout(Duration(seconds: 60)),

--- a/tools/serverpod_cli/test/commands/start/native_assets_builder_test.dart
+++ b/tools/serverpod_cli/test/commands/start/native_assets_builder_test.dart
@@ -1,0 +1,120 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:serverpod_cli/src/commands/start/native_assets_builder.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Given a project with no packages that have build hooks', () {
+    late Directory tempDir;
+    late NativeAssetsBuilder builder;
+
+    setUp(() async {
+      tempDir = await Directory.systemTemp.createTemp(
+        'native_assets_builder_test_',
+      );
+      await _createMinimalDartProject(tempDir.path);
+      builder = NativeAssetsBuilder(
+        dartExecutable: _dartExecutable(),
+        serverDir: tempDir.path,
+        packageConfigPath: p.join(
+          tempDir.path,
+          '.dart_tool',
+          'package_config.json',
+        ),
+        outputDir: p.join(tempDir.path, '.dart_tool', 'serverpod', 'na'),
+      );
+    });
+
+    tearDown(() async {
+      if (await tempDir.exists()) {
+        await tempDir.delete(recursive: true);
+      }
+    });
+
+    test(
+      'when build is called, '
+      'then it returns NativeAssetsBuildSkipped',
+      () async {
+        final outcome = await builder.build();
+        expect(outcome, isA<NativeAssetsBuildSkipped>());
+      },
+      timeout: const Timeout(Duration(seconds: 60)),
+    );
+
+    test(
+      'when build is called, '
+      'then no manifest yaml is written',
+      () async {
+        await builder.build();
+        expect(File(builder.manifestPath).existsSync(), isFalse);
+      },
+      timeout: const Timeout(Duration(seconds: 60)),
+    );
+
+    test(
+      'when build is called twice, '
+      'then both calls succeed without error',
+      () async {
+        final first = await builder.build();
+        final second = await builder.build();
+        expect(first, isA<NativeAssetsBuildSkipped>());
+        expect(second, isA<NativeAssetsBuildSkipped>());
+      },
+      timeout: const Timeout(Duration(seconds: 60)),
+    );
+  });
+}
+
+/// Creates a minimal Dart project with `pubspec.yaml` and a
+/// `package_config.json` that has no packages with `hook/` directories. This
+/// is the smallest input the hook runner accepts.
+Future<void> _createMinimalDartProject(String dir) async {
+  await Directory('$dir/.dart_tool').create(recursive: true);
+
+  await File('$dir/pubspec.yaml').writeAsString('''
+name: test_server
+environment:
+  sdk: ^3.0.0
+''');
+
+  await File('$dir/.dart_tool/package_config.json').writeAsString('''
+{
+  "configVersion": 2,
+  "packages": [
+    {
+      "name": "test_server",
+      "rootUri": "..",
+      "packageUri": "lib/"
+    }
+  ]
+}
+''');
+
+  // hooks_runner asserts this file exists alongside package_config.json.
+  await File('$dir/.dart_tool/package_graph.json').writeAsString('''
+{
+  "roots": ["test_server"],
+  "packages": [
+    {
+      "name": "test_server",
+      "version": "1.0.0",
+      "dependencies": [],
+      "devDependencies": []
+    }
+  ],
+  "configVersion": 1
+}
+''');
+}
+
+/// Resolves the dart executable from the SDK currently running these tests.
+String _dartExecutable() {
+  final exe = Platform.resolvedExecutable;
+  // When tests run under `dart test`, resolvedExecutable is dart itself.
+  // When run under dartaotruntime (e.g. via the AOT serverpod CLI), prefer
+  // the sibling `dart` binary in the same SDK bin directory.
+  if (p.basenameWithoutExtension(exe) == 'dart') return exe;
+  final dir = p.dirname(exe);
+  return p.join(dir, Platform.isWindows ? 'dart.exe' : 'dart');
+}

--- a/tools/serverpod_cli/test/test_util/file_system_entity_helpers.dart
+++ b/tools/serverpod_cli/test/test_util/file_system_entity_helpers.dart
@@ -1,0 +1,26 @@
+import 'dart:io';
+
+extension FileSystemEntityDeleteWithRetry on FileSystemEntity {
+  /// Deletes this entity, retrying briefly on failures
+  ///
+  /// POSIX permits unlinking files with open handles, so this is effectively a
+  /// single delete on macOS/Linux. On Windows that would raise a [PathAccessException].
+  /// Hence, due to how file handles can linger a bit after a process exits a regular
+  /// [delete] can race with process exit on Windows.
+  Future<void> deleteWithRetry({
+    bool recursive = false,
+    int attempts = 10,
+    Duration delay = const Duration(milliseconds: 200),
+  }) async {
+    if (!await exists()) return;
+    for (var i = 0; i < attempts; i++) {
+      try {
+        await delete(recursive: recursive);
+        return;
+      } on PathAccessException {
+        if (i == attempts - 1) rethrow;
+        await Future<void>.delayed(delay);
+      }
+    }
+  }
+}

--- a/tools/serverpod_cli/test/test_util/file_system_entity_helpers.dart
+++ b/tools/serverpod_cli/test/test_util/file_system_entity_helpers.dart
@@ -9,10 +9,12 @@ extension FileSystemEntityDeleteWithRetry on FileSystemEntity {
   /// [delete] can race with process exit on Windows.
   Future<void> deleteWithRetry({
     bool recursive = false,
-    int attempts = 10,
-    Duration delay = const Duration(milliseconds: 200),
+    int attempts = 30,
+    Duration initialDelay = const Duration(milliseconds: 100),
+    Duration maxDelay = const Duration(seconds: 2),
   }) async {
     if (!await exists()) return;
+    var delay = initialDelay;
     for (var i = 0; i < attempts; i++) {
       try {
         await delete(recursive: recursive);
@@ -20,6 +22,8 @@ extension FileSystemEntityDeleteWithRetry on FileSystemEntity {
       } on PathAccessException {
         if (i == attempts - 1) rethrow;
         await Future<void>.delayed(delay);
+        final next = delay * 2;
+        delay = next > maxDelay ? maxDelay : next;
       }
     }
   }


### PR DESCRIPTION
Adds support for `package:native_assets` build hooks to the Serverpod CLI so that server packages depending on FFI libraries with `hook/build.dart` scripts (fx `package:sqlite3`) actually build and load their native assets when running `serverpod start`.

`dart compile` refuses build hooks and `frontend_server` does not know about them, so we drive `package:hooks_runner` ourselves and feed the resulting `native_assets.yaml` to `frontend_server` via the existing `--native-assets` flag. 

`--no-fes` mode is unaffected - it already goes through `dart run`/dartdev which handles hooks natively.

Highlights:
- New `NativeAssetsBuilder` that wraps `hooks_runner`, bundles assets, and writes `.dart_tool/serverpod/native_assets.yaml` (only when content changes).
- `WatchSession` reruns hooks per reload cycle and restarts the frontend server when the manifest changes; migrations and IDE `reloadSources` callbacks rerun hooks too.
- `KernelCompiler` / `FrontendServerClient` plumbed with a mutable `nativeAssetsPath`.
- Workspace-aware package_config discovery: walks up from the server dir to the first pubspec with `resolution != 'workspace'`.
- Vendored `bundleNativeAssets`, `writeNativeAssetsYaml`, and the macOS install-name rewriter from dartdev (BSD-attributed) since they are not exported by `package:hooks_runner` and dartdev itself is unpublishable.
- New deps: `hooks_runner`, `hooks`, `code_assets`, `data_assets`, `file`, `logging`; `pubspec_parse` bumped for `PubSpec.resolution`.

Fixes: #?

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None. `--native-assets` plumbing in `KernelCompiler`/`FrontendServerClient` is opt-in via an optional parameter, and behavior is unchanged when no server package declares build hooks.
