### PR TITLE
refactor: Add httpClientOverride parameter to ServerpodClientShared

### DIFF
--- a/examples/auth/auth_client/lib/src/protocol/client.dart
+++ b/examples/auth/auth_client/lib/src/protocol/client.dart
@@ -18,7 +18,8 @@ import 'package:serverpod_auth_core_client/serverpod_auth_core_client.dart'
     as _i4;
 import 'dart:typed_data' as _i5;
 import 'package:auth_client/src/protocol/greeting.dart' as _i6;
-import 'protocol.dart' as _i7;
+import 'package:http/http.dart' as _i7;
+import 'protocol.dart' as _i8;
 
 /// {@category Endpoint}
 class EndpointAnonymousIdp extends _i1.EndpointAnonymousIdpBase {
@@ -585,10 +586,10 @@ class Client extends _i2.ServerpodClientShared {
     onFailedCall,
     Function(_i2.MethodCallContext)? onSucceededCall,
     bool? disconnectStreamsOnLostInternetConnection,
-    bool withCredentials = false,
+    _i7.Client? httpClientOverride,
   }) : super(
          host,
-         _i7.Protocol(),
+         _i8.Protocol(),
          securityContext: securityContext,
          streamingConnectionTimeout: streamingConnectionTimeout,
          connectionTimeout: connectionTimeout,
@@ -596,7 +597,7 @@ class Client extends _i2.ServerpodClientShared {
          onSucceededCall: onSucceededCall,
          disconnectStreamsOnLostInternetConnection:
              disconnectStreamsOnLostInternetConnection,
-         withCredentials: withCredentials,
+         httpClientOverride: httpClientOverride,
        ) {
     anonymousIdp = EndpointAnonymousIdp(this);
     appleIdp = EndpointAppleIdp(this);

--- a/examples/auth/auth_client/lib/src/protocol/client.dart
+++ b/examples/auth/auth_client/lib/src/protocol/client.dart
@@ -585,6 +585,7 @@ class Client extends _i2.ServerpodClientShared {
     onFailedCall,
     Function(_i2.MethodCallContext)? onSucceededCall,
     bool? disconnectStreamsOnLostInternetConnection,
+    bool withCredentials = false,
   }) : super(
          host,
          _i7.Protocol(),
@@ -595,6 +596,7 @@ class Client extends _i2.ServerpodClientShared {
          onSucceededCall: onSucceededCall,
          disconnectStreamsOnLostInternetConnection:
              disconnectStreamsOnLostInternetConnection,
+         withCredentials: withCredentials,
        ) {
     anonymousIdp = EndpointAnonymousIdp(this);
     appleIdp = EndpointAppleIdp(this);

--- a/examples/legacy/auth_example/auth_example_client/lib/src/protocol/client.dart
+++ b/examples/legacy/auth_example/auth_example_client/lib/src/protocol/client.dart
@@ -55,6 +55,7 @@ class Client extends _i1.ServerpodClientShared {
     onFailedCall,
     Function(_i1.MethodCallContext)? onSucceededCall,
     bool? disconnectStreamsOnLostInternetConnection,
+    bool withCredentials = false,
   }) : super(
          host,
          _i4.Protocol(),
@@ -65,6 +66,7 @@ class Client extends _i1.ServerpodClientShared {
          onSucceededCall: onSucceededCall,
          disconnectStreamsOnLostInternetConnection:
              disconnectStreamsOnLostInternetConnection,
+         withCredentials: withCredentials,
        ) {
     example = EndpointExample(this);
     modules = Modules(this);

--- a/examples/legacy/auth_example/auth_example_client/lib/src/protocol/client.dart
+++ b/examples/legacy/auth_example/auth_example_client/lib/src/protocol/client.dart
@@ -13,7 +13,8 @@
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import 'dart:async' as _i2;
 import 'package:serverpod_auth_client/serverpod_auth_client.dart' as _i3;
-import 'protocol.dart' as _i4;
+import 'package:http/http.dart' as _i4;
+import 'protocol.dart' as _i5;
 
 /// {@category Endpoint}
 class EndpointExample extends _i1.EndpointRef {
@@ -55,10 +56,10 @@ class Client extends _i1.ServerpodClientShared {
     onFailedCall,
     Function(_i1.MethodCallContext)? onSucceededCall,
     bool? disconnectStreamsOnLostInternetConnection,
-    bool withCredentials = false,
+    _i4.Client? httpClientOverride,
   }) : super(
          host,
-         _i4.Protocol(),
+         _i5.Protocol(),
          securityContext: securityContext,
          streamingConnectionTimeout: streamingConnectionTimeout,
          connectionTimeout: connectionTimeout,
@@ -66,7 +67,7 @@ class Client extends _i1.ServerpodClientShared {
          onSucceededCall: onSucceededCall,
          disconnectStreamsOnLostInternetConnection:
              disconnectStreamsOnLostInternetConnection,
-         withCredentials: withCredentials,
+         httpClientOverride: httpClientOverride,
        ) {
     example = EndpointExample(this);
     modules = Modules(this);

--- a/examples/legacy/chat/chat_client/lib/src/protocol/client.dart
+++ b/examples/legacy/chat/chat_client/lib/src/protocol/client.dart
@@ -15,7 +15,8 @@ import 'dart:async' as _i2;
 import 'package:chat_client/src/protocol/channel.dart' as _i3;
 import 'package:serverpod_auth_client/serverpod_auth_client.dart' as _i4;
 import 'package:serverpod_chat_client/serverpod_chat_client.dart' as _i5;
-import 'protocol.dart' as _i6;
+import 'package:http/http.dart' as _i6;
+import 'protocol.dart' as _i7;
 
 /// {@category Endpoint}
 class EndpointChannels extends _i1.EndpointRef {
@@ -61,10 +62,10 @@ class Client extends _i1.ServerpodClientShared {
     onFailedCall,
     Function(_i1.MethodCallContext)? onSucceededCall,
     bool? disconnectStreamsOnLostInternetConnection,
-    bool withCredentials = false,
+    _i6.Client? httpClientOverride,
   }) : super(
          host,
-         _i6.Protocol(),
+         _i7.Protocol(),
          securityContext: securityContext,
          streamingConnectionTimeout: streamingConnectionTimeout,
          connectionTimeout: connectionTimeout,
@@ -72,7 +73,7 @@ class Client extends _i1.ServerpodClientShared {
          onSucceededCall: onSucceededCall,
          disconnectStreamsOnLostInternetConnection:
              disconnectStreamsOnLostInternetConnection,
-         withCredentials: withCredentials,
+         httpClientOverride: httpClientOverride,
        ) {
     channels = EndpointChannels(this);
     modules = Modules(this);

--- a/examples/legacy/chat/chat_client/lib/src/protocol/client.dart
+++ b/examples/legacy/chat/chat_client/lib/src/protocol/client.dart
@@ -61,6 +61,7 @@ class Client extends _i1.ServerpodClientShared {
     onFailedCall,
     Function(_i1.MethodCallContext)? onSucceededCall,
     bool? disconnectStreamsOnLostInternetConnection,
+    bool withCredentials = false,
   }) : super(
          host,
          _i6.Protocol(),
@@ -71,6 +72,7 @@ class Client extends _i1.ServerpodClientShared {
          onSucceededCall: onSucceededCall,
          disconnectStreamsOnLostInternetConnection:
              disconnectStreamsOnLostInternetConnection,
+         withCredentials: withCredentials,
        ) {
     channels = EndpointChannels(this);
     modules = Modules(this);

--- a/examples/middleware/middleware_client/lib/src/protocol/client.dart
+++ b/examples/middleware/middleware_client/lib/src/protocol/client.dart
@@ -13,7 +13,8 @@
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import 'dart:async' as _i2;
 import 'package:middleware_client/src/protocol/greeting.dart' as _i3;
-import 'protocol.dart' as _i4;
+import 'package:http/http.dart' as _i4;
+import 'protocol.dart' as _i5;
 
 /// This is an example endpoint that returns a greeting message through
 /// its [hello] method.
@@ -51,10 +52,10 @@ class Client extends _i1.ServerpodClientShared {
     onFailedCall,
     Function(_i1.MethodCallContext)? onSucceededCall,
     bool? disconnectStreamsOnLostInternetConnection,
-    bool withCredentials = false,
+    _i4.Client? httpClientOverride,
   }) : super(
          host,
-         _i4.Protocol(),
+         _i5.Protocol(),
          securityContext: securityContext,
          streamingConnectionTimeout: streamingConnectionTimeout,
          connectionTimeout: connectionTimeout,
@@ -62,7 +63,7 @@ class Client extends _i1.ServerpodClientShared {
          onSucceededCall: onSucceededCall,
          disconnectStreamsOnLostInternetConnection:
              disconnectStreamsOnLostInternetConnection,
-         withCredentials: withCredentials,
+         httpClientOverride: httpClientOverride,
        ) {
     greeting = EndpointGreeting(this);
   }

--- a/examples/middleware/middleware_client/lib/src/protocol/client.dart
+++ b/examples/middleware/middleware_client/lib/src/protocol/client.dart
@@ -51,6 +51,7 @@ class Client extends _i1.ServerpodClientShared {
     onFailedCall,
     Function(_i1.MethodCallContext)? onSucceededCall,
     bool? disconnectStreamsOnLostInternetConnection,
+    bool withCredentials = false,
   }) : super(
          host,
          _i4.Protocol(),
@@ -61,6 +62,7 @@ class Client extends _i1.ServerpodClientShared {
          onSucceededCall: onSucceededCall,
          disconnectStreamsOnLostInternetConnection:
              disconnectStreamsOnLostInternetConnection,
+         withCredentials: withCredentials,
        ) {
     greeting = EndpointGreeting(this);
   }

--- a/packages/serverpod_client/lib/src/serverpod_client_browser.dart
+++ b/packages/serverpod_client/lib/src/serverpod_client_browser.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 
+import 'package:http/browser_client.dart';
 import 'package:http/http.dart' as http;
-
 import 'package:serverpod_client/serverpod_client.dart';
 
 import 'serverpod_client_shared_private.dart';
@@ -24,8 +24,9 @@ class ServerpodClientRequestDelegateImpl
     required this.connectionTimeout,
     required this.serializationManager,
     dynamic securityContext,
+    bool withCredentials = false,
   }) {
-    _httpClient = http.Client();
+    _httpClient = BrowserClient()..withCredentials = withCredentials;
   }
 
   @override

--- a/packages/serverpod_client/lib/src/serverpod_client_browser.dart
+++ b/packages/serverpod_client/lib/src/serverpod_client_browser.dart
@@ -1,6 +1,3 @@
-import 'dart:async';
-
-import 'package:http/browser_client.dart';
 import 'package:http/http.dart' as http;
 import 'package:serverpod_client/serverpod_client.dart';
 
@@ -24,9 +21,9 @@ class ServerpodClientRequestDelegateImpl
     required this.connectionTimeout,
     required this.serializationManager,
     dynamic securityContext,
-    bool withCredentials = false,
+    http.Client? httpClientOverride,
   }) {
-    _httpClient = BrowserClient()..withCredentials = withCredentials;
+    _httpClient = httpClientOverride ?? http.Client();
   }
 
   @override

--- a/packages/serverpod_client/lib/src/serverpod_client_io.dart
+++ b/packages/serverpod_client/lib/src/serverpod_client_io.dart
@@ -1,7 +1,7 @@
-import 'dart:async';
-import 'dart:convert';
 import 'dart:io';
 
+import 'package:http/http.dart' as http;
+import 'package:http/io_client.dart';
 import 'package:serverpod_client/serverpod_client.dart';
 
 import 'serverpod_client_shared_private.dart';
@@ -17,23 +17,32 @@ class ServerpodClientRequestDelegateImpl
   /// The serialization manager used to serialize and deserialize data.
   final SerializationManager serializationManager;
 
-  late HttpClient _httpClient;
+  late http.Client _httpClient;
 
   /// Creates a new ServerpodClientRequestDelegateImpl.
   ServerpodClientRequestDelegateImpl({
     required this.connectionTimeout,
     required this.serializationManager,
     dynamic securityContext,
-    bool withCredentials = false,
+    http.Client? httpClientOverride,
   }) {
     assert(
       securityContext == null || securityContext is SecurityContext,
       'Context must be of type SecurityContext',
     );
+    assert(
+      httpClientOverride == null || securityContext == null,
+      'httpClientOverride and securityContext cannot both be set. '
+      'Configure the security context on the httpClientOverride directly.',
+    );
 
-    // Setup client
-    _httpClient = HttpClient(context: securityContext);
-    _httpClient.connectionTimeout = connectionTimeout;
+    if (httpClientOverride != null) {
+      _httpClient = httpClientOverride;
+    } else {
+      final inner = HttpClient(context: securityContext as SecurityContext?);
+      inner.connectionTimeout = connectionTimeout;
+      _httpClient = IOClient(inner);
+    }
   }
 
   @override
@@ -43,26 +52,18 @@ class ServerpodClientRequestDelegateImpl
     String? authenticationValue,
   }) async {
     try {
-      var request = await _httpClient.postUrl(url);
-      request.headers.contentType = ContentType(
-        'application',
-        'json',
-        charset: 'utf-8',
-      );
-      request.contentLength = utf8.encode(body).length;
-      if (authenticationValue != null) {
-        request.headers.add(
-          HttpHeaders.authorizationHeader,
-          authenticationValue,
-        );
-      }
-      request.write(body);
+      final response = await _httpClient
+          .post(
+            url,
+            body: body,
+            headers: {
+              HttpHeaders.contentTypeHeader: ContentType.json.toString(),
+              HttpHeaders.authorizationHeader: ?authenticationValue,
+            },
+          )
+          .timeout(connectionTimeout);
 
-      await request.flush();
-
-      var response = await request.close().timeout(connectionTimeout);
-
-      var data = await _readResponse(response);
+      final data = response.body;
 
       if (response.statusCode != HttpStatus.ok) {
         throw getExceptionFrom(
@@ -75,25 +76,10 @@ class ServerpodClientRequestDelegateImpl
       return data;
     } on SocketException catch (e) {
       throw ServerpodClientException(e.toString(), -1);
+    } on http.ClientException catch (e) {
+      var message = 'Unknown server response code. ($e)';
+      throw ServerpodClientException(message, -1);
     }
-  }
-
-  Future<String> _readResponse(HttpClientResponse response) {
-    var completer = Completer<String>();
-    var contents = StringBuffer();
-    response
-        .transform(const Utf8Decoder())
-        .listen(
-          (String data) {
-            contents.write(data);
-          },
-          onDone:
-              () //
-              {
-                return completer.complete(contents.toString());
-              },
-        );
-    return completer.future;
   }
 
   @override

--- a/packages/serverpod_client/lib/src/serverpod_client_io.dart
+++ b/packages/serverpod_client/lib/src/serverpod_client_io.dart
@@ -24,6 +24,7 @@ class ServerpodClientRequestDelegateImpl
     required this.connectionTimeout,
     required this.serializationManager,
     dynamic securityContext,
+    bool withCredentials = false,
   }) {
     assert(
       securityContext == null || securityContext is SecurityContext,

--- a/packages/serverpod_client/lib/src/serverpod_client_shared.dart
+++ b/packages/serverpod_client/lib/src/serverpod_client_shared.dart
@@ -3,6 +3,7 @@
 import 'dart:async';
 import 'dart:convert';
 
+import 'package:http/http.dart' as http;
 import 'package:serverpod_client/serverpod_client.dart';
 import 'package:serverpod_client/src/client_method_stream_manager.dart';
 import 'package:serverpod_client/src/method_stream/method_stream_connection_details.dart';
@@ -230,7 +231,7 @@ abstract class ServerpodClientShared extends EndpointCaller {
     this.onFailedCall,
     this.onSucceededCall,
     bool? disconnectStreamsOnLostInternetConnection,
-    bool withCredentials = false,
+    http.Client? httpClientOverride,
   }) : host = host.endsWith('/') ? host : '$host/',
        connectionTimeout = connectionTimeout ?? const Duration(seconds: 20),
        streamingConnectionTimeout =
@@ -243,7 +244,7 @@ abstract class ServerpodClientShared extends EndpointCaller {
       connectionTimeout: this.connectionTimeout,
       serializationManager: serializationManager,
       securityContext: securityContext,
-      withCredentials: withCredentials,
+      httpClientOverride: httpClientOverride,
     );
     disconnectStreamsOnLostInternetConnection ??= false;
     _disconnectMethodStreamsOnLostInternetConnection =

--- a/packages/serverpod_client/lib/src/serverpod_client_shared.dart
+++ b/packages/serverpod_client/lib/src/serverpod_client_shared.dart
@@ -230,6 +230,7 @@ abstract class ServerpodClientShared extends EndpointCaller {
     this.onFailedCall,
     this.onSucceededCall,
     bool? disconnectStreamsOnLostInternetConnection,
+    bool withCredentials = false,
   }) : host = host.endsWith('/') ? host : '$host/',
        connectionTimeout = connectionTimeout ?? const Duration(seconds: 20),
        streamingConnectionTimeout =
@@ -242,6 +243,7 @@ abstract class ServerpodClientShared extends EndpointCaller {
       connectionTimeout: this.connectionTimeout,
       serializationManager: serializationManager,
       securityContext: securityContext,
+      withCredentials: withCredentials,
     );
     disconnectStreamsOnLostInternetConnection ??= false;
     _disconnectMethodStreamsOnLostInternetConnection =

--- a/packages/serverpod_service_client/lib/src/protocol/client.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/client.dart
@@ -244,6 +244,7 @@ class Client extends _i1.ServerpodClientShared {
     onFailedCall,
     Function(_i1.MethodCallContext)? onSucceededCall,
     bool? disconnectStreamsOnLostInternetConnection,
+    bool withCredentials = false,
   }) : super(
          host,
          _i14.Protocol(),
@@ -254,6 +255,7 @@ class Client extends _i1.ServerpodClientShared {
          onSucceededCall: onSucceededCall,
          disconnectStreamsOnLostInternetConnection:
              disconnectStreamsOnLostInternetConnection,
+         withCredentials: withCredentials,
        ) {
     insights = EndpointInsights(this);
   }

--- a/packages/serverpod_service_client/lib/src/protocol/client.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/client.dart
@@ -30,7 +30,8 @@ import 'package:serverpod_database/src/generated/bulk_data.dart' as _i11;
 import 'package:serverpod_database/src/generated/filter/filter.dart' as _i12;
 import 'package:serverpod_database/src/generated/bulk_query_result.dart'
     as _i13;
-import 'protocol.dart' as _i14;
+import 'package:http/http.dart' as _i14;
+import 'protocol.dart' as _i15;
 
 /// The [InsightsEndpoint] provides a way to access real time information from
 /// the running server or to change settings.
@@ -244,10 +245,10 @@ class Client extends _i1.ServerpodClientShared {
     onFailedCall,
     Function(_i1.MethodCallContext)? onSucceededCall,
     bool? disconnectStreamsOnLostInternetConnection,
-    bool withCredentials = false,
+    _i14.Client? httpClientOverride,
   }) : super(
          host,
-         _i14.Protocol(),
+         _i15.Protocol(),
          securityContext: securityContext,
          streamingConnectionTimeout: streamingConnectionTimeout,
          connectionTimeout: connectionTimeout,
@@ -255,7 +256,7 @@ class Client extends _i1.ServerpodClientShared {
          onSucceededCall: onSucceededCall,
          disconnectStreamsOnLostInternetConnection:
              disconnectStreamsOnLostInternetConnection,
-         withCredentials: withCredentials,
+         httpClientOverride: httpClientOverride,
        ) {
     insights = EndpointInsights(this);
   }

--- a/packages/serverpod_service_client/pubspec.yaml
+++ b/packages/serverpod_service_client/pubspec.yaml
@@ -12,6 +12,7 @@ environment:
   sdk: '^3.10.3'
 
 dependencies:
+  http: '>=1.1.0 <2.0.0'
   meta: ^1.15.0
   serverpod_client: 3.5.0-beta.7
   serverpod_database: 3.5.0-beta.7

--- a/templates/pubspecs/packages/serverpod_service_client/pubspec.yaml
+++ b/templates/pubspecs/packages/serverpod_service_client/pubspec.yaml
@@ -11,6 +11,7 @@ environment:
   sdk: DART_VERSION
 
 dependencies:
+  http: '>=1.1.0 <2.0.0'
   meta: ^1.15.0
   serverpod_client: SERVERPOD_VERSION
   serverpod_database: SERVERPOD_VERSION

--- a/tests/serverpod_auth_test/serverpod_auth_test_client/lib/src/protocol/client.dart
+++ b/tests/serverpod_auth_test/serverpod_auth_test_client/lib/src/protocol/client.dart
@@ -22,7 +22,8 @@ import 'package:serverpod_auth_bridge_client/serverpod_auth_bridge_client.dart'
     as _i7;
 import 'package:serverpod_auth_migration_client/serverpod_auth_migration_client.dart'
     as _i8;
-import 'protocol.dart' as _i9;
+import 'package:http/http.dart' as _i9;
+import 'protocol.dart' as _i10;
 
 /// Endpoint for Apple-based authentication.
 /// {@category Endpoint}
@@ -942,10 +943,10 @@ class Client extends _i2.ServerpodClientShared {
     onFailedCall,
     Function(_i2.MethodCallContext)? onSucceededCall,
     bool? disconnectStreamsOnLostInternetConnection,
-    bool withCredentials = false,
+    _i9.Client? httpClientOverride,
   }) : super(
          host,
-         _i9.Protocol(),
+         _i10.Protocol(),
          securityContext: securityContext,
          streamingConnectionTimeout: streamingConnectionTimeout,
          connectionTimeout: connectionTimeout,
@@ -953,7 +954,7 @@ class Client extends _i2.ServerpodClientShared {
          onSucceededCall: onSucceededCall,
          disconnectStreamsOnLostInternetConnection:
              disconnectStreamsOnLostInternetConnection,
-         withCredentials: withCredentials,
+         httpClientOverride: httpClientOverride,
        ) {
     appleAccount = EndpointAppleAccount(this);
     authTest = EndpointAuthTest(this);

--- a/tests/serverpod_auth_test/serverpod_auth_test_client/lib/src/protocol/client.dart
+++ b/tests/serverpod_auth_test/serverpod_auth_test_client/lib/src/protocol/client.dart
@@ -942,6 +942,7 @@ class Client extends _i2.ServerpodClientShared {
     onFailedCall,
     Function(_i2.MethodCallContext)? onSucceededCall,
     bool? disconnectStreamsOnLostInternetConnection,
+    bool withCredentials = false,
   }) : super(
          host,
          _i9.Protocol(),
@@ -952,6 +953,7 @@ class Client extends _i2.ServerpodClientShared {
          onSucceededCall: onSucceededCall,
          disconnectStreamsOnLostInternetConnection:
              disconnectStreamsOnLostInternetConnection,
+         withCredentials: withCredentials,
        ) {
     appleAccount = EndpointAppleAccount(this);
     authTest = EndpointAuthTest(this);

--- a/tests/serverpod_test_client/lib/src/protocol/client.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/client.dart
@@ -55,7 +55,8 @@ import 'package:serverpod_test_client/src/protocol/object_with_dynamic.dart'
     as _i28;
 import 'package:serverpod_test_client/src/protocol/my_feature/models/my_feature_model.dart'
     as _i29;
-import 'protocol.dart' as _i30;
+import 'package:http/http.dart' as _i30;
+import 'protocol.dart' as _i31;
 
 /// {@category Endpoint}
 class EndpointAsyncTasks extends _i1.EndpointRef {
@@ -4452,10 +4453,10 @@ class Client extends _i1.ServerpodClientShared {
     onFailedCall,
     Function(_i1.MethodCallContext)? onSucceededCall,
     bool? disconnectStreamsOnLostInternetConnection,
-    bool withCredentials = false,
+    _i30.Client? httpClientOverride,
   }) : super(
          host,
-         _i30.Protocol(),
+         _i31.Protocol(),
          securityContext: securityContext,
          streamingConnectionTimeout: streamingConnectionTimeout,
          connectionTimeout: connectionTimeout,
@@ -4463,7 +4464,7 @@ class Client extends _i1.ServerpodClientShared {
          onSucceededCall: onSucceededCall,
          disconnectStreamsOnLostInternetConnection:
              disconnectStreamsOnLostInternetConnection,
-         withCredentials: withCredentials,
+         httpClientOverride: httpClientOverride,
        ) {
     asyncTasks = EndpointAsyncTasks(this);
     authentication = EndpointAuthentication(this);

--- a/tests/serverpod_test_client/lib/src/protocol/client.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/client.dart
@@ -4452,6 +4452,7 @@ class Client extends _i1.ServerpodClientShared {
     onFailedCall,
     Function(_i1.MethodCallContext)? onSucceededCall,
     bool? disconnectStreamsOnLostInternetConnection,
+    bool withCredentials = false,
   }) : super(
          host,
          _i30.Protocol(),
@@ -4462,6 +4463,7 @@ class Client extends _i1.ServerpodClientShared {
          onSucceededCall: onSucceededCall,
          disconnectStreamsOnLostInternetConnection:
              disconnectStreamsOnLostInternetConnection,
+         withCredentials: withCredentials,
        ) {
     asyncTasks = EndpointAsyncTasks(this);
     authentication = EndpointAuthentication(this);

--- a/tests/serverpod_test_nonvector/serverpod_test_nonvector_client/lib/src/protocol/client.dart
+++ b/tests/serverpod_test_nonvector/serverpod_test_nonvector_client/lib/src/protocol/client.dart
@@ -49,6 +49,7 @@ class Client extends _i1.ServerpodClientShared {
     onFailedCall,
     Function(_i1.MethodCallContext)? onSucceededCall,
     bool? disconnectStreamsOnLostInternetConnection,
+    bool withCredentials = false,
   }) : super(
          host,
          _i4.Protocol(),
@@ -59,6 +60,7 @@ class Client extends _i1.ServerpodClientShared {
          onSucceededCall: onSucceededCall,
          disconnectStreamsOnLostInternetConnection:
              disconnectStreamsOnLostInternetConnection,
+         withCredentials: withCredentials,
        ) {
     greeting = EndpointGreeting(this);
   }

--- a/tests/serverpod_test_nonvector/serverpod_test_nonvector_client/lib/src/protocol/client.dart
+++ b/tests/serverpod_test_nonvector/serverpod_test_nonvector_client/lib/src/protocol/client.dart
@@ -14,7 +14,8 @@ import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import 'dart:async' as _i2;
 import 'package:serverpod_test_nonvector_client/src/protocol/greeting.dart'
     as _i3;
-import 'protocol.dart' as _i4;
+import 'package:http/http.dart' as _i4;
+import 'protocol.dart' as _i5;
 
 /// {@category Endpoint}
 class EndpointGreeting extends _i1.EndpointRef {
@@ -49,10 +50,10 @@ class Client extends _i1.ServerpodClientShared {
     onFailedCall,
     Function(_i1.MethodCallContext)? onSucceededCall,
     bool? disconnectStreamsOnLostInternetConnection,
-    bool withCredentials = false,
+    _i4.Client? httpClientOverride,
   }) : super(
          host,
-         _i4.Protocol(),
+         _i5.Protocol(),
          securityContext: securityContext,
          streamingConnectionTimeout: streamingConnectionTimeout,
          connectionTimeout: connectionTimeout,
@@ -60,7 +61,7 @@ class Client extends _i1.ServerpodClientShared {
          onSucceededCall: onSucceededCall,
          disconnectStreamsOnLostInternetConnection:
              disconnectStreamsOnLostInternetConnection,
-         withCredentials: withCredentials,
+         httpClientOverride: httpClientOverride,
        ) {
     greeting = EndpointGreeting(this);
   }

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/client.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/client.dart
@@ -14,8 +14,9 @@ import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import 'dart:async' as _i2;
 import 'package:serverpod_test_sqlite_client/src/protocol/simple_data.dart'
     as _i3;
-import 'protocol.dart' as _i4;
-import 'package:serverpod_database/serverpod_database.dart' as _i5;
+import 'package:http/http.dart' as _i4;
+import 'protocol.dart' as _i5;
+import 'package:serverpod_database/serverpod_database.dart' as _i6;
 import 'package:serverpod_test_sqlite_client/migrations/migration_registry.dart';
 
 /// {@category Endpoint}
@@ -79,10 +80,10 @@ class Client extends _i1.ServerpodClientShared {
     onFailedCall,
     Function(_i1.MethodCallContext)? onSucceededCall,
     bool? disconnectStreamsOnLostInternetConnection,
-    bool withCredentials = false,
+    _i4.Client? httpClientOverride,
   }) : super(
          host,
-         _i4.Protocol(),
+         _i5.Protocol(),
          securityContext: securityContext,
          streamingConnectionTimeout: streamingConnectionTimeout,
          connectionTimeout: connectionTimeout,
@@ -90,7 +91,7 @@ class Client extends _i1.ServerpodClientShared {
          onSucceededCall: onSucceededCall,
          disconnectStreamsOnLostInternetConnection:
              disconnectStreamsOnLostInternetConnection,
-         withCredentials: withCredentials,
+         httpClientOverride: httpClientOverride,
        ) {
     testTools = EndpointTestTools(this);
   }
@@ -118,14 +119,14 @@ class Client extends _i1.ServerpodClientShared {
   /// If [isDebugMode] is true, the database integrity will be verified after
   /// the migrations are applied to provide feedback of possible issues. On a
   /// Flutter application, this should be set to [kDebugMode].
-  _i2.Future<_i5.ClientDatabaseSession> createSession(
+  _i2.Future<_i6.ClientDatabaseSession> createSession(
     String path, {
     bool runMigrations = true,
     bool isDebugMode = false,
   }) async {
-    return await _i5.ClientDatabaseSession.open(
+    return await _i6.ClientDatabaseSession.open(
       path,
-      _i4.Protocol(),
+      _i5.Protocol(),
       clientMigrations: MigrationRegistry.migrations,
       runMigrations: runMigrations,
       isDebugMode: isDebugMode,

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/client.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/client.dart
@@ -79,6 +79,7 @@ class Client extends _i1.ServerpodClientShared {
     onFailedCall,
     Function(_i1.MethodCallContext)? onSucceededCall,
     bool? disconnectStreamsOnLostInternetConnection,
+    bool withCredentials = false,
   }) : super(
          host,
          _i4.Protocol(),
@@ -89,6 +90,7 @@ class Client extends _i1.ServerpodClientShared {
          onSucceededCall: onSucceededCall,
          disconnectStreamsOnLostInternetConnection:
              disconnectStreamsOnLostInternetConnection,
+         withCredentials: withCredentials,
        ) {
     testTools = EndpointTestTools(this);
   }

--- a/tools/serverpod_cli/lib/src/generator/dart/library_generators/library_generator.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart/library_generators/library_generator.dart
@@ -1089,15 +1089,14 @@ class LibraryGenerator {
                     ),
                     Parameter(
                       (p) => p
-                        ..name = 'withCredentials'
+                        ..name = 'httpClientOverride'
                         ..named = true
                         ..type = TypeReference(
                           (t) => t
-                            ..symbol = 'bool'
-                            ..url = 'dart:core'
-                            ..isNullable = false,
-                        )
-                        ..defaultTo = literalFalse.code,
+                            ..symbol = 'Client'
+                            ..url = 'package:http/http.dart'
+                            ..isNullable = true,
+                        ),
                     ),
                   ])
                   ..initializers.add(
@@ -1118,7 +1117,7 @@ class LibraryGenerator {
                             'disconnectStreamsOnLostInternetConnection': refer(
                               'disconnectStreamsOnLostInternetConnection',
                             ),
-                            'withCredentials': refer('withCredentials'),
+                            'httpClientOverride': refer('httpClientOverride'),
                           },
                         )
                         .code,

--- a/tools/serverpod_cli/lib/src/generator/dart/library_generators/library_generator.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart/library_generators/library_generator.dart
@@ -1087,6 +1087,18 @@ class LibraryGenerator {
                             ..isNullable = true,
                         ),
                     ),
+                    Parameter(
+                      (p) => p
+                        ..name = 'withCredentials'
+                        ..named = true
+                        ..type = TypeReference(
+                          (t) => t
+                            ..symbol = 'bool'
+                            ..url = 'dart:core'
+                            ..isNullable = false,
+                        )
+                        ..defaultTo = literalFalse.code,
+                    ),
                   ])
                   ..initializers.add(
                     refer('super')
@@ -1106,6 +1118,7 @@ class LibraryGenerator {
                             'disconnectStreamsOnLostInternetConnection': refer(
                               'disconnectStreamsOnLostInternetConnection',
                             ),
+                            'withCredentials': refer('withCredentials'),
                           },
                         )
                         .code,


### PR DESCRIPTION
Adds an optional `http.Client? httpClientOverride` parameter to `ServerpodClientShared` and all generated client constructors.

If no override is provided the default `http.Client()` is used on web and an `IOClient` (wrapping `dart:io`'s `HttpClient`) is used on native. If an override is provided it is used directly, giving users full control over the underlying HTTP transport.

This allows passing any `http.Client` implementation — including platform-native clients from packages such as [cupertino_http](https://pub.dev/packages/cupertino_http) (NSURLSession on iOS/macOS) or [cronet_http](https://pub.dev/packages/cronet_http) (Cronet on Android), as well as configuring browser-specific behaviour on web.

**Examples:**

Enable CORS credentials on web:
```dart
Client(
  serverUrl,
  httpClientOverride: BrowserClient()..withCredentials = true,
)
  ..connectivityMonitor = FlutterConnectivityMonitor()
  ..authSessionManager = FlutterAuthSessionManager();
  
  ```

Use platform-native HTTP on iOS/macOS ([cupertino_http]):
```dart
Client(
  serverUrl,
  httpClientOverride: CupertinoClient.defaultSessionConfiguration(),
);
```

Use Cronet on Android ([cronet_http]):
```dart
Client(
  serverUrl,
  httpClientOverride: CronetClient.fromCronetEngine(engine),
);
```

Note: `httpClientOverride` and `securityContext` cannot be set simultaneously — an assertion enforces this since securityContext is only meaningful when the framework builds the client internally. 


Fixes  https://github.com/serverpod/serverpod/issues/4850

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

No breaking changes.