### PR TITLE
feat(cli): Add hot_restart and create_repair_migration MCP tools and TUI buttons

### DIFF
--- a/packages/serverpod_shared/lib/src/migration_exceptions.dart
+++ b/packages/serverpod_shared/lib/src/migration_exceptions.dart
@@ -15,6 +15,13 @@ class MigrationVersionLoadException implements Exception {
     required this.moduleName,
     required this.exception,
   });
+
+  @override
+  String toString() =>
+      'Unable to determine latest database definition due to a corrupted '
+      'migration. Please re-create or remove the migration version and try '
+      'again. Migration version: "$versionName" for module "$moduleName".\n'
+      '$exception';
 }
 
 /// Exception thrown when trying to load the live database definition.
@@ -26,6 +33,11 @@ class MigrationLiveDatabaseDefinitionException implements Exception {
   MigrationLiveDatabaseDefinitionException({
     required this.exception,
   });
+
+  @override
+  String toString() =>
+      'Unable to fetch live database schema from server. Make sure the '
+      'server is running and is connected to the database.\n$exception';
 }
 
 /// Exception thrown when writing a migration fails.
@@ -37,6 +49,9 @@ class MigrationRepairWriteException implements Exception {
   MigrationRepairWriteException({
     required this.exception,
   });
+
+  @override
+  String toString() => 'Unable to write repair migration.\n$exception';
 }
 
 /// Exception thrown when a migration target is not found.
@@ -52,11 +67,20 @@ class MigrationRepairTargetNotFoundException implements Exception {
     required this.versionsFound,
     required this.targetName,
   });
+
+  @override
+  String toString() => versionsFound.isEmpty
+      ? 'Unable to find any migration versions.'
+      : 'Unable to find the specified target migration "$targetName". '
+            'Available versions: $versionsFound.';
 }
 
 /// Exception thrown when the migration failed to create a database definition
 /// from the projects model files.
-class GenerateMigrationDatabaseDefinitionException implements Exception {}
+class GenerateMigrationDatabaseDefinitionException implements Exception {
+  @override
+  String toString() => 'Unable to generate database definition for project.';
+}
 
 /// Exception thrown when the migration directory already exists.
 class MigrationVersionAlreadyExistsException implements Exception {
@@ -67,10 +91,18 @@ class MigrationVersionAlreadyExistsException implements Exception {
   MigrationVersionAlreadyExistsException({
     required this.directoryPath,
   });
+
+  @override
+  String toString() =>
+      'Unable to create migration. A directory with the same name already '
+      'exists: "$directoryPath".';
 }
 
 /// Exception thrown when a migration is aborted.
 class MigrationAbortedException implements Exception {
   /// Creates a new [MigrationAbortedException].
   const MigrationAbortedException();
+
+  @override
+  String toString() => 'Migration aborted due to warnings.';
 }

--- a/tools/serverpod_cli/lib/src/commands/create/tui/main_screen.dart
+++ b/tools/serverpod_cli/lib/src/commands/create/tui/main_screen.dart
@@ -352,7 +352,7 @@ class MainScreen extends StatelessComponent {
             onQuit.call();
           },
         ),
-        const Button.tip('Click to select'),
+        const Tip('Click to select'),
       ],
     );
   }

--- a/tools/serverpod_cli/lib/src/commands/create_repair_migration.dart
+++ b/tools/serverpod_cli/lib/src/commands/create_repair_migration.dart
@@ -104,10 +104,13 @@ class CreateRepairMigrationCommand
           type: TextLogType.bullet,
         );
         log.info('Done.', type: TextLogType.success);
-      case RepairMigrationNotCreated():
-        // MigrationGenerator.repairMigration logs the specific reason
-        // ("No changes detected" or "Migration aborted") via log.info before
-        // returning null, so we just exit non-zero here.
+      case RepairMigrationNoChanges():
+        log.info(
+          'No changes detected. Use --force to create an empty repair migration.',
+        );
+        throw ExitException.error();
+      case RepairMigrationAborted():
+        log.info('Migration aborted. Use --force to ignore warnings.');
         throw ExitException.error();
       case RepairMigrationFailed(:final message):
         log.error(message);

--- a/tools/serverpod_cli/lib/src/commands/create_repair_migration.dart
+++ b/tools/serverpod_cli/lib/src/commands/create_repair_migration.dart
@@ -8,6 +8,7 @@ import 'package:serverpod_cli/src/migrations/create_repair_migration_action.dart
 import 'package:serverpod_cli/src/runner/serverpod_command.dart';
 import 'package:serverpod_cli/src/runner/serverpod_command_runner.dart';
 import 'package:serverpod_cli/src/util/serverpod_cli_logger.dart';
+import 'package:serverpod_shared/serverpod_shared.dart' hide ExitException;
 
 import 'create_migration.dart' show CreateMigrationCommand;
 
@@ -82,39 +83,40 @@ class CreateRepairMigrationCommand
       throw ExitException(ServerpodCommand.commandInvokedCannotExecute);
     }
 
-    late RepairMigrationOutcome outcome;
-    await log.progress('Creating repair migration', () async {
-      outcome = await createRepairMigrationAction(
-        config: config,
-        tag: tag,
-        force: force,
-        runMode: mode,
-        targetMigrationVersion: targetVersion,
-      );
-      return outcome is RepairMigrationCreated;
-    });
-
-    switch (outcome) {
-      case RepairMigrationCreated(:final filePath):
-        log.info(
-          'Repair migration created: ${path.relative(
-            filePath,
-            from: Directory.current.path,
-          )}',
-          type: TextLogType.bullet,
+    File? repairMigration;
+    try {
+      await log.progress('Creating repair migration', () async {
+        repairMigration = await createRepairMigrationAction(
+          config: config,
+          tag: tag,
+          force: force,
+          runMode: mode,
+          targetMigrationVersion: targetVersion,
         );
-        log.info('Done.', type: TextLogType.success);
-      case RepairMigrationNoChanges():
-        log.info(
-          'No changes detected. Use --force to create an empty repair migration.',
-        );
-        throw ExitException.error();
-      case RepairMigrationAborted():
-        log.info('Migration aborted. Use --force to ignore warnings.');
-        throw ExitException.error();
-      case RepairMigrationFailed(:final message):
-        log.error(message);
-        throw ExitException.error();
+        return repairMigration != null;
+      });
+    } on MigrationAbortedException {
+      log.info('Migration aborted. Use --force to ignore warnings.');
+      throw ExitException.error();
+    } on Exception catch (e) {
+      log.error('$e');
+      throw ExitException.error();
     }
+
+    if (repairMigration == null) {
+      log.info(
+        'No changes detected. Use --force to create an empty repair migration.',
+      );
+      throw ExitException.error();
+    }
+
+    log.info(
+      'Repair migration created: ${path.relative(
+        repairMigration!.path,
+        from: Directory.current.path,
+      )}',
+      type: TextLogType.bullet,
+    );
+    log.info('Done.', type: TextLogType.success);
   }
 }

--- a/tools/serverpod_cli/lib/src/commands/create_repair_migration.dart
+++ b/tools/serverpod_cli/lib/src/commands/create_repair_migration.dart
@@ -4,12 +4,10 @@ import 'package:cli_tools/cli_tools.dart';
 import 'package:config/config.dart';
 import 'package:path/path.dart' as path;
 import 'package:serverpod_cli/analyzer.dart';
-import 'package:serverpod_cli/src/config/serverpod_feature.dart';
+import 'package:serverpod_cli/src/migrations/create_repair_migration_action.dart';
 import 'package:serverpod_cli/src/runner/serverpod_command.dart';
 import 'package:serverpod_cli/src/runner/serverpod_command_runner.dart';
-import 'package:serverpod_cli/src/util/project_name.dart';
 import 'package:serverpod_cli/src/util/serverpod_cli_logger.dart';
-import 'package:serverpod_shared/serverpod_shared.dart' hide ExitException;
 
 import 'create_migration.dart' show CreateMigrationCommand;
 
@@ -84,82 +82,36 @@ class CreateRepairMigrationCommand
       throw ExitException(ServerpodCommand.commandInvokedCannotExecute);
     }
 
-    if (!config.isFeatureEnabled(ServerpodFeature.database)) {
-      log.error(
-        'The database feature is not enabled in this project. '
-        'This command cannot be used.',
-      );
-      throw ExitException(ServerpodCommand.commandInvokedCannotExecute);
-    }
-
-    var serverDirectory = Directory(
-      path.joinAll(config.serverPackageDirectoryPathParts),
-    );
-
-    var projectName = await getProjectName(serverDirectory);
-    if (projectName == null) {
-      throw ExitException(ServerpodCommand.commandInvokedCannotExecute);
-    }
-
-    var generator = MigrationGenerator(
-      directory: serverDirectory,
-      projectName: projectName,
-    );
-
-    File? repairMigration;
+    late RepairMigrationOutcome outcome;
     await log.progress('Creating repair migration', () async {
-      try {
-        repairMigration = await generator.repairMigration(
-          tag: tag,
-          force: force,
-          runMode: mode,
-          dialect: config.databaseDialect,
-          targetMigrationVersion: targetVersion,
-        );
-      } on MigrationRepairTargetNotFoundException catch (e) {
-        if (e.versionsFound.isEmpty) {
-          log.error('Unable to find any migration versions.');
-        } else {
-          log.error(
-            'Unable to find the specified target migration "${e.targetName}".'
-            'Please select on of the available versions: ${e.versionsFound}.',
-          );
-        }
-      } on MigrationVersionLoadException catch (e) {
-        log.error(
-          'Unable to determine latest database definition due to a corrupted '
-          'migration. Please re-create or remove the migration version and try '
-          'again. Migration version: "${e.versionName}" for module '
-          '"${e.moduleName}".',
-        );
-        log.error(e.exception);
-      } on MigrationLiveDatabaseDefinitionException catch (e) {
-        log.error(
-          'Unable to fetch live database schema from server. '
-          'Make sure the server is running and is connected to the '
-          'database.',
-        );
-        log.error(e.exception);
-      } on MigrationRepairWriteException catch (e) {
-        log.error('Unable to write repair migration.');
-        log.error(e.exception);
-      }
-
-      return repairMigration != null;
+      outcome = await createRepairMigrationAction(
+        config: config,
+        tag: tag,
+        force: force,
+        runMode: mode,
+        targetMigrationVersion: targetVersion,
+      );
+      return outcome is RepairMigrationCreated;
     });
 
-    var repairMigrationPath = repairMigration?.path;
-    if (repairMigration == null || repairMigrationPath == null) {
-      throw ExitException.error();
+    switch (outcome) {
+      case RepairMigrationCreated(:final filePath):
+        log.info(
+          'Repair migration created: ${path.relative(
+            filePath,
+            from: Directory.current.path,
+          )}',
+          type: TextLogType.bullet,
+        );
+        log.info('Done.', type: TextLogType.success);
+      case RepairMigrationNotCreated():
+        // MigrationGenerator.repairMigration logs the specific reason
+        // ("No changes detected" or "Migration aborted") via log.info before
+        // returning null, so we just exit non-zero here.
+        throw ExitException.error();
+      case RepairMigrationFailed(:final message):
+        log.error(message);
+        throw ExitException.error();
     }
-
-    log.info(
-      'Repair migration created: ${path.relative(
-        repairMigrationPath,
-        from: Directory.current.path,
-      )}',
-      type: TextLogType.bullet,
-    );
-    log.info('Done.', type: TextLogType.success);
   }
 }

--- a/tools/serverpod_cli/lib/src/commands/messages.dart
+++ b/tools/serverpod_cli/lib/src/commands/messages.dart
@@ -11,6 +11,7 @@ const serverRunning = 'Server running.';
 const serverReloaded = '✓ Server reloaded.';
 const serverRestarted = '✓ Server restarted.';
 const flutterAppReloaded = '✓ Flutter app reloaded.';
+const flutterAppRestarted = '✓ Flutter app restarted.';
 const flutterPackageNotFound =
     'No Flutter package found; skipping --flutter. '
     'Pass --no-flutter to silence this notice.';

--- a/tools/serverpod_cli/lib/src/commands/start.dart
+++ b/tools/serverpod_cli/lib/src/commands/start.dart
@@ -28,6 +28,7 @@ import 'package:serverpod_cli/src/generator/generation_staleness.dart';
 import 'package:serverpod_cli/src/generator/isolated_analyzers.dart';
 import 'package:serverpod_cli/src/migrations/cli_migration_runner.dart';
 import 'package:serverpod_cli/src/migrations/create_migration_action.dart';
+import 'package:serverpod_cli/src/migrations/create_repair_migration_action.dart';
 import 'package:serverpod_cli/src/runner/serverpod_command.dart';
 import 'package:serverpod_cli/src/runner/serverpod_command_runner.dart';
 import 'package:serverpod_cli/src/util/serverpod_cli_logger.dart';
@@ -540,7 +541,19 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
       onApplyMigration: session.applyMigration,
       onCreateMigration: ({String? tag, bool force = false}) =>
           _createMigrationForMcp(config, tag: tag, force: force),
+      onCreateRepairMigration:
+          ({
+            String? tag,
+            bool force = false,
+            String? targetMigrationVersion,
+          }) => _createRepairMigrationForMcp(
+            config,
+            tag: tag,
+            force: force,
+            targetMigrationVersion: targetMigrationVersion,
+          ),
       onHotReload: session.forceReload,
+      onHotRestart: session.forceRestart,
       getLogHistory: mcpGetLogHistory,
       getVmServiceUri: () => proxy?.httpUri.toString(),
       vmServiceUriChanges: session.vmServiceUriChanges,
@@ -817,11 +830,21 @@ Future<void> _runTuiBackend({
         holder.onHotReload = () {
           runTrackedAction(holder, 'Hot reload', ctx.session.forceReload);
         };
+        holder.onHotRestart = () {
+          runTrackedAction(holder, 'Hot restart', ctx.session.forceRestart);
+        };
         holder.onCreateMigration = () {
           runTrackedAction(
             holder,
             'Creating migration',
             () => _runCreateMigrationForTui(config),
+          );
+        };
+        holder.onCreateRepairMigration = () {
+          runTrackedAction(
+            holder,
+            'Creating repair migration',
+            () => _runCreateRepairMigrationForTui(config),
           );
         };
         holder.onApplyMigration = () {
@@ -935,6 +958,73 @@ Future<CreateMigrationMcpResult> _createMigrationForMcp(
     forceHint: 'Call again with `force: true` to create it anyway.',
   );
   final followUp = outcome is CreateMigrationCreated
+      ? ' Call `apply_migrations` to run it against the database.'
+      : '';
+  return CreateMigrationMcpResult(
+    message: result.message + followUp,
+    isError: result.isError,
+  );
+}
+
+/// Maps a [RepairMigrationOutcome] to a `(message, isError)` pair shared by
+/// the TUI and MCP wrappers. [forceHint] is the surface-specific instruction
+/// for retrying past warnings or empty diffs.
+({String message, bool isError}) _describeCreateRepairMigration(
+  RepairMigrationOutcome outcome, {
+  required String forceHint,
+}) {
+  return switch (outcome) {
+    RepairMigrationCreated(:final versionName, :final filePath) => (
+      message: 'Repair migration "$versionName" created at $filePath.',
+      isError: false,
+    ),
+    RepairMigrationNotCreated() => (
+      message:
+          'No repair migration created. Either no schema drift was '
+          'detected, or warnings were present. $forceHint',
+      isError: true,
+    ),
+    RepairMigrationFailed(:final message) => (
+      message: message,
+      isError: true,
+    ),
+  };
+}
+
+/// Runs `create-repair-migration` for the TUI's Repair Migration button.
+///
+/// Logs the outcome; throws on failure so [runTrackedAction] marks the
+/// operation red.
+Future<void> _runCreateRepairMigrationForTui(GeneratorConfig config) async {
+  final outcome = await createRepairMigrationAction(config: config);
+  final result = _describeCreateRepairMigration(
+    outcome,
+    forceHint:
+        'Run `serverpod create-repair-migration --force` to create it anyway.',
+  );
+  if (result.isError) throw Exception(result.message);
+  log.info(result.message);
+}
+
+/// Runs `create-repair-migration` for the MCP `create_repair_migration` tool.
+/// Returns a structured result so the MCP server can flag errors.
+Future<CreateMigrationMcpResult> _createRepairMigrationForMcp(
+  GeneratorConfig config, {
+  String? tag,
+  bool force = false,
+  String? targetMigrationVersion,
+}) async {
+  final outcome = await createRepairMigrationAction(
+    config: config,
+    tag: tag,
+    force: force,
+    targetMigrationVersion: targetMigrationVersion,
+  );
+  final result = _describeCreateRepairMigration(
+    outcome,
+    forceHint: 'Call again with `force: true` to create it anyway.',
+  );
+  final followUp = outcome is RepairMigrationCreated
       ? ' Call `apply_migrations` to run it against the database.'
       : '';
   return CreateMigrationMcpResult(

--- a/tools/serverpod_cli/lib/src/commands/start.dart
+++ b/tools/serverpod_cli/lib/src/commands/start.dart
@@ -671,6 +671,7 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
             String? targetMigrationVersion,
           }) => _createRepairMigrationForMcp(
             config,
+            runMode: runMode,
             tag: tag,
             force: force,
             targetMigrationVersion: targetMigrationVersion,
@@ -1012,7 +1013,11 @@ Future<void> _runTuiBackend({
             force
                 ? 'Force-creating repair migration'
                 : 'Creating repair migration',
-            () => _runCreateRepairMigrationForTui(config, force: force),
+            () => _runCreateRepairMigrationForTui(
+              config,
+              runMode: runModeFromServerArgs(serverArgs),
+              force: force,
+            ),
           );
         };
         holder.onApplyMigration = () {
@@ -1143,11 +1148,16 @@ Future<CreateMigrationMcpResult> _createMigrationForMcp(
 /// operation red.
 Future<void> _runCreateRepairMigrationForTui(
   GeneratorConfig config, {
+  required String runMode,
   bool force = false,
 }) async {
   final File? file;
   try {
-    file = await createRepairMigrationAction(config: config, force: force);
+    file = await createRepairMigrationAction(
+      config: config,
+      runMode: runMode,
+      force: force,
+    );
   } on MigrationAbortedException {
     log.info(
       'Run `serverpod create-repair-migration --force` to create it anyway.',
@@ -1167,6 +1177,7 @@ Future<void> _runCreateRepairMigrationForTui(
 /// Returns a structured result so the MCP server can flag errors.
 Future<CreateMigrationMcpResult> _createRepairMigrationForMcp(
   GeneratorConfig config, {
+  required String runMode,
   String? tag,
   bool force = false,
   String? targetMigrationVersion,
@@ -1176,6 +1187,7 @@ Future<CreateMigrationMcpResult> _createRepairMigrationForMcp(
     file = await createRepairMigrationAction(
       config: config,
       tag: tag,
+      runMode: runMode,
       force: force,
       targetMigrationVersion: targetMigrationVersion,
     );

--- a/tools/serverpod_cli/lib/src/commands/start.dart
+++ b/tools/serverpod_cli/lib/src/commands/start.dart
@@ -833,18 +833,20 @@ Future<void> _runTuiBackend({
         holder.onHotRestart = () {
           runTrackedAction(holder, 'Hot restart', ctx.session.forceRestart);
         };
-        holder.onCreateMigration = () {
+        holder.onCreateMigration = ({bool force = false}) {
           runTrackedAction(
             holder,
-            'Creating migration',
-            () => _runCreateMigrationForTui(config),
+            force ? 'Force-creating migration' : 'Creating migration',
+            () => _runCreateMigrationForTui(config, force: force),
           );
         };
-        holder.onCreateRepairMigration = () {
+        holder.onCreateRepairMigration = ({bool force = false}) {
           runTrackedAction(
             holder,
-            'Creating repair migration',
-            () => _runCreateRepairMigrationForTui(config),
+            force
+                ? 'Force-creating repair migration'
+                : 'Creating repair migration',
+            () => _runCreateRepairMigrationForTui(config, force: force),
           );
         };
         holder.onApplyMigration = () {
@@ -931,8 +933,11 @@ Future<void> _runTuiBackend({
 ///
 /// Logs the outcome; throws on failure so [runTrackedAction] marks the
 /// operation red.
-Future<void> _runCreateMigrationForTui(GeneratorConfig config) async {
-  final outcome = await createMigrationAction(config: config);
+Future<void> _runCreateMigrationForTui(
+  GeneratorConfig config, {
+  bool force = false,
+}) async {
+  final outcome = await createMigrationAction(config: config, force: force);
   final result = _describeCreateMigration(
     outcome,
     forceHint: 'Run `serverpod create-migration --force` to create it anyway.',
@@ -970,10 +975,13 @@ Future<CreateMigrationMcpResult> _createMigrationForMcp(
 ///
 /// Logs the outcome; throws on failure so [runTrackedAction] marks the
 /// operation red.
-Future<void> _runCreateRepairMigrationForTui(GeneratorConfig config) async {
+Future<void> _runCreateRepairMigrationForTui(
+  GeneratorConfig config, {
+  bool force = false,
+}) async {
   final File? file;
   try {
-    file = await createRepairMigrationAction(config: config);
+    file = await createRepairMigrationAction(config: config, force: force);
   } on MigrationAbortedException {
     log.info(
       'Run `serverpod create-repair-migration --force` to create it anyway.',

--- a/tools/serverpod_cli/lib/src/commands/start.dart
+++ b/tools/serverpod_cli/lib/src/commands/start.dart
@@ -978,10 +978,12 @@ Future<CreateMigrationMcpResult> _createMigrationForMcp(
       message: 'Repair migration "$versionName" created at $filePath.',
       isError: false,
     ),
-    RepairMigrationNotCreated() => (
-      message:
-          'No repair migration created. Either no schema drift was '
-          'detected, or warnings were present. $forceHint',
+    RepairMigrationNoChanges() => (
+      message: 'Repair migration skipped. No schema drift detected.',
+      isError: false,
+    ),
+    RepairMigrationAborted() => (
+      message: 'Repair migration aborted due to warnings. $forceHint',
       isError: true,
     ),
     RepairMigrationFailed(:final message) => (

--- a/tools/serverpod_cli/lib/src/commands/start.dart
+++ b/tools/serverpod_cli/lib/src/commands/start.dart
@@ -1111,7 +1111,7 @@ Future<void> _runCreateMigrationForTui(
   final outcome = await createMigrationAction(config: config, force: force);
   final result = _describeCreateMigration(
     outcome,
-    forceHint: 'Run `serverpod create-migration --force` to create it anyway.',
+    forceHint: 'Use ⇧+M to force-create it anyway.',
   );
   if (result.isError) throw Exception(result.message);
   log.info(result.message);
@@ -1159,9 +1159,7 @@ Future<void> _runCreateRepairMigrationForTui(
       force: force,
     );
   } on MigrationAbortedException {
-    log.info(
-      'Run `serverpod create-repair-migration --force` to create it anyway.',
-    );
+    log.info('Use ⇧+P to force-create it anyway.');
     rethrow;
   }
 

--- a/tools/serverpod_cli/lib/src/commands/start.dart
+++ b/tools/serverpod_cli/lib/src/commands/start.dart
@@ -966,46 +966,27 @@ Future<CreateMigrationMcpResult> _createMigrationForMcp(
   );
 }
 
-/// Maps a [RepairMigrationOutcome] to a `(message, isError)` pair shared by
-/// the TUI and MCP wrappers. [forceHint] is the surface-specific instruction
-/// for retrying past warnings or empty diffs.
-({String message, bool isError}) _describeCreateRepairMigration(
-  RepairMigrationOutcome outcome, {
-  required String forceHint,
-}) {
-  return switch (outcome) {
-    RepairMigrationCreated(:final versionName, :final filePath) => (
-      message: 'Repair migration "$versionName" created at $filePath.',
-      isError: false,
-    ),
-    RepairMigrationNoChanges() => (
-      message: 'Repair migration skipped. No schema drift detected.',
-      isError: false,
-    ),
-    RepairMigrationAborted() => (
-      message: 'Repair migration aborted due to warnings. $forceHint',
-      isError: true,
-    ),
-    RepairMigrationFailed(:final message) => (
-      message: message,
-      isError: true,
-    ),
-  };
-}
-
 /// Runs `create-repair-migration` for the TUI's Repair Migration button.
 ///
 /// Logs the outcome; throws on failure so [runTrackedAction] marks the
 /// operation red.
 Future<void> _runCreateRepairMigrationForTui(GeneratorConfig config) async {
-  final outcome = await createRepairMigrationAction(config: config);
-  final result = _describeCreateRepairMigration(
-    outcome,
-    forceHint:
-        'Run `serverpod create-repair-migration --force` to create it anyway.',
-  );
-  if (result.isError) throw Exception(result.message);
-  log.info(result.message);
+  final File? file;
+  try {
+    file = await createRepairMigrationAction(config: config);
+  } on MigrationAbortedException {
+    log.info(
+      'Run `serverpod create-repair-migration --force` to create it anyway.',
+    );
+    rethrow;
+  }
+
+  if (file == null) {
+    log.info('Repair migration skipped. No schema drift detected.');
+    return;
+  }
+  final versionName = p.basenameWithoutExtension(file.path);
+  log.info('Repair migration "$versionName" created at ${file.path}.');
 }
 
 /// Runs `create-repair-migration` for the MCP `create_repair_migration` tool.
@@ -1016,21 +997,35 @@ Future<CreateMigrationMcpResult> _createRepairMigrationForMcp(
   bool force = false,
   String? targetMigrationVersion,
 }) async {
-  final outcome = await createRepairMigrationAction(
-    config: config,
-    tag: tag,
-    force: force,
-    targetMigrationVersion: targetMigrationVersion,
-  );
-  final result = _describeCreateRepairMigration(
-    outcome,
-    forceHint: 'Call again with `force: true` to create it anyway.',
-  );
-  final followUp = outcome is RepairMigrationCreated
-      ? ' Call `apply_migrations` to run it against the database.'
-      : '';
+  final File? file;
+  try {
+    file = await createRepairMigrationAction(
+      config: config,
+      tag: tag,
+      force: force,
+      targetMigrationVersion: targetMigrationVersion,
+    );
+  } on MigrationAbortedException {
+    return const CreateMigrationMcpResult(
+      message:
+          'Repair migration aborted due to warnings. '
+          'Call again with `force: true` to create it anyway.',
+      isError: true,
+    );
+  } on Exception catch (e) {
+    return CreateMigrationMcpResult(message: '$e', isError: true);
+  }
+
+  if (file == null) {
+    return const CreateMigrationMcpResult(
+      message: 'Repair migration skipped. No schema drift detected.',
+    );
+  }
+
+  final versionName = p.basenameWithoutExtension(file.path);
   return CreateMigrationMcpResult(
-    message: result.message + followUp,
-    isError: result.isError,
+    message:
+        'Repair migration "$versionName" created at ${file.path}. '
+        'Call `apply_migrations` to run it against the database.',
   );
 }

--- a/tools/serverpod_cli/lib/src/commands/start.dart
+++ b/tools/serverpod_cli/lib/src/commands/start.dart
@@ -369,12 +369,11 @@ Future<ApplyMigrationsOutcome> _applyMigrationsForSession({
   required void Function() onDeferToPod,
 }) async {
   try {
-    final applied = await applyPendingMigrations(
+    await applyPendingMigrations(
       serverDir: serverDir,
       runMode: runMode,
       moduleName: moduleName,
     );
-    log.info(formatAppliedMigrations(applied));
     return const MigrationsApplied();
   } catch (e) {
     if (!isMissingNativeAssetError(e)) rethrow;

--- a/tools/serverpod_cli/lib/src/commands/start/mcp_server.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/mcp_server.dart
@@ -105,10 +105,7 @@ base class ServerpodMcpServer extends MCPServer
   Future<CallToolResult> _applyMigrations(CallToolRequest request) async {
     final callback = onApplyMigration;
     if (callback == null) {
-      return CallToolResult(
-        content: [TextContent(text: 'Watch session not connected.')],
-        isError: true,
-      );
+      return _notConnectedError();
     }
 
     try {
@@ -154,10 +151,7 @@ base class ServerpodMcpServer extends MCPServer
   Future<CallToolResult> _createMigration(CallToolRequest request) async {
     final callback = onCreateMigration;
     if (callback == null) {
-      return CallToolResult(
-        content: [TextContent(text: 'Watch session not connected.')],
-        isError: true,
-      );
+      return _notConnectedError();
     }
 
     final tag = _stringArg(request, 'tag');
@@ -209,10 +203,7 @@ base class ServerpodMcpServer extends MCPServer
   Future<CallToolResult> _createRepairMigration(CallToolRequest request) async {
     final callback = onCreateRepairMigration;
     if (callback == null) {
-      return CallToolResult(
-        content: [TextContent(text: 'Watch session not connected.')],
-        isError: true,
-      );
+      return _notConnectedError();
     }
 
     try {
@@ -266,10 +257,7 @@ base class ServerpodMcpServer extends MCPServer
   Future<CallToolResult> _hotReload(CallToolRequest request) async {
     final callback = onHotReload;
     if (callback == null) {
-      return CallToolResult(
-        content: [TextContent(text: 'Watch session not connected.')],
-        isError: true,
-      );
+      return _notConnectedError();
     }
     try {
       await callback();
@@ -297,10 +285,7 @@ base class ServerpodMcpServer extends MCPServer
   Future<CallToolResult> _hotRestart(CallToolRequest request) async {
     final callback = onHotRestart;
     if (callback == null) {
-      return CallToolResult(
-        content: [TextContent(text: 'Watch session not connected.')],
-        isError: true,
-      );
+      return _notConnectedError();
     }
     try {
       await callback();
@@ -356,6 +341,13 @@ base class ServerpodMcpServer extends MCPServer
     );
   }
 }
+
+/// Returns the standard error response for tools whose callback is unset
+/// because the watch session has not yet attached.
+CallToolResult _notConnectedError() => CallToolResult(
+  content: [TextContent(text: 'Watch session not connected.')],
+  isError: true,
+);
 
 /// Reads a string argument; treats missing, non-string, and empty values as
 /// `null`.

--- a/tools/serverpod_cli/lib/src/commands/start/mcp_server.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/mcp_server.dart
@@ -32,8 +32,21 @@ base class ServerpodMcpServer extends MCPServer
   Future<CreateMigrationMcpResult> Function({String? tag, bool force})?
   onCreateMigration;
 
+  /// Callback to create a repair migration that brings the database in line
+  /// with a target migration version.
+  Future<CreateMigrationMcpResult> Function({
+    String? tag,
+    bool force,
+    String? targetMigrationVersion,
+  })?
+  onCreateRepairMigration;
+
   /// Callback to recompile and hot-reload the running server isolate.
   Future<void> Function()? onHotReload;
+
+  /// Callback to perform a full server process restart, clearing in-memory
+  /// state. Boots from the current compiled kernel; does not recompile.
+  Future<void> Function()? onHotRestart;
 
   /// Returns the current log history snapshot.
   List<Object> Function()? getLogHistory;
@@ -55,7 +68,9 @@ base class ServerpodMcpServer extends MCPServer
       ) {
     registerTool(_applyMigrationsTool, _applyMigrations);
     registerTool(_createMigrationTool, _createMigration);
+    registerTool(_createRepairMigrationTool, _createRepairMigration);
     registerTool(_hotReloadTool, _hotReload);
+    registerTool(_hotRestartTool, _hotRestart);
     registerTool(_tailLogsTool, _tailLogs);
 
     addResource(_vmServiceResource, _readVmService);
@@ -145,10 +160,8 @@ base class ServerpodMcpServer extends MCPServer
       );
     }
 
-    final tagArg = request.arguments?['tag'];
-    final forceArg = request.arguments?['force'];
-    final tag = tagArg is String && tagArg.isNotEmpty ? tagArg : null;
-    final force = forceArg is bool ? forceArg : false;
+    final tag = _stringArg(request, 'tag');
+    final force = _boolArg(request, 'force');
 
     try {
       final result = await callback(tag: tag, force: force);
@@ -159,6 +172,62 @@ base class ServerpodMcpServer extends MCPServer
     } catch (e) {
       return CallToolResult(
         content: [TextContent(text: 'Failed to create migration: $e')],
+        isError: true,
+      );
+    }
+  }
+
+  static final _createRepairMigrationTool = Tool(
+    name: 'create_repair_migration',
+    description:
+        'Create a repair migration that brings the live database in line '
+        'with the target migration version (default: latest). Connects to '
+        'the running server to read the live schema, diffs it against the '
+        'target, and writes a `.sql` repair file. Use when a migration was '
+        'partially applied or the database drifted out of sync. Does not '
+        'apply the migration; follow up with `apply_migrations`.',
+    inputSchema: Schema.object(
+      properties: {
+        'tag': Schema.string(
+          description:
+              'Optional tag appended to the repair migration version name.',
+        ),
+        'force': Schema.bool(
+          description:
+              'Create the repair migration even when warnings are present '
+              'or when no schema drift is detected (data may be destroyed).',
+        ),
+        'version': Schema.string(
+          description:
+              'Optional target migration version to repair against. '
+              'Defaults to the latest migration version.',
+        ),
+      },
+    ),
+  );
+
+  Future<CallToolResult> _createRepairMigration(CallToolRequest request) async {
+    final callback = onCreateRepairMigration;
+    if (callback == null) {
+      return CallToolResult(
+        content: [TextContent(text: 'Watch session not connected.')],
+        isError: true,
+      );
+    }
+
+    try {
+      final result = await callback(
+        tag: _stringArg(request, 'tag'),
+        force: _boolArg(request, 'force'),
+        targetMigrationVersion: _stringArg(request, 'version'),
+      );
+      return CallToolResult(
+        content: [TextContent(text: result.message)],
+        isError: result.isError ? true : null,
+      );
+    } catch (e) {
+      return CallToolResult(
+        content: [TextContent(text: 'Failed to create repair migration: $e')],
         isError: true,
       );
     }
@@ -215,6 +284,37 @@ base class ServerpodMcpServer extends MCPServer
     }
   }
 
+  static final _hotRestartTool = Tool(
+    name: 'hot_restart',
+    description:
+        'Recompile from scratch and restart the server process. Clears all '
+        'in-memory state (singletons, connection pools, caches). Use when '
+        'hot_reload is not enough - for example, to reset state that '
+        'survives source reloads.',
+    inputSchema: Schema.object(),
+  );
+
+  Future<CallToolResult> _hotRestart(CallToolRequest request) async {
+    final callback = onHotRestart;
+    if (callback == null) {
+      return CallToolResult(
+        content: [TextContent(text: 'Watch session not connected.')],
+        isError: true,
+      );
+    }
+    try {
+      await callback();
+      return CallToolResult(
+        content: [TextContent(text: 'Hot restart completed.')],
+      );
+    } catch (e) {
+      return CallToolResult(
+        content: [TextContent(text: 'Hot restart failed: $e')],
+        isError: true,
+      );
+    }
+  }
+
   static final _tailLogsTool = Tool(
     name: 'tail_logs',
     description:
@@ -255,6 +355,23 @@ base class ServerpodMcpServer extends MCPServer
       ],
     );
   }
+}
+
+/// Reads a string argument; treats missing, non-string, and empty values as
+/// `null`.
+String? _stringArg(CallToolRequest request, String name) {
+  final v = request.arguments?[name];
+  return v is String && v.isNotEmpty ? v : null;
+}
+
+/// Reads a bool argument; treats missing or non-bool values as [defaultValue].
+bool _boolArg(
+  CallToolRequest request,
+  String name, {
+  bool defaultValue = false,
+}) {
+  final v = request.arguments?[name];
+  return v is bool ? v : defaultValue;
 }
 
 Map<String, Object?> _encodeLogHistoryItem(Object item) {

--- a/tools/serverpod_cli/lib/src/commands/start/mcp_socket.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/mcp_socket.dart
@@ -29,7 +29,14 @@ class McpSocketServer {
   Future<void> Function()? _onApplyMigration;
   Future<CreateMigrationMcpResult> Function({String? tag, bool force})?
   _onCreateMigration;
+  Future<CreateMigrationMcpResult> Function({
+    String? tag,
+    bool force,
+    String? targetMigrationVersion,
+  })?
+  _onCreateRepairMigration;
   Future<void> Function()? _onHotReload;
+  Future<void> Function()? _onHotRestart;
   List<Object> Function()? _getLogHistory;
   String? Function()? _getVmServiceUri;
   Stream<void>? _vmServiceUriChanges;
@@ -54,14 +61,23 @@ class McpSocketServer {
     required Future<void> Function() onApplyMigration,
     Future<CreateMigrationMcpResult> Function({String? tag, bool force})?
     onCreateMigration,
+    Future<CreateMigrationMcpResult> Function({
+      String? tag,
+      bool force,
+      String? targetMigrationVersion,
+    })?
+    onCreateRepairMigration,
     Future<void> Function()? onHotReload,
+    Future<void> Function()? onHotRestart,
     List<Object> Function()? getLogHistory,
     String? Function()? getVmServiceUri,
     Stream<void>? vmServiceUriChanges,
   }) {
     _onApplyMigration = onApplyMigration;
     _onCreateMigration = onCreateMigration;
+    _onCreateRepairMigration = onCreateRepairMigration;
     _onHotReload = onHotReload;
+    _onHotRestart = onHotRestart;
     _getLogHistory = getLogHistory;
     _getVmServiceUri = getVmServiceUri;
     _vmServiceUriChanges = vmServiceUriChanges;
@@ -69,7 +85,9 @@ class McpSocketServer {
     if (server != null) {
       server.onApplyMigration = onApplyMigration;
       server.onCreateMigration = onCreateMigration;
+      server.onCreateRepairMigration = onCreateRepairMigration;
       server.onHotReload = onHotReload;
+      server.onHotRestart = onHotRestart;
       server.getLogHistory = getLogHistory;
       server.getVmServiceUri = getVmServiceUri;
       server.vmServiceUriChanges = vmServiceUriChanges;
@@ -124,7 +142,9 @@ class McpSocketServer {
     // Wire callbacks if already connected.
     server.onApplyMigration = _onApplyMigration;
     server.onCreateMigration = _onCreateMigration;
+    server.onCreateRepairMigration = _onCreateRepairMigration;
     server.onHotReload = _onHotReload;
+    server.onHotRestart = _onHotRestart;
     server.getLogHistory = _getLogHistory;
     server.getVmServiceUri = _getVmServiceUri;
     server.vmServiceUriChanges = _vmServiceUriChanges;

--- a/tools/serverpod_cli/lib/src/commands/start/tui/app.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/tui/app.dart
@@ -17,8 +17,8 @@ class StartAppStateHolder extends ServerpodAppStateHolder<ServerWatchState> {
   ServerpodWatchAppState? _widgetState;
   VoidCallback? _onHotReload;
   VoidCallback? _onHotRestart;
-  VoidCallback? _onCreateMigration;
-  VoidCallback? _onCreateRepairMigration;
+  void Function({bool force})? _onCreateMigration;
+  void Function({bool force})? _onCreateRepairMigration;
   VoidCallback? _onApplyMigration;
   VoidCallback? _onQuit;
 
@@ -54,12 +54,12 @@ class StartAppStateHolder extends ServerpodAppStateHolder<ServerWatchState> {
     _widgetState?.onHotRestart = cb;
   }
 
-  set onCreateMigration(VoidCallback? cb) {
+  set onCreateMigration(void Function({bool force})? cb) {
     _onCreateMigration = cb;
     _widgetState?.onCreateMigration = cb;
   }
 
-  set onCreateRepairMigration(VoidCallback? cb) {
+  set onCreateRepairMigration(void Function({bool force})? cb) {
     _onCreateRepairMigration = cb;
     _widgetState?.onCreateRepairMigration = cb;
   }
@@ -97,8 +97,8 @@ class ServerpodWatchAppState extends ServerpodAppState<ServerpodWatchApp> {
   /// Callbacks wired by the backend.
   VoidCallback? onHotReload;
   VoidCallback? onHotRestart;
-  VoidCallback? onCreateMigration;
-  VoidCallback? onCreateRepairMigration;
+  void Function({bool force})? onCreateMigration;
+  void Function({bool force})? onCreateRepairMigration;
   VoidCallback? onApplyMigration;
   VoidCallback? onQuit;
 

--- a/tools/serverpod_cli/lib/src/commands/start/tui/app.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/tui/app.dart
@@ -16,7 +16,9 @@ class StartAppStateHolder extends ServerpodAppStateHolder<ServerWatchState> {
 
   ServerpodWatchAppState? _widgetState;
   VoidCallback? _onHotReload;
+  VoidCallback? _onHotRestart;
   VoidCallback? _onCreateMigration;
+  VoidCallback? _onCreateRepairMigration;
   VoidCallback? _onApplyMigration;
   VoidCallback? _onQuit;
 
@@ -30,7 +32,9 @@ class StartAppStateHolder extends ServerpodAppStateHolder<ServerWatchState> {
   void attach(ServerpodWatchAppState widgetState) {
     _widgetState = widgetState;
     widgetState.onHotReload = _onHotReload;
+    widgetState.onHotRestart = _onHotRestart;
     widgetState.onCreateMigration = _onCreateMigration;
+    widgetState.onCreateRepairMigration = _onCreateRepairMigration;
     widgetState.onApplyMigration = _onApplyMigration;
     widgetState.onQuit = _onQuit;
   }
@@ -45,9 +49,19 @@ class StartAppStateHolder extends ServerpodAppStateHolder<ServerWatchState> {
     _widgetState?.onHotReload = cb;
   }
 
+  set onHotRestart(VoidCallback? cb) {
+    _onHotRestart = cb;
+    _widgetState?.onHotRestart = cb;
+  }
+
   set onCreateMigration(VoidCallback? cb) {
     _onCreateMigration = cb;
     _widgetState?.onCreateMigration = cb;
+  }
+
+  set onCreateRepairMigration(VoidCallback? cb) {
+    _onCreateRepairMigration = cb;
+    _widgetState?.onCreateRepairMigration = cb;
   }
 
   set onApplyMigration(VoidCallback? cb) {
@@ -82,7 +96,9 @@ class ServerpodWatchAppState extends ServerpodAppState<ServerpodWatchApp> {
 
   /// Callbacks wired by the backend.
   VoidCallback? onHotReload;
+  VoidCallback? onHotRestart;
   VoidCallback? onCreateMigration;
+  VoidCallback? onCreateRepairMigration;
   VoidCallback? onApplyMigration;
   VoidCallback? onQuit;
 
@@ -149,7 +165,9 @@ class ServerpodWatchAppState extends ServerpodAppState<ServerpodWatchApp> {
           _rebuild();
         },
         onHotReload: onHotReload,
+        onHotRestart: onHotRestart,
         onCreateMigration: onCreateMigration,
+        onCreateRepairMigration: onCreateRepairMigration,
         onApplyMigration: onApplyMigration,
         onQuit: onQuit,
       ),

--- a/tools/serverpod_cli/lib/src/commands/start/tui/main_screen.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/tui/main_screen.dart
@@ -169,7 +169,7 @@ class MainScreen extends StatelessComponent {
     return ButtonBar(
       buttons: [
         Button(
-          name: 'Reload',
+          name: 'Hot reload / restart',
           activationChar: 'R',
           activationKeys: const [LogicalKey.keyR],
           onActivate: (_) => onHotReload?.call(),
@@ -177,7 +177,7 @@ class MainScreen extends StatelessComponent {
           enabled: actionsEnabled && onHotReload != null,
         ),
         Button(
-          name: 'Migrate',
+          name: 'Create migration',
           activationChar: 'M',
           activationKeys: const [LogicalKey.keyM],
           onActivate: (_) => onCreateMigration?.call(),
@@ -185,7 +185,7 @@ class MainScreen extends StatelessComponent {
           enabled: actionsEnabled && onCreateMigration != null,
         ),
         Button(
-          name: 'Repair',
+          name: 'Repair migration',
           activationChar: 'P',
           activationKeys: const [LogicalKey.keyP],
           onActivate: (_) => onCreateRepairMigration?.call(),
@@ -193,7 +193,7 @@ class MainScreen extends StatelessComponent {
           enabled: actionsEnabled && onCreateRepairMigration != null,
         ),
         Button(
-          name: 'Apply',
+          name: 'Apply migrations',
           activationChar: 'A',
           activationKeys: const [LogicalKey.keyA],
           onActivate: (_) => onApplyMigration?.call(),

--- a/tools/serverpod_cli/lib/src/commands/start/tui/main_screen.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/tui/main_screen.dart
@@ -136,9 +136,9 @@ class MainScreen extends StatelessComponent {
   Component _buildTabBar(ServerpodThemeData st) {
     return TabBar(
       labels: [
-        'Log Messages',
-        'Raw server output',
-        if (state.showFlutterOutput) 'Flutter output',
+        'Server logs',
+        if (state.showFlutterOutput) 'Flutter logs',
+        'Raw server logs',
       ],
       selectedTab: state.selectedTab,
       onTabChanged: onTabChanged,
@@ -147,11 +147,11 @@ class MainScreen extends StatelessComponent {
 
   Component _buildTabContent() {
     return switch (state.selectedTab) {
-      1 => _buildRawOutputView(state.rawLines, rawScrollController),
-      2 => _buildRawOutputView(
+      1 => _buildRawOutputView(
         state.rawFlutterLines,
         flutterRawScrollController,
       ),
+      2 => _buildRawOutputView(state.rawLines, rawScrollController),
       _ => _buildStructuredLogView(),
     };
   }

--- a/tools/serverpod_cli/lib/src/commands/start/tui/main_screen.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/tui/main_screen.dart
@@ -29,7 +29,9 @@ class MainScreen extends StatelessComponent {
     required this.helpScrollController,
     this.onToggleHelp,
     this.onHotReload,
+    this.onHotRestart,
     this.onCreateMigration,
+    this.onCreateRepairMigration,
     this.onApplyMigration,
     this.onQuit,
   });
@@ -42,7 +44,9 @@ class MainScreen extends StatelessComponent {
   final ScrollController helpScrollController;
   final VoidCallback? onToggleHelp;
   final VoidCallback? onHotReload;
+  final VoidCallback? onHotRestart;
   final VoidCallback? onCreateMigration;
+  final VoidCallback? onCreateRepairMigration;
   final VoidCallback? onApplyMigration;
   final VoidCallback? onQuit;
 
@@ -168,19 +172,41 @@ class MainScreen extends StatelessComponent {
           name: 'Hot Reload',
           activationChar: 'R',
           activationKeys: const [LogicalKey.keyR],
+          shift: false,
           onActivate: (_) {
             onHotReload?.call();
           },
           enabled: actionsEnabled && onHotReload != null,
         ),
         Button(
+          name: 'Hot Restart',
+          activationChar: '⇧R',
+          activationKeys: const [LogicalKey.keyR],
+          shift: true,
+          onActivate: (_) {
+            onHotRestart?.call();
+          },
+          enabled: actionsEnabled && onHotRestart != null,
+        ),
+        Button(
           name: 'Create Migration',
           activationChar: 'M',
           activationKeys: const [LogicalKey.keyM],
+          shift: false,
           onActivate: (_) {
             onCreateMigration?.call();
           },
           enabled: actionsEnabled && onCreateMigration != null,
+        ),
+        Button(
+          name: 'Repair Migration',
+          activationChar: '⇧M',
+          activationKeys: const [LogicalKey.keyM],
+          shift: true,
+          onActivate: (_) {
+            onCreateRepairMigration?.call();
+          },
+          enabled: actionsEnabled && onCreateRepairMigration != null,
         ),
         Button(
           name: 'Apply Migration',

--- a/tools/serverpod_cli/lib/src/commands/start/tui/main_screen.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/tui/main_screen.dart
@@ -45,8 +45,8 @@ class MainScreen extends StatelessComponent {
   final VoidCallback? onToggleHelp;
   final VoidCallback? onHotReload;
   final VoidCallback? onHotRestart;
-  final VoidCallback? onCreateMigration;
-  final VoidCallback? onCreateRepairMigration;
+  final void Function({bool force})? onCreateMigration;
+  final void Function({bool force})? onCreateRepairMigration;
   final VoidCallback? onApplyMigration;
   final VoidCallback? onQuit;
 
@@ -169,61 +169,41 @@ class MainScreen extends StatelessComponent {
     return ButtonBar(
       buttons: [
         Button(
-          name: 'Hot Reload',
+          name: 'Reload',
           activationChar: 'R',
           activationKeys: const [LogicalKey.keyR],
-          shift: false,
-          onActivate: (_) {
-            onHotReload?.call();
-          },
+          onActivate: (_) => onHotReload?.call(),
+          onShiftActivate: (_) => onHotRestart?.call(),
           enabled: actionsEnabled && onHotReload != null,
         ),
         Button(
-          name: 'Hot Restart',
-          activationChar: '⇧R',
-          activationKeys: const [LogicalKey.keyR],
-          shift: true,
-          onActivate: (_) {
-            onHotRestart?.call();
-          },
-          enabled: actionsEnabled && onHotRestart != null,
-        ),
-        Button(
-          name: 'Create Migration',
+          name: 'Migrate',
           activationChar: 'M',
           activationKeys: const [LogicalKey.keyM],
-          shift: false,
-          onActivate: (_) {
-            onCreateMigration?.call();
-          },
+          onActivate: (_) => onCreateMigration?.call(),
+          onShiftActivate: (_) => onCreateMigration?.call(force: true),
           enabled: actionsEnabled && onCreateMigration != null,
         ),
         Button(
-          name: 'Repair Migration',
-          activationChar: '⇧M',
-          activationKeys: const [LogicalKey.keyM],
-          shift: true,
-          onActivate: (_) {
-            onCreateRepairMigration?.call();
-          },
+          name: 'Repair',
+          activationChar: 'P',
+          activationKeys: const [LogicalKey.keyP],
+          onActivate: (_) => onCreateRepairMigration?.call(),
+          onShiftActivate: (_) => onCreateRepairMigration?.call(force: true),
           enabled: actionsEnabled && onCreateRepairMigration != null,
         ),
         Button(
-          name: 'Apply Migration',
+          name: 'Apply',
           activationChar: 'A',
           activationKeys: const [LogicalKey.keyA],
-          onActivate: (_) {
-            onApplyMigration?.call();
-          },
+          onActivate: (_) => onApplyMigration?.call(),
           enabled: actionsEnabled && onApplyMigration != null,
         ),
         Button(
           name: 'Help',
           activationChar: 'H',
           activationKeys: const [LogicalKey.keyH],
-          onActivate: (_) {
-            onToggleHelp?.call();
-          },
+          onActivate: (_) => onToggleHelp?.call(),
           enabled: onToggleHelp != null,
         ),
         Button(

--- a/tools/serverpod_cli/lib/src/commands/start/tui/main_screen.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/tui/main_screen.dart
@@ -70,11 +70,7 @@ class MainScreen extends StatelessComponent {
                       padding: const EdgeInsets.only(left: 1),
                       child: _buildTabBar(st),
                     ),
-                    if (_flutterStatusLine() case final line?)
-                      Padding(
-                        padding: const EdgeInsets.only(left: 1),
-                        child: Text(line),
-                      ),
+                    ?_buildFlutterStatusLine(st),
                     Expanded(child: _buildTabContent()),
                     // Pinned active operations
                     if (state.activeOperations.isNotEmpty) ...[
@@ -97,16 +93,44 @@ class MainScreen extends StatelessComponent {
     );
   }
 
-  /// URL when ready, startup stage while compiling, `null` when no
-  /// Flutter app is attached.
-  String? _flutterStatusLine() {
+  /// Breadcrumb when a Flutter app is attached: horizontal rules, muted
+  /// label, vertical divider, and value.
+  ///
+  /// Returns `null` when no Flutter app is running or starting.
+  Component? _buildFlutterStatusLine(ServerpodThemeData st) {
+    final mutedText = TextStyle(
+      color: st.debugLevel,
+      fontWeight: FontWeight.dim,
+    );
+    final separatorStyle = TextStyle(
+      color: st.subtleDivider,
+      fontWeight: FontWeight.dim,
+    );
+
+    String? value;
     if (state.flutterReady) {
-      final url = state.flutterUrl;
-      return url == null ? 'Flutter: ready' : 'Flutter: $url';
+      value = state.flutterUrl ?? 'ready';
+    } else {
+      value = state.flutterStartupStage;
     }
-    final stage = state.flutterStartupStage;
-    if (stage != null) return 'Flutter: $stage';
-    return null;
+    if (value == null) return null;
+
+    return Column(
+      children: [
+        Divider(color: st.subtleDivider),
+        Padding(
+          padding: const EdgeInsets.only(left: 1),
+          child: Row(
+            children: [
+              Text('Flutter app', style: mutedText),
+              Text(' │ ', style: separatorStyle),
+              Text(value, style: mutedText),
+            ],
+          ),
+        ),
+        Divider(color: st.subtleDivider),
+      ],
+    );
   }
 
   Component _buildTabBar(ServerpodThemeData st) {

--- a/tools/serverpod_cli/lib/src/commands/start/watch_session.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/watch_session.dart
@@ -419,12 +419,9 @@ class WatchSession {
     );
   }
 
-  /// Forces a full server process restart (stop + spawn).
-  ///
-  /// Unlike [forceReload], this does not attempt VM-level reload - it always
-  /// restarts the pod. With a compiler, this resets the compiler and produces
-  /// a fresh full dill before spawning, since incremental dills accumulated
-  /// across reloads are not bootable. Useful for clearing in-memory state.
+  /// Forces a full server process restart (clears singletons, pools, and
+  /// caches that survive a hot reload). More expensive than [forceReload];
+  /// recompiles from scratch.
   Future<void> forceRestart() {
     if (_state == SessionState.disposed) {
       throw StateError('Session has been disposed.');

--- a/tools/serverpod_cli/lib/src/commands/start/watch_session.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/watch_session.dart
@@ -384,7 +384,10 @@ class WatchSession {
   ///
   /// The full compile is required because the FES `outputDill` after accepted
   /// increments is not generally bootable.
-  Future<void> _fullCompileAndRestart() async {
+  ///
+  /// Returns `true` if the server was restarted, `false` if compile failed or
+  /// the session was disposed before restart.
+  Future<bool> _fullCompileAndRestart() async {
     String? dillPath;
     final compiler = _compiler;
     if (compiler != null) {
@@ -395,15 +398,16 @@ class WatchSession {
         compiler,
         rejectOnFailure: true,
       );
-      if (fullResult == null) return;
+      if (fullResult == null) return false;
       compiler.accept();
       dillPath = fullResult.dillOutput!;
     }
 
     // dispose() isn't queued onto [_chain], so it can race the compile above.
-    if (_state == SessionState.disposed) return;
+    if (_state == SessionState.disposed) return false;
 
     await _restartServer(dillPath);
+    return true;
   }
 
   /// Forces a hot reload.
@@ -441,7 +445,11 @@ class WatchSession {
     if (_createServer == null) {
       throw StateError('Restart is not supported in this session.');
     }
-    return _chain(_fullCompileAndRestart);
+    return _chain(() async {
+      if (await _fullCompileAndRestart()) {
+        await _restartFlutter();
+      }
+    });
   }
 
   /// Applies pending database migrations.
@@ -541,6 +549,22 @@ class WatchSession {
       log.info(flutterAppReloaded);
     } else {
       log.warning('Flutter reload failed.');
+    }
+  }
+
+  /// Hot-restarts the Flutter app and logs the outcome. Never throws.
+  Future<void> _restartFlutter() async {
+    final flutter = _flutterProcess;
+    if (flutter == null) return;
+    if (!flutter.isVmServiceConnected) {
+      log.debug('Flutter not ready; skipping restart.');
+      return;
+    }
+    final ok = await flutter.restart();
+    if (ok) {
+      log.info(flutterAppRestarted);
+    } else {
+      log.warning('Flutter restart failed.');
     }
   }
 

--- a/tools/serverpod_cli/lib/src/commands/start/watch_session.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/watch_session.dart
@@ -367,19 +367,20 @@ class WatchSession {
   }
 
   /// Attempts hot reload; falls back to a server restart if reload fails.
-  ///
-  /// With a [KernelCompiler], the fallback resets the compiler and produces a
-  /// fresh full dill to boot the new pod. Without one, the new pod is spawned
-  /// via `dart run` and the VM's kernel service compiles on the next reload.
   Future<void> _reloadOrRestart(CompileResult? result) async {
     if (await _reload(result?.dillOutput)) return;
+    await _fullCompileAndRestart();
+  }
 
-    // Fall back to restart. With a compiler, produce a full dill (incremental
-    // dills only contain deltas, so they can't boot a new process). Without
-    // one, restart via `dart run` and let the VM's kernel service take over.
+  /// Resets the compiler, produces a fresh full dill, and restarts the server.
+  ///
+  /// The full compile is required because the FES `outputDill` after accepted
+  /// increments is not generally bootable.
+  Future<void> _fullCompileAndRestart() async {
     String? dillPath;
     final compiler = _compiler;
     if (compiler != null) {
+      _pendingPaths.clear();
       await compiler.reset();
       final fullResult = await compileWithProgress(
         'Compiling server',
@@ -391,14 +392,8 @@ class WatchSession {
       dillPath = fullResult.dillOutput!;
     }
 
-    switch (_state) {
-      case SessionState.idle:
-        break; // proceed
-      case SessionState.restarting:
-      case SessionState.applyingMigration:
-      case SessionState.disposed:
-        return;
-    }
+    // dispose() isn't queued onto [_chain], so it can race the compile above.
+    if (_state == SessionState.disposed) return;
 
     await _restartServer(dillPath);
   }
@@ -422,6 +417,22 @@ class WatchSession {
         forceFullCompile: true,
       ),
     );
+  }
+
+  /// Forces a full server process restart (stop + spawn).
+  ///
+  /// Unlike [forceReload], this does not attempt VM-level reload - it always
+  /// restarts the pod. With a compiler, this resets the compiler and produces
+  /// a fresh full dill before spawning, since incremental dills accumulated
+  /// across reloads are not bootable. Useful for clearing in-memory state.
+  Future<void> forceRestart() {
+    if (_state == SessionState.disposed) {
+      throw StateError('Session has been disposed.');
+    }
+    if (_createServer == null) {
+      throw StateError('Restart is not supported in this session.');
+    }
+    return _chain(_fullCompileAndRestart);
   }
 
   /// Applies pending database migrations.

--- a/tools/serverpod_cli/lib/src/commands/tui/components/button.dart
+++ b/tools/serverpod_cli/lib/src/commands/tui/components/button.dart
@@ -18,8 +18,6 @@ class Button extends StatelessComponent {
     this.enabled = true,
   }) : assert(activationKeys.length > 0, 'activationKeys can not be empty');
 
-  const factory Button.tip(String tip) = _TipButton;
-
   final String name;
   final String activationChar;
   final List<LogicalKey> activationKeys;
@@ -82,9 +80,8 @@ class Button extends StatelessComponent {
   }
 }
 
-class _TipButton extends Button {
-  const _TipButton(this.tip)
-    : super(name: '', activationChar: '', activationKeys: const []);
+class Tip extends StatelessComponent {
+  const Tip(this.tip);
 
   final String tip;
 

--- a/tools/serverpod_cli/lib/src/commands/tui/components/button.dart
+++ b/tools/serverpod_cli/lib/src/commands/tui/components/button.dart
@@ -4,9 +4,7 @@ import 'package:serverpod_cli/src/commands/tui/serverpod_theme.dart';
 /// A keyboard-activated button with a highlighted activation character.
 ///
 /// When [onShiftActivate] is non-null, the button also dispatches `Shift+key`
-/// to that callback and appends a `⇧` glyph to [name] as a discoverability
-/// cue (terminals can't tell us when Shift is pressed without a key, so the
-/// hint is shown statically). Help (`H`) lists what each `⇧` does.
+/// to that callback.
 class Button extends StatelessComponent {
   const Button({
     super.key,
@@ -68,7 +66,7 @@ class Button extends StatelessComponent {
             ),
             const Text(' '),
             Text(
-              hasShiftVariant ? '$name⇧' : name,
+              name,
               style: TextStyle(
                 fontWeight: enabled ? FontWeight.normal : FontWeight.dim,
               ),

--- a/tools/serverpod_cli/lib/src/commands/tui/components/button.dart
+++ b/tools/serverpod_cli/lib/src/commands/tui/components/button.dart
@@ -2,6 +2,11 @@ import 'package:nocterm/nocterm.dart';
 import 'package:serverpod_cli/src/commands/tui/serverpod_theme.dart';
 
 /// A keyboard-activated button with a highlighted activation character.
+///
+/// When [onShiftActivate] is non-null, the button also dispatches `Shift+key`
+/// to that callback and appends a `⇧` glyph to [name] as a discoverability
+/// cue (terminals can't tell us when Shift is pressed without a key, so the
+/// hint is shown statically). Help (`H`) lists what each `⇧` does.
 class Button extends StatelessComponent {
   const Button({
     super.key,
@@ -9,43 +14,36 @@ class Button extends StatelessComponent {
     required this.activationChar,
     required this.activationKeys,
     required this.onActivate,
+    this.onShiftActivate,
     this.enabled = true,
-    this.shift,
-    this.ctrl,
-    this.alt,
-    this.meta,
   }) : assert(activationKeys.length > 0, 'activationKeys can not be empty');
 
   final String name;
   final String activationChar;
   final List<LogicalKey> activationKeys;
   final void Function(LogicalKey) onActivate;
+  final void Function(LogicalKey)? onShiftActivate;
   final bool enabled;
-
-  /// Modifier requirements forwarded to [KeyboardEvent.matches]. `null` means
-  /// "don't care" (matches with or without). Set explicitly to disambiguate
-  /// when two buttons share the same key (e.g. `r` with `shift: false` and
-  /// `Shift+R` with `shift: true`).
-  final bool? shift;
-  final bool? ctrl;
-  final bool? alt;
-  final bool? meta;
 
   @override
   Component build(BuildContext context) {
     final theme = ServerpodTheme.of(context);
+    final hasShiftVariant = onShiftActivate != null;
 
     return Focusable(
       focused: enabled,
       onKeyEvent: (event) {
         for (final key in activationKeys) {
-          if (event.matches(
-            key,
-            shift: shift,
-            ctrl: ctrl,
-            alt: alt,
-            meta: meta,
-          )) {
+          if (hasShiftVariant) {
+            if (event.matches(key, shift: false)) {
+              onActivate(key);
+              return true;
+            }
+            if (event.matches(key, shift: true)) {
+              onShiftActivate!(key);
+              return true;
+            }
+          } else if (event.matches(key)) {
             onActivate(key);
             return true;
           }
@@ -70,7 +68,7 @@ class Button extends StatelessComponent {
             ),
             const Text(' '),
             Text(
-              name,
+              hasShiftVariant ? '$name⇧' : name,
               style: TextStyle(
                 fontWeight: enabled ? FontWeight.normal : FontWeight.dim,
               ),

--- a/tools/serverpod_cli/lib/src/commands/tui/components/button.dart
+++ b/tools/serverpod_cli/lib/src/commands/tui/components/button.dart
@@ -10,6 +10,10 @@ class Button extends StatelessComponent {
     required this.activationKeys,
     required this.onActivate,
     this.enabled = true,
+    this.shift,
+    this.ctrl,
+    this.alt,
+    this.meta,
   }) : assert(activationKeys == const [], 'activationKeys can not be empty');
 
   final String name;
@@ -18,6 +22,15 @@ class Button extends StatelessComponent {
   final void Function(LogicalKey) onActivate;
   final bool enabled;
 
+  /// Modifier requirements forwarded to [KeyboardEvent.matches]. `null` means
+  /// "don't care" (matches with or without). Set explicitly to disambiguate
+  /// when two buttons share the same key (e.g. `r` with `shift: false` and
+  /// `Shift+R` with `shift: true`).
+  final bool? shift;
+  final bool? ctrl;
+  final bool? alt;
+  final bool? meta;
+
   @override
   Component build(BuildContext context) {
     final theme = ServerpodTheme.of(context);
@@ -25,9 +38,17 @@ class Button extends StatelessComponent {
     return Focusable(
       focused: enabled,
       onKeyEvent: (event) {
-        if (activationKeys.contains(event.logicalKey)) {
-          onActivate(event.logicalKey);
-          return true;
+        for (final key in activationKeys) {
+          if (event.matches(
+            key,
+            shift: shift,
+            ctrl: ctrl,
+            alt: alt,
+            meta: meta,
+          )) {
+            onActivate(key);
+            return true;
+          }
         }
         return false;
       },

--- a/tools/serverpod_cli/lib/src/commands/tui/components/button.dart
+++ b/tools/serverpod_cli/lib/src/commands/tui/components/button.dart
@@ -14,7 +14,7 @@ class Button extends StatelessComponent {
     this.ctrl,
     this.alt,
     this.meta,
-  }) : assert(activationKeys == const [], 'activationKeys can not be empty');
+  }) : assert(activationKeys.length > 0, 'activationKeys can not be empty');
 
   final String name;
   final String activationChar;

--- a/tools/serverpod_cli/lib/src/commands/tui/components/button_bar.dart
+++ b/tools/serverpod_cli/lib/src/commands/tui/components/button_bar.dart
@@ -4,13 +4,13 @@ import 'package:serverpod_cli/src/commands/tui/components/wrap.dart';
 
 /// A horizontal bar of [Button] widgets with consistent spacing.
 ///
-/// Renders buttons with a 1-column left margin, 2-column gaps between
-/// adjacent buttons, and a 1-column right margin, matching the standard
+/// Renders buttons or tips with a 1-column left margin, 2-column gaps between
+/// adjacent components, and a 1-column right margin, matching the standard
 /// TUI button bar layout.
 class ButtonBar extends StatelessComponent {
   const ButtonBar({super.key, required this.buttons});
 
-  final List<Button> buttons;
+  final List<Component> buttons;
 
   @override
   Component build(BuildContext context) {

--- a/tools/serverpod_cli/lib/src/commands/tui/components/help_overlay.dart
+++ b/tools/serverpod_cli/lib/src/commands/tui/components/help_overlay.dart
@@ -100,6 +100,7 @@ class _HelpOverlayState extends State<HelpOverlay> {
             children: [
               ShrinkWrapScrollView(
                 controller: scrollController,
+                thumbVisibility: true,
                 child: Column(
                   mainAxisSize: MainAxisSize.min,
                   crossAxisAlignment: CrossAxisAlignment.start,

--- a/tools/serverpod_cli/lib/src/commands/tui/components/help_overlay.dart
+++ b/tools/serverpod_cli/lib/src/commands/tui/components/help_overlay.dart
@@ -47,7 +47,9 @@ class _HelpOverlayState extends State<HelpOverlay> {
       'Actions',
       [
         ('R', 'Hot Reload'),
+        ('Shift+R', 'Hot Restart'),
         ('M', 'Create Migration'),
+        ('Shift+M', 'Repair Migration'),
         ('A', 'Apply Migration'),
         ('Q', 'Quit'),
       ],

--- a/tools/serverpod_cli/lib/src/commands/tui/components/help_overlay.dart
+++ b/tools/serverpod_cli/lib/src/commands/tui/components/help_overlay.dart
@@ -46,11 +46,10 @@ class _HelpOverlayState extends State<HelpOverlay> {
     (
       'Actions',
       [
-        ('R', 'Hot Reload'),
-        ('Shift+R', 'Hot Restart'),
-        ('M', 'Create Migration'),
-        ('Shift+M', 'Repair Migration'),
-        ('A', 'Apply Migration'),
+        ('R / Shift+R', 'Hot reload / restart'),
+        ('M / Shift+M', 'Create migration (⇧ = force)'),
+        ('P / Shift+P', 'Repair migration (⇧ = force)'),
+        ('A', 'Apply migration'),
         ('Q', 'Quit'),
       ],
     ),

--- a/tools/serverpod_cli/lib/src/commands/tui/components/help_overlay.dart
+++ b/tools/serverpod_cli/lib/src/commands/tui/components/help_overlay.dart
@@ -51,7 +51,7 @@ class _HelpOverlayState extends State<HelpOverlay> {
         ('R / Shift+R', 'Hot reload / restart'),
         ('M / Shift+M', 'Create migration (⇧ = force)'),
         ('P / Shift+P', 'Repair migration (⇧ = force)'),
-        ('A', 'Apply migration'),
+        ('A', 'Apply migrations'),
         ('Q', 'Quit'),
       ],
     ),

--- a/tools/serverpod_cli/lib/src/commands/tui/components/help_overlay.dart
+++ b/tools/serverpod_cli/lib/src/commands/tui/components/help_overlay.dart
@@ -1,12 +1,14 @@
 import 'package:nocterm/nocterm.dart';
+import 'package:serverpod_cli/src/commands/tui/components/shrink_wrap_scroll_view.dart';
 import 'package:serverpod_cli/src/commands/tui/serverpod_theme.dart';
 
 typedef HelpOverlayBindings = List<(String, List<(String, String)>)>;
 
-/// Help overlay showing all keybindings.
-///
-/// Pass [controller] to drive the help body's scroll position from outside.
-/// When null, the overlay manages its own controller.
+/// Width reserved for the activation-key column in the help body.
+const _keyColumnWidth = 24.0;
+
+/// Help overlay showing all keybindings. Sizes to its content; scrolls if
+/// content exceeds the available terminal height.
 class HelpOverlay extends StatefulComponent {
   const HelpOverlay({super.key, this.bindings, this.controller});
 
@@ -18,7 +20,7 @@ class HelpOverlay extends StatefulComponent {
 }
 
 class _HelpOverlayState extends State<HelpOverlay> {
-  static const _bindings = [
+  static const _defaultBindings = [
     (
       'Navigation',
       [
@@ -69,16 +71,18 @@ class _HelpOverlayState extends State<HelpOverlay> {
   @override
   Component build(BuildContext context) {
     final st = ServerpodTheme.of(context);
-
     final theme = TuiTheme.of(context);
-    final effectiveBindings = component.bindings ?? _bindings;
+    final effectiveBindings = component.bindings ?? _defaultBindings;
     final scrollController = _effectiveController;
 
-    return Center(
-      child: SizedBox(
-        width: 56,
-        height: 29,
+    // Outer Padding bounds the panel to (screen - 4) on each axis so
+    // SingleChildScrollView has finite extent to clamp against and scroll
+    // within when content overflows.
+    return Padding(
+      padding: const EdgeInsets.all(2),
+      child: Center(
         child: Container(
+          padding: const EdgeInsets.symmetric(horizontal: 2),
           decoration: BoxDecoration(
             color: theme.surface,
             border: BoxBorder.all(
@@ -90,62 +94,58 @@ class _HelpOverlayState extends State<HelpOverlay> {
               style: TextStyle(color: st.primary),
             ),
           ),
-          child: Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 2),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Expanded(
-                  child: Scrollbar(
-                    controller: scrollController,
-                    thumbVisibility: true,
-                    child: ListView(
-                      controller: scrollController,
-                      children: [
-                        for (final (section, bindings)
-                            in effectiveBindings) ...[
-                          Text(
-                            section,
-                            style: TextStyle(
-                              color: st.primary,
-                              fontWeight: FontWeight.bold,
-                            ),
-                          ),
-                          for (final (key, desc) in bindings)
-                            Row(
-                              children: [
-                                SizedBox(
-                                  width: 24,
-                                  child: Text(
-                                    '  $key',
-                                    style: TextStyle(
-                                      color: theme.onSurface,
-                                      fontWeight: FontWeight.dim,
-                                    ),
-                                  ),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              ShrinkWrapScrollView(
+                controller: scrollController,
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    for (final (section, items) in effectiveBindings) ...[
+                      Text(
+                        section,
+                        style: TextStyle(
+                          color: st.primary,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                      for (final (key, desc) in items)
+                        Row(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            SizedBox(
+                              width: _keyColumnWidth,
+                              child: Text(
+                                '  $key',
+                                style: TextStyle(
+                                  color: theme.onSurface,
+                                  fontWeight: FontWeight.dim,
                                 ),
-                                Text(
-                                  desc,
-                                  style: TextStyle(color: theme.onSurface),
-                                ),
-                              ],
+                              ),
                             ),
-                          const SizedBox(height: 1),
-                        ],
-                      ],
-                    ),
-                  ),
+                            Text(
+                              desc,
+                              style: TextStyle(color: theme.onSurface),
+                            ),
+                          ],
+                        ),
+                      const SizedBox(height: 1),
+                    ],
+                  ],
                 ),
-                const SizedBox(height: 1),
-                Text(
-                  'Press H or Esc to close',
-                  style: TextStyle(
-                    color: theme.onSurface,
-                    fontWeight: FontWeight.dim,
-                  ),
+              ),
+              const SizedBox(height: 1),
+              Text(
+                'Press H or Esc to close',
+                style: TextStyle(
+                  color: theme.onSurface,
+                  fontWeight: FontWeight.dim,
                 ),
-              ],
-            ),
+              ),
+            ],
           ),
         ),
       ),

--- a/tools/serverpod_cli/lib/src/commands/tui/components/shrink_wrap_scroll_view.dart
+++ b/tools/serverpod_cli/lib/src/commands/tui/components/shrink_wrap_scroll_view.dart
@@ -1,0 +1,26 @@
+import 'package:nocterm/nocterm.dart';
+
+/// Scrolls when bounded, shrink-wraps when not.
+///
+/// Must sit inside a [Column] whose vertical extent is bounded - under
+/// unbounded constraints it can't scroll and degrades to plain shrink-wrap.
+class ShrinkWrapScrollView extends StatelessComponent {
+  const ShrinkWrapScrollView({
+    super.key,
+    required this.child,
+    this.controller,
+  });
+
+  final Component child;
+  final ScrollController? controller;
+
+  @override
+  Component build(BuildContext context) {
+    return Flexible(
+      child: SingleChildScrollView(
+        controller: controller,
+        child: child,
+      ),
+    );
+  }
+}

--- a/tools/serverpod_cli/lib/src/commands/tui/components/shrink_wrap_scroll_view.dart
+++ b/tools/serverpod_cli/lib/src/commands/tui/components/shrink_wrap_scroll_view.dart
@@ -2,25 +2,34 @@ import 'package:nocterm/nocterm.dart';
 
 /// Scrolls when bounded, shrink-wraps when not.
 ///
-/// Must sit inside a [Column] whose vertical extent is bounded - under
-/// unbounded constraints it can't scroll and degrades to plain shrink-wrap.
+/// Must sit inside a [Column] whose vertical extent is bounded.
+/// Under unbounded constraints it can't scroll and degrades to plain shrink-wrap.
+/// Pass [thumbVisibility] to wrap the scrollable in a [Scrollbar] with the thumb shown.
 class ShrinkWrapScrollView extends StatelessComponent {
   const ShrinkWrapScrollView({
     super.key,
     required this.child,
     this.controller,
+    this.thumbVisibility = false,
   });
 
   final Component child;
   final ScrollController? controller;
+  final bool thumbVisibility;
 
   @override
   Component build(BuildContext context) {
-    return Flexible(
-      child: SingleChildScrollView(
-        controller: controller,
-        child: child,
-      ),
+    Component scrollable = SingleChildScrollView(
+      controller: controller,
+      child: child,
     );
+    if (thumbVisibility) {
+      scrollable = Scrollbar(
+        controller: controller,
+        thumbVisibility: true,
+        child: scrollable,
+      );
+    }
+    return Flexible(child: scrollable);
   }
 }

--- a/tools/serverpod_cli/lib/src/migrations/create_migration_action.dart
+++ b/tools/serverpod_cli/lib/src/migrations/create_migration_action.dart
@@ -101,10 +101,8 @@ Future<CreateMigrationOutcome> createMigrationAction({
   MigrationGenerationContext generationContext;
   try {
     generationContext = await MigrationGenerationContext.load(config);
-  } on GenerateMigrationDatabaseDefinitionException {
-    return const CreateMigrationFailed(
-      'Unable to generate database definition for project.',
-    );
+  } on GenerateMigrationDatabaseDefinitionException catch (e) {
+    return CreateMigrationFailed('$e');
   }
 
   final hasClientMigrations = generationContext.hasClientDatabaseTables;
@@ -169,23 +167,10 @@ Future<CreateMigrationOutcome> _createMigration({
       context: context,
       precomputedVersion: precomputedVersion,
     );
-  } on MigrationVersionLoadException catch (e) {
-    return CreateMigrationFailed(
-      'Unable to determine latest database definition due to a corrupted '
-      'migration. Please re-create or remove the migration version and try '
-      'again. Migration version: "${e.versionName}".\n${e.exception}',
-    );
-  } on GenerateMigrationDatabaseDefinitionException {
-    return const CreateMigrationFailed(
-      'Unable to generate database definition for project.',
-    );
-  } on MigrationVersionAlreadyExistsException catch (e) {
-    return CreateMigrationFailed(
-      'Unable to create migration. A directory with the same name already '
-      'exists: "${e.directoryPath}".',
-    );
   } on MigrationAbortedException {
     return const CreateMigrationAborted();
+  } on Exception catch (e) {
+    return CreateMigrationFailed('$e');
   }
 
   if (migration == null) {

--- a/tools/serverpod_cli/lib/src/migrations/create_repair_migration_action.dart
+++ b/tools/serverpod_cli/lib/src/migrations/create_repair_migration_action.dart
@@ -25,11 +25,16 @@ class RepairMigrationCreated extends RepairMigrationOutcome {
   final String filePath;
 }
 
-/// The generator returned `null` - either no schema drift was detected, or
-/// warnings were present and `force` was false. Both cases require `force`
-/// to override.
-class RepairMigrationNotCreated extends RepairMigrationOutcome {
-  const RepairMigrationNotCreated();
+/// No schema drift was detected between the target migration version and the
+/// live database. `force` will create an empty repair migration anyway.
+class RepairMigrationNoChanges extends RepairMigrationOutcome {
+  const RepairMigrationNoChanges();
+}
+
+/// Warnings were present and `force` was false. `force` will create the
+/// migration despite the warnings (data may be destroyed).
+class RepairMigrationAborted extends RepairMigrationOutcome {
+  const RepairMigrationAborted();
 }
 
 /// The repair migration could not be created.
@@ -86,6 +91,8 @@ Future<RepairMigrationOutcome> createRepairMigrationAction({
       dialect: config.databaseDialect,
       targetMigrationVersion: targetMigrationVersion,
     );
+  } on MigrationAbortedException {
+    return const RepairMigrationAborted();
   } on MigrationRepairTargetNotFoundException catch (e) {
     if (e.versionsFound.isEmpty) {
       return const RepairMigrationFailed(
@@ -114,7 +121,7 @@ Future<RepairMigrationOutcome> createRepairMigrationAction({
   }
 
   if (repairMigration == null) {
-    return const RepairMigrationNotCreated();
+    return const RepairMigrationNoChanges();
   }
 
   final versionName = path.basenameWithoutExtension(repairMigration.path);

--- a/tools/serverpod_cli/lib/src/migrations/create_repair_migration_action.dart
+++ b/tools/serverpod_cli/lib/src/migrations/create_repair_migration_action.dart
@@ -38,9 +38,9 @@ class RepairMigrationException implements Exception {
 ///   message, so callers can display them with `'$e'`.
 Future<File?> createRepairMigrationAction({
   required GeneratorConfig config,
+  required String runMode,
   String? tag,
   bool force = false,
-  String runMode = 'development',
   String? targetMigrationVersion,
 }) async {
   if (!config.isFeatureEnabled(ServerpodFeature.database)) {

--- a/tools/serverpod_cli/lib/src/migrations/create_repair_migration_action.dart
+++ b/tools/serverpod_cli/lib/src/migrations/create_repair_migration_action.dart
@@ -6,43 +6,15 @@ import 'package:serverpod_cli/src/config/serverpod_feature.dart';
 import 'package:serverpod_cli/src/util/project_name.dart';
 import 'package:serverpod_shared/serverpod_shared.dart';
 
-/// Outcome of a [createRepairMigrationAction] call.
-sealed class RepairMigrationOutcome {
-  const RepairMigrationOutcome();
-}
-
-/// A repair migration was written to disk.
-class RepairMigrationCreated extends RepairMigrationOutcome {
-  const RepairMigrationCreated({
-    required this.versionName,
-    required this.filePath,
-  });
-
-  /// The repair migration's version name (timestamp + optional tag).
-  final String versionName;
-
-  /// Absolute path to the generated `.sql` file.
-  final String filePath;
-}
-
-/// No schema drift was detected between the target migration version and the
-/// live database. `force` will create an empty repair migration anyway.
-class RepairMigrationNoChanges extends RepairMigrationOutcome {
-  const RepairMigrationNoChanges();
-}
-
-/// Warnings were present and `force` was false. `force` will create the
-/// migration despite the warnings (data may be destroyed).
-class RepairMigrationAborted extends RepairMigrationOutcome {
-  const RepairMigrationAborted();
-}
-
-/// The repair migration could not be created.
-class RepairMigrationFailed extends RepairMigrationOutcome {
-  const RepairMigrationFailed(this.message);
-
-  /// User-facing description of the failure.
+/// Thrown by [createRepairMigrationAction] for pre-flight failures (feature
+/// flag, project name lookup). Migration-time failures propagate as their
+/// typed exception (see [createRepairMigrationAction]'s docs).
+class RepairMigrationException implements Exception {
+  const RepairMigrationException(this.message);
   final String message;
+
+  @override
+  String toString() => message;
 }
 
 /// Shared implementation behind the `serverpod create-repair-migration`
@@ -52,7 +24,19 @@ class RepairMigrationFailed extends RepairMigrationOutcome {
 /// Connects to the running server (in [runMode]) to fetch the live database
 /// schema, diffs it against the target migration version, and writes a repair
 /// migration if drift is found.
-Future<RepairMigrationOutcome> createRepairMigrationAction({
+///
+/// Returns the generated `.sql` file, or `null` when no schema drift is
+/// detected (override with [force]).
+///
+/// Throws:
+/// - [MigrationAbortedException] when warnings are present and [force] is
+///   false (callers typically handle this with a surface-specific message).
+/// - [RepairMigrationException] for pre-flight failures.
+/// - [MigrationRepairTargetNotFoundException], [MigrationVersionLoadException],
+///   [MigrationLiveDatabaseDefinitionException], [MigrationRepairWriteException]
+///   for typed generator failures. Each `toString()`s into a user-facing
+///   message, so callers can display them with `'$e'`.
+Future<File?> createRepairMigrationAction({
   required GeneratorConfig config,
   String? tag,
   bool force = false,
@@ -60,7 +44,7 @@ Future<RepairMigrationOutcome> createRepairMigrationAction({
   String? targetMigrationVersion,
 }) async {
   if (!config.isFeatureEnabled(ServerpodFeature.database)) {
-    return const RepairMigrationFailed(
+    throw const RepairMigrationException(
       'The database feature is not enabled in this project. '
       'Repair migrations cannot be created.',
     );
@@ -72,61 +56,19 @@ Future<RepairMigrationOutcome> createRepairMigrationAction({
 
   final projectName = await getProjectName(serverDirectory);
   if (projectName == null) {
-    return const RepairMigrationFailed(
+    throw const RepairMigrationException(
       'Unable to determine project name from the server package.',
     );
   }
 
-  final generator = MigrationGenerator(
+  return MigrationGenerator(
     directory: serverDirectory,
     projectName: projectName,
-  );
-
-  File? repairMigration;
-  try {
-    repairMigration = await generator.repairMigration(
-      tag: tag,
-      force: force,
-      runMode: runMode,
-      dialect: config.databaseDialect,
-      targetMigrationVersion: targetMigrationVersion,
-    );
-  } on MigrationAbortedException {
-    return const RepairMigrationAborted();
-  } on MigrationRepairTargetNotFoundException catch (e) {
-    if (e.versionsFound.isEmpty) {
-      return const RepairMigrationFailed(
-        'Unable to find any migration versions.',
-      );
-    }
-    return RepairMigrationFailed(
-      'Unable to find the specified target migration "${e.targetName}". '
-      'Available versions: ${e.versionsFound}.',
-    );
-  } on MigrationVersionLoadException catch (e) {
-    return RepairMigrationFailed(
-      'Unable to determine latest database definition due to a corrupted '
-      'migration. Migration version: "${e.versionName}" for module '
-      '"${e.moduleName}".\n${e.exception}',
-    );
-  } on MigrationLiveDatabaseDefinitionException catch (e) {
-    return RepairMigrationFailed(
-      'Unable to fetch live database schema from server. Make sure the '
-      'server is running and is connected to the database.\n${e.exception}',
-    );
-  } on MigrationRepairWriteException catch (e) {
-    return RepairMigrationFailed(
-      'Unable to write repair migration.\n${e.exception}',
-    );
-  }
-
-  if (repairMigration == null) {
-    return const RepairMigrationNoChanges();
-  }
-
-  final versionName = path.basenameWithoutExtension(repairMigration.path);
-  return RepairMigrationCreated(
-    versionName: versionName,
-    filePath: repairMigration.path,
+  ).repairMigration(
+    tag: tag,
+    force: force,
+    runMode: runMode,
+    dialect: config.databaseDialect,
+    targetMigrationVersion: targetMigrationVersion,
   );
 }

--- a/tools/serverpod_cli/lib/src/migrations/create_repair_migration_action.dart
+++ b/tools/serverpod_cli/lib/src/migrations/create_repair_migration_action.dart
@@ -1,0 +1,125 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as path;
+import 'package:serverpod_cli/analyzer.dart';
+import 'package:serverpod_cli/src/config/serverpod_feature.dart';
+import 'package:serverpod_cli/src/util/project_name.dart';
+import 'package:serverpod_shared/serverpod_shared.dart';
+
+/// Outcome of a [createRepairMigrationAction] call.
+sealed class RepairMigrationOutcome {
+  const RepairMigrationOutcome();
+}
+
+/// A repair migration was written to disk.
+class RepairMigrationCreated extends RepairMigrationOutcome {
+  const RepairMigrationCreated({
+    required this.versionName,
+    required this.filePath,
+  });
+
+  /// The repair migration's version name (timestamp + optional tag).
+  final String versionName;
+
+  /// Absolute path to the generated `.sql` file.
+  final String filePath;
+}
+
+/// The generator returned `null` - either no schema drift was detected, or
+/// warnings were present and `force` was false. Both cases require `force`
+/// to override.
+class RepairMigrationNotCreated extends RepairMigrationOutcome {
+  const RepairMigrationNotCreated();
+}
+
+/// The repair migration could not be created.
+class RepairMigrationFailed extends RepairMigrationOutcome {
+  const RepairMigrationFailed(this.message);
+
+  /// User-facing description of the failure.
+  final String message;
+}
+
+/// Shared implementation behind the `serverpod create-repair-migration`
+/// command, the TUI's "Repair Migration" button, and the
+/// `create_repair_migration` MCP tool.
+///
+/// Connects to the running server (in [runMode]) to fetch the live database
+/// schema, diffs it against the target migration version, and writes a repair
+/// migration if drift is found.
+Future<RepairMigrationOutcome> createRepairMigrationAction({
+  required GeneratorConfig config,
+  String? tag,
+  bool force = false,
+  String runMode = 'development',
+  String? targetMigrationVersion,
+}) async {
+  if (!config.isFeatureEnabled(ServerpodFeature.database)) {
+    return const RepairMigrationFailed(
+      'The database feature is not enabled in this project. '
+      'Repair migrations cannot be created.',
+    );
+  }
+
+  final serverDirectory = Directory(
+    path.joinAll(config.serverPackageDirectoryPathParts),
+  );
+
+  final projectName = await getProjectName(serverDirectory);
+  if (projectName == null) {
+    return const RepairMigrationFailed(
+      'Unable to determine project name from the server package.',
+    );
+  }
+
+  final generator = MigrationGenerator(
+    directory: serverDirectory,
+    projectName: projectName,
+  );
+
+  File? repairMigration;
+  try {
+    repairMigration = await generator.repairMigration(
+      tag: tag,
+      force: force,
+      runMode: runMode,
+      dialect: config.databaseDialect,
+      targetMigrationVersion: targetMigrationVersion,
+    );
+  } on MigrationRepairTargetNotFoundException catch (e) {
+    if (e.versionsFound.isEmpty) {
+      return const RepairMigrationFailed(
+        'Unable to find any migration versions.',
+      );
+    }
+    return RepairMigrationFailed(
+      'Unable to find the specified target migration "${e.targetName}". '
+      'Available versions: ${e.versionsFound}.',
+    );
+  } on MigrationVersionLoadException catch (e) {
+    return RepairMigrationFailed(
+      'Unable to determine latest database definition due to a corrupted '
+      'migration. Migration version: "${e.versionName}" for module '
+      '"${e.moduleName}".\n${e.exception}',
+    );
+  } on MigrationLiveDatabaseDefinitionException catch (e) {
+    return RepairMigrationFailed(
+      'Unable to fetch live database schema from server. Make sure the '
+      'server is running and is connected to the database.\n${e.exception}',
+    );
+  } on MigrationRepairWriteException catch (e) {
+    return RepairMigrationFailed(
+      'Unable to write repair migration.\n${e.exception}',
+    );
+  }
+
+  if (repairMigration == null) {
+    return const RepairMigrationNotCreated();
+  }
+
+  final versionName = path.basenameWithoutExtension(repairMigration.path);
+  return RepairMigrationCreated(
+    versionName: versionName,
+    filePath: repairMigration.path,
+  );
+}

--- a/tools/serverpod_cli/lib/src/migrations/generator.dart
+++ b/tools/serverpod_cli/lib/src/migrations/generator.dart
@@ -178,8 +178,13 @@ class MigrationGenerator {
   /// If [targetMigrationVersion] is not specified, the latest migration version
   /// will be used.
   ///
-  /// Returns the repair migration file, or null if no migration was
-  /// created.
+  /// Returns the repair migration file, or `null` when no schema drift is
+  /// detected between the live database and the target version (callers can
+  /// override with [force]).
+  ///
+  /// Throws [MigrationAbortedException] when warnings are present and [force]
+  /// is false. Other typed exceptions surface specific failure modes; see the
+  /// `MigrationRepair*Exception` types.
   Future<File?> repairMigration({
     String? tag,
     required bool force,
@@ -230,16 +235,12 @@ class MigrationGenerator {
     _logWarnings(warnings);
 
     if (warnings.isNotEmpty && !force) {
-      log.info('Migration aborted. Use --force to ignore warnings.');
-      return null;
+      throw const MigrationAbortedException();
     }
 
     bool versionsMismatch = _moduleVersionMismatch(liveDatabase, dstDatabase);
 
     if (migration.isEmpty && !versionsMismatch && !force) {
-      log.info(
-        'No changes detected. Use --force to create an empty repair migration.',
-      );
       return null;
     }
 

--- a/tools/serverpod_cli/test/commands/start/mcp_server_test.dart
+++ b/tools/serverpod_cli/test/commands/start/mcp_server_test.dart
@@ -56,8 +56,7 @@ void main() {
 
     test(
       'when listing tools, '
-      'then apply_migrations, create_migration, create_repair_migration, '
-      'hot_reload, hot_restart, and tail_logs are available',
+      'then all tools that operate on the running server are available',
       () async {
         final result = await connection.listTools();
 
@@ -75,7 +74,7 @@ void main() {
       },
     );
 
-    group('Given no connected callback', () {
+    group('with no connected callback', () {
       test(
         'when calling apply_migrations, '
         'then it returns an error',
@@ -141,7 +140,7 @@ void main() {
       );
     });
 
-    group('Given a connected callback', () {
+    group('with a connected callback', () {
       test(
         'when calling apply_migrations, '
         'then it invokes the callback and returns success',

--- a/tools/serverpod_cli/test/commands/start/mcp_server_test.dart
+++ b/tools/serverpod_cli/test/commands/start/mcp_server_test.dart
@@ -56,7 +56,8 @@ void main() {
 
     test(
       'when listing tools, '
-      'then apply_migrations, create_migration, hot_reload, and tail_logs are available',
+      'then apply_migrations, create_migration, create_repair_migration, '
+      'hot_reload, hot_restart, and tail_logs are available',
       () async {
         final result = await connection.listTools();
 
@@ -65,7 +66,9 @@ void main() {
           containsAll([
             'apply_migrations',
             'create_migration',
+            'create_repair_migration',
             'hot_reload',
+            'hot_restart',
             'tail_logs',
           ]),
         );
@@ -95,6 +98,38 @@ void main() {
         () async {
           final result = await connection.callTool(
             CallToolRequest(name: 'create_migration'),
+          );
+
+          expect(result.isError, isTrue);
+          expect(
+            (result.content.first as TextContent).text,
+            contains('not connected'),
+          );
+        },
+      );
+
+      test(
+        'when calling hot_restart, '
+        'then it returns an error',
+        () async {
+          final result = await connection.callTool(
+            CallToolRequest(name: 'hot_restart'),
+          );
+
+          expect(result.isError, isTrue);
+          expect(
+            (result.content.first as TextContent).text,
+            contains('not connected'),
+          );
+        },
+      );
+
+      test(
+        'when calling create_repair_migration, '
+        'then it returns an error',
+        () async {
+          final result = await connection.callTool(
+            CallToolRequest(name: 'create_repair_migration'),
           );
 
           expect(result.isError, isTrue);
@@ -240,6 +275,173 @@ void main() {
           expect(
             (result.content.first as TextContent).text,
             contains('model parse failed'),
+          );
+        },
+      );
+
+      test(
+        'when calling hot_restart, '
+        'then it invokes the callback and returns success',
+        () async {
+          var called = false;
+          server.onHotRestart = () async {
+            called = true;
+          };
+
+          final result = await connection.callTool(
+            CallToolRequest(name: 'hot_restart'),
+          );
+
+          expect(called, isTrue);
+          expect(result.isError, isNull);
+          expect(
+            (result.content.first as TextContent).text,
+            contains('Hot restart completed'),
+          );
+        },
+      );
+
+      test(
+        'when the hot_restart callback throws, '
+        'then the tool result is an error with the message',
+        () async {
+          server.onHotRestart = () async {
+            throw Exception('createServer null');
+          };
+
+          final result = await connection.callTool(
+            CallToolRequest(name: 'hot_restart'),
+          );
+
+          expect(result.isError, isTrue);
+          expect(
+            (result.content.first as TextContent).text,
+            contains('createServer null'),
+          );
+        },
+      );
+
+      test(
+        'when calling create_repair_migration without args, '
+        'then the callback is invoked with null tag, force=false, and null version',
+        () async {
+          String? receivedTag;
+          bool? receivedForce;
+          String? receivedVersion;
+          server.onCreateRepairMigration =
+              ({
+                String? tag,
+                bool force = false,
+                String? targetMigrationVersion,
+              }) async {
+                receivedTag = tag;
+                receivedForce = force;
+                receivedVersion = targetMigrationVersion;
+                return const CreateMigrationMcpResult(
+                  message: 'Repair migration "v1" created at /tmp/v1.sql.',
+                );
+              };
+
+          final result = await connection.callTool(
+            CallToolRequest(name: 'create_repair_migration'),
+          );
+
+          expect(receivedTag, isNull);
+          expect(receivedForce, isFalse);
+          expect(receivedVersion, isNull);
+          expect(result.isError, isNull);
+          expect(
+            (result.content.first as TextContent).text,
+            contains('Repair migration "v1" created'),
+          );
+        },
+      );
+
+      test(
+        'when calling create_repair_migration with tag, force, and version, '
+        'then the callback receives them',
+        () async {
+          String? receivedTag;
+          bool? receivedForce;
+          String? receivedVersion;
+          server.onCreateRepairMigration =
+              ({
+                String? tag,
+                bool force = false,
+                String? targetMigrationVersion,
+              }) async {
+                receivedTag = tag;
+                receivedForce = force;
+                receivedVersion = targetMigrationVersion;
+                return const CreateMigrationMcpResult(message: 'ok');
+              };
+
+          await connection.callTool(
+            CallToolRequest(
+              name: 'create_repair_migration',
+              arguments: {
+                'tag': 'fix-drift',
+                'force': true,
+                'version': '20240101000000',
+              },
+            ),
+          );
+
+          expect(receivedTag, 'fix-drift');
+          expect(receivedForce, isTrue);
+          expect(receivedVersion, '20240101000000');
+        },
+      );
+
+      test(
+        'when create_repair_migration returns an error result, '
+        'then the tool result is flagged as error',
+        () async {
+          server.onCreateRepairMigration =
+              ({
+                String? tag,
+                bool force = false,
+                String? targetMigrationVersion,
+              }) async {
+                return const CreateMigrationMcpResult(
+                  message: 'No repair migration created.',
+                  isError: true,
+                );
+              };
+
+          final result = await connection.callTool(
+            CallToolRequest(name: 'create_repair_migration'),
+          );
+
+          expect(result.isError, isTrue);
+          expect(
+            (result.content.first as TextContent).text,
+            contains('No repair migration created'),
+          );
+        },
+      );
+
+      test(
+        'when the create_repair_migration callback throws, '
+        'then the tool result is an error with the message',
+        () async {
+          server.onCreateRepairMigration =
+              ({
+                String? tag,
+                bool force = false,
+                String? targetMigrationVersion,
+              }) async {
+                throw Exception('live db unreachable');
+              };
+
+          final result = await connection.callTool(
+            CallToolRequest(name: 'create_repair_migration'),
+          );
+
+          expect(result.isError, isTrue);
+          expect(
+            (result.content.first as TextContent).text,
+            contains('live db unreachable'),
           );
         },
       );

--- a/tools/serverpod_cli/test/commands/start/watch_session_test.dart
+++ b/tools/serverpod_cli/test/commands/start/watch_session_test.dart
@@ -796,6 +796,65 @@ void main() {
     );
   });
 
+  group('Given forceRestart is called', () {
+    test(
+      'when invoked, '
+      'then it resets the compiler, produces a fresh full dill, and '
+      'spawns a new server with that dill',
+      () async {
+        await session.forceRestart();
+
+        expect(compiler.calls, ['reset', 'compile', 'accept']);
+        expect(server.calls, contains('stop'));
+        expect(factoryCalls, ['createServer:/out.dill']);
+      },
+    );
+
+    test(
+      'when the full compile fails, '
+      'then it does not stop the server or spawn a new one',
+      () async {
+        compiler.nextCompileResult = _failResult();
+
+        await session.forceRestart();
+
+        expect(server.calls, isNot(contains('stop')));
+        expect(factoryCalls, isEmpty);
+      },
+    );
+
+    test(
+      'when invoked after dispose, '
+      'then it throws a StateError',
+      () async {
+        await session.dispose();
+
+        expect(() => session.forceRestart(), throwsStateError);
+      },
+    );
+
+    test(
+      'when invoked while a forceReload is in flight, '
+      'then it runs after the reload completes',
+      () async {
+        final order = <String>[];
+        compiler.calls.clear();
+        server.calls.clear();
+        factoryCalls.clear();
+
+        // Both calls return immediately; we just verify ordering.
+        final reload = session.forceReload().then((_) => order.add('reload'));
+        final restart = session.forceRestart().then(
+          (_) => order.add('restart'),
+        );
+
+        await Future.wait([reload, restart]);
+
+        expect(order, ['reload', 'restart']);
+      },
+    );
+  });
+
   group('Given dispose is called', () {
     test(
       'when disposing, '
@@ -1128,6 +1187,17 @@ class Counter {
     );
 
     test(
+      'when forceRestart is called, '
+      'then it stops the server and spawns a new one with null dill',
+      () async {
+        await noCompilerSession.forceRestart();
+
+        expect(noCompilerServer.calls, contains('stop'));
+        expect(noCompilerFactoryCalls, ['createServer:null']);
+      },
+    );
+
+    test(
       'when dispose is called, '
       'then it stops the server (no compiler to dispose)',
       () async {
@@ -1160,6 +1230,14 @@ class Counter {
         await noFactorySession.forceReload();
 
         expect(noFactoryServer.calls, ['reload:null']);
+      },
+    );
+
+    test(
+      'when forceRestart is called, '
+      'then it throws a StateError',
+      () {
+        expect(() => noFactorySession.forceRestart(), throwsStateError);
       },
     );
   });

--- a/tools/serverpod_cli/test/commands/start/watch_session_test.dart
+++ b/tools/serverpod_cli/test/commands/start/watch_session_test.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:serverpod_cli/src/commands/start/file_watcher.dart';
+import 'package:serverpod_cli/src/commands/start/flutter_process.dart';
 import 'package:serverpod_cli/src/commands/start/kernel_compiler.dart';
 import 'package:serverpod_cli/src/commands/start/server_process.dart';
 import 'package:serverpod_cli/src/commands/start/watch_session.dart';
@@ -111,6 +112,35 @@ class _FakeServer extends Fake implements ServerProcess {
   }
 }
 
+class _FakeFlutter extends Fake implements FlutterProcess {
+  final List<String> calls = [];
+
+  bool _vmServiceConnected = true;
+  bool restartSuccess = true;
+
+  @override
+  bool get isVmServiceConnected => _vmServiceConnected;
+  set isVmServiceConnected(bool value) => _vmServiceConnected = value;
+
+  @override
+  Future<bool> reload() async {
+    calls.add('reload');
+    return true;
+  }
+
+  @override
+  Future<bool> restart() async {
+    calls.add('restart');
+    return restartSuccess;
+  }
+
+  @override
+  Future<int> stop({Duration timeout = const Duration(seconds: 5)}) async {
+    calls.add('stop');
+    return 0;
+  }
+}
+
 void main() {
   setUpAll(() {
     initializeLogger();
@@ -136,6 +166,7 @@ void main() {
     GenerateAction? generate,
     ApplyMigrationsAction? applyMigrationsAction,
     ProtocolChangeClassifier? classifyProtocolChange,
+    FlutterProcess? flutterProcess,
   }) {
     return WatchSession(
       compiler: compiler,
@@ -160,6 +191,7 @@ void main() {
           applyMigrationsAction ?? () async => const MigrationsApplied(),
       classifyProtocolChange:
           classifyProtocolChange ?? defaultProtocolChangeClassifier,
+      flutterProcess: flutterProcess,
     );
   }
 
@@ -878,6 +910,116 @@ void main() {
       },
     );
   });
+
+  group('Given a Flutter process with a connected VM service,', () {
+    late _FakeFlutter flutter;
+
+    setUp(() {
+      flutter = _FakeFlutter();
+      session = buildSession(
+        compiler: compiler,
+        initialServer: server,
+        flutterProcess: flutter,
+      );
+    });
+
+    test(
+      'when force restarting, '
+      'then the Flutter app is hot-restarted after the server restarts.',
+      () async {
+        await session.forceRestart();
+
+        expect(server.calls, contains('stop'));
+        expect(factoryCalls, ['createServer:/out.dill']);
+        expect(flutter.calls, ['restart']);
+      },
+    );
+  });
+
+  group(
+    'Given a Flutter process with a connected VM service and a next compile that fails,',
+    () {
+      late _FakeFlutter flutter;
+
+      setUp(() {
+        flutter = _FakeFlutter();
+        session = buildSession(
+          compiler: compiler,
+          initialServer: server,
+          flutterProcess: flutter,
+        );
+
+        compiler.nextCompileResult = _failResult();
+      });
+
+      test(
+        'when force restarting, '
+        'then the Flutter app is not hot-restarted.',
+        () async {
+          await session.forceRestart();
+
+          expect(server.calls, isNot(contains('stop')));
+          expect(flutter.calls, isEmpty);
+        },
+      );
+    },
+  );
+
+  group('Given a Flutter process with a disconnected VM service,', () {
+    late _FakeFlutter flutter;
+
+    setUp(() {
+      flutter = _FakeFlutter();
+      session = buildSession(
+        compiler: compiler,
+        initialServer: server,
+        flutterProcess: flutter,
+      );
+
+      flutter.isVmServiceConnected = false;
+    });
+
+    test(
+      'when force restarting, '
+      'then the Flutter app is not hot-restarted.',
+      () async {
+        await session.forceRestart();
+
+        expect(server.calls, contains('stop'));
+        expect(flutter.calls, isEmpty);
+      },
+    );
+  });
+
+  group(
+    'Given a Flutter process with a connected VM service and a hot restart that fails,',
+    () {
+      late _FakeFlutter flutter;
+
+      setUp(() {
+        flutter = _FakeFlutter();
+        session = buildSession(
+          compiler: compiler,
+          initialServer: server,
+          flutterProcess: flutter,
+        );
+
+        flutter.restartSuccess = false;
+      });
+
+      test(
+        'when force restarting, '
+        'then the server restart still completes.',
+        () async {
+          await session.forceRestart();
+
+          expect(server.calls, contains('stop'));
+          expect(factoryCalls, ['createServer:/out.dill']);
+          expect(flutter.calls, ['restart']);
+        },
+      );
+    },
+  );
 
   group('Given dispose is called', () {
     test(

--- a/tools/serverpod_cli/test/commands/start/watch_session_test.dart
+++ b/tools/serverpod_cli/test/commands/start/watch_session_test.dart
@@ -828,54 +828,71 @@ void main() {
     );
   });
 
-  group('Given forceRestart is called', () {
-    test(
-      'when invoked, '
-      'then it resets the compiler, produces a fresh full dill, and '
-      'spawns a new server with that dill',
-      () async {
+  group(
+    'Given a watch session with a compiler with no errors,'
+    'when force restart is called,',
+    () {
+      setUp(() async {
         await session.forceRestart();
+      });
 
+      test('then it resets the compiler.', () {
         expect(compiler.calls, ['reset', 'compile', 'accept']);
+      });
+
+      test('then it stops the server.', () {
         expect(server.calls, contains('stop'));
+      });
+
+      test('then it creates a new server with the fresh full dill.', () {
         expect(factoryCalls, ['createServer:/out.dill']);
-      },
-    );
+      });
+    },
+  );
+
+  test(
+    'Given a watch session with a compiler that fails,'
+    'when force restart is called,'
+    'then it does not stop the server or spawn a new one.',
+    () async {
+      compiler.nextCompileResult = _failResult();
+
+      await session.forceRestart();
+
+      expect(server.calls, isNot(contains('stop')));
+      expect(factoryCalls, isEmpty);
+    },
+  );
+
+  test(
+    'Given a watch session that is disposed,'
+    'when force restart is called, '
+    'then it throws a StateError.',
+    () async {
+      await session.dispose();
+
+      expect(() => session.forceRestart(), throwsStateError);
+    },
+  );
+
+  group('Given a watch session with an in-flight forceReload,', () {
+    late List<String> order;
+    late Future<void> reload;
+
+    setUp(() async {
+      order = <String>[];
+      compiler.calls.clear();
+      server.calls.clear();
+      factoryCalls.clear();
+
+      // Both calls return immediately; we just verify ordering.
+      reload = session.forceReload().then((_) => order.add('reload'));
+    });
 
     test(
-      'when the full compile fails, '
-      'then it does not stop the server or spawn a new one',
-      () async {
-        compiler.nextCompileResult = _failResult();
-
-        await session.forceRestart();
-
-        expect(server.calls, isNot(contains('stop')));
-        expect(factoryCalls, isEmpty);
-      },
-    );
-
-    test(
-      'when invoked after dispose, '
-      'then it throws a StateError',
-      () async {
-        await session.dispose();
-
-        expect(() => session.forceRestart(), throwsStateError);
-      },
-    );
-
-    test(
-      'when invoked while a forceReload is in flight, '
+      'when force restart is called, '
       'then it runs after the reload completes',
       () async {
-        final order = <String>[];
-        compiler.calls.clear();
-        server.calls.clear();
-        factoryCalls.clear();
-
-        // Both calls return immediately; we just verify ordering.
-        final reload = session.forceReload().then((_) => order.add('reload'));
         final restart = session.forceRestart().then(
           (_) => order.add('restart'),
         );
@@ -885,21 +902,27 @@ void main() {
         expect(order, ['reload', 'restart']);
       },
     );
+  });
+
+  group('Given a watch session with an in-flight applyMigration,', () {
+    late List<String> order;
+    late Future<void> apply;
+
+    setUp(() async {
+      order = <String>[];
+      compiler.calls.clear();
+      server.calls.clear();
+      factoryCalls.clear();
+
+      // applyMigration also queues onto [_chain], so a forceRestart issued
+      // before it returns must wait for it.
+      apply = session.applyMigration().then((_) => order.add('apply'));
+    });
 
     test(
-      'when invoked while an applyMigration is in flight, '
-      'then it runs after the migration completes',
+      'when force restart is called, '
+      'then it runs after the applyMigration completes.',
       () async {
-        final order = <String>[];
-        compiler.calls.clear();
-        server.calls.clear();
-        factoryCalls.clear();
-
-        // applyMigration also queues onto [_chain], so a forceRestart issued
-        // before it returns must wait for it.
-        final apply = session.applyMigration().then(
-          (_) => order.add('apply'),
-        );
         final restart = session.forceRestart().then(
           (_) => order.add('restart'),
         );
@@ -924,7 +947,7 @@ void main() {
     });
 
     test(
-      'when force restarting, '
+      'when force restart is called, '
       'then the Flutter app is hot-restarted after the server restarts.',
       () async {
         await session.forceRestart();
@@ -953,7 +976,7 @@ void main() {
       });
 
       test(
-        'when force restarting, '
+        'when force restart is called, '
         'then the Flutter app is not hot-restarted.',
         () async {
           await session.forceRestart();
@@ -980,7 +1003,7 @@ void main() {
     });
 
     test(
-      'when force restarting, '
+      'when force restart is called, '
       'then the Flutter app is not hot-restarted.',
       () async {
         await session.forceRestart();
@@ -1008,7 +1031,7 @@ void main() {
       });
 
       test(
-        'when force restarting, '
+        'when force restart is called, '
         'then the server restart still completes.',
         () async {
           await session.forceRestart();

--- a/tools/serverpod_cli/test/commands/start/watch_session_test.dart
+++ b/tools/serverpod_cli/test/commands/start/watch_session_test.dart
@@ -853,6 +853,30 @@ void main() {
         expect(order, ['reload', 'restart']);
       },
     );
+
+    test(
+      'when invoked while an applyMigration is in flight, '
+      'then it runs after the migration completes',
+      () async {
+        final order = <String>[];
+        compiler.calls.clear();
+        server.calls.clear();
+        factoryCalls.clear();
+
+        // applyMigration also queues onto [_chain], so a forceRestart issued
+        // before it returns must wait for it.
+        final apply = session.applyMigration().then(
+          (_) => order.add('apply'),
+        );
+        final restart = session.forceRestart().then(
+          (_) => order.add('restart'),
+        );
+
+        await Future.wait([apply, restart]);
+
+        expect(order, ['apply', 'restart']);
+      },
+    );
   });
 
   group('Given dispose is called', () {

--- a/tools/serverpod_cli/test/commands/tui/components_test.dart
+++ b/tools/serverpod_cli/test/commands/tui/components_test.dart
@@ -1,0 +1,115 @@
+import 'package:nocterm/nocterm.dart';
+import 'package:serverpod_cli/src/commands/tui/components/button.dart';
+import 'package:test/test.dart';
+
+Future<NoctermTester> _pumpButton({
+  required void Function(LogicalKey) onActivate,
+  void Function(LogicalKey)? onShiftActivate,
+  String name = 'Reload',
+}) async {
+  final tester = await NoctermTester.create(size: const Size(20, 1));
+  await tester.pumpComponent(
+    Button(
+      name: name,
+      activationChar: 'R',
+      activationKeys: const [LogicalKey.keyR],
+      onActivate: onActivate,
+      onShiftActivate: onShiftActivate,
+    ),
+  );
+  return tester;
+}
+
+Future<void> _send(NoctermTester tester, LogicalKey key, {bool shift = false}) {
+  return tester.sendKeyEvent(
+    KeyboardEvent(
+      logicalKey: key,
+      modifiers: ModifierKeys(shift: shift),
+    ),
+  );
+}
+
+void main() {
+  // NoctermTestBinding is a process-wide singleton, so every test must
+  // dispose its tester before the next one can call NoctermTester.create.
+  late NoctermTester tester;
+  tearDown(() => tester.dispose());
+
+  group('Given a Button without onShiftActivate', () {
+    test(
+      'when a bare activation key is pressed, '
+      'then onActivate fires with that key',
+      () async {
+        LogicalKey? activated;
+        tester = await _pumpButton(onActivate: (k) => activated = k);
+
+        await _send(tester, LogicalKey.keyR);
+
+        expect(activated, LogicalKey.keyR);
+      },
+    );
+
+    test(
+      'when rendered, '
+      'then the name has no ⇧ glyph',
+      () async {
+        tester = await _pumpButton(name: 'Reload', onActivate: (_) {});
+
+        expect(tester.terminalState, containsText('Reload'));
+        expect(tester.terminalState, isNot(containsText('⇧')));
+      },
+    );
+  });
+
+  group('Given a Button with onShiftActivate', () {
+    test(
+      'when a bare activation key is pressed, '
+      'then onActivate fires and onShiftActivate does not',
+      () async {
+        LogicalKey? activated;
+        var shiftFired = false;
+        tester = await _pumpButton(
+          onActivate: (k) => activated = k,
+          onShiftActivate: (_) => shiftFired = true,
+        );
+
+        await _send(tester, LogicalKey.keyR);
+
+        expect(activated, LogicalKey.keyR);
+        expect(shiftFired, isFalse);
+      },
+    );
+
+    test(
+      'when Shift+activation key is pressed, '
+      'then onShiftActivate fires and onActivate does not',
+      () async {
+        var activateFired = false;
+        LogicalKey? shiftActivated;
+        tester = await _pumpButton(
+          onActivate: (_) => activateFired = true,
+          onShiftActivate: (k) => shiftActivated = k,
+        );
+
+        await _send(tester, LogicalKey.keyR, shift: true);
+
+        expect(shiftActivated, LogicalKey.keyR);
+        expect(activateFired, isFalse);
+      },
+    );
+
+    test(
+      'when rendered, '
+      'then the name carries a trailing ⇧ glyph',
+      () async {
+        tester = await _pumpButton(
+          name: 'Reload',
+          onActivate: (_) {},
+          onShiftActivate: (_) {},
+        );
+
+        expect(tester.terminalState, containsText('Reload⇧'));
+      },
+    );
+  });
+}

--- a/tools/serverpod_cli/test/commands/tui/components_test.dart
+++ b/tools/serverpod_cli/test/commands/tui/components_test.dart
@@ -48,17 +48,6 @@ void main() {
         expect(activated, LogicalKey.keyR);
       },
     );
-
-    test(
-      'when rendered, '
-      'then the name has no ⇧ glyph',
-      () async {
-        tester = await _pumpButton(name: 'Reload', onActivate: (_) {});
-
-        expect(tester.terminalState, containsText('Reload'));
-        expect(tester.terminalState, isNot(containsText('⇧')));
-      },
-    );
   });
 
   group('Given a Button with onShiftActivate', () {
@@ -95,20 +84,6 @@ void main() {
 
         expect(shiftActivated, LogicalKey.keyR);
         expect(activateFired, isFalse);
-      },
-    );
-
-    test(
-      'when rendered, '
-      'then the name carries a trailing ⇧ glyph',
-      () async {
-        tester = await _pumpButton(
-          name: 'Reload',
-          onActivate: (_) {},
-          onShiftActivate: (_) {},
-        );
-
-        expect(tester.terminalState, containsText('Reload⇧'));
       },
     );
   });

--- a/tools/serverpod_cli/test/mcp/bridge_mcp_server_test.dart
+++ b/tools/serverpod_cli/test/mcp/bridge_mcp_server_test.dart
@@ -91,7 +91,9 @@ void main() {
           // Forwarded tools are not registered until connect.
           expect(names, isNot(contains('apply_migrations')));
           expect(names, isNot(contains('create_migration')));
+          expect(names, isNot(contains('create_repair_migration')));
           expect(names, isNot(contains('hot_reload')));
+          expect(names, isNot(contains('hot_restart')));
           expect(names, isNot(contains('tail_logs')));
         },
       );
@@ -196,7 +198,9 @@ void main() {
                 'stop',
                 'apply_migrations',
                 'create_migration',
+                'create_repair_migration',
                 'hot_reload',
+                'hot_restart',
                 'tail_logs',
               }),
             );


### PR DESCRIPTION
Adds two new tools to the serverpod MCP server, each with a matching TUI button, and establishes a Flutter-style Shift convention for the TUI: lowercase keys are the common case, Shift+key is the more disruptive sibling.

- `hot_restart` (MCP) / `Shift+R` (TUI) - Full server-process restart with a fresh recompile.
- `create_repair_migration` (MCP) / `Shift+P` (TUI) 

## Migration refactor

- Now warnings throw `MigrationAbortedException` (matching the create-migration sibling); null means only "no changes detected".
- Exceptions (`MigrationVersionLoadException`, `MigrationRepairTargetNotFoundException`, etc.) now own their user-facing prose via `toString`. 

## TUI niceties

- Help overlay now shrink-wraps and scrolls when the terminal is short.
- New `ShrinkWrapScrollView` component (`tui/components/shrink_wrap_scroll_view.dart`) for that pattern.

Closes: #5088 
Closes: #5117

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

## Breaking changes

None. (If you don't count Human interface - which we don't).