### PR TITLE
fix: Fix Postgres throwing when using row-lock with includes

### DIFF
--- a/packages/serverpod_database/lib/src/adapters/postgres/sql_query_builder.dart
+++ b/packages/serverpod_database/lib/src/adapters/postgres/sql_query_builder.dart
@@ -106,7 +106,7 @@ class SelectQueryBuilder {
     if (groupBy != null) query += ' GROUP BY $groupBy';
     if (_having != null) query += ' HAVING $_having';
     if (orderBy != null) query += ' ORDER BY $orderBy';
-    var lockClause = _buildLockClause();
+    var lockClause = _buildLockClause(restrictLockToBaseTable: join != null);
     if (lockClause != null) query += ' $lockClause';
     if (limit != null) query += ' LIMIT $limit';
     if (offset != null) query += ' OFFSET $_offset';
@@ -303,7 +303,7 @@ class SelectQueryBuilder {
     return this;
   }
 
-  String? _buildLockClause() {
+  String? _buildLockClause({required bool restrictLockToBaseTable}) {
     if (_lockMode == null) return null;
 
     var clause = switch (_lockMode!) {
@@ -312,6 +312,10 @@ class SelectQueryBuilder {
       LockMode.forShare => 'FOR SHARE',
       LockMode.forKeyShare => 'FOR KEY SHARE',
     };
+
+    if (restrictLockToBaseTable) {
+      clause += ' OF "${_table.tableName}"';
+    }
 
     if (_lockBehavior != null && _lockBehavior != LockBehavior.wait) {
       clause += switch (_lockBehavior!) {

--- a/packages/serverpod_database/test/sql_query_builder_test.dart
+++ b/packages/serverpod_database/test/sql_query_builder_test.dart
@@ -1088,6 +1088,38 @@ void main() {
       });
     });
 
+    test(
+      'when building with lock mode, lock behavior noWait and a where clause that adds a left join '
+      'then the query contains OF clause before NOWAIT',
+      () {
+        var companyTbl = Table<int?>(tableName: 'company');
+        var relationTable = Table<int?>(
+          tableName: companyTbl.tableName,
+          tableRelation: TableRelation([
+            TableRelationEntry(
+              relationAlias: 'company',
+              field: ColumnInt('companyId', table),
+              foreignField: ColumnInt('id', companyTbl),
+            ),
+          ]),
+        );
+
+        var query = SelectQueryBuilder(table: table)
+            .withWhere(ColumnString('name', relationTable).equals('Serverpod'))
+            .withLockMode(LockMode.forUpdate, LockBehavior.noWait)
+            .build();
+
+        expect(
+          query,
+          'SELECT "citizen"."id" AS "citizen.id" FROM "citizen" '
+          'LEFT JOIN "company" AS "citizen_company_company" '
+          'ON "citizen"."companyId" = "citizen_company_company"."id" '
+          'WHERE "citizen_company_company"."name" = \'Serverpod\' '
+          'FOR UPDATE OF "citizen" NOWAIT',
+        );
+      },
+    );
+
     group('when building with lock behavior skipLocked', () {
       test('then query contains SKIP LOCKED suffix', () {
         var query = SelectQueryBuilder(
@@ -1114,6 +1146,38 @@ void main() {
         );
       });
     });
+
+    test(
+      'when building with lock mode and a where clause that adds a left join '
+      'then lock clause uses FOR UPDATE OF base table.',
+      () {
+        var companyTbl = Table<int?>(tableName: 'company');
+        var relationTable = Table<int?>(
+          tableName: companyTbl.tableName,
+          tableRelation: TableRelation([
+            TableRelationEntry(
+              relationAlias: 'company',
+              field: ColumnInt('companyId', table),
+              foreignField: ColumnInt('id', companyTbl),
+            ),
+          ]),
+        );
+
+        var query = SelectQueryBuilder(table: table)
+            .withWhere(ColumnString('name', relationTable).equals('Serverpod'))
+            .withLockMode(LockMode.forUpdate)
+            .build();
+
+        expect(
+          query,
+          'SELECT "citizen"."id" AS "citizen.id" FROM "citizen" '
+          'LEFT JOIN "company" AS "citizen_company_company" '
+          'ON "citizen"."companyId" = "citizen_company_company"."id" '
+          'WHERE "citizen_company_company"."name" = \'Serverpod\' '
+          'FOR UPDATE OF "citizen"',
+        );
+      },
+    );
 
     group('when building with lock mode and order by', () {
       test('then lock clause appears after order by', () {

--- a/tests/serverpod_test_server/test_integration/database_operations/row_lock_test.dart
+++ b/tests/serverpod_test_server/test_integration/database_operations/row_lock_test.dart
@@ -106,6 +106,126 @@ void main() {
   );
 
   withServerpod(
+    'Given tables with existing data for related models',
+    (sessionBuilder, _) {
+      late Session session;
+      late Town town;
+      late Company company;
+      late City city;
+      late Organization organization;
+      late Person person;
+
+      setUp(() async {
+        session = sessionBuilder.build();
+
+        town = await Town.db.insertRow(session, Town(name: 'LockTown'));
+        company = await Company.db.insertRow(
+          session,
+          Company(name: 'LockCo', townId: town.id!),
+        );
+
+        city = await City.db.insertRow(session, City(name: 'LockCity'));
+        organization = await Organization.db.insertRow(
+          session,
+          Organization(name: 'LockOrg', cityId: city.id!),
+        );
+        person = await Person.db.insertRow(session, Person(name: 'LockPerson'));
+        await Organization.db.attach.people(session, organization, [person]);
+      });
+
+      test(
+        'when finding by id with forUpdate and object include '
+        'then the row and relation are returned.',
+        () async {
+          await session.db.transaction((transaction) async {
+            final row = await Company.db.findById(
+              session,
+              company.id!,
+              lockMode: LockMode.forUpdate,
+              transaction: transaction,
+              include: Company.include(town: Town.include()),
+            );
+
+            expect(row, isNotNull);
+            expect(row!.id, company.id);
+            expect(row.name, 'LockCo');
+            expect(row.town, isNotNull);
+            expect(row.town!.name, 'LockTown');
+          });
+        },
+      );
+
+      test(
+        'when finding rows with forUpdate and object include '
+        'then the row and relation are returned.',
+        () async {
+          await session.db.transaction((transaction) async {
+            final rows = await Company.db.find(
+              session,
+              where: (t) => t.id.equals(company.id!),
+              lockMode: LockMode.forUpdate,
+              transaction: transaction,
+              include: Company.include(town: Town.include()),
+            );
+
+            expect(rows, hasLength(1));
+            expect(rows.single.id, company.id);
+            expect(rows.single.town?.name, 'LockTown');
+          });
+        },
+      );
+
+      test(
+        'when finding first row with forUpdate and object include '
+        'then the row and relation are returned.',
+        () async {
+          await session.db.transaction((transaction) async {
+            final row = await Company.db.findFirstRow(
+              session,
+              where: (t) => t.name.equals('LockCo'),
+              lockMode: LockMode.forUpdate,
+              transaction: transaction,
+              include: Company.include(town: Town.include()),
+            );
+
+            expect(row, isNotNull);
+            expect(row!.id, company.id);
+            expect(row.town?.name, 'LockTown');
+          });
+        },
+      );
+
+      test(
+        'when finding by id with forUpdate and both object and list includes '
+        'then the row and the related objects are returned.',
+        () async {
+          await session.db.transaction((transaction) async {
+            final row = await Organization.db.findById(
+              session,
+              organization.id!,
+              lockMode: LockMode.forUpdate,
+              transaction: transaction,
+              include: Organization.include(
+                city: City.include(),
+                people: Person.includeList(),
+              ),
+            );
+
+            expect(row, isNotNull);
+            expect(row!.id, organization.id);
+            expect(row.name, 'LockOrg');
+            expect(row.city, isNotNull);
+            expect(row.city!.name, 'LockCity');
+            expect(row.people, hasLength(1));
+            expect(row.people!.single.id, person.id);
+            expect(row.people!.single.name, 'LockPerson');
+          });
+        },
+      );
+    },
+  );
+
+  withServerpod(
     'Given a table with existing data and a forUpdate lock in place that holds all rows acquired using find method',
     // Concurrency tests require real parallel transactions, which are not
     // compatible with the test framework's database rollback mechanism.
@@ -301,6 +421,122 @@ void main() {
 
         expect(rows.length, 1);
         expect(rows.first.num, 2);
+      });
+    },
+  );
+
+  withServerpod(
+    'Given related tables and a forUpdate lock in place on one company row acquired using find with includes',
+    // Concurrency tests require real parallel transactions, which are not
+    // compatible with the test framework's database rollback mechanism.
+    rollbackDatabase: RollbackDatabase.disabled,
+    testGroupTagsOverride: [TestTags.concurrencyOneTestTag],
+    (sessionBuilder, _) {
+      late Session session;
+      late Town town;
+      late Completer<void> lockAcquired;
+      late Completer<void> testDone;
+      late Future<void> t1;
+
+      setUp(() async {
+        session = sessionBuilder.build();
+
+        town = await Town.db.insertRow(session, Town(name: 'IncludeLockTown'));
+        await Company.db.insertRow(
+          session,
+          Company(name: 'LockedCo', townId: town.id!),
+        );
+        await Company.db.insertRow(
+          session,
+          Company(name: 'OtherCo', townId: town.id!),
+        );
+
+        lockAcquired = Completer<void>();
+        testDone = Completer<void>();
+
+        t1 = session.db.transaction((transaction) async {
+          await Company.db.find(
+            session,
+            where: (t) => t.name.equals('LockedCo'),
+            lockMode: LockMode.forUpdate,
+            transaction: transaction,
+            include: Company.include(town: Town.include()),
+          );
+          lockAcquired.complete();
+          await testDone.future;
+        });
+
+        await lockAcquired.future;
+      });
+
+      tearDown(() async {
+        testDone.complete();
+        await t1;
+
+        await Company.db.deleteWhere(
+          session,
+          where: (t) => Constant.bool(true),
+        );
+        await Town.db.deleteWhere(
+          session,
+          where: (t) => Constant.bool(true),
+        );
+      });
+
+      test('when finding matching company rows with noWait '
+          'then the operation throws due to rows being locked.', () async {
+        final t2 = session.db.transaction((transaction) async {
+          await Company.db.find(
+            session,
+            where: (t) => t.name.equals('LockedCo'),
+            lockMode: LockMode.forUpdate,
+            lockBehavior: LockBehavior.noWait,
+            transaction: transaction,
+          );
+        });
+
+        await expectLater(t2, throwsA(isA<Exception>()));
+      });
+
+      test(
+        'when finding the included town row with noWait '
+        'then the operation succeeds since related rows are not locked.',
+        () async {
+          final t2 = session.db.transaction((transaction) async {
+            return await Town.db.find(
+              session,
+              where: (t) => t.id.equals(town.id!),
+              lockMode: LockMode.forUpdate,
+              lockBehavior: LockBehavior.noWait,
+              transaction: transaction,
+            );
+          });
+
+          await expectLater(t2, completes);
+          final towns = await t2;
+
+          expect(towns, hasLength(1));
+          expect(towns.single.name, 'IncludeLockTown');
+        },
+      );
+
+      test('when finding another company sharing the town with noWait '
+          'then the rows are returned.', () async {
+        final t2 = session.db.transaction((transaction) async {
+          return await Company.db.find(
+            session,
+            where: (t) => t.name.equals('OtherCo'),
+            lockMode: LockMode.forUpdate,
+            lockBehavior: LockBehavior.noWait,
+            transaction: transaction,
+          );
+        });
+
+        await expectLater(t2, completes);
+        final rows = await t2;
+
+        expect(rows.length, 1);
+        expect(rows.single.name, 'OtherCo');
       });
     },
   );


### PR DESCRIPTION
Fixes: #5005

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.