### PR TITLE
refactor: Consolidate TUI shutdown on the `shutdownServerpodApp` function

### DIFF
--- a/tools/serverpod_cli/lib/src/commands/create.dart
+++ b/tools/serverpod_cli/lib/src/commands/create.dart
@@ -3,7 +3,6 @@ import 'dart:async';
 import 'package:ci/ci.dart' as ci;
 import 'package:cli_tools/cli_tools.dart';
 import 'package:config/config.dart';
-import 'package:nocterm/nocterm.dart';
 import 'package:serverpod_cli/src/commands/create/tui/app.dart';
 import 'package:serverpod_cli/src/commands/create/tui/state.dart';
 import 'package:serverpod_cli/src/commands/create/tui/state_holder.dart';
@@ -185,18 +184,17 @@ class CreateCommand extends ServerpodCommand<CreateOption> {
     }
   }
 
-  /// Shuts down Nocterm and closes the TuiLogWriter.
-  /// Initializes the default logger for post-nocterm logs.
-  Future<void> _shutdownNocterm([int exitCode = 0]) async {
+  /// Shuts down TUI and closes the TuiLogWriter.
+  /// Initializes the default logger for post-tui logs.
+  Future<void> _shutdownTuiApp([int exitCode = 0]) async {
     await closeLogger();
     initializeLogger();
-    restoreServerpodTerminal();
-    shutdownApp(exitCode);
+    shutdownServerpodApp(exitCode);
   }
 
   /// Flushes success logs if [projectPath] is not null.
   /// Error logs are flushed if any.
-  /// This is done when shutting down nocterm but before exiting
+  /// This is done when shutting down TUI but before exiting
   /// the Dart process.
   Future<void> _preExit({
     required ServerpodTemplateType template,
@@ -261,12 +259,9 @@ class CreateCommand extends ServerpodCommand<CreateOption> {
 
           final success = projectPath != null;
 
-          // Wait for the user to at least briefly see the success message.
-          await Future<void>.delayed(const Duration(seconds: 3));
-
-          await _shutdownNocterm(success ? 0 : 1);
+          await _shutdownTuiApp(success ? 0 : 1);
         },
-        onQuit: () => _shutdownNocterm(1),
+        onQuit: () => _shutdownTuiApp(1),
         onSkipFlutterBuild: () {
           if (!flutterBuildCompleter.isCompleted) {
             flutterBuildCompleter.complete(0);

--- a/tools/serverpod_cli/lib/src/commands/start.dart
+++ b/tools/serverpod_cli/lib/src/commands/start.dart
@@ -5,7 +5,6 @@ import 'dart:io';
 import 'package:args/args.dart';
 import 'package:cli_tools/cli_tools.dart';
 import 'package:config/config.dart';
-import 'package:nocterm/nocterm.dart';
 import 'package:path/path.dart' as p;
 import 'package:serverpod_cli/analyzer.dart';
 import 'package:serverpod_cli/src/commands/generate.dart';
@@ -719,7 +718,7 @@ Future<int> _runWithTui({
 
   // Captured so the renderer tear-down listener can wait for the
   // backend's cleanup (ctx.dispose) to finish before calling
-  // shutdownApp. Default to a no-op so the listener is safe to invoke
+  // shutdownServerpodApp. Default to a no-op so the listener is safe to invoke
   // even if SIGINT arrives before onReady fires.
   Future<void> backendFuture = Future.value();
 
@@ -742,12 +741,11 @@ Future<int> _runWithTui({
         });
   }
 
-  // Wait for the backend's dispose to finish before calling shutdownApp
+  // Wait for the backend's dispose to finish before calling shutdownServerpodApp
   unawaited(
     shutdown.future.then((code) async {
       await backendFuture;
-      restoreServerpodTerminal();
-      shutdownApp(code);
+      shutdownServerpodApp(code);
     }),
   );
 
@@ -756,7 +754,7 @@ Future<int> _runWithTui({
     onShutdownSignal: () => shutdown.complete(0),
   );
 
-  // runServerpodApp returned, so shutdownApp ran, so the listener fired,
+  // runServerpodApp returned, so shutdownServerpodApp ran, so the listener fired,
   // so shutdown.future is completed.
   return shutdown.future;
 }

--- a/tools/serverpod_cli/lib/src/commands/start/tui/main_screen.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/tui/main_screen.dart
@@ -224,8 +224,7 @@ class MainScreen extends StatelessComponent {
               onQuit?.call();
             } else {
               // Boot path: [onQuit] is wired only after [WatchLoopReady].
-              restoreServerpodTerminal();
-              shutdownApp(0);
+              shutdownServerpodApp(0);
             }
           },
         ),

--- a/tools/serverpod_cli/lib/src/commands/tui/run_app.dart
+++ b/tools/serverpod_cli/lib/src/commands/tui/run_app.dart
@@ -47,6 +47,7 @@ Future<void> runServerpodApp(
   }
 
   void onShutDownSignalDelegated(ProcessSignal _) {
+    _restoreServerpodTerminal();
     onShutdownSignal!.call();
   }
 

--- a/tools/serverpod_cli/lib/src/commands/tui/run_app.dart
+++ b/tools/serverpod_cli/lib/src/commands/tui/run_app.dart
@@ -18,7 +18,7 @@ void _captureTerminalState() {
 /// Restores stdin terminal modes captured by [runServerpodApp].
 ///
 /// Safe to call multiple times.
-void restoreServerpodTerminal() {
+void _restoreServerpodTerminal() {
   if (!_terminalStateCaptured || _terminalStateRestored) return;
   stdin.echoMode = _originalEchoMode;
   stdin.lineMode = _originalLineMode;
@@ -28,12 +28,12 @@ void restoreServerpodTerminal() {
 /// Run a TUI app with terminal settings restoration.
 ///
 /// When [onShutdownSignal] is null (the default), SIGINT/SIGTERM trigger an
-/// immediate `shutdownApp()` and the app exits without running any user
+/// immediate `shutdownServerpodApp()` and the app exits without running any user
 /// cleanup.
 ///
 /// When [onShutdownSignal] is provided, signals invoke that callback instead.
 /// The caller is then responsible for running cleanup and eventually calling
-/// `shutdownApp(...)` to tear down the nocterm renderer.
+/// `shutdownServerpodApp(...)` to tear down the nocterm renderer.
 Future<void> runServerpodApp(
   Component app, {
   bool enableHotReload = true,
@@ -43,12 +43,10 @@ Future<void> runServerpodApp(
   _captureTerminalState();
 
   void onShutDownSignalDefault(ProcessSignal _) {
-    restoreServerpodTerminal();
-    shutdownApp();
+    shutdownServerpodApp();
   }
 
   void onShutDownSignalDelegated(ProcessSignal _) {
-    restoreServerpodTerminal();
     onShutdownSignal!.call();
   }
 
@@ -61,13 +59,12 @@ Future<void> runServerpodApp(
     ProcessSignal.sigterm.watch().listen(handler);
   }
 
-  try {
-    await runApp(
-      app,
-      enableHotReload: enableHotReload,
-      backend: backend,
-    );
-  } finally {
-    restoreServerpodTerminal();
-  }
+  await runApp(app, enableHotReload: enableHotReload, backend: backend);
+}
+
+/// Restores stdin terminal modes captured by [runServerpodApp]
+/// then shuts down the nocterm app with proper terminal cleanup.
+void shutdownServerpodApp([int exitCode = 0]) {
+  _restoreServerpodTerminal();
+  shutdownApp(exitCode);
 }

--- a/tools/serverpod_cli/lib/src/commands/tui/terminal_backend.dart
+++ b/tools/serverpod_cli/lib/src/commands/tui/terminal_backend.dart
@@ -1,5 +1,7 @@
 import 'package:nocterm/nocterm.dart';
 
+/// A terminal backend for nocterm that allows executing
+/// [preExit] callback before exiting the Dart process.
 class ServerpodTerminalBackend extends StdioBackend {
   ServerpodTerminalBackend({required this.preExit});
 
@@ -8,11 +10,7 @@ class ServerpodTerminalBackend extends StdioBackend {
   @override
   void requestExit([int exitCode = 0]) {
     preExit()
-        .then((_) {
-          super.requestExit(exitCode);
-        })
-        .catchError((_) {
-          super.requestExit(exitCode);
-        });
+        .then((_) => super.requestExit(exitCode))
+        .catchError((_) => super.requestExit(exitCode));
   }
 }


### PR DESCRIPTION
This PR adds a dedicated method for shutting down the TUI app which restores terminal settings. Remove duplicated calls to `restoreServerpodTerminal`.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None