### PR TITLE
fix(cli): Serialize handleFileChange through _pending

### DIFF
--- a/tools/serverpod_cli/lib/src/commands/start/watch_session.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/watch_session.dart
@@ -175,7 +175,10 @@ class WatchSession {
   Stream<void> get vmServiceUriChanges => _vmServiceUriChangesController.stream;
 
   /// Processes a single (merged) file change event.
-  Future<void> handleFileChange(FileChangeEvent event) async {
+  Future<void> handleFileChange(FileChangeEvent event) =>
+      _chain(() => _handleFileChange(event));
+
+  Future<void> _handleFileChange(FileChangeEvent event) async {
     final hasDartChanges =
         event.dartFiles.isNotEmpty ||
         event.modelFiles.isNotEmpty ||
@@ -199,7 +202,7 @@ class WatchSession {
       }
     }
 
-    log.info('\nFiles changed, reloading server...');
+    log.info('Files changed');
     if (sourceDartFiles.isNotEmpty) log.debug('  .dart: $sourceDartFiles');
     if (generatedDartFiles.isNotEmpty) {
       log.debug('  .dart (generated): $generatedDartFiles');


### PR DESCRIPTION
Route handleFileChange through _pending so all entry points (file watcher, vm-service proxy, MCP/TUI buttons) serialize.

Previously, if using `serverpod start --watch` (now default) and _hot-reload on save_ in you IDE (common), when saving a file would trigger two codepaths concurrently. One via the file change, and the other via the requested hot-reload. This would compete for accessing the `FES` causing a crash.

This PR ensures file handling is serialized on the session with all other operations.
