### PR TITLE
fix: Add docs and the `runMigrations` parameter to the client-side `createSession`

### DIFF
--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/client.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/client.dart
@@ -103,14 +103,29 @@ class Client extends _i1.ServerpodClientShared {
   @override
   Map<String, _i1.ModuleEndpointCaller> get moduleLookup => {};
 
+  /// Creates a new client-side database session for the given path.
+  ///
+  /// The [path] is the file path to the SQLite database file. Since SQLite uses
+  /// WAL mode, note that `[path]-shm` and `[path]-wal` files might also exist
+  /// transiently for the database while the session is open.
+  ///
+  /// If [runMigrations] is true, pending migrations will be applied when
+  /// opening the database. Be careful when setting this to false, as it might
+  /// lead to inconsistencies between the models and the database.
+  ///
+  /// If [isDebugMode] is true, the database integrity will be verified after
+  /// the migrations are applied to provide feedback of possible issues. On a
+  /// Flutter application, this should be set to [kDebugMode].
   _i2.Future<_i5.ClientDatabaseSession> createSession(
     String path, {
+    bool runMigrations = true,
     bool isDebugMode = false,
   }) async {
     return await _i5.ClientDatabaseSession.open(
       path,
       _i4.Protocol(),
       clientMigrations: MigrationRegistry.migrations,
+      runMigrations: runMigrations,
       isDebugMode: isDebugMode,
     );
   }

--- a/tools/serverpod_cli/lib/src/generator/dart/library_generators/library_generator.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart/library_generators/library_generator.dart
@@ -1190,6 +1190,20 @@ class LibraryGenerator {
               if (hasClientDatabaseTables && config.type != PackageType.module)
                 Method(
                   (m) => m
+                    ..docs.add('''
+  /// Creates a new client-side database session for the given path.
+  ///
+  /// The [path] is the file path to the SQLite database file. Since SQLite uses
+  /// WAL mode, note that `[path]-shm` and `[path]-wal` files might also exist
+  /// transiently for the database while the session is open.
+  ///
+  /// If [runMigrations] is true, pending migrations will be applied when
+  /// opening the database. Be careful when setting this to false, as it might
+  /// lead to inconsistencies between the models and the database.
+  ///
+  /// If [isDebugMode] is true, the database integrity will be verified after
+  /// the migrations are applied to provide feedback of possible issues. On a
+  /// Flutter application, this should be set to [kDebugMode].''')
                     ..name = 'createSession'
                     ..modifier = MethodModifier.async
                     ..returns = TypeReference(
@@ -1210,7 +1224,14 @@ class LibraryGenerator {
                           ..type = refer('String'),
                       ),
                     )
-                    ..optionalParameters.add(
+                    ..optionalParameters.addAll([
+                      Parameter(
+                        (p) => p
+                          ..name = 'runMigrations'
+                          ..named = true
+                          ..type = refer('bool')
+                          ..defaultTo = literalTrue.code,
+                      ),
                       Parameter(
                         (p) => p
                           ..name = 'isDebugMode'
@@ -1218,7 +1239,7 @@ class LibraryGenerator {
                           ..type = refer('bool')
                           ..defaultTo = literalFalse.code,
                       ),
-                    )
+                    ])
                     ..body =
                         refer(
                               'ClientDatabaseSession',
@@ -1234,6 +1255,7 @@ class LibraryGenerator {
                                 'clientMigrations': refer(
                                   'MigrationRegistry',
                                 ).property('migrations'),
+                                'runMigrations': refer('runMigrations'),
                                 'isDebugMode': refer('isDebugMode'),
                               },
                             )

--- a/tools/serverpod_cli/test/generator/dart/client_code_generator/client_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/client_code_generator/client_test.dart
@@ -445,8 +445,37 @@ void main() {
           expect(createSessionMethod, contains('bool isDebugMode = false'));
         });
 
+        test('has an optional runMigrations parameter.', () {
+          expect(createSessionMethod, contains('bool runMigrations = true'));
+        });
+
+        test('forwards runMigrations to ClientDatabaseSession.open.', () {
+          expect(createSessionMethod, contains('runMigrations: runMigrations'));
+        });
+
         test('calls ClientDatabaseSession.open.', () {
           expect(createSessionMethod, contains('ClientDatabaseSession.open('));
+        });
+
+        test('contains docs for path, runMigrations, and isDebugMode.', () {
+          expect(
+            clientFile,
+            contains(
+              '/// Creates a new client-side database session for the given path.',
+            ),
+          );
+          expect(
+            clientFile,
+            contains(
+              '/// If [runMigrations] is true, pending migrations will be applied when',
+            ),
+          );
+          expect(
+            clientFile,
+            contains(
+              '/// If [isDebugMode] is true, the database integrity will be verified after',
+            ),
+          );
         });
       });
     },


### PR DESCRIPTION
While writing the docs for client-side databases, I noticed that we're missing docs on the generated method to guide the user on the parameters.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.