### PR TITLE
fix: Fallback to restarting pod with --apply-migration on FFI resolver errors"

### DIFF
--- a/tools/serverpod_cli/lib/src/commands/start.dart
+++ b/tools/serverpod_cli/lib/src/commands/start.dart
@@ -178,13 +178,14 @@ class StartCommand extends ServerpodCommand<StartOption> {
       if (shutdown.isShutdown) return;
 
       // Extract passthrough args (everything after '--').
-      final serverArgs = argResults?.rest ?? [];
+      var serverArgs = argResults?.rest ?? [];
 
-      await _applyMigrationsOnBoot(
+      final deferToPod = await _applyMigrationsOnBoot(
         serverDir: serverDir,
         runMode: runModeFromServerArgs(serverArgs),
         moduleName: config.name,
       );
+      if (deferToPod) serverArgs = _withApplyMigrations(serverArgs);
 
       final exitCode = await _runSession(
         config: config,
@@ -293,7 +294,10 @@ Future<void> _stopDockerServices(String serverDir) async {
 }
 
 /// Applies pending database migrations before the pod starts.
-Future<void> _applyMigrationsOnBoot({
+///
+/// Returns `true` when the caller should pass `--apply-migrations` to the
+/// pod because the in-process apply was skipped.
+Future<bool> _applyMigrationsOnBoot({
   required String serverDir,
   required String runMode,
   required String moduleName,
@@ -305,8 +309,48 @@ Future<void> _applyMigrationsOnBoot({
       moduleName: moduleName,
     );
     log.info(formatAppliedMigrations(applied));
+    return false;
   } on StateError {
     // No database configured for this run mode - nothing to apply.
+    return false;
+  } catch (e) {
+    if (!isMissingNativeAssetError(e)) rethrow;
+    log.warning(
+      'Cannot apply migrations from the CLI: this build is missing the '
+      'native asset for the configured database driver (typically SQLite). '
+      'Falling back to --apply-migrations on the pod.',
+    );
+    return true;
+  }
+}
+
+/// Prepends `--apply-migrations` to [serverArgs] unless it is already
+/// present. Used by the boot path when [_applyMigrationsOnBoot] defers
+/// migration apply to the pod.
+List<String> _withApplyMigrations(List<String> serverArgs) {
+  if (serverArgs.contains('--apply-migrations')) return serverArgs;
+  return ['--apply-migrations', ...serverArgs];
+}
+
+/// Watch-session [ApplyMigrationsAction] that wraps [applyPendingMigrations]
+/// with the same FFI-resolver fallback policy as the boot path
+Future<ApplyMigrationsOutcome> _applyMigrationsForSession({
+  required String serverDir,
+  required String runMode,
+  required String moduleName,
+  required void Function() onDeferToPod,
+}) async {
+  try {
+    final applied = await applyPendingMigrations(
+      serverDir: serverDir,
+      runMode: runMode,
+      moduleName: moduleName,
+    );
+    return MigrationsApplied(applied);
+  } catch (e) {
+    if (!isMissingNativeAssetError(e)) rethrow;
+    onDeferToPod();
+    return const MigrationsRequirePodRestart();
   }
 }
 
@@ -499,10 +543,17 @@ Future<int> _startSession({
     createServer: serverProcessFactory,
     initialServer: initialServerProcess,
     generatedDirPaths: generatedDirPaths,
-    applyMigrationsAction: () => applyPendingMigrations(
+    applyMigrationsAction: () => _applyMigrationsForSession(
       serverDir: serverDir,
       runMode: runMode,
       moduleName: config.name,
+      onDeferToPod: () {
+        log.warning(
+          'Cannot apply migrations from the CLI.\n'
+          'Falling back to restarting the pod with --apply-migrations.',
+        );
+        serverArgs = _withApplyMigrations(serverArgs);
+      },
     ),
   );
 
@@ -752,11 +803,12 @@ Future<void> _runTuiBackend({
       return;
     }
 
-    await _applyMigrationsOnBoot(
+    final deferToPod = await _applyMigrationsOnBoot(
       serverDir: serverDir,
       runMode: runModeFromServerArgs(serverArgs),
       moduleName: config.name,
     );
+    if (deferToPod) serverArgs = _withApplyMigrations(serverArgs);
 
     // Start analyzer initialization on a worker isolate in the background.
     final analyzersFuture = IsolatedAnalyzers.create(config);
@@ -889,10 +941,17 @@ Future<void> _runTuiBackend({
       createServer: serverProcessFactory,
       initialServer: initialServer,
       generatedDirPaths: config.generatedDirPaths,
-      applyMigrationsAction: () => applyPendingMigrations(
+      applyMigrationsAction: () => _applyMigrationsForSession(
         serverDir: serverDir,
         runMode: runMode,
         moduleName: config.name,
+        onDeferToPod: () {
+          log.warning(
+            'Cannot apply migrations from the CLI.\n'
+            'Falling back to restarting the pod with --apply-migrations.',
+          );
+          serverArgs = _withApplyMigrations(serverArgs);
+        },
       ),
     );
 

--- a/tools/serverpod_cli/lib/src/commands/start/watch_session.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/watch_session.dart
@@ -77,12 +77,26 @@ final _endpointOrFutureCallRegex = RegExp(
   r'\bextends\s+(?:\w*Endpoint|FutureCall)\b',
 );
 
-/// Action invoked by [WatchSession.applyMigration].
+/// Outcome of an [ApplyMigrationsAction].
+sealed class ApplyMigrationsOutcome {
+  const ApplyMigrationsOutcome();
+}
+
+/// Migrations were applied in-process.
 ///
-/// Runs migrations against the live database without restarting the
-/// pod. Returns the list of versions applied (empty if already up to
-/// date). Throws on failure.
-typedef ApplyMigrationsAction = Future<List<String>> Function();
+/// [versions] are the versions just applied (empty when nothing was pending).
+class MigrationsApplied extends ApplyMigrationsOutcome {
+  final List<String> versions;
+  const MigrationsApplied(this.versions);
+}
+
+/// In-process apply was skipped. Session must restart pod to apply migrations.
+class MigrationsRequirePodRestart extends ApplyMigrationsOutcome {
+  const MigrationsRequirePodRestart();
+}
+
+/// Action invoked by [WatchSession.applyMigration].
+typedef ApplyMigrationsAction = Future<ApplyMigrationsOutcome> Function();
 
 /// Orchestrates the watch-mode reload cycle.
 ///
@@ -417,8 +431,7 @@ class WatchSession {
   ///
   /// Migrations are applied via the [ApplyMigrationsAction] supplied at
   /// construction time (typically a CLI-side runner that connects to
-  /// the database directly), and the running pod is left in place -
-  /// hot reload covers any model code changes.
+  /// the database directly).
   ///
   /// If another restart or migration is in progress, this call waits
   /// for it to finish before proceeding. Throws a [StateError] if the
@@ -434,8 +447,13 @@ class WatchSession {
       }
       _state = SessionState.applyingMigration;
       try {
-        final applied = await _applyMigrationsAction();
-        log.info(formatAppliedMigrations(applied));
+        final outcome = await _applyMigrationsAction();
+        switch (outcome) {
+          case MigrationsApplied(:final versions):
+            log.info(formatAppliedMigrations(versions));
+          case MigrationsRequirePodRestart():
+            await _restartServer(_compiler?.outputDill);
+        }
       } finally {
         if (_state == SessionState.applyingMigration) {
           _state = SessionState.idle;

--- a/tools/serverpod_cli/lib/src/migrations/cli_migration_runner.dart
+++ b/tools/serverpod_cli/lib/src/migrations/cli_migration_runner.dart
@@ -64,6 +64,17 @@ String formatAppliedMigrations(List<String> applied) {
   return 'Applied ${applied.length} migration$plural: ${applied.join(", ")}';
 }
 
+/// Whether [error] is a FFI resolver failure
+///
+/// The CLI may be installed as a `pub global activate` snapshot, that doesn't
+/// run build hooks for transitive deps.
+bool isMissingNativeAssetError(Object error) {
+  if (error is! ArgumentError) return false;
+  final s = error.toString();
+  return s.contains("Couldn't resolve native function") ||
+      s.contains('No available native assets');
+}
+
 /// Extracts `--mode` / `-m` from [serverArgs] (the passthrough args
 /// that `serverpod start [-- <server-args>]` forwards to the pod), so
 /// the CLI applies migrations against the same config the pod will

--- a/tools/serverpod_cli/test/commands/start/watch_session_test.dart
+++ b/tools/serverpod_cli/test/commands/start/watch_session_test.dart
@@ -34,6 +34,9 @@ class _FakeCompiler extends Fake implements KernelCompiler {
   CompileResult nextIncrementalResult = _successResult();
 
   @override
+  String get outputDill => '/tmp/fake.dill';
+
+  @override
   Future<CompileResult> compile({Set<String> changedPaths = const {}}) async {
     if (changedPaths.isEmpty) {
       calls.add('compile');
@@ -154,7 +157,7 @@ void main() {
       initialServer: initialServer,
       generatedDirPaths: {'/generated'},
       applyMigrationsAction:
-          applyMigrationsAction ?? () async => const <String>[],
+          applyMigrationsAction ?? () async => const MigrationsApplied([]),
       classifyProtocolChange:
           classifyProtocolChange ?? defaultProtocolChangeClassifier,
     );
@@ -660,13 +663,13 @@ void main() {
   });
 
   group('Given applyMigration is called with an in-place action', () {
-    late List<String> Function() appliedVersions;
+    late ApplyMigrationsOutcome Function() outcomeBuilder;
     late int actionCalls;
-    late Completer<List<String>>? gate;
+    late Completer<ApplyMigrationsOutcome>? gate;
     late WatchSession inPlaceSession;
 
     setUp(() {
-      appliedVersions = () => ['20251030_120000_user'];
+      outcomeBuilder = () => const MigrationsApplied(['20251030_120000_user']);
       actionCalls = 0;
       gate = null;
 
@@ -677,7 +680,7 @@ void main() {
           actionCalls++;
           final localGate = gate;
           if (localGate != null) return localGate.future;
-          return appliedVersions();
+          return outcomeBuilder();
         },
       );
     });
@@ -699,7 +702,7 @@ void main() {
       'when the action returns an empty list, '
       'then it succeeds (already up to date)',
       () async {
-        appliedVersions = () => const [];
+        outcomeBuilder = () => const MigrationsApplied([]);
 
         await inPlaceSession.applyMigration();
 
@@ -713,7 +716,7 @@ void main() {
       'when the action throws, '
       'then the error propagates and state returns to idle',
       () async {
-        appliedVersions = () => throw StateError('boom');
+        outcomeBuilder = () => throw StateError('boom');
 
         await expectLater(
           inPlaceSession.applyMigration(),
@@ -724,7 +727,7 @@ void main() {
 
         // Same session: a follow-up call must reach the action rather
         // than hit the in-flight latch.
-        appliedVersions = () => const [];
+        outcomeBuilder = () => const MigrationsApplied([]);
         await inPlaceSession.applyMigration();
         expect(actionCalls, 2);
       },
@@ -754,7 +757,7 @@ void main() {
       'when applyMigration is called twice, '
       'then the calls serialize via _pending',
       () async {
-        gate = Completer<List<String>>();
+        gate = Completer<ApplyMigrationsOutcome>();
 
         final firstCall = inPlaceSession.applyMigration();
         // Second call queues behind the first.
@@ -764,11 +767,31 @@ void main() {
         await Future<void>.delayed(Duration.zero);
         expect(actionCalls, 1, reason: 'second call must wait for first');
 
-        gate!.complete(['v1']);
+        gate!.complete(const MigrationsApplied(['v1']));
         await firstCall;
         await secondCall;
 
         expect(actionCalls, 2);
+      },
+    );
+  });
+
+  group('Given the action returns MigrationsRequirePodRestart', () {
+    test(
+      'when applyMigration completes, '
+      'then the pod is restarted via the factory with the compiler dill',
+      () async {
+        final fallbackSession = buildSession(
+          compiler: compiler,
+          initialServer: server,
+          applyMigrationsAction: () async =>
+              const MigrationsRequirePodRestart(),
+        );
+
+        await fallbackSession.applyMigration();
+
+        expect(server.calls, contains('stop'));
+        expect(factoryCalls, ['createServer:/tmp/fake.dill']);
       },
     );
   });
@@ -1026,7 +1049,7 @@ class Counter {
         },
         initialServer: noCompilerServer,
         generatedDirPaths: {'/generated'},
-        applyMigrationsAction: () async => const <String>[],
+        applyMigrationsAction: () async => const MigrationsApplied([]),
       );
     });
 
@@ -1128,7 +1151,7 @@ class Counter {
             (success: true, generatedFiles: <String>{}),
         initialServer: noFactoryServer,
         generatedDirPaths: {'/generated'},
-        applyMigrationsAction: () async => const <String>[],
+        applyMigrationsAction: () async => const MigrationsApplied([]),
       );
     });
 

--- a/tools/serverpod_cli/test/migrations/cli_migration_runner_test.dart
+++ b/tools/serverpod_cli/test/migrations/cli_migration_runner_test.dart
@@ -2,6 +2,41 @@ import 'package:serverpod_cli/src/migrations/cli_migration_runner.dart';
 import 'package:test/test.dart';
 
 void main() {
+  group('Given isMissingNativeAssetError', () {
+    test(
+      'when called with the FFI resolver ArgumentError, '
+      'then it returns true',
+      () {
+        final error = ArgumentError(
+          // Verbatim from a real failure (Dart 3.11.5 + sqlite3_connection_pool).
+          "Couldn't resolve native function 'pkg_sqlite3_connection_pool_open' "
+          "in 'package:sqlite3_connection_pool/sqlite3_connection_pool.dart' : "
+          'No available native assets.',
+        );
+        expect(isMissingNativeAssetError(error), isTrue);
+      },
+    );
+
+    test(
+      'when called with an unrelated ArgumentError, '
+      'then it returns false',
+      () {
+        expect(isMissingNativeAssetError(ArgumentError('bad input')), isFalse);
+      },
+    );
+
+    test(
+      'when called with a non-ArgumentError, '
+      'then it returns false',
+      () {
+        expect(
+          isMissingNativeAssetError(StateError('No available native assets')),
+          isFalse,
+        );
+      },
+    );
+  });
+
   group('Given runModeFromServerArgs', () {
     test(
       'when args are empty, '


### PR DESCRIPTION
The combination of:
- The new cli-side apply migrations feature, 
- build hooks (needed when using sqlite), and 
- install with `dart pub global activate serverpod_cli` instead of `dart install serverpod_cli` (the former doesn't run the hooks).

Would cause `serverpod start` to fail with:
```
...
Invalid argument(s): Couldn't resolve native function 'pkg_sqlite3_connection_pool_open' in 'package:sqlite3_connection_pool/sqlite3_connection_pool.dart' : No asset
with id 'package:sqlite3_connection_pool/sqlite3_connection_pool.dart' found. No available native assets. Attempted to fallback to process lookup. dlsym(RTLD_DEFAULT,
pkg_sqlite3_connection_pool_open): symbol not found.


#0      Native._ffi_resolver.#ffiClosure0 (dart:ffi-patch/ffi_patch.dart)
#1      Native._ffi_resolver_function (dart:ffi-patch/ffi_patch.dart:1943:20)
#2      pkg_sqlite3_connection_pool_open (package:sqlite3_connection_pool/src/ffi.g.dart)
#3      RawSqliteConnectionPool.open.<anonymous closure> (package:sqlite3_connection_pool/src/raw.dart:203:26)
#4      using (package:ffi/src/arena.dart:127:31)
#5      RawSqliteConnectionPool.open (package:sqlite3_connection_pool/src/raw.dart:153:18)
#6      SqliteConnectionPool.open (package:sqlite3_connection_pool/src/pool.dart:273:31)
#7      SqliteConnectionPool._openAsyncEntrypoint (package:sqlite3_connection_pool/src/pool.dart:320:35)
#8      _delayEntrypointInvocation.<anonymous closure> (dart:isolate-patch/isolate_patch.dart:317:17)
#9      _RawReceivePort._handleMessage (dart:isolate-patch/isolate_patch.dart:193:12)
```

on projects using `SQLite`. 

The easy work-around is to ensure `serverpod_cli` is installed with `dart install`, but as that is hard to control this PR fixes it for users using `dart pub global activate` by falling back to restarting the pod with `--apply-migrations`.
