### PR TITLE
feat: Restore terminal settings when exiting tui process

### DIFF
--- a/tools/serverpod_cli/lib/src/commands/create.dart
+++ b/tools/serverpod_cli/lib/src/commands/create.dart
@@ -7,6 +7,7 @@ import 'package:nocterm/nocterm.dart';
 import 'package:serverpod_cli/src/commands/create/tui/app.dart';
 import 'package:serverpod_cli/src/commands/create/tui/state.dart';
 import 'package:serverpod_cli/src/commands/create/tui/state_holder.dart';
+import 'package:serverpod_cli/src/commands/tui/run_app.dart';
 import 'package:serverpod_cli/src/commands/tui/terminal_backend.dart';
 import 'package:serverpod_cli/src/commands/tui/tui_log_writer.dart';
 import 'package:serverpod_cli/src/create/create.dart';
@@ -232,7 +233,7 @@ class CreateCommand extends ServerpodCommand<CreateOption> {
 
     String? projectPath;
 
-    await runApp(
+    await runServerpodApp(
       backend: ServerpodTerminalBackend(
         preExit: () => _preExit(
           template: template,

--- a/tools/serverpod_cli/lib/src/commands/start.dart
+++ b/tools/serverpod_cli/lib/src/commands/start.dart
@@ -20,6 +20,7 @@ import 'package:serverpod_cli/src/commands/start/tui/app.dart';
 import 'package:serverpod_cli/src/commands/start/tui/event_handler.dart';
 import 'package:serverpod_cli/src/commands/start/tui/state.dart';
 import 'package:serverpod_cli/src/commands/start/watch_session.dart';
+import 'package:serverpod_cli/src/commands/tui/run_app.dart';
 import 'package:serverpod_cli/src/commands/tui/tui_log_sink.dart';
 import 'package:serverpod_cli/src/commands/tui/tui_log_writer.dart';
 import 'package:serverpod_cli/src/commands/watcher.dart';
@@ -727,7 +728,7 @@ Future<int> _runWithTui({
   }
 
   // Block on the TUI.
-  await runApp(ServerpodWatchApp(holder: holder, onReady: onReady));
+  await runServerpodApp(ServerpodWatchApp(holder: holder, onReady: onReady));
 
   return exitCode;
 }

--- a/tools/serverpod_cli/lib/src/commands/tui/run_app.dart
+++ b/tools/serverpod_cli/lib/src/commands/tui/run_app.dart
@@ -1,0 +1,35 @@
+import 'dart:io';
+
+import 'package:nocterm/nocterm.dart';
+
+/// Run a TUI app with terminal settings restoration.
+Future<void> runServerpodApp(
+  Component app, {
+  bool enableHotReload = true,
+  TerminalBackend? backend,
+}) async {
+  final originalEchoMode = stdin.echoMode;
+  final originalLineMode = stdin.lineMode;
+
+  void restoreTerminal() {
+    stdin.echoMode = originalEchoMode;
+    stdin.lineMode = originalLineMode;
+  }
+
+  void onShutDownSignal(ProcessSignal _) {
+    restoreTerminal();
+    shutdownApp();
+  }
+
+  ProcessSignal.sigint.watch().listen(onShutDownSignal);
+
+  if (!Platform.isWindows) {
+    ProcessSignal.sigterm.watch().listen(onShutDownSignal);
+  }
+
+  try {
+    await runApp(app, enableHotReload: enableHotReload, backend: backend);
+  } finally {
+    restoreTerminal();
+  }
+}


### PR DESCRIPTION
`echoMode` and `lineMode` are restored when exiting nocterm. Restoration also happens on SIGINT and SIGTERM.

Closes [5024](https://github.com/serverpod/serverpod/issues/5024)

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None