### PR TITLE
fix: Fix index type defaulting to `gin` if `serializeAsJsonbByDefault` is set on the project

### DIFF
--- a/tools/serverpod_cli/lib/src/analyzer/models/model_parser/model_parser.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/model_parser/model_parser.dart
@@ -266,6 +266,23 @@ class ModelParser {
     );
   }
 
+  static void _resolveSerializationDataType(
+    TypeDefinition typeResult,
+    YamlMap documentContents,
+    SerializationDataType? defaultSerializationDataType,
+  ) {
+    final explicitValue = _parseSerializationDataType(documentContents);
+    if (explicitValue != null) {
+      typeResult.serializationDataType = explicitValue;
+    } else if (typeResult.isColumnSerializable ||
+        typeResult.isColumnStructured) {
+      // Only serializable types should receive the default override (like
+      // lists, maps, serializable models and custom classes). Otherwise we
+      // would incorrectly flag other types as `.isJsonbSerialized`.
+      typeResult.serializationDataType = defaultSerializationDataType;
+    }
+  }
+
   static EnumSerialization _parseSerializedAs(YamlMap documentContents) {
     var serializedAs = documentContents.nodes[Keyword.serialized]?.value;
 
@@ -370,12 +387,14 @@ class ModelParser {
       typeValue,
       extraClasses: extraClasses,
     );
+    _resolveSerializationDataType(
+      typeResult,
+      node,
+      defaultSerializationDataType,
+    );
 
     var scope = _parseClassFieldScope(node, serverOnlyClass);
     var shouldPersist = _parseShouldPersist(node);
-
-    typeResult.serializationDataType =
-        _parseSerializationDataType(node) ?? defaultSerializationDataType;
 
     var defaultModelValue = _parseDefaultValue(
       node,

--- a/tools/serverpod_cli/lib/src/analyzer/models/validation/restrictions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/validation/restrictions.dart
@@ -1845,8 +1845,8 @@ class Restrictions {
         if (nonJsonbFields.isNotEmpty) {
           return [
             SourceSpanSeverityException(
-              'The "gin" index type requires all indexed fields to use '
-              '"${Keyword.serializationDataType}: jsonb" (fields: ${nonJsonbFields.join(', ')}).',
+              'The "gin" index type requires all indexed fields to be stored '
+              'as jsonb columns (fields: ${nonJsonbFields.join(', ')}).',
               span,
             ),
           ];

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/class_serialization_data_type_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/class_serialization_data_type_test.dart
@@ -182,4 +182,37 @@ void main() {
       );
     },
   );
+
+  test(
+    'Given class with `serializationDataType` set and a non-serializable field, '
+    'when validating, '
+    'then the field has no `serializationDataType` set.',
+    () {
+      var models = [
+        ModelSourceBuilder().withYaml('''
+        class: Example
+        table: example
+        serializationDataType: jsonb
+        fields:
+          name: String
+        ''').build(),
+      ];
+
+      var collector = CodeGenerationCollector();
+      var analyzer = StatefulAnalyzer(
+        config,
+        models,
+        onErrorsCollector(collector),
+      );
+
+      var definitions = analyzer.validateAll();
+
+      var definition = definitions.first as ModelClassDefinition;
+      expect(collector.errors, isEmpty);
+      expect(
+        definition.fields.last.type.serializationDataType,
+        isNull,
+      );
+    },
+  );
 }

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/indexes/index_type_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/indexes/index_type_test.dart
@@ -88,8 +88,8 @@ void main() {
       );
       expect(
         collector.errors.first.message,
-        'The "gin" index type requires all indexed fields to use '
-        '"serializationDataType: jsonb" (fields: name).',
+        'The "gin" index type requires all indexed fields to be stored '
+        'as jsonb columns (fields: name).',
       );
     },
   );
@@ -159,6 +159,49 @@ void main() {
       var index = definition.indexes.first;
 
       expect(index.type, 'btree');
+    },
+  );
+
+  test(
+    'Given a project with `serializeAsJsonbByDefault` set and an index on scalar fields with no explicit type, '
+    'when validating, '
+    'then the index type defaults to btree.',
+    () {
+      var jsonbDefaultConfig = GeneratorConfigBuilder()
+          .withEnabledSerializeAsJsonbByDefault()
+          .build();
+      var models = [
+        ModelSourceBuilder().withYaml(
+          '''
+          class: Example
+          table: example
+          fields:
+            userId: int
+            name: String
+          indexes:
+            example_scalar_idx:
+              fields: userId, name
+              unique: true
+          ''',
+        ).build(),
+      ];
+
+      var collector = CodeGenerationCollector();
+      var analyzer = StatefulAnalyzer(
+        jsonbDefaultConfig,
+        models,
+        onErrorsCollector(collector),
+      );
+      var definitions = analyzer.validateAll();
+
+      expect(
+        collector.errors,
+        isEmpty,
+        reason: 'Expected no errors, but errors were collected.',
+      );
+
+      var definition = definitions.first as ModelClassDefinition;
+      expect(definition.indexes.first.type, 'btree');
     },
   );
 

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/project_serialization_data_type_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/project_serialization_data_type_test.dart
@@ -162,4 +162,36 @@ void main() {
       );
     },
   );
+
+  test(
+    'Given `serializeAsJsonbByDefault` enabled and a class without `serializationDataType` and a non-serializable field, '
+    'when validating, '
+    'then the field has no `serializationDataType` set.',
+    () {
+      var models = [
+        ModelSourceBuilder().withYaml('''
+        class: Example
+        table: example
+        fields:
+          name: String
+        ''').build(),
+      ];
+
+      var collector = CodeGenerationCollector();
+      var analyzer = StatefulAnalyzer(
+        config,
+        models,
+        onErrorsCollector(collector),
+      );
+
+      var definitions = analyzer.validateAll();
+
+      var definition = definitions.first as ModelClassDefinition;
+      expect(collector.errors, isEmpty);
+      expect(
+        definition.fields.last.type.serializationDataType,
+        isNull,
+      );
+    },
+  );
 }


### PR DESCRIPTION
Fixes: #5033

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.