### PR TITLE
feat: Add FlutterWebAuth2RedirectRoute for OAuth2 PKCE web sign-in flow

### DIFF
--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/core.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/core.dart
@@ -7,7 +7,7 @@ export 'package:serverpod_auth_core_server/serverpod_auth_core_server.dart'
     hide Endpoints, Protocol;
 
 export 'src/common/idp/endpoints/idp_endpoint.dart';
-export 'src/common/oauth2_pkce/flutter_web_auth2_redirect_route.dart';
+export 'src/common/oauth2_pkce/flutter_web_auth2_callback_route.dart';
 export 'src/common/oauth2_pkce/oauth2_exception.dart';
 export 'src/common/oauth2_pkce/oauth2_pkce_server_config.dart';
 export 'src/common/oauth2_pkce/oauth2_pkce_token_response.dart';

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/core.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/core.dart
@@ -7,6 +7,7 @@ export 'package:serverpod_auth_core_server/serverpod_auth_core_server.dart'
     hide Endpoints, Protocol;
 
 export 'src/common/idp/endpoints/idp_endpoint.dart';
+export 'src/common/oauth2_pkce/flutter_web_auth2_redirect_route.dart';
 export 'src/common/oauth2_pkce/oauth2_exception.dart';
 export 'src/common/oauth2_pkce/oauth2_pkce_server_config.dart';
 export 'src/common/oauth2_pkce/oauth2_pkce_token_response.dart';

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/common/oauth2_pkce/flutter_web_auth2_callback_route.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/common/oauth2_pkce/flutter_web_auth2_callback_route.dart
@@ -2,9 +2,9 @@ import 'dart:async';
 
 import 'package:serverpod/serverpod.dart';
 
-/// {@template flutter_web_auth2_redirect_route}
+/// {@template flutter_web_auth2_callback_route}
 /// Route that serves the [flutter_web_auth_2](https://pub.dev/packages/flutter_web_auth_2)
-/// redirect page for the OAuth2 PKCE web sign-in flow.
+/// callback page for the OAuth2 PKCE web sign-in flow.
 ///
 /// This route is **provider-agnostic** — register it once and share it across
 /// all OAuth2 PKCE-based identity providers (Google, GitHub, Microsoft, etc.).
@@ -12,7 +12,7 @@ import 'package:serverpod/serverpod.dart';
 /// ## Same-origin requirement
 ///
 /// This route **must** be served from the same host and port as your Flutter
-/// web application. The redirect page uses `window.postMessage` to deliver
+/// web application. The callback page uses `window.postMessage` to deliver
 /// the OAuth result back to the Flutter app. Browsers enforce that
 /// `postMessage` with a specific `targetOrigin` is only delivered when the
 /// receiving window has the same origin (scheme + host + port).
@@ -29,7 +29,7 @@ import 'package:serverpod/serverpod.dart';
 ///
 /// ```dart
 /// // server.dart
-/// pod.configureOAuth2WebRedirectRoute(
+/// pod.configureFlutterWebAuth2CallbackRoute(
 ///   host: 'example.com',
 /// );
 ///
@@ -51,15 +51,15 @@ import 'package:serverpod/serverpod.dart';
 /// file provided by `flutter_web_auth_2` in your Flutter app's `web/`
 /// directory and use its URL as the `redirectUri`.
 /// {@endtemplate}
-final class FlutterWebAuth2RedirectRoute extends Route {
-  /// Creates a [FlutterWebAuth2RedirectRoute].
+final class FlutterWebAuth2CallbackRoute extends Route {
+  /// Creates a [FlutterWebAuth2CallbackRoute].
   ///
   /// The optional [host] restricts this route to requests whose `Host` header
   /// matches the given value. Defaults to `null`, which matches any host.
   ///
   /// Set [host] to the domain that serves your Flutter web app to ensure the
   /// callback is only reachable from the correct origin.
-  FlutterWebAuth2RedirectRoute({super.host}) : super(methods: {Method.get});
+  FlutterWebAuth2CallbackRoute({super.host}) : super(methods: {Method.get});
 
   @override
   FutureOr<Result> handleCall(final Session session, final Request request) {
@@ -95,15 +95,15 @@ final class FlutterWebAuth2RedirectRoute extends Route {
 </script>''';
 }
 
-/// Extension to register the [FlutterWebAuth2RedirectRoute] on the web server.
-extension FlutterWebAuth2ConfigureRoute on Serverpod {
-  /// {@macro flutter_web_auth2_redirect_route}
-  void configureOAuth2WebRedirectRoute({
+/// Extension to register the [FlutterWebAuth2CallbackRoute] on the web server.
+extension FlutterWebAuth2ConfigureCallbackRoute on Serverpod {
+  /// {@macro flutter_web_auth2_callback_route}
+  void configureFlutterWebAuth2CallbackRoute({
     final String path = '/auth/callback',
     final String? host,
   }) {
     webServer.addRoute(
-      FlutterWebAuth2RedirectRoute(host: host),
+      FlutterWebAuth2CallbackRoute(host: host),
       path,
     );
   }

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/common/oauth2_pkce/flutter_web_auth2_callback_route.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/common/oauth2_pkce/flutter_web_auth2_callback_route.dart
@@ -29,8 +29,9 @@ import 'package:serverpod/serverpod.dart';
 ///
 /// ```dart
 /// // server.dart
-/// pod.configureFlutterWebAuth2CallbackRoute(
-///   host: 'example.com',
+/// pod.webServer.addRoute(
+///   FlutterWebAuth2CallbackRoute(),
+///   '/auth/callback',
 /// );
 ///
 /// // Flutter app
@@ -93,18 +94,4 @@ final class FlutterWebAuth2CallbackRoute extends Route {
 
   postAuthenticationMessage();
 </script>''';
-}
-
-/// Extension to register the [FlutterWebAuth2CallbackRoute] on the web server.
-extension FlutterWebAuth2ConfigureCallbackRoute on Serverpod {
-  /// {@macro flutter_web_auth2_callback_route}
-  void configureFlutterWebAuth2CallbackRoute({
-    final String path = '/auth/callback',
-    final String? host,
-  }) {
-    webServer.addRoute(
-      FlutterWebAuth2CallbackRoute(host: host),
-      path,
-    );
-  }
 }

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/common/oauth2_pkce/flutter_web_auth2_redirect_route.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/common/oauth2_pkce/flutter_web_auth2_redirect_route.dart
@@ -1,0 +1,110 @@
+import 'dart:async';
+
+import 'package:serverpod/serverpod.dart';
+
+/// {@template flutter_web_auth2_redirect_route}
+/// Route that serves the [flutter_web_auth_2](https://pub.dev/packages/flutter_web_auth_2)
+/// redirect page for the OAuth2 PKCE web sign-in flow.
+///
+/// This route is **provider-agnostic** — register it once and share it across
+/// all OAuth2 PKCE-based identity providers (Google, GitHub, Microsoft, etc.).
+///
+/// ## Same-origin requirement
+///
+/// This route **must** be served from the same host and port as your Flutter
+/// web application. The redirect page uses `window.postMessage` to deliver
+/// the OAuth result back to the Flutter app. Browsers enforce that
+/// `postMessage` with a specific `targetOrigin` is only delivered when the
+/// receiving window has the same origin (scheme + host + port).
+///
+/// Use the [host] parameter to restrict this route to the exact host that
+/// serves your Flutter web app, preventing it from responding to requests
+/// aimed at other virtual hosts.
+///
+/// ## When to use
+///
+/// Use this route when Serverpod is serving your Flutter web app directly.
+/// Register the route once and set its full URL as the `redirectUri` when
+/// initializing any OAuth2 PKCE provider in the Flutter app:
+///
+/// ```dart
+/// // server.dart
+/// pod.configureOAuth2WebRedirectRoute(
+///   host: 'example.com',
+/// );
+///
+/// // Flutter app
+/// await client.auth.initializeGoogleSignIn(
+///   redirectUri: 'https://example.com/auth/callback',
+/// );
+/// await client.auth.initializeGitHubSignIn(
+///   redirectUri: 'https://example.com/auth/callback',
+/// );
+/// ```
+///
+/// ## When NOT to use
+///
+/// If your Flutter web app is hosted separately from Serverpod (for example,
+/// on a CDN at `app.example.com` while Serverpod runs on `api.example.com`),
+/// the `postMessage` call from the callback page will be blocked by the
+/// browser because the origins differ. In that case, place the `auth.html`
+/// file provided by `flutter_web_auth_2` in your Flutter app's `web/`
+/// directory and use its URL as the `redirectUri`.
+/// {@endtemplate}
+final class FlutterWebAuth2RedirectRoute extends Route {
+  /// Creates a [FlutterWebAuth2RedirectRoute].
+  ///
+  /// The optional [host] restricts this route to requests whose `Host` header
+  /// matches the given value. Defaults to `null`, which matches any host.
+  ///
+  /// Set [host] to the domain that serves your Flutter web app to ensure the
+  /// callback is only reachable from the correct origin.
+  FlutterWebAuth2RedirectRoute({super.host}) : super(methods: {Method.get});
+
+  @override
+  FutureOr<Result> handleCall(final Session session, final Request request) {
+    return Response.ok(
+      body: Body.fromString(_callbackHtml, mimeType: MimeType.html),
+      headers: Headers.build(
+        (final mh) => mh.cacheControl = CacheControlHeader(noStore: true),
+      ),
+    );
+  }
+
+  static const _callbackHtml = '''<!DOCTYPE html>
+<title>Authentication complete</title>
+<p>Authentication is complete. If this does not happen automatically, please close the window.</p>
+<script>
+  function postAuthenticationMessage() {
+    const message = {
+      'flutter-web-auth-2': window.location.href
+    };
+
+    if (window.opener) {
+      window.opener.postMessage(message, window.location.origin);
+      window.close();
+    } else if (window.parent && window.parent !== window) {
+      window.parent.postMessage(message, window.location.origin);
+    } else {
+      localStorage.setItem('flutter-web-auth-2', window.location.href);
+      window.close();
+    }
+  }
+
+  postAuthenticationMessage();
+</script>''';
+}
+
+/// Extension to register the [FlutterWebAuth2RedirectRoute] on the web server.
+extension FlutterWebAuth2ConfigureRoute on Serverpod {
+  /// {@macro flutter_web_auth2_redirect_route}
+  void configureOAuth2WebRedirectRoute({
+    final String path = '/auth/callback',
+    final String? host,
+  }) {
+    webServer.addRoute(
+      FlutterWebAuth2RedirectRoute(host: host),
+      path,
+    );
+  }
+}


### PR DESCRIPTION
Regarding @vlidholt comment in https://github.com/serverpod/serverpod_docs/pull/494#issuecomment-4441744264. This PR adds `FlutterWebAuth2RedirectRoute` for generic`OAuth2` web sign-in flow. 
Users have to register a callback router like  `pod.webServer.addRoute(FlutterWebAuth2CallbackRoute(), '/auth/callback');` before `pod.start()` instead of putting `web/auth.html` in setup Idp. This route that serves some Identity Providers callback. By default it serves in `/auth/callback` path but user can set his `path` and `host`. 

**NOTE:** This route should be in the same `host` with frontend app. 

This route is **provider-agnostic** — register it once and share it across all OAuth2 PKCE-based identity providers (Google, GitHub, Microsoft, etc.).

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

No breaking changes


## Same-origin requirement

This route **must** be served from the same host and port as your Flutter web application. The redirect page uses `window.postMessage` and browsers enforce that`postMessage` is only delivered when the receiving window has the same origin (scheme + host + port).

### example
Server
```dart
pod.webServer.addRoute(
  FlutterRoute(Directory(Uri(path: 'web/app').toFilePath()), host: 'cloud.serverpod.dev'),
  '/',
);
pod.webServer.addRoute(
  FlutterRoute(Directory(Uri(path: 'web/app').toFilePath()), host: 'accounts.serverpod.dev'),
  '/',
);

pod.webServer.addRoute(
  FlutterWebAuth2CallbackRoute(host: 'cloud.serverpod.dev'), // this route should be in the same-origin
  '/auth/callback',
);
```

Frontent
```dart
client.auth.initializeGoogleSignIn(
  clientId:'.apps.googleusercontent.com',
  redirectUri: 'https://cloud.serverpod.dev/auth/callback',
);

client.auth.initializeGitHubSignIn(
  clientId: '0000cc000cc',
  redirectUri: 'https://cloud.serverpod.dev/auth/callback',
);
```

## When NOT to use

If your Flutter web app is hosted separately.
In that case, place the `auth.html` file provided by (flutter_web_auth_2 README)[https://pub.dev/packages/flutter_web_auth_2#web] in your Flutter app's `web/` directory and use its URL as the `redirectUri`.