### PR TITLE
fix: Fix missing `_Undefined` sentinel on generated code for `dynamic` fields

### DIFF
--- a/tools/serverpod_cli/lib/src/generator/dart/library_generators/model_library_generator.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart/library_generators/model_library_generator.dart
@@ -63,9 +63,9 @@ class SerializableModelLibraryGenerator {
   Library _generateExceptionLibrary(ExceptionClassDefinition definition) {
     var fields = definition.fields;
     var className = definition.className;
-    var nonNullableField = fields
+    var needsUndefinedClass = fields
         .where((field) => field.shouldIncludeField(serverCode))
-        .any((field) => field.type.nullable);
+        .any(_fieldUsesUndefinedCopyWithSentinel);
 
     return Library(
       (libraryBuilder) {
@@ -75,7 +75,7 @@ class SerializableModelLibraryGenerator {
             definition,
             fields,
           ),
-          if (nonNullableField) _buildUndefinedClass(),
+          if (needsUndefinedClass) _buildUndefinedClass(),
           _buildModelImplClass(
             className,
             null,
@@ -563,6 +563,12 @@ class SerializableModelLibraryGenerator {
     });
   }
 
+  /// Nullable params and `dynamic` fields use `Object? ... = _Undefined` so
+  /// omitted args differ from explicit `null`.
+  bool _fieldUsesUndefinedCopyWithSentinel(
+    SerializableModelFieldDefinition field,
+  ) => field.type.nullable || field.type.className == 'dynamic';
+
   bool _shouldCreateUndefinedClass(
     ModelClassDefinition classDefinition,
     List<SerializableModelFieldDefinition> fields,
@@ -570,7 +576,7 @@ class SerializableModelLibraryGenerator {
     if (classDefinition.sealedTopNode == null) {
       return fields
           .where((field) => field.shouldIncludeField(serverCode))
-          .any((field) => field.type.nullable);
+          .any(_fieldUsesUndefinedCopyWithSentinel);
     }
 
     if (!classDefinition.isSealedTopNode) {
@@ -586,7 +592,7 @@ class SerializableModelLibraryGenerator {
 
     return descendantFields
         .where((field) => field.shouldIncludeField(serverCode))
-        .any((field) => field.type.nullable);
+        .any(_fieldUsesUndefinedCopyWithSentinel);
   }
 
   Class _buildUndefinedClass() {
@@ -876,11 +882,8 @@ class SerializableModelLibraryGenerator {
                 config: config,
               );
 
-              // `dynamic` is stored as non-null in [TypeDefinition], but like
-              // nullable fields it needs the `_Undefined` sentinel so omitted
-              // `copyWith` args are not confused with explicit `null`.
               final usesUndefinedCopyWithDefault =
-                  field.type.nullable || field.type.className == 'dynamic';
+                  _fieldUsesUndefinedCopyWithSentinel(field);
               var type = usesUndefinedCopyWithDefault
                   ? refer('Object?')
                   : fieldType;

--- a/tools/serverpod_cli/test/generator/dart/client_code_generator/class_copy_with_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/client_code_generator/class_copy_with_test.dart
@@ -529,4 +529,52 @@ void main() {
       skip: copyWithMethod == null,
     );
   });
+
+  group(
+    'Given a class with only dynamic fields when generating code',
+    () {
+      var models = [
+        ModelClassDefinitionBuilder()
+            .withClassName(testClassName)
+            .withFileName(testClassFileName)
+            .withSimpleField('payload', 'dynamic', nullable: false)
+            .build(),
+      ];
+
+      late var codeMap = generator.generateSerializableModelsCode(
+        models: models,
+        config: config,
+      );
+
+      late var compilationUnit = parseString(
+        content: codeMap[expectedFilePath]!,
+      ).unit;
+
+      test('then an empty class named _Undefined is generated.', () {
+        expect(
+          CompilationUnitHelpers.tryFindClassDeclaration(
+            compilationUnit,
+            name: '_Undefined',
+          ),
+          isNotNull,
+          reason: 'copyWith uses _Undefined for non-null dynamic fields',
+        );
+      });
+
+      test('then impl copyWith uses Object? payload = _Undefined.', () {
+        var impl = CompilationUnitHelpers.tryFindClassDeclaration(
+          compilationUnit,
+          name: '_${testClassName}Impl',
+        );
+        var copyWithMethod = CompilationUnitHelpers.tryFindMethodDeclaration(
+          impl!,
+          name: 'copyWith',
+        );
+        expect(
+          copyWithMethod?.parameters?.toSource(),
+          '({Object? payload = _Undefined})',
+        );
+      });
+    },
+  );
 }

--- a/tools/serverpod_cli/test/generator/dart/server_code_generator/class_copy_with_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/server_code_generator/class_copy_with_test.dart
@@ -533,4 +533,52 @@ void main() {
       skip: copyWithMethod == null,
     );
   });
+
+  group(
+    'Given a class with only dynamic fields when generating code',
+    () {
+      var models = [
+        ModelClassDefinitionBuilder()
+            .withClassName(testClassName)
+            .withFileName(testClassFileName)
+            .withSimpleField('payload', 'dynamic', nullable: false)
+            .build(),
+      ];
+
+      late var codeMap = generator.generateSerializableModelsCode(
+        models: models,
+        config: config,
+      );
+
+      late var compilationUnit = parseString(
+        content: codeMap[expectedFilePath]!,
+      ).unit;
+
+      test('then an empty class named _Undefined is generated.', () {
+        expect(
+          CompilationUnitHelpers.tryFindClassDeclaration(
+            compilationUnit,
+            name: '_Undefined',
+          ),
+          isNotNull,
+          reason: 'copyWith uses _Undefined for non-null dynamic fields',
+        );
+      });
+
+      test('then impl copyWith uses Object? payload = _Undefined.', () {
+        var impl = CompilationUnitHelpers.tryFindClassDeclaration(
+          compilationUnit,
+          name: '_${testClassName}Impl',
+        );
+        var copyWithMethod = CompilationUnitHelpers.tryFindMethodDeclaration(
+          impl!,
+          name: 'copyWith',
+        );
+        expect(
+          copyWithMethod?.parameters?.toSource(),
+          '({Object? payload = _Undefined})',
+        );
+      });
+    },
+  );
 }

--- a/tools/serverpod_cli/test/generator/dart/shared_code_generator/class_copy_with_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/shared_code_generator/class_copy_with_test.dart
@@ -560,4 +560,53 @@ void main() {
       skip: copyWithMethod == null,
     );
   });
+
+  group(
+    'Given a class with only dynamic fields when generating code',
+    () {
+      var models = [
+        ModelClassDefinitionBuilder()
+            .withClassName(testClassName)
+            .withFileName(testClassFileName)
+            .withSimpleField('payload', 'dynamic', nullable: false)
+            .withSharedPackageName(sharedPackageName)
+            .build(),
+      ];
+
+      late var codeMap = generator.generateSerializableModelsCode(
+        models: models,
+        config: config,
+      );
+
+      late var compilationUnit = parseString(
+        content: codeMap[expectedFilePath]!,
+      ).unit;
+
+      test('then an empty class named _Undefined is generated.', () {
+        expect(
+          CompilationUnitHelpers.tryFindClassDeclaration(
+            compilationUnit,
+            name: '_Undefined',
+          ),
+          isNotNull,
+          reason: 'copyWith uses _Undefined for non-null dynamic fields',
+        );
+      });
+
+      test('then impl copyWith uses Object? payload = _Undefined.', () {
+        var impl = CompilationUnitHelpers.tryFindClassDeclaration(
+          compilationUnit,
+          name: '_${testClassName}Impl',
+        );
+        var copyWithMethod = CompilationUnitHelpers.tryFindMethodDeclaration(
+          impl!,
+          name: 'copyWith',
+        );
+        expect(
+          copyWithMethod?.parameters?.toSource(),
+          '({Object? payload = _Undefined})',
+        );
+      });
+    },
+  );
 }


### PR DESCRIPTION
On models with `dynamic` fields (introduced with #5013) and no other nullable fields, a syntax error is being generated due to the missing `_Undefined` sentinel for the `copyWith` method.

This was because the `dynamic` field was stored as non-null in the `TypeDefinition`, but like nullable fields it needs the `_Undefined` sentinel so omitted `copyWith` args are not confused with explicit `null`.

On the test models, this issue was masked due to the presence of other nullable fields.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.