### PR TITLE
feat: Run flutter app on serverpod start

### DIFF
--- a/templates/serverpod_templates/vscode/launch.json
+++ b/templates/serverpod_templates/vscode/launch.json
@@ -6,7 +6,9 @@
       "cwd": "${workspaceFolder}/projectname_flutter",
       "request": "launch",
       "type": "dart",
-      "program": "lib/main.dart"
+      "program": "lib/main.dart",
+      "debugServer": 9000,
+      "preLaunchTask": "serverpod_start_debug_adapter"
     },
     {
       "name": "projectname_server",
@@ -20,7 +22,10 @@
   "compounds": [
     {
       "name": "projectname (full stack)",
-      "configurations": ["projectname_server", "projectname_flutter"],
+      "configurations": [
+        "projectname_server",
+        "projectname_flutter"
+      ],
       "presentation": {
         "order": 1
       }

--- a/templates/serverpod_templates/vscode/tasks.json
+++ b/templates/serverpod_templates/vscode/tasks.json
@@ -2,10 +2,38 @@
   "version": "2.0.0",
   "tasks": [
     {
+      "label": "serverpod_start_debug_adapter",
+      "type": "shell",
+      "command": "serverpod",
+      "args": [
+        "start-debug-adapter"
+      ],
+      "isBackground": true,
+      "problemMatcher": {
+        "owner": "serverpod",
+        "pattern": [
+          {
+            "regexp": ".",
+            "file": 1,
+            "line": 2,
+            "message": 1
+          }
+        ],
+        "background": {
+          "activeOnStart": true,
+          "beginsPattern": "Starting flutter debug adapter",
+          "endsPattern": "Flutter debug adapter ready"
+        }
+      }
+    },
+    {
       "label": "serverpod_start",
       "type": "shell",
       "command": "serverpod",
-      "args": ["start"],
+      "args": [
+        "start",
+        "--no-flutter"
+      ],
       "options": {
         "cwd": "${workspaceFolder}/projectname_server",
         // {{#postgres}}

--- a/tools/serverpod_cli/bin/serverpod_cli.dart
+++ b/tools/serverpod_cli/bin/serverpod_cli.dart
@@ -16,6 +16,7 @@ import 'package:serverpod_cli/src/commands/migrate.dart';
 import 'package:serverpod_cli/src/commands/quickstart.dart';
 import 'package:serverpod_cli/src/commands/run.dart';
 import 'package:serverpod_cli/src/commands/start.dart';
+import 'package:serverpod_cli/src/commands/start_debug_adapter.dart';
 import 'package:serverpod_cli/src/commands/upgrade.dart';
 import 'package:serverpod_cli/src/commands/version.dart';
 import 'package:serverpod_cli/src/downloads/resource_manager.dart';
@@ -126,6 +127,7 @@ ServerpodCommandRunner buildCommandRunner() {
     StartCommand(),
     UpgradeCommand(),
     VersionCommand(version),
+    StartDebugAdapterCommand(),
   ]);
 }
 

--- a/tools/serverpod_cli/lib/src/commands/messages.dart
+++ b/tools/serverpod_cli/lib/src/commands/messages.dart
@@ -10,3 +10,5 @@ const serverRunning = 'Server running.';
 // Watch command messages
 const serverReloaded = '✓ Server reloaded.';
 const serverRestarted = '✓ Server restarted.';
+const flutterAppReloaded = '✓ Flutter app reloaded.';
+const flutterAppRestarted = '✓ Flutter app restarted.';

--- a/tools/serverpod_cli/lib/src/commands/messages.dart
+++ b/tools/serverpod_cli/lib/src/commands/messages.dart
@@ -10,5 +10,3 @@ const serverRunning = 'Server running.';
 // Watch command messages
 const serverReloaded = '✓ Server reloaded.';
 const serverRestarted = '✓ Server restarted.';
-const flutterAppReloaded = '✓ Flutter app reloaded.';
-const flutterAppRestarted = '✓ Flutter app restarted.';

--- a/tools/serverpod_cli/lib/src/commands/start.dart
+++ b/tools/serverpod_cli/lib/src/commands/start.dart
@@ -10,6 +10,7 @@ import 'package:serverpod_cli/analyzer.dart';
 import 'package:serverpod_cli/src/commands/generate.dart';
 import 'package:serverpod_cli/src/commands/messages.dart';
 import 'package:serverpod_cli/src/commands/start/file_watcher.dart';
+import 'package:serverpod_cli/src/commands/start/flutter_process.dart';
 import 'package:serverpod_cli/src/commands/start/kernel_compiler.dart';
 import 'package:serverpod_cli/src/commands/start/mcp_server.dart';
 import 'package:serverpod_cli/src/commands/start/mcp_socket.dart';
@@ -74,6 +75,13 @@ enum StartOption<V> implements OptionDefinition<V> {
       helpText: 'Show interactive terminal UI.',
     ),
   ),
+  flutter(
+    FlagOption(
+      argName: 'flutter',
+      defaultsTo: true,
+      helpText: 'Launch the Flutter app.',
+    ),
+  ),
   ;
 
   const StartOption(this.option);
@@ -117,6 +125,7 @@ class StartCommand extends ServerpodCommand<StartOption> {
   ) async {
     final watch = commandConfig.value(StartOption.watch);
     final useTui = commandConfig.value(StartOption.tui) && stdout.hasTerminal;
+    final launchFlutterApp = commandConfig.value(StartOption.flutter);
 
     // In TUI mode, start the UI immediately and do all setup in onReady.
     // This avoids a visible delay from config loading and Docker checks.
@@ -135,6 +144,7 @@ class StartCommand extends ServerpodCommand<StartOption> {
       final exitCode = await _runWithTui(
         commandConfig: commandConfig,
         watch: watch,
+        launchFlutterApp: launchFlutterApp,
         serverArgs: argResults?.rest ?? [],
         config: config,
       );
@@ -184,6 +194,7 @@ class StartCommand extends ServerpodCommand<StartOption> {
         serverArgs: serverArgs,
         watch: watch,
         docker: docker,
+        launchFlutterApp: launchFlutterApp,
         shutdown: shutdown,
       );
       switch (result) {
@@ -333,9 +344,13 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
   required ServerArgsRef serverArgs,
   required bool watch,
   required bool docker,
+  required bool launchFlutterApp,
   required _ShutdownSignal shutdown,
+  bool useTui = false,
   IOSink? serverStdoutSink,
   IOSink? serverStderrSink,
+  IOSink? flutterStdoutSink,
+  IOSink? flutterStderrSink,
   Future<void> Function(ServerProcess server)? onServerStart,
   List<Object> Function()? mcpGetLogHistory,
 }) async {
@@ -489,6 +504,19 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
     return true;
   });
 
+  FlutterProcess? flutterProcess;
+
+  if (launchFlutterApp) {
+    flutterProcess = FlutterProcess(
+      flutterPackageDir: p.joinAll(config.flutterPackagePathParts),
+      spawnFromTui: useTui,
+      stdoutSink: flutterStdoutSink,
+      stderrSink: flutterStderrSink,
+    );
+
+    await flutterProcess.start();
+  }
+
   // Construct the watch session.
   final runMode = runModeFromServerArgs(serverArgs.value);
   session = WatchSession(
@@ -505,6 +533,7 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
     },
     createServer: serverProcessFactory,
     initialServer: initialServerProcess,
+    flutterProcess: flutterProcess,
     generatedDirPaths: config.generatedDirPaths,
     applyMigrationsAction: () => _applyMigrationsForSession(
       serverDir: serverDir,
@@ -547,6 +576,7 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
 
   // File watcher (watch mode only).
   StreamSubscription<void>? fileChangeSub;
+  StreamSubscription<void>? flutterFileChangeSub;
   if (watch) {
     final watcher = FileWatcher(
       watchPaths: {
@@ -558,9 +588,24 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
         ),
       },
     );
+
     fileChangeSub = watcher.onFilesChanged
         .asyncMapBuffer((events) => session.handleFileChange(events.merge()))
         .listen((_) {});
+
+    FileWatcher? flutterWatcher;
+
+    if (launchFlutterApp) {
+      flutterWatcher = FileWatcher(
+        watchPaths: {
+          p.absolute(p.joinAll([...config.flutterPackagePathParts, 'lib'])),
+        },
+      );
+
+      flutterFileChangeSub = flutterWatcher.onFilesChanged
+          .asyncMapBuffer((events) async => flutterProcess?.reload())
+          .listen((_) {});
+    }
   }
 
   return WatchLoopReady(
@@ -571,6 +616,10 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
       fileChangeSub: fileChangeSub,
       closeAnalyzers: closeAnalyzers,
       stopDocker: startedDocker ? () => _stopDockerServices(serverDir) : null,
+      stopFlutterProcess: () async {
+        await flutterFileChangeSub?.cancel();
+        await flutterProcess?.stop();
+      },
       vmServiceInfoFile: vmServiceInfoFile,
     ),
   );
@@ -707,10 +756,12 @@ Future<String?> _checkExistingServer(String infoPath) async {
 Future<int> _runWithTui({
   required Configuration<StartOption> commandConfig,
   required bool watch,
+  required bool launchFlutterApp,
   required List<String> serverArgs,
   required GeneratorConfig config,
 }) async {
-  final holder = StartAppStateHolder(ServerWatchState());
+  final state = ServerWatchState()..showFlutterOutput = launchFlutterApp;
+  final holder = StartAppStateHolder(state);
   var backendStarted = false;
 
   // Shared shutdown signal
@@ -731,6 +782,7 @@ Future<int> _runWithTui({
           holder: h,
           commandConfig: commandConfig,
           watch: watch,
+          launchFlutterApp: launchFlutterApp,
           serverArgs: serverArgs,
           config: config,
           shutdown: shutdown,
@@ -764,6 +816,7 @@ Future<void> _runTuiBackend({
   required StartAppStateHolder holder,
   required Configuration<StartOption> commandConfig,
   required bool watch,
+  required bool launchFlutterApp,
   required List<String> serverArgs,
   required GeneratorConfig config,
   required _ShutdownSignal shutdown,
@@ -779,8 +832,23 @@ Future<void> _runTuiBackend({
 
     final argsRef = ServerArgsRef(serverArgs);
 
-    final stdoutSink = TuiLogSink(holder);
-    final stderrSink = TuiLogSink(holder);
+    final serverStdoutSink = TuiLogSink(
+      holder,
+      addLine: holder.state.rawLines.add,
+    );
+    final serverStderrSink = TuiLogSink(
+      holder,
+      addLine: holder.state.rawLines.add,
+    );
+
+    final flutterStdoutSink = TuiLogSink(
+      holder,
+      addLine: holder.state.rawFlutterProcessLines.add,
+    );
+    final flutterStderrSink = TuiLogSink(
+      holder,
+      addLine: holder.state.rawFlutterProcessLines.add,
+    );
 
     final result = await _setupWatchLoop(
       config: config,
@@ -788,9 +856,13 @@ Future<void> _runTuiBackend({
       serverArgs: argsRef,
       watch: watch,
       docker: docker,
+      launchFlutterApp: launchFlutterApp,
+      useTui: true,
       shutdown: shutdown,
-      serverStdoutSink: stdoutSink,
-      serverStderrSink: stderrSink,
+      serverStdoutSink: serverStdoutSink,
+      serverStderrSink: serverStderrSink,
+      flutterStdoutSink: flutterStdoutSink,
+      flutterStderrSink: flutterStderrSink,
       onServerStart: (server) async {
         final vmService = server.vmService;
         if (vmService == null) return;

--- a/tools/serverpod_cli/lib/src/commands/start.dart
+++ b/tools/serverpod_cli/lib/src/commands/start.dart
@@ -11,6 +11,7 @@ import 'package:serverpod_cli/src/commands/generate.dart';
 import 'package:serverpod_cli/src/commands/messages.dart';
 import 'package:serverpod_cli/src/commands/start/file_watcher.dart';
 import 'package:serverpod_cli/src/commands/start/flutter_process.dart';
+import 'package:serverpod_cli/src/commands/start/flutter_reloader.dart';
 import 'package:serverpod_cli/src/commands/start/kernel_compiler.dart';
 import 'package:serverpod_cli/src/commands/start/mcp_server.dart';
 import 'package:serverpod_cli/src/commands/start/mcp_socket.dart';
@@ -82,6 +83,22 @@ enum StartOption<V> implements OptionDefinition<V> {
       helpText: 'Launch the Flutter app.',
     ),
   ),
+  debugAdapterProxyPort(
+    IntOption(
+      argName: 'debug-adapter-proxy-port',
+      defaultsTo: 9000,
+      helpText:
+          'The port where the flutter debug adapter proxy server will listen.',
+    ),
+  ),
+  debugAdapterControlPort(
+    IntOption(
+      argName: 'debug-adapter-control-port',
+      defaultsTo: 4567,
+      helpText:
+          'The port where the flutter debug adapter control server will listen.',
+    ),
+  ),
   ;
 
   const StartOption(this.option);
@@ -126,6 +143,12 @@ class StartCommand extends ServerpodCommand<StartOption> {
     final watch = commandConfig.value(StartOption.watch);
     final useTui = commandConfig.value(StartOption.tui) && stdout.hasTerminal;
     final launchFlutterApp = commandConfig.value(StartOption.flutter);
+    final debugAdapterProxyPort = commandConfig.value(
+      StartOption.debugAdapterProxyPort,
+    );
+    final debugAdapterControlPort = commandConfig.value(
+      StartOption.debugAdapterControlPort,
+    );
 
     // In TUI mode, start the UI immediately and do all setup in onReady.
     // This avoids a visible delay from config loading and Docker checks.
@@ -147,6 +170,8 @@ class StartCommand extends ServerpodCommand<StartOption> {
         launchFlutterApp: launchFlutterApp,
         serverArgs: argResults?.rest ?? [],
         config: config,
+        debugAdapterProxyPort: debugAdapterProxyPort,
+        debugAdapterControlPort: debugAdapterControlPort,
       );
       if (exitCode != 0) throw ExitException(exitCode);
       return;
@@ -196,6 +221,8 @@ class StartCommand extends ServerpodCommand<StartOption> {
         docker: docker,
         launchFlutterApp: launchFlutterApp,
         shutdown: shutdown,
+        debugAdapterProxyPort: debugAdapterProxyPort,
+        debugAdapterControlPort: debugAdapterControlPort,
       );
       switch (result) {
         case WatchLoopAborted(:final exitCode):
@@ -346,6 +373,8 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
   required bool docker,
   required bool launchFlutterApp,
   required _ShutdownSignal shutdown,
+  required int debugAdapterProxyPort,
+  required int debugAdapterControlPort,
   bool useTui = false,
   IOSink? serverStdoutSink,
   IOSink? serverStderrSink,
@@ -362,6 +391,12 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
   // user-facing vm-service-info.json receives the proxy URI written by
   // _mountOrRetargetProxy.
   final podInfoFile = p.join(serverpodToolDir, 'vm-service-info.pod.json');
+
+  // The file is modified when start is called with an already running server.
+  // FlutterReloader watches this file to reconnect to the debug adapter.
+  final flutterAppInfoPath = p.join(serverpodToolDir, 'flutter-app-info');
+
+  final hasFlutterPackage = config.flutterPackagePathParts.isNotEmpty;
 
   // Start Docker Compose services if needed.
   var startedDocker = false;
@@ -383,6 +418,13 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
     log.info('Existing server found.');
     log.info('VM service proxy listening on $existingUri');
     await stopDockerIfStarted();
+    if (hasFlutterPackage) {
+      // write to flutter info file to trigger
+      // possible reconnection to the debug adapter
+      final flutterAppInfoFile = File(flutterAppInfoPath);
+      await flutterAppInfoFile.create(recursive: true);
+      await flutterAppInfoFile.writeAsString(' ');
+    }
     return const WatchLoopAborted(0);
   }
 
@@ -504,21 +546,34 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
     return true;
   });
 
-  bool canCreateFlutterProcess =
-      launchFlutterApp && config.flutterPackagePathParts.isNotEmpty;
+  bool canCreateFlutterProcess = launchFlutterApp && hasFlutterPackage;
+
+  final flutterPackageDir = p.joinAll(config.flutterPackagePathParts);
 
   FlutterProcess? flutterProcess;
+  FlutterReloader? flutterReloader;
+
+  if (hasFlutterPackage) {
+    flutterReloader = FlutterReloader(
+      debugAdapterControlPort: debugAdapterControlPort,
+      flutterAppInfoPath: flutterAppInfoPath,
+    );
+  }
 
   if (canCreateFlutterProcess) {
     flutterProcess = FlutterProcess(
-      flutterPackageDir: p.joinAll(config.flutterPackagePathParts),
-      spawnFromTui: useTui,
+      flutterPackageDir: flutterPackageDir,
+      args: serverArgs.value..remove('--apply-migrations'),
       stdoutSink: flutterStdoutSink,
       stderrSink: flutterStderrSink,
+      debugAdapterProxyPort: debugAdapterProxyPort,
+      debugAdapterControlPort: debugAdapterControlPort,
     );
 
     await flutterProcess.start();
   }
+
+  await flutterReloader?.start();
 
   // Construct the watch session.
   final runMode = runModeFromServerArgs(serverArgs.value);
@@ -536,7 +591,7 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
     },
     createServer: serverProcessFactory,
     initialServer: initialServerProcess,
-    flutterProcess: flutterProcess,
+    flutterReloader: flutterReloader,
     generatedDirPaths: config.generatedDirPaths,
     applyMigrationsAction: () => _applyMigrationsForSession(
       serverDir: serverDir,
@@ -599,12 +654,13 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
     if (canCreateFlutterProcess) {
       final flutterWatcher = FileWatcher(
         watchPaths: {
+          p.absolute(p.joinAll([...config.clientPackagePathParts, 'lib'])),
           p.absolute(p.joinAll([...config.flutterPackagePathParts, 'lib'])),
         },
       );
 
       flutterFileChangeSub = flutterWatcher.onFilesChanged
-          .asyncMapBuffer((events) async => flutterProcess?.reload())
+          .asyncMapBuffer((events) async => flutterReloader?.reload())
           .listen((_) {});
     }
   }
@@ -620,6 +676,7 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
       stopFlutterProcess: () async {
         await flutterFileChangeSub?.cancel();
         await flutterProcess?.stop();
+        await flutterReloader?.stop();
       },
       vmServiceInfoFile: vmServiceInfoFile,
     ),
@@ -760,6 +817,8 @@ Future<int> _runWithTui({
   required bool launchFlutterApp,
   required List<String> serverArgs,
   required GeneratorConfig config,
+  required int debugAdapterProxyPort,
+  required int debugAdapterControlPort,
 }) async {
   bool showFlutterOutput =
       launchFlutterApp && config.flutterPackagePathParts.isNotEmpty;
@@ -790,6 +849,8 @@ Future<int> _runWithTui({
           serverArgs: serverArgs,
           config: config,
           shutdown: shutdown,
+          debugAdapterProxyPort: debugAdapterProxyPort,
+          debugAdapterControlPort: debugAdapterControlPort,
         ).catchError((Object e, StackTrace st) {
           // Show the error in the TUI.
           // The TUI stays open until Ctrl-C / Quit completes shutdown.
@@ -824,6 +885,8 @@ Future<void> _runTuiBackend({
   required List<String> serverArgs,
   required GeneratorConfig config,
   required _ShutdownSignal shutdown,
+  required int debugAdapterProxyPort,
+  required int debugAdapterControlPort,
 }) async {
   try {
     // Replace the CLI logger with a TUI-backed logger.
@@ -861,6 +924,8 @@ Future<void> _runTuiBackend({
       watch: watch,
       docker: docker,
       launchFlutterApp: launchFlutterApp,
+      debugAdapterProxyPort: debugAdapterProxyPort,
+      debugAdapterControlPort: debugAdapterControlPort,
       useTui: true,
       shutdown: shutdown,
       serverStdoutSink: serverStdoutSink,
@@ -886,6 +951,9 @@ Future<void> _runTuiBackend({
         holder.onQuit = () => shutdown.complete(0);
         holder.onHotReload = () {
           runTrackedAction(holder, 'Hot reload', ctx.session.forceReload);
+        };
+        holder.onHotRestart = () {
+          runTrackedAction(holder, 'Hot restart', ctx.session.forceRestart);
         };
         holder.onCreateMigration = () {
           runTrackedAction(

--- a/tools/serverpod_cli/lib/src/commands/start.dart
+++ b/tools/serverpod_cli/lib/src/commands/start.dart
@@ -504,9 +504,12 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
     return true;
   });
 
+  bool canCreateFlutterProcess =
+      launchFlutterApp && config.flutterPackagePathParts.isNotEmpty;
+
   FlutterProcess? flutterProcess;
 
-  if (launchFlutterApp) {
+  if (canCreateFlutterProcess) {
     flutterProcess = FlutterProcess(
       flutterPackageDir: p.joinAll(config.flutterPackagePathParts),
       spawnFromTui: useTui,
@@ -593,10 +596,8 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
         .asyncMapBuffer((events) => session.handleFileChange(events.merge()))
         .listen((_) {});
 
-    FileWatcher? flutterWatcher;
-
-    if (launchFlutterApp) {
-      flutterWatcher = FileWatcher(
+    if (canCreateFlutterProcess) {
+      final flutterWatcher = FileWatcher(
         watchPaths: {
           p.absolute(p.joinAll([...config.flutterPackagePathParts, 'lib'])),
         },
@@ -760,7 +761,10 @@ Future<int> _runWithTui({
   required List<String> serverArgs,
   required GeneratorConfig config,
 }) async {
-  final state = ServerWatchState()..showFlutterOutput = launchFlutterApp;
+  bool showFlutterOutput =
+      launchFlutterApp && config.flutterPackagePathParts.isNotEmpty;
+
+  final state = ServerWatchState()..showFlutterOutput = showFlutterOutput;
   final holder = StartAppStateHolder(state);
   var backendStarted = false;
 

--- a/tools/serverpod_cli/lib/src/commands/start/dap_proxy_commands.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/dap_proxy_commands.dart
@@ -1,0 +1,6 @@
+/// Commands supported by the DAP proxy's control server.
+class DapProxyCommands {
+  static const hotReload = 'reload';
+  static const hotRestart = 'restart';
+  static const stop = 'stop';
+}

--- a/tools/serverpod_cli/lib/src/commands/start/dap_proxy_server.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/dap_proxy_server.dart
@@ -1,0 +1,525 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:serverpod_cli/src/commands/start/dap_proxy_commands.dart';
+import 'package:serverpod_cli/src/util/serverpod_cli_logger.dart';
+import 'package:super_string/super_string.dart';
+
+/// A proxy server for connecting to a Flutter debug adapter.
+/// [DapProxyServer] also exposes a control server which
+/// non-Flutter clients can connect to and send structured commands
+/// for hot reload/restart.
+/// Typically, `serverpod start` connects to this control server
+/// to enable hot reload/restart from the tui.
+class DapProxyServer {
+  final int proxyPort;
+  final int controlPort;
+  final void Function(String) _infoWriter;
+  final void Function(String) _errorWriter;
+
+  ServerSocket? _dapServer;
+  ServerSocket? _controlServer;
+  StreamSubscription? _stdoutSub;
+  StreamSubscription? _stderrSub;
+  StreamSubscription? _clientPacketsSub;
+  StreamSubscription? _debugAdapterPacketsSub;
+  StreamSubscription? _controlSub;
+  StreamSubscription? _sigtermSub;
+  Stream<List<int>>? _stdoutStream;
+
+  final _outputReplacementRegex = RegExp(r'Content-Length:\s+\d+');
+
+  Process? _flutterAdapterProcess;
+
+  final _exitCompleter = Completer<void>();
+  Future<void> get exitFuture => _exitCompleter.future;
+
+  int _nextSeq = 1;
+
+  DapProxyServer({
+    required this.proxyPort,
+    required this.controlPort,
+    IOSink? stdoutSink,
+    IOSink? stderrSink,
+  }) : _infoWriter = stdoutSink != null ? stdoutSink.writeln : log.info,
+       _errorWriter = stderrSink != null ? stderrSink.writeln : log.error;
+
+  /// Close sockets with active connections at [proxyPort] and [controlPort], if any.
+  Future<void> _stopIfStarted() {
+    return Future.wait(
+      [proxyPort, controlPort].map((port) async {
+        try {
+          final sock = await Socket.connect(InternetAddress.anyIPv4, port);
+          sock.writeln(DapProxyCommands.stop);
+          // Wait for the server to respond to the command.
+          await Future.delayed(const Duration(seconds: 1));
+        } catch (_) {}
+      }),
+    );
+  }
+
+  /// Starts the proxy server.
+  ///
+  /// Runs flutter debug adapter in a process,
+  /// then pipes writes to the proxy socket into the debug adapter's stdin.
+  /// Typically, the `FlutterProcess` from `serverpod start` writes
+  /// structured commands (reload, restart)
+  /// to the control socket at [controlPort] which produces DAP-formatted
+  /// commands that are piped to the debug adapter's stdin.
+  Future<bool> start() async {
+    try {
+      await _stopIfStarted();
+      _infoWriter('Starting Flutter debug adapter');
+
+      final process = await Process.start('flutter', ['debug_adapter']);
+
+      _flutterAdapterProcess = process;
+
+      if (!Platform.isWindows) {
+        _sigtermSub = ProcessSignal.sigterm.watch().listen(
+          (_) => process.kill(),
+        );
+      }
+
+      final stream = process.stdout.asBroadcastStream();
+      _stdoutStream = stream;
+
+      _stdoutSub = stream
+          .transform(utf8.decoder)
+          .transform(const LineSplitter())
+          .listen((data) {
+            try {
+              if (!data.contains('"event":"output"')) return;
+
+              final decoded = Map.from(
+                jsonDecode(data.replaceAll(_outputReplacementRegex, '')),
+              );
+              final message = Map.from(decoded['body'])['output'] as String;
+              _infoWriter(message);
+            } catch (_) {}
+          });
+
+      _stderrSub = process.stderr.transform(utf8.decoder).listen((e) {
+        _errorWriter(e);
+      });
+
+      _controlServer = await ServerSocket.bind(
+        InternetAddress.anyIPv4,
+        controlPort,
+      );
+
+      _infoWriter('DAP control server listening on :$controlPort');
+
+      _controlServer?.listen(_handleControlConnection);
+
+      _dapServer = await ServerSocket.bind(InternetAddress.anyIPv4, proxyPort);
+
+      _infoWriter('DAP proxy server listening on :$proxyPort');
+
+      _dapServer?.listen(_handleClientConnection);
+
+      unawaited(process.exitCode.then((_) async => await stop()));
+
+      return true;
+    } catch (e) {
+      _errorWriter('Error starting DAP proxy server: $e');
+    }
+    return false;
+  }
+
+  void _handleClientConnection(Socket socket) {
+    final stdoutStream = _stdoutStream;
+    if (stdoutStream == null) return;
+
+    final process = _flutterAdapterProcess;
+    if (process == null) return;
+
+    _infoWriter('DAP client connected');
+
+    final broadcastSock = socket.asBroadcastStream().cast<List<int>>();
+
+    broadcastSock
+        .transform(utf8.decoder)
+        .transform(const LineSplitter())
+        .listen((line) {
+          if (line == DapProxyCommands.stop) stop();
+        });
+
+    final clientPackets = DapPacketReader(broadcastSock);
+    final debugAdapterPackets = DapPacketReader(stdoutStream);
+
+    _clientPacketsSub = clientPackets.stream.listen((data) {
+      final command = data['command'];
+      _infoWriter('Client Packet: $data');
+      _infoWriter(
+        'Client -> Flutter: ${data['command'] ?? data['event']}',
+      );
+
+      _writeData(process.stdin, data);
+
+      if (command == 'disconnect') {
+        stop();
+      }
+    });
+
+    _debugAdapterPacketsSub = debugAdapterPackets.stream.listen((data) {
+      _infoWriter('Flutter Packet: $data');
+      _infoWriter(
+        'Flutter -> Client: ${data['command'] ?? data['event']}',
+      );
+
+      _writeData(socket, data);
+    });
+
+    socket.done.then((_) async {
+      _infoWriter('DAP client disconnected');
+      _flutterAdapterProcess?.kill();
+      _flutterAdapterProcess = null;
+    });
+  }
+
+  void _handleControlConnection(Socket socket) {
+    _infoWriter('DAP proxy control client connected');
+
+    _controlSub = socket
+        .cast<List<int>>()
+        .transform(utf8.decoder)
+        .transform(const LineSplitter())
+        .listen((line) {
+          switch (line) {
+            case DapProxyCommands.stop:
+              stop();
+              break;
+
+            case DapProxyCommands.hotReload:
+              _performHotReload(socket);
+              break;
+
+            case DapProxyCommands.hotRestart:
+              _performHotRestart(socket);
+              break;
+
+            default:
+              socket.writeln('Unknown command');
+          }
+        });
+  }
+
+  /// Waits for response to [command] or [event].
+  Future<bool> _waitForResponseOrEvent({
+    String? command,
+    String? event,
+    Duration timeLimit = const Duration(seconds: 1),
+  }) async {
+    final stream = _stdoutStream;
+    final process = _flutterAdapterProcess;
+    if (stream == null || process == null) return false;
+
+    final completer = Completer<bool>();
+
+    final sub = stream.transform(utf8.decoder).listen((data) {
+      if (data.contains('terminated')) {
+        if (!completer.isCompleted) completer.complete(false);
+      }
+
+      if (command != null) {
+        if (data.containsAll([
+          '"type":"response"',
+          '"command":"$command"',
+          '"success":true',
+        ])) {
+          if (!completer.isCompleted) completer.complete(true);
+        }
+      }
+
+      if (event != null) {
+        if (data.containsAll(['"type":"event"', '"event":"$event"'])) {
+          if (!completer.isCompleted) completer.complete(true);
+        }
+      }
+    });
+
+    return completer.future
+        .timeout(timeLimit, onTimeout: () => false)
+        .whenComplete(() => sub.cancel());
+  }
+
+  /// Launches flutter app on device with id
+  /// [deviceId] using the debug adapter.
+  Future<bool> launchFlutterApp({
+    required String deviceId,
+    required String projectRootPath,
+    List<String> args = const [],
+  }) async {
+    final process = _flutterAdapterProcess;
+    if (process == null) return false;
+
+    final initializationRequest = {
+      'seq': _nextSeq++,
+      'type': 'request',
+      'command': 'initialize',
+      'arguments': {
+        'clientID': 'serverpod',
+        'clientName': 'Serverpod',
+        'adapterID': 'dart',
+        'pathFormat': 'path',
+        'locale': 'en',
+        // Required to receive progress events for hot reload and restart
+        'supportsProgressReporting': true,
+      },
+    };
+
+    _writeData(process.stdin, initializationRequest);
+
+    bool launchSuccess = await _waitForResponseOrEvent(
+      event: 'initialized',
+    );
+
+    final launchRequest = {
+      'seq': _nextSeq++,
+      'type': 'request',
+      'command': 'launch',
+      'arguments': {
+        'deviceId': deviceId,
+        'cwd': projectRootPath,
+        'projectRootPath': projectRootPath,
+        'args': args,
+        'toolArgs': ['-d', deviceId],
+      },
+    };
+
+    _writeData(process.stdin, launchRequest);
+
+    final configurationRequest = {
+      'seq': _nextSeq++,
+      'type': 'request',
+      'command': 'configurationDone',
+    };
+
+    _writeData(process.stdin, configurationRequest);
+    launchSuccess &= await _waitForResponseOrEvent(
+      command: 'configurationDone',
+    );
+
+    final threadsRequest = {
+      'seq': _nextSeq++,
+      'type': 'request',
+      'command': 'threads',
+    };
+
+    _writeData(process.stdin, threadsRequest);
+
+    final result = await _waitForProgress(
+      'launch',
+      timeLimit: const Duration(minutes: 3),
+    );
+
+    launchSuccess &= result == success;
+
+    return launchSuccess;
+  }
+
+  static const success = 'success';
+  static const failure = 'error';
+  static const timeout = 'timeout';
+
+  /// Waits for progress to end for [event].
+  ///
+  /// Returns a Future that:
+  /// - resolves to 'success'
+  ///   when progress ends for [event].
+  /// - resolves to 'timeout'
+  ///   when [timeLimit] is reached before progress ends.
+  /// - resolves to 'failure' when the debug adapter is terminated.
+  Future<String> _waitForProgress(
+    String event, {
+    Duration timeLimit = const Duration(seconds: 1),
+  }) async {
+    final stream = _stdoutStream;
+    final process = _flutterAdapterProcess;
+    if (stream == null || process == null) return failure;
+
+    final completer = Completer<String>();
+
+    final sub = stream.transform(utf8.decoder).listen((data) {
+      // progressEnd indicates progress tracking has ended.
+      // The payload contains the tracked progressId
+      // which will contain the event name.
+      if (data.contains('progressEnd') && data.contains(event)) {
+        if (!completer.isCompleted) completer.complete(success);
+      }
+
+      if (data.contains('terminated')) {
+        if (!completer.isCompleted) completer.complete(failure);
+      }
+    });
+
+    return completer.future
+        .timeout(timeLimit, onTimeout: () async => timeout)
+        .whenComplete(() => sub.cancel());
+  }
+
+  /// Sends hot reload request to the debug adapter.
+  Future<void> _performHotReload(Socket socket) async {
+    final process = _flutterAdapterProcess;
+    if (process == null) return;
+
+    final request = {
+      'seq': _nextSeq++,
+      'type': 'request',
+      'command': 'hotReload',
+      'arguments': {},
+    };
+
+    _writeData(process.stdin, request);
+    final status = await _waitForProgress('hotReload');
+    socket.writeln('${DapProxyCommands.hotReload}: $status');
+  }
+
+  /// Sends hot restart request to the debug adapter.
+  Future<void> _performHotRestart(Socket socket) async {
+    final process = _flutterAdapterProcess;
+    if (process == null) return;
+
+    final request = {
+      'seq': _nextSeq++,
+      'type': 'request',
+      'command': 'hotRestart',
+      'arguments': {},
+    };
+
+    _writeData(process.stdin, request);
+    final status = await _waitForProgress('hotRestart');
+    socket.writeln('${DapProxyCommands.hotRestart}: $status');
+  }
+
+  void _killFlutterApp() {
+    final process = _flutterAdapterProcess;
+    if (process == null) return;
+
+    final request = {
+      'seq': _nextSeq++,
+      'type': 'request',
+      'command': 'terminate',
+      'arguments': {'restart': false},
+    };
+
+    _writeData(process.stdin, request);
+  }
+
+  /// Writes [data] to [sink].
+  void _writeData(IOSink sink, Map<String, dynamic> data) {
+    final jsonString = jsonEncode(data);
+    final bytes = utf8.encode(jsonString);
+
+    sink.write('Content-Length: ${bytes.length}\r\n');
+    sink.write('\r\n');
+    sink.add(bytes);
+  }
+
+  Future<void> _cleanup() async {
+    final process = _flutterAdapterProcess;
+    if (process != null) {
+      _killFlutterApp();
+      process.kill();
+      _flutterAdapterProcess = null;
+    }
+
+    await _dapServer?.close();
+    await _controlServer?.close();
+    await _stdoutSub?.cancel();
+    await _stderrSub?.cancel();
+    await _clientPacketsSub?.cancel();
+    await _debugAdapterPacketsSub?.cancel();
+    await _controlSub?.cancel();
+    await _sigtermSub?.cancel();
+    _dapServer = null;
+    _controlServer = null;
+    _stdoutSub = null;
+    _stderrSub = null;
+    _clientPacketsSub = null;
+    _debugAdapterPacketsSub = null;
+    _controlSub = null;
+    _sigtermSub = null;
+  }
+
+  /// Cleanup resources and stop server.
+  Future<void> stop() async {
+    await _cleanup();
+    if (!_exitCompleter.isCompleted) {
+      _exitCompleter.complete();
+    }
+  }
+}
+
+final _contentLengthRegex = RegExp(r'Content-Length: (\d+)');
+
+class DapPacketReader {
+  final Stream<List<int>> _stream;
+
+  final _controller = StreamController<Map<String, dynamic>>.broadcast();
+
+  Stream<Map<String, dynamic>> get stream => _controller.stream;
+
+  DapPacketReader(this._stream) {
+    _start();
+  }
+
+  void _start() async {
+    final iterator = StreamIterator(_stream);
+
+    final buffer = <int>[];
+
+    while (await iterator.moveNext()) {
+      buffer.addAll(iterator.current);
+
+      while (true) {
+        final headerEnd = _indexOfHeaderEnd(buffer);
+
+        if (headerEnd == -1) break;
+
+        final headerBytes = buffer.sublist(0, headerEnd);
+        final contentLength = _parseContentLength(utf8.decode(headerBytes));
+
+        if (contentLength == null) {
+          throw Exception('Missing Content-Length header');
+        }
+
+        final packetStart = headerEnd + 4;
+
+        if (buffer.length < packetStart + contentLength) break;
+
+        final bodyBytes = buffer.sublist(
+          packetStart,
+          packetStart + contentLength,
+        );
+
+        final body = jsonDecode(utf8.decode(bodyBytes));
+
+        _controller.add(body);
+
+        buffer.removeRange(0, packetStart + contentLength);
+      }
+    }
+  }
+
+  int _indexOfHeaderEnd(List<int> bytes) {
+    for (var i = 0; i < bytes.length - 3; i++) {
+      if (bytes[i] == 13 &&
+          bytes[i + 1] == 10 &&
+          bytes[i + 2] == 13 &&
+          bytes[i + 3] == 10) {
+        return i;
+      }
+    }
+
+    return -1;
+  }
+
+  int? _parseContentLength(String header) {
+    final match = _contentLengthRegex.firstMatch(header);
+    if (match == null) return null;
+    return int.parse(match.group(1)!);
+  }
+}

--- a/tools/serverpod_cli/lib/src/commands/start/flutter_process.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/flutter_process.dart
@@ -48,7 +48,7 @@ class FlutterProcess {
 
     // Enable raw keyboard input if process is spawn
     // in --no-tui mode.
-    if (!_spawnFromTui) {
+    if (!_spawnFromTui && stdin.hasTerminal) {
       originalEchoMode = stdin.echoMode;
       originalLineMode = stdin.lineMode;
       stdin.echoMode = false;

--- a/tools/serverpod_cli/lib/src/commands/start/flutter_process.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/flutter_process.dart
@@ -1,0 +1,159 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:serverpod_cli/src/commands/messages.dart';
+import 'package:serverpod_cli/src/util/serverpod_cli_logger.dart';
+
+class FlutterProcess {
+  FlutterProcess({
+    required String flutterPackageDir,
+    required bool spawnFromTui,
+    IOSink? stdoutSink,
+    IOSink? stderrSink,
+  }) : _spawnFromTui = spawnFromTui,
+       _flutterPackageDir = flutterPackageDir,
+       _stdout = stdoutSink ?? stdout,
+       _stderr = stderrSink ?? stderr;
+
+  /// Whether the process was spawn from tui mode.
+  final bool _spawnFromTui;
+  final String _flutterPackageDir;
+  final IOSink _stdout;
+  final IOSink _stderr;
+
+  Process? _process;
+  StreamSubscription? _sigtermSub;
+  StreamSubscription? _stdinSub;
+  StreamSubscription? _stdoutSub;
+  StreamSubscription? _stderrSub;
+
+  bool? originalEchoMode;
+  bool? originalLineMode;
+
+  /// Matches the `flutter run` output that points to the
+  /// URL where the app is served.
+  late final _hostRegex = RegExp(r'(served)\s+(at)\s+(http:\/\/localhost:\d+)');
+
+  Future<void> start() async {
+    if (_process != null) return;
+
+    final progressCompleter = Completer<bool>();
+
+    unawaited(
+      log.progress('Launching Flutter app', () async {
+        return await progressCompleter.future;
+      }),
+    );
+
+    // Enable raw keyboard input if process is spawn
+    // in --no-tui mode.
+    if (!_spawnFromTui) {
+      originalEchoMode = stdin.echoMode;
+      originalLineMode = stdin.lineMode;
+      stdin.echoMode = false;
+      stdin.lineMode = false;
+    }
+
+    final process = await Process.start(
+      'flutter',
+      ['run', '-d', 'web-server'],
+      workingDirectory: _flutterPackageDir,
+    );
+    _process = process;
+
+    if (!Platform.isWindows) {
+      _sigtermSub = ProcessSignal.sigterm.watch().listen(
+        (_) => process.kill(ProcessSignal.sigint),
+      );
+    }
+
+    // Forward stdin if process is spawn in --no-tui mode.
+    if (!_spawnFromTui) {
+      _stdinSub = stdin.listen((data) {
+        if (utf8.decode(data) == 'q') _restoreTerminal();
+        process.stdin.add(data);
+      });
+    }
+
+    // Forward process output without exclusively binding the sinks,
+    // so that the CLI logger can still write to stdout/stderr.
+    _stdoutSub = process.stdout.listen((data) {
+      _stdout.add(data);
+
+      final line = utf8.decode(data);
+      final match = _hostRegex.firstMatch(line);
+      final url = match?.group(3);
+      if (url != null) {
+        log.info('Flutter app is running at $url');
+        if (!progressCompleter.isCompleted) {
+          progressCompleter.complete(true);
+        }
+      }
+    });
+
+    _stderrSub = process.stderr.listen((data) {
+      if (!progressCompleter.isCompleted) {
+        progressCompleter.complete(false);
+      }
+      _stderr.add(data);
+    });
+
+    // Handle process exit asynchronously.
+    unawaited(
+      process.exitCode.then((code) async {
+        if (!progressCompleter.isCompleted) {
+          progressCompleter.complete(false);
+        }
+        await _cleanup();
+      }),
+    );
+  }
+
+  void reload() {
+    if (_process == null) return;
+    _process?.stdin.write('r');
+    log.info(flutterAppReloaded);
+  }
+
+  void restart() {
+    if (_process == null) return;
+    _process?.stdin.write('R');
+    log.info(flutterAppRestarted);
+  }
+
+  void _restoreTerminal() {
+    try {
+      stdin.echoMode = originalEchoMode!;
+      stdin.lineMode = originalLineMode!;
+    } catch (_) {}
+  }
+
+  Future<void> _cleanup() async {
+    _process = null;
+    await _stdoutSub?.cancel();
+    await _stderrSub?.cancel();
+    await _sigtermSub?.cancel();
+    await _stdinSub?.cancel();
+    _stdoutSub = null;
+    _stderrSub = null;
+    _sigtermSub = null;
+    _stdinSub = null;
+    _restoreTerminal();
+  }
+
+  Future<void> stop() async {
+    final process = _process;
+    // Cancel signal forwarding before sending our own signal.
+    await _sigtermSub?.cancel();
+    _sigtermSub = null;
+
+    if (process != null) {
+      // Use SIGINT rather than SIGTERM: on Windows SIGTERM maps to
+      // TerminateProcess (immediate kill), while SIGINT sends CTRL_C_EVENT
+      // which allows the server to shut down gracefully.
+      process.kill(ProcessSignal.sigint);
+    }
+    await _cleanup();
+  }
+}

--- a/tools/serverpod_cli/lib/src/commands/start/flutter_process.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/flutter_process.dart
@@ -5,6 +5,8 @@ import 'dart:io';
 import 'package:serverpod_cli/src/commands/messages.dart';
 import 'package:serverpod_cli/src/util/serverpod_cli_logger.dart';
 
+/// Manages the flutter run subprocess lifecycle.
+/// Handles spawning, signal forwarding, output streaming and graceful shutdown.
 class FlutterProcess {
   FlutterProcess({
     required String flutterPackageDir,

--- a/tools/serverpod_cli/lib/src/commands/start/flutter_process.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/flutter_process.dart
@@ -35,7 +35,7 @@ class FlutterProcess {
 
   /// Matches the `flutter run` output that points to the
   /// URL where the app is served.
-  late final _hostRegex = RegExp(r'(served)\s+(at)\s+(http:\/\/localhost:\d+)');
+  late final _hostRegex = RegExp(r'served\s+at\s+(http:\/\/localhost:\d+)');
 
   Future<void> start() async {
     if (_process != null) return;
@@ -73,7 +73,6 @@ class FlutterProcess {
     // Forward stdin if process is spawn in --no-tui mode.
     if (!_spawnFromTui) {
       _stdinSub = stdin.listen((data) {
-        if (utf8.decode(data) == 'q') _restoreTerminal();
         process.stdin.add(data);
       });
     }
@@ -85,7 +84,7 @@ class FlutterProcess {
 
       final line = utf8.decode(data);
       final match = _hostRegex.firstMatch(line);
-      final url = match?.group(3);
+      final url = match?.group(1);
       if (url != null) {
         log.info('Flutter app is running at $url');
         if (!progressCompleter.isCompleted) {

--- a/tools/serverpod_cli/lib/src/commands/start/flutter_process.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/flutter_process.dart
@@ -1,160 +1,82 @@
 import 'dart:async';
-import 'dart:convert';
 import 'dart:io';
 
-import 'package:serverpod_cli/src/commands/messages.dart';
+import 'package:serverpod_cli/src/commands/start/dap_proxy_server.dart';
 import 'package:serverpod_cli/src/util/serverpod_cli_logger.dart';
 
-/// Manages the flutter run subprocess lifecycle.
-/// Handles spawning, signal forwarding, output streaming and graceful shutdown.
+/// Responsible for launching the flutter app.
 class FlutterProcess {
   FlutterProcess({
     required String flutterPackageDir,
-    required bool spawnFromTui,
+    required int debugAdapterProxyPort,
+    required int debugAdapterControlPort,
+    required List<String> args,
     IOSink? stdoutSink,
     IOSink? stderrSink,
-  }) : _spawnFromTui = spawnFromTui,
-       _flutterPackageDir = flutterPackageDir,
-       _stdout = stdoutSink ?? stdout,
-       _stderr = stderrSink ?? stderr;
+  }) : _flutterPackageDir = flutterPackageDir,
+       _args = args,
+       _dapProxy = DapProxyServer(
+         proxyPort: debugAdapterProxyPort,
+         controlPort: debugAdapterControlPort,
+         stderrSink: stderrSink,
+         stdoutSink: stdoutSink,
+       );
 
-  /// Whether the process was spawn from tui mode.
-  final bool _spawnFromTui;
   final String _flutterPackageDir;
-  final IOSink _stdout;
-  final IOSink _stderr;
+  final DapProxyServer _dapProxy;
+  final List<String> _args;
 
-  Process? _process;
-  StreamSubscription? _sigtermSub;
-  StreamSubscription? _stdinSub;
-  StreamSubscription? _stdoutSub;
-  StreamSubscription? _stderrSub;
-
-  bool? originalEchoMode;
-  bool? originalLineMode;
-
-  /// Matches the `flutter run` output that points to the
-  /// URL where the app is served.
-  late final _hostRegex = RegExp(r'served\s+at\s+(http:\/\/localhost:\d+)');
-
+  /// Starts the debug adapter proxy server and launches
+  /// the flutter app on successful start.
   Future<void> start() async {
-    if (_process != null) return;
-
-    final progressCompleter = Completer<bool>();
-
-    unawaited(
-      log.progress('Launching Flutter app', () async {
-        return await progressCompleter.future;
-      }),
-    );
-
-    // Enable raw keyboard input if process is spawn
-    // in --no-tui mode.
-    if (!_spawnFromTui && stdin.hasTerminal) {
-      originalEchoMode = stdin.echoMode;
-      originalLineMode = stdin.lineMode;
-      stdin.echoMode = false;
-      stdin.lineMode = false;
+    final success = await _dapProxy.start();
+    if (!success) {
+      log.error('Unable to start flutter debug adapter');
+      return;
     }
 
-    final process = await Process.start(
-      'flutter',
-      ['run', '-d', 'web-server'],
-      workingDirectory: _flutterPackageDir,
-    );
-    _process = process;
+    final result = _parseArgs(_args);
+    final deviceId = result['device-id'] ?? result['d'];
 
-    if (!Platform.isWindows) {
-      _sigtermSub = ProcessSignal.sigterm.watch().listen(
-        (_) => process.kill(ProcessSignal.sigint),
+    await log.progress('Launching flutter app', () async {
+      return await _dapProxy.launchFlutterApp(
+        projectRootPath: _flutterPackageDir,
+        deviceId: deviceId,
+        args: _args,
       );
-    }
+    });
+  }
 
-    // Forward stdin if process is spawn in --no-tui mode.
-    if (!_spawnFromTui) {
-      _stdinSub = stdin.listen((data) {
-        process.stdin.add(data);
-      });
-    }
+  Map<String, dynamic> _parseArgs(List<String> args) {
+    final result = <String, dynamic>{};
 
-    // Forward process output without exclusively binding the sinks,
-    // so that the CLI logger can still write to stdout/stderr.
-    _stdoutSub = process.stdout.listen((data) {
-      _stdout.add(data);
+    for (var i = 0; i < args.length; i++) {
+      final arg = args[i];
 
-      final line = utf8.decode(data);
-      final match = _hostRegex.firstMatch(line);
-      final url = match?.group(1);
-      if (url != null) {
-        log.info('Flutter app is running at $url');
-        if (!progressCompleter.isCompleted) {
-          progressCompleter.complete(true);
+      // --optionName=value
+      if (arg.startsWith('--') && arg.contains('=')) {
+        final parts = arg.substring(2).split('=');
+        final key = parts.first;
+        final value = parts.last;
+
+        result[key] = value;
+      }
+      // -optionName value
+      else if (arg.startsWith('-')) {
+        final key = arg.substring(1);
+
+        if (i + 1 < args.length && !args[i + 1].startsWith('-')) {
+          result[key] = args[++i];
         }
       }
-    });
+    }
 
-    _stderrSub = process.stderr.listen((data) {
-      if (!progressCompleter.isCompleted) {
-        progressCompleter.complete(false);
-      }
-      _stderr.add(data);
-    });
-
-    // Handle process exit asynchronously.
-    unawaited(
-      process.exitCode.then((code) async {
-        if (!progressCompleter.isCompleted) {
-          progressCompleter.complete(false);
-        }
-        await _cleanup();
-      }),
-    );
+    return result;
   }
 
-  void reload() {
-    if (_process == null) return;
-    _process?.stdin.write('r');
-    log.info(flutterAppReloaded);
-  }
-
-  void restart() {
-    if (_process == null) return;
-    _process?.stdin.write('R');
-    log.info(flutterAppRestarted);
-  }
-
-  void _restoreTerminal() {
-    try {
-      stdin.echoMode = originalEchoMode!;
-      stdin.lineMode = originalLineMode!;
-    } catch (_) {}
-  }
-
-  Future<void> _cleanup() async {
-    _process = null;
-    await _stdoutSub?.cancel();
-    await _stderrSub?.cancel();
-    await _sigtermSub?.cancel();
-    await _stdinSub?.cancel();
-    _stdoutSub = null;
-    _stderrSub = null;
-    _sigtermSub = null;
-    _stdinSub = null;
-    _restoreTerminal();
-  }
-
+  /// Stops the debug adapter proxy server.
+  /// This also terminates the flutter app.
   Future<void> stop() async {
-    final process = _process;
-    // Cancel signal forwarding before sending our own signal.
-    await _sigtermSub?.cancel();
-    _sigtermSub = null;
-
-    if (process != null) {
-      // Use SIGINT rather than SIGTERM: on Windows SIGTERM maps to
-      // TerminateProcess (immediate kill), while SIGINT sends CTRL_C_EVENT
-      // which allows the server to shut down gracefully.
-      process.kill(ProcessSignal.sigint);
-    }
-    await _cleanup();
+    await _dapProxy.stop();
   }
 }

--- a/tools/serverpod_cli/lib/src/commands/start/flutter_reloader.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/flutter_reloader.dart
@@ -1,0 +1,145 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:serverpod_cli/src/commands/start/dap_proxy_commands.dart';
+import 'package:serverpod_cli/src/util/serverpod_cli_logger.dart';
+
+enum _FlutterReloadStatus {
+  success,
+  error,
+  timeout
+  ;
+
+  const _FlutterReloadStatus();
+
+  factory _FlutterReloadStatus.fromString(String data) {
+    return _FlutterReloadStatus.values.firstWhere(
+      (e) => data.contains(e.name),
+      orElse: () => _FlutterReloadStatus.error,
+    );
+  }
+}
+
+/// Responsible for reloading/restarting a running flutter app.
+/// [FlutterReloader] connects to a control port exposed by the
+/// [DapProxyServer] and sends structured commands for hot reload
+/// and hot restart.
+class FlutterReloader {
+  FlutterReloader({
+    required this.debugAdapterControlPort,
+    required this.flutterAppInfoPath,
+  });
+
+  /// The port to connect to for sending hot reload
+  /// and restart commands to the debug adapter.
+  final int debugAdapterControlPort;
+
+  /// Path to the file to watch for reconnection signal.
+  /// When this file is modified, [FlutterReloader] will
+  /// attempt to reconnect to to [debugAdapterControlPort].
+  final String flutterAppInfoPath;
+
+  Socket? _debugAdapterControlSocket;
+  Stream<List<int>>? _socketStream;
+  StreamSubscription? _fileStreamSubscription;
+
+  /// Establishes a connection to [debugAdapterControlPort]
+  /// and watches for reconnection signal.
+  Future<void> start() async {
+    const maxAttempts = 100;
+    const delay = Duration(seconds: 1);
+
+    for (var i = 0; i < maxAttempts; i++) {
+      try {
+        _debugAdapterControlSocket ??= await Socket.connect(
+          InternetAddress.anyIPv4,
+          debugAdapterControlPort,
+        );
+        final socket = _debugAdapterControlSocket!;
+        _socketStream = socket.asBroadcastStream().cast<List<int>>();
+
+        // These events are produced before `serverpod start` is aborted
+        // when there is an already running server.
+        // This allows the running process to reconnect
+        // to the debug adapter when the Flutter app is launched again from the IDE
+        _fileStreamSubscription = File(flutterAppInfoPath)
+            .watch(events: FileSystemEvent.create | FileSystemEvent.modify)
+            .listen((event) async {
+              await stop();
+              log.info('Reconnecting to debug adapter control server');
+              await start();
+            });
+
+        log.info('Connected to debug adapter control server');
+        return;
+      } catch (_) {}
+      await Future<void>.delayed(delay);
+    }
+  }
+
+  Future<_FlutterReloadStatus> _sendCommand(String command) async {
+    final stream = _socketStream;
+    final socket = _debugAdapterControlSocket;
+    if (stream == null || socket == null) return _FlutterReloadStatus.error;
+
+    socket.writeln(command);
+
+    final completer = Completer<_FlutterReloadStatus>();
+    final sub = stream
+        .transform(utf8.decoder)
+        .transform(const LineSplitter())
+        .listen((data) {
+          if (data.contains(command)) {
+            final status = _FlutterReloadStatus.fromString(data);
+            if (!completer.isCompleted) completer.complete(status);
+          }
+        });
+
+    return completer.future
+        .timeout(
+          const Duration(seconds: 1),
+          onTimeout: () => _FlutterReloadStatus.timeout,
+        )
+        .whenComplete(() => sub.cancel());
+  }
+
+  /// Sends hot reload command to the debug adapter.
+  Future<void> reload() async {
+    final status = await _sendCommand(DapProxyCommands.hotReload);
+    final message = switch (status) {
+      _FlutterReloadStatus.success => '✓ Flutter app reloaded.',
+      _FlutterReloadStatus.error => 'Flutter app hot reload failed.',
+      _FlutterReloadStatus.timeout => 'Flutter app hot reload timed out.',
+    };
+
+    _logForStatus(message, status);
+  }
+
+  /// Sends hot restart command to the debug adapter.
+  Future<void> restart() async {
+    final status = await _sendCommand(DapProxyCommands.hotRestart);
+    final message = switch (status) {
+      _FlutterReloadStatus.success => '✓ Flutter app restarted.',
+      _FlutterReloadStatus.error => 'Flutter app hot restart failed.',
+      _FlutterReloadStatus.timeout => 'Flutter app hot restart timed out.',
+    };
+    _logForStatus(message, status);
+  }
+
+  void _logForStatus(String message, _FlutterReloadStatus status) {
+    if (status == _FlutterReloadStatus.success) {
+      log.info(message);
+    } else {
+      log.error(message);
+    }
+  }
+
+  /// Closes the connection to [debugAdapterControlPort]
+  /// and cleans up held resources.
+  Future<void> stop() async {
+    await _fileStreamSubscription?.cancel();
+    _debugAdapterControlSocket?.destroy();
+    _debugAdapterControlSocket = null;
+  }
+}

--- a/tools/serverpod_cli/lib/src/commands/start/tui/app.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/tui/app.dart
@@ -16,6 +16,7 @@ class StartAppStateHolder extends ServerpodAppStateHolder<ServerWatchState> {
 
   ServerpodWatchAppState? _widgetState;
   VoidCallback? _onHotReload;
+  VoidCallback? _onHotRestart;
   VoidCallback? _onCreateMigration;
   VoidCallback? _onApplyMigration;
   VoidCallback? _onQuit;
@@ -30,6 +31,7 @@ class StartAppStateHolder extends ServerpodAppStateHolder<ServerWatchState> {
   void attach(ServerpodWatchAppState widgetState) {
     _widgetState = widgetState;
     widgetState.onHotReload = _onHotReload;
+    widgetState.onHotRestart = _onHotRestart;
     widgetState.onCreateMigration = _onCreateMigration;
     widgetState.onApplyMigration = _onApplyMigration;
     widgetState.onQuit = _onQuit;
@@ -43,6 +45,11 @@ class StartAppStateHolder extends ServerpodAppStateHolder<ServerWatchState> {
   set onHotReload(VoidCallback? cb) {
     _onHotReload = cb;
     _widgetState?.onHotReload = cb;
+  }
+
+  set onHotRestart(VoidCallback? cb) {
+    _onHotRestart = cb;
+    _widgetState?.onHotRestart = cb;
   }
 
   set onCreateMigration(VoidCallback? cb) {
@@ -82,6 +89,7 @@ class ServerpodWatchAppState extends ServerpodAppState<ServerpodWatchApp> {
 
   /// Callbacks wired by the backend.
   VoidCallback? onHotReload;
+  VoidCallback? onHotRestart;
   VoidCallback? onCreateMigration;
   VoidCallback? onApplyMigration;
   VoidCallback? onQuit;
@@ -149,6 +157,7 @@ class ServerpodWatchAppState extends ServerpodAppState<ServerpodWatchApp> {
           _rebuild();
         },
         onHotReload: onHotReload,
+        onHotRestart: onHotRestart,
         onCreateMigration: onCreateMigration,
         onApplyMigration: onApplyMigration,
         onQuit: onQuit,

--- a/tools/serverpod_cli/lib/src/commands/start/tui/main_screen.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/tui/main_screen.dart
@@ -1,4 +1,5 @@
 import 'package:nocterm/nocterm.dart' hide LogEntry;
+import 'package:serverpod_cli/src/commands/tui/bounded_queue_list.dart';
 import 'package:serverpod_cli/src/commands/tui/components/bordered_box.dart';
 import 'package:serverpod_cli/src/commands/tui/components/button.dart';
 import 'package:serverpod_cli/src/commands/tui/components/button_bar.dart';
@@ -86,17 +87,22 @@ class MainScreen extends StatelessComponent {
 
   Component _buildTabBar(ServerpodThemeData st) {
     return TabBar(
-      labels: const ['Log Messages', 'Raw server output'],
+      labels: [
+        'Log Messages',
+        'Raw server output',
+        if (state.showFlutterOutput) 'Flutter output',
+      ],
       selectedTab: state.selectedTab,
       onTabChanged: onTabChanged,
     );
   }
 
   Component _buildTabContent() {
-    if (state.selectedTab == 0) {
-      return _buildStructuredLogView();
-    }
-    return _buildRawOutputView();
+    return switch (state.selectedTab) {
+      1 => _buildRawOutputView(state.rawLines),
+      2 => _buildRawOutputView(state.rawFlutterProcessLines),
+      _ => _buildStructuredLogView(),
+    };
   }
 
   Component _buildStructuredLogView() {
@@ -135,9 +141,7 @@ class MainScreen extends StatelessComponent {
     );
   }
 
-  Component _buildRawOutputView() {
-    final lines = state.rawLines;
-
+  Component _buildRawOutputView(BoundedQueueList<String> lines) {
     return SelectionArea(
       onSelectionCompleted: (text) {
         if (text.isNotEmpty) ClipboardManager.copy(text);

--- a/tools/serverpod_cli/lib/src/commands/start/tui/main_screen.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/tui/main_screen.dart
@@ -30,6 +30,7 @@ class MainScreen extends StatelessComponent {
     required this.helpScrollController,
     this.onToggleHelp,
     this.onHotReload,
+    this.onHotRestart,
     this.onCreateMigration,
     this.onApplyMigration,
     this.onQuit,
@@ -43,6 +44,7 @@ class MainScreen extends StatelessComponent {
   final ScrollController helpScrollController;
   final VoidCallback? onToggleHelp;
   final VoidCallback? onHotReload;
+  final VoidCallback? onHotRestart;
   final VoidCallback? onCreateMigration;
   final VoidCallback? onApplyMigration;
   final VoidCallback? onQuit;
@@ -176,6 +178,15 @@ class MainScreen extends StatelessComponent {
             onHotReload?.call();
           },
           enabled: actionsEnabled && onHotReload != null,
+        ),
+        Button(
+          name: 'Hot Restart',
+          activationChar: 'S',
+          activationKeys: const [LogicalKey.keyS],
+          onActivate: (_) {
+            onHotRestart?.call();
+          },
+          enabled: actionsEnabled && onHotRestart != null,
         ),
         Button(
           name: 'Create Migration',

--- a/tools/serverpod_cli/lib/src/commands/start/tui/state.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/tui/state.dart
@@ -14,6 +14,9 @@ class ServerWatchState extends ServerpodState {
   @override
   final rawLines = BoundedQueueList<String>(maxRawLines);
 
+  /// Raw stdout/stderr lines for the "Flutter output" tab.
+  final rawFlutterProcessLines = BoundedQueueList<String>(maxRawLines);
+
   /// Currently active tracked operations (keyed by ID).
   @override
   final Map<String, TrackedOperation> activeOperations = {};
@@ -26,6 +29,9 @@ class ServerWatchState extends ServerpodState {
 
   /// Whether the server is running and ready for actions.
   bool serverReady = false;
+
+  /// Whether to show the "Flutter output" tab.
+  bool showFlutterOutput = false;
 
   /// Whether to show the splash overlay. Starts true, set to false
   /// after 5 seconds or explicitly by the backend.

--- a/tools/serverpod_cli/lib/src/commands/start/watch_loop.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/watch_loop.dart
@@ -36,6 +36,7 @@ class WatchLoopContext {
   final StreamSubscription<void>? fileChangeSub;
   final Future<void> Function() closeAnalyzers;
   final Future<void> Function()? stopDocker;
+  final Future<void> Function()? stopFlutterProcess;
   final String vmServiceInfoFile;
   bool _disposed = false;
 
@@ -46,6 +47,7 @@ class WatchLoopContext {
     required this.fileChangeSub,
     required this.closeAnalyzers,
     required this.stopDocker,
+    required this.stopFlutterProcess,
     required this.vmServiceInfoFile,
   });
 
@@ -62,5 +64,6 @@ class WatchLoopContext {
     await proxy?.close();
     await File(vmServiceInfoFile).deleteIfExists();
     await stopDocker?.call();
+    await stopFlutterProcess?.call();
   }
 }

--- a/tools/serverpod_cli/lib/src/commands/start/watch_session.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/watch_session.dart
@@ -5,6 +5,7 @@ import 'package:path/path.dart' as p;
 import 'package:serverpod_cli/src/commands/generate.dart';
 import 'package:serverpod_cli/src/commands/messages.dart';
 import 'package:serverpod_cli/src/commands/start/file_watcher.dart';
+import 'package:serverpod_cli/src/commands/start/flutter_process.dart';
 import 'package:serverpod_cli/src/commands/start/kernel_compiler.dart';
 import 'package:serverpod_cli/src/commands/start/native_assets_builder.dart';
 import 'package:serverpod_cli/src/commands/start/server_process.dart';
@@ -127,6 +128,7 @@ class WatchSession {
   final Set<String> _pendingPaths = {};
 
   ServerProcess _server;
+  final FlutterProcess? _flutterProcess;
 
   SessionState _state = SessionState.idle;
 
@@ -155,6 +157,7 @@ class WatchSession {
     ProtocolChangeClassifier classifyProtocolChange =
         defaultProtocolChangeClassifier,
     required ApplyMigrationsAction applyMigrationsAction,
+    FlutterProcess? flutterProcess,
   }) : _compiler = compiler,
        _nativeAssetsBuilder = nativeAssetsBuilder,
        _generate = generate,
@@ -162,7 +165,8 @@ class WatchSession {
        _server = initialServer,
        _generatedDirPaths = generatedDirPaths,
        _classifyProtocolChange = classifyProtocolChange,
-       _applyMigrationsAction = applyMigrationsAction {
+       _applyMigrationsAction = applyMigrationsAction,
+       _flutterProcess = flutterProcess {
     assert(
       nativeAssetsBuilder == null || compiler != null,
       'nativeAssetsBuilder requires a compiler.',
@@ -403,6 +407,14 @@ class WatchSession {
     await _restartServer(dillPath);
   }
 
+  /// Hot reloads the Flutter process then runs [call].
+  Future<void> _runWithFlutterProcessReload(
+    Future<void> Function() call,
+  ) async {
+    _flutterProcess?.reload();
+    await call();
+  }
+
   /// Forces a hot reload.
   ///
   /// Forces a full recompile and hot reload (or restart).
@@ -413,13 +425,15 @@ class WatchSession {
       throw StateError('Session has been disposed.');
     }
     if (_compiler == null) {
-      return _chain(() => _reload(null));
+      return _chain(() => _runWithFlutterProcessReload(() => _reload(null)));
     }
     return _chain(
-      () => _compileAndReload(
-        dartFiles: const {},
-        packageConfigChanged: false,
-        forceFullCompile: true,
+      () => _runWithFlutterProcessReload(
+        () => _compileAndReload(
+          dartFiles: const {},
+          packageConfigChanged: false,
+          forceFullCompile: true,
+        ),
       ),
     );
   }

--- a/tools/serverpod_cli/lib/src/commands/start/watch_session.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/watch_session.dart
@@ -5,7 +5,7 @@ import 'package:path/path.dart' as p;
 import 'package:serverpod_cli/src/commands/generate.dart';
 import 'package:serverpod_cli/src/commands/messages.dart';
 import 'package:serverpod_cli/src/commands/start/file_watcher.dart';
-import 'package:serverpod_cli/src/commands/start/flutter_process.dart';
+import 'package:serverpod_cli/src/commands/start/flutter_reloader.dart';
 import 'package:serverpod_cli/src/commands/start/kernel_compiler.dart';
 import 'package:serverpod_cli/src/commands/start/native_assets_builder.dart';
 import 'package:serverpod_cli/src/commands/start/server_process.dart';
@@ -128,7 +128,7 @@ class WatchSession {
   final Set<String> _pendingPaths = {};
 
   ServerProcess _server;
-  final FlutterProcess? _flutterProcess;
+  final FlutterReloader? _flutterReloader;
 
   SessionState _state = SessionState.idle;
 
@@ -157,7 +157,7 @@ class WatchSession {
     ProtocolChangeClassifier classifyProtocolChange =
         defaultProtocolChangeClassifier,
     required ApplyMigrationsAction applyMigrationsAction,
-    FlutterProcess? flutterProcess,
+    FlutterReloader? flutterReloader,
   }) : _compiler = compiler,
        _nativeAssetsBuilder = nativeAssetsBuilder,
        _generate = generate,
@@ -166,7 +166,7 @@ class WatchSession {
        _generatedDirPaths = generatedDirPaths,
        _classifyProtocolChange = classifyProtocolChange,
        _applyMigrationsAction = applyMigrationsAction,
-       _flutterProcess = flutterProcess {
+       _flutterReloader = flutterReloader {
     assert(
       nativeAssetsBuilder == null || compiler != null,
       'nativeAssetsBuilder requires a compiler.',
@@ -407,11 +407,19 @@ class WatchSession {
     await _restartServer(dillPath);
   }
 
-  /// Hot reloads the Flutter process then runs [call].
-  Future<void> _runWithFlutterProcessReload(
+  /// Hot reloads the Flutter app then runs [call].
+  Future<void> _runWithFlutterReload(
     Future<void> Function() call,
   ) async {
-    _flutterProcess?.reload();
+    await _flutterReloader?.reload();
+    await call();
+  }
+
+  /// Hot restarts the Flutter app then runs [call].
+  Future<void> _runWithFlutterRestart(
+    Future<void> Function() call,
+  ) async {
+    await _flutterReloader?.restart();
     await call();
   }
 
@@ -425,10 +433,22 @@ class WatchSession {
       throw StateError('Session has been disposed.');
     }
     if (_compiler == null) {
-      return _chain(() => _runWithFlutterProcessReload(() => _reload(null)));
+      return _chain(() => _runWithFlutterReload(() => _reload(null)));
     }
     return _chain(
-      () => _runWithFlutterProcessReload(
+      () => _runWithFlutterReload(
+        () => _compileAndReload(
+          dartFiles: const {},
+          packageConfigChanged: false,
+          forceFullCompile: true,
+        ),
+      ),
+    );
+  }
+
+  Future<void> forceRestart() {
+    return _chain(
+      () => _runWithFlutterRestart(
         () => _compileAndReload(
           dartFiles: const {},
           packageConfigChanged: false,

--- a/tools/serverpod_cli/lib/src/commands/start_debug_adapter.dart
+++ b/tools/serverpod_cli/lib/src/commands/start_debug_adapter.dart
@@ -1,0 +1,73 @@
+import 'dart:io';
+
+import 'package:config/config.dart';
+import 'package:serverpod_cli/src/commands/start/dap_proxy_server.dart';
+import 'package:serverpod_cli/src/runner/serverpod_command.dart';
+import 'package:serverpod_cli/src/util/serverpod_cli_logger.dart';
+
+/// Options for the `start-debug-adapter` command.
+enum StartDebugAdapterOption<V> implements OptionDefinition<V> {
+  proxyPort(
+    IntOption(
+      argName: 'proxy-port',
+      argAbbrev: 'p',
+      defaultsTo: 9000,
+      helpText:
+          'The port where the flutter debug adapter proxy server will listen.',
+    ),
+  ),
+  controlPort(
+    IntOption(
+      argName: 'control-port',
+      argAbbrev: 'c',
+      defaultsTo: 4567,
+      helpText:
+          'The port where the flutter debug adapter control server will listen.',
+    ),
+  ),
+  ;
+
+  const StartDebugAdapterOption(this.option);
+
+  @override
+  final ConfigOptionBase<V> option;
+}
+
+/// Command to start the flutter debug adapter with the proxy and control servers
+/// for interacting with the adapter.
+class StartDebugAdapterCommand
+    extends ServerpodCommand<StartDebugAdapterOption> {
+  @override
+  final name = 'start-debug-adapter';
+
+  @override
+  final description =
+      'Starts a Flutter debug adapter and a proxy server to interact with the adapter.';
+
+  StartDebugAdapterCommand() : super(options: StartDebugAdapterOption.values);
+
+  @override
+  Future<void> runWithConfig(
+    final Configuration<StartDebugAdapterOption> commandConfig,
+  ) async {
+    final port = commandConfig.value(StartDebugAdapterOption.proxyPort);
+    final controlPort = commandConfig.value(
+      StartDebugAdapterOption.controlPort,
+    );
+
+    // Written to match VS Code's task begin pattern
+    stdout.writeln('Starting flutter debug adapter');
+
+    final proxy = DapProxyServer(proxyPort: port, controlPort: controlPort);
+
+    final success = await log.progress(
+      'Starting flutter debug adapter proxy server...',
+      () async => await proxy.start(),
+    );
+
+    // Written to match VS Code's task end pattern
+    if (success) stdout.writeln('Flutter debug adapter ready');
+
+    await proxy.exitFuture;
+  }
+}

--- a/tools/serverpod_cli/lib/src/commands/tui/tui_log_sink.dart
+++ b/tools/serverpod_cli/lib/src/commands/tui/tui_log_sink.dart
@@ -5,11 +5,15 @@ import 'package:serverpod_cli/src/commands/tui/app_state_holder.dart';
 import 'package:serverpod_cli/src/util/strip_ansi.dart';
 
 /// An [IOSink] implementation that captures server stdout/stderr output
-/// and routes it to the TUI's "Raw server output" tab.
+/// and routes it to [addLine].
+/// The output is typically routed to the TUI's "Raw server output" tab
+/// or "Flutter output" tab.
 class TuiLogSink implements IOSink {
-  TuiLogSink(this._holder);
+  TuiLogSink(this._holder, {required this.addLine});
 
   final ServerpodAppStateHolder _holder;
+  final void Function(String) addLine;
+
   final StringBuffer _lineBuffer = StringBuffer();
 
   @override
@@ -18,7 +22,7 @@ class TuiLogSink implements IOSink {
     for (var i = 0; i < text.length; i++) {
       final char = text[i];
       if (char == '\n') {
-        _holder.state.rawLines.add(stripAnsi(_lineBuffer.toString()));
+        addLine(stripAnsi(_lineBuffer.toString()));
         _lineBuffer.clear();
         _holder.markDirty();
       } else if (char != '\r') {
@@ -42,9 +46,9 @@ class TuiLogSink implements IOSink {
 
   @override
   void addError(Object error, [StackTrace? stackTrace]) {
-    _holder.state.rawLines.add(stripAnsi('ERROR: $error'));
+    addLine(stripAnsi('ERROR: $error'));
     if (stackTrace != null) {
-      _holder.state.rawLines.add(stripAnsi('$stackTrace'));
+      addLine(stripAnsi('$stackTrace'));
     }
     _holder.markDirty();
   }
@@ -58,7 +62,7 @@ class TuiLogSink implements IOSink {
   @override
   Future close() async {
     if (_lineBuffer.isNotEmpty) {
-      _holder.state.rawLines.add(stripAnsi(_lineBuffer.toString()));
+      addLine(stripAnsi(_lineBuffer.toString()));
       _lineBuffer.clear();
       _holder.markDirty();
     }

--- a/tools/serverpod_cli/lib/src/config/config.dart
+++ b/tools/serverpod_cli/lib/src/config/config.dart
@@ -87,6 +87,7 @@ class GeneratorConfig implements ModelLoadConfig {
     required this.extraClasses,
     required this.enabledFeatures,
     required this.databaseDialect,
+    required this.relativeFlutterPackagePathParts,
     this.experimentalFeatures = const [],
   }) : _relativeDartClientPackagePathParts = relativeDartClientPackagePathParts,
        _relativeServerTestToolsPathParts = relativeServerTestToolsPathParts,
@@ -127,6 +128,9 @@ class GeneratorConfig implements ModelLoadConfig {
   /// The key is the package name, the value is the path parts to the package
   /// relative to the server package.
   final Map<String, List<String>> sharedModelsSourcePathsParts;
+
+  /// Path parts from the server package to the flutter package.
+  final List<String> relativeFlutterPackagePathParts;
 
   @override
   List<String> get libSourcePathParts => [
@@ -223,6 +227,12 @@ class GeneratorConfig implements ModelLoadConfig {
   List<String> get clientPackagePathParts => [
     ...serverPackageDirectoryPathParts,
     ..._relativeDartClientPackagePathParts,
+  ];
+
+  /// Path parts to the flutter package.
+  List<String> get flutterPackagePathParts => [
+    ...serverPackageDirectoryPathParts,
+    ...relativeFlutterPackagePathParts,
   ];
 
   final List<String>? _relativeServerTestToolsPathParts;
@@ -355,6 +365,7 @@ class GeneratorConfig implements ModelLoadConfig {
         : YamlMap();
     var type = getPackageType(generatorConfig);
 
+    final relativeFlutterPackagePathParts = ['..', '${name}_flutter'];
     var relativeDartClientPackagePathParts = ['..', '${name}_client'];
 
     if (generatorConfig['client_package_path'] != null) {
@@ -495,6 +506,7 @@ class GeneratorConfig implements ModelLoadConfig {
       enabledFeatures: enabledFeatures,
       databaseDialect: databaseDialect,
       experimentalFeatures: enabledExperimentalFeatures,
+      relativeFlutterPackagePathParts: relativeFlutterPackagePathParts,
     );
   }
 

--- a/tools/serverpod_cli/lib/src/generated/completion_script_carapace.dart
+++ b/tools/serverpod_cli/lib/src/generated/completion_script_carapace.dart
@@ -103,6 +103,11 @@ commands:
 
   - name: version
 
+  - name: start-debug-adapter
+    flags:
+      -p, --proxy-port=: "The port where the flutter debug adapter proxy server will listen."
+      -c, --control-port=: "The port where the flutter debug adapter control server will listen."
+
 
 ''';
 

--- a/tools/serverpod_cli/lib/src/generator/dart/shared_code_generator.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart/shared_code_generator.dart
@@ -90,6 +90,8 @@ class DartSharedCodeGenerator extends CodeGenerator {
           modules: [],
           databaseDialect: config.databaseDialect,
           experimentalFeatures: config.experimentalFeatures,
+          relativeFlutterPackagePathParts:
+              config.relativeFlutterPackagePathParts,
         ),
       );
 

--- a/tools/serverpod_cli/test/commands/start/watch_loop_test.dart
+++ b/tools/serverpod_cli/test/commands/start/watch_loop_test.dart
@@ -152,6 +152,7 @@ void main() {
     late _FakeMcpSocket mcp;
     late int closeAnalyzersCalls;
     late int stopDockerCalls;
+    late int stopFlutterProcessCalls;
     late int fileSubCancelCalls;
     late StreamSubscription<void> fileSub;
     late Directory tempDir;
@@ -164,6 +165,7 @@ void main() {
       mcp = _FakeMcpSocket();
       closeAnalyzersCalls = 0;
       stopDockerCalls = 0;
+      stopFlutterProcessCalls = 0;
       fileSubCancelCalls = 0;
 
       // A real StreamSubscription whose cancel we count via a wrapper
@@ -187,7 +189,10 @@ void main() {
       }
     });
 
-    WatchLoopContext build({bool startedDocker = false}) {
+    WatchLoopContext build({
+      bool startedDocker = false,
+      bool startedFlutterProcess = false,
+    }) {
       return WatchLoopContext(
         session: _buildSession(compiler, server),
         proxy: proxy,
@@ -201,6 +206,11 @@ void main() {
                 stopDockerCalls++;
               }
             : null,
+        stopFlutterProcess: startedFlutterProcess
+            ? () async {
+                stopFlutterProcessCalls++;
+              }
+            : null,
         vmServiceInfoFile: vmServiceInfoFile,
       );
     }
@@ -209,7 +219,7 @@ void main() {
       'when dispose is called once, '
       'then every member close is invoked',
       () async {
-        final ctx = build(startedDocker: true);
+        final ctx = build(startedDocker: true, startedFlutterProcess: true);
 
         await ctx.dispose();
 
@@ -221,6 +231,7 @@ void main() {
         expect(proxy.closeCalls, 1);
         expect(File(vmServiceInfoFile).existsSync(), isFalse);
         expect(stopDockerCalls, 1);
+        expect(stopFlutterProcessCalls, 1);
         expect(ctx.isDisposed, isTrue);
       },
     );
@@ -229,7 +240,7 @@ void main() {
       'when dispose is called twice, '
       'then the second call is a no-op',
       () async {
-        final ctx = build(startedDocker: true);
+        final ctx = build(startedDocker: true, startedFlutterProcess: true);
 
         await ctx.dispose();
         await ctx.dispose();
@@ -249,6 +260,7 @@ void main() {
         );
         expect(proxy.closeCalls, 1, reason: 'proxy.close');
         expect(stopDockerCalls, 1, reason: 'stopDocker');
+        expect(stopFlutterProcessCalls, 1, reason: 'stopFlutterProcess');
       },
     );
 
@@ -261,6 +273,21 @@ void main() {
         await ctx.dispose();
 
         expect(stopDockerCalls, 0);
+        // Other steps still run.
+        expect(closeAnalyzersCalls, 1);
+        expect(server.calls, contains('stop'));
+      },
+    );
+
+    test(
+      'when stopFlutterProcess is null, '
+      'then dispose skips the Flutter process step',
+      () async {
+        final ctx = build(startedFlutterProcess: false);
+
+        await ctx.dispose();
+
+        expect(stopFlutterProcessCalls, 0);
         // Other steps still run.
         expect(closeAnalyzersCalls, 1);
         expect(server.calls, contains('stop'));
@@ -290,6 +317,7 @@ void main() {
           closeAnalyzers: () async {
             closeAnalyzersCalls++;
           },
+          stopFlutterProcess: null,
           stopDocker: null,
           vmServiceInfoFile: vmServiceInfoFile,
         );

--- a/tools/serverpod_cli/test/commands/tui/tui_log_sink_test.dart
+++ b/tools/serverpod_cli/test/commands/tui/tui_log_sink_test.dart
@@ -13,7 +13,7 @@ void main() {
   setUp(() {
     state = ServerWatchState();
     holder = StartAppStateHolder(state);
-    sink = TuiLogSink(holder);
+    sink = TuiLogSink(holder, addLine: state.rawLines.add);
   });
 
   group('Given a TuiLogSink', () {

--- a/tools/serverpod_cli/test/test_util/builders/generator_config_builder.dart
+++ b/tools/serverpod_cli/test/test_util/builders/generator_config_builder.dart
@@ -23,6 +23,7 @@ class GeneratorConfigBuilder {
   DatabaseDialect _databaseDialect;
   List<ExperimentalFeature> _enabledExperimentalFeatures;
   List<String>? _relativeServerTestToolsPathParts;
+  List<String> _relativeFlutterPackagePathParts;
 
   GeneratorConfigBuilder()
     : _name = _defaultName,
@@ -33,6 +34,7 @@ class GeneratorConfigBuilder {
       _serverPackageDirectoryPathParts = [],
       _sharedModelsSourcePathsParts = {},
       _relativeDartClientPackagePathParts = ['..', 'example_client'],
+      _relativeFlutterPackagePathParts = ['..', 'example_flutter'],
       _modules = [
         ModuleConfig(
           type: PackageType.internal,
@@ -158,6 +160,13 @@ class GeneratorConfigBuilder {
     return this;
   }
 
+  GeneratorConfigBuilder withRelativeFlutterPackagePathParts(
+    List<String> relativeFlutterPackagePathParts,
+  ) {
+    _relativeFlutterPackagePathParts = relativeFlutterPackagePathParts;
+    return this;
+  }
+
   GeneratorConfig build() {
     return GeneratorConfig(
       name: _name,
@@ -175,6 +184,7 @@ class GeneratorConfigBuilder {
       databaseDialect: _databaseDialect,
       experimentalFeatures: _enabledExperimentalFeatures,
       relativeServerTestToolsPathParts: _relativeServerTestToolsPathParts,
+      relativeFlutterPackagePathParts: _relativeFlutterPackagePathParts,
     );
   }
 }


### PR DESCRIPTION
This PR adds `flutter run` to `serverpod start`. 
The running flutter app is reloaded when dart files in the `lib` directory are modified.
In tui mode, a separate tab is added for the raw logs from the flutter process.
In non-tui mode, output is streamed to stdout with support for sending stdin to the flutter process to keep support for the Flutter command keys.

This new behaviour is turned on by default and opt-out with `--no-flutter`

Closes [5127](https://github.com/serverpod/serverpod/issues/5127)
Closes #5073

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None