### PR TITLE
feat: Add custom serverpod dap that forward hot-reload to serverpod start

### DIFF
--- a/templates/pubspecs/tools/serverpod_cli/pubspec.yaml
+++ b/templates/pubspecs/tools/serverpod_cli/pubspec.yaml
@@ -28,6 +28,13 @@ dependencies:
   # details, see: https://github.com/dart-lang/dart_style/issues/1785
   dart_style: 3.1.5
   data_assets: '>=0.19.0 <0.20.0'
+  # dds is the Dart Development Service. We only use its DAP exports
+  # (DartCliDebugAdapter and friends) for the `serverpod dap` subcommand.
+  # Pinned to ^5.0.3 (the version flutter 3.38.1 shipped with) to keep this
+  # CLI installable alongside the broadest set of editor toolchains. The
+  # `package:dds/src/dap/...` import we rely on is identical across 5.0.3
+  # through 5.3.0; if a future 5.x release moves the file, CI catches it.
+  dds: ^5.0.3
   file: ^7.0.1
   hooks: ^1.0.0
   hooks_runner: ^1.2.1

--- a/tools/serverpod_cli/bin/serverpod_cli.dart
+++ b/tools/serverpod_cli/bin/serverpod_cli.dart
@@ -8,6 +8,7 @@ import 'package:serverpod_cli/src/commands/analyze_pubspecs.dart';
 import 'package:serverpod_cli/src/commands/create.dart';
 import 'package:serverpod_cli/src/commands/create_migration.dart';
 import 'package:serverpod_cli/src/commands/create_repair_migration.dart';
+import 'package:serverpod_cli/src/commands/dap.dart';
 import 'package:serverpod_cli/src/commands/generate.dart';
 import 'package:serverpod_cli/src/commands/generate_pubspecs.dart';
 import 'package:serverpod_cli/src/commands/language_server.dart';
@@ -114,6 +115,7 @@ ServerpodCommandRunner buildCommandRunner() {
     AnalyzePubspecsCommand(),
     CreateCommand(),
     QuickstartCommand(),
+    DapCommand(),
     GenerateCommand(),
     GeneratePubspecsCommand(),
     LanguageServerCommand(),

--- a/tools/serverpod_cli/lib/src/commands/dap.dart
+++ b/tools/serverpod_cli/lib/src/commands/dap.dart
@@ -1,0 +1,71 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:config/config.dart';
+import 'package:dds/dap.dart';
+import 'package:serverpod_cli/src/dap/serverpod_debug_adapter.dart';
+import 'package:serverpod_cli/src/runner/serverpod_command.dart';
+
+/// Options for the `dap` command. Currently mirrors the subset of
+/// `dart debug_adapter`'s options that we forward to the underlying adapter.
+enum DapOption<V> implements OptionDefinition<V> {
+  ipv6(
+    FlagOption(
+      argName: 'ipv6',
+      defaultsTo: false,
+      negatable: false,
+      helpText: 'Whether to bind DAP/VM Service connections to IPv6 addresses.',
+    ),
+  )
+  ;
+
+  const DapOption(this.option);
+
+  @override
+  final ConfigOptionBase<V> option;
+}
+
+/// `serverpod dap` - spawns a Debug Adapter Protocol server on stdin/stdout
+/// for editors (currently the serverpod VS Code extension).
+///
+/// Hidden because end users invoke it via launch.json, not directly.
+class DapCommand extends ServerpodCommand<DapOption> {
+  static const String commandName = 'dap';
+
+  @override
+  final name = commandName;
+
+  @override
+  bool get hidden => true;
+
+  @override
+  final description =
+      'Start a Debug Adapter Protocol server for serverpod, intended to be '
+      'launched by an editor as the debug adapter for `type: "serverpod"`.';
+
+  DapCommand() : super(options: DapOption.values);
+
+  @override
+  Future<void> runWithConfig(Configuration<DapOption> commandConfig) async {
+    final ipv6 = commandConfig.value(DapOption.ipv6);
+
+    // The non-blocking sink can fail mid-flush when the editor disconnects;
+    // the failure is benign at shutdown. Match `dart debug_adapter`'s
+    // behaviour and swallow it explicitly.
+    unawaited(stdout.nonBlocking.done.catchError((Object _) {}));
+
+    final channel = ByteStreamServerChannel(stdin, stdout.nonBlocking, null);
+    ServerpodDebugAdapter(
+      channel,
+      ipv6: ipv6,
+      onError: (e) => stderr.writeln(
+        'Input could not be parsed as a Debug Adapter Protocol message.\n'
+        'The `serverpod dap` command is intended to be invoked by an editor '
+        'using the Debug Adapter Protocol.\n\n'
+        '$e',
+      ),
+    );
+
+    await channel.closed;
+  }
+}

--- a/tools/serverpod_cli/lib/src/commands/dap.dart
+++ b/tools/serverpod_cli/lib/src/commands/dap.dart
@@ -3,11 +3,14 @@ import 'dart:io';
 
 import 'package:config/config.dart';
 import 'package:dds/dap.dart';
+import 'package:path/path.dart' as p;
 import 'package:serverpod_cli/src/dap/serverpod_debug_adapter.dart';
 import 'package:serverpod_cli/src/runner/serverpod_command.dart';
+import 'package:serverpod_cli/src/util/file_ex.dart';
+import 'package:serverpod_cli/src/util/platform_check.dart';
+import 'package:serverpod_cli/src/util/server_directory_finder.dart';
 
-/// Options for the `dap` command. Currently mirrors the subset of
-/// `dart debug_adapter`'s options that we forward to the underlying adapter.
+/// Options for the `dap` command.
 enum DapOption<V> implements OptionDefinition<V> {
   ipv6(
     FlagOption(
@@ -25,12 +28,41 @@ enum DapOption<V> implements OptionDefinition<V> {
   final ConfigOptionBase<V> option;
 }
 
-/// `serverpod dap` - spawns a Debug Adapter Protocol server on stdin/stdout
-/// for editors (currently the serverpod VS Code extension).
+/// `serverpod dap` - runs a Debug Adapter Protocol server.
+///
+/// Picks a transport at startup and announces it on stderr so the launching
+/// extension knows how to connect:
+///
+/// - When [hasUnixSocketSupport] holds (macOS / Linux always; Windows on
+///   Dart 3.11+) and the server package can be discovered, binds a Unix
+///   domain socket at `<server-dir>/.dart_tool/serverpod/dap.sock` and
+///   announces `SERVERPOD_DAP_SOCKET=<path>`. The extension connects via
+///   VS Code's `DebugAdapterNamedPipeServer`.
+/// - Otherwise announces `SERVERPOD_DAP_STDIO` and speaks DAP on
+///   stdin/stdout. The extension drops its monitoring spawn and returns
+///   `DebugAdapterExecutable` so VS Code respawns the CLI with its own
+///   stdio framing.
+///
+/// UDS is preferred over TCP because TCP loopback is reachable by every
+/// local process, while UDS access is restricted by file permissions
+/// (default umask 022 makes the socket 0644 = owner-only-connect, since
+/// UDS `connect()` needs write permission).
 ///
 /// Hidden because end users invoke it via launch.json, not directly.
 class DapCommand extends ServerpodCommand<DapOption> {
   static const String commandName = 'dap';
+
+  /// Marker prefix written to stderr when UDS is the chosen transport. The
+  /// full line is `SERVERPOD_DAP_SOCKET=<absolute-path>`. The literal is
+  /// also matched on the extension side; if you change it here, update
+  /// `tools/serverpod_vscode_extension/src/debug.ts` to match.
+  static const String socketAnnouncement = 'SERVERPOD_DAP_SOCKET';
+
+  /// Marker line written to stderr when stdio is the chosen transport. The
+  /// extension responds by killing this process and returning
+  /// `DebugAdapterExecutable` so VS Code respawns with managed stdio
+  /// framing.
+  static const String stdioAnnouncement = 'SERVERPOD_DAP_STDIO';
 
   @override
   final name = commandName;
@@ -49,23 +81,117 @@ class DapCommand extends ServerpodCommand<DapOption> {
   Future<void> runWithConfig(Configuration<DapOption> commandConfig) async {
     final ipv6 = commandConfig.value(DapOption.ipv6);
 
+    if (await _tryRunOverUnixSocket(ipv6: ipv6)) return;
+    await _runOverStdio(ipv6: ipv6);
+  }
+
+  /// Attempts UDS transport. Returns `true` if the session ran on UDS;
+  /// `false` if UDS isn't available on this platform, the server package
+  /// could not be discovered, or the bind itself failed - the caller
+  /// should fall back to stdio.
+  Future<bool> _tryRunOverUnixSocket({required bool ipv6}) async {
+    if (!hasUnixSocketSupport()) return false;
+
+    final Directory serverDir;
+    try {
+      serverDir = await ServerDirectoryFinder.findOrPrompt(interactive: false);
+    } on Object {
+      return false;
+    }
+
+    final socketPath = p.join(
+      serverDir.path,
+      '.dart_tool',
+      'serverpod',
+      'dap.sock',
+    );
+    await Directory(p.dirname(socketPath)).create(recursive: true);
+
+    final ServerSocket server;
+    try {
+      server = await bindUnixSocket(socketPath);
+    } on Object {
+      return false;
+    }
+
+    // Subscribe before announcing so a fast SIGTERM between announce and
+    // the first await still cleans up the socket file.
+    final signalSubs = _registerSignalCleanup(socketPath);
+
+    stderr.writeln('$socketAnnouncement=$socketPath');
+    await stderr.flush();
+
+    try {
+      // The launcher opens exactly one connection per debug session.
+      final socket = await server.first;
+      await server.close();
+
+      // Socket is Stream<Uint8List>; ByteStreamServerChannel's transformer
+      // expects Stream<List<int>>. The cast adapts the runtime stream type
+      // (Uint8List IS-A List<int>, but transformers are contravariant in
+      // the input parameter so the static types don't unify).
+      final channel = ByteStreamServerChannel(
+        socket.cast<List<int>>(),
+        socket,
+        null,
+      );
+      ServerpodDebugAdapter(channel, ipv6: ipv6, onError: _onProtocolError);
+
+      await channel.closed;
+      await socket.close();
+    } finally {
+      for (final sub in signalSubs) {
+        await sub.cancel();
+      }
+      await File(socketPath).deleteIfExists();
+    }
+    return true;
+  }
+
+  Future<void> _runOverStdio({required bool ipv6}) async {
+    stderr.writeln(stdioAnnouncement);
+    await stderr.flush();
+
     // The non-blocking sink can fail mid-flush when the editor disconnects;
     // the failure is benign at shutdown. Match `dart debug_adapter`'s
     // behaviour and swallow it explicitly.
     unawaited(stdout.nonBlocking.done.catchError((Object _) {}));
 
     final channel = ByteStreamServerChannel(stdin, stdout.nonBlocking, null);
-    ServerpodDebugAdapter(
-      channel,
-      ipv6: ipv6,
-      onError: (e) => stderr.writeln(
-        'Input could not be parsed as a Debug Adapter Protocol message.\n'
-        'The `serverpod dap` command is intended to be invoked by an editor '
-        'using the Debug Adapter Protocol.\n\n'
-        '$e',
-      ),
-    );
+    ServerpodDebugAdapter(channel, ipv6: ipv6, onError: _onProtocolError);
 
     await channel.closed;
+  }
+
+  /// Registers SIGTERM/SIGINT handlers that unlink [socketPath] before
+  /// exiting. Skips signals that aren't deliverable on the current
+  /// platform (SIGTERM on Windows).
+  List<StreamSubscription<ProcessSignal>> _registerSignalCleanup(
+    String socketPath,
+  ) {
+    final subs = <StreamSubscription<ProcessSignal>>[];
+    void handle(ProcessSignal sig) {
+      try {
+        File(socketPath).deleteSync();
+      } on FileSystemException catch (_) {
+        // Already gone (race with normal cleanup) - nothing to do.
+      }
+      exit(sig == ProcessSignal.sigint ? 130 : 143);
+    }
+
+    subs.add(ProcessSignal.sigint.watch().listen(handle));
+    if (!Platform.isWindows) {
+      subs.add(ProcessSignal.sigterm.watch().listen(handle));
+    }
+    return subs;
+  }
+
+  void _onProtocolError(Object e) {
+    stderr.writeln(
+      'Input could not be parsed as a Debug Adapter Protocol message.\n'
+      'The `serverpod dap` command is intended to be invoked by an editor '
+      'using the Debug Adapter Protocol.\n\n'
+      '$e',
+    );
   }
 }

--- a/tools/serverpod_cli/lib/src/commands/dap.dart
+++ b/tools/serverpod_cli/lib/src/commands/dap.dart
@@ -35,9 +35,10 @@ enum DapOption<V> implements OptionDefinition<V> {
 ///
 /// - When [hasUnixSocketSupport] holds (macOS / Linux always; Windows on
 ///   Dart 3.11+) and the server package can be discovered, binds a Unix
-///   domain socket at `<server-dir>/.dart_tool/serverpod/dap.sock` and
-///   announces `SERVERPOD_DAP_SOCKET=<path>`. The extension connects via
-///   VS Code's `DebugAdapterNamedPipeServer`.
+///   domain socket at `<systemTemp>/serverpod-dap-<hash>.sock` (hashed by
+///   the absolute server-dir path so projects don't collide) and announces
+///   `SERVERPOD_DAP_SOCKET=<path>`. The extension connects via VS Code's
+///   `DebugAdapterNamedPipeServer`.
 /// - Otherwise announces `SERVERPOD_DAP_STDIO` and speaks DAP on
 ///   stdin/stdout. The extension drops its monitoring spawn and returns
 ///   `DebugAdapterExecutable` so VS Code respawns the CLI with its own
@@ -99,13 +100,23 @@ class DapCommand extends ServerpodCommand<DapOption> {
       return false;
     }
 
+    // Socket lives in systemTemp, not under the server's .dart_tool/, because
+    // macOS limits sockaddr_un.sun_path to 104 bytes (incl. NUL): a typical
+    // <home>/Projects/.../<name>_server/.dart_tool/serverpod/dap.sock easily
+    // exceeds that. bindUnixSocket's shortestPath helper makes our bind side
+    // fit by going relative, but the announcement (and VS Code's connect on
+    // it) is absolute - which hits the limit on the client. systemTemp gives
+    // a short, predictable base on every platform. It is also already a
+    // per-user directory on macOS (0700) and Windows (per-user ACL); on Linux
+    // /tmp is world-traversable but the socket file inherits umask 022 -> 0644
+    // which denies connect to non-owners (UDS connect needs write).
+    final hash = serverDir.absolute.path.hashCode
+        .toUnsigned(32)
+        .toRadixString(36);
     final socketPath = p.join(
-      serverDir.path,
-      '.dart_tool',
-      'serverpod',
-      'dap.sock',
+      Directory.systemTemp.path,
+      'serverpod-dap-$hash.sock',
     );
-    await Directory(p.dirname(socketPath)).create(recursive: true);
 
     final ServerSocket server;
     try {

--- a/tools/serverpod_cli/lib/src/commands/start.dart
+++ b/tools/serverpod_cli/lib/src/commands/start.dart
@@ -486,6 +486,11 @@ Future<int> _startWatchSession({
   NativeAssetsBuilder? nativeAssetsBuilder;
   ServerProcessFactory? serverProcessFactory;
   ServerProcess initialServerProcess;
+  // Late-initialised so the serverProcessFactory closure can reference it
+  // before the WatchSession is constructed below; the closure body is only
+  // evaluated when a VM service client invokes serverpod-cli.hotReload,
+  // by which point this is assigned.
+  late final WatchSession session;
 
   if (noFes) {
     // No compiler - the IDE handles compilation and hot reload.
@@ -562,6 +567,8 @@ Future<int> _startWatchSession({
             enableVmService: true,
             vmServiceInfoFile: vmServiceInfoFile,
             onReloadRequested: onReloadRequested,
+            onHotReload: () => session.forceReload(),
+            onHotRestart: () => session.forceRestart(),
           );
           await serverProcess.start(dillPath: dillPath);
           await serverProcess.connectToVmService();
@@ -578,7 +585,7 @@ Future<int> _startWatchSession({
     nativeAssetsBuilder = localBuilder;
   }
 
-  final session = WatchSession(
+  session = WatchSession(
     compiler: compiler,
     nativeAssetsBuilder: nativeAssetsBuilder,
     generate: generate,
@@ -871,6 +878,12 @@ Future<void> _runTuiBackend({
       return result.dillOutput ?? initialDill;
     }
 
+    // Late-initialised so the serverProcessFactory closure can reference it
+    // before the WatchSession is constructed below; the closure body is only
+    // evaluated when a VM service client invokes serverpod-cli.hotReload,
+    // by which point this is assigned.
+    late final WatchSession session;
+
     // Server process factory. Subscribes to VM service extension events
     // on each new server process so restarts pick up the new connection.
     ServerProcessFactory serverProcessFactory;
@@ -886,6 +899,8 @@ Future<void> _runTuiBackend({
             enableVmService: true,
             vmServiceInfoFile: vmServiceInfoFile,
             onReloadRequested: onReloadRequested,
+            onHotReload: () => session.forceReload(),
+            onHotRestart: () => session.forceRestart(),
             stdoutSink: stdoutSink,
             stderrSink: stderrSink,
           );
@@ -910,7 +925,7 @@ Future<void> _runTuiBackend({
     });
 
     // Create watch session.
-    final session = WatchSession(
+    session = WatchSession(
       compiler: compiler,
       nativeAssetsBuilder: nativeAssetsBuilder,
       generate: (affectedPaths, requirements) async {

--- a/tools/serverpod_cli/lib/src/commands/start/server_process.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/server_process.dart
@@ -23,6 +23,16 @@ String vmServiceWsUri(String httpUri) {
 /// on compilation failure.
 typedef ReloadRequestedCallback = Future<String?> Function();
 
+/// Callback for the registered `serverpod-cli.hotReload` VM service method.
+/// Runs the full watch-session reload pipeline (codegen + hooks + compile +
+/// reload). Throws to signal failure to the caller.
+typedef HotReloadCallback = Future<void> Function();
+
+/// Callback for the registered `serverpod-cli.hotRestart` VM service method.
+/// Runs a full recompile and stops/starts the server subprocess - the
+/// restart counterpart to [HotReloadCallback]. Throws on failure.
+typedef HotRestartCallback = Future<void> Function();
+
 /// Manages the server subprocess lifecycle.
 ///
 /// Handles spawning, signal forwarding, output streaming, graceful shutdown,
@@ -37,6 +47,14 @@ class ServerProcess {
 
   /// Callback invoked when an IDE requests a reload via the VM service.
   final ReloadRequestedCallback? _onReloadRequested;
+
+  /// Callback invoked when a client (typically `serverpod_dap`) calls the
+  /// registered `serverpod-cli.hotReload` VM service method.
+  final HotReloadCallback? _onHotReload;
+
+  /// Callback invoked when a client (typically `serverpod_dap`) calls the
+  /// registered `serverpod-cli.hotRestart` VM service method.
+  final HotRestartCallback? _onHotRestart;
 
   /// Path to write the VM service info JSON file to. When set, the file
   /// is passed to the child via `--write-service-info` and the URI is read
@@ -69,6 +87,8 @@ class ServerProcess {
     IOSink? stdoutSink,
     IOSink? stderrSink,
     ReloadRequestedCallback? onReloadRequested,
+    HotReloadCallback? onHotReload,
+    HotRestartCallback? onHotRestart,
   }) : _serverDir = serverDir,
        _serverArgs = serverArgs,
        _dartExecutable = dartExecutable ?? p.join(getSdkPath(), 'bin', 'dart'),
@@ -76,7 +96,9 @@ class ServerProcess {
        _vmServiceInfoFile = vmServiceInfoFile,
        _stdout = stdoutSink ?? stdout,
        _stderr = stderrSink ?? stderr,
-       _onReloadRequested = onReloadRequested;
+       _onReloadRequested = onReloadRequested,
+       _onHotReload = onHotReload,
+       _onHotRestart = onHotRestart;
 
   /// Whether the server process is currently running.
   bool get isRunning => _process != null;
@@ -213,7 +235,7 @@ class ServerProcess {
     // Register custom reloadSources service so IDE reload requests
     // go through the FES compilation pipeline.
     if (_onReloadRequested != null) {
-      vmService.registerServiceCallback('reloadSources', (params) async {
+      await _registerCliService(vmService, 'reloadSources', (params) async {
         final dillPath = await _onReloadRequested();
         if (dillPath == null) {
           return {'type': 'ReloadReport', 'success': false};
@@ -225,8 +247,54 @@ class ServerProcess {
         );
         return report.json!;
       });
-      await vmService.registerService('reloadSources', 'serverpod-cli');
     }
+
+    // Register `serverpod-cli.hotReload` so `serverpod_dap` (and any other
+    // VM service client) can drive the full watch-session reload pipeline
+    // - codegen, hooks, compile, reload - rather than calling the VM's
+    // built-in `reloadSources` and bypassing it.
+    if (_onHotReload != null) {
+      await _registerCliService(vmService, 'hotReload', (params) async {
+        try {
+          await _onHotReload();
+          return {'type': 'Success'};
+        } on Object catch (e) {
+          throw RPCError(
+            'serverpod-cli.hotReload',
+            RPCErrorKind.kInternalError.code,
+            e.toString(),
+          );
+        }
+      });
+    }
+
+    // Hot restart counterpart: full recompile + restart the server
+    // subprocess. Registered separately so DAP clients can route VS Code's
+    // "Restart" button to a true restart instead of a reload.
+    if (_onHotRestart != null) {
+      await _registerCliService(vmService, 'hotRestart', (params) async {
+        try {
+          await _onHotRestart();
+          return {'type': 'Success'};
+        } on Object catch (e) {
+          throw RPCError(
+            'serverpod-cli.hotRestart',
+            RPCErrorKind.kInternalError.code,
+            e.toString(),
+          );
+        }
+      });
+    }
+  }
+
+  /// Registers a VM service method under the `serverpod-cli` alias.
+  static Future<void> _registerCliService(
+    VmService vmService,
+    String name,
+    Future<Map<String, dynamic>> Function(Map<String, dynamic>) callback,
+  ) async {
+    vmService.registerServiceCallback(name, callback);
+    await vmService.registerService(name, 'serverpod-cli');
   }
 
   /// Hot reloads the server with a new kernel file.

--- a/tools/serverpod_cli/lib/src/commands/start/watch_session.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/watch_session.dart
@@ -394,6 +394,55 @@ class WatchSession {
     return _pending;
   }
 
+  /// Forces a full recompile and restarts the server subprocess.
+  ///
+  /// Counterpart to [forceReload] for the "hot restart" path: tear down the
+  /// running server, build a fresh dill, start a new process. Used by the
+  /// DAP `hotRestart` custom request so VS Code's restart button actually
+  /// restarts instead of reloading.
+  Future<void> forceRestart() {
+    if (_state == SessionState.disposed) {
+      throw StateError('Session has been disposed.');
+    }
+    final compiler = _compiler;
+    final createServer = _createServer;
+    if (compiler == null || createServer == null) {
+      throw StateError('Cannot force restart in --no-fes mode.');
+    }
+    _pending = _pending.then((_) => _forceRestart(compiler, createServer));
+    return _pending;
+  }
+
+  Future<void> _forceRestart(
+    KernelCompiler compiler,
+    ServerProcessFactory createServer,
+  ) async {
+    if (_state == SessionState.disposed) {
+      throw StateError('Session has been disposed.');
+    }
+
+    _state = SessionState.restarting;
+    try {
+      await compiler.reset();
+      final result = await compileWithProgress(
+        'Compiling server',
+        compiler,
+        rejectOnFailure: true,
+      );
+      if (result == null) {
+        throw StateError('Compilation failed. Server not restarted.');
+      }
+      compiler.accept();
+
+      await _server.stop();
+      _server = await createServer(result.dillOutput!);
+      _monitorExit(_server);
+      log.info(serverRestarted);
+    } finally {
+      _state = SessionState.idle;
+    }
+  }
+
   /// Restarts the server with `--apply-migrations` (one-shot).
   ///
   /// If another restart or migration is in progress, this call waits for it

--- a/tools/serverpod_cli/lib/src/dap/serverpod_debug_adapter.dart
+++ b/tools/serverpod_cli/lib/src/dap/serverpod_debug_adapter.dart
@@ -1,0 +1,22 @@
+// `DartCliDebugAdapter` is the right base class but it lives in `dds/src/`
+// and isn't re-exported from `package:dds/dap.dart`. Subclassing it is what
+// flutter_tools does for its own DAP, and pinning `dds: ^5.3.0` (matched to
+// the SDK floor) bounds the risk that the surface changes under us.
+// ignore: implementation_imports
+import 'package:dds/src/dap/adapters/dart_cli_adapter.dart';
+
+/// Serverpod's Debug Adapter.
+///
+/// Currently a thin pass-through over [DartCliDebugAdapter]; the next step
+/// adds a `customRequest` override that routes `hotReload` / `hotRestart`
+/// from the IDE through a `serverpod-cli.hotReload` VM service method
+/// registered by the running `serverpod start` process. Until that override
+/// lands, this class behaves exactly like the stock Dart adapter.
+class ServerpodDebugAdapter extends DartCliDebugAdapter {
+  ServerpodDebugAdapter(
+    super.channel, {
+    super.ipv6,
+    super.logger,
+    super.onError,
+  });
+}

--- a/tools/serverpod_cli/lib/src/dap/serverpod_debug_adapter.dart
+++ b/tools/serverpod_cli/lib/src/dap/serverpod_debug_adapter.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:dds/dap.dart';
 // `DartCliDebugAdapter` is the right base class but it lives in `dds/src/`
 // and isn't re-exported from `package:dds/dap.dart`. Subclassing it is what
@@ -5,6 +7,8 @@ import 'package:dds/dap.dart';
 // the SDK floor) bounds the risk that the surface changes under us.
 // ignore: implementation_imports
 import 'package:dds/src/dap/adapters/dart_cli_adapter.dart';
+import 'package:path/path.dart' as p;
+import 'package:serverpod_cli/src/util/server_directory_finder.dart';
 import 'package:vm_service/vm_service.dart' as vm;
 
 /// Service alias the `serverpod start` process uses when it registers its
@@ -39,6 +43,65 @@ class ServerpodDebugAdapter extends DartCliDebugAdapter {
     super.logger,
     super.onError,
   });
+
+  /// Enriches incoming attach args with `cwd` and `vmServiceInfoFile`
+  /// derived from [ServerDirectoryFinder] so the user's launch.json can be
+  /// just `{name, type: 'serverpod', request: 'attach'}`. Both fields are
+  /// only filled when missing - a user-supplied value always wins.
+  ///
+  /// `args` is `late final` on the base class, so we substitute an enriched
+  /// copy *before* delegating to super (which sets it).
+  @override
+  Future<void> attachRequest(
+    Request request,
+    DartAttachRequestArguments args,
+    void Function() sendResponse,
+  ) async {
+    final enriched = await _enrichAttachArgs(args);
+    return super.attachRequest(request, enriched, sendResponse);
+  }
+
+  Future<DartAttachRequestArguments> _enrichAttachArgs(
+    DartAttachRequestArguments args,
+  ) async {
+    final hasUri = args.vmServiceUri != null;
+    final hasInfoFile = args.vmServiceInfoFile != null;
+    final hasCwd = args.cwd != null;
+    if (hasCwd && (hasUri || hasInfoFile)) return args;
+
+    // Only run the directory walk when we actually need a server dir.
+    // If the user already provided cwd, derive vmServiceInfoFile from it.
+    if (hasCwd) {
+      final json = Map<String, Object?>.from(args.toJson());
+      json['vmServiceInfoFile'] = p.join(
+        args.cwd!,
+        '.dart_tool',
+        'serverpod',
+        'vm-service-info.json',
+      );
+      return DartAttachRequestArguments.fromJson(json);
+    }
+
+    final Directory dir;
+    try {
+      dir = await ServerDirectoryFinder.findOrPrompt(interactive: false);
+    } on Object {
+      // Discovery failed; let the base adapter raise its standard error.
+      return args;
+    }
+
+    final json = Map<String, Object?>.from(args.toJson());
+    json['cwd'] = dir.path;
+    if (!hasUri && !hasInfoFile) {
+      json['vmServiceInfoFile'] = p.join(
+        dir.path,
+        '.dart_tool',
+        'serverpod',
+        'vm-service-info.json',
+      );
+    }
+    return DartAttachRequestArguments.fromJson(json);
+  }
 
   @override
   Future<void> handleServiceEvent(vm.Event event) async {

--- a/tools/serverpod_cli/lib/src/dap/serverpod_debug_adapter.dart
+++ b/tools/serverpod_cli/lib/src/dap/serverpod_debug_adapter.dart
@@ -1,22 +1,115 @@
+import 'package:dds/dap.dart';
 // `DartCliDebugAdapter` is the right base class but it lives in `dds/src/`
 // and isn't re-exported from `package:dds/dap.dart`. Subclassing it is what
 // flutter_tools does for its own DAP, and pinning `dds: ^5.3.0` (matched to
 // the SDK floor) bounds the risk that the surface changes under us.
 // ignore: implementation_imports
 import 'package:dds/src/dap/adapters/dart_cli_adapter.dart';
+import 'package:vm_service/vm_service.dart' as vm;
+
+/// Service alias the `serverpod start` process uses when it registers its
+/// hot-reload / hot-restart entrypoints on the pod's VM service. See
+/// `ServerProcess.connectToVmService`.
+const _serverpodAlias = 'serverpod-cli';
+const _hotReloadService = 'hotReload';
+const _hotRestartService = 'hotRestart';
 
 /// Serverpod's Debug Adapter.
 ///
-/// Currently a thin pass-through over [DartCliDebugAdapter]; the next step
-/// adds a `customRequest` override that routes `hotReload` / `hotRestart`
-/// from the IDE through a `serverpod-cli.hotReload` VM service method
-/// registered by the running `serverpod start` process. Until that override
-/// lands, this class behaves exactly like the stock Dart adapter.
+/// Adds an override for the IDE's `hotReload` / `hotRestart` custom requests:
+/// instead of letting the base adapter call the VM's built-in `reloadSources`
+/// (which crashes the kernel_service when the isolate was booted from a
+/// precompiled dill), we route the call to the `serverpod-cli.hotReload` /
+/// `serverpod-cli.hotRestart` VM service method registered by the running
+/// `serverpod start` process. That process owns the FES, build hooks, and
+/// code-gen pipeline and runs the full reload / restart cycle through them.
 class ServerpodDebugAdapter extends DartCliDebugAdapter {
+  /// Fully-qualified namespaced method name (e.g. `s0.hotReload`) discovered
+  /// via `ServiceRegistered` events. Null until we observe the registration.
+  String? _hotReloadMethod;
+
+  /// Fully-qualified namespaced method name for the hot-restart entrypoint.
+  /// Tracked separately so VS Code's restart button doesn't quietly fall
+  /// back to a reload when only one of the two is registered.
+  String? _hotRestartMethod;
+
   ServerpodDebugAdapter(
     super.channel, {
     super.ipv6,
     super.logger,
     super.onError,
   });
+
+  @override
+  Future<void> handleServiceEvent(vm.Event event) async {
+    final isRegister = event.kind == vm.EventKind.kServiceRegistered;
+    final isUnregister = event.kind == vm.EventKind.kServiceUnregistered;
+    if ((isRegister || isUnregister) && event.alias == _serverpodAlias) {
+      final method = isRegister ? event.method : null;
+      switch (event.service) {
+        case _hotReloadService:
+          _hotReloadMethod = method;
+        case _hotRestartService:
+          _hotRestartMethod = method;
+      }
+    }
+    await super.handleServiceEvent(event);
+  }
+
+  @override
+  Future<void> customRequest(
+    Request request,
+    RawRequestArguments? args,
+    void Function(Object?) sendResponse,
+  ) async {
+    switch (request.command) {
+      case 'hotReload':
+        await _callServerpodService(
+          method: _hotReloadMethod,
+          serviceName: 'serverpod-cli.hotReload',
+          action: 'hot reload',
+          sendResponse: sendResponse,
+        );
+        return;
+      case 'hotRestart':
+        await _callServerpodService(
+          method: _hotRestartMethod,
+          serviceName: 'serverpod-cli.hotRestart',
+          action: 'hot restart',
+          sendResponse: sendResponse,
+        );
+        return;
+      default:
+        await super.customRequest(request, args, sendResponse);
+    }
+  }
+
+  Future<void> _callServerpodService({
+    required String? method,
+    required String serviceName,
+    required String action,
+    required void Function(Object?) sendResponse,
+  }) async {
+    if (method == null) {
+      throw DebugAdapterException(
+        'Cannot $action: $serviceName is not registered on the VM '
+        'service. Make sure `serverpod start --watch` is running.',
+      );
+    }
+    final service = vmService;
+    if (service == null) {
+      throw DebugAdapterException(
+        'Cannot $action: no VM service connection.',
+      );
+    }
+    try {
+      final response = await service.callMethod(method);
+      sendResponse(response.json);
+    } on vm.RPCError catch (e) {
+      throw DebugAdapterException(
+        '${action[0].toUpperCase()}${action.substring(1)} failed: '
+        '${e.details ?? e.message}',
+      );
+    }
+  }
 }

--- a/tools/serverpod_cli/lib/src/runner/serverpod_command_runner.dart
+++ b/tools/serverpod_cli/lib/src/runner/serverpod_command_runner.dart
@@ -3,6 +3,7 @@ import 'package:ci/ci.dart' as ci;
 import 'package:cli_tools/cli_tools.dart';
 import 'package:config/config.dart';
 import 'package:pub_semver/pub_semver.dart';
+import 'package:serverpod_cli/src/commands/dap.dart';
 import 'package:serverpod_cli/src/commands/language_server.dart';
 import 'package:serverpod_cli/src/config/experimental_feature.dart';
 import 'package:serverpod_cli/src/update_prompt/prompt_to_update.dart';
@@ -105,6 +106,14 @@ class ServerpodCommandRunner extends BetterCommandRunner<GlobalOption, void> {
     );
   }
 
+  /// Subcommands that speak a wire protocol on stdout. Any log line written
+  /// while one of these is active would corrupt the protocol framing, so
+  /// their effective log level is forced to `nothing`.
+  static const _wireProtocolCommands = <String>{
+    LanguageServerCommand.commandName,
+    DapCommand.commandName,
+  };
+
   static void _configureLogLevel({
     required CommandRunnerLogLevel parsedLogLevel,
     String? commandName,
@@ -115,7 +124,9 @@ class ServerpodCommandRunner extends BetterCommandRunner<GlobalOption, void> {
       logLevel = LogLevel.debug;
     } else if (parsedLogLevel == CommandRunnerLogLevel.quiet) {
       logLevel = LogLevel.nothing;
-    } else if (commandName == LanguageServerCommand.commandName) {
+    } else if (_wireProtocolCommands.contains(commandName)) {
+      // These subcommands speak a wire protocol on stdout (LSP / DAP); any
+      // extra log line would corrupt the framing.
       logLevel = LogLevel.nothing;
     }
 

--- a/tools/serverpod_cli/pubspec.yaml
+++ b/tools/serverpod_cli/pubspec.yaml
@@ -29,6 +29,13 @@ dependencies:
   # details, see: https://github.com/dart-lang/dart_style/issues/1785
   dart_style: 3.1.5
   data_assets: '>=0.19.0 <0.20.0'
+  # dds is the Dart Development Service. We only use its DAP exports
+  # (DartCliDebugAdapter and friends) for the `serverpod dap` subcommand.
+  # Pinned to ^5.0.3 (the version flutter 3.38.1 shipped with) to keep this
+  # CLI installable alongside the broadest set of editor toolchains. The
+  # `package:dds/src/dap/...` import we rely on is identical across 5.0.3
+  # through 5.3.0; if a future 5.x release moves the file, CI catches it.
+  dds: ^5.0.3
   file: ^7.0.1
   hooks: ^1.0.0
   hooks_runner: ^1.2.1

--- a/tools/serverpod_cli/test/commands/dap/serverpod_debug_adapter_test.dart
+++ b/tools/serverpod_cli/test/commands/dap/serverpod_debug_adapter_test.dart
@@ -1,0 +1,166 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:async/async.dart';
+import 'package:dds/dap.dart';
+import 'package:serverpod_cli/src/dap/serverpod_debug_adapter.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Given a ServerpodDebugAdapter wired to in-memory streams', () {
+    late StreamController<List<int>> stdinPipe;
+    late StreamController<List<int>> stdoutPipe;
+    late ByteStreamServerChannel channel;
+    late ServerpodDebugAdapter adapter;
+    late StreamQueue<Map<String, dynamic>> outQueue;
+
+    setUp(() {
+      stdinPipe = StreamController<List<int>>();
+      stdoutPipe = StreamController<List<int>>();
+      channel = ByteStreamServerChannel(
+        stdinPipe.stream,
+        stdoutPipe.sink,
+        null,
+      );
+      adapter = ServerpodDebugAdapter(channel);
+      outQueue = StreamQueue<Map<String, dynamic>>(
+        _frameStream(stdoutPipe.stream),
+      );
+      // Suppress unused_local warning while keeping `adapter` referenced so
+      // the channel doesn't get garbage-collected mid-test.
+      expect(adapter, isNotNull);
+    });
+
+    tearDown(() async {
+      await outQueue.cancel(immediate: true);
+      await stdinPipe.close();
+      await stdoutPipe.close();
+      await adapter.shutdown();
+    });
+
+    test(
+      'when an initialize request is sent, '
+      'then a successful initialize response is returned',
+      () async {
+        _send(stdinPipe, {
+          'seq': 1,
+          'type': 'request',
+          'command': 'initialize',
+          'arguments': {'adapterID': 'serverpod'},
+        });
+
+        final response = await _nextResponseFor(outQueue, 'initialize');
+        expect(response['success'], isTrue);
+        expect(response['body'], isA<Map>());
+      },
+    );
+
+    test(
+      'when a hotReload customRequest is sent before serverpod-cli.hotReload '
+      'is registered, '
+      'then the response is an unsuccessful response with a clear message',
+      () async {
+        _send(stdinPipe, {
+          'seq': 1,
+          'type': 'request',
+          'command': 'initialize',
+          'arguments': {'adapterID': 'serverpod'},
+        });
+        await _nextResponseFor(outQueue, 'initialize');
+
+        _send(stdinPipe, {
+          'seq': 2,
+          'type': 'request',
+          'command': 'hotReload',
+          'arguments': {},
+        });
+
+        final response = await _nextResponseFor(outQueue, 'hotReload');
+        expect(response['success'], isFalse);
+        expect(response['message'], contains('serverpod-cli.hotReload'));
+      },
+    );
+
+    test(
+      'when a hotRestart customRequest is sent before '
+      'serverpod-cli.hotRestart is registered, '
+      'then the response references hotRestart, not hotReload',
+      () async {
+        _send(stdinPipe, {
+          'seq': 1,
+          'type': 'request',
+          'command': 'initialize',
+          'arguments': {'adapterID': 'serverpod'},
+        });
+        await _nextResponseFor(outQueue, 'initialize');
+
+        _send(stdinPipe, {
+          'seq': 2,
+          'type': 'request',
+          'command': 'hotRestart',
+          'arguments': {},
+        });
+
+        final response = await _nextResponseFor(outQueue, 'hotRestart');
+        expect(response['success'], isFalse);
+        // The two paths are distinct services; the failure message must
+        // identify hot restart, otherwise users will think reload is broken
+        // when they pressed restart.
+        expect(response['message'], contains('serverpod-cli.hotRestart'));
+        expect(response['message'], isNot(contains('hotReload')));
+      },
+    );
+  });
+}
+
+/// Pulls messages off [queue] (skipping events) until a response with the
+/// matching command is found, then returns it.
+Future<Map<String, dynamic>> _nextResponseFor(
+  StreamQueue<Map<String, dynamic>> queue,
+  String command,
+) async {
+  while (true) {
+    final m = await queue.next.timeout(const Duration(seconds: 10));
+    if (m['type'] == 'response' && m['command'] == command) return m;
+  }
+}
+
+void _send(StreamController<List<int>> sink, Map<String, Object?> message) {
+  final body = utf8.encode(jsonEncode(message));
+  sink.add(utf8.encode('Content-Length: ${body.length}\r\n\r\n'));
+  sink.add(body);
+}
+
+/// Decodes a stream of DAP-framed bytes into individual JSON messages.
+Stream<Map<String, dynamic>> _frameStream(Stream<List<int>> source) async* {
+  final buffer = BytesBuilder();
+  await for (final chunk in source) {
+    buffer.add(chunk);
+    while (true) {
+      final all = buffer.toBytes();
+      final asText = utf8.decode(all, allowMalformed: true);
+      final headerEnd = asText.indexOf('\r\n\r\n');
+      if (headerEnd == -1) break;
+
+      final lengthMatch = RegExp(
+        r'Content-Length:\s*(\d+)',
+        caseSensitive: false,
+      ).firstMatch(asText.substring(0, headerEnd));
+      if (lengthMatch == null) {
+        throw StateError('Missing Content-Length in headers');
+      }
+      final contentLength = int.parse(lengthMatch.group(1)!);
+      final bodyStart = headerEnd + 4;
+      if (all.length - bodyStart < contentLength) break;
+
+      final bodyBytes = all.sublist(bodyStart, bodyStart + contentLength);
+      yield jsonDecode(utf8.decode(bodyBytes)) as Map<String, dynamic>;
+
+      // Keep only what's left after this message.
+      final remainder = all.sublist(bodyStart + contentLength);
+      buffer.clear();
+      buffer.add(remainder);
+    }
+  }
+}

--- a/tools/serverpod_vscode_extension/package-lock.json
+++ b/tools/serverpod_vscode_extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "serverpod",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "serverpod",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "vscode-languageclient": "^9.0.1"

--- a/tools/serverpod_vscode_extension/package.json
+++ b/tools/serverpod_vscode_extension/package.json
@@ -88,19 +88,17 @@
           {
             "name": "Attach to Serverpod",
             "type": "serverpod",
-            "request": "attach",
-            "vmServiceInfoFile": "${workspaceFolder}/.dart_tool/serverpod/vm-service-info.json"
+            "request": "attach"
           }
         ],
         "configurationSnippets": [
           {
             "label": "Serverpod: Attach",
-            "description": "Attach to a running `serverpod start --watch`. Hot-reload routes through serverpod's pipeline (codegen, hooks, compile, reload).",
+            "description": "Attach to a running `serverpod start --watch`. cwd and vmServiceInfoFile are auto-discovered; override either by adding the corresponding attribute, or set vmServiceUri for full manual control.",
             "body": {
               "name": "Attach to Serverpod",
               "type": "serverpod",
-              "request": "attach",
-              "vmServiceInfoFile": "^\"\\${workspaceFolder}/.dart_tool/serverpod/vm-service-info.json\""
+              "request": "attach"
             }
           }
         ]

--- a/tools/serverpod_vscode_extension/package.json
+++ b/tools/serverpod_vscode_extension/package.json
@@ -8,17 +8,21 @@
     "color": "#020E24",
     "theme": "dark"
   },
-  "version": "1.3.0",
+  "version": "1.4.0",
   "engines": {
     "vscode": "^1.75.0"
   },
   "categories": [
     "Programming Languages",
-    "Linters"
+    "Linters",
+    "Debuggers"
   ],
   "activationEvents": [
     "onLanguage:yaml",
-    "activationEvents:serverpod"
+    "activationEvents:serverpod",
+    "onDebug",
+    "onDebugResolve:serverpod",
+    "onDebugDynamicConfigurations:serverpod"
   ],
   "pricing": "Free",
   "homepage": "https://serverpod.dev",
@@ -56,6 +60,50 @@
         "language": "serverpod",
         "scopeName": "source.serverpod",
         "path": "./syntaxes/serverpod.tmLanguage.json"
+      }
+    ],
+    "debuggers": [
+      {
+        "type": "serverpod",
+        "label": "Serverpod",
+        "languages": [
+          "dart"
+        ],
+        "configurationAttributes": {
+          "attach": {
+            "properties": {
+              "vmServiceUri": {
+                "type": "string",
+                "description": "HTTP URI of the running pod's VM service. If omitted, vmServiceInfoFile is read instead."
+              },
+              "vmServiceInfoFile": {
+                "type": "string",
+                "description": "Path to the vm-service-info.json file written by `serverpod start --watch`. Defaults to ${workspaceFolder}/.dart_tool/serverpod/vm-service-info.json.",
+                "default": "${workspaceFolder}/.dart_tool/serverpod/vm-service-info.json"
+              }
+            }
+          }
+        },
+        "initialConfigurations": [
+          {
+            "name": "Attach to Serverpod",
+            "type": "serverpod",
+            "request": "attach",
+            "vmServiceInfoFile": "${workspaceFolder}/.dart_tool/serverpod/vm-service-info.json"
+          }
+        ],
+        "configurationSnippets": [
+          {
+            "label": "Serverpod: Attach",
+            "description": "Attach to a running `serverpod start --watch`. Hot-reload routes through serverpod's pipeline (codegen, hooks, compile, reload).",
+            "body": {
+              "name": "Attach to Serverpod",
+              "type": "serverpod",
+              "request": "attach",
+              "vmServiceInfoFile": "^\"\\${workspaceFolder}/.dart_tool/serverpod/vm-service-info.json\""
+            }
+          }
+        ]
       }
     ]
   },

--- a/tools/serverpod_vscode_extension/src/debug.ts
+++ b/tools/serverpod_vscode_extension/src/debug.ts
@@ -1,0 +1,65 @@
+import {
+	DebugAdapterDescriptor,
+	DebugAdapterDescriptorFactory,
+	DebugAdapterExecutable,
+	DebugConfigurationProvider,
+	DebugSession,
+	ExtensionContext,
+	ProviderResult,
+	WorkspaceFolder,
+	debug,
+} from 'vscode';
+
+/**
+ * Registers the `serverpod` debug type. Spawns `serverpod dap` (a hidden
+ * subcommand of the serverpod CLI) as the debug adapter and fills in
+ * launch.json defaults so the user only has to specify the bare minimum.
+ */
+export function registerServerpodDebug(context: ExtensionContext): void {
+	context.subscriptions.push(
+		debug.registerDebugAdapterDescriptorFactory(
+			'serverpod',
+			new ServerpodDebugAdapterFactory(),
+		),
+		debug.registerDebugConfigurationProvider(
+			'serverpod',
+			new ServerpodDebugConfigurationProvider(),
+		),
+	);
+}
+
+class ServerpodDebugAdapterFactory implements DebugAdapterDescriptorFactory {
+	createDebugAdapterDescriptor(
+		_session: DebugSession,
+	): ProviderResult<DebugAdapterDescriptor> {
+		// DebugAdapterExecutable wants `{ [key: string]: string }`; strip
+		// undefined values from process.env so the cast is safe.
+		const env: { [key: string]: string } = {};
+		for (const [k, v] of Object.entries(process.env)) {
+			if (v !== undefined) env[k] = v;
+		}
+		return new DebugAdapterExecutable('serverpod', ['dap'], { env });
+	}
+}
+
+class ServerpodDebugConfigurationProvider
+	implements DebugConfigurationProvider {
+	resolveDebugConfiguration(
+		folder: WorkspaceFolder | undefined,
+		config: any,
+	): ProviderResult<any> {
+		// Only attach is supported today; launch.json snippet should reflect that.
+		if (config.request !== 'attach') {
+			return config;
+		}
+
+		// If neither vmServiceUri nor vmServiceInfoFile is given, default to
+		// the standard location written by `serverpod start --watch`.
+		if (!config.vmServiceUri && !config.vmServiceInfoFile && folder) {
+			config.vmServiceInfoFile =
+				'${workspaceFolder}/.dart_tool/serverpod/vm-service-info.json';
+		}
+
+		return config;
+	}
+}

--- a/tools/serverpod_vscode_extension/src/debug.ts
+++ b/tools/serverpod_vscode_extension/src/debug.ts
@@ -1,65 +1,228 @@
+import { spawn, ChildProcess } from 'child_process';
 import {
 	DebugAdapterDescriptor,
 	DebugAdapterDescriptorFactory,
 	DebugAdapterExecutable,
-	DebugConfigurationProvider,
+	DebugAdapterNamedPipeServer,
 	DebugSession,
+	Disposable,
 	ExtensionContext,
-	ProviderResult,
-	WorkspaceFolder,
+	OutputChannel,
 	debug,
+	window,
 } from 'vscode';
 
+/** Marker lines `serverpod dap` writes to stderr to announce its chosen
+ *  transport. The literals are the contract between the two sides; if you
+ *  change them here, update `DapCommand.socketAnnouncement` /
+ *  `DapCommand.stdioAnnouncement` in
+ *  `tools/serverpod_cli/lib/src/commands/dap.dart` to match. */
+const SOCKET_LINE = /^SERVERPOD_DAP_SOCKET=(.+?)\s*$/;
+const STDIO_LINE = /^SERVERPOD_DAP_STDIO\s*$/;
+
+/** Single shared output channel; created lazily on first attach so the user
+ *  doesn't see an empty channel until they actually try to debug. */
+let sharedChannel: OutputChannel | undefined;
+
+function getOutput(): OutputChannel {
+	return (sharedChannel ??= window.createOutputChannel('Serverpod DAP'));
+}
+
 /**
- * Registers the `serverpod` debug type. Spawns `serverpod dap` (a hidden
- * subcommand of the serverpod CLI) as the debug adapter and fills in
- * launch.json defaults so the user only has to specify the bare minimum.
+ * Registers the `serverpod` debug type. For each session, spawns
+ * `serverpod dap` (with cwd = the active workspace folder so the CLI's
+ * `ServerDirectoryFinder` has a starting point), waits for the CLI to
+ * announce its chosen transport on stderr, and dispatches:
+ *
+ * - `SERVERPOD_DAP_SOCKET=<path>` -> `DebugAdapterNamedPipeServer(path)`.
+ *   VS Code connects to the Unix domain socket the CLI bound at the
+ *   announced path.
+ * - `SERVERPOD_DAP_STDIO` -> kill the spawned process and return
+ *   `DebugAdapterExecutable` so VS Code respawns the CLI and manages stdio
+ *   framing itself. Used when the CLI's platform doesn't support AF_UNIX
+ *   (Windows on Dart < 3.11).
  */
 export function registerServerpodDebug(context: ExtensionContext): void {
 	context.subscriptions.push(
 		debug.registerDebugAdapterDescriptorFactory(
 			'serverpod',
-			new ServerpodDebugAdapterFactory(),
-		),
-		debug.registerDebugConfigurationProvider(
-			'serverpod',
-			new ServerpodDebugConfigurationProvider(),
+			new ServerpodDebugAdapterFactory(context),
 		),
 	);
 }
 
 class ServerpodDebugAdapterFactory implements DebugAdapterDescriptorFactory {
-	createDebugAdapterDescriptor(
-		_session: DebugSession,
-	): ProviderResult<DebugAdapterDescriptor> {
-		// DebugAdapterExecutable wants `{ [key: string]: string }`; strip
-		// undefined values from process.env so the cast is safe.
+	constructor(private readonly context: ExtensionContext) {}
+
+	async createDebugAdapterDescriptor(
+		session: DebugSession,
+	): Promise<DebugAdapterDescriptor> {
+		const out = getOutput();
+		out.show(true);
+		out.appendLine(`--- ${new Date().toISOString()} attach request ---`);
+		out.appendLine(`PATH=${process.env.PATH ?? '(unset)'}`);
+		out.appendLine(
+			`resolved config: ${JSON.stringify(session.configuration, null, 2)}`,
+		);
+
 		const env: { [key: string]: string } = {};
 		for (const [k, v] of Object.entries(process.env)) {
 			if (v !== undefined) env[k] = v;
 		}
-		return new DebugAdapterExecutable('serverpod', ['dap'], { env });
+
+		// Anchor the CLI's working directory at the workspace folder so its
+		// `ServerDirectoryFinder` has a meaningful starting point for
+		// discovering the server package. Falls back to no override (CLI
+		// will start from process.cwd()) if there's no folder context.
+		const folder = session.workspaceFolder;
+		const cwd = folder?.uri.fsPath;
+
+		out.appendLine(`spawning: serverpod dap (cwd=${cwd ?? '(none)'})`);
+		const proc = spawn('serverpod', ['dap'], {
+			env,
+			cwd,
+			shell: true,
+			// Pipe both streams so we can surface every byte the CLI writes,
+			// regardless of whether log lines / banners go to stdout or
+			// stderr.
+			stdio: ['ignore', 'pipe', 'pipe'],
+		});
+		out.appendLine(
+			`spawned: pid=${proc.pid ?? '(none)'}, ` +
+			`stdout=${proc.stdout ? 'piped' : 'null'}, ` +
+			`stderr=${proc.stderr ? 'piped' : 'null'}`,
+		);
+
+		// Tie process lifetime to this debug session: kill it when the
+		// session ends instead of waiting for extension shutdown, so
+		// repeated attaches don't accumulate adapter processes.
+		const sessionEnd = debug.onDidTerminateDebugSession((ended) => {
+			if (ended.id !== session.id) return;
+			sessionEnd.dispose();
+			if (proc.exitCode === null) proc.kill();
+		});
+		// Belt-and-braces: also kill on extension dispose so a stuck
+		// process doesn't survive the editor.
+		const disposeKill = killOnDispose(proc);
+		this.context.subscriptions.push(disposeKill);
+
+		const announcement = await waitForAnnouncement(proc, out);
+
+		if (announcement.kind === 'socket') {
+			out.appendLine(
+				`got socket path ${announcement.path}; ` +
+				'returning DebugAdapterNamedPipeServer',
+			);
+			return new DebugAdapterNamedPipeServer(announcement.path);
+		}
+
+		// stdio path: this spawn was just for the announcement. VS Code
+		// will respawn via DebugAdapterExecutable and manage stdio framing
+		// itself.
+		out.appendLine(
+			'got stdio announcement; killing probe spawn and ' +
+			'returning DebugAdapterExecutable',
+		);
+		sessionEnd.dispose();
+		disposeKill.dispose();
+		return new DebugAdapterExecutable('serverpod', ['dap'], { env, cwd });
 	}
 }
 
-class ServerpodDebugConfigurationProvider
-	implements DebugConfigurationProvider {
-	resolveDebugConfiguration(
-		folder: WorkspaceFolder | undefined,
-		config: any,
-	): ProviderResult<any> {
-		// Only attach is supported today; launch.json snippet should reflect that.
-		if (config.request !== 'attach') {
-			return config;
-		}
+type Announcement =
+	| { kind: 'socket'; path: string }
+	| { kind: 'stdio' };
 
-		// If neither vmServiceUri nor vmServiceInfoFile is given, default to
-		// the standard location written by `serverpod start --watch`.
-		if (!config.vmServiceUri && !config.vmServiceInfoFile && folder) {
-			config.vmServiceInfoFile =
-				'${workspaceFolder}/.dart_tool/serverpod/vm-service-info.json';
-		}
+/** Resolves with the transport announcement from `serverpod dap`. Watches
+ *  both stdout and stderr because we don't know upfront which stream a
+ *  given Dart/puro/log layer chose, and we don't want a missed
+ *  announcement to be invisible to the user. Every non-marker line is
+ *  echoed to [out]. */
+function waitForAnnouncement(
+	proc: ChildProcess,
+	out: OutputChannel,
+): Promise<Announcement> {
+	return new Promise<Announcement>((resolve, reject) => {
+		let resolved = false;
+		const buffers: { [key: string]: string } = { stdout: '', stderr: '' };
 
-		return config;
-	}
+		const onLine = (source: 'stdout' | 'stderr', line: string) => {
+			const m = SOCKET_LINE.exec(line);
+			if (m) {
+				resolved = true;
+				out.appendLine(`[${source}] (socket announcement) ${line}`);
+				resolve({ kind: 'socket', path: m[1] });
+				return;
+			}
+			if (STDIO_LINE.test(line)) {
+				resolved = true;
+				out.appendLine(`[${source}] (stdio announcement) ${line}`);
+				resolve({ kind: 'stdio' });
+				return;
+			}
+			out.appendLine(`[${source}] ${line}`);
+		};
+
+		const attach = (
+			stream: NodeJS.ReadableStream | null,
+			source: 'stdout' | 'stderr',
+		) => {
+			if (!stream) {
+				out.appendLine(`(${source} is not piped)`);
+				return;
+			}
+			stream.on('data', (chunk: Buffer | string) => {
+				const text = typeof chunk === 'string' ? chunk : chunk.toString('utf8');
+				// Once the announcement is known we no longer need to scan
+				// line-by-line; just forward bytes verbatim.
+				if (resolved) {
+					out.append(text);
+					return;
+				}
+				buffers[source] += text;
+				let nl: number;
+				while ((nl = buffers[source].indexOf('\n')) !== -1) {
+					const line = buffers[source].slice(0, nl).replace(/\r$/, '');
+					buffers[source] = buffers[source].slice(nl + 1);
+					onLine(source, line);
+				}
+			});
+		};
+
+		attach(proc.stdout, 'stdout');
+		attach(proc.stderr, 'stderr');
+
+		proc.on('exit', (code, signal) => {
+			out.appendLine(`process exited: code=${code}, signal=${signal}`);
+			if (resolved) return;
+			reject(new Error(
+				`serverpod dap exited (code=${code}, signal=${signal}) ` +
+				'before announcing a transport. See the "Serverpod DAP" output channel.',
+			));
+		});
+		proc.on('error', (err) => {
+			out.appendLine(`process error: ${err.message}`);
+			if (resolved) return;
+			reject(err);
+		});
+
+		// Cap the wait so a stuck CLI fails fast instead of hanging the IDE.
+		setTimeout(() => {
+			if (resolved) return;
+			out.appendLine('timed out waiting for transport announcement; killing.');
+			proc.kill();
+			reject(new Error(
+				'Timed out waiting for `serverpod dap` to announce a transport. ' +
+				'See the "Serverpod DAP" output channel.',
+			));
+		}, 30_000);
+	});
+}
+
+function killOnDispose(proc: ChildProcess): Disposable {
+	return {
+		dispose: () => {
+			if (proc.exitCode === null) proc.kill();
+		},
+	};
 }

--- a/tools/serverpod_vscode_extension/src/extension.ts
+++ b/tools/serverpod_vscode_extension/src/extension.ts
@@ -9,6 +9,7 @@ import {
 } from 'vscode-languageclient/node';
 import { execSync } from 'child_process';
 import { satisfies, coerce } from 'semver';
+import { registerServerpodDebug } from './debug';
 
 let client: LanguageClient;
 
@@ -55,6 +56,8 @@ export function activate(context: ExtensionContext) {
 	);
 
 	client.start();
+
+	registerServerpodDebug(context);
 }
 
 export function deactivate(): Thenable<void> | undefined {


### PR DESCRIPTION
This PR adds a custom Debug Adapter Protocol (DAP) server to the CLI and wires the VS Code extension up to it, so editors can attach to a running `serverpod start --watch` and trigger Serverpod-aware hot reload from the standard debug surface (Cmd-Shift-F5, the IDE reload button, REPL `hotReload` requests).

## Why

Serverpod runs its server isolate from a precompiled dill produced by the Frontend Server (FES). The VM's built-in `reloadSources` doesn't go through the FES, the build hooks, or codegen, and crashes the kernel_service on a precompiled-dill isolate. Today users either restart the watcher manually or edit `launch.json` to attach via the generic Dart adapter and hit the same crash. A Serverpod-specific adapter that delegates reload to the watcher's pipeline removes that mismatch.

## How

`serverpod dap` boots a DAP server that subclasses `DartCliDebugAdapter` (from `dds`), auto-discovers the server package, and overrides hot-reload/hot-restart to call a new `serverpod-cli.hotReload` VM service method registered by `serverpod start --watch`. The VS Code extension contributes a `serverpod` debug type whose factory spawns the CLI, picks a transport from a stderr announcement, and returns the appropriate VS Code descriptor.

### Highlights

- **`serverpod dap` (hidden subcommand).** New `tools/serverpod_cli/lib/src/commands/dap.dart`. Picks a transport at startup and announces it on stderr - `SERVERPOD_DAP_SOCKET=<path>` or `SERVERPOD_DAP_STDIO` - so the launcher knows how to connect.
- **`ServerpodDebugAdapter`.** Subclass of `DartCliDebugAdapter`. Enriches `attachRequest` args with `cwd` and `vmServiceInfoFile` from `ServerDirectoryFinder` so `launch.json` only needs `{name, type: 'serverpod', request: 'attach'}`. User-supplied values always win. Tracks the namespaced `serverpod-cli.hotReload` method via `ServiceRegistered`/`ServiceUnregistered` events and routes `hotReload`/`hotRestart`/`$/hotReload` custom requests to it. Falls back to a clear `DebugAdapterException` when the alias isn't registered (i.e. no watcher running).
- **`serverpod-cli.hotReload` VM service.** `ServerProcess` registers the alias when `onHotReload` is provided. The callback runs the full watch-session reload pipeline (codegen + hooks + compile + reload) - the same path as the file-watcher and the `hot_reload` MCP tool. Refactor pulls a small `_registerCliService` helper to share registration with `reloadSources`.
- **UDS-preferred transport.** UDS is preferred over TCP because TCP loopback is reachable by every local process, while UDS access is restricted by file permissions (umask 022 → 0644 → owner-only-connect, since UDS `connect()` needs write). The socket is bound under `<systemTemp>/serverpod-dap-<hash>.sock` (hash of the absolute server-dir path), **not** under `.dart_tool/serverpod/`: macOS limits `sockaddr_un.sun_path` to 104 bytes and a typical home-relative dart_tool path easily exceeds that on the announcement (client-side connect is absolute). Stdio fallback covers Windows on Dart < 3.11.
- **VS Code extension (`serverpod_vscode_extension` v1.4.0).** Registers the `serverpod` debug type via a `DebugAdapterDescriptorFactory`. The factory spawns `serverpod dap` (cwd anchored at the workspace folder), parses the stderr announcement on both stdout and stderr (so missed announcements don't go invisible), then returns either `DebugAdapterNamedPipeServer(path)` for UDS or - after killing the probe spawn - `DebugAdapterExecutable` for stdio so VS Code respawns and manages framing itself. Process lifetime is tied to the debug session (kill on `onDidTerminateDebugSession`) with a belt-and-braces extension-dispose handler.
- **`launch.json` contributions.** `initialConfigurations` and `configurationSnippets` reduced to `{name, type, request}` so users get a minimal snippet; `cwd` and `vmServiceInfoFile` are auto-discovered, `vmServiceUri` remains an escape hatch.

### Supporting changes

- **Wire-protocol log silencing.** `ServerpodCliLogger` now actually silences output when `logLevel == LogLevel.nothing`: previously the underlying `serverpod_shared` logger had no `nothing` sentinel and the setter mapped `nothing → debug`, leaking lines to stdout. Both LSP and DAP frame on stdout, so any leak corrupts the protocol.
- **Wire-protocol command set.** `ServerpodCommandRunner._wireProtocolCommands = {language-server, dap}` replaces the previous single-command branch and forces both to `LogLevel.nothing`.
- **`launch.json` debugger contribution metadata** in `package.json`: new `Debuggers` category, `onDebug`/`onDebugResolve:serverpod`/`onDebugDynamicConfigurations:serverpod` activation events.


## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.
