### PR TITLE
fix: Remove the requirement of `SERVERPOD_HOME` for CLI commands that doesn't touch it

### DIFF
--- a/tools/serverpod_cli/lib/src/runner/serverpod_command_runner.dart
+++ b/tools/serverpod_cli/lib/src/runner/serverpod_command_runner.dart
@@ -4,8 +4,6 @@ import 'package:config/config.dart';
 import 'package:pub_semver/pub_semver.dart';
 import 'package:serverpod_cli/src/commands/language_server.dart';
 import 'package:serverpod_cli/src/config/experimental_feature.dart';
-import 'package:serverpod_cli/src/downloads/resource_manager.dart';
-import 'package:serverpod_cli/src/shared/environment.dart';
 import 'package:serverpod_cli/src/update_prompt/prompt_to_update.dart';
 import 'package:serverpod_cli/src/util/command_line_tools.dart';
 import 'package:serverpod_cli/src/util/serverpod_cli_logger.dart';
@@ -27,20 +25,13 @@ Future<void> _preCommandEnvironmentChecks() async {
     );
     throw ExitException.error();
   }
-
-  if (!loadEnvironmentVars()) {
-    throw ExitException.error();
-  }
 }
 
 Future<void> _preCommandPrints(ServerpodCommandRunner runner) async {
   if (runner._productionMode) {
     await promptToUpdateIfNeeded(runner._cliVersion);
   } else {
-    log.debug(
-      'Development mode. Using templates from: ${resourceManager.templateDirectory.path}',
-    );
-    log.debug('SERVERPOD_HOME is set to $serverpodHome');
+    log.debug('Development mode.');
   }
 }
 

--- a/tools/serverpod_cli/lib/src/shared/environment.dart
+++ b/tools/serverpod_cli/lib/src/shared/environment.dart
@@ -1,22 +1,47 @@
 import 'dart:io';
 
+import 'package:cli_tools/cli_tools.dart';
 import 'package:serverpod_cli/src/util/serverpod_cli_logger.dart';
 
 import '../generated/version.dart';
 
-String serverpodHome = '';
+String get serverpodHome {
+  if (_serverpodHome == null) {
+    loadEnvironmentVars();
+  }
+  return _serverpodHome!;
+}
 
+String? _serverpodHome;
+
+/// Loads the environment variables for the serverpod CLI.
+///
+/// If in dev mode and the SERVERPOD_HOME environment variable is not set,
+/// it will throw an ExitException.error().
 bool loadEnvironmentVars() {
-  if (!productionMode) {
-    var home = Platform.environment['SERVERPOD_HOME'];
-    if (home == null || home == '' || !Directory(home).existsSync()) {
-      log.error(
-        'The SERVERPOD_HOME environmental variable is required in development mode,',
-      );
-      return false;
-    }
-    serverpodHome = home;
+  if (_serverpodHome != null) {
+    return true;
   }
 
+  if (!productionMode) {
+    var home = Platform.environment['SERVERPOD_HOME'];
+
+    if (home == null || home == '') {
+      log.error(
+        'The "SERVERPOD_HOME" environmental variable is required in development mode.',
+      );
+      throw ExitException.error();
+    } else if (!Directory(home).existsSync()) {
+      log.error(
+        'The "SERVERPOD_HOME" environmental variable points to a non-existent directory: "$home"',
+      );
+      throw ExitException.error();
+    }
+
+    log.debug('Set "SERVERPOD_HOME" to "$home"');
+    _serverpodHome = home;
+  }
+
+  _serverpodHome ??= '';
   return true;
 }

--- a/tools/serverpod_cli/lib/src/shared/environment.dart
+++ b/tools/serverpod_cli/lib/src/shared/environment.dart
@@ -18,9 +18,9 @@ String? _serverpodHome;
 ///
 /// If in dev mode and the SERVERPOD_HOME environment variable is not set,
 /// it will throw an ExitException.error().
-bool loadEnvironmentVars() {
+void loadEnvironmentVars() {
   if (_serverpodHome != null) {
-    return true;
+    return;
   }
 
   if (!productionMode) {
@@ -43,5 +43,5 @@ bool loadEnvironmentVars() {
   }
 
   _serverpodHome ??= '';
-  return true;
+  return;
 }


### PR DESCRIPTION
This PR prevents the CLI from throwing when running `generate` or `create-migration` with a locally installed CLI - commands that don't use the `serverpodHome`. This is a small QoL improvement for testing on projects outside of the Serverpod monorepo while using the locally installed CLI.

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.