### PR TITLE
fix: Skip `pubspec_overrides.yaml` and `melos` files when creating project locally

### DIFF
--- a/tests/bootstrap_project/test/module_test.dart
+++ b/tests/bootstrap_project/test/module_test.dart
@@ -347,6 +347,58 @@ void main() {
           );
         });
 
+        test('does not copy template pubspec lock files into packages', () {
+          final packageDirs = [serverDir, clientDir];
+
+          for (final packageDir in packageDirs) {
+            expect(
+              File(
+                path.join(tempPath, packageDir, 'pubspec.lock'),
+              ).existsSync(),
+              isFalse,
+              reason: 'Template pubspec.lock was copied into $packageDir.',
+            );
+          }
+        });
+
+        test('does not copy template pubspec override files', () {
+          final packageDirs = [projectName, serverDir, clientDir];
+
+          for (final packageDir in packageDirs) {
+            expect(
+              File(
+                path.join(tempPath, packageDir, 'pubspec_overrides.yaml'),
+              ).existsSync(),
+              isFalse,
+              reason:
+                  'Template pubspec_overrides.yaml was copied into $packageDir.',
+            );
+          }
+        });
+
+        test('does not copy template melos project files', () {
+          final packageDirs = [projectName, serverDir, clientDir];
+
+          for (final packageDir in packageDirs) {
+            final directory = Directory(path.join(tempPath, packageDir));
+            final melosProjectFiles = directory
+                .listSync()
+                .whereType<File>()
+                .where((file) {
+                  final fileName = path.basename(file.path);
+                  return fileName.startsWith('melos_') &&
+                      fileName.endsWith('.iml');
+                });
+
+            expect(
+              melosProjectFiles,
+              isEmpty,
+              reason:
+                  'Template melos project file was copied into $packageDir.',
+            );
+          }
+        });
+
         test('has agent skills installed', () {
           expect(
             Directory(

--- a/tests/bootstrap_project/test/project_test.dart
+++ b/tests/bootstrap_project/test/project_test.dart
@@ -695,6 +695,58 @@ void main() async {
           );
         });
 
+        test('does not copy template pubspec lock files into packages', () {
+          final packageDirs = [serverDir, clientDir, flutterDir];
+
+          for (final packageDir in packageDirs) {
+            expect(
+              File(
+                path.join(tempPath, packageDir, 'pubspec.lock'),
+              ).existsSync(),
+              isFalse,
+              reason: 'Template pubspec.lock was copied into $packageDir.',
+            );
+          }
+        });
+
+        test('does not copy template pubspec override files', () {
+          final packageDirs = [projectName, serverDir, clientDir, flutterDir];
+
+          for (final packageDir in packageDirs) {
+            expect(
+              File(
+                path.join(tempPath, packageDir, 'pubspec_overrides.yaml'),
+              ).existsSync(),
+              isFalse,
+              reason:
+                  'Template pubspec_overrides.yaml was copied into $packageDir.',
+            );
+          }
+        });
+
+        test('does not copy template melos project files', () {
+          final packageDirs = [projectName, serverDir, clientDir, flutterDir];
+
+          for (final packageDir in packageDirs) {
+            final directory = Directory(path.join(tempPath, packageDir));
+            final melosProjectFiles = directory
+                .listSync()
+                .whereType<File>()
+                .where((file) {
+                  final fileName = path.basename(file.path);
+                  return fileName.startsWith('melos_') &&
+                      fileName.endsWith('.iml');
+                });
+
+            expect(
+              melosProjectFiles,
+              isEmpty,
+              reason:
+                  'Template melos project file was copied into $packageDir.',
+            );
+          }
+        });
+
         test(
           'then the flutter pubspec contains override for flutter secure storage',
           () {

--- a/tools/serverpod_cli/lib/src/create/copier.dart
+++ b/tools/serverpod_cli/lib/src/create/copier.dart
@@ -15,7 +15,7 @@ class Copier {
 
   List<String> removePatterns;
 
-  List<String> ignoreFileNames;
+  Set<String> ignoreFileNames;
 
   bool processUncommentMarker;
 
@@ -25,9 +25,12 @@ class Copier {
     required this.replacements,
     required this.fileNameReplacements,
     this.removePatterns = const <String>[],
-    this.ignoreFileNames = const <String>[],
+    List<String> ignoreFileNames = const <String>[],
     this.processUncommentMarker = true,
-  });
+  }) : ignoreFileNames = ignoreFileNames.toSet()
+         // Automatically ignore files that might exist in the local clone of
+         // the Serverpod repository when using a local built CLI.
+         ..addAll(['pubspec.lock', 'pubspec_overrides.yaml']);
 
   void copyFiles() {
     _copyDirectory(srcDir, '');
@@ -52,6 +55,9 @@ class Copier {
   void _copyFile(File srcFile, String relativePath) {
     var fileName = p.basename(srcFile.path);
     if (fileName.startsWith('.')) return;
+
+    // Ignore melos project files.
+    if (fileName.startsWith('melos_') && fileName.endsWith('.iml')) return;
 
     var dstFileName = _replace(
       p.join(relativePath, fileName),

--- a/tools/serverpod_cli/lib/src/create/create.dart
+++ b/tools/serverpod_cli/lib/src/create/create.dart
@@ -1087,7 +1087,6 @@ void _copyServerTemplates(
         replacement: '.gitignore',
       ),
     ],
-    ignoreFileNames: ['pubspec.lock', 'pubspec_overrides.yaml'],
   );
   copier.copyFiles();
 
@@ -1118,7 +1117,6 @@ void _copyServerTemplates(
         replacement: '.gitignore',
       ),
     ],
-    ignoreFileNames: ['pubspec.lock', 'pubspec_overrides.yaml'],
   );
   copier.copyFiles();
 
@@ -1150,8 +1148,6 @@ void _copyServerTemplates(
       ),
     ],
     ignoreFileNames: [
-      'pubspec.lock',
-      'pubspec_overrides.yaml',
       'ios',
       'android',
       'web',
@@ -1238,7 +1234,6 @@ void _copyModuleTemplates(
         replacement: '.gitignore',
       ),
     ],
-    ignoreFileNames: ['pubspec.lock', 'pubspec_overrides.yaml'],
   );
   copier.copyFiles();
 
@@ -1269,7 +1264,6 @@ void _copyModuleTemplates(
         replacement: '.gitignore',
       ),
     ],
-    ignoreFileNames: ['pubspec.lock', 'pubspec_overrides.yaml'],
   );
   copier.copyFiles();
 


### PR DESCRIPTION
Fixes: #5112

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.