### PR TITLE
refactor: Consolidate --tui and --no-tui flow

### DIFF
--- a/packages/serverpod/lib/src/server/serverpod.dart
+++ b/packages/serverpod/lib/src/server/serverpod.dart
@@ -142,6 +142,9 @@ class Serverpod {
 
   DatabasePoolManager? _databasePoolManager;
 
+  /// Future for the eager database pool start kicked off in the constructor.
+  late final Future<void> _databasePoolInit;
+
   /// The last time a database operation was performed. This can be used to
   /// determine if the database is sleeping.
   DateTime? get lastDatabaseOperationTime =>
@@ -595,7 +598,7 @@ class Serverpod {
     if (Features.enableDatabase && databaseConfiguration != null) {
       final databaseDialect = databaseConfiguration.dialect;
       final databaseProvider = DatabaseProvider.forDialect(databaseDialect);
-      _databasePoolManager = databaseProvider.createPoolManager(
+      final databasePoolManager = databaseProvider.createPoolManager(
         serializationManager,
         runtimeParametersBuilder,
         databaseConfiguration,
@@ -606,18 +609,11 @@ class Serverpod {
       // This is required because other operations in Serverpod assumes that
       // the database is connected when the Serverpod is created
       // (such as createSession(...)).
-      //
-      // The constructor is sync, so we can't await `start()` here. Attach
-      // a swallowing error handler so a failed eager start doesn't surface
-      // as an unhandled async error; the same `start()` is awaited inside
-      // `_unguardedStart` (it is idempotent), which surfaces the failure
-      // to the awaited caller.
-      unawaited(
-        _databasePoolManager?.start().catchError(
-              (Object _, StackTrace _) {},
-            ) ??
-            Future.value(),
-      );
+      _databasePoolInit = databasePoolManager.start();
+      _databasePoolManager = databasePoolManager;
+      unawaited(_databasePoolInit.catchError((_) {})); // if pool never used
+    } else {
+      _databasePoolInit = Future.value();
     }
 
     if (Features.enableDatabase) {
@@ -772,9 +768,8 @@ class Serverpod {
       CloudStoragePublicEndpoint().register(this);
     }
 
-    // It is important that we start the database pool manager before
-    // attempting to connect to the database.
-    await _databasePoolManager?.start();
+    // Ensure database pool manager has started
+    await _databasePoolInit;
 
     if (Features.enableMigrations) {
       int? maxAttempts = config.role == ServerpodRole.maintenance ? 6 : null;
@@ -1225,6 +1220,7 @@ class Serverpod {
   /// creating a [Session] you are responsible of calling the [close] method
   /// when you are done.
   Future<InternalSession> createSession({bool enableLogging = true}) async {
+    await _databasePoolInit;
     var session = InternalSession(
       server: server,
       enableLogging: enableLogging,

--- a/packages/serverpod/lib/src/server/serverpod.dart
+++ b/packages/serverpod/lib/src/server/serverpod.dart
@@ -606,7 +606,18 @@ class Serverpod {
       // This is required because other operations in Serverpod assumes that
       // the database is connected when the Serverpod is created
       // (such as createSession(...)).
-      _databasePoolManager?.start();
+      //
+      // The constructor is sync, so we can't await `start()` here. Attach
+      // a swallowing error handler so a failed eager start doesn't surface
+      // as an unhandled async error; the same `start()` is awaited inside
+      // `_unguardedStart` (it is idempotent), which surfaces the failure
+      // to the awaited caller.
+      unawaited(
+        _databasePoolManager?.start().catchError(
+              (Object _, StackTrace _) {},
+            ) ??
+            Future.value(),
+      );
     }
 
     if (Features.enableDatabase) {
@@ -763,7 +774,7 @@ class Serverpod {
 
     // It is important that we start the database pool manager before
     // attempting to connect to the database.
-    _databasePoolManager?.start();
+    await _databasePoolManager?.start();
 
     if (Features.enableMigrations) {
       int? maxAttempts = config.role == ServerpodRole.maintenance ? 6 : null;

--- a/packages/serverpod/lib/src/server/serverpod.dart
+++ b/packages/serverpod/lib/src/server/serverpod.dart
@@ -142,9 +142,6 @@ class Serverpod {
 
   DatabasePoolManager? _databasePoolManager;
 
-  /// Future for the most recent database pool start.
-  Future<void> _databasePoolInit = Future.value();
-
   /// The last time a database operation was performed. This can be used to
   /// determine if the database is sleeping.
   DateTime? get lastDatabaseOperationTime =>
@@ -609,9 +606,12 @@ class Serverpod {
       // This is required because other operations in Serverpod assumes that
       // the database is connected when the Serverpod is created
       // (such as createSession(...)).
-      _databasePoolInit = databasePoolManager.start();
+      databasePoolManager.start();
       _databasePoolManager = databasePoolManager;
-      unawaited(_databasePoolInit.catchError((_) {})); // if pool never used
+      // Swallow async-init failures so the pool isn't reported as an
+      // unhandled async error; awaiters of [DatabasePoolManager.started]
+      // (notably _unguardedStart) still observe the failure.
+      unawaited(databasePoolManager.started.catchError((_) {}));
     }
 
     if (Features.enableDatabase) {
@@ -766,10 +766,16 @@ class Serverpod {
       CloudStoragePublicEndpoint().register(this);
     }
 
-    // Ensure database pool manager has started.
-    // Re-kick start() in case there was a shutdown() in between
-    _databasePoolInit = _databasePoolManager?.start() ?? Future.value();
-    await _databasePoolInit;
+    // Ensure the database pool manager has started. start() is sync
+    // and idempotent on an already-running pool; after shutdown() the
+    // pool manager has reset its internal state, so this re-kicks the
+    // pool when Serverpod is started again. Awaiting [started] surfaces
+    // any failure from async init (e.g. SQLite's PRAGMA) to this caller.
+    final pool = _databasePoolManager;
+    if (pool != null) {
+      pool.start();
+      await pool.started;
+    }
 
     if (Features.enableMigrations) {
       int? maxAttempts = config.role == ServerpodRole.maintenance ? 6 : null;
@@ -1220,7 +1226,11 @@ class Serverpod {
   /// creating a [Session] you are responsible of calling the [close] method
   /// when you are done.
   Future<InternalSession> createSession({bool enableLogging = true}) async {
-    await _databasePoolInit;
+    // The constructor's eager start() left _db assigned synchronously,
+    // but await [started] so callers that issue queries synchronously
+    // after createSession() returns are guaranteed any async init
+    // (SQLite PRAGMA) has completed.
+    await _databasePoolManager?.started;
     var session = InternalSession(
       server: server,
       enableLogging: enableLogging,

--- a/packages/serverpod/lib/src/server/serverpod.dart
+++ b/packages/serverpod/lib/src/server/serverpod.dart
@@ -142,8 +142,8 @@ class Serverpod {
 
   DatabasePoolManager? _databasePoolManager;
 
-  /// Future for the eager database pool start kicked off in the constructor.
-  late final Future<void> _databasePoolInit;
+  /// Future for the most recent database pool start.
+  Future<void> _databasePoolInit = Future.value();
 
   /// The last time a database operation was performed. This can be used to
   /// determine if the database is sleeping.
@@ -612,8 +612,6 @@ class Serverpod {
       _databasePoolInit = databasePoolManager.start();
       _databasePoolManager = databasePoolManager;
       unawaited(_databasePoolInit.catchError((_) {})); // if pool never used
-    } else {
-      _databasePoolInit = Future.value();
     }
 
     if (Features.enableDatabase) {
@@ -768,7 +766,9 @@ class Serverpod {
       CloudStoragePublicEndpoint().register(this);
     }
 
-    // Ensure database pool manager has started
+    // Ensure database pool manager has started.
+    // Re-kick start() in case there was a shutdown() in between
+    _databasePoolInit = _databasePoolManager?.start() ?? Future.value();
     await _databasePoolInit;
 
     if (Features.enableMigrations) {

--- a/packages/serverpod_database/lib/src/adapters/postgres/postgres_pool_manager.dart
+++ b/packages/serverpod_database/lib/src/adapters/postgres/postgres_pool_manager.dart
@@ -82,7 +82,7 @@ class PostgresPoolManager implements DatabasePoolManager {
   }
 
   @override
-  Future<void> start() async {
+  void start() {
     // Setup database connection pool
     _pgPool ??= pg.Pool.withEndpoints(
       [
@@ -98,6 +98,12 @@ class PostgresPoolManager implements DatabasePoolManager {
       settings: _poolSettings,
     );
   }
+
+  /// Postgres [start] is synchronous - the pool is fully ready as soon
+  /// as [pg.Pool.withEndpoints] returns - so this is just a resolved
+  /// future for interface symmetry with SQLite.
+  @override
+  Future<void> get started => Future.value();
 
   @override
   Future<void> stop() async {

--- a/packages/serverpod_database/lib/src/adapters/postgres/postgres_pool_manager.dart
+++ b/packages/serverpod_database/lib/src/adapters/postgres/postgres_pool_manager.dart
@@ -82,7 +82,7 @@ class PostgresPoolManager implements DatabasePoolManager {
   }
 
   @override
-  void start() {
+  Future<void> start() async {
     // Setup database connection pool
     _pgPool ??= pg.Pool.withEndpoints(
       [

--- a/packages/serverpod_database/lib/src/adapters/sqlite/sqlite_pool_manager.dart
+++ b/packages/serverpod_database/lib/src/adapters/sqlite/sqlite_pool_manager.dart
@@ -28,10 +28,8 @@ class SqlitePoolManager implements DatabasePoolManager {
 
   SqliteDatabase? _db;
 
-  /// In-flight [start] future, used to coalesce concurrent callers onto
-  /// a single start cycle. Cleared once the cycle completes (or fails)
-  /// and again by [stop] so a restart kicks off a fresh cycle.
-  Future<void>? _starting;
+  /// Tracks the PRAGMA future kicked off by [start]
+  Future<void> _started = Future.value();
 
   /// The SQLite database instance.
   ///
@@ -59,39 +57,32 @@ class SqlitePoolManager implements DatabasePoolManager {
 
   /// Starts the database connection.
   ///
-  /// Safe to call concurrently or repeatedly: in-flight calls share the
-  /// same future, and a call after [stop] begins a fresh start cycle.
+  /// Callers can await [started] to ensure initialization is complete,
+  /// and surface any errors.
   @override
-  Future<void> start() async {
+  void start() {
     if (_db != null) return;
-    return _starting ??= _start();
+    final db = SqliteDatabase(
+      path: config.filePath,
+      // This will only be available from 0.14 onwards.
+      // options: SqliteOptions(
+      //   maxReaders:
+      //       config.maxConnectionCount ?? SqliteOptions.defaultMaxReaders,
+      // ),
+    );
+    _db = db;
+    _started = db.execute('PRAGMA foreign_keys = ON');
   }
 
-  Future<void> _start() async {
-    try {
-      final db = SqliteDatabase(
-        path: config.filePath,
-        // This will only be available from 0.14 onwards.
-        // options: SqliteOptions(
-        //   maxReaders:
-        //       config.maxConnectionCount ?? SqliteOptions.defaultMaxReaders,
-        // ),
-      );
-      await db.execute('PRAGMA foreign_keys = ON');
-      // Assign after the await so a failed start leaves _db null and the
-      // caller can retry.
-      _db = db;
-    } finally {
-      _starting = null;
-    }
-  }
+  @override
+  Future<void> get started => _started;
 
   /// Closes the database.
   @override
   Future<void> stop() async {
     await _db?.close();
     _db = null;
-    _starting = null;
+    _started = Future.value();
   }
 
   /// Tests the database connection.

--- a/packages/serverpod_database/lib/src/adapters/sqlite/sqlite_pool_manager.dart
+++ b/packages/serverpod_database/lib/src/adapters/sqlite/sqlite_pool_manager.dart
@@ -28,6 +28,11 @@ class SqlitePoolManager implements DatabasePoolManager {
 
   SqliteDatabase? _db;
 
+  /// In-flight [start] future, used to coalesce concurrent callers onto
+  /// a single start cycle. Cleared once the cycle completes (or fails)
+  /// and again by [stop] so a restart kicks off a fresh cycle.
+  Future<void>? _starting;
+
   /// The SQLite database instance.
   ///
   /// Throws a [StateError] if the database has not been started.
@@ -53,21 +58,32 @@ class SqlitePoolManager implements DatabasePoolManager {
   }
 
   /// Starts the database connection.
+  ///
+  /// Safe to call concurrently or repeatedly: in-flight calls share the
+  /// same future, and a call after [stop] begins a fresh start cycle.
   @override
   Future<void> start() async {
     if (_db != null) return;
-    final db = SqliteDatabase(
-      path: config.filePath,
-      // This will only be available from 0.14 onwards.
-      // options: SqliteOptions(
-      //   maxReaders:
-      //       config.maxConnectionCount ?? SqliteOptions.defaultMaxReaders,
-      // ),
-    );
-    await db.execute('PRAGMA foreign_keys = ON');
-    // Assign after the await so a failed start leaves _db null and the
-    // caller can retry.
-    _db = db;
+    return _starting ??= _start();
+  }
+
+  Future<void> _start() async {
+    try {
+      final db = SqliteDatabase(
+        path: config.filePath,
+        // This will only be available from 0.14 onwards.
+        // options: SqliteOptions(
+        //   maxReaders:
+        //       config.maxConnectionCount ?? SqliteOptions.defaultMaxReaders,
+        // ),
+      );
+      await db.execute('PRAGMA foreign_keys = ON');
+      // Assign after the await so a failed start leaves _db null and the
+      // caller can retry.
+      _db = db;
+    } finally {
+      _starting = null;
+    }
   }
 
   /// Closes the database.
@@ -75,6 +91,7 @@ class SqlitePoolManager implements DatabasePoolManager {
   Future<void> stop() async {
     await _db?.close();
     _db = null;
+    _starting = null;
   }
 
   /// Tests the database connection.

--- a/packages/serverpod_database/lib/src/adapters/sqlite/sqlite_pool_manager.dart
+++ b/packages/serverpod_database/lib/src/adapters/sqlite/sqlite_pool_manager.dart
@@ -54,15 +54,20 @@ class SqlitePoolManager implements DatabasePoolManager {
 
   /// Starts the database connection.
   @override
-  void start() {
-    _db ??= SqliteDatabase(
+  Future<void> start() async {
+    if (_db != null) return;
+    final db = SqliteDatabase(
       path: config.filePath,
       // This will only be available from 0.14 onwards.
       // options: SqliteOptions(
       //   maxReaders:
       //       config.maxConnectionCount ?? SqliteOptions.defaultMaxReaders,
       // ),
-    )..execute('PRAGMA foreign_keys = ON');
+    );
+    await db.execute('PRAGMA foreign_keys = ON');
+    // Assign after the await so a failed start leaves _db null and the
+    // caller can retry.
+    _db = db;
   }
 
   /// Closes the database.

--- a/packages/serverpod_database/lib/src/interface/client_database_session.dart
+++ b/packages/serverpod_database/lib/src/interface/client_database_session.dart
@@ -37,7 +37,8 @@ class ClientDatabaseSession implements DatabaseSession {
     final poolManager = SqlitePoolManager(
       serializationManager,
       SqliteDatabaseConfig(filePath: path),
-    )..start();
+    );
+    await poolManager.start();
     final session = ClientDatabaseSession._(poolManager);
     if (runMigrations) {
       await session._runMigrations(

--- a/packages/serverpod_database/lib/src/interface/client_database_session.dart
+++ b/packages/serverpod_database/lib/src/interface/client_database_session.dart
@@ -37,8 +37,8 @@ class ClientDatabaseSession implements DatabaseSession {
     final poolManager = SqlitePoolManager(
       serializationManager,
       SqliteDatabaseConfig(filePath: path),
-    );
-    await poolManager.start();
+    )..start();
+    await poolManager.started;
     final session = ClientDatabaseSession._(poolManager);
     if (runMigrations) {
       await session._runMigrations(

--- a/packages/serverpod_database/lib/src/interface/database_pool_manager.dart
+++ b/packages/serverpod_database/lib/src/interface/database_pool_manager.dart
@@ -20,7 +20,7 @@ abstract interface class DatabasePoolManager {
   ValueEncoder get encoder;
 
   /// Starts the database pool.
-  void start();
+  Future<void> start();
 
   /// Closes the database pool.
   Future<void> stop();

--- a/packages/serverpod_database/lib/src/interface/database_pool_manager.dart
+++ b/packages/serverpod_database/lib/src/interface/database_pool_manager.dart
@@ -20,12 +20,16 @@ abstract interface class DatabasePoolManager {
   ValueEncoder get encoder;
 
   /// Starts the database pool.
-  Future<void> start();
+  void start();
+
+  /// Resolves once async initialisation kicked off by [start] has completed.
+  Future<void> get started;
 
   /// Closes the database pool.
   Future<void> stop();
 
   /// Tests the database connection.
+  ///
   /// Throws an exception if the connection is not working.
   Future<bool> testConnection();
 }

--- a/packages/serverpod_database/test/sqlite_migration_runner_test.dart
+++ b/packages/serverpod_database/test/sqlite_migration_runner_test.dart
@@ -21,7 +21,8 @@ void main() {
     poolManager = SqlitePoolManager(
       _TestSerializationManager(),
       SqliteDatabaseConfig(filePath: p.join(tempDir.path, 'test.db')),
-    )..start();
+    );
+    await poolManager.start();
 
     session = _TestSession(() => database);
     database = DatabaseConstructor.create(

--- a/packages/serverpod_database/test/sqlite_migration_runner_test.dart
+++ b/packages/serverpod_database/test/sqlite_migration_runner_test.dart
@@ -21,8 +21,8 @@ void main() {
     poolManager = SqlitePoolManager(
       _TestSerializationManager(),
       SqliteDatabaseConfig(filePath: p.join(tempDir.path, 'test.db')),
-    );
-    await poolManager.start();
+    )..start();
+    await poolManager.started;
 
     session = _TestSession(() => database);
     database = DatabaseConstructor.create(

--- a/tools/serverpod_cli/lib/src/commands/start.dart
+++ b/tools/serverpod_cli/lib/src/commands/start.dart
@@ -726,25 +726,38 @@ Future<int> _runWithTui({
   // Shared shutdown signal
   final shutdown = _ShutdownSignal(listenForSignals: false);
 
+  // Captured so the renderer tear-down listener can wait for the
+  // backend's cleanup (ctx.dispose) to finish before calling
+  // shutdownApp. Default to a no-op so the listener is safe to invoke
+  // even if SIGINT arrives before onReady fires.
+  Future<void> backendFuture = Future.value();
+
   void onReady(StartAppStateHolder h) {
     if (backendStarted) return;
     backendStarted = true;
 
-    _runTuiBackend(
-      holder: h,
-      commandConfig: commandConfig,
-      watch: watch,
-      serverArgs: serverArgs,
-      interactive: interactive,
-      shutdown: shutdown,
-    ).catchError((Object e, StackTrace st) {
-      log.error('Fatal error: $e', stackTrace: st);
-      shutdown.complete(1);
-    });
+    backendFuture =
+        _runTuiBackend(
+          holder: h,
+          commandConfig: commandConfig,
+          watch: watch,
+          serverArgs: serverArgs,
+          interactive: interactive,
+          shutdown: shutdown,
+        ).catchError((Object e, StackTrace st) {
+          // Show the error in the TUI.
+          // The TUI stays open until Ctrl-C / Quit completes shutdown.
+          log.error('Fatal error: $e', stackTrace: st);
+        });
   }
 
-  // Single tear-down point for the nocterm renderer.
-  unawaited(shutdown.future.then(shutdownApp));
+  // Wait for the backend's dispose to finish before calling shutdownApp
+  unawaited(
+    shutdown.future.then((code) async {
+      await backendFuture;
+      shutdownApp(code);
+    }),
+  );
 
   await runServerpodApp(
     ServerpodWatchApp(holder: holder, onReady: onReady),

--- a/tools/serverpod_cli/lib/src/commands/start.dart
+++ b/tools/serverpod_cli/lib/src/commands/start.dart
@@ -19,12 +19,12 @@ import 'package:serverpod_cli/src/commands/start/server_process.dart';
 import 'package:serverpod_cli/src/commands/start/tui/app.dart';
 import 'package:serverpod_cli/src/commands/start/tui/event_handler.dart';
 import 'package:serverpod_cli/src/commands/start/tui/state.dart';
+import 'package:serverpod_cli/src/commands/start/watch_loop.dart';
 import 'package:serverpod_cli/src/commands/start/watch_session.dart';
 import 'package:serverpod_cli/src/commands/tui/run_app.dart';
 import 'package:serverpod_cli/src/commands/tui/tui_log_sink.dart';
 import 'package:serverpod_cli/src/commands/tui/tui_log_writer.dart';
 import 'package:serverpod_cli/src/commands/watcher.dart';
-import 'package:serverpod_cli/src/generator/analyzers.dart';
 import 'package:serverpod_cli/src/generator/generation_staleness.dart';
 import 'package:serverpod_cli/src/generator/isolated_analyzers.dart';
 import 'package:serverpod_cli/src/migrations/cli_migration_runner.dart';
@@ -164,42 +164,33 @@ class StartCommand extends ServerpodCommand<StartOption> {
     // cleanup) rather than killing the process.
     final shutdown = _ShutdownSignal();
 
-    // Start Docker Compose services if needed.
-    var startedDocker = false;
-    if (docker) {
-      await log.progress('Starting Docker services', () async {
-        startedDocker = await _ensureDockerServices(serverDir);
-        return true;
-      });
-    }
-
     try {
-      // If a signal arrived during Docker startup, skip starting the server.
-      if (shutdown.isShutdown) return;
+      // Extract passthrough args (everything after '--'). _setupWatchLoop
+      // mutates the ref's value if the in-process migration apply has
+      // to defer to the pod's `--apply-migrations`.
+      final serverArgs = ServerArgsRef(argResults?.rest ?? []);
 
-      // Extract passthrough args (everything after '--').
-      var serverArgs = argResults?.rest ?? [];
-
-      final deferToPod = await _applyMigrationsOnBoot(
-        serverDir: serverDir,
-        runMode: runModeFromServerArgs(serverArgs),
-        moduleName: config.name,
-      );
-      if (deferToPod) serverArgs = _withApplyMigrations(serverArgs);
-
-      final exitCode = await _runSession(
+      final result = await _setupWatchLoop(
         config: config,
         serverDir: serverDir,
         serverArgs: serverArgs,
-        shutdownSignal: shutdown.future,
         watch: watch,
+        docker: docker,
+        shutdown: shutdown,
       );
-      if (exitCode != 0) throw ExitException(exitCode);
+      switch (result) {
+        case WatchLoopAborted(:final exitCode):
+          if (exitCode != 0) throw ExitException(exitCode);
+          return;
+        case WatchLoopReady(:final ctx):
+          if (ctx.session.isRunning) log.info(serverRunning);
+          final exitCode = await shutdown.future;
+          log.info('Server stopped (exitCode: $exitCode).');
+          await ctx.dispose();
+          if (exitCode != 0) throw ExitException(exitCode);
+      }
     } finally {
       shutdown.dispose();
-      if (startedDocker) {
-        await _stopDockerServices(serverDir);
-      }
     }
   }
 }
@@ -346,7 +337,8 @@ Future<ApplyMigrationsOutcome> _applyMigrationsForSession({
       runMode: runMode,
       moduleName: moduleName,
     );
-    return MigrationsApplied(applied);
+    log.info(formatAppliedMigrations(applied));
+    return const MigrationsApplied();
   } catch (e) {
     if (!isMissingNativeAssetError(e)) rethrow;
     onDeferToPod();
@@ -354,46 +346,69 @@ Future<ApplyMigrationsOutcome> _applyMigrationsForSession({
   }
 }
 
-/// Runs the entire watch-mode loop.
-///
-/// Analyzers are created once and updated incrementally on each file change,
-/// avoiding the cost of re-initializing them from scratch every time.
-Future<int> _runSession({
+/// Runs the unified watch-loop setup shared by the TUI and non-TUI flows.
+Future<WatchLoopSetupResult> _setupWatchLoop({
   required GeneratorConfig config,
   required String serverDir,
-  required List<String> serverArgs,
-  required Future<int> shutdownSignal,
+  required ServerArgsRef serverArgs,
   required bool watch,
+  required bool docker,
+  required _ShutdownSignal shutdown,
+  IOSink? serverStdoutSink,
+  IOSink? serverStderrSink,
+  Future<void> Function(ServerProcess server)? onServerStart,
+  List<Object> Function()? mcpGetLogHistory,
 }) async {
-  log.info(
-    watch ? 'Starting server in watch mode...' : 'Starting server...',
-  );
+  log.info(watch ? 'Starting server in watch mode...' : 'Starting server...');
 
   final serverpodToolDir = p.join(serverDir, '.dart_tool', 'serverpod');
   final vmServiceInfoFile = p.join(serverpodToolDir, 'vm-service-info.json');
+  // The pod always writes its raw VM service URI to a separate file; the
+  // user-facing vm-service-info.json receives the proxy URI written by
+  // _mountOrRetargetProxy.
+  final podInfoFile = p.join(serverpodToolDir, 'vm-service-info.pod.json');
 
-  // If a server is already running, no-op so the IDE can attach to the
-  // existing instance via the unchanged info file. Stale files are cleaned
-  // up by _checkExistingServer.
+  // Start Docker Compose services if needed.
+  var startedDocker = false;
+  if (docker) {
+    await log.progress('Starting Docker services', () async {
+      startedDocker = await _ensureDockerServices(serverDir);
+      return true;
+    });
+  }
+
+  Future<void> stopDockerIfStarted() async {
+    if (startedDocker) await _stopDockerServices(serverDir);
+  }
+
+  // If a server is already running, abort so the IDE can attach to the
+  // existing instance via the unchanged info file.
   final existingUri = await _checkExistingServer(vmServiceInfoFile);
   if (existingUri != null) {
     log.info('Existing server found.');
     log.info('VM service proxy listening on $existingUri');
-    log.info('Server running.');
-    return 0;
+    await stopDockerIfStarted();
+    return const WatchLoopAborted(0);
   }
 
-  // Start analyzer initialization in the background.
-  final analyzersFuture = Analyzers.createAndUpdate(config);
+  // Apply pending migrations from the CLI before booting the pod.
+  try {
+    final deferToPod = await _applyMigrationsOnBoot(
+      serverDir: serverDir,
+      runMode: runModeFromServerArgs(serverArgs.value),
+      moduleName: config.name,
+    );
+    if (deferToPod) serverArgs.value = _withApplyMigrations(serverArgs.value);
+  } catch (_) {
+    await stopDockerIfStarted();
+    rethrow;
+  }
 
-  // Ensure generated code is up to date (runs concurrently with analyzers).
+  final analyzers = await IsolatedAnalyzers.create(config);
+
+  // Code generation staleness check.
   final allSources = await enumerateSourceFiles(config);
   if (!await isGenerationUpToDate(config, allSources)) {
-    late final Analyzers analyzers;
-    await log.progress('Initializing analyzers', () async {
-      analyzers = await analyzersFuture;
-      return true;
-    });
     final genResult = await analyzeAndGenerate(
       analyzers: analyzers,
       config: config,
@@ -402,80 +417,17 @@ Future<int> _runSession({
     );
     if (!genResult.success) {
       log.error('Code generation failed.');
-      return 1;
+      await analyzers.close();
+      await stopDockerIfStarted();
+      return const WatchLoopAborted(1);
     }
   }
 
-  return _startSession(
-    config: config,
-    serverDir: serverDir,
-    serverArgs: serverArgs,
-    serverpodToolDir: serverpodToolDir,
-    vmServiceInfoFile: vmServiceInfoFile,
-    shutdownSignal: shutdownSignal,
-    watcher: watch
-        ? FileWatcher(
-            watchPaths: {
-              p.absolute(p.joinAll(config.libSourcePathParts)),
-              ...config.sharedModelsLibSourcePaths.map(p.absolute),
-              p.absolute(
-                p.joinAll([...config.clientPackagePathParts, 'lib']),
-              ),
-              p.absolute(
-                p.joinAll([...config.serverPackageDirectoryPathParts, 'web']),
-              ),
-            },
-          )
-        : null,
-    generatedDirPaths: config.generatedDirPaths,
-    generate: (affectedPaths, requirements) async {
-      final analyzers = await analyzersFuture;
-      return analyzeAndGenerate(
-        analyzers: analyzers,
-        config: config,
-        affectedPaths: affectedPaths,
-        skipStalenessCheck: true,
-        requirements: requirements,
-      );
-    },
-  );
-}
-
-/// Sets up the server process, creates a [WatchSession], and runs until the
-/// server exits or a termination signal arrives.
-///
-/// When [watcher] is non-null, file change events are routed into the
-/// session for incremental reload and the Frontend Server pipeline is used
-/// for compilation. When `null`, the server is started with `dart run` and
-/// reloads against the running pod are routed through the VM's own kernel
-/// service via the vm-service proxy; manual reloads still work via the
-/// proxy / MCP / TUI buttons.
-Future<int> _startSession({
-  required GeneratorConfig config,
-  required String serverDir,
-  required List<String> serverArgs,
-  required String serverpodToolDir,
-  required String vmServiceInfoFile,
-  required Future<int> shutdownSignal,
-  required FileWatcher? watcher,
-  required Set<String> generatedDirPaths,
-  required GenerateAction generate,
-}) async {
-  final watch = watcher != null;
+  // FES setup (watch mode only).
   KernelCompiler? compiler;
   NativeAssetsBuilder? nativeAssetsBuilder;
-  late final ServerProcess initialServerProcess;
-  late final WatchSession session;
-  VmServiceProxy? proxy;
-
-  // The pod always writes its raw VM service URI to a separate file; the
-  // user-facing vm-service-info.json receives the proxy URI written by
-  // _mountOrRetargetProxy.
-  final podInfoFile = p.join(serverpodToolDir, 'vm-service-info.pod.json');
-
   String? dartExecutable;
   if (watch) {
-    // Set up incremental compiler.
     final entryPoint = p.join(serverDir, 'bin', 'main.dart');
     final initialDill = p.join(serverpodToolDir, 'server.dill');
     final localCompiler = KernelCompiler(
@@ -489,7 +441,9 @@ Future<int> _startSession({
       dartExecutable: localCompiler.dartExecutable,
     );
     if (!await _runHooksFor(localBuilder, localCompiler)) {
-      return 1;
+      await analyzers.close();
+      await stopDockerIfStarted();
+      return const WatchLoopAborted(1);
     }
 
     await localCompiler.start();
@@ -502,7 +456,9 @@ Future<int> _startSession({
     )) {
       await localCompiler.dispose();
       log.error('Initial compilation failed.');
-      return 1;
+      await analyzers.close();
+      await stopDockerIfStarted();
+      return const WatchLoopAborted(1);
     }
 
     compiler = localCompiler;
@@ -510,16 +466,23 @@ Future<int> _startSession({
     dartExecutable = localCompiler.dartExecutable;
   }
 
+  // Server process factory. Invoked for the initial start and for each
+  // subsequent restart driven by the WatchSession
+  late final WatchSession session;
+  VmServiceProxy? proxy;
   Future<ServerProcess> serverProcessFactory(String? dillPath) async {
     final serverProcess = ServerProcess(
       serverDir: serverDir,
-      serverArgs: serverArgs,
+      serverArgs: serverArgs.value,
       dartExecutable: dartExecutable,
       enableVmService: true,
       vmServiceInfoFile: podInfoFile,
+      stdoutSink: serverStdoutSink,
+      stderrSink: serverStderrSink,
     );
     await serverProcess.start(dillPath: dillPath);
     await serverProcess.connectToVmService();
+    if (onServerStart != null) await onServerStart(serverProcess);
     proxy = await _mountOrRetargetProxy(
       serverProcess: serverProcess,
       existing: proxy,
@@ -529,20 +492,30 @@ Future<int> _startSession({
     return serverProcess;
   }
 
+  late final ServerProcess initialServerProcess;
   await log.progress('Starting server', () async {
     final initialDill = watch ? p.join(serverpodToolDir, 'server.dill') : null;
     initialServerProcess = await serverProcessFactory(initialDill);
     return true;
   });
 
-  final runMode = runModeFromServerArgs(serverArgs);
+  // Construct the watch session.
+  final runMode = runModeFromServerArgs(serverArgs.value);
   session = WatchSession(
     compiler: compiler,
     nativeAssetsBuilder: nativeAssetsBuilder,
-    generate: generate,
+    generate: (affectedPaths, requirements) async {
+      return analyzeAndGenerate(
+        analyzers: analyzers,
+        config: config,
+        affectedPaths: affectedPaths,
+        skipStalenessCheck: true,
+        requirements: requirements,
+      );
+    },
     createServer: serverProcessFactory,
     initialServer: initialServerProcess,
-    generatedDirPaths: generatedDirPaths,
+    generatedDirPaths: config.generatedDirPaths,
     applyMigrationsAction: () => _applyMigrationsForSession(
       serverDir: serverDir,
       runMode: runMode,
@@ -552,10 +525,14 @@ Future<int> _startSession({
           'Cannot apply migrations from the CLI.\n'
           'Falling back to restarting the pod with --apply-migrations.',
         );
-        serverArgs = _withApplyMigrations(serverArgs);
+        serverArgs.value = _withApplyMigrations(serverArgs.value);
       },
     ),
   );
+
+  // Forward server exit into the shutdown signal so the wait-for-exit
+  // point only ever has to await [shutdown.future]
+  unawaited(session.done.then(shutdown.complete));
 
   // Start MCP socket server for AI agent integration. Exposes the proxy
   // URI (not the pod's) so MCP-initiated reloads flow through the same
@@ -568,6 +545,7 @@ Future<int> _startSession({
       onCreateMigration: ({String? tag, bool force = false}) =>
           _createMigrationForMcp(config, tag: tag, force: force),
       onHotReload: session.forceReload,
+      getLogHistory: mcpGetLogHistory,
       getVmServiceUri: () => proxy?.httpUri.toString(),
       vmServiceUriChanges: session.vmServiceUriChanges,
     );
@@ -577,26 +555,35 @@ Future<int> _startSession({
     mcpSocket = null;
   }
 
-  final fileChangeSub = watcher?.onFilesChanged
-      .asyncMapBuffer(
-        (events) => session.handleFileChange(events.merge()),
-      )
-      .listen((_) {});
+  // File watcher (watch mode only).
+  StreamSubscription<void>? fileChangeSub;
+  if (watch) {
+    final watcher = FileWatcher(
+      watchPaths: {
+        p.absolute(p.joinAll(config.libSourcePathParts)),
+        ...config.sharedModelsLibSourcePaths.map(p.absolute),
+        p.absolute(p.joinAll([...config.clientPackagePathParts, 'lib'])),
+        p.absolute(
+          p.joinAll([...config.serverPackageDirectoryPathParts, 'web']),
+        ),
+      },
+    );
+    fileChangeSub = watcher.onFilesChanged
+        .asyncMapBuffer((events) => session.handleFileChange(events.merge()))
+        .listen((_) {});
+  }
 
-  if (session.isRunning) log.info(serverRunning);
-
-  final exitCode = await Future.any([shutdownSignal, session.done]);
-
-  log.info('Server stopped (exitCode: $exitCode).');
-
-  // Clean up.
-  await fileChangeSub?.cancel();
-  await mcpSocket?.close();
-  await session.dispose();
-  await proxy?.close();
-  await File(vmServiceInfoFile).deleteIfExists();
-
-  return exitCode;
+  return WatchLoopReady(
+    WatchLoopContext(
+      session: session,
+      proxy: proxy,
+      mcpSocket: mcpSocket,
+      fileChangeSub: fileChangeSub,
+      closeAnalyzers: analyzers.close,
+      stopDocker: startedDocker ? () => _stopDockerServices(serverDir) : null,
+      vmServiceInfoFile: vmServiceInfoFile,
+    ),
+  );
 }
 
 /// Mounts a fresh [VmServiceProxy] in front of [serverProcess] (writing
@@ -648,35 +635,48 @@ Future<VmServiceProxy?> _mountOrRetargetProxy({
   return proxy;
 }
 
-/// Listens for SIGINT/SIGTERM and exposes a [future] that completes when
-/// a termination signal is received.
+/// One-shot exit signal shared between the orchestrator, the
+/// presentation layer, and `_setupWatchLoop`.
 ///
-/// Call [dispose] to cancel the signal subscriptions.
+/// When [listenForSignals] is true (the default for non-TUI), SIGINT and
+/// SIGTERM complete [future] with 0. The TUI passes `false` because
+/// `runServerpodApp` already owns the signal subscriptions and forwards
+/// them via its own callback. Either way, callers can [complete] the
+/// signal directly (e.g. when the server crashes or the Quit button is
+/// pressed) so the wait-for-exit point only ever has to await [future].
+///
+/// Call [dispose] to cancel the signal subscriptions, if any.
 class _ShutdownSignal {
   final Completer<int> _completer = Completer<int>();
-  late final StreamSubscription<void> _sigintSub;
-  late final StreamSubscription<void>? _sigtermSub;
+  StreamSubscription<void>? _sigintSub;
+  StreamSubscription<void>? _sigtermSub;
 
-  _ShutdownSignal() {
-    _sigintSub = ProcessSignal.sigint.watch().listen(_complete);
+  _ShutdownSignal({bool listenForSignals = true}) {
+    if (!listenForSignals) return;
+    _sigintSub = ProcessSignal.sigint.watch().listen(_completeFromSignal);
     if (!Platform.isWindows) {
-      _sigtermSub = ProcessSignal.sigterm.watch().listen(_complete);
+      _sigtermSub = ProcessSignal.sigterm.watch().listen(_completeFromSignal);
     }
   }
 
-  void _complete(ProcessSignal _) {
-    if (!_completer.isCompleted) _completer.complete(0);
+  void _completeFromSignal(ProcessSignal _) => complete(0);
+
+  /// Completes [future] with [code] if it isn't completed yet; no-op
+  /// otherwise. Safe to call from multiple paths (signal handlers, the
+  /// Quit button, server-exit forwarders).
+  void complete([int code = 0]) {
+    if (!_completer.isCompleted) _completer.complete(code);
   }
 
-  /// Whether a termination signal has been received.
+  /// Whether shutdown has been requested.
   bool get isShutdown => _completer.isCompleted;
 
-  /// Completes with 0 when a termination signal is received.
+  /// Completes with the requested exit code.
   Future<int> get future => _completer.future;
 
   /// Cancels the signal subscriptions.
   void dispose() {
-    _sigintSub.cancel();
+    _sigintSub?.cancel();
     _sigtermSub?.cancel();
   }
 }
@@ -721,8 +721,10 @@ Future<int> _runWithTui({
   required bool? interactive,
 }) async {
   final holder = StartAppStateHolder(ServerWatchState());
-  var exitCode = 0;
   var backendStarted = false;
+
+  // Shared shutdown signal
+  final shutdown = _ShutdownSignal(listenForSignals: false);
 
   void onReady(StartAppStateHolder h) {
     if (backendStarted) return;
@@ -734,17 +736,24 @@ Future<int> _runWithTui({
       watch: watch,
       serverArgs: serverArgs,
       interactive: interactive,
-      onExitCode: (code) => exitCode = code,
+      shutdown: shutdown,
     ).catchError((Object e, StackTrace st) {
       log.error('Fatal error: $e', stackTrace: st);
-      exitCode = 1;
+      shutdown.complete(1);
     });
   }
 
-  // Block on the TUI.
-  await runServerpodApp(ServerpodWatchApp(holder: holder, onReady: onReady));
+  // Single tear-down point for the nocterm renderer.
+  unawaited(shutdown.future.then(shutdownApp));
 
-  return exitCode;
+  await runServerpodApp(
+    ServerpodWatchApp(holder: holder, onReady: onReady),
+    onShutdownSignal: () => shutdown.complete(0),
+  );
+
+  // runServerpodApp returned, so shutdownApp ran, so the listener fired,
+  // so shutdown.future is completed.
+  return shutdown.future;
 }
 
 /// Backend logic that runs after the TUI is mounted and ready.
@@ -754,12 +763,11 @@ Future<void> _runTuiBackend({
   required bool watch,
   required List<String> serverArgs,
   required bool? interactive,
-  required void Function(int) onExitCode,
+  required _ShutdownSignal shutdown,
 }) async {
-  final tuiWriter = TuiLogWriter();
-
   try {
     // Replace the CLI logger with a TUI-backed logger.
+    final tuiWriter = TuiLogWriter();
     initializeLoggerWith(ServerpodCliLogger(tuiWriter));
     tuiWriter.attach(holder);
 
@@ -776,277 +784,76 @@ Future<void> _runTuiBackend({
     });
 
     final serverDir = p.joinAll(config.serverPackageDirectoryPathParts);
-
-    // Start Docker Compose services if needed.
     final docker = commandConfig.value(StartOption.docker);
-    var startedDocker = false;
-    if (docker) {
-      await log.progress('Starting Docker services', () async {
-        startedDocker = await _ensureDockerServices(serverDir);
-        return true;
-      });
-    }
 
-    final serverpodToolDir = p.join(serverDir, '.dart_tool', 'serverpod');
-    final vmServiceInfoFile = p.join(serverpodToolDir, 'vm-service-info.json');
-    final podInfoFile = p.join(serverpodToolDir, 'vm-service-info.pod.json');
+    final argsRef = ServerArgsRef(serverArgs);
 
-    // If a server is already running, exit cleanly so the IDE can attach
-    // to the existing instance via the unchanged info file. Stale files
-    // are cleaned up by _checkExistingServer.
-    final existingUri = await _checkExistingServer(vmServiceInfoFile);
-    if (existingUri != null) {
-      log.info('Existing server found.');
-      log.info('VM service proxy listening on $existingUri');
-      onExitCode(0);
-      shutdownApp(0);
-      return;
-    }
-
-    final deferToPod = await _applyMigrationsOnBoot(
-      serverDir: serverDir,
-      runMode: runModeFromServerArgs(serverArgs),
-      moduleName: config.name,
-    );
-    if (deferToPod) serverArgs = _withApplyMigrations(serverArgs);
-
-    // Start analyzer initialization on a worker isolate in the background.
-    final analyzersFuture = IsolatedAnalyzers.create(config);
-
-    // Code generation (staleness check runs concurrently with analyzers).
-    final allSources = await enumerateSourceFiles(config);
-    if (!await isGenerationUpToDate(config, allSources)) {
-      late final IsolatedAnalyzers analyzers;
-      await log.progress('Initializing analyzers', () async {
-        analyzers = await analyzersFuture;
-        return true;
-      });
-      final genResult = await analyzeAndGenerate(
-        analyzers: analyzers,
-        config: config,
-        affectedPaths: allSources,
-        requirements: GenerationRequirements.full,
-      );
-      if (!genResult.success) {
-        log.error('Code generation failed.');
-        await (await analyzersFuture).close();
-        onExitCode(1);
-        shutdownApp(1);
-        return;
-      }
-    }
-
-    // Compilation (FES mode only).
-    KernelCompiler? compiler;
-    NativeAssetsBuilder? nativeAssetsBuilder;
-    String? dartExecutable;
-    if (watch) {
-      final entryPoint = p.join(serverDir, 'bin', 'main.dart');
-      final initialDill = p.join(serverpodToolDir, 'server.dill');
-      final localCompiler = KernelCompiler(
-        entryPoint: entryPoint,
-        outputDill: initialDill,
-      );
-
-      final localBuilder = _createNativeAssetsBuilder(
-        serverDir: serverDir,
-        serverpodToolDir: serverpodToolDir,
-        dartExecutable: localCompiler.dartExecutable,
-      );
-      if (!await _runHooksFor(localBuilder, localCompiler)) {
-        onExitCode(1);
-        return;
-      }
-
-      await localCompiler.start();
-
-      if (!await localCompiler.compileIfNeeded(
-        config.watchPaths(includeWeb: true, includeClientPackage: true),
-      )) {
-        await localCompiler.dispose();
-        log.error('Initial compilation failed.');
-        onExitCode(1);
-        shutdownApp(1);
-        return;
-      }
-
-      compiler = localCompiler;
-      nativeAssetsBuilder = localBuilder;
-      dartExecutable = localCompiler.dartExecutable;
-    }
-
-    // Create TUI log sinks for server output.
     final stdoutSink = TuiLogSink(holder);
     final stderrSink = TuiLogSink(holder);
 
-    late final WatchSession session;
-    VmServiceProxy? proxy;
-
-    // Server process factory. Subscribes to VM service extension events
-    // on each new server process so restarts pick up the new connection.
-    Future<ServerProcess> serverProcessFactory(String? dillPath) async {
-      final serverProcess = ServerProcess(
-        serverDir: serverDir,
-        serverArgs: serverArgs,
-        dartExecutable: dartExecutable,
-        enableVmService: true,
-        vmServiceInfoFile: podInfoFile,
-        stdoutSink: stdoutSink,
-        stderrSink: stderrSink,
-      );
-      await serverProcess.start(dillPath: dillPath);
-      await serverProcess.connectToVmService();
-
-      final vmService = serverProcess.vmService;
-      if (vmService != null) {
+    final result = await _setupWatchLoop(
+      config: config,
+      serverDir: serverDir,
+      serverArgs: argsRef,
+      watch: watch,
+      docker: docker,
+      shutdown: shutdown,
+      serverStdoutSink: stdoutSink,
+      serverStderrSink: stderrSink,
+      onServerStart: (server) async {
+        final vmService = server.vmService;
+        if (vmService == null) return;
         await vmService.streamListen('Extension');
         vmService.onExtensionEvent.listen(
           (event) => handleServerLogEvent(holder, event),
         );
-      }
-
-      proxy = await _mountOrRetargetProxy(
-        serverProcess: serverProcess,
-        existing: proxy,
-        userInfoFile: vmServiceInfoFile,
-        reload: watch ? () => session.forceReload() : null,
-      );
-
-      return serverProcess;
-    }
-
-    late final ServerProcess initialServer;
-    await log.progress('Starting server', () async {
-      final initialDill = watch
-          ? p.join(serverpodToolDir, 'server.dill')
-          : null;
-      initialServer = await serverProcessFactory(initialDill);
-      return true;
-    });
-
-    // Create watch session.
-    final runMode = runModeFromServerArgs(serverArgs);
-    session = WatchSession(
-      compiler: compiler,
-      nativeAssetsBuilder: nativeAssetsBuilder,
-      generate: (affectedPaths, requirements) async {
-        return analyzeAndGenerate(
-          analyzers: await analyzersFuture,
-          config: config,
-          affectedPaths: affectedPaths,
-          skipStalenessCheck: true,
-          requirements: requirements,
-        );
       },
-      createServer: serverProcessFactory,
-      initialServer: initialServer,
-      generatedDirPaths: config.generatedDirPaths,
-      applyMigrationsAction: () => _applyMigrationsForSession(
-        serverDir: serverDir,
-        runMode: runMode,
-        moduleName: config.name,
-        onDeferToPod: () {
-          log.warning(
-            'Cannot apply migrations from the CLI.\n'
-            'Falling back to restarting the pod with --apply-migrations.',
-          );
-          serverArgs = _withApplyMigrations(serverArgs);
-        },
-      ),
+      mcpGetLogHistory: () => holder.state.logHistory.toList(),
     );
 
-    // Start MCP socket server. Exposes the proxy URI (not the pod's) so
-    // MCP-initiated reloads flow through the same interceptor that IDE
-    // attach uses.
-    McpSocketServer? mcpSocket = McpSocketServer(project: config.name);
-    try {
-      await mcpSocket.start();
-      mcpSocket.connect(
-        onApplyMigration: session.applyMigration,
-        onCreateMigration: ({String? tag, bool force = false}) =>
-            _createMigrationForMcp(config, tag: tag, force: force),
-        onHotReload: session.forceReload,
-        getLogHistory: () => holder.state.logHistory.toList(),
-        getVmServiceUri: () => proxy?.httpUri.toString(),
-        vmServiceUriChanges: session.vmServiceUriChanges,
-      );
-      log.info('MCP server listening on ${mcpSocket.socketPath}');
-    } on SocketException catch (e) {
-      log.warning('Failed to start MCP server: $e');
-      mcpSocket = null;
+    switch (result) {
+      case WatchLoopAborted(:final exitCode):
+        shutdown.complete(exitCode);
+        return;
+      case WatchLoopReady(:final ctx):
+        holder.onQuit = () => shutdown.complete(0);
+        holder.onHotReload = () {
+          runTrackedAction(holder, 'Hot reload', ctx.session.forceReload);
+        };
+        holder.onCreateMigration = () {
+          runTrackedAction(
+            holder,
+            'Creating migration',
+            () => _runCreateMigrationForTui(config),
+          );
+        };
+        holder.onApplyMigration = () {
+          runTrackedAction(
+            holder,
+            'Applying migrations',
+            ctx.session.applyMigration,
+          );
+        };
+
+        holder.state.serverReady = ctx.session.isRunning;
+        holder.markDirty();
+
+        if (ctx.session.isRunning) log.info(serverRunning);
+
+        // All termination triggers (Quit, SIGINT/SIGTERM, server crash,
+        // unhandled errors) funnel through `shutdown`
+        final exitCode = await shutdown.future;
+        holder.state.serverReady = false;
+        holder.markDirty();
+        log.info('Server stopped (exitCode: $exitCode).');
+
+        await ctx.dispose();
     }
-
-    // Start file watcher if in watch mode.
-    StreamSubscription? fileChangeSub;
-    if (watch) {
-      final watcher = FileWatcher(
-        watchPaths: {
-          p.absolute(p.joinAll(config.libSourcePathParts)),
-          ...config.sharedModelsLibSourcePaths.map(p.absolute),
-          p.absolute(p.joinAll([...config.clientPackagePathParts, 'lib'])),
-          p.absolute(
-            p.joinAll([...config.serverPackageDirectoryPathParts, 'web']),
-          ),
-        },
-      );
-      fileChangeSub = watcher.onFilesChanged
-          .asyncMapBuffer(
-            (events) => session.handleFileChange(events.merge()),
-          )
-          .listen((_) {});
-    }
-
-    // Wire button callbacks.
-    holder.onQuit = () async {
-      holder.state.serverReady = false;
-      holder.markDirty();
-      await fileChangeSub?.cancel();
-      await mcpSocket?.close();
-      await session.dispose();
-      await proxy?.close();
-      await File(vmServiceInfoFile).deleteIfExists();
-      if (startedDocker) {
-        await _stopDockerServices(serverDir);
-      }
-      shutdownApp(0);
-    };
-    holder.onHotReload = () {
-      runTrackedAction(holder, 'Hot reload', session.forceReload);
-    };
-    holder.onCreateMigration = () {
-      runTrackedAction(
-        holder,
-        'Creating migration',
-        () => _runCreateMigrationForTui(config),
-      );
-    };
-    holder.onApplyMigration = () {
-      runTrackedAction(holder, 'Applying migrations', session.applyMigration);
-    };
-
-    holder.state.serverReady = session.isRunning;
-    holder.markDirty();
-
-    if (session.isRunning) log.info(serverRunning);
-
-    // Wait for server exit.
-    final serverExitCode = await session.done;
-    holder.state.serverReady = false;
-    holder.markDirty();
-    onExitCode(serverExitCode);
-    log.info('Server stopped (exitCode: $serverExitCode).');
-
-    // Clean up.
-    await fileChangeSub?.cancel();
-    await mcpSocket?.close();
-    await session.dispose();
-    await proxy?.close();
-    await File(vmServiceInfoFile).deleteIfExists();
   } catch (e, st) {
-    // Show the error in the TUI. Keep it open so the user can read it.
+    // Show the error in the TUI; let the user read it. Quitting still
+    // works via the Ctrl-C signal handler routed through shutdown.
     holder.state.showSplash = false;
     log.error('$e', stackTrace: st);
-    onExitCode(1);
   }
 }
 

--- a/tools/serverpod_cli/lib/src/commands/start.dart
+++ b/tools/serverpod_cli/lib/src/commands/start.dart
@@ -404,20 +404,30 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
     rethrow;
   }
 
-  final analyzers = await IsolatedAnalyzers.create(config);
+  final analyzersFuture = IsolatedAnalyzers.create(config);
+  Future<void> closeAnalyzers() async => (await analyzersFuture).close();
 
   // Code generation staleness check.
   final allSources = await enumerateSourceFiles(config);
   if (!await isGenerationUpToDate(config, allSources)) {
-    final genResult = await analyzeAndGenerate(
-      analyzers: analyzers,
-      config: config,
-      affectedPaths: allSources,
-      requirements: GenerationRequirements.full,
-    );
+    late final IsolatedAnalyzers analyzers;
+    await log.progress('Initializing analyzers', () async {
+      analyzers = await analyzersFuture;
+      return true;
+    });
+    late final ({bool success, Set<String> generatedFiles}) genResult;
+    await log.progress('Generating code', () async {
+      genResult = await analyzeAndGenerate(
+        analyzers: analyzers,
+        config: config,
+        affectedPaths: allSources,
+        requirements: GenerationRequirements.full,
+      );
+      return genResult.success;
+    });
     if (!genResult.success) {
       log.error('Code generation failed.');
-      await analyzers.close();
+      await closeAnalyzers();
       await stopDockerIfStarted();
       return const WatchLoopAborted(1);
     }
@@ -440,8 +450,13 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
       serverpodToolDir: serverpodToolDir,
       dartExecutable: localCompiler.dartExecutable,
     );
-    if (!await _runHooksFor(localBuilder, localCompiler)) {
-      await analyzers.close();
+    late final bool hooksOk;
+    await log.progress('Running build hooks', () async {
+      hooksOk = await _runHooksFor(localBuilder, localCompiler);
+      return hooksOk;
+    });
+    if (!hooksOk) {
+      await closeAnalyzers();
       await stopDockerIfStarted();
       return const WatchLoopAborted(1);
     }
@@ -456,7 +471,7 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
     )) {
       await localCompiler.dispose();
       log.error('Initial compilation failed.');
-      await analyzers.close();
+      await closeAnalyzers();
       await stopDockerIfStarted();
       return const WatchLoopAborted(1);
     }
@@ -506,7 +521,7 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
     nativeAssetsBuilder: nativeAssetsBuilder,
     generate: (affectedPaths, requirements) async {
       return analyzeAndGenerate(
-        analyzers: analyzers,
+        analyzers: await analyzersFuture,
         config: config,
         affectedPaths: affectedPaths,
         skipStalenessCheck: true,
@@ -579,7 +594,7 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
       proxy: proxy,
       mcpSocket: mcpSocket,
       fileChangeSub: fileChangeSub,
-      closeAnalyzers: analyzers.close,
+      closeAnalyzers: closeAnalyzers,
       stopDocker: startedDocker ? () => _stopDockerServices(serverDir) : null,
       vmServiceInfoFile: vmServiceInfoFile,
     ),

--- a/tools/serverpod_cli/lib/src/commands/start/watch_loop.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/watch_loop.dart
@@ -1,0 +1,66 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:serverpod_cli/src/commands/start/mcp_socket.dart';
+import 'package:serverpod_cli/src/commands/start/watch_session.dart';
+import 'package:serverpod_cli/src/util/file_ex.dart';
+import 'package:serverpod_cli/src/vm_proxy/proxy.dart';
+
+/// Mutable holder for `serverArgs` so the migration-fallback hook can
+/// prepend `--apply-migrations` and have the next pod start observe it.
+class ServerArgsRef {
+  List<String> value;
+  ServerArgsRef(this.value);
+}
+
+sealed class WatchLoopSetupResult {
+  const WatchLoopSetupResult();
+}
+
+final class WatchLoopReady extends WatchLoopSetupResult {
+  final WatchLoopContext ctx;
+  const WatchLoopReady(this.ctx);
+}
+
+final class WatchLoopAborted extends WatchLoopSetupResult {
+  final int exitCode;
+  const WatchLoopAborted(this.exitCode);
+}
+
+/// Owns everything constructed by the watch-loop setup and provides a
+/// single, idempotent [dispose] for cleanup.
+class WatchLoopContext {
+  final WatchSession session;
+  final VmServiceProxy? proxy;
+  final McpSocketServer? mcpSocket;
+  final StreamSubscription<void>? fileChangeSub;
+  final Future<void> Function() closeAnalyzers;
+  final Future<void> Function()? stopDocker;
+  final String vmServiceInfoFile;
+  bool _disposed = false;
+
+  WatchLoopContext({
+    required this.session,
+    required this.proxy,
+    required this.mcpSocket,
+    required this.fileChangeSub,
+    required this.closeAnalyzers,
+    required this.stopDocker,
+    required this.vmServiceInfoFile,
+  });
+
+  /// Whether [dispose] has been called.
+  bool get isDisposed => _disposed;
+
+  Future<void> dispose() async {
+    if (_disposed) return;
+    _disposed = true;
+    await fileChangeSub?.cancel();
+    await mcpSocket?.close();
+    await closeAnalyzers();
+    await session.dispose();
+    await proxy?.close();
+    await File(vmServiceInfoFile).deleteIfExists();
+    await stopDocker?.call();
+  }
+}

--- a/tools/serverpod_cli/lib/src/commands/start/watch_session.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/watch_session.dart
@@ -82,12 +82,10 @@ sealed class ApplyMigrationsOutcome {
   const ApplyMigrationsOutcome();
 }
 
-/// Migrations were applied in-process.
-///
-/// [versions] are the versions just applied (empty when nothing was pending).
+/// Migrations were applied in-process. The action is responsible for
+/// any user-facing logging (e.g. via [formatAppliedMigrations]).
 class MigrationsApplied extends ApplyMigrationsOutcome {
-  final List<String> versions;
-  const MigrationsApplied(this.versions);
+  const MigrationsApplied();
 }
 
 /// In-process apply was skipped. Session must restart pod to apply migrations.
@@ -449,8 +447,8 @@ class WatchSession {
       try {
         final outcome = await _applyMigrationsAction();
         switch (outcome) {
-          case MigrationsApplied(:final versions):
-            log.info(formatAppliedMigrations(versions));
+          case MigrationsApplied():
+            break;
           case MigrationsRequirePodRestart():
             await _restartServer(_compiler?.outputDill);
         }
@@ -497,12 +495,14 @@ class WatchSession {
     }
   }
 
-  /// Disposes the session: stops server and disposes compiler.
+  /// Disposes the session: stops server and disposes compiler. After
+  /// this returns, [done] is guaranteed to be completed.
   Future<void> dispose() async {
     _state = SessionState.disposed;
     await _vmServiceUriChangesController.close();
-    await _server.stop();
+    final code = await _server.stop();
     await _compiler?.dispose();
+    if (!_done.isCompleted) _done.complete(code);
   }
 
   void _monitorExit(ServerProcess server) {

--- a/tools/serverpod_cli/lib/src/commands/tui/run_app.dart
+++ b/tools/serverpod_cli/lib/src/commands/tui/run_app.dart
@@ -3,10 +3,19 @@ import 'dart:io';
 import 'package:nocterm/nocterm.dart';
 
 /// Run a TUI app with terminal settings restoration.
+///
+/// When [onShutdownSignal] is null (the default), SIGINT/SIGTERM trigger an
+/// immediate `shutdownApp()` and the app exits without running any user
+/// cleanup.
+///
+/// When [onShutdownSignal] is provided, signals invoke that callback instead.
+/// The caller is then responsible for running cleanup and eventually calling
+/// `shutdownApp(...)` to tear down the nocterm renderer.
 Future<void> runServerpodApp(
   Component app, {
   bool enableHotReload = true,
   TerminalBackend? backend,
+  void Function()? onShutdownSignal,
 }) async {
   final originalEchoMode = stdin.echoMode;
   final originalLineMode = stdin.lineMode;
@@ -16,15 +25,22 @@ Future<void> runServerpodApp(
     stdin.lineMode = originalLineMode;
   }
 
-  void onShutDownSignal(ProcessSignal _) {
+  void onShutDownSignalDefault(ProcessSignal _) {
     restoreTerminal();
     shutdownApp();
   }
 
-  ProcessSignal.sigint.watch().listen(onShutDownSignal);
+  void onShutDownSignalDelegated(ProcessSignal _) {
+    onShutdownSignal!.call();
+  }
 
+  final handler = onShutdownSignal == null
+      ? onShutDownSignalDefault
+      : onShutDownSignalDelegated;
+
+  ProcessSignal.sigint.watch().listen(handler);
   if (!Platform.isWindows) {
-    ProcessSignal.sigterm.watch().listen(onShutDownSignal);
+    ProcessSignal.sigterm.watch().listen(handler);
   }
 
   try {

--- a/tools/serverpod_cli/lib/src/migrations/cli_migration_runner.dart
+++ b/tools/serverpod_cli/lib/src/migrations/cli_migration_runner.dart
@@ -34,7 +34,7 @@ Future<List<String>> applyPendingMigrations({
   final pool = DatabaseProvider.forDialect(
     dbConfig.dialect,
   ).createPoolManager(_CliSerializationManager(moduleName), null, dbConfig);
-  pool.start();
+  await pool.start();
 
   try {
     // Session and Database have a circular construction dependency:

--- a/tools/serverpod_cli/lib/src/migrations/cli_migration_runner.dart
+++ b/tools/serverpod_cli/lib/src/migrations/cli_migration_runner.dart
@@ -37,14 +37,12 @@ Future<List<String>> applyPendingMigrations({
   final resolvedDbConfig = _resolveDbConfigPaths(dbConfig, serverDir);
 
   final pool =
-      DatabaseProvider.forDialect(
-        resolvedDbConfig.dialect,
-      ).createPoolManager(
+      DatabaseProvider.forDialect(resolvedDbConfig.dialect).createPoolManager(
         _CliSerializationManager(moduleName),
         null,
         resolvedDbConfig,
-      );
-  await pool.start();
+      )..start();
+  await pool.started;
 
   try {
     // Session and Database have a circular construction dependency:

--- a/tools/serverpod_cli/lib/src/migrations/cli_migration_runner.dart
+++ b/tools/serverpod_cli/lib/src/migrations/cli_migration_runner.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:path/path.dart' as p;
 import 'package:serverpod_cli/src/config_info/config_info.dart';
 import 'package:serverpod_database/serverpod_database.dart';
 import 'package:serverpod_shared/serverpod_shared.dart';
@@ -31,9 +32,18 @@ Future<List<String>> applyPendingMigrations({
     throw StateError('No database configured for run mode "$runMode".');
   }
 
-  final pool = DatabaseProvider.forDialect(
-    dbConfig.dialect,
-  ).createPoolManager(_CliSerializationManager(moduleName), null, dbConfig);
+  // Resolve relative SQLite paths against [serverDir] so the CLI opens
+  // the same file the pod will
+  final resolvedDbConfig = _resolveDbConfigPaths(dbConfig, serverDir);
+
+  final pool =
+      DatabaseProvider.forDialect(
+        resolvedDbConfig.dialect,
+      ).createPoolManager(
+        _CliSerializationManager(moduleName),
+        null,
+        resolvedDbConfig,
+      );
   await pool.start();
 
   try {
@@ -99,6 +109,21 @@ String runModeFromServerArgs(List<String> serverArgs) {
     }
   }
   return 'development';
+}
+
+/// Returns [dbConfig] with any relative SQLite [SqliteDatabaseConfig.filePath]
+/// resolved against [serverDir]. Non-SQLite configs and already-absolute
+/// paths are returned unchanged.
+DatabaseConfig _resolveDbConfigPaths(
+  DatabaseConfig dbConfig,
+  String serverDir,
+) {
+  if (dbConfig is! SqliteDatabaseConfig) return dbConfig;
+  if (p.isAbsolute(dbConfig.filePath)) return dbConfig;
+  return SqliteDatabaseConfig(
+    filePath: p.normalize(p.join(serverDir, dbConfig.filePath)),
+    maxConnectionCount: dbConfig.maxConnectionCount,
+  );
 }
 
 /// Wraps [ConfigInfo] with a chdir into [serverDir] so it picks up

--- a/tools/serverpod_cli/test/commands/start/watch_loop_test.dart
+++ b/tools/serverpod_cli/test/commands/start/watch_loop_test.dart
@@ -1,0 +1,304 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:serverpod_cli/src/commands/start/kernel_compiler.dart';
+import 'package:serverpod_cli/src/commands/start/mcp_socket.dart';
+import 'package:serverpod_cli/src/commands/start/server_process.dart';
+import 'package:serverpod_cli/src/commands/start/watch_loop.dart';
+import 'package:serverpod_cli/src/commands/start/watch_session.dart';
+import 'package:serverpod_cli/src/util/serverpod_cli_logger.dart';
+import 'package:serverpod_cli/src/vendored/frontend_server_client.dart';
+import 'package:serverpod_cli/src/vm_proxy/proxy.dart';
+import 'package:test/fake.dart';
+import 'package:test/test.dart';
+
+CompileResult _successResult({String? dillOutput = '/out.dill'}) {
+  return CompileResultInternal.create(
+    dillOutput: dillOutput,
+    compilerOutputLines: [],
+    errorCount: 0,
+    newSources: [],
+  );
+}
+
+class _FakeCompiler extends Fake implements KernelCompiler {
+  final List<String> calls = [];
+
+  @override
+  String get outputDill => '/tmp/fake.dill';
+
+  @override
+  Future<CompileResult> compile({Set<String> changedPaths = const {}}) async {
+    return _successResult();
+  }
+
+  @override
+  void accept() {}
+
+  @override
+  Future<void> reject() async {}
+
+  @override
+  Future<void> reset() async {}
+
+  @override
+  Future<void> restart() async {}
+
+  @override
+  Future<void> dispose() async => calls.add('dispose');
+}
+
+class _FakeServer extends Fake implements ServerProcess {
+  final List<String> calls = [];
+  final Completer<int> _exitCodeCompleter = Completer<int>();
+  final Completer<void> _vmServiceReadyCompleter = Completer<void>();
+
+  @override
+  bool get isVmServiceConnected => false;
+
+  @override
+  Future<int> get exitCode => _exitCodeCompleter.future;
+
+  @override
+  Future<void> get vmServiceReady => _vmServiceReadyCompleter.future;
+
+  @override
+  String? get vmServiceUri => null;
+
+  @override
+  Future<int> stop({Duration timeout = const Duration(seconds: 5)}) async {
+    calls.add('stop');
+    if (!_exitCodeCompleter.isCompleted) _exitCodeCompleter.complete(0);
+    return 0;
+  }
+}
+
+class _FakeProxy extends Fake implements VmServiceProxy {
+  int closeCalls = 0;
+  @override
+  Future<void> close() async => closeCalls++;
+}
+
+class _FakeMcpSocket extends Fake implements McpSocketServer {
+  int closeCalls = 0;
+  @override
+  Future<void> close() async => closeCalls++;
+}
+
+WatchSession _buildSession(_FakeCompiler compiler, _FakeServer server) {
+  return WatchSession(
+    compiler: compiler,
+    generate: (_, _) async => (success: true, generatedFiles: const <String>{}),
+    createServer: (_) async => server,
+    initialServer: server,
+    generatedDirPaths: const {},
+    applyMigrationsAction: () async => const MigrationsApplied(),
+  );
+}
+
+void main() {
+  setUpAll(() {
+    initializeLogger();
+  });
+
+  tearDownAll(() async {
+    await closeLogger();
+  });
+
+  group('Given a ServerArgsRef', () {
+    test(
+      'when the value is mutated after a closure captured the ref, '
+      'then the closure observes the new value',
+      () {
+        final ref = ServerArgsRef(['initial']);
+        List<String> reader() => ref.value;
+
+        expect(reader(), ['initial']);
+
+        ref.value = ['mutated'];
+
+        expect(reader(), ['mutated']);
+      },
+    );
+
+    test(
+      'when the same closure is invoked multiple times across mutations, '
+      'then each invocation sees the current value',
+      () {
+        final ref = ServerArgsRef([]);
+        final readings = <List<String>>[];
+        void capture() => readings.add(List.of(ref.value));
+
+        capture();
+        ref.value = ['a'];
+        capture();
+        ref.value = ['a', 'b'];
+        capture();
+
+        expect(readings, [
+          <String>[],
+          ['a'],
+          ['a', 'b'],
+        ]);
+      },
+    );
+  });
+
+  group('Given a WatchLoopContext', () {
+    late _FakeCompiler compiler;
+    late _FakeServer server;
+    late _FakeProxy proxy;
+    late _FakeMcpSocket mcp;
+    late int closeAnalyzersCalls;
+    late int stopDockerCalls;
+    late int fileSubCancelCalls;
+    late StreamSubscription<void> fileSub;
+    late Directory tempDir;
+    late String vmServiceInfoFile;
+
+    setUp(() {
+      compiler = _FakeCompiler();
+      server = _FakeServer();
+      proxy = _FakeProxy();
+      mcp = _FakeMcpSocket();
+      closeAnalyzersCalls = 0;
+      stopDockerCalls = 0;
+      fileSubCancelCalls = 0;
+
+      // A real StreamSubscription whose cancel we count via a wrapper
+      // controller; cancelling the inner sub increments the counter.
+      final controller = StreamController<void>();
+      fileSub = controller.stream.listen((_) {});
+      controller.onCancel = () {
+        fileSubCancelCalls++;
+      };
+
+      tempDir = Directory.systemTemp.createTempSync('watch_loop_test_');
+      vmServiceInfoFile = p.join(tempDir.path, 'vm-service-info.json');
+      File(vmServiceInfoFile).writeAsStringSync('{}');
+    });
+
+    tearDown(() {
+      try {
+        tempDir.deleteSync(recursive: true);
+      } on FileSystemException {
+        // Already gone.
+      }
+    });
+
+    WatchLoopContext build({bool startedDocker = false}) {
+      return WatchLoopContext(
+        session: _buildSession(compiler, server),
+        proxy: proxy,
+        mcpSocket: mcp,
+        fileChangeSub: fileSub,
+        closeAnalyzers: () async {
+          closeAnalyzersCalls++;
+        },
+        stopDocker: startedDocker
+            ? () async {
+                stopDockerCalls++;
+              }
+            : null,
+        vmServiceInfoFile: vmServiceInfoFile,
+      );
+    }
+
+    test(
+      'when dispose is called once, '
+      'then every member close is invoked',
+      () async {
+        final ctx = build(startedDocker: true);
+
+        await ctx.dispose();
+
+        expect(fileSubCancelCalls, 1);
+        expect(mcp.closeCalls, 1);
+        expect(closeAnalyzersCalls, 1);
+        expect(server.calls, contains('stop'));
+        expect(compiler.calls, contains('dispose'));
+        expect(proxy.closeCalls, 1);
+        expect(File(vmServiceInfoFile).existsSync(), isFalse);
+        expect(stopDockerCalls, 1);
+        expect(ctx.isDisposed, isTrue);
+      },
+    );
+
+    test(
+      'when dispose is called twice, '
+      'then the second call is a no-op',
+      () async {
+        final ctx = build(startedDocker: true);
+
+        await ctx.dispose();
+        await ctx.dispose();
+
+        expect(fileSubCancelCalls, 1, reason: 'fileChangeSub.cancel');
+        expect(mcp.closeCalls, 1, reason: 'mcpSocket.close');
+        expect(closeAnalyzersCalls, 1, reason: 'closeAnalyzers');
+        expect(
+          server.calls.where((c) => c == 'stop').length,
+          1,
+          reason: 'server.stop',
+        );
+        expect(
+          compiler.calls.where((c) => c == 'dispose').length,
+          1,
+          reason: 'compiler.dispose',
+        );
+        expect(proxy.closeCalls, 1, reason: 'proxy.close');
+        expect(stopDockerCalls, 1, reason: 'stopDocker');
+      },
+    );
+
+    test(
+      'when stopDocker is null (Docker was not started), '
+      'then dispose skips the Docker step',
+      () async {
+        final ctx = build(startedDocker: false);
+
+        await ctx.dispose();
+
+        expect(stopDockerCalls, 0);
+        // Other steps still run.
+        expect(closeAnalyzersCalls, 1);
+        expect(server.calls, contains('stop'));
+      },
+    );
+
+    test(
+      'when the vm-service-info file is already missing, '
+      'then dispose succeeds without throwing',
+      () async {
+        File(vmServiceInfoFile).deleteSync();
+        final ctx = build();
+
+        await expectLater(ctx.dispose(), completes);
+      },
+    );
+
+    test(
+      'when proxy and mcpSocket and fileChangeSub are null, '
+      'then dispose skips them and runs the rest',
+      () async {
+        final ctx = WatchLoopContext(
+          session: _buildSession(compiler, server),
+          proxy: null,
+          mcpSocket: null,
+          fileChangeSub: null,
+          closeAnalyzers: () async {
+            closeAnalyzersCalls++;
+          },
+          stopDocker: null,
+          vmServiceInfoFile: vmServiceInfoFile,
+        );
+
+        await ctx.dispose();
+
+        expect(closeAnalyzersCalls, 1);
+        expect(server.calls, contains('stop'));
+      },
+    );
+  });
+}

--- a/tools/serverpod_cli/test/commands/start/watch_session_test.dart
+++ b/tools/serverpod_cli/test/commands/start/watch_session_test.dart
@@ -157,7 +157,7 @@ void main() {
       initialServer: initialServer,
       generatedDirPaths: {'/generated'},
       applyMigrationsAction:
-          applyMigrationsAction ?? () async => const MigrationsApplied([]),
+          applyMigrationsAction ?? () async => const MigrationsApplied(),
       classifyProtocolChange:
           classifyProtocolChange ?? defaultProtocolChangeClassifier,
     );
@@ -669,7 +669,7 @@ void main() {
     late WatchSession inPlaceSession;
 
     setUp(() {
-      outcomeBuilder = () => const MigrationsApplied(['20251030_120000_user']);
+      outcomeBuilder = () => const MigrationsApplied();
       actionCalls = 0;
       gate = null;
 
@@ -702,7 +702,7 @@ void main() {
       'when the action returns an empty list, '
       'then it succeeds (already up to date)',
       () async {
-        outcomeBuilder = () => const MigrationsApplied([]);
+        outcomeBuilder = () => const MigrationsApplied();
 
         await inPlaceSession.applyMigration();
 
@@ -727,7 +727,7 @@ void main() {
 
         // Same session: a follow-up call must reach the action rather
         // than hit the in-flight latch.
-        outcomeBuilder = () => const MigrationsApplied([]);
+        outcomeBuilder = () => const MigrationsApplied();
         await inPlaceSession.applyMigration();
         expect(actionCalls, 2);
       },
@@ -767,7 +767,7 @@ void main() {
         await Future<void>.delayed(Duration.zero);
         expect(actionCalls, 1, reason: 'second call must wait for first');
 
-        gate!.complete(const MigrationsApplied(['v1']));
+        gate!.complete(const MigrationsApplied());
         await firstCall;
         await secondCall;
 
@@ -809,17 +809,15 @@ void main() {
     );
 
     test(
-      'when server exit completes from stop, '
-      'then done does not complete',
+      'when disposing, '
+      'then done completes with the server exit code',
       () async {
-        // dispose() calls stop(), which completes initialExitCode.
+        // dispose() stops the server and must complete `done` so callers
+        // that `await session.done` from any path (e.g. the TUI quit
+        // path) do not hang.
         await session.dispose();
 
-        var doneCompleted = false;
-        unawaited(session.done.then((_) => doneCompleted = true));
-        await Future<void>.delayed(Duration.zero);
-
-        expect(doneCompleted, isFalse);
+        await expectLater(session.done, completion(0));
       },
     );
   });
@@ -1049,7 +1047,7 @@ class Counter {
         },
         initialServer: noCompilerServer,
         generatedDirPaths: {'/generated'},
-        applyMigrationsAction: () async => const MigrationsApplied([]),
+        applyMigrationsAction: () async => const MigrationsApplied(),
       );
     });
 
@@ -1151,7 +1149,7 @@ class Counter {
             (success: true, generatedFiles: <String>{}),
         initialServer: noFactoryServer,
         generatedDirPaths: {'/generated'},
-        applyMigrationsAction: () async => const MigrationsApplied([]),
+        applyMigrationsAction: () async => const MigrationsApplied(),
       );
     });
 


### PR DESCRIPTION
Consolidate TUI/watch flow + fix database pool start lifecycle

  - Collapse _startSession and _runTuiBackend into a single _setupWatchLoop
  - Stop TUI cleanup from racing shutdownApp
  - Make DatabasePoolManager.start() async 
  - Ensure CLI in-process migration use correct DB (when using sqlite)