### PR TITLE
chore: Link database feature docs in validation warning

### DIFF
--- a/tools/serverpod_cli/lib/src/analyzer/models/validation/restrictions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/validation/restrictions.dart
@@ -248,7 +248,8 @@ class Restrictions {
     if (!config.isFeatureEnabled(ServerpodFeature.database)) {
       return [
         SourceSpanSeverityException(
-          'The "table" property cannot be used when the database feature is disabled.',
+          'The "table" property cannot be used when the database feature is disabled. '
+          'See https://docs.serverpod.dev/upgrading/upgrade-from-mini to enable the database.',
           span,
           severity: SourceSpanSeverity.warning,
         ),


### PR DESCRIPTION
Added a link to documentation for enabling the database feature to help user and agent to navigate

## Description
Update the validation warning for the ‎`table` property when the database feature is disabled to include a direct link to the upgrade guide for enabling the database feature from Serverpod Mini.

- Previous message: only stated that ‎`table` cannot be used when the database feature is disabled. This causes the coding agent to get confused.
- New message: keeps the original warning and appends a link: `See https://docs.serverpod.dev/upgrading/upgrade-from-mini to enable the database.`

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.