### PR TITLE
feat: Make the `global` cache fallback to local in development/testing

### DIFF
--- a/packages/serverpod/lib/src/cache/caches.dart
+++ b/packages/serverpod/lib/src/cache/caches.dart
@@ -1,4 +1,5 @@
 import 'package:serverpod/server.dart';
+import 'package:serverpod/src/cache/cache.dart';
 import 'package:serverpod/src/cache/global_cache.dart';
 import 'package:serverpod/src/cache/redis_cache.dart';
 import 'package:serverpod/src/redis/controller.dart';
@@ -21,10 +22,11 @@ class Caches {
   ) {
     _local = LocalCache(10000, _serializationManager);
     _localPrio = LocalCache(10000, _serializationManager);
-    _global = RedisCache(
-      _serializationManager,
-      redisController,
-    );
+    if (redisController != null) {
+      _redis = RedisCache(_serializationManager, redisController);
+    } else {
+      _localFallback = LocalCache(10000, _serializationManager);
+    }
     _query = LocalCache(10000, _serializationManager);
   }
 
@@ -42,22 +44,33 @@ class Caches {
   /// but objects are not guaranteed to be the same across servers.
   LocalCache get localPrio => _localPrio;
 
-  late GlobalCache _global;
+  GlobalCache? _redis;
+
+  /// Separate local cache used as a fallback if Redis is not configured. Must
+  /// not be the same as the main local cache to avoid introducing bugs in which
+  /// a locally cached object can be globally accessed in development.
+  LocalCache? _localFallback;
 
   /// Used to cache objects that are of lower priority, and need to stay
   /// consistent across servers. Provides slower access than the local cache,
   /// but objects are guaranteed to be the same across servers.
-  GlobalCache get global => _global;
+  ///
+  /// Fallback to a separate local cache if Redis is not configured or not
+  /// available in development or testing run modes. In fallback mode, the
+  /// cache will not guarantee consistency across servers.
+  Cache get global => _redis ?? _localFallback!;
 
   late LocalCache _query;
 
-  /// Cache used to automatically save cachable database queries.
+  /// Cache used to automatically save cacheable database queries.
   LocalCache get query => _query;
 
   /// Clears all caches.
   Future<void> clear() async {
     await _local.clear();
     await _localPrio.clear();
+    await _redis?.clear();
+    await _localFallback?.clear();
     await _query.clear();
   }
 }

--- a/packages/serverpod/lib/src/redis/controller.dart
+++ b/packages/serverpod/lib/src/redis/controller.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io';
 
 import 'package:redis/redis.dart';
 import 'package:serverpod_shared/log.dart';
@@ -28,6 +29,13 @@ class RedisController {
   /// require ssl
   final bool requireSsl;
 
+  /// Maximum time to wait while opening the TCP/TLS connection to Redis.
+  ///
+  /// After this duration, the attempt fails with [TimeoutException] instead of
+  /// relying on OS-level connect timeouts (which can be very long when traffic
+  /// is dropped).
+  final Duration connectTimeout;
+
   final Map<String, RedisSubscriptionCallback> _subscriptions = {};
 
   Command? _command;
@@ -46,16 +54,23 @@ class RedisController {
     required this.requireSsl,
     this.user,
     this.password,
+    this.connectTimeout = const Duration(seconds: 10),
   });
 
   /// Starts the controller and connects to Redis. Maintains an open connection
   /// until [stop] is called.
-  Future<void> start([bool Function(Exception e)? handleError]) async {
-    final connected = await _connect(handleError);
+  ///
+  /// If [connectTimeout] is set, it overrides [RedisController.connectTimeout]
+  /// for the TCP/TLS connections opened during this [start] call only.
+  Future<void> start({
+    bool Function(Exception e)? handleError,
+    Duration? connectTimeout,
+  }) async {
+    final connected = await _connect(handleError, connectTimeout);
     if (!connected && handleError != null) {
       return;
     }
-    await _connectPubSub();
+    await _connectPubSub(connectTimeout);
 
     unawaited(_keepAlive());
   }
@@ -67,16 +82,23 @@ class RedisController {
     await _pubSubCommand?.get_connection().close();
   }
 
+  Future<Socket> _openRedisSocket([Duration? connectTimeoutOverride]) async {
+    final timeout = connectTimeoutOverride ?? connectTimeout;
+    if (requireSsl) {
+      return SecureSocket.connect(host, port, timeout: timeout);
+    }
+    return Socket.connect(host, port, timeout: timeout);
+  }
+
   /// Shared helper to create and authenticate a Redis Command connection.
-  Future<Command?> _createAndAuthCommand([
+  Future<Command?> _createAndAuthCommand({
     bool Function(Exception e)? handleError,
-  ]) async {
+    Duration? connectTimeoutOverride,
+  }) async {
     try {
+      final socket = await _openRedisSocket(connectTimeoutOverride);
       var connection = RedisConnection();
-      Command command = switch (requireSsl) {
-        true => await connection.connectSecure(host, port),
-        false => await connection.connect(host, port),
-      };
+      var command = await connection.connectWithSocket(socket);
 
       if (password != null) {
         dynamic result = switch (user) {
@@ -100,7 +122,10 @@ class RedisController {
     }
   }
 
-  Future<bool> _connect([bool Function(Exception e)? handleError]) async {
+  Future<bool> _connect([
+    bool Function(Exception e)? handleError,
+    Duration? connectTimeoutOverride,
+  ]) async {
     if (_command != null) {
       return true;
     }
@@ -109,7 +134,10 @@ class RedisController {
     }
     _connecting = true;
 
-    _command = await _createAndAuthCommand(handleError);
+    _command = await _createAndAuthCommand(
+      handleError: handleError,
+      connectTimeoutOverride: connectTimeoutOverride,
+    );
     _connecting = false;
     return _command != null;
   }
@@ -123,7 +151,7 @@ class RedisController {
     }
   }
 
-  Future<bool> _connectPubSub() async {
+  Future<bool> _connectPubSub([Duration? connectTimeoutOverride]) async {
     if (_pubSub != null) {
       return true;
     }
@@ -132,7 +160,9 @@ class RedisController {
     }
     _connectingPubSub = true;
 
-    _pubSubCommand = await _createAndAuthCommand();
+    _pubSubCommand = await _createAndAuthCommand(
+      connectTimeoutOverride: connectTimeoutOverride,
+    );
     if (_pubSubCommand == null) {
       _connectingPubSub = false;
       return false;

--- a/packages/serverpod/lib/src/redis/controller.dart
+++ b/packages/serverpod/lib/src/redis/controller.dart
@@ -50,8 +50,11 @@ class RedisController {
 
   /// Starts the controller and connects to Redis. Maintains an open connection
   /// until [stop] is called.
-  Future<void> start() async {
-    await _connect();
+  Future<void> start([bool Function(Exception e)? handleError]) async {
+    final connected = await _connect(handleError);
+    if (!connected && handleError != null) {
+      return;
+    }
     await _connectPubSub();
 
     unawaited(_keepAlive());
@@ -65,7 +68,9 @@ class RedisController {
   }
 
   /// Shared helper to create and authenticate a Redis Command connection.
-  Future<Command?> _createAndAuthCommand() async {
+  Future<Command?> _createAndAuthCommand([
+    bool Function(Exception e)? handleError,
+  ]) async {
     try {
       var connection = RedisConnection();
       Command command = switch (requireSsl) {
@@ -83,6 +88,9 @@ class RedisController {
       }
       return command;
     } catch (e, stackTrace) {
+      if (handleError != null && e is Exception && handleError(e)) {
+        return null;
+      }
       log.error(
         'Internal server error. Failed to connect to Redis.',
         error: e,
@@ -92,7 +100,7 @@ class RedisController {
     }
   }
 
-  Future<bool> _connect() async {
+  Future<bool> _connect([bool Function(Exception e)? handleError]) async {
     if (_command != null) {
       return true;
     }
@@ -101,7 +109,7 @@ class RedisController {
     }
     _connecting = true;
 
-    _command = await _createAndAuthCommand();
+    _command = await _createAndAuthCommand(handleError);
     _connecting = false;
     return _command != null;
   }

--- a/packages/serverpod/lib/src/server/serverpod.dart
+++ b/packages/serverpod/lib/src/server/serverpod.dart
@@ -808,7 +808,13 @@ class Serverpod {
     // Connect to Redis
     if (Features.enableRedis) {
       _internalLogVerbose('Connecting to Redis.');
-      await redisController?.start();
+      await redisController?.start((e) {
+        if (runMode == ServerpodRunMode.production) return false;
+        log.warning('Failed to connect to Redis. Falling back to local cache.');
+        redisController = null;
+        _caches = Caches(serializationManager, config, serverId, null);
+        return true;
+      });
     } else {
       _internalLogVerbose('Redis is disabled, skipping.');
     }

--- a/packages/serverpod/lib/src/server/serverpod.dart
+++ b/packages/serverpod/lib/src/server/serverpod.dart
@@ -808,13 +808,23 @@ class Serverpod {
     // Connect to Redis
     if (Features.enableRedis) {
       _internalLogVerbose('Connecting to Redis.');
-      await redisController?.start((e) {
-        if (runMode == ServerpodRunMode.production) return false;
-        log.warning('Failed to connect to Redis. Falling back to local cache.');
-        redisController = null;
-        _caches = Caches(serializationManager, config, serverId, null);
-        return true;
-      });
+      await redisController?.start(
+        // In local development, we want to fail fast if Redis is not available
+        // to avoid waiting for a potentially long connect timeout. This is
+        // specially important when running tests.
+        connectTimeout: runMode != ServerpodRunMode.production
+            ? const Duration(seconds: 1)
+            : null,
+        handleError: (e) {
+          if (runMode == ServerpodRunMode.production) return false;
+          log.warning(
+            'Failed to connect to Redis. Falling back to local cache.',
+          );
+          redisController = null;
+          _caches = Caches(serializationManager, config, serverId, null);
+          return true;
+        },
+      );
     } else {
       _internalLogVerbose('Redis is disabled, skipping.');
     }

--- a/packages/serverpod/test/cache/caches_test.dart
+++ b/packages/serverpod/test/cache/caches_test.dart
@@ -1,0 +1,127 @@
+import 'package:serverpod/src/cache/caches.dart';
+import 'package:serverpod/src/cache/local_cache.dart';
+import 'package:serverpod/src/cache/redis_cache.dart';
+import 'package:serverpod/src/generated/protocol.dart';
+import 'package:serverpod/src/redis/controller.dart';
+import 'package:serverpod_shared/serverpod_shared.dart';
+import 'package:test/test.dart';
+
+void main() {
+  final apiServer = ServerConfig(
+    port: 0,
+    publicScheme: 'http',
+    publicHost: 'localhost',
+    publicPort: 0,
+  );
+
+  final config = ServerpodConfig(
+    apiServer: apiServer,
+    webServer: apiServer,
+    serverId: 'test-server',
+  );
+
+  final serializationManager = Protocol();
+
+  group(
+    'Given a Caches collection with Redis configured, '
+    'when global cache is accessed, ',
+    () {
+      late Caches caches;
+
+      setUp(() {
+        caches = Caches(
+          serializationManager,
+          config,
+          config.serverId,
+          RedisController(
+            host: '127.0.0.1',
+            port: 6379,
+            requireSsl: false,
+          ),
+        );
+      });
+
+      test(
+        'then global uses Redis-backed cache.',
+        () {
+          expect(caches.global, isA<RedisCache>());
+        },
+      );
+    },
+  );
+
+  group(
+    'Given a Caches collection without Redis, '
+    'when global cache is accessed, ',
+    () {
+      late Caches caches;
+
+      setUp(() {
+        caches = Caches(
+          serializationManager,
+          config,
+          config.serverId,
+          null,
+        );
+      });
+
+      test(
+        'then global uses a dedicated local cache.',
+        () {
+          expect(caches.global, isA<LocalCache>());
+        },
+      );
+
+      test(
+        'then global cache is not the same instance as the existing local caches.',
+        () {
+          expect(caches.global, isNot(same(caches.local)));
+          expect(caches.global, isNot(same(caches.localPrio)));
+        },
+      );
+
+      test(
+        'when values are stored on local and global under the same key, '
+        'then reads stay isolated per cache.',
+        () async {
+          const key = 'shared-key';
+          await caches.local.put(key, 1);
+          await caches.global.put(key, 2);
+
+          expect(await caches.local.get<int>(key), 1);
+          expect(await caches.global.get<int>(key), 2);
+        },
+      );
+    },
+  );
+
+  group(
+    'Given a Caches collection without Redis with entries in local and global, '
+    'when clear is called, ',
+    () {
+      late Caches caches;
+
+      setUp(() async {
+        caches = Caches(
+          serializationManager,
+          config,
+          config.serverId,
+          null,
+        );
+
+        await caches.local.put('k', 1);
+        await caches.global.put('k', 2);
+      });
+
+      test(
+        'then both primary local and fallback global caches are emptied.',
+        () async {
+          await caches.clear();
+
+          expect(await caches.local.get<int>('k'), isNull);
+          expect(await caches.global.get<int>('k'), isNull);
+        },
+      );
+    },
+  );
+}

--- a/packages/serverpod/test/redis/redis_controller_test.dart
+++ b/packages/serverpod/test/redis/redis_controller_test.dart
@@ -1,0 +1,88 @@
+import 'package:serverpod/src/redis/controller.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Given a Redis controller that is not reachable on localhost', () {
+    late RedisController controller;
+
+    setUp(() {
+      controller = RedisController(
+        host: '127.0.0.1',
+        port: 1,
+        requireSsl: false,
+      );
+    });
+
+    tearDown(() {
+      controller.stop();
+    });
+
+    test(
+      'when starting with no handleError, '
+      'then it completes with no error.',
+      () async {
+        await expectLater(controller.start(), completes);
+      },
+    );
+
+    test(
+      'when starting with handleError that absorbs failures, '
+      'then handleError is invoked.',
+      () async {
+        var handleErrorInvoked = false;
+
+        await controller.start(
+          handleError: (e) {
+            handleErrorInvoked = true;
+            return true;
+          },
+        );
+
+        expect(handleErrorInvoked, isTrue);
+      },
+    );
+
+    test(
+      'when starting with a short connectTimeout, '
+      'then it does not wait the default timeout.',
+      () async {
+        final stopwatch = Stopwatch()..start();
+        await expectLater(
+          controller.start(connectTimeout: const Duration(milliseconds: 400)),
+          completes,
+        );
+        expect(stopwatch.elapsed, lessThan(const Duration(seconds: 2)));
+      },
+    );
+  });
+
+  group(
+    'Given a Redis controller that is not reachable on localhost and connectTimeout is short',
+    () {
+      late RedisController controller;
+
+      setUp(() {
+        controller = RedisController(
+          host: '127.0.0.1',
+          port: 1,
+          requireSsl: false,
+          connectTimeout: const Duration(milliseconds: 400),
+        );
+      });
+
+      tearDown(() {
+        controller.stop();
+      });
+
+      test(
+        'when starting, '
+        'then it does not wait the default timeout.',
+        () async {
+          final stopwatch = Stopwatch()..start();
+          await expectLater(controller.start(), completes);
+          expect(stopwatch.elapsed, lessThan(const Duration(seconds: 2)));
+        },
+      );
+    },
+  );
+}

--- a/packages/serverpod/test/server/redis_run_mode_fallback_test.dart
+++ b/packages/serverpod/test/server/redis_run_mode_fallback_test.dart
@@ -1,4 +1,6 @@
 import 'package:serverpod/serverpod.dart';
+import 'package:serverpod/src/cache/local_cache.dart';
+import 'package:serverpod/src/cache/redis_cache.dart';
 import 'package:serverpod/src/generated/protocol.dart' as internal;
 import 'package:test/test.dart';
 
@@ -48,6 +50,10 @@ void main() {
       test('then Redis controller is cleared.', () async {
         expect(pod.redisController, isNull);
       });
+
+      test('then global cache falls back to local storage.', () async {
+        expect(pod.caches.global, isA<LocalCache>());
+      });
     },
   );
 
@@ -81,6 +87,10 @@ void main() {
 
       test('then Redis controller remains configured.', () async {
         expect(pod.redisController, isNotNull);
+      });
+
+      test('then global cache stays Redis-backed.', () async {
+        expect(pod.caches.global, isA<RedisCache>());
       });
     },
   );

--- a/packages/serverpod/test/server/redis_run_mode_fallback_test.dart
+++ b/packages/serverpod/test/server/redis_run_mode_fallback_test.dart
@@ -1,0 +1,92 @@
+import 'package:serverpod/serverpod.dart';
+import 'package:serverpod/src/generated/protocol.dart' as internal;
+import 'package:test/test.dart';
+
+void main() {
+  final portZeroConfig = ServerConfig(
+    port: 0,
+    publicScheme: 'http',
+    publicHost: 'localhost',
+    publicPort: 0,
+  );
+
+  RedisConfig unreachableRedis() => RedisConfig(
+    enabled: true,
+    host: '127.0.0.1',
+    port: 1,
+    requireSsl: false,
+  );
+
+  group(
+    'Given Redis is enabled but unreachable in development run mode, '
+    'when Serverpod completes startup, ',
+    () {
+      late Serverpod pod;
+
+      setUp(() async {
+        pod = Serverpod(
+          [],
+          internal.Protocol(),
+          _EmptyEndpoints(),
+          config: ServerpodConfig(
+            apiServer: portZeroConfig,
+            webServer: portZeroConfig,
+            database: null,
+            redis: unreachableRedis(),
+            runMode: ServerpodRunMode.development,
+            healthCheckInterval: Duration.zero,
+          ),
+        );
+
+        await pod.start(runInGuardedZone: false);
+      });
+
+      tearDown(() async {
+        await pod.shutdown(exitProcess: false);
+      });
+
+      test('then Redis controller is cleared.', () async {
+        expect(pod.redisController, isNull);
+      });
+    },
+  );
+
+  group(
+    'Given Redis is enabled but unreachable in production run mode, '
+    'when Serverpod completes startup, ',
+    () {
+      late Serverpod pod;
+
+      setUp(() async {
+        pod = Serverpod(
+          [],
+          internal.Protocol(),
+          _EmptyEndpoints(),
+          config: ServerpodConfig(
+            apiServer: portZeroConfig,
+            webServer: portZeroConfig,
+            database: null,
+            redis: unreachableRedis(),
+            runMode: ServerpodRunMode.production,
+            healthCheckInterval: Duration.zero,
+          ),
+        );
+
+        await pod.start(runInGuardedZone: false);
+      });
+
+      tearDown(() async {
+        await pod.shutdown(exitProcess: false);
+      });
+
+      test('then Redis controller remains configured.', () async {
+        expect(pod.redisController, isNotNull);
+      });
+    },
+  );
+}
+
+class _EmptyEndpoints extends EndpointDispatch {
+  @override
+  void initializeEndpoints(Server server) {}
+}


### PR DESCRIPTION
Closes: #5138

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.