### PR TITLE
feat: Update GitHub IDP to fetch email strongly

### DIFF
--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/providers/github/business/github_idp_config.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/providers/github/business/github_idp_config.dart
@@ -63,8 +63,8 @@ class GitHubIdpConfig extends IdentityProviderBuilder<GitHubIdp> {
   /// Callback that can be used with the access token to extract additional
   /// information from GitHub.
   ///
-  /// This callback is invoked during [GitHubIdpUtils.fetchAccountDetails],
-  /// before the system determines if the user is new or returning. It runs on
+  /// This callback is invoked in [GitHubIdpUtils.authenticate],
+  /// after the GitHub account has been linked. It runs on
   /// EVERY authentication attempt.
   ///
   /// **CRITICAL - Do NOT create these models in the callback:**

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/providers/github/business/github_idp_config.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/providers/github/business/github_idp_config.dart
@@ -63,9 +63,8 @@ class GitHubIdpConfig extends IdentityProviderBuilder<GitHubIdp> {
   /// Callback that can be used with the access token to extract additional
   /// information from GitHub.
   ///
-  /// This callback is invoked in [GitHubIdpUtils.authenticate],
-  /// after the GitHub account has been linked. It runs on
-  /// EVERY authentication attempt.
+  /// This callback is invoked after the GitHub account has been created.
+  /// It runs on EVERY authentication attempt.
   ///
   /// **CRITICAL - Do NOT create these models in the callback:**
   /// - [GitHubAccount] - Breaks new account detection

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/providers/github/business/github_idp_utils.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/providers/github/business/github_idp_utils.dart
@@ -207,7 +207,7 @@ class GitHubIdpUtils {
     try {
       data = jsonDecode(response.body) as Map<String, dynamic>;
     } catch (e) {
-      session.logAndThrow('Failed to decode GitHub user response: $e');
+      session.logAndThrow('Invalid user info from GitHub: $e');
     }
 
     if (data['email'] == null) {
@@ -244,13 +244,7 @@ class GitHubIdpUtils {
     try {
       details = _parseAccountDetails(data);
     } catch (e) {
-      session.logAndThrow('Failed to parse GitHub account details: $e');
-    }
-
-    try {
-      config.githubAccountDetailsValidation(details);
-    } catch (e) {
-      session.logAndThrow('Failed to get extra GitHub account info: $e');
+      session.logAndThrow('Invalid user info from GitHub: $e');
     }
 
     return details;
@@ -272,6 +266,12 @@ class GitHubIdpUtils {
       name: name,
       image: avatarUrl != null ? Uri.tryParse(avatarUrl) : null,
     );
+
+    try {
+      config.githubAccountDetailsValidation(details);
+    } catch (e) {
+      throw GitHubUserInfoMissingDataException();
+    }
 
     return details;
   }

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/providers/github/business/github_idp_utils.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/providers/github/business/github_idp_utils.dart
@@ -244,7 +244,11 @@ class GitHubIdpUtils {
             );
           }
         } catch (e) {
-          session.log(e.toString(), level: LogLevel.debug);
+          session.log(
+            'Failed to fetch primary email from GitHub: $e',
+            level: LogLevel.debug,
+            exception: e,
+          );
         }
       }
     }

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/providers/github/business/github_idp_utils.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/providers/github/business/github_idp_utils.dart
@@ -207,7 +207,7 @@ class GitHubIdpUtils {
     try {
       data = jsonDecode(response.body) as Map<String, dynamic>;
     } catch (e) {
-      session.logAndThrow('Invalid user info from GitHub: $e');
+      session.logAndThrow('Failed to decode GitHub user response: $e');
     }
 
     if (data['email'] == null) {
@@ -244,13 +244,13 @@ class GitHubIdpUtils {
     try {
       details = _parseAccountDetails(data);
     } catch (e) {
-      session.logAndThrow('Invalid user info from GitHub: $e');
+      session.logAndThrow('Failed to parse GitHub account details: $e');
     }
 
     try {
       config.githubAccountDetailsValidation(details);
     } catch (e) {
-      throw GitHubUserInfoMissingDataException();
+      session.logAndThrow('Failed to get extra GitHub account info: $e');
     }
 
     return details;

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/providers/github/business/github_idp_utils.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/providers/github/business/github_idp_utils.dart
@@ -210,14 +210,7 @@ class GitHubIdpUtils {
       session.logAndThrow('Invalid user info from GitHub: $e');
     }
 
-    GitHubAccountDetails details;
-    try {
-      details = _parseAccountDetails(data);
-    } catch (e) {
-      session.logAndThrow('Invalid user info from GitHub: $e');
-    }
-
-    if (details.email == null) {
+    if (data['email'] == null) {
       final emailResponse = await http.get(
         Uri.https('api.github.com', '/user/emails'),
         headers: {
@@ -231,17 +224,11 @@ class GitHubIdpUtils {
           final emails = (jsonDecode(emailResponse.body) as List)
               .cast<Map<String, dynamic>>();
           final primary = emails.firstWhere(
-            (final Map<String, dynamic> e) =>
-                e['primary'] == true && e['verified'] == true,
+            (final e) => e['primary'] == true && e['verified'] == true,
             orElse: () => <String, dynamic>{},
           );
           if (primary['email'] is String) {
-            details = (
-              userIdentifier: details.userIdentifier,
-              email: (primary['email'] as String).toLowerCase(),
-              name: details.name,
-              image: details.image,
-            );
+            data['email'] = primary['email'];
           }
         } catch (e) {
           session.log(
@@ -251,6 +238,13 @@ class GitHubIdpUtils {
           );
         }
       }
+    }
+
+    GitHubAccountDetails details;
+    try {
+      details = _parseAccountDetails(data);
+    } catch (e) {
+      session.logAndThrow('Invalid user info from GitHub: $e');
     }
 
     try {

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/providers/github/business/github_idp_utils.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/providers/github/business/github_idp_utils.dart
@@ -146,6 +146,15 @@ class GitHubIdpUtils {
         transaction: transaction,
       );
 
+      await config.onAfterGitHubAccountCreated?.call(
+        session,
+        authUser,
+        githubAccount,
+        transaction: transaction,
+      );
+    }
+
+    try {
       final getExtraInfoCallback = config.getExtraGitHubInfoCallback;
       if (getExtraInfoCallback != null) {
         await getExtraInfoCallback(
@@ -155,13 +164,8 @@ class GitHubIdpUtils {
           transaction: transaction,
         );
       }
-
-      await config.onAfterGitHubAccountCreated?.call(
-        session,
-        authUser,
-        githubAccount,
-        transaction: transaction,
-      );
+    } catch (e) {
+      session.logAndThrow('Failed to get extra GitHub account info: $e');
     }
 
     return (
@@ -224,12 +228,14 @@ class GitHubIdpUtils {
       );
       if (emailResponse.statusCode == 200) {
         try {
-          final emails = jsonDecode(emailResponse.body) as List<dynamic>;
+          final emails = (jsonDecode(emailResponse.body) as List)
+              .cast<Map<String, dynamic>>();
           final primary = emails.firstWhere(
-            (final e) => e['primary'] == true && e['verified'] == true,
-            orElse: () => null,
+            (final Map<String, dynamic> e) =>
+                e['primary'] == true && e['verified'] == true,
+            orElse: () => <String, dynamic>{},
           );
-          if (primary != null && primary['email'] is String) {
+          if (primary['email'] is String) {
             details = (
               userIdentifier: details.userIdentifier,
               email: (primary['email'] as String).toLowerCase(),

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/providers/github/business/github_idp_utils.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/providers/github/business/github_idp_utils.dart
@@ -146,6 +146,16 @@ class GitHubIdpUtils {
         transaction: transaction,
       );
 
+      final getExtraInfoCallback = config.getExtraGitHubInfoCallback;
+      if (getExtraInfoCallback != null) {
+        await getExtraInfoCallback(
+          session,
+          accountDetails: accountDetails,
+          accessToken: accessToken,
+          transaction: transaction,
+        );
+      }
+
       await config.onAfterGitHubAccountCreated?.call(
         session,
         authUser,
@@ -203,18 +213,40 @@ class GitHubIdpUtils {
       session.logAndThrow('Invalid user info from GitHub: $e');
     }
 
-    try {
-      final getExtraInfoCallback = config.getExtraGitHubInfoCallback;
-      if (getExtraInfoCallback != null) {
-        await getExtraInfoCallback(
-          session,
-          accountDetails: details,
-          accessToken: accessToken,
-          transaction: null,
-        );
+    if (details.email == null) {
+      final emailResponse = await http.get(
+        Uri.https('api.github.com', '/user/emails'),
+        headers: {
+          'Authorization': 'Bearer $accessToken',
+          'Accept': 'application/vnd.github+json',
+          'X-GitHub-Api-Version': '2022-11-28',
+        },
+      );
+      if (emailResponse.statusCode == 200) {
+        try {
+          final emails = jsonDecode(emailResponse.body) as List<dynamic>;
+          final primary = emails.firstWhere(
+            (final e) => e['primary'] == true && e['verified'] == true,
+            orElse: () => null,
+          );
+          if (primary != null && primary['email'] is String) {
+            details = (
+              userIdentifier: details.userIdentifier,
+              email: (primary['email'] as String).toLowerCase(),
+              name: details.name,
+              image: details.image,
+            );
+          }
+        } catch (e) {
+          session.log(e.toString(), level: LogLevel.debug);
+        }
       }
+    }
+
+    try {
+      config.githubAccountDetailsValidation(details);
     } catch (e) {
-      session.logAndThrow('Failed to get extra GitHub account info: $e');
+      throw GitHubUserInfoMissingDataException();
     }
 
     return details;
@@ -236,12 +268,6 @@ class GitHubIdpUtils {
       name: name,
       image: avatarUrl != null ? Uri.tryParse(avatarUrl) : null,
     );
-
-    try {
-      config.githubAccountDetailsValidation(details);
-    } catch (e) {
-      throw GitHubUserInfoMissingDataException();
-    }
 
     return details;
   }


### PR DESCRIPTION
This PR do extra request for fetching user email in GitHub Idp and move `getExtraGitHubInfoCallback` callback in useful  place.

- Decrease risk of null email in Githib IdP

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

No breaking changes