### PR TITLE
fix: Terminal restoration after exiting TUI

### DIFF
--- a/tools/serverpod_cli/lib/src/commands/create.dart
+++ b/tools/serverpod_cli/lib/src/commands/create.dart
@@ -212,6 +212,7 @@ class CreateCommand extends ServerpodCommand<CreateOption> {
       );
 
       if (template.isServer) logStartInstructions(projectPath);
+      if (template.isMini) logMiniStartInstructions(projectPath);
     }
 
     await log.flush();
@@ -238,7 +239,7 @@ class CreateCommand extends ServerpodCommand<CreateOption> {
 
     backend.onExit(
       () => _preExit(
-        template: template,
+        template: state.template ?? template,
         projectPath: projectPath,
       ),
     );

--- a/tools/serverpod_cli/lib/src/commands/create.dart
+++ b/tools/serverpod_cli/lib/src/commands/create.dart
@@ -190,6 +190,7 @@ class CreateCommand extends ServerpodCommand<CreateOption> {
   Future<void> _shutdownNocterm([int exitCode = 0]) async {
     await closeLogger();
     initializeLogger();
+    restoreServerpodTerminal();
     shutdownApp(exitCode);
   }
 

--- a/tools/serverpod_cli/lib/src/commands/create.dart
+++ b/tools/serverpod_cli/lib/src/commands/create.dart
@@ -235,10 +235,8 @@ class CreateCommand extends ServerpodCommand<CreateOption> {
 
     String? projectPath;
 
-    final backend = ServerpodTerminalBackend();
-
-    backend.onExit(
-      () => _preExit(
+    final backend = ServerpodTerminalBackend(
+      preExit: () => _preExit(
         template: state.template ?? template,
         projectPath: projectPath,
       ),

--- a/tools/serverpod_cli/lib/src/commands/create.dart
+++ b/tools/serverpod_cli/lib/src/commands/create.dart
@@ -234,13 +234,17 @@ class CreateCommand extends ServerpodCommand<CreateOption> {
 
     String? projectPath;
 
-    await runServerpodApp(
-      backend: ServerpodTerminalBackend(
-        preExit: () => _preExit(
-          template: template,
-          projectPath: projectPath,
-        ),
+    final backend = ServerpodTerminalBackend();
+
+    backend.onExit(
+      () => _preExit(
+        template: template,
+        projectPath: projectPath,
       ),
+    );
+
+    await runServerpodApp(
+      backend: backend,
       ServerpodCreateApp(
         name: name,
         holder: holder,

--- a/tools/serverpod_cli/lib/src/commands/start.dart
+++ b/tools/serverpod_cli/lib/src/commands/start.dart
@@ -315,6 +315,56 @@ Future<bool> _applyMigrationsOnBoot({
   }
 }
 
+/// Applies migrations at boot, retrying transient socket errors while Docker
+/// services are still warming up.
+///
+/// This primarily targets first-run Postgres startup where the container may
+/// briefly reset connections during initialization.
+Future<bool> _applyMigrationsOnBootWithRetry({
+  required String serverDir,
+  required String runMode,
+  required String moduleName,
+  required bool retryOnSocketErrors,
+}) async {
+  final maxAttempts = retryOnSocketErrors ? 8 : 1;
+  const delay = Duration(seconds: 2);
+  Object? lastError;
+
+  for (var attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      return await _applyMigrationsOnBoot(
+        serverDir: serverDir,
+        runMode: runMode,
+        moduleName: moduleName,
+      );
+    } catch (e) {
+      if (!_isTransientDatabaseStartupError(e) || attempt == maxAttempts) {
+        rethrow;
+      }
+      lastError = e;
+      if (attempt == 1) {
+        log.info(
+          'Database is not ready yet. Waiting for Docker services to warm up...',
+        );
+      }
+      await Future<void>.delayed(delay);
+    }
+  }
+
+  // Defensive fallback: the loop either returns or throws on the final attempt.
+  if (lastError != null) throw lastError;
+  return false;
+}
+
+/// The postgres package can wrap socket failures in an error string like:
+/// "Severity.error Socket error: SocketException: ..."
+bool _isTransientDatabaseStartupError(Object error) {
+  if (error is SocketException) return true;
+  final message = error.toString().toLowerCase();
+  return message.contains('severity.error socket error') &&
+      message.contains('socketexception');
+}
+
 /// Prepends `--apply-migrations` to [serverArgs] unless it is already
 /// present. Used by the boot path when [_applyMigrationsOnBoot] defers
 /// migration apply to the pod.
@@ -393,10 +443,11 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
 
   // Apply pending migrations from the CLI before booting the pod.
   try {
-    final deferToPod = await _applyMigrationsOnBoot(
+    final deferToPod = await _applyMigrationsOnBootWithRetry(
       serverDir: serverDir,
       runMode: runModeFromServerArgs(serverArgs.value),
       moduleName: config.name,
+      retryOnSocketErrors: startedDocker,
     );
     if (deferToPod) serverArgs.value = _withApplyMigrations(serverArgs.value);
   } catch (_) {

--- a/tools/serverpod_cli/lib/src/commands/start.dart
+++ b/tools/serverpod_cli/lib/src/commands/start.dart
@@ -770,6 +770,7 @@ Future<int> _runWithTui({
   unawaited(
     shutdown.future.then((code) async {
       await backendFuture;
+      restoreServerpodTerminal();
       shutdownApp(code);
     }),
   );

--- a/tools/serverpod_cli/lib/src/commands/tui/run_app.dart
+++ b/tools/serverpod_cli/lib/src/commands/tui/run_app.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:nocterm/nocterm.dart';
+import 'package:serverpod_cli/src/commands/tui/terminal_backend.dart';
 
 /// Run a TUI app with terminal settings restoration.
 ///
@@ -14,9 +15,10 @@ import 'package:nocterm/nocterm.dart';
 Future<void> runServerpodApp(
   Component app, {
   bool enableHotReload = true,
-  TerminalBackend? backend,
+  ServerpodTerminalBackend? backend,
   void Function()? onShutdownSignal,
 }) async {
+  final effectiveBackend = backend ?? ServerpodTerminalBackend();
   final originalEchoMode = stdin.echoMode;
   final originalLineMode = stdin.lineMode;
 
@@ -25,8 +27,11 @@ Future<void> runServerpodApp(
     stdin.lineMode = originalLineMode;
   }
 
-  void onShutDownSignalDefault(ProcessSignal _) {
+  effectiveBackend.onExit(() async {
     restoreTerminal();
+  });
+
+  void onShutDownSignalDefault(ProcessSignal _) {
     shutdownApp();
   }
 
@@ -44,7 +49,11 @@ Future<void> runServerpodApp(
   }
 
   try {
-    await runApp(app, enableHotReload: enableHotReload, backend: backend);
+    await runApp(
+      app,
+      enableHotReload: enableHotReload,
+      backend: effectiveBackend,
+    );
   } finally {
     restoreTerminal();
   }

--- a/tools/serverpod_cli/lib/src/commands/tui/run_app.dart
+++ b/tools/serverpod_cli/lib/src/commands/tui/run_app.dart
@@ -23,13 +23,13 @@ Future<void> runServerpodApp(
   final originalLineMode = stdin.lineMode;
 
   void restoreTerminal() {
-    stdin.echoMode = originalEchoMode;
-    stdin.lineMode = originalLineMode;
+    try {
+      stdin.lineMode = originalLineMode;
+      stdin.echoMode = originalEchoMode;
+    } catch (_) {}
   }
 
-  effectiveBackend.onExit(() async {
-    restoreTerminal();
-  });
+  effectiveBackend.onExit(() => restoreTerminal());
 
   void onShutDownSignalDefault(ProcessSignal _) {
     shutdownApp();

--- a/tools/serverpod_cli/lib/src/commands/tui/run_app.dart
+++ b/tools/serverpod_cli/lib/src/commands/tui/run_app.dart
@@ -1,7 +1,29 @@
 import 'dart:io';
 
 import 'package:nocterm/nocterm.dart';
-import 'package:serverpod_cli/src/commands/tui/terminal_backend.dart';
+
+bool _terminalStateCaptured = false;
+bool _terminalStateRestored = false;
+
+late bool _originalEchoMode;
+late bool _originalLineMode;
+
+void _captureTerminalState() {
+  _originalEchoMode = stdin.echoMode;
+  _originalLineMode = stdin.lineMode;
+  _terminalStateCaptured = true;
+  _terminalStateRestored = false;
+}
+
+/// Restores stdin terminal modes captured by [runServerpodApp].
+///
+/// Safe to call multiple times.
+void restoreServerpodTerminal() {
+  if (!_terminalStateCaptured || _terminalStateRestored) return;
+  stdin.echoMode = _originalEchoMode;
+  stdin.lineMode = _originalLineMode;
+  _terminalStateRestored = true;
+}
 
 /// Run a TUI app with terminal settings restoration.
 ///
@@ -15,27 +37,18 @@ import 'package:serverpod_cli/src/commands/tui/terminal_backend.dart';
 Future<void> runServerpodApp(
   Component app, {
   bool enableHotReload = true,
-  ServerpodTerminalBackend? backend,
+  TerminalBackend? backend,
   void Function()? onShutdownSignal,
 }) async {
-  final effectiveBackend = backend ?? ServerpodTerminalBackend();
-  final originalEchoMode = stdin.echoMode;
-  final originalLineMode = stdin.lineMode;
-
-  void restoreTerminal() {
-    try {
-      stdin.lineMode = originalLineMode;
-      stdin.echoMode = originalEchoMode;
-    } catch (_) {}
-  }
-
-  effectiveBackend.onExit(() => restoreTerminal());
+  _captureTerminalState();
 
   void onShutDownSignalDefault(ProcessSignal _) {
+    restoreServerpodTerminal();
     shutdownApp();
   }
 
   void onShutDownSignalDelegated(ProcessSignal _) {
+    restoreServerpodTerminal();
     onShutdownSignal!.call();
   }
 
@@ -52,9 +65,9 @@ Future<void> runServerpodApp(
     await runApp(
       app,
       enableHotReload: enableHotReload,
-      backend: effectiveBackend,
+      backend: backend,
     );
   } finally {
-    restoreTerminal();
+    restoreServerpodTerminal();
   }
 }

--- a/tools/serverpod_cli/lib/src/commands/tui/terminal_backend.dart
+++ b/tools/serverpod_cli/lib/src/commands/tui/terminal_backend.dart
@@ -1,34 +1,18 @@
-import 'dart:async';
-
 import 'package:nocterm/nocterm.dart';
 
-/// A terminal backend for nocterm that allows executing
-/// callbacks before exiting the Dart process.
-/// Callbacks are and added using [onExit] and [preExit].
 class ServerpodTerminalBackend extends StdioBackend {
-  ServerpodTerminalBackend({this.preExit});
+  ServerpodTerminalBackend({required this.preExit});
 
-  final Future<void> Function()? preExit;
-
-  final List<VoidCallback> _onExitCalls = [];
-
-  void onExit(VoidCallback callback) {
-    _onExitCalls.add(callback);
-  }
+  final Future<void> Function() preExit;
 
   @override
   void requestExit([int exitCode = 0]) {
-    for (final exitCall in _onExitCalls) {
-      exitCall();
-    }
-
-    preExit
-        ?.call()
-        .then((_) => super.requestExit(exitCode))
-        .catchError((_) => super.requestExit(exitCode));
-
-    if (preExit == null) {
-      super.requestExit(exitCode);
-    }
+    preExit()
+        .then((_) {
+          super.requestExit(exitCode);
+        })
+        .catchError((_) {
+          super.requestExit(exitCode);
+        });
   }
 }

--- a/tools/serverpod_cli/lib/src/commands/tui/terminal_backend.dart
+++ b/tools/serverpod_cli/lib/src/commands/tui/terminal_backend.dart
@@ -1,13 +1,24 @@
+import 'dart:async';
+
 import 'package:nocterm/nocterm.dart';
 
-class ServerpodTerminalBackend extends StdioBackend {
-  ServerpodTerminalBackend({required this.preExit});
+typedef ExitCall = Future<void> Function();
 
-  final Future<void> Function() preExit;
+/// A terminal backend for nocterm that allows executing
+/// callbacks before exiting the Dart process.
+/// Callbacks are and added using [onExit].
+class ServerpodTerminalBackend extends StdioBackend {
+  ServerpodTerminalBackend();
+
+  final List<ExitCall> _onExitCalls = [];
+
+  void onExit(ExitCall callback) {
+    _onExitCalls.add(callback);
+  }
 
   @override
   void requestExit([int exitCode = 0]) {
-    preExit()
+    Future.wait<void>([for (final future in _onExitCalls) future.call()])
         .then((_) {
           super.requestExit(exitCode);
         })

--- a/tools/serverpod_cli/lib/src/commands/tui/terminal_backend.dart
+++ b/tools/serverpod_cli/lib/src/commands/tui/terminal_backend.dart
@@ -2,28 +2,33 @@ import 'dart:async';
 
 import 'package:nocterm/nocterm.dart';
 
-typedef ExitCall = Future<void> Function();
-
 /// A terminal backend for nocterm that allows executing
 /// callbacks before exiting the Dart process.
-/// Callbacks are and added using [onExit].
+/// Callbacks are and added using [onExit] and [preExit].
 class ServerpodTerminalBackend extends StdioBackend {
-  ServerpodTerminalBackend();
+  ServerpodTerminalBackend({this.preExit});
 
-  final List<ExitCall> _onExitCalls = [];
+  final Future<void> Function()? preExit;
 
-  void onExit(ExitCall callback) {
+  final List<VoidCallback> _onExitCalls = [];
+
+  void onExit(VoidCallback callback) {
     _onExitCalls.add(callback);
   }
 
   @override
   void requestExit([int exitCode = 0]) {
-    Future.wait<void>([for (final future in _onExitCalls) future.call()])
-        .then((_) {
-          super.requestExit(exitCode);
-        })
-        .catchError((_) {
-          super.requestExit(exitCode);
-        });
+    for (final exitCall in _onExitCalls) {
+      exitCall();
+    }
+
+    preExit
+        ?.call()
+        .then((_) => super.requestExit(exitCode))
+        .catchError((_) => super.requestExit(exitCode));
+
+    if (preExit == null) {
+      super.requestExit(exitCode);
+    }
   }
 }

--- a/tools/serverpod_cli/lib/src/create/create.dart
+++ b/tools/serverpod_cli/lib/src/create/create.dart
@@ -353,7 +353,7 @@ Future<String?> performCreate(
     if (template == ServerpodTemplateType.server) {
       logStartInstructions(projectDirPath);
     } else if (template == ServerpodTemplateType.mini) {
-      _logMiniStartInstructions(projectDirPath);
+      logMiniStartInstructions(projectDirPath);
     }
 
     return projectDirPath;
@@ -533,7 +533,7 @@ Future<bool> _renderTemplates(Directory dir, TemplateContext context) async {
   });
 }
 
-void _logMiniStartInstructions(String relativeProjectPath) {
+void logMiniStartInstructions(String relativeProjectPath) {
   log.info(
     'All setup. You are ready to rock! 🥳',
     type: TextLogType.header,


### PR DESCRIPTION
The happy path for exiting TUI never reaches the terminal settings restoration execution because nocterm exits the Dart process on shutdown.

This PR extends support for registering pre-exit callbacks in `ServerpodTerminalBackend` and use this to restore terminal settings when exiting TUI.

## Other fixes

This PR also fixes:

- Logging of start instructions for mini projects created using the TUI.
- Connection to Postgres on the first start of a new project if the docker takes longer to start.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None