### PR TITLE
feat: Configure Serverpod MCP server on create

### DIFF
--- a/templates/serverpod_templates/modulename/gitignore
+++ b/templates/serverpod_templates/modulename/gitignore
@@ -11,4 +11,6 @@ pubspec_overrides.yaml
 .claude/
 .gemini/
 .cursor/
+.vscode/mcp.json
+.codex/
 .mcp.json

--- a/templates/serverpod_templates/modulename/gitignore
+++ b/templates/serverpod_templates/modulename/gitignore
@@ -9,3 +9,6 @@ pubspec_overrides.yaml
 .dart_skills/
 .agents/
 .claude/
+.gemini/
+.cursor/
+.mcp.json

--- a/templates/serverpod_templates/projectname/gitignore
+++ b/templates/serverpod_templates/projectname/gitignore
@@ -11,4 +11,6 @@ pubspec_overrides.yaml
 .claude/
 .gemini/
 .cursor/
+.vscode/mcp.json
+.codex/
 .mcp.json

--- a/templates/serverpod_templates/projectname/gitignore
+++ b/templates/serverpod_templates/projectname/gitignore
@@ -9,3 +9,6 @@ pubspec_overrides.yaml
 .dart_skills/
 .agents/
 .claude/
+.gemini/
+.cursor/
+.mcp.json

--- a/tests/bootstrap_project/test/module_quickstart_test.dart
+++ b/tests/bootstrap_project/test/module_quickstart_test.dart
@@ -352,19 +352,20 @@ void main() {
         });
 
         group('has Serverpod and Dart MCP servers configured', () {
-          final genericConfig =
-              r'\{\n'
-              r'  \"mcpServers\": \{\n'
-              r'    \"serverpod\": \{\n'
-              r'      \"command\": \"serverpod\",\n'
-              r'      \"args\": \[\"mcp\"\]\n'
-              r'    \},\n'
-              r'    \"dart\": \{\n'
-              r'      \"command\": \"dart\",\n'
-              r'      \"args\": \[\"mcp-server\"\]\n'
-              r'    \}\n'
-              r'  \}\n'
-              r'\}';
+          final genericConfig = '''
+{
+  "mcpServers": {
+    "serverpod": {
+      "command": "serverpod",
+      "args": ["mcp"]
+    },
+    "dart": {
+      "command": "dart",
+      "args": ["mcp-server"]
+    }
+  }
+}
+''';
 
           test('for Antigravity', () {
             final antigravity = File(
@@ -377,9 +378,7 @@ void main() {
             expect(antigravity.existsSync(), isTrue);
             expect(
               antigravity.readAsStringSync(),
-              matches(
-                genericConfig.replaceAll(r'\"dart\":', r'\"dart-mcp-server\":'),
-              ),
+              genericConfig.replaceAll('"dart":', '"dart-mcp-server":'),
             );
           });
 
@@ -390,15 +389,15 @@ void main() {
             expect(codex.existsSync(), isTrue);
             expect(
               codex.readAsStringSync(),
-              matches(
-                r'\[mcp_servers.serverpod\]\n'
-                r'command = \"serverpod\"\n'
-                r'args = \[\"mcp\"\]\n'
-                r'\n'
-                r'\[mcp_servers.dart_mcp\]\n'
-                r'command = \"dart\"\n'
-                r'args = \[\"mcp-server\", \"--force-roots-fallback\"\]',
-              ),
+              '''
+[mcp_servers.serverpod]
+command = "serverpod"
+args = ["mcp"]
+
+[mcp_servers.dart_mcp]
+command = "dart"
+args = ["mcp-server", "--force-roots-fallback"]
+''',
             );
           });
 
@@ -407,7 +406,7 @@ void main() {
               path.join(tempPath, projectName, '.mcp.json'),
             );
             expect(claude.existsSync(), isTrue);
-            expect(claude.readAsStringSync(), matches(genericConfig));
+            expect(claude.readAsStringSync(), genericConfig);
           });
 
           test('for Cursor', () {
@@ -415,7 +414,7 @@ void main() {
               path.join(tempPath, projectName, '.cursor/mcp.json'),
             );
             expect(cursor.existsSync(), isTrue);
-            expect(cursor.readAsStringSync(), matches(genericConfig));
+            expect(cursor.readAsStringSync(), genericConfig);
           });
 
           test('for VSCode', () {
@@ -425,7 +424,7 @@ void main() {
             expect(vscode.existsSync(), isTrue);
             expect(
               vscode.readAsStringSync(),
-              matches(genericConfig.replaceAll('mcpServers', 'servers')),
+              genericConfig.replaceAll('mcpServers', 'servers'),
             );
           });
         });

--- a/tests/bootstrap_project/test/module_quickstart_test.dart
+++ b/tests/bootstrap_project/test/module_quickstart_test.dart
@@ -350,6 +350,75 @@ void main() {
             isTrue,
           );
         });
+
+        group(
+          'has Serverpod MCP server configured',
+          () {
+            test('for Antigravity', () {
+              final antigravity = File(
+                path.join(
+                  tempPath,
+                  projectName,
+                  '.gemini/antigravity/mcp_config.json',
+                ),
+              );
+              expect(antigravity.existsSync(), isTrue);
+              expect(
+                antigravity.readAsStringSync(),
+                matches(
+                  r'\{\n'
+                  r'  \"mcpServers\": \{\n'
+                  r'    \"serverpod\": \{\n'
+                  r'      \"command\": \"serverpod\",\n'
+                  r'      \"args\": \[\"mcp\"\]\n'
+                  r'    \}\n'
+                  r'  \}\n'
+                  r'\}',
+                ),
+              );
+            });
+
+            test('for Claude', () {
+              final claude = File(
+                path.join(tempPath, projectName, '.mcp.json'),
+              );
+              expect(claude.existsSync(), isTrue);
+              expect(
+                claude.readAsStringSync(),
+                matches(
+                  r'\{\n'
+                  r'  \"mcpServers\": \{\n'
+                  r'    \"serverpod\": \{\n'
+                  r'      \"command\": \"serverpod\",\n'
+                  r'      \"args\": \[\"mcp\"\]\n'
+                  r'    \}\n'
+                  r'  \}\n'
+                  r'\}',
+                ),
+              );
+            });
+
+            test('for Cursor', () {
+              final cursor = File(
+                path.join(tempPath, projectName, '.cursor/mcp.json'),
+              );
+              expect(cursor.existsSync(), isTrue);
+              expect(
+                cursor.readAsStringSync(),
+                matches(
+                  r'\{\n'
+                  r'  \"mcpServers\": \{\n'
+                  r'    \"serverpod\": \{\n'
+                  r'      \"command\": \"serverpod\",\n'
+                  r'      \"args\": \[\"mcp\"\]\n'
+                  r'    \}\n'
+                  r'  \}\n'
+                  r'\}',
+                ),
+              );
+            });
+          },
+        );
       });
     });
   });

--- a/tests/bootstrap_project/test/module_quickstart_test.dart
+++ b/tests/bootstrap_project/test/module_quickstart_test.dart
@@ -351,74 +351,106 @@ void main() {
           );
         });
 
-        group(
-          'has Serverpod MCP server configured',
-          () {
-            test('for Antigravity', () {
-              final antigravity = File(
-                path.join(
-                  tempPath,
-                  projectName,
-                  '.gemini/antigravity/mcp_config.json',
-                ),
-              );
-              expect(antigravity.existsSync(), isTrue);
-              expect(
-                antigravity.readAsStringSync(),
-                matches(
-                  r'\{\n'
-                  r'  \"mcpServers\": \{\n'
-                  r'    \"serverpod\": \{\n'
-                  r'      \"command\": \"serverpod\",\n'
-                  r'      \"args\": \[\"mcp\"\]\n'
-                  r'    \}\n'
-                  r'  \}\n'
-                  r'\}',
-                ),
-              );
-            });
+        group('has Serverpod MCP server configured', () {
+          test('for Antigravity', () {
+            final antigravity = File(
+              path.join(
+                tempPath,
+                projectName,
+                '.gemini/antigravity/mcp_config.json',
+              ),
+            );
+            expect(antigravity.existsSync(), isTrue);
+            expect(
+              antigravity.readAsStringSync(),
+              matches(
+                r'\{\n'
+                r'  \"mcpServers\": \{\n'
+                r'    \"serverpod\": \{\n'
+                r'      \"command\": \"serverpod\",\n'
+                r'      \"args\": \[\"mcp\"\]\n'
+                r'    \}\n'
+                r'  \}\n'
+                r'\}',
+              ),
+            );
+          });
 
-            test('for Claude', () {
-              final claude = File(
-                path.join(tempPath, projectName, '.mcp.json'),
-              );
-              expect(claude.existsSync(), isTrue);
-              expect(
-                claude.readAsStringSync(),
-                matches(
-                  r'\{\n'
-                  r'  \"mcpServers\": \{\n'
-                  r'    \"serverpod\": \{\n'
-                  r'      \"command\": \"serverpod\",\n'
-                  r'      \"args\": \[\"mcp\"\]\n'
-                  r'    \}\n'
-                  r'  \}\n'
-                  r'\}',
-                ),
-              );
-            });
+          test('for Codex', () {
+            final codex = File(
+              path.join(tempPath, projectName, '.codex/config.toml'),
+            );
+            expect(codex.existsSync(), isTrue);
+            expect(
+              codex.readAsStringSync(),
+              matches(
+                r'\[mcp_servers.serverpod\]\n'
+                r'command = \"serverpod\"\n'
+                r'args = \[\"mcp\"\]\n',
+              ),
+            );
+          });
 
-            test('for Cursor', () {
-              final cursor = File(
-                path.join(tempPath, projectName, '.cursor/mcp.json'),
-              );
-              expect(cursor.existsSync(), isTrue);
-              expect(
-                cursor.readAsStringSync(),
-                matches(
-                  r'\{\n'
-                  r'  \"mcpServers\": \{\n'
-                  r'    \"serverpod\": \{\n'
-                  r'      \"command\": \"serverpod\",\n'
-                  r'      \"args\": \[\"mcp\"\]\n'
-                  r'    \}\n'
-                  r'  \}\n'
-                  r'\}',
-                ),
-              );
-            });
-          },
-        );
+          test('for Claude', () {
+            final claude = File(
+              path.join(tempPath, projectName, '.mcp.json'),
+            );
+            expect(claude.existsSync(), isTrue);
+            expect(
+              claude.readAsStringSync(),
+              matches(
+                r'\{\n'
+                r'  \"mcpServers\": \{\n'
+                r'    \"serverpod\": \{\n'
+                r'      \"command\": \"serverpod\",\n'
+                r'      \"args\": \[\"mcp\"\]\n'
+                r'    \}\n'
+                r'  \}\n'
+                r'\}',
+              ),
+            );
+          });
+
+          test('for Cursor', () {
+            final cursor = File(
+              path.join(tempPath, projectName, '.cursor/mcp.json'),
+            );
+            expect(cursor.existsSync(), isTrue);
+            expect(
+              cursor.readAsStringSync(),
+              matches(
+                r'\{\n'
+                r'  \"mcpServers\": \{\n'
+                r'    \"serverpod\": \{\n'
+                r'      \"command\": \"serverpod\",\n'
+                r'      \"args\": \[\"mcp\"\]\n'
+                r'    \}\n'
+                r'  \}\n'
+                r'\}',
+              ),
+            );
+          });
+
+          test('for VSCode', () {
+            final vscode = File(
+              path.join(tempPath, projectName, '.vscode/mcp.json'),
+            );
+            expect(vscode.existsSync(), isTrue);
+            expect(
+              vscode.readAsStringSync(),
+              matches(
+                r'\{\n'
+                r'  \"servers\": \{\n'
+                r'    \"serverpod\": \{\n'
+                r'      \"command\": \"serverpod\",\n'
+                r'      \"args\": \[\"mcp\"\]\n'
+                r'    \}\n'
+                r'  \}\n'
+                r'\}',
+              ),
+            );
+          });
+        });
       });
     });
   });

--- a/tests/bootstrap_project/test/module_quickstart_test.dart
+++ b/tests/bootstrap_project/test/module_quickstart_test.dart
@@ -351,7 +351,21 @@ void main() {
           );
         });
 
-        group('has Serverpod MCP server configured', () {
+        group('has Serverpod and Dart MCP servers configured', () {
+          final genericConfig =
+              r'\{\n'
+              r'  \"mcpServers\": \{\n'
+              r'    \"serverpod\": \{\n'
+              r'      \"command\": \"serverpod\",\n'
+              r'      \"args\": \[\"mcp\"\]\n'
+              r'    \},\n'
+              r'    \"dart\": \{\n'
+              r'      \"command\": \"dart\",\n'
+              r'      \"args\": \[\"mcp-server\"\]\n'
+              r'    \}\n'
+              r'  \}\n'
+              r'\}';
+
           test('for Antigravity', () {
             final antigravity = File(
               path.join(
@@ -364,14 +378,7 @@ void main() {
             expect(
               antigravity.readAsStringSync(),
               matches(
-                r'\{\n'
-                r'  \"mcpServers\": \{\n'
-                r'    \"serverpod\": \{\n'
-                r'      \"command\": \"serverpod\",\n'
-                r'      \"args\": \[\"mcp\"\]\n'
-                r'    \}\n'
-                r'  \}\n'
-                r'\}',
+                genericConfig.replaceAll(r'\"dart\":', r'\"dart-mcp-server\":'),
               ),
             );
           });
@@ -386,7 +393,11 @@ void main() {
               matches(
                 r'\[mcp_servers.serverpod\]\n'
                 r'command = \"serverpod\"\n'
-                r'args = \[\"mcp\"\]\n',
+                r'args = \[\"mcp\"\]\n'
+                r'\n'
+                r'\[mcp_servers.dart_mcp\]\n'
+                r'command = \"dart\"\n'
+                r'args = \[\"mcp-server\", \"--force-roots-fallback\"\]',
               ),
             );
           });
@@ -396,19 +407,7 @@ void main() {
               path.join(tempPath, projectName, '.mcp.json'),
             );
             expect(claude.existsSync(), isTrue);
-            expect(
-              claude.readAsStringSync(),
-              matches(
-                r'\{\n'
-                r'  \"mcpServers\": \{\n'
-                r'    \"serverpod\": \{\n'
-                r'      \"command\": \"serverpod\",\n'
-                r'      \"args\": \[\"mcp\"\]\n'
-                r'    \}\n'
-                r'  \}\n'
-                r'\}',
-              ),
-            );
+            expect(claude.readAsStringSync(), matches(genericConfig));
           });
 
           test('for Cursor', () {
@@ -416,19 +415,7 @@ void main() {
               path.join(tempPath, projectName, '.cursor/mcp.json'),
             );
             expect(cursor.existsSync(), isTrue);
-            expect(
-              cursor.readAsStringSync(),
-              matches(
-                r'\{\n'
-                r'  \"mcpServers\": \{\n'
-                r'    \"serverpod\": \{\n'
-                r'      \"command\": \"serverpod\",\n'
-                r'      \"args\": \[\"mcp\"\]\n'
-                r'    \}\n'
-                r'  \}\n'
-                r'\}',
-              ),
-            );
+            expect(cursor.readAsStringSync(), matches(genericConfig));
           });
 
           test('for VSCode', () {
@@ -438,16 +425,7 @@ void main() {
             expect(vscode.existsSync(), isTrue);
             expect(
               vscode.readAsStringSync(),
-              matches(
-                r'\{\n'
-                r'  \"servers\": \{\n'
-                r'    \"serverpod\": \{\n'
-                r'      \"command\": \"serverpod\",\n'
-                r'      \"args\": \[\"mcp\"\]\n'
-                r'    \}\n'
-                r'  \}\n'
-                r'\}',
-              ),
+              matches(genericConfig.replaceAll('mcpServers', 'servers')),
             );
           });
         });

--- a/tests/bootstrap_project/test/module_test.dart
+++ b/tests/bootstrap_project/test/module_test.dart
@@ -363,19 +363,20 @@ void main() {
         });
 
         group('has Serverpod and Dart MCP servers configured', () {
-          final genericConfig =
-              r'\{\n'
-              r'  \"mcpServers\": \{\n'
-              r'    \"serverpod\": \{\n'
-              r'      \"command\": \"serverpod\",\n'
-              r'      \"args\": \[\"mcp\"\]\n'
-              r'    \},\n'
-              r'    \"dart\": \{\n'
-              r'      \"command\": \"dart\",\n'
-              r'      \"args\": \[\"mcp-server\"\]\n'
-              r'    \}\n'
-              r'  \}\n'
-              r'\}';
+          final genericConfig = '''
+{
+  "mcpServers": {
+    "serverpod": {
+      "command": "serverpod",
+      "args": ["mcp"]
+    },
+    "dart": {
+      "command": "dart",
+      "args": ["mcp-server"]
+    }
+  }
+}
+''';
 
           test('for Antigravity', () {
             final antigravity = File(
@@ -388,9 +389,7 @@ void main() {
             expect(antigravity.existsSync(), isTrue);
             expect(
               antigravity.readAsStringSync(),
-              matches(
-                genericConfig.replaceAll(r'\"dart\":', r'\"dart-mcp-server\":'),
-              ),
+              genericConfig.replaceAll('"dart":', '"dart-mcp-server":'),
             );
           });
 
@@ -401,15 +400,15 @@ void main() {
             expect(codex.existsSync(), isTrue);
             expect(
               codex.readAsStringSync(),
-              matches(
-                r'\[mcp_servers.serverpod\]\n'
-                r'command = \"serverpod\"\n'
-                r'args = \[\"mcp\"\]\n'
-                r'\n'
-                r'\[mcp_servers.dart_mcp\]\n'
-                r'command = \"dart\"\n'
-                r'args = \[\"mcp-server\", \"--force-roots-fallback\"\]',
-              ),
+              '''
+[mcp_servers.serverpod]
+command = "serverpod"
+args = ["mcp"]
+
+[mcp_servers.dart_mcp]
+command = "dart"
+args = ["mcp-server", "--force-roots-fallback"]
+''',
             );
           });
 
@@ -418,7 +417,7 @@ void main() {
               path.join(tempPath, projectName, '.mcp.json'),
             );
             expect(claude.existsSync(), isTrue);
-            expect(claude.readAsStringSync(), matches(genericConfig));
+            expect(claude.readAsStringSync(), genericConfig);
           });
 
           test('for Cursor', () {
@@ -426,7 +425,7 @@ void main() {
               path.join(tempPath, projectName, '.cursor/mcp.json'),
             );
             expect(cursor.existsSync(), isTrue);
-            expect(cursor.readAsStringSync(), matches(genericConfig));
+            expect(cursor.readAsStringSync(), genericConfig);
           });
 
           test('for VSCode', () {
@@ -436,7 +435,7 @@ void main() {
             expect(vscode.existsSync(), isTrue);
             expect(
               vscode.readAsStringSync(),
-              matches(genericConfig.replaceAll('mcpServers', 'servers')),
+              genericConfig.replaceAll('mcpServers', 'servers'),
             );
           });
         });

--- a/tests/bootstrap_project/test/module_test.dart
+++ b/tests/bootstrap_project/test/module_test.dart
@@ -362,7 +362,21 @@ void main() {
           );
         });
 
-        group('has Serverpod MCP server configured', () {
+        group('has Serverpod and Dart MCP servers configured', () {
+          final genericConfig =
+              r'\{\n'
+              r'  \"mcpServers\": \{\n'
+              r'    \"serverpod\": \{\n'
+              r'      \"command\": \"serverpod\",\n'
+              r'      \"args\": \[\"mcp\"\]\n'
+              r'    \},\n'
+              r'    \"dart\": \{\n'
+              r'      \"command\": \"dart\",\n'
+              r'      \"args\": \[\"mcp-server\"\]\n'
+              r'    \}\n'
+              r'  \}\n'
+              r'\}';
+
           test('for Antigravity', () {
             final antigravity = File(
               path.join(
@@ -375,14 +389,7 @@ void main() {
             expect(
               antigravity.readAsStringSync(),
               matches(
-                r'\{\n'
-                r'  \"mcpServers\": \{\n'
-                r'    \"serverpod\": \{\n'
-                r'      \"command\": \"serverpod\",\n'
-                r'      \"args\": \[\"mcp\"\]\n'
-                r'    \}\n'
-                r'  \}\n'
-                r'\}',
+                genericConfig.replaceAll(r'\"dart\":', r'\"dart-mcp-server\":'),
               ),
             );
           });
@@ -397,7 +404,11 @@ void main() {
               matches(
                 r'\[mcp_servers.serverpod\]\n'
                 r'command = \"serverpod\"\n'
-                r'args = \[\"mcp\"\]\n',
+                r'args = \[\"mcp\"\]\n'
+                r'\n'
+                r'\[mcp_servers.dart_mcp\]\n'
+                r'command = \"dart\"\n'
+                r'args = \[\"mcp-server\", \"--force-roots-fallback\"\]',
               ),
             );
           });
@@ -407,19 +418,7 @@ void main() {
               path.join(tempPath, projectName, '.mcp.json'),
             );
             expect(claude.existsSync(), isTrue);
-            expect(
-              claude.readAsStringSync(),
-              matches(
-                r'\{\n'
-                r'  \"mcpServers\": \{\n'
-                r'    \"serverpod\": \{\n'
-                r'      \"command\": \"serverpod\",\n'
-                r'      \"args\": \[\"mcp\"\]\n'
-                r'    \}\n'
-                r'  \}\n'
-                r'\}',
-              ),
-            );
+            expect(claude.readAsStringSync(), matches(genericConfig));
           });
 
           test('for Cursor', () {
@@ -427,19 +426,7 @@ void main() {
               path.join(tempPath, projectName, '.cursor/mcp.json'),
             );
             expect(cursor.existsSync(), isTrue);
-            expect(
-              cursor.readAsStringSync(),
-              matches(
-                r'\{\n'
-                r'  \"mcpServers\": \{\n'
-                r'    \"serverpod\": \{\n'
-                r'      \"command\": \"serverpod\",\n'
-                r'      \"args\": \[\"mcp\"\]\n'
-                r'    \}\n'
-                r'  \}\n'
-                r'\}',
-              ),
-            );
+            expect(cursor.readAsStringSync(), matches(genericConfig));
           });
 
           test('for VSCode', () {
@@ -449,16 +436,7 @@ void main() {
             expect(vscode.existsSync(), isTrue);
             expect(
               vscode.readAsStringSync(),
-              matches(
-                r'\{\n'
-                r'  \"servers\": \{\n'
-                r'    \"serverpod\": \{\n'
-                r'      \"command\": \"serverpod\",\n'
-                r'      \"args\": \[\"mcp\"\]\n'
-                r'    \}\n'
-                r'  \}\n'
-                r'\}',
-              ),
+              matches(genericConfig.replaceAll('mcpServers', 'servers')),
             );
           });
         });

--- a/tests/bootstrap_project/test/module_test.dart
+++ b/tests/bootstrap_project/test/module_test.dart
@@ -362,74 +362,106 @@ void main() {
           );
         });
 
-        group(
-          'has Serverpod MCP server configured',
-          () {
-            test('for Antigravity', () {
-              final antigravity = File(
-                path.join(
-                  tempPath,
-                  projectName,
-                  '.gemini/antigravity/mcp_config.json',
-                ),
-              );
-              expect(antigravity.existsSync(), isTrue);
-              expect(
-                antigravity.readAsStringSync(),
-                matches(
-                  r'\{\n'
-                  r'  \"mcpServers\": \{\n'
-                  r'    \"serverpod\": \{\n'
-                  r'      \"command\": \"serverpod\",\n'
-                  r'      \"args\": \[\"mcp\"\]\n'
-                  r'    \}\n'
-                  r'  \}\n'
-                  r'\}',
-                ),
-              );
-            });
+        group('has Serverpod MCP server configured', () {
+          test('for Antigravity', () {
+            final antigravity = File(
+              path.join(
+                tempPath,
+                projectName,
+                '.gemini/antigravity/mcp_config.json',
+              ),
+            );
+            expect(antigravity.existsSync(), isTrue);
+            expect(
+              antigravity.readAsStringSync(),
+              matches(
+                r'\{\n'
+                r'  \"mcpServers\": \{\n'
+                r'    \"serverpod\": \{\n'
+                r'      \"command\": \"serverpod\",\n'
+                r'      \"args\": \[\"mcp\"\]\n'
+                r'    \}\n'
+                r'  \}\n'
+                r'\}',
+              ),
+            );
+          });
 
-            test('for Claude', () {
-              final claude = File(
-                path.join(tempPath, projectName, '.mcp.json'),
-              );
-              expect(claude.existsSync(), isTrue);
-              expect(
-                claude.readAsStringSync(),
-                matches(
-                  r'\{\n'
-                  r'  \"mcpServers\": \{\n'
-                  r'    \"serverpod\": \{\n'
-                  r'      \"command\": \"serverpod\",\n'
-                  r'      \"args\": \[\"mcp\"\]\n'
-                  r'    \}\n'
-                  r'  \}\n'
-                  r'\}',
-                ),
-              );
-            });
+          test('for Codex', () {
+            final codex = File(
+              path.join(tempPath, projectName, '.codex/config.toml'),
+            );
+            expect(codex.existsSync(), isTrue);
+            expect(
+              codex.readAsStringSync(),
+              matches(
+                r'\[mcp_servers.serverpod\]\n'
+                r'command = \"serverpod\"\n'
+                r'args = \[\"mcp\"\]\n',
+              ),
+            );
+          });
 
-            test('for Cursor', () {
-              final cursor = File(
-                path.join(tempPath, projectName, '.cursor/mcp.json'),
-              );
-              expect(cursor.existsSync(), isTrue);
-              expect(
-                cursor.readAsStringSync(),
-                matches(
-                  r'\{\n'
-                  r'  \"mcpServers\": \{\n'
-                  r'    \"serverpod\": \{\n'
-                  r'      \"command\": \"serverpod\",\n'
-                  r'      \"args\": \[\"mcp\"\]\n'
-                  r'    \}\n'
-                  r'  \}\n'
-                  r'\}',
-                ),
-              );
-            });
-          },
-        );
+          test('for Claude', () {
+            final claude = File(
+              path.join(tempPath, projectName, '.mcp.json'),
+            );
+            expect(claude.existsSync(), isTrue);
+            expect(
+              claude.readAsStringSync(),
+              matches(
+                r'\{\n'
+                r'  \"mcpServers\": \{\n'
+                r'    \"serverpod\": \{\n'
+                r'      \"command\": \"serverpod\",\n'
+                r'      \"args\": \[\"mcp\"\]\n'
+                r'    \}\n'
+                r'  \}\n'
+                r'\}',
+              ),
+            );
+          });
+
+          test('for Cursor', () {
+            final cursor = File(
+              path.join(tempPath, projectName, '.cursor/mcp.json'),
+            );
+            expect(cursor.existsSync(), isTrue);
+            expect(
+              cursor.readAsStringSync(),
+              matches(
+                r'\{\n'
+                r'  \"mcpServers\": \{\n'
+                r'    \"serverpod\": \{\n'
+                r'      \"command\": \"serverpod\",\n'
+                r'      \"args\": \[\"mcp\"\]\n'
+                r'    \}\n'
+                r'  \}\n'
+                r'\}',
+              ),
+            );
+          });
+
+          test('for VSCode', () {
+            final vscode = File(
+              path.join(tempPath, projectName, '.vscode/mcp.json'),
+            );
+            expect(vscode.existsSync(), isTrue);
+            expect(
+              vscode.readAsStringSync(),
+              matches(
+                r'\{\n'
+                r'  \"servers\": \{\n'
+                r'    \"serverpod\": \{\n'
+                r'      \"command\": \"serverpod\",\n'
+                r'      \"args\": \[\"mcp\"\]\n'
+                r'    \}\n'
+                r'  \}\n'
+                r'\}',
+              ),
+            );
+          });
+        });
       });
     });
   });

--- a/tests/bootstrap_project/test/module_test.dart
+++ b/tests/bootstrap_project/test/module_test.dart
@@ -361,6 +361,75 @@ void main() {
             isTrue,
           );
         });
+
+        group(
+          'has Serverpod MCP server configured',
+          () {
+            test('for Antigravity', () {
+              final antigravity = File(
+                path.join(
+                  tempPath,
+                  projectName,
+                  '.gemini/antigravity/mcp_config.json',
+                ),
+              );
+              expect(antigravity.existsSync(), isTrue);
+              expect(
+                antigravity.readAsStringSync(),
+                matches(
+                  r'\{\n'
+                  r'  \"mcpServers\": \{\n'
+                  r'    \"serverpod\": \{\n'
+                  r'      \"command\": \"serverpod\",\n'
+                  r'      \"args\": \[\"mcp\"\]\n'
+                  r'    \}\n'
+                  r'  \}\n'
+                  r'\}',
+                ),
+              );
+            });
+
+            test('for Claude', () {
+              final claude = File(
+                path.join(tempPath, projectName, '.mcp.json'),
+              );
+              expect(claude.existsSync(), isTrue);
+              expect(
+                claude.readAsStringSync(),
+                matches(
+                  r'\{\n'
+                  r'  \"mcpServers\": \{\n'
+                  r'    \"serverpod\": \{\n'
+                  r'      \"command\": \"serverpod\",\n'
+                  r'      \"args\": \[\"mcp\"\]\n'
+                  r'    \}\n'
+                  r'  \}\n'
+                  r'\}',
+                ),
+              );
+            });
+
+            test('for Cursor', () {
+              final cursor = File(
+                path.join(tempPath, projectName, '.cursor/mcp.json'),
+              );
+              expect(cursor.existsSync(), isTrue);
+              expect(
+                cursor.readAsStringSync(),
+                matches(
+                  r'\{\n'
+                  r'  \"mcpServers\": \{\n'
+                  r'    \"serverpod\": \{\n'
+                  r'      \"command\": \"serverpod\",\n'
+                  r'      \"args\": \[\"mcp\"\]\n'
+                  r'    \}\n'
+                  r'  \}\n'
+                  r'\}',
+                ),
+              );
+            });
+          },
+        );
       });
     });
   });

--- a/tests/bootstrap_project/test/project_mini_test.dart
+++ b/tests/bootstrap_project/test/project_mini_test.dart
@@ -347,74 +347,106 @@ void main() async {
           );
         });
 
-        group(
-          'has Serverpod MCP server configured',
-          () {
-            test('for Antigravity', () {
-              final antigravity = File(
-                path.join(
-                  tempPath,
-                  projectName,
-                  '.gemini/antigravity/mcp_config.json',
-                ),
-              );
-              expect(antigravity.existsSync(), isTrue);
-              expect(
-                antigravity.readAsStringSync(),
-                matches(
-                  r'\{\n'
-                  r'  \"mcpServers\": \{\n'
-                  r'    \"serverpod\": \{\n'
-                  r'      \"command\": \"serverpod\",\n'
-                  r'      \"args\": \[\"mcp\"\]\n'
-                  r'    \}\n'
-                  r'  \}\n'
-                  r'\}',
-                ),
-              );
-            });
+        group('has Serverpod MCP server configured', () {
+          test('for Antigravity', () {
+            final antigravity = File(
+              path.join(
+                tempPath,
+                projectName,
+                '.gemini/antigravity/mcp_config.json',
+              ),
+            );
+            expect(antigravity.existsSync(), isTrue);
+            expect(
+              antigravity.readAsStringSync(),
+              matches(
+                r'\{\n'
+                r'  \"mcpServers\": \{\n'
+                r'    \"serverpod\": \{\n'
+                r'      \"command\": \"serverpod\",\n'
+                r'      \"args\": \[\"mcp\"\]\n'
+                r'    \}\n'
+                r'  \}\n'
+                r'\}',
+              ),
+            );
+          });
 
-            test('for Claude', () {
-              final claude = File(
-                path.join(tempPath, projectName, '.mcp.json'),
-              );
-              expect(claude.existsSync(), isTrue);
-              expect(
-                claude.readAsStringSync(),
-                matches(
-                  r'\{\n'
-                  r'  \"mcpServers\": \{\n'
-                  r'    \"serverpod\": \{\n'
-                  r'      \"command\": \"serverpod\",\n'
-                  r'      \"args\": \[\"mcp\"\]\n'
-                  r'    \}\n'
-                  r'  \}\n'
-                  r'\}',
-                ),
-              );
-            });
+          test('for Codex', () {
+            final codex = File(
+              path.join(tempPath, projectName, '.codex/config.toml'),
+            );
+            expect(codex.existsSync(), isTrue);
+            expect(
+              codex.readAsStringSync(),
+              matches(
+                r'\[mcp_servers.serverpod\]\n'
+                r'command = \"serverpod\"\n'
+                r'args = \[\"mcp\"\]\n',
+              ),
+            );
+          });
 
-            test('for Cursor', () {
-              final cursor = File(
-                path.join(tempPath, projectName, '.cursor/mcp.json'),
-              );
-              expect(cursor.existsSync(), isTrue);
-              expect(
-                cursor.readAsStringSync(),
-                matches(
-                  r'\{\n'
-                  r'  \"mcpServers\": \{\n'
-                  r'    \"serverpod\": \{\n'
-                  r'      \"command\": \"serverpod\",\n'
-                  r'      \"args\": \[\"mcp\"\]\n'
-                  r'    \}\n'
-                  r'  \}\n'
-                  r'\}',
-                ),
-              );
-            });
-          },
-        );
+          test('for Claude', () {
+            final claude = File(
+              path.join(tempPath, projectName, '.mcp.json'),
+            );
+            expect(claude.existsSync(), isTrue);
+            expect(
+              claude.readAsStringSync(),
+              matches(
+                r'\{\n'
+                r'  \"mcpServers\": \{\n'
+                r'    \"serverpod\": \{\n'
+                r'      \"command\": \"serverpod\",\n'
+                r'      \"args\": \[\"mcp\"\]\n'
+                r'    \}\n'
+                r'  \}\n'
+                r'\}',
+              ),
+            );
+          });
+
+          test('for Cursor', () {
+            final cursor = File(
+              path.join(tempPath, projectName, '.cursor/mcp.json'),
+            );
+            expect(cursor.existsSync(), isTrue);
+            expect(
+              cursor.readAsStringSync(),
+              matches(
+                r'\{\n'
+                r'  \"mcpServers\": \{\n'
+                r'    \"serverpod\": \{\n'
+                r'      \"command\": \"serverpod\",\n'
+                r'      \"args\": \[\"mcp\"\]\n'
+                r'    \}\n'
+                r'  \}\n'
+                r'\}',
+              ),
+            );
+          });
+
+          test('for VSCode', () {
+            final vscode = File(
+              path.join(tempPath, projectName, '.vscode/mcp.json'),
+            );
+            expect(vscode.existsSync(), isTrue);
+            expect(
+              vscode.readAsStringSync(),
+              matches(
+                r'\{\n'
+                r'  \"servers\": \{\n'
+                r'    \"serverpod\": \{\n'
+                r'      \"command\": \"serverpod\",\n'
+                r'      \"args\": \[\"mcp\"\]\n'
+                r'    \}\n'
+                r'  \}\n'
+                r'\}',
+              ),
+            );
+          });
+        });
       });
     });
   });

--- a/tests/bootstrap_project/test/project_mini_test.dart
+++ b/tests/bootstrap_project/test/project_mini_test.dart
@@ -348,19 +348,20 @@ void main() async {
         });
 
         group('has Serverpod and Dart MCP servers configured', () {
-          final genericConfig =
-              r'\{\n'
-              r'  \"mcpServers\": \{\n'
-              r'    \"serverpod\": \{\n'
-              r'      \"command\": \"serverpod\",\n'
-              r'      \"args\": \[\"mcp\"\]\n'
-              r'    \},\n'
-              r'    \"dart\": \{\n'
-              r'      \"command\": \"dart\",\n'
-              r'      \"args\": \[\"mcp-server\"\]\n'
-              r'    \}\n'
-              r'  \}\n'
-              r'\}';
+          final genericConfig = '''
+{
+  "mcpServers": {
+    "serverpod": {
+      "command": "serverpod",
+      "args": ["mcp"]
+    },
+    "dart": {
+      "command": "dart",
+      "args": ["mcp-server"]
+    }
+  }
+}
+''';
 
           test('for Antigravity', () {
             final antigravity = File(
@@ -373,9 +374,7 @@ void main() async {
             expect(antigravity.existsSync(), isTrue);
             expect(
               antigravity.readAsStringSync(),
-              matches(
-                genericConfig.replaceAll(r'\"dart\":', r'\"dart-mcp-server\":'),
-              ),
+              genericConfig.replaceAll('"dart":', '"dart-mcp-server":'),
             );
           });
 
@@ -386,15 +385,15 @@ void main() async {
             expect(codex.existsSync(), isTrue);
             expect(
               codex.readAsStringSync(),
-              matches(
-                r'\[mcp_servers.serverpod\]\n'
-                r'command = \"serverpod\"\n'
-                r'args = \[\"mcp\"\]\n'
-                r'\n'
-                r'\[mcp_servers.dart_mcp\]\n'
-                r'command = \"dart\"\n'
-                r'args = \[\"mcp-server\", \"--force-roots-fallback\"\]',
-              ),
+              '''
+[mcp_servers.serverpod]
+command = "serverpod"
+args = ["mcp"]
+
+[mcp_servers.dart_mcp]
+command = "dart"
+args = ["mcp-server", "--force-roots-fallback"]
+''',
             );
           });
 
@@ -403,7 +402,7 @@ void main() async {
               path.join(tempPath, projectName, '.mcp.json'),
             );
             expect(claude.existsSync(), isTrue);
-            expect(claude.readAsStringSync(), matches(genericConfig));
+            expect(claude.readAsStringSync(), genericConfig);
           });
 
           test('for Cursor', () {
@@ -411,7 +410,7 @@ void main() async {
               path.join(tempPath, projectName, '.cursor/mcp.json'),
             );
             expect(cursor.existsSync(), isTrue);
-            expect(cursor.readAsStringSync(), matches(genericConfig));
+            expect(cursor.readAsStringSync(), genericConfig);
           });
 
           test('for VSCode', () {
@@ -421,7 +420,7 @@ void main() async {
             expect(vscode.existsSync(), isTrue);
             expect(
               vscode.readAsStringSync(),
-              matches(genericConfig.replaceAll('mcpServers', 'servers')),
+              genericConfig.replaceAll('mcpServers', 'servers'),
             );
           });
         });

--- a/tests/bootstrap_project/test/project_mini_test.dart
+++ b/tests/bootstrap_project/test/project_mini_test.dart
@@ -346,6 +346,75 @@ void main() async {
             isTrue,
           );
         });
+
+        group(
+          'has Serverpod MCP server configured',
+          () {
+            test('for Antigravity', () {
+              final antigravity = File(
+                path.join(
+                  tempPath,
+                  projectName,
+                  '.gemini/antigravity/mcp_config.json',
+                ),
+              );
+              expect(antigravity.existsSync(), isTrue);
+              expect(
+                antigravity.readAsStringSync(),
+                matches(
+                  r'\{\n'
+                  r'  \"mcpServers\": \{\n'
+                  r'    \"serverpod\": \{\n'
+                  r'      \"command\": \"serverpod\",\n'
+                  r'      \"args\": \[\"mcp\"\]\n'
+                  r'    \}\n'
+                  r'  \}\n'
+                  r'\}',
+                ),
+              );
+            });
+
+            test('for Claude', () {
+              final claude = File(
+                path.join(tempPath, projectName, '.mcp.json'),
+              );
+              expect(claude.existsSync(), isTrue);
+              expect(
+                claude.readAsStringSync(),
+                matches(
+                  r'\{\n'
+                  r'  \"mcpServers\": \{\n'
+                  r'    \"serverpod\": \{\n'
+                  r'      \"command\": \"serverpod\",\n'
+                  r'      \"args\": \[\"mcp\"\]\n'
+                  r'    \}\n'
+                  r'  \}\n'
+                  r'\}',
+                ),
+              );
+            });
+
+            test('for Cursor', () {
+              final cursor = File(
+                path.join(tempPath, projectName, '.cursor/mcp.json'),
+              );
+              expect(cursor.existsSync(), isTrue);
+              expect(
+                cursor.readAsStringSync(),
+                matches(
+                  r'\{\n'
+                  r'  \"mcpServers\": \{\n'
+                  r'    \"serverpod\": \{\n'
+                  r'      \"command\": \"serverpod\",\n'
+                  r'      \"args\": \[\"mcp\"\]\n'
+                  r'    \}\n'
+                  r'  \}\n'
+                  r'\}',
+                ),
+              );
+            });
+          },
+        );
       });
     });
   });

--- a/tests/bootstrap_project/test/project_mini_test.dart
+++ b/tests/bootstrap_project/test/project_mini_test.dart
@@ -347,7 +347,21 @@ void main() async {
           );
         });
 
-        group('has Serverpod MCP server configured', () {
+        group('has Serverpod and Dart MCP servers configured', () {
+          final genericConfig =
+              r'\{\n'
+              r'  \"mcpServers\": \{\n'
+              r'    \"serverpod\": \{\n'
+              r'      \"command\": \"serverpod\",\n'
+              r'      \"args\": \[\"mcp\"\]\n'
+              r'    \},\n'
+              r'    \"dart\": \{\n'
+              r'      \"command\": \"dart\",\n'
+              r'      \"args\": \[\"mcp-server\"\]\n'
+              r'    \}\n'
+              r'  \}\n'
+              r'\}';
+
           test('for Antigravity', () {
             final antigravity = File(
               path.join(
@@ -360,14 +374,7 @@ void main() async {
             expect(
               antigravity.readAsStringSync(),
               matches(
-                r'\{\n'
-                r'  \"mcpServers\": \{\n'
-                r'    \"serverpod\": \{\n'
-                r'      \"command\": \"serverpod\",\n'
-                r'      \"args\": \[\"mcp\"\]\n'
-                r'    \}\n'
-                r'  \}\n'
-                r'\}',
+                genericConfig.replaceAll(r'\"dart\":', r'\"dart-mcp-server\":'),
               ),
             );
           });
@@ -382,7 +389,11 @@ void main() async {
               matches(
                 r'\[mcp_servers.serverpod\]\n'
                 r'command = \"serverpod\"\n'
-                r'args = \[\"mcp\"\]\n',
+                r'args = \[\"mcp\"\]\n'
+                r'\n'
+                r'\[mcp_servers.dart_mcp\]\n'
+                r'command = \"dart\"\n'
+                r'args = \[\"mcp-server\", \"--force-roots-fallback\"\]',
               ),
             );
           });
@@ -392,19 +403,7 @@ void main() async {
               path.join(tempPath, projectName, '.mcp.json'),
             );
             expect(claude.existsSync(), isTrue);
-            expect(
-              claude.readAsStringSync(),
-              matches(
-                r'\{\n'
-                r'  \"mcpServers\": \{\n'
-                r'    \"serverpod\": \{\n'
-                r'      \"command\": \"serverpod\",\n'
-                r'      \"args\": \[\"mcp\"\]\n'
-                r'    \}\n'
-                r'  \}\n'
-                r'\}',
-              ),
-            );
+            expect(claude.readAsStringSync(), matches(genericConfig));
           });
 
           test('for Cursor', () {
@@ -412,19 +411,7 @@ void main() async {
               path.join(tempPath, projectName, '.cursor/mcp.json'),
             );
             expect(cursor.existsSync(), isTrue);
-            expect(
-              cursor.readAsStringSync(),
-              matches(
-                r'\{\n'
-                r'  \"mcpServers\": \{\n'
-                r'    \"serverpod\": \{\n'
-                r'      \"command\": \"serverpod\",\n'
-                r'      \"args\": \[\"mcp\"\]\n'
-                r'    \}\n'
-                r'  \}\n'
-                r'\}',
-              ),
-            );
+            expect(cursor.readAsStringSync(), matches(genericConfig));
           });
 
           test('for VSCode', () {
@@ -434,16 +421,7 @@ void main() async {
             expect(vscode.existsSync(), isTrue);
             expect(
               vscode.readAsStringSync(),
-              matches(
-                r'\{\n'
-                r'  \"servers\": \{\n'
-                r'    \"serverpod\": \{\n'
-                r'      \"command\": \"serverpod\",\n'
-                r'      \"args\": \[\"mcp\"\]\n'
-                r'    \}\n'
-                r'  \}\n'
-                r'\}',
-              ),
+              matches(genericConfig.replaceAll('mcpServers', 'servers')),
             );
           });
         });

--- a/tests/bootstrap_project/test/project_quickstart_test.dart
+++ b/tests/bootstrap_project/test/project_quickstart_test.dart
@@ -443,6 +443,75 @@ void main() async {
                 isTrue,
               );
             });
+
+            group(
+              'has Serverpod MCP server configured',
+              () {
+                test('for Antigravity', () {
+                  final antigravity = File(
+                    path.join(
+                      tempPath,
+                      projectName,
+                      '.gemini/antigravity/mcp_config.json',
+                    ),
+                  );
+                  expect(antigravity.existsSync(), isTrue);
+                  expect(
+                    antigravity.readAsStringSync(),
+                    matches(
+                      r'\{\n'
+                      r'  \"mcpServers\": \{\n'
+                      r'    \"serverpod\": \{\n'
+                      r'      \"command\": \"serverpod\",\n'
+                      r'      \"args\": \[\"mcp\"\]\n'
+                      r'    \}\n'
+                      r'  \}\n'
+                      r'\}',
+                    ),
+                  );
+                });
+
+                test('for Claude', () {
+                  final claude = File(
+                    path.join(tempPath, projectName, '.mcp.json'),
+                  );
+                  expect(claude.existsSync(), isTrue);
+                  expect(
+                    claude.readAsStringSync(),
+                    matches(
+                      r'\{\n'
+                      r'  \"mcpServers\": \{\n'
+                      r'    \"serverpod\": \{\n'
+                      r'      \"command\": \"serverpod\",\n'
+                      r'      \"args\": \[\"mcp\"\]\n'
+                      r'    \}\n'
+                      r'  \}\n'
+                      r'\}',
+                    ),
+                  );
+                });
+
+                test('for Cursor', () {
+                  final cursor = File(
+                    path.join(tempPath, projectName, '.cursor/mcp.json'),
+                  );
+                  expect(cursor.existsSync(), isTrue);
+                  expect(
+                    cursor.readAsStringSync(),
+                    matches(
+                      r'\{\n'
+                      r'  \"mcpServers\": \{\n'
+                      r'    \"serverpod\": \{\n'
+                      r'      \"command\": \"serverpod\",\n'
+                      r'      \"args\": \[\"mcp\"\]\n'
+                      r'    \}\n'
+                      r'  \}\n'
+                      r'\}',
+                    ),
+                  );
+                });
+              },
+            );
           });
 
           group('then the .github directory', () {

--- a/tests/bootstrap_project/test/project_quickstart_test.dart
+++ b/tests/bootstrap_project/test/project_quickstart_test.dart
@@ -444,7 +444,21 @@ void main() async {
               );
             });
 
-            group('has Serverpod MCP server configured', () {
+            group('has Serverpod and Dart MCP servers configured', () {
+              final genericConfig =
+                  r'\{\n'
+                  r'  \"mcpServers\": \{\n'
+                  r'    \"serverpod\": \{\n'
+                  r'      \"command\": \"serverpod\",\n'
+                  r'      \"args\": \[\"mcp\"\]\n'
+                  r'    \},\n'
+                  r'    \"dart\": \{\n'
+                  r'      \"command\": \"dart\",\n'
+                  r'      \"args\": \[\"mcp-server\"\]\n'
+                  r'    \}\n'
+                  r'  \}\n'
+                  r'\}';
+
               test('for Antigravity', () {
                 final antigravity = File(
                   path.join(
@@ -457,14 +471,10 @@ void main() async {
                 expect(
                   antigravity.readAsStringSync(),
                   matches(
-                    r'\{\n'
-                    r'  \"mcpServers\": \{\n'
-                    r'    \"serverpod\": \{\n'
-                    r'      \"command\": \"serverpod\",\n'
-                    r'      \"args\": \[\"mcp\"\]\n'
-                    r'    \}\n'
-                    r'  \}\n'
-                    r'\}',
+                    genericConfig.replaceAll(
+                      r'\"dart\":',
+                      r'\"dart-mcp-server\":',
+                    ),
                   ),
                 );
               });
@@ -479,7 +489,11 @@ void main() async {
                   matches(
                     r'\[mcp_servers.serverpod\]\n'
                     r'command = \"serverpod\"\n'
-                    r'args = \[\"mcp\"\]\n',
+                    r'args = \[\"mcp\"\]\n'
+                    r'\n'
+                    r'\[mcp_servers.dart_mcp\]\n'
+                    r'command = \"dart\"\n'
+                    r'args = \[\"mcp-server\", \"--force-roots-fallback\"\]',
                   ),
                 );
               });
@@ -489,19 +503,7 @@ void main() async {
                   path.join(tempPath, projectName, '.mcp.json'),
                 );
                 expect(claude.existsSync(), isTrue);
-                expect(
-                  claude.readAsStringSync(),
-                  matches(
-                    r'\{\n'
-                    r'  \"mcpServers\": \{\n'
-                    r'    \"serverpod\": \{\n'
-                    r'      \"command\": \"serverpod\",\n'
-                    r'      \"args\": \[\"mcp\"\]\n'
-                    r'    \}\n'
-                    r'  \}\n'
-                    r'\}',
-                  ),
-                );
+                expect(claude.readAsStringSync(), matches(genericConfig));
               });
 
               test('for Cursor', () {
@@ -509,19 +511,7 @@ void main() async {
                   path.join(tempPath, projectName, '.cursor/mcp.json'),
                 );
                 expect(cursor.existsSync(), isTrue);
-                expect(
-                  cursor.readAsStringSync(),
-                  matches(
-                    r'\{\n'
-                    r'  \"mcpServers\": \{\n'
-                    r'    \"serverpod\": \{\n'
-                    r'      \"command\": \"serverpod\",\n'
-                    r'      \"args\": \[\"mcp\"\]\n'
-                    r'    \}\n'
-                    r'  \}\n'
-                    r'\}',
-                  ),
-                );
+                expect(cursor.readAsStringSync(), matches(genericConfig));
               });
 
               test('for VSCode', () {
@@ -531,16 +521,7 @@ void main() async {
                 expect(vscode.existsSync(), isTrue);
                 expect(
                   vscode.readAsStringSync(),
-                  matches(
-                    r'\{\n'
-                    r'  \"servers\": \{\n'
-                    r'    \"serverpod\": \{\n'
-                    r'      \"command\": \"serverpod\",\n'
-                    r'      \"args\": \[\"mcp\"\]\n'
-                    r'    \}\n'
-                    r'  \}\n'
-                    r'\}',
-                  ),
+                  matches(genericConfig.replaceAll('mcpServers', 'servers')),
                 );
               });
             });

--- a/tests/bootstrap_project/test/project_quickstart_test.dart
+++ b/tests/bootstrap_project/test/project_quickstart_test.dart
@@ -444,74 +444,106 @@ void main() async {
               );
             });
 
-            group(
-              'has Serverpod MCP server configured',
-              () {
-                test('for Antigravity', () {
-                  final antigravity = File(
-                    path.join(
-                      tempPath,
-                      projectName,
-                      '.gemini/antigravity/mcp_config.json',
-                    ),
-                  );
-                  expect(antigravity.existsSync(), isTrue);
-                  expect(
-                    antigravity.readAsStringSync(),
-                    matches(
-                      r'\{\n'
-                      r'  \"mcpServers\": \{\n'
-                      r'    \"serverpod\": \{\n'
-                      r'      \"command\": \"serverpod\",\n'
-                      r'      \"args\": \[\"mcp\"\]\n'
-                      r'    \}\n'
-                      r'  \}\n'
-                      r'\}',
-                    ),
-                  );
-                });
+            group('has Serverpod MCP server configured', () {
+              test('for Antigravity', () {
+                final antigravity = File(
+                  path.join(
+                    tempPath,
+                    projectName,
+                    '.gemini/antigravity/mcp_config.json',
+                  ),
+                );
+                expect(antigravity.existsSync(), isTrue);
+                expect(
+                  antigravity.readAsStringSync(),
+                  matches(
+                    r'\{\n'
+                    r'  \"mcpServers\": \{\n'
+                    r'    \"serverpod\": \{\n'
+                    r'      \"command\": \"serverpod\",\n'
+                    r'      \"args\": \[\"mcp\"\]\n'
+                    r'    \}\n'
+                    r'  \}\n'
+                    r'\}',
+                  ),
+                );
+              });
 
-                test('for Claude', () {
-                  final claude = File(
-                    path.join(tempPath, projectName, '.mcp.json'),
-                  );
-                  expect(claude.existsSync(), isTrue);
-                  expect(
-                    claude.readAsStringSync(),
-                    matches(
-                      r'\{\n'
-                      r'  \"mcpServers\": \{\n'
-                      r'    \"serverpod\": \{\n'
-                      r'      \"command\": \"serverpod\",\n'
-                      r'      \"args\": \[\"mcp\"\]\n'
-                      r'    \}\n'
-                      r'  \}\n'
-                      r'\}',
-                    ),
-                  );
-                });
+              test('for Codex', () {
+                final codex = File(
+                  path.join(tempPath, projectName, '.codex/config.toml'),
+                );
+                expect(codex.existsSync(), isTrue);
+                expect(
+                  codex.readAsStringSync(),
+                  matches(
+                    r'\[mcp_servers.serverpod\]\n'
+                    r'command = \"serverpod\"\n'
+                    r'args = \[\"mcp\"\]\n',
+                  ),
+                );
+              });
 
-                test('for Cursor', () {
-                  final cursor = File(
-                    path.join(tempPath, projectName, '.cursor/mcp.json'),
-                  );
-                  expect(cursor.existsSync(), isTrue);
-                  expect(
-                    cursor.readAsStringSync(),
-                    matches(
-                      r'\{\n'
-                      r'  \"mcpServers\": \{\n'
-                      r'    \"serverpod\": \{\n'
-                      r'      \"command\": \"serverpod\",\n'
-                      r'      \"args\": \[\"mcp\"\]\n'
-                      r'    \}\n'
-                      r'  \}\n'
-                      r'\}',
-                    ),
-                  );
-                });
-              },
-            );
+              test('for Claude', () {
+                final claude = File(
+                  path.join(tempPath, projectName, '.mcp.json'),
+                );
+                expect(claude.existsSync(), isTrue);
+                expect(
+                  claude.readAsStringSync(),
+                  matches(
+                    r'\{\n'
+                    r'  \"mcpServers\": \{\n'
+                    r'    \"serverpod\": \{\n'
+                    r'      \"command\": \"serverpod\",\n'
+                    r'      \"args\": \[\"mcp\"\]\n'
+                    r'    \}\n'
+                    r'  \}\n'
+                    r'\}',
+                  ),
+                );
+              });
+
+              test('for Cursor', () {
+                final cursor = File(
+                  path.join(tempPath, projectName, '.cursor/mcp.json'),
+                );
+                expect(cursor.existsSync(), isTrue);
+                expect(
+                  cursor.readAsStringSync(),
+                  matches(
+                    r'\{\n'
+                    r'  \"mcpServers\": \{\n'
+                    r'    \"serverpod\": \{\n'
+                    r'      \"command\": \"serverpod\",\n'
+                    r'      \"args\": \[\"mcp\"\]\n'
+                    r'    \}\n'
+                    r'  \}\n'
+                    r'\}',
+                  ),
+                );
+              });
+
+              test('for VSCode', () {
+                final vscode = File(
+                  path.join(tempPath, projectName, '.vscode/mcp.json'),
+                );
+                expect(vscode.existsSync(), isTrue);
+                expect(
+                  vscode.readAsStringSync(),
+                  matches(
+                    r'\{\n'
+                    r'  \"servers\": \{\n'
+                    r'    \"serverpod\": \{\n'
+                    r'      \"command\": \"serverpod\",\n'
+                    r'      \"args\": \[\"mcp\"\]\n'
+                    r'    \}\n'
+                    r'  \}\n'
+                    r'\}',
+                  ),
+                );
+              });
+            });
           });
 
           group('then the .github directory', () {

--- a/tests/bootstrap_project/test/project_quickstart_test.dart
+++ b/tests/bootstrap_project/test/project_quickstart_test.dart
@@ -445,19 +445,20 @@ void main() async {
             });
 
             group('has Serverpod and Dart MCP servers configured', () {
-              final genericConfig =
-                  r'\{\n'
-                  r'  \"mcpServers\": \{\n'
-                  r'    \"serverpod\": \{\n'
-                  r'      \"command\": \"serverpod\",\n'
-                  r'      \"args\": \[\"mcp\"\]\n'
-                  r'    \},\n'
-                  r'    \"dart\": \{\n'
-                  r'      \"command\": \"dart\",\n'
-                  r'      \"args\": \[\"mcp-server\"\]\n'
-                  r'    \}\n'
-                  r'  \}\n'
-                  r'\}';
+              final genericConfig = '''
+{
+  "mcpServers": {
+    "serverpod": {
+      "command": "serverpod",
+      "args": ["mcp"]
+    },
+    "dart": {
+      "command": "dart",
+      "args": ["mcp-server"]
+    }
+  }
+}
+''';
 
               test('for Antigravity', () {
                 final antigravity = File(
@@ -470,12 +471,7 @@ void main() async {
                 expect(antigravity.existsSync(), isTrue);
                 expect(
                   antigravity.readAsStringSync(),
-                  matches(
-                    genericConfig.replaceAll(
-                      r'\"dart\":',
-                      r'\"dart-mcp-server\":',
-                    ),
-                  ),
+                  genericConfig.replaceAll('"dart":', '"dart-mcp-server":'),
                 );
               });
 
@@ -486,15 +482,15 @@ void main() async {
                 expect(codex.existsSync(), isTrue);
                 expect(
                   codex.readAsStringSync(),
-                  matches(
-                    r'\[mcp_servers.serverpod\]\n'
-                    r'command = \"serverpod\"\n'
-                    r'args = \[\"mcp\"\]\n'
-                    r'\n'
-                    r'\[mcp_servers.dart_mcp\]\n'
-                    r'command = \"dart\"\n'
-                    r'args = \[\"mcp-server\", \"--force-roots-fallback\"\]',
-                  ),
+                  '''
+[mcp_servers.serverpod]
+command = "serverpod"
+args = ["mcp"]
+
+[mcp_servers.dart_mcp]
+command = "dart"
+args = ["mcp-server", "--force-roots-fallback"]
+''',
                 );
               });
 
@@ -503,7 +499,7 @@ void main() async {
                   path.join(tempPath, projectName, '.mcp.json'),
                 );
                 expect(claude.existsSync(), isTrue);
-                expect(claude.readAsStringSync(), matches(genericConfig));
+                expect(claude.readAsStringSync(), genericConfig);
               });
 
               test('for Cursor', () {
@@ -511,7 +507,7 @@ void main() async {
                   path.join(tempPath, projectName, '.cursor/mcp.json'),
                 );
                 expect(cursor.existsSync(), isTrue);
-                expect(cursor.readAsStringSync(), matches(genericConfig));
+                expect(cursor.readAsStringSync(), genericConfig);
               });
 
               test('for VSCode', () {
@@ -521,7 +517,7 @@ void main() async {
                 expect(vscode.existsSync(), isTrue);
                 expect(
                   vscode.readAsStringSync(),
-                  matches(genericConfig.replaceAll('mcpServers', 'servers')),
+                  genericConfig.replaceAll('mcpServers', 'servers'),
                 );
               });
             });

--- a/tests/bootstrap_project/test/project_test.dart
+++ b/tests/bootstrap_project/test/project_test.dart
@@ -722,19 +722,20 @@ void main() async {
         });
 
         group('has Serverpod and Dart MCP servers configured', () {
-          final genericConfig =
-              r'\{\n'
-              r'  \"mcpServers\": \{\n'
-              r'    \"serverpod\": \{\n'
-              r'      \"command\": \"serverpod\",\n'
-              r'      \"args\": \[\"mcp\"\]\n'
-              r'    \},\n'
-              r'    \"dart\": \{\n'
-              r'      \"command\": \"dart\",\n'
-              r'      \"args\": \[\"mcp-server\"\]\n'
-              r'    \}\n'
-              r'  \}\n'
-              r'\}';
+          final genericConfig = '''
+{
+  "mcpServers": {
+    "serverpod": {
+      "command": "serverpod",
+      "args": ["mcp"]
+    },
+    "dart": {
+      "command": "dart",
+      "args": ["mcp-server"]
+    }
+  }
+}
+''';
 
           test('for Antigravity', () {
             final antigravity = File(
@@ -747,9 +748,7 @@ void main() async {
             expect(antigravity.existsSync(), isTrue);
             expect(
               antigravity.readAsStringSync(),
-              matches(
-                genericConfig.replaceAll(r'\"dart\":', r'\"dart-mcp-server\":'),
-              ),
+              genericConfig.replaceAll('"dart":', '"dart-mcp-server":'),
             );
           });
 
@@ -760,15 +759,15 @@ void main() async {
             expect(codex.existsSync(), isTrue);
             expect(
               codex.readAsStringSync(),
-              matches(
-                r'\[mcp_servers.serverpod\]\n'
-                r'command = \"serverpod\"\n'
-                r'args = \[\"mcp\"\]\n'
-                r'\n'
-                r'\[mcp_servers.dart_mcp\]\n'
-                r'command = \"dart\"\n'
-                r'args = \[\"mcp-server\", \"--force-roots-fallback\"\]',
-              ),
+              '''
+[mcp_servers.serverpod]
+command = "serverpod"
+args = ["mcp"]
+
+[mcp_servers.dart_mcp]
+command = "dart"
+args = ["mcp-server", "--force-roots-fallback"]
+''',
             );
           });
 
@@ -777,7 +776,7 @@ void main() async {
               path.join(tempPath, projectName, '.mcp.json'),
             );
             expect(claude.existsSync(), isTrue);
-            expect(claude.readAsStringSync(), matches(genericConfig));
+            expect(claude.readAsStringSync(), genericConfig);
           });
 
           test('for Cursor', () {
@@ -785,7 +784,7 @@ void main() async {
               path.join(tempPath, projectName, '.cursor/mcp.json'),
             );
             expect(cursor.existsSync(), isTrue);
-            expect(cursor.readAsStringSync(), matches(genericConfig));
+            expect(cursor.readAsStringSync(), genericConfig);
           });
 
           test('for VSCode', () {
@@ -795,7 +794,7 @@ void main() async {
             expect(vscode.existsSync(), isTrue);
             expect(
               vscode.readAsStringSync(),
-              matches(genericConfig.replaceAll('mcpServers', 'servers')),
+              genericConfig.replaceAll('mcpServers', 'servers'),
             );
           });
         });

--- a/tests/bootstrap_project/test/project_test.dart
+++ b/tests/bootstrap_project/test/project_test.dart
@@ -720,6 +720,75 @@ void main() async {
             isTrue,
           );
         });
+
+        group(
+          'has Serverpod MCP server configured',
+          () {
+            test('for Antigravity', () {
+              final antigravity = File(
+                path.join(
+                  tempPath,
+                  projectName,
+                  '.gemini/antigravity/mcp_config.json',
+                ),
+              );
+              expect(antigravity.existsSync(), isTrue);
+              expect(
+                antigravity.readAsStringSync(),
+                matches(
+                  r'\{\n'
+                  r'  \"mcpServers\": \{\n'
+                  r'    \"serverpod\": \{\n'
+                  r'      \"command\": \"serverpod\",\n'
+                  r'      \"args\": \[\"mcp\"\]\n'
+                  r'    \}\n'
+                  r'  \}\n'
+                  r'\}',
+                ),
+              );
+            });
+
+            test('for Claude', () {
+              final claude = File(
+                path.join(tempPath, projectName, '.mcp.json'),
+              );
+              expect(claude.existsSync(), isTrue);
+              expect(
+                claude.readAsStringSync(),
+                matches(
+                  r'\{\n'
+                  r'  \"mcpServers\": \{\n'
+                  r'    \"serverpod\": \{\n'
+                  r'      \"command\": \"serverpod\",\n'
+                  r'      \"args\": \[\"mcp\"\]\n'
+                  r'    \}\n'
+                  r'  \}\n'
+                  r'\}',
+                ),
+              );
+            });
+
+            test('for Cursor', () {
+              final cursor = File(
+                path.join(tempPath, projectName, '.cursor/mcp.json'),
+              );
+              expect(cursor.existsSync(), isTrue);
+              expect(
+                cursor.readAsStringSync(),
+                matches(
+                  r'\{\n'
+                  r'  \"mcpServers\": \{\n'
+                  r'    \"serverpod\": \{\n'
+                  r'      \"command\": \"serverpod\",\n'
+                  r'      \"args\": \[\"mcp\"\]\n'
+                  r'    \}\n'
+                  r'  \}\n'
+                  r'\}',
+                ),
+              );
+            });
+          },
+        );
       });
 
       group('then the .vscode directory', () {

--- a/tests/bootstrap_project/test/project_test.dart
+++ b/tests/bootstrap_project/test/project_test.dart
@@ -721,74 +721,106 @@ void main() async {
           );
         });
 
-        group(
-          'has Serverpod MCP server configured',
-          () {
-            test('for Antigravity', () {
-              final antigravity = File(
-                path.join(
-                  tempPath,
-                  projectName,
-                  '.gemini/antigravity/mcp_config.json',
-                ),
-              );
-              expect(antigravity.existsSync(), isTrue);
-              expect(
-                antigravity.readAsStringSync(),
-                matches(
-                  r'\{\n'
-                  r'  \"mcpServers\": \{\n'
-                  r'    \"serverpod\": \{\n'
-                  r'      \"command\": \"serverpod\",\n'
-                  r'      \"args\": \[\"mcp\"\]\n'
-                  r'    \}\n'
-                  r'  \}\n'
-                  r'\}',
-                ),
-              );
-            });
+        group('has Serverpod MCP server configured', () {
+          test('for Antigravity', () {
+            final antigravity = File(
+              path.join(
+                tempPath,
+                projectName,
+                '.gemini/antigravity/mcp_config.json',
+              ),
+            );
+            expect(antigravity.existsSync(), isTrue);
+            expect(
+              antigravity.readAsStringSync(),
+              matches(
+                r'\{\n'
+                r'  \"mcpServers\": \{\n'
+                r'    \"serverpod\": \{\n'
+                r'      \"command\": \"serverpod\",\n'
+                r'      \"args\": \[\"mcp\"\]\n'
+                r'    \}\n'
+                r'  \}\n'
+                r'\}',
+              ),
+            );
+          });
 
-            test('for Claude', () {
-              final claude = File(
-                path.join(tempPath, projectName, '.mcp.json'),
-              );
-              expect(claude.existsSync(), isTrue);
-              expect(
-                claude.readAsStringSync(),
-                matches(
-                  r'\{\n'
-                  r'  \"mcpServers\": \{\n'
-                  r'    \"serverpod\": \{\n'
-                  r'      \"command\": \"serverpod\",\n'
-                  r'      \"args\": \[\"mcp\"\]\n'
-                  r'    \}\n'
-                  r'  \}\n'
-                  r'\}',
-                ),
-              );
-            });
+          test('for Codex', () {
+            final codex = File(
+              path.join(tempPath, projectName, '.codex/config.toml'),
+            );
+            expect(codex.existsSync(), isTrue);
+            expect(
+              codex.readAsStringSync(),
+              matches(
+                r'\[mcp_servers.serverpod\]\n'
+                r'command = \"serverpod\"\n'
+                r'args = \[\"mcp\"\]\n',
+              ),
+            );
+          });
 
-            test('for Cursor', () {
-              final cursor = File(
-                path.join(tempPath, projectName, '.cursor/mcp.json'),
-              );
-              expect(cursor.existsSync(), isTrue);
-              expect(
-                cursor.readAsStringSync(),
-                matches(
-                  r'\{\n'
-                  r'  \"mcpServers\": \{\n'
-                  r'    \"serverpod\": \{\n'
-                  r'      \"command\": \"serverpod\",\n'
-                  r'      \"args\": \[\"mcp\"\]\n'
-                  r'    \}\n'
-                  r'  \}\n'
-                  r'\}',
-                ),
-              );
-            });
-          },
-        );
+          test('for Claude', () {
+            final claude = File(
+              path.join(tempPath, projectName, '.mcp.json'),
+            );
+            expect(claude.existsSync(), isTrue);
+            expect(
+              claude.readAsStringSync(),
+              matches(
+                r'\{\n'
+                r'  \"mcpServers\": \{\n'
+                r'    \"serverpod\": \{\n'
+                r'      \"command\": \"serverpod\",\n'
+                r'      \"args\": \[\"mcp\"\]\n'
+                r'    \}\n'
+                r'  \}\n'
+                r'\}',
+              ),
+            );
+          });
+
+          test('for Cursor', () {
+            final cursor = File(
+              path.join(tempPath, projectName, '.cursor/mcp.json'),
+            );
+            expect(cursor.existsSync(), isTrue);
+            expect(
+              cursor.readAsStringSync(),
+              matches(
+                r'\{\n'
+                r'  \"mcpServers\": \{\n'
+                r'    \"serverpod\": \{\n'
+                r'      \"command\": \"serverpod\",\n'
+                r'      \"args\": \[\"mcp\"\]\n'
+                r'    \}\n'
+                r'  \}\n'
+                r'\}',
+              ),
+            );
+          });
+
+          test('for VSCode', () {
+            final vscode = File(
+              path.join(tempPath, projectName, '.vscode/mcp.json'),
+            );
+            expect(vscode.existsSync(), isTrue);
+            expect(
+              vscode.readAsStringSync(),
+              matches(
+                r'\{\n'
+                r'  \"servers\": \{\n'
+                r'    \"serverpod\": \{\n'
+                r'      \"command\": \"serverpod\",\n'
+                r'      \"args\": \[\"mcp\"\]\n'
+                r'    \}\n'
+                r'  \}\n'
+                r'\}',
+              ),
+            );
+          });
+        });
       });
 
       group('then the .vscode directory', () {

--- a/tests/bootstrap_project/test/project_test.dart
+++ b/tests/bootstrap_project/test/project_test.dart
@@ -721,7 +721,21 @@ void main() async {
           );
         });
 
-        group('has Serverpod MCP server configured', () {
+        group('has Serverpod and Dart MCP servers configured', () {
+          final genericConfig =
+              r'\{\n'
+              r'  \"mcpServers\": \{\n'
+              r'    \"serverpod\": \{\n'
+              r'      \"command\": \"serverpod\",\n'
+              r'      \"args\": \[\"mcp\"\]\n'
+              r'    \},\n'
+              r'    \"dart\": \{\n'
+              r'      \"command\": \"dart\",\n'
+              r'      \"args\": \[\"mcp-server\"\]\n'
+              r'    \}\n'
+              r'  \}\n'
+              r'\}';
+
           test('for Antigravity', () {
             final antigravity = File(
               path.join(
@@ -734,14 +748,7 @@ void main() async {
             expect(
               antigravity.readAsStringSync(),
               matches(
-                r'\{\n'
-                r'  \"mcpServers\": \{\n'
-                r'    \"serverpod\": \{\n'
-                r'      \"command\": \"serverpod\",\n'
-                r'      \"args\": \[\"mcp\"\]\n'
-                r'    \}\n'
-                r'  \}\n'
-                r'\}',
+                genericConfig.replaceAll(r'\"dart\":', r'\"dart-mcp-server\":'),
               ),
             );
           });
@@ -756,7 +763,11 @@ void main() async {
               matches(
                 r'\[mcp_servers.serverpod\]\n'
                 r'command = \"serverpod\"\n'
-                r'args = \[\"mcp\"\]\n',
+                r'args = \[\"mcp\"\]\n'
+                r'\n'
+                r'\[mcp_servers.dart_mcp\]\n'
+                r'command = \"dart\"\n'
+                r'args = \[\"mcp-server\", \"--force-roots-fallback\"\]',
               ),
             );
           });
@@ -766,19 +777,7 @@ void main() async {
               path.join(tempPath, projectName, '.mcp.json'),
             );
             expect(claude.existsSync(), isTrue);
-            expect(
-              claude.readAsStringSync(),
-              matches(
-                r'\{\n'
-                r'  \"mcpServers\": \{\n'
-                r'    \"serverpod\": \{\n'
-                r'      \"command\": \"serverpod\",\n'
-                r'      \"args\": \[\"mcp\"\]\n'
-                r'    \}\n'
-                r'  \}\n'
-                r'\}',
-              ),
-            );
+            expect(claude.readAsStringSync(), matches(genericConfig));
           });
 
           test('for Cursor', () {
@@ -786,19 +785,7 @@ void main() async {
               path.join(tempPath, projectName, '.cursor/mcp.json'),
             );
             expect(cursor.existsSync(), isTrue);
-            expect(
-              cursor.readAsStringSync(),
-              matches(
-                r'\{\n'
-                r'  \"mcpServers\": \{\n'
-                r'    \"serverpod\": \{\n'
-                r'      \"command\": \"serverpod\",\n'
-                r'      \"args\": \[\"mcp\"\]\n'
-                r'    \}\n'
-                r'  \}\n'
-                r'\}',
-              ),
-            );
+            expect(cursor.readAsStringSync(), matches(genericConfig));
           });
 
           test('for VSCode', () {
@@ -808,16 +795,7 @@ void main() async {
             expect(vscode.existsSync(), isTrue);
             expect(
               vscode.readAsStringSync(),
-              matches(
-                r'\{\n'
-                r'  \"servers\": \{\n'
-                r'    \"serverpod\": \{\n'
-                r'      \"command\": \"serverpod\",\n'
-                r'      \"args\": \[\"mcp\"\]\n'
-                r'    \}\n'
-                r'  \}\n'
-                r'\}',
-              ),
+              matches(genericConfig.replaceAll('mcpServers', 'servers')),
             );
           });
         });

--- a/tools/serverpod_cli/lib/src/create/create.dart
+++ b/tools/serverpod_cli/lib/src/create/create.dart
@@ -392,9 +392,21 @@ Future<void> _configureMcpServer(String projectDirPath) async {
   const antigravityPath = '.gemini/antigravity/mcp_config.json';
   const cursorPath = '.cursor/mcp.json';
   const claudePath = '.mcp.json';
+  const vscodePath = '.vscode/mcp.json';
+  const codexPath = '.codex/config.toml';
 
-  const config = '''{
+  const genericConfig = '''{
   "mcpServers": {
+    "serverpod": {
+      "command": "serverpod",
+      "args": ["mcp"]
+    }
+  }
+}
+
+''';
+  const vscodeConfig = '''{
+  "servers": {
     "serverpod": {
       "command": "serverpod",
       "args": ["mcp"]
@@ -403,18 +415,29 @@ Future<void> _configureMcpServer(String projectDirPath) async {
 }
 ''';
 
+  const codexConfig = '''[mcp_servers.serverpod]
+command = "serverpod"
+args = ["mcp"]
+''';
+
   await Future.forEach(
     [antigravityPath, cursorPath, claudePath],
     (path) async {
-      final file = File(p.join(projectDirPath, path));
-      try {
-        await file.create(recursive: true);
-        await file.writeAsString(config);
-      } on FileSystemException {
-        //
-      }
+      await _createFileAndWrite(p.join(projectDirPath, path), genericConfig);
     },
   );
+  await _createFileAndWrite(p.join(projectDirPath, vscodePath), vscodeConfig);
+  await _createFileAndWrite(p.join(projectDirPath, codexPath), codexConfig);
+}
+
+Future<void> _createFileAndWrite(String path, String content) async {
+  final file = File(path);
+  try {
+    await file.create(recursive: true);
+    await file.writeAsString(content);
+  } on FileSystemException {
+    //
+  }
 }
 
 /// Upgrades a server project.

--- a/tools/serverpod_cli/lib/src/create/create.dart
+++ b/tools/serverpod_cli/lib/src/create/create.dart
@@ -400,16 +400,10 @@ Future<void> _configureMcpServer(String projectDirPath) async {
     "serverpod": {
       "command": "serverpod",
       "args": ["mcp"]
-    }
-  }
-}
-
-''';
-  const vscodeConfig = '''{
-  "servers": {
-    "serverpod": {
-      "command": "serverpod",
-      "args": ["mcp"]
+    },
+    "dart": {
+      "command": "dart",
+      "args": ["mcp-server"]
     }
   }
 }
@@ -418,15 +412,29 @@ Future<void> _configureMcpServer(String projectDirPath) async {
   const codexConfig = '''[mcp_servers.serverpod]
 command = "serverpod"
 args = ["mcp"]
+
+[mcp_servers.dart_mcp]
+command = "dart"
+args = ["mcp-server", "--force-roots-fallback"]
 ''';
 
   await Future.forEach(
-    [antigravityPath, cursorPath, claudePath],
+    [cursorPath, claudePath],
     (path) async {
       await _createFileAndWrite(p.join(projectDirPath, path), genericConfig);
     },
   );
-  await _createFileAndWrite(p.join(projectDirPath, vscodePath), vscodeConfig);
+
+  await _createFileAndWrite(
+    p.join(projectDirPath, antigravityPath),
+    genericConfig.replaceAll(r'"dart":', r'"dart-mcp-server":'),
+  );
+
+  await _createFileAndWrite(
+    p.join(projectDirPath, vscodePath),
+    genericConfig.replaceAll(r'"mcpServers":', r'"servers":'),
+  );
+
   await _createFileAndWrite(p.join(projectDirPath, codexPath), codexConfig);
 }
 

--- a/tools/serverpod_cli/lib/src/create/create.dart
+++ b/tools/serverpod_cli/lib/src/create/create.dart
@@ -283,6 +283,11 @@ Future<String?> performCreate(
     );
   }
 
+  await log.progress('Configuring Serverpod MCP server', () async {
+    await _configureMcpServer(serverpodDirs.projectDir.path);
+    return true;
+  });
+
   if (context.skills) {
     await log.progress('Installing agent skills', () async {
       try {
@@ -381,6 +386,35 @@ Future<void> _moveDirectoryContents(
       await entity.delete();
     }
   }
+}
+
+Future<void> _configureMcpServer(String projectDirPath) async {
+  const antigravityPath = '.gemini/antigravity/mcp_config.json';
+  const cursorPath = '.cursor/mcp.json';
+  const claudePath = '.mcp.json';
+
+  const config = '''{
+  "mcpServers": {
+    "serverpod": {
+      "command": "serverpod",
+      "args": ["mcp"]
+    }
+  }
+}
+''';
+
+  await Future.forEach(
+    [antigravityPath, cursorPath, claudePath],
+    (path) async {
+      final file = File(p.join(projectDirPath, path));
+      try {
+        await file.create(recursive: true);
+        await file.writeAsString(config);
+      } on FileSystemException {
+        //
+      }
+    },
+  );
 }
 
 /// Upgrades a server project.


### PR DESCRIPTION
New projects now have Serverpod MCP configured for Antigravity, Codex, Cursor, Claude and VSCode.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None