### PR TITLE
feat: Add skills configuration to create command

### DIFF
--- a/templates/pubspecs/tools/serverpod_cli/pubspec.yaml
+++ b/templates/pubspecs/tools/serverpod_cli/pubspec.yaml
@@ -51,9 +51,7 @@ dependencies:
   serverpod_serialization: SERVERPOD_VERSION
   serverpod_service_client: SERVERPOD_VERSION
   serverpod_shared: SERVERPOD_VERSION
-  # skills must be pinned to 0.2.2 to avoid breaking changes
-  # as the package receives external contribution
-  skills: 0.2.2
+  skills: ^0.3.0
   source_span: ^1.10.0
   stream_channel: ^2.1.1
   stream_transform: ^2.1.0

--- a/templates/pubspecs/tools/serverpod_cli/pubspec.yaml
+++ b/templates/pubspecs/tools/serverpod_cli/pubspec.yaml
@@ -51,7 +51,7 @@ dependencies:
   serverpod_serialization: SERVERPOD_VERSION
   serverpod_service_client: SERVERPOD_VERSION
   serverpod_shared: SERVERPOD_VERSION
-  skills: ^0.2.2
+  skills: 0.2.2
   source_span: ^1.10.0
   stream_channel: ^2.1.1
   stream_transform: ^2.1.0

--- a/templates/pubspecs/tools/serverpod_cli/pubspec.yaml
+++ b/templates/pubspecs/tools/serverpod_cli/pubspec.yaml
@@ -51,6 +51,7 @@ dependencies:
   serverpod_serialization: SERVERPOD_VERSION
   serverpod_service_client: SERVERPOD_VERSION
   serverpod_shared: SERVERPOD_VERSION
+  skills: ^0.2.2
   source_span: ^1.10.0
   stream_channel: ^2.1.1
   stream_transform: ^2.1.0

--- a/templates/pubspecs/tools/serverpod_cli/pubspec.yaml
+++ b/templates/pubspecs/tools/serverpod_cli/pubspec.yaml
@@ -51,6 +51,8 @@ dependencies:
   serverpod_serialization: SERVERPOD_VERSION
   serverpod_service_client: SERVERPOD_VERSION
   serverpod_shared: SERVERPOD_VERSION
+  # skills must be pinned to 0.2.2 to avoid breaking changes
+  # as the package receives external contribution
   skills: 0.2.2
   source_span: ^1.10.0
   stream_channel: ^2.1.1

--- a/templates/serverpod_templates/modulename/gitignore
+++ b/templates/serverpod_templates/modulename/gitignore
@@ -6,5 +6,6 @@
 pubspec_overrides.yaml
 
 # Agents
+.dart_skills/
 .agents/
 .claude/

--- a/templates/serverpod_templates/modulename/gitignore
+++ b/templates/serverpod_templates/modulename/gitignore
@@ -4,3 +4,7 @@
 
 # Pubspec overrides
 pubspec_overrides.yaml
+
+# Agents
+.agents/
+.claude/

--- a/templates/serverpod_templates/projectname/gitignore
+++ b/templates/serverpod_templates/projectname/gitignore
@@ -6,5 +6,6 @@
 pubspec_overrides.yaml
 
 # Agents
+.dart_skills/
 .agents/
 .claude/

--- a/templates/serverpod_templates/projectname/gitignore
+++ b/templates/serverpod_templates/projectname/gitignore
@@ -4,3 +4,7 @@
 
 # Pubspec overrides
 pubspec_overrides.yaml
+
+# Agents
+.agents/
+.claude/

--- a/tests/bootstrap_project/test/module_quickstart_test.dart
+++ b/tests/bootstrap_project/test/module_quickstart_test.dart
@@ -339,7 +339,7 @@ void main() {
         test('has agent skills installed', () {
           expect(
             Directory(
-              path.join(tempPath, projectName, '.agent', 'skills'),
+              path.join(tempPath, projectName, '.agents', 'skills'),
             ).existsSync(),
             isTrue,
           );

--- a/tests/bootstrap_project/test/module_quickstart_test.dart
+++ b/tests/bootstrap_project/test/module_quickstart_test.dart
@@ -335,6 +335,21 @@ void main() {
             isTrue,
           );
         });
+
+        test('has agent skills installed', () {
+          expect(
+            Directory(
+              path.join(tempPath, projectName, '.agent', 'skills'),
+            ).existsSync(),
+            isTrue,
+          );
+          expect(
+            Directory(
+              path.join(tempPath, projectName, '.claude', 'skills'),
+            ).existsSync(),
+            isTrue,
+          );
+        });
       });
     });
   });

--- a/tests/bootstrap_project/test/module_test.dart
+++ b/tests/bootstrap_project/test/module_test.dart
@@ -350,7 +350,7 @@ void main() {
         test('has agent skills installed', () {
           expect(
             Directory(
-              path.join(tempPath, projectName, '.agent', 'skills'),
+              path.join(tempPath, projectName, '.agents', 'skills'),
             ).existsSync(),
             isTrue,
           );

--- a/tests/bootstrap_project/test/module_test.dart
+++ b/tests/bootstrap_project/test/module_test.dart
@@ -346,6 +346,21 @@ void main() {
             reason: 'Root pubspec.lock file does not exist.',
           );
         });
+
+        test('has agent skills installed', () {
+          expect(
+            Directory(
+              path.join(tempPath, projectName, '.agent', 'skills'),
+            ).existsSync(),
+            isTrue,
+          );
+          expect(
+            Directory(
+              path.join(tempPath, projectName, '.claude', 'skills'),
+            ).existsSync(),
+            isTrue,
+          );
+        });
       });
     });
   });

--- a/tests/bootstrap_project/test/project_mini_test.dart
+++ b/tests/bootstrap_project/test/project_mini_test.dart
@@ -331,6 +331,21 @@ void main() async {
             reason: 'Root pubspec.lock file does not exist.',
           );
         });
+
+        test('has agent skills installed', () {
+          expect(
+            Directory(
+              path.join(tempPath, projectName, '.agent', 'skills'),
+            ).existsSync(),
+            isTrue,
+          );
+          expect(
+            Directory(
+              path.join(tempPath, projectName, '.claude', 'skills'),
+            ).existsSync(),
+            isTrue,
+          );
+        });
       });
     });
   });

--- a/tests/bootstrap_project/test/project_mini_test.dart
+++ b/tests/bootstrap_project/test/project_mini_test.dart
@@ -335,7 +335,7 @@ void main() async {
         test('has agent skills installed', () {
           expect(
             Directory(
-              path.join(tempPath, projectName, '.agent', 'skills'),
+              path.join(tempPath, projectName, '.agents', 'skills'),
             ).existsSync(),
             isTrue,
           );

--- a/tests/bootstrap_project/test/project_quickstart_test.dart
+++ b/tests/bootstrap_project/test/project_quickstart_test.dart
@@ -432,7 +432,7 @@ void main() async {
             test('has agent skills installed', () {
               expect(
                 Directory(
-                  path.join(tempPath, projectName, '.agent', 'skills'),
+                  path.join(tempPath, projectName, '.agents', 'skills'),
                 ).existsSync(),
                 isTrue,
               );

--- a/tests/bootstrap_project/test/project_quickstart_test.dart
+++ b/tests/bootstrap_project/test/project_quickstart_test.dart
@@ -428,6 +428,21 @@ void main() async {
                 isTrue,
               );
             });
+
+            test('has agent skills installed', () {
+              expect(
+                Directory(
+                  path.join(tempPath, projectName, '.agent', 'skills'),
+                ).existsSync(),
+                isTrue,
+              );
+              expect(
+                Directory(
+                  path.join(tempPath, projectName, '.claude', 'skills'),
+                ).existsSync(),
+                isTrue,
+              );
+            });
           });
 
           group('then the .github directory', () {

--- a/tests/bootstrap_project/test/project_test.dart
+++ b/tests/bootstrap_project/test/project_test.dart
@@ -709,7 +709,7 @@ void main() async {
         test('has agent skills installed', () {
           expect(
             Directory(
-              path.join(tempPath, projectName, '.agent', 'skills'),
+              path.join(tempPath, projectName, '.agents', 'skills'),
             ).existsSync(),
             isTrue,
           );

--- a/tests/bootstrap_project/test/project_test.dart
+++ b/tests/bootstrap_project/test/project_test.dart
@@ -705,6 +705,21 @@ void main() async {
             expect(content, contains('flutter_secure_storage'));
           },
         );
+
+        test('has agent skills installed', () {
+          expect(
+            Directory(
+              path.join(tempPath, projectName, '.agent', 'skills'),
+            ).existsSync(),
+            isTrue,
+          );
+          expect(
+            Directory(
+              path.join(tempPath, projectName, '.claude', 'skills'),
+            ).existsSync(),
+            isTrue,
+          );
+        });
       });
 
       group('then the .vscode directory', () {

--- a/tools/serverpod_cli/lib/src/commands/create.dart
+++ b/tools/serverpod_cli/lib/src/commands/create.dart
@@ -142,6 +142,7 @@ class CreateCommand extends ServerpodCommand<CreateOption> {
       redis: true,
       postgres: true,
       web: true,
+      skills: true,
     );
 
     final useTui = (interactive ?? true) && !ci.isCI;

--- a/tools/serverpod_cli/lib/src/commands/create/tui/config.dart
+++ b/tools/serverpod_cli/lib/src/commands/create/tui/config.dart
@@ -8,11 +8,7 @@ enum ServerpodCreateConfig<T extends ConfigOption> {
     label: 'Project Type',
     options: TemplateTypeOption.values,
     defaultOption: TemplateTypeOption.server,
-    templates: [
-      ServerpodTemplateType.server,
-      ServerpodTemplateType.module,
-      ServerpodTemplateType.mini,
-    ],
+    templates: ServerpodTemplateType.values,
   ),
   database<DatabaseConfigOption>(
     label: 'Database',
@@ -44,6 +40,12 @@ enum ServerpodCreateConfig<T extends ConfigOption> {
         disabledOption: BoolConfigOption.disabled,
       ),
     ],
+  ),
+  skills<BoolConfigOption>(
+    label: 'Agent Skills',
+    options: BoolConfigOption.values,
+    defaultOption: BoolConfigOption.enabled,
+    templates: ServerpodTemplateType.values,
   )
   ;
 

--- a/tools/serverpod_cli/lib/src/commands/create/tui/state.dart
+++ b/tools/serverpod_cli/lib/src/commands/create/tui/state.dart
@@ -202,6 +202,7 @@ class CreateConfigState extends ServerpodState {
         DatabaseConfigOption.sqlite,
       ),
       web: getStatus(ServerpodCreateConfig.web, BoolConfigOption.enabled),
+      skills: getStatus(ServerpodCreateConfig.skills, BoolConfigOption.enabled),
     );
   }
 }

--- a/tools/serverpod_cli/lib/src/commands/quickstart.dart
+++ b/tools/serverpod_cli/lib/src/commands/quickstart.dart
@@ -121,7 +121,7 @@ class QuickstartCommand extends ServerpodCommand<QuickstartOption> {
       template,
       force,
       interactive: interactive,
-      context: TemplateContext(sqlite: true, web: true),
+      context: TemplateContext(sqlite: true, web: true, skills: true),
     );
 
     if (projectPath == null) {

--- a/tools/serverpod_cli/lib/src/create/create.dart
+++ b/tools/serverpod_cli/lib/src/create/create.dart
@@ -310,9 +310,27 @@ Future<String?> performCreate(
           stderr: toErrorLog,
         );
 
-        if (!success) _logError('Failed to install agent skills');
+        if (!success) {
+          _logError('Failed to install agent skills');
+          return false;
+        }
+
+        final agentDir = Directory(
+          p.join(serverpodDirs.projectDir.path, '.agent'),
+        );
+        final agentsDir = Directory(
+          p.join(serverpodDirs.projectDir.path, '.agents'),
+        );
+
+        try {
+          await _moveDirectoryContents(agentDir, agentsDir);
+          await agentDir.delete();
+        } on FileSystemException {
+          //
+        }
       } catch (_) {
         _logError('Failed to install agent skills');
+        return false;
       }
       return true;
     });
@@ -337,6 +355,32 @@ Future<String?> performCreate(
   }
 
   return null;
+}
+
+Future<void> _moveDirectoryContents(
+  Directory source,
+  Directory destination,
+) async {
+  if (!await source.exists()) {
+    throw Exception('Source directory does not exist: ${source.path}');
+  }
+
+  // Ensure destination exists
+  if (!await destination.exists()) {
+    await destination.create(recursive: true);
+  }
+
+  await for (final entity in source.list()) {
+    final newPath = p.join(destination.path, p.basename(entity.path));
+
+    if (entity is File) {
+      await entity.rename(newPath);
+    } else if (entity is Directory) {
+      final newDir = await Directory(newPath).create(recursive: true);
+      await _moveDirectoryContents(entity, newDir);
+      await entity.delete();
+    }
+  }
 }
 
 /// Upgrades a server project.

--- a/tools/serverpod_cli/lib/src/create/create.dart
+++ b/tools/serverpod_cli/lib/src/create/create.dart
@@ -26,7 +26,7 @@ import 'package:serverpod_cli/src/util/pubspec_helpers.dart';
 import 'package:serverpod_cli/src/util/serverpod_cli_logger.dart';
 import 'package:serverpod_cli/src/util/string_validators.dart';
 import 'package:serverpod_shared/serverpod_shared.dart';
-import 'package:skills/src/commands/get_skills.dart';
+import 'package:skills/skills.dart';
 import 'package:skills/src/core/workspace_resolver.dart';
 import 'package:skills/src/ide/ide.dart';
 import 'package:yaml_edit/yaml_edit.dart';

--- a/tools/serverpod_cli/lib/src/create/create.dart
+++ b/tools/serverpod_cli/lib/src/create/create.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: implementation_imports
+
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
@@ -24,6 +26,9 @@ import 'package:serverpod_cli/src/util/pubspec_helpers.dart';
 import 'package:serverpod_cli/src/util/serverpod_cli_logger.dart';
 import 'package:serverpod_cli/src/util/string_validators.dart';
 import 'package:serverpod_shared/serverpod_shared.dart';
+import 'package:skills/src/commands/get_skills.dart';
+import 'package:skills/src/core/workspace_resolver.dart';
+import 'package:skills/src/ide/ide.dart';
 import 'package:yaml_edit/yaml_edit.dart';
 
 import 'copier.dart';
@@ -276,6 +281,41 @@ Future<String?> performCreate(
         return exitCode == 0;
       },
     );
+  }
+
+  if (context.skills) {
+    await log.progress('Installing agent skills', () async {
+      try {
+        final workspace = await const WorkspaceResolver().resolve(
+          serverpodDirs.projectDir.path,
+        );
+
+        final stdoutController = StreamController<List<int>>();
+        stdoutController.stream
+            .transform(const Utf8Decoder(allowMalformed: true))
+            .transform(const LineSplitter())
+            .listen((data) => log.debug(data));
+        final toDebugLog = IOSink(stdoutController);
+        final stderrController = StreamController<List<int>>();
+        stderrController.stream
+            .transform(const Utf8Decoder(allowMalformed: true))
+            .transform(const LineSplitter())
+            .listen((data) => _logError(data));
+        final toErrorLog = IOSink(stderrController);
+
+        final success = await getSkills(
+          ides: [Ide.claude, Ide.generic],
+          workspace: workspace,
+          stdout: toDebugLog,
+          stderr: toErrorLog,
+        );
+
+        if (!success) _logError('Failed to install agent skills');
+      } catch (_) {
+        _logError('Failed to install agent skills');
+      }
+      return true;
+    });
   }
 
   if (success || force) {

--- a/tools/serverpod_cli/lib/src/create/template_context.dart
+++ b/tools/serverpod_cli/lib/src/create/template_context.dart
@@ -6,6 +6,7 @@ class TemplateContext {
     this.postgres = false,
     this.sqlite = false,
     this.web = false,
+    this.skills = false,
   });
 
   /// True if auth is enabled.
@@ -23,6 +24,9 @@ class TemplateContext {
   /// True if web is enabled.
   final bool web;
 
+  /// True if agent skills is enabled.
+  final bool skills;
+
   /// True if docker is enabled.
   bool get docker => postgres || redis;
 
@@ -38,6 +42,7 @@ class TemplateContext {
       'web': web,
       'docker': docker,
       'database': database,
+      'skills': skills,
     };
   }
 }

--- a/tools/serverpod_cli/lib/src/create/template_renderer.dart
+++ b/tools/serverpod_cli/lib/src/create/template_renderer.dart
@@ -29,13 +29,11 @@ class TemplateRenderer {
     Directory dir,
     TemplateContext context,
   ) async {
-    final entries = dir.listSync();
-
-    for (final entry in entries) {
-      if (entry is File) {
-        await _renderFile(entry, context);
-      } else if (entry is Directory) {
-        await _handleDirectoryRendering(entry, context);
+    await for (final entity in dir.list(recursive: false, followLinks: false)) {
+      if (entity is File) {
+        await _renderFile(entity, context);
+      } else if (entity is Directory) {
+        await _handleDirectoryRendering(entity, context);
       }
     }
   }

--- a/tools/serverpod_cli/pubspec.yaml
+++ b/tools/serverpod_cli/pubspec.yaml
@@ -52,6 +52,8 @@ dependencies:
   serverpod_serialization: 3.5.0-beta.5
   serverpod_service_client: 3.5.0-beta.5
   serverpod_shared: 3.5.0-beta.5
+  # skills must be pinned to 0.2.2 to avoid breaking changes
+  # as the package receives external contribution
   skills: 0.2.2
   source_span: ^1.10.0
   stream_channel: ^2.1.1

--- a/tools/serverpod_cli/pubspec.yaml
+++ b/tools/serverpod_cli/pubspec.yaml
@@ -52,7 +52,7 @@ dependencies:
   serverpod_serialization: 3.5.0-beta.5
   serverpod_service_client: 3.5.0-beta.5
   serverpod_shared: 3.5.0-beta.5
-  skills: ^0.2.2
+  skills: 0.2.2
   source_span: ^1.10.0
   stream_channel: ^2.1.1
   stream_transform: ^2.1.0

--- a/tools/serverpod_cli/pubspec.yaml
+++ b/tools/serverpod_cli/pubspec.yaml
@@ -52,6 +52,7 @@ dependencies:
   serverpod_serialization: 3.5.0-beta.5
   serverpod_service_client: 3.5.0-beta.5
   serverpod_shared: 3.5.0-beta.5
+  skills: ^0.2.2
   source_span: ^1.10.0
   stream_channel: ^2.1.1
   stream_transform: ^2.1.0

--- a/tools/serverpod_cli/pubspec.yaml
+++ b/tools/serverpod_cli/pubspec.yaml
@@ -52,9 +52,7 @@ dependencies:
   serverpod_serialization: 3.5.0-beta.5
   serverpod_service_client: 3.5.0-beta.5
   serverpod_shared: 3.5.0-beta.5
-  # skills must be pinned to 0.2.2 to avoid breaking changes
-  # as the package receives external contribution
-  skills: 0.2.2
+  skills: ^0.3.0
   source_span: ^1.10.0
   stream_channel: ^2.1.1
   stream_transform: ^2.1.0

--- a/tools/serverpod_cli/test/commands/create/template_renderer/template_context_test.dart
+++ b/tools/serverpod_cli/test/commands/create/template_renderer/template_context_test.dart
@@ -79,6 +79,7 @@ void main() {
         redis: true,
         web: true,
         sqlite: true,
+        skills: true,
       );
       expect(
         context.toJson(),
@@ -90,6 +91,7 @@ void main() {
           'web': true,
           'docker': true,
           'database': true,
+          'skills': true,
         },
       );
     },

--- a/tools/serverpod_cli/test/commands/create/tui/state_test.dart
+++ b/tools/serverpod_cli/test/commands/create/tui/state_test.dart
@@ -21,6 +21,7 @@ void main() {
           containsAll([
             ServerpodCreateConfig.database,
             ServerpodCreateConfig.redis,
+            ServerpodCreateConfig.skills,
           ]),
         );
         expect(
@@ -42,6 +43,7 @@ void main() {
           expect(context.postgres, isTrue);
           expect(context.sqlite, isFalse);
           expect(context.web, isFalse);
+          expect(context.skills, isTrue);
         },
       );
 
@@ -70,15 +72,7 @@ void main() {
       test('when created then defaults are correct', () {
         expect(state.focusedConfigIndex, 0);
         expect(state.creatingProject, false);
-        expect(
-          state.configValues,
-          containsAll([
-            ServerpodCreateConfig.database,
-            ServerpodCreateConfig.redis,
-            ServerpodCreateConfig.web,
-            ServerpodCreateConfig.auth,
-          ]),
-        );
+
         expect(
           state.getStateFor(ServerpodCreateConfig.database)?.focusedOptionIndex,
           0,
@@ -93,6 +87,10 @@ void main() {
         );
         expect(
           state.getStateFor(ServerpodCreateConfig.auth)?.focusedOptionIndex,
+          0,
+        );
+        expect(
+          state.getStateFor(ServerpodCreateConfig.skills)?.focusedOptionIndex,
           0,
         );
       });
@@ -119,6 +117,7 @@ void main() {
               ServerpodCreateConfig.redis,
               ServerpodCreateConfig.web,
               ServerpodCreateConfig.auth,
+              ServerpodCreateConfig.skills,
             ]),
           );
         },
@@ -136,6 +135,7 @@ void main() {
               ServerpodCreateConfig.template,
               ServerpodCreateConfig.database,
               ServerpodCreateConfig.redis,
+              ServerpodCreateConfig.skills,
             ]),
           );
         },
@@ -149,7 +149,10 @@ void main() {
 
           expect(
             state.configValues,
-            containsAllInOrder([ServerpodCreateConfig.template]),
+            containsAllInOrder([
+              ServerpodCreateConfig.template,
+              ServerpodCreateConfig.skills,
+            ]),
           );
         },
       );
@@ -163,6 +166,7 @@ void main() {
           expect(context.postgres, isTrue);
           expect(context.sqlite, isFalse);
           expect(context.web, isTrue);
+          expect(context.skills, true);
         },
       );
 


### PR DESCRIPTION
Exposed skills configuration in the create command's TUI. When enabled, skills are installed for Claude and other IDEs using the `skills` package. Skills are enabled by default for `quickstart` and `create --no-interactive`.

Closes [5038](https://github.com/serverpod/serverpod/issues/5038)

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None