### PR TITLE
feat: Make the `global` cache fallback to local in development/testing

### DIFF
--- a/packages/serverpod_client/lib/src/serverpod_client_io.dart
+++ b/packages/serverpod_client/lib/src/serverpod_client_io.dart
@@ -1,14 +1,15 @@
-import 'dart:async';
-import 'dart:convert';
 import 'dart:io';
+
+import 'package:http/http.dart' as http;
+import 'package:http/io_client.dart';
 
 import 'package:serverpod_client/serverpod_client.dart';
 
 import 'serverpod_client_shared_private.dart';
 
 /// Handles communication with the server.
-/// This is the concrete implementation using the io library
-/// (for Flutter native apps).
+/// This is the concrete implementation using [http.Client] via [IOClient]
+/// (for Flutter native apps), backed by [HttpClient] for TLS configuration.
 class ServerpodClientRequestDelegateImpl
     extends ServerpodClientRequestDelegate {
   /// The timeout for the connection and the requests.
@@ -17,7 +18,7 @@ class ServerpodClientRequestDelegateImpl
   /// The serialization manager used to serialize and deserialize data.
   final SerializationManager serializationManager;
 
-  late HttpClient _httpClient;
+  late http.Client _httpClient;
 
   /// Creates a new ServerpodClientRequestDelegateImpl.
   ServerpodClientRequestDelegateImpl({
@@ -30,9 +31,9 @@ class ServerpodClientRequestDelegateImpl
       'Context must be of type SecurityContext',
     );
 
-    // Setup client
-    _httpClient = HttpClient(context: securityContext);
-    _httpClient.connectionTimeout = connectionTimeout;
+    final inner = HttpClient(context: securityContext as SecurityContext?);
+    inner.connectionTimeout = connectionTimeout;
+    _httpClient = IOClient(inner);
   }
 
   @override
@@ -42,26 +43,18 @@ class ServerpodClientRequestDelegateImpl
     String? authenticationValue,
   }) async {
     try {
-      var request = await _httpClient.postUrl(url);
-      request.headers.contentType = ContentType(
-        'application',
-        'json',
-        charset: 'utf-8',
-      );
-      request.contentLength = utf8.encode(body).length;
-      if (authenticationValue != null) {
-        request.headers.add(
-          HttpHeaders.authorizationHeader,
-          authenticationValue,
-        );
-      }
-      request.write(body);
+      var response = await _httpClient
+          .post(
+            url,
+            body: body,
+            headers: {
+              HttpHeaders.contentTypeHeader: ContentType.json.toString(),
+              HttpHeaders.authorizationHeader: ?authenticationValue,
+            },
+          )
+          .timeout(connectionTimeout);
 
-      await request.flush();
-
-      var response = await request.close().timeout(connectionTimeout);
-
-      var data = await _readResponse(response);
+      var data = response.body;
 
       if (response.statusCode != HttpStatus.ok) {
         throw getExceptionFrom(
@@ -74,25 +67,10 @@ class ServerpodClientRequestDelegateImpl
       return data;
     } on SocketException catch (e) {
       throw ServerpodClientException(e.toString(), -1);
+    } on http.ClientException catch (e) {
+      var message = 'Unknown server response code. ($e)';
+      throw ServerpodClientException(message, -1);
     }
-  }
-
-  Future<String> _readResponse(HttpClientResponse response) {
-    var completer = Completer<String>();
-    var contents = StringBuffer();
-    response
-        .transform(const Utf8Decoder())
-        .listen(
-          (String data) {
-            contents.write(data);
-          },
-          onDone:
-              () //
-              {
-                return completer.complete(contents.toString());
-              },
-        );
-    return completer.future;
   }
 
   @override


### PR DESCRIPTION
This PR is actually wrong... Some messa happened on the IDE UI that attached the wrong branch.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.