### PR TITLE
feat: Add inheritance and sealed support to exception models

### DIFF
--- a/tools/serverpod_cli/lib/src/analyzer/models/definitions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/definitions.dart
@@ -266,8 +266,8 @@ final class ModelClassDefinition extends ClassDefinition
 }
 
 /// A [ClassDefinition] specialization that represents an exception.
-final class ExceptionClassDefinition extends ClassDefinition 
-  with InheritanceClassDefinition<ExceptionClassDefinition> {
+final class ExceptionClassDefinition extends ClassDefinition
+    with InheritanceClassDefinition<ExceptionClassDefinition> {
   /// If set to true the class is sealed.
   @override
   final bool isSealed;
@@ -291,7 +291,7 @@ final class ExceptionClassDefinition extends ClassDefinition
     this.extendsClass = extendsClass;
   }
 
-    /// Returns a list of all fields in the parent class.
+  /// Returns a list of all fields in the parent class.
   /// If there is no parent class, an empty list is returned.
   /// Excludes the id field, as it is re-declared on child classes.
   List<SerializableModelFieldDefinition> get inheritedFields =>

--- a/tools/serverpod_cli/lib/src/analyzer/models/definitions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/definitions.dart
@@ -70,8 +70,87 @@ sealed class ClassDefinition extends SerializableModelDefinition {
   }
 }
 
+/// A shared inheritance and sealed mixin on [ClassDefinition]
+mixin InheritanceClassDefinition<T extends InheritanceClassDefinition<T>>
+    on ClassDefinition {
+  /// If set to true the class is sealed.
+  bool get isSealed;
+
+  /// Returns a list of all fields in this class, including inherited fields.
+  List<SerializableModelFieldDefinition> get fieldsIncludingInherited;
+
+  /// If set to [InheritanceDefinitions] the class extends another class and stores the [ClassDefinition] of it's parent.
+  InheritanceDefinition? extendsClass;
+
+  /// If set to a List of [InheritanceDefinitions] the class is a parent class and stores the child classes.
+  List<InheritanceDefinition> childClasses = [];
+
+  /// Returns the `ClassDefinition` of the parent class.
+  /// If there is no parent class, `null` is returned.
+  T? get parentClass {
+    var extendsClass = this.extendsClass;
+    if (extendsClass is! ResolvedInheritanceDefinition) return null;
+
+    var classDefinition = extendsClass.classDefinition;
+    if (classDefinition is! T) return null;
+    return classDefinition;
+  }
+
+  /// Returns `true` if this class is a parent class or sealed.
+  bool get isParentClass => childClasses.isNotEmpty || isSealed;
+
+  /// Returns the top node of the sealed hierarchy. If the class is the top node it returns itself.
+  /// If the class is not part of a sealed hierarchy, `null` is returned.
+  T? get sealedTopNode {
+    final parent = parentClass;
+    if (parent != null) {
+      final parentsSealedTopNode = parent.sealedTopNode;
+      if (parentsSealedTopNode != null) return parentsSealedTopNode;
+    }
+
+    if (isSealed) return this as T;
+
+    return null;
+  }
+
+  /// Returns `true` if this class is the top node of a sealed hierarchy.
+  bool get isSealedTopNode => identical(sealedTopNode, this);
+
+  /// Returns `true` if all parent classes are sealed.
+  /// Returns `true` if the class does not have a parent class.
+  bool get everyParentIsSealed {
+    var parent = parentClass;
+    if (parent == null) return true;
+
+    if (!parent.isSealed) {
+      return false;
+    }
+
+    return parent.everyParentIsSealed;
+  }
+
+  /// Returns a list of all descendant classes.
+  /// This includes all child classes and their descendants.
+  /// If the class has no child classes, an empty list is returned.
+  List<T> get descendantClasses {
+    List<T> descendants = [];
+
+    for (var child in childClasses) {
+      if (child is! ResolvedInheritanceDefinition) continue;
+      var classDefinition = child.classDefinition;
+      if (classDefinition is! T) continue;
+
+      descendants.add(classDefinition);
+      descendants.addAll(classDefinition.descendantClasses);
+    }
+
+    return descendants;
+  }
+}
+
 /// A [ClassDefinition] specialization that represents a model class.
-final class ModelClassDefinition extends ClassDefinition {
+final class ModelClassDefinition extends ClassDefinition
+    with InheritanceClassDefinition<ModelClassDefinition> {
   /// If set, the name of the table, this class should be stored in, in the
   /// database.
   final String? tableName;
@@ -88,6 +167,7 @@ final class ModelClassDefinition extends ClassDefinition {
   final bool manageMigration;
 
   /// If set to true the class is sealed.
+  @override
   final bool isSealed;
 
   /// If set to true the class is immutable.
@@ -96,14 +176,6 @@ final class ModelClassDefinition extends ClassDefinition {
   /// If set, the default data type used for serialization of the JSON columns in this class.
   /// It can be overridden for each field.
   final SerializationDataType? serializationDataType;
-
-  /// If set to a List of [InheritanceDefinitions] the class is a parent class and stores the child classes.
-  List<InheritanceDefinition> childClasses;
-
-  /// If set to [InheritanceDefinitions] the class extends another class and stores the [ClassDefinition] of it's parent.
-  InheritanceDefinition? extendsClass;
-
-  List<ModelClassDefinition>? _descendantClasses;
 
   /// Create a new [ModelClassDefinition].
   ModelClassDefinition({
@@ -118,14 +190,17 @@ final class ModelClassDefinition extends ClassDefinition {
     required this.isImmutable,
     this.database = ModelDatabaseDefinition.server,
     List<InheritanceDefinition>? childClasses,
-    this.extendsClass,
+    InheritanceDefinition? extendsClass,
     this.tableName,
     this.serializationDataType,
     this.indexes = const [],
     super.subDirParts,
     super.documentation,
     super.sharedPackageName,
-  }) : childClasses = childClasses ?? <InheritanceDefinition>[];
+  }) {
+    this.childClasses = childClasses ?? <InheritanceDefinition>[];
+    this.extendsClass = extendsClass;
+  }
 
   /// Returns the `SerializableModelFieldDefinition` of the 'id' field.
   /// If the field is not present, an error is thrown.
@@ -143,15 +218,6 @@ final class ModelClassDefinition extends ClassDefinition {
     };
   }
 
-  /// Returns the `ModelClassDefinition` of the parent class.
-  /// If there is no parent class, `null` is returned.
-  ModelClassDefinition? get parentClass {
-    var extendsClass = this.extendsClass;
-    if (extendsClass is! ResolvedInheritanceDefinition) return null;
-
-    return extendsClass.classDefinition;
-  }
-
   /// Returns a list of all fields in the parent class.
   /// If there is no parent class, an empty list is returned.
   /// Excludes the id field, as it is re-declared on child classes.
@@ -167,6 +233,7 @@ final class ModelClassDefinition extends ClassDefinition {
 
   /// Returns a list of all fields in this class, including inherited fields.
   /// It ensures that the 'id' field, if present, is always included at the beginning of the list.
+  @override
   List<SerializableModelFieldDefinition> get fieldsIncludingInherited {
     bool hasIdField = fields.any((element) => element.name == 'id');
 
@@ -196,64 +263,15 @@ final class ModelClassDefinition extends ClassDefinition {
       ...indexes,
     ];
   }
-
-  /// Returns `true` if this class is a parent class or sealed.
-  bool get isParentClass => childClasses.isNotEmpty || isSealed;
-
-  /// Returns the top node of the sealed hierarchy. If the class is the top node it returns itself.
-  /// If the class is not part of a sealed hierarchy, `null` is returned.
-  ClassDefinition? get sealedTopNode {
-    var parent = parentClass;
-    if (parent != null) {
-      var parentsSealedTopNode = parent.sealedTopNode;
-      if (parentsSealedTopNode != null) return parentsSealedTopNode;
-    }
-
-    if (isSealed) return this;
-
-    return null;
-  }
-
-  /// Returns `true` if this class is the top node of a sealed hierarchy.
-  bool get isSealedTopNode => sealedTopNode == this;
-
-  /// Returns `true` if all parent classes are sealed.
-  /// Returns `true` if the class does not have a parent class.
-  bool get everyParentIsSealed {
-    var parent = parentClass;
-    if (parent == null) return true;
-
-    if (!parent.isSealed) {
-      return false;
-    }
-
-    return parent.everyParentIsSealed;
-  }
-
-  /// Returns a list of all descendant classes.
-  /// This includes all child classes and their descendants.
-  /// If the class has no child classes, an empty list is returned.
-  List<ModelClassDefinition> get descendantClasses {
-    return _descendantClasses ??= _computeDescendantClasses();
-  }
-
-  List<ModelClassDefinition> _computeDescendantClasses() {
-    List<ModelClassDefinition> descendants = [];
-
-    var resolvedChildClasses = childClasses
-        .whereType<ResolvedInheritanceDefinition>();
-
-    for (var child in resolvedChildClasses) {
-      descendants.add(child.classDefinition);
-      descendants.addAll(child.classDefinition.descendantClasses);
-    }
-
-    return descendants;
-  }
 }
 
 /// A [ClassDefinition] specialization that represents an exception.
-final class ExceptionClassDefinition extends ClassDefinition {
+final class ExceptionClassDefinition extends ClassDefinition 
+  with InheritanceClassDefinition<ExceptionClassDefinition> {
+  /// If set to true the class is sealed.
+  @override
+  final bool isSealed;
+
   /// Create a new [ExceptionClassDefinition].
   ExceptionClassDefinition({
     required super.className,
@@ -262,10 +280,31 @@ final class ExceptionClassDefinition extends ClassDefinition {
     required super.serverOnly,
     required super.sourceFileName,
     required super.type,
+    required this.isSealed,
+    List<InheritanceDefinition>? childClasses,
+    InheritanceDefinition? extendsClass,
     super.documentation,
     super.subDirParts,
     super.sharedPackageName,
-  });
+  }) {
+    this.childClasses = childClasses ?? <InheritanceDefinition>[];
+    this.extendsClass = extendsClass;
+  }
+
+    /// Returns a list of all fields in the parent class.
+  /// If there is no parent class, an empty list is returned.
+  /// Excludes the id field, as it is re-declared on child classes.
+  List<SerializableModelFieldDefinition> get inheritedFields =>
+      parentClass?.fieldsIncludingInherited.toList() ?? [];
+
+  /// Returns a list of all fields in this class, including inherited fields.
+  @override
+  List<SerializableModelFieldDefinition> get fieldsIncludingInherited {
+    return [
+      ...inheritedFields,
+      ...fields,
+    ];
+  }
 }
 
 /// Describes a single field of a [ClassDefinition].
@@ -615,8 +654,9 @@ class UnresolvedInheritanceDefinition extends InheritanceDefinition {
   UnresolvedInheritanceDefinition(this.className);
 }
 
-class ResolvedInheritanceDefinition extends InheritanceDefinition {
-  final ModelClassDefinition classDefinition;
+class ResolvedInheritanceDefinition<T extends ClassDefinition>
+    extends InheritanceDefinition {
+  final T classDefinition;
 
   ResolvedInheritanceDefinition(this.classDefinition);
 }

--- a/tools/serverpod_cli/lib/src/analyzer/models/entity_dependency_resolver.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/entity_dependency_resolver.dart
@@ -18,6 +18,15 @@ class ModelDependencyResolver {
       _resolveInheritance(classDefinition, modelDefinitions);
     });
 
+    modelDefinitions.whereType<ExceptionClassDefinition>().forEach((
+      classDefinition,
+    ) {
+      _resolveInheritance(
+        classDefinition,
+        modelDefinitions,
+      );
+    });
+
     // Then resolve inherited id fields or create default id fields.
     modelDefinitions.whereType<ModelClassDefinition>().forEach((
       classDefinition,
@@ -27,7 +36,7 @@ class ModelDependencyResolver {
 
     // Then resolve everything else, including relations on inherited ids.
     modelDefinitions.whereType<ClassDefinition>().forEach((classDefinition) {
-      var fields = classDefinition is ModelClassDefinition
+      var fields = classDefinition is InheritanceClassDefinition
           ? classDefinition.fieldsIncludingInherited
           : classDefinition.fields;
 
@@ -52,8 +61,8 @@ class ModelDependencyResolver {
     });
   }
 
-  static void _resolveInheritance(
-    ModelClassDefinition classDefinition,
+  static void _resolveInheritance<T extends InheritanceClassDefinition<T>>(
+    T classDefinition,
     List<SerializableModelDefinition> modelDefinitions,
   ) {
     var extendedClass = classDefinition.extendsClass;
@@ -63,7 +72,7 @@ class ModelDependencyResolver {
     var parentClassName = extendedClass.className;
 
     var parentClass = modelDefinitions
-        .whereType<ModelClassDefinition>()
+        .whereType<T>()
         .where((element) => element.className == parentClassName)
         .firstOrNull;
 

--- a/tools/serverpod_cli/lib/src/analyzer/models/model_parser/model_parser.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/model_parser/model_parser.dart
@@ -84,6 +84,8 @@ class ModelParser {
     YamlDocumentationExtractor docsExtractor,
     GeneratorConfig config,
   ) {
+    var isSealed = _parseIsSealed(documentContents);
+    var extendsClass = _parseExtendsClass(documentContents);
     return _initializeFromClassFields(
       documentTypeName: documentTypeName,
       protocolSource: protocolSource,
@@ -101,6 +103,8 @@ class ModelParser {
             required List<String>? classDocumentation,
           }) => ExceptionClassDefinition(
             className: className,
+            isSealed: isSealed,
+            extendsClass: extendsClass,
             fields: fields,
             fileName: outFileName,
             serverOnly: serverOnly,

--- a/tools/serverpod_cli/lib/src/analyzer/models/validation/restrictions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/validation/restrictions.dart
@@ -470,6 +470,26 @@ class Restrictions {
       documentDefinition!.className,
     );
 
+    if (currentModel is ModelClassDefinition &&
+        parentClass is! ModelClassDefinition) {
+      return [
+        SourceSpanSeverityException(
+          'A class can only extend another class.',
+          span,
+        ),
+      ];
+    }
+
+    if (currentModel is ExceptionClassDefinition &&
+        parentClass is! ExceptionClassDefinition) {
+      return [
+        SourceSpanSeverityException(
+          'An exception can only extend another exception.',
+          span,
+        ),
+      ];
+    }
+
     if (currentModel is ModelClassDefinition) {
       var ancestorServerOnlyClass = _findServerOnlyClassInParentClasses(
         currentModel,

--- a/tools/serverpod_cli/lib/src/analyzer/models/validation/restrictions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/validation/restrictions.dart
@@ -455,7 +455,7 @@ class Restrictions {
     if (parentClass.type.moduleAlias != documentDefinition?.type.moduleAlias &&
         parentClass is InheritanceClassDefinition &&
         parentClass.isSealed) {
-        final type = parentClass is ExceptionClassDefinition
+      final type = parentClass is ExceptionClassDefinition
           ? 'exception'
           : 'model';
       return [

--- a/tools/serverpod_cli/lib/src/analyzer/models/validation/restrictions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/validation/restrictions.dart
@@ -453,11 +453,14 @@ class Restrictions {
     }
 
     if (parentClass.type.moduleAlias != documentDefinition?.type.moduleAlias &&
-        parentClass is ModelClassDefinition &&
+        parentClass is InheritanceClassDefinition &&
         parentClass.isSealed) {
+        final type = parentClass is ExceptionClassDefinition
+          ? 'exception'
+          : 'model';
       return [
         SourceSpanSeverityException(
-          'Can not extend a sealed model from another package.',
+          'Cannot extend a sealed $type from another package.',
           span,
         ),
       ];
@@ -469,6 +472,22 @@ class Restrictions {
 
     if (currentModel is ModelClassDefinition) {
       var ancestorServerOnlyClass = _findServerOnlyClassInParentClasses(
+        currentModel,
+      );
+
+      if (!documentDefinition!.serverOnly && ancestorServerOnlyClass != null) {
+        return [
+          SourceSpanSeverityException(
+            'Cannot extend a "serverOnly" class in the inheritance chain ("${ancestorServerOnlyClass.className}") unless class is marked as "serverOnly".',
+            span,
+          ),
+        ];
+      }
+    }
+
+    if (currentModel is ExceptionClassDefinition &&
+        parentClass is ExceptionClassDefinition) {
+      var ancestorServerOnlyClass = _findServerOnlyExceptionInParentClasses(
         currentModel,
       );
 
@@ -2663,12 +2682,12 @@ class Restrictions {
     return classDefinitions;
   }
 
-  ModelClassDefinition? _getParentClass(ModelClassDefinition currentClass) {
+  T? _getParentClass<T extends InheritanceClassDefinition<T>>(T currentClass) {
     if (currentClass.extendsClass is! ResolvedInheritanceDefinition) {
       return null;
     }
 
-    return (currentClass.extendsClass as ResolvedInheritanceDefinition)
+    return (currentClass.extendsClass as ResolvedInheritanceDefinition<T>)
         .classDefinition;
   }
 
@@ -2681,17 +2700,17 @@ class Restrictions {
   ///  (ClassDefinition ancestor) => ancestor.serverOnly ? ancestor : null,
   /// );
   /// ```
-  T? _findInParentHierarchy<T>(
-    ModelClassDefinition currentModel,
-    T? Function(ModelClassDefinition) predicate,
+  R? _findInParentHierarchy<R, T extends InheritanceClassDefinition<T>>(
+    T currentModel,
+    R? Function(T) predicate,
   ) {
-    var parentModel = _getParentClass(currentModel);
+    var parentModel = _getParentClass<T>(currentModel);
 
     while (parentModel != null) {
       var result = predicate(parentModel);
       if (result != null) return result;
 
-      parentModel = _getParentClass(parentModel);
+      parentModel = _getParentClass<T>(parentModel);
     }
 
     return null;
@@ -2713,6 +2732,16 @@ class Restrictions {
     return _findInParentHierarchy(
       currentModel,
       (ModelClassDefinition ancestor) => ancestor.serverOnly ? ancestor : null,
+    );
+  }
+
+  ExceptionClassDefinition? _findServerOnlyExceptionInParentClasses(
+    ExceptionClassDefinition currentExceptionModel,
+  ) {
+    return _findInParentHierarchy(
+      currentExceptionModel,
+      (ExceptionClassDefinition ancestor) =>
+          ancestor.serverOnly ? ancestor : null,
     );
   }
 

--- a/tools/serverpod_cli/lib/src/analyzer/models/yaml_definitions/exception_yaml_definition.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/yaml_definitions/exception_yaml_definition.dart
@@ -22,6 +22,17 @@ class ExceptionYamlDefinition {
         valueRestriction: restrictions.validateClassName,
       ),
       ValidateNode(
+        Keyword.isSealed,
+        valueRestriction: BooleanValueRestriction().validate,
+        mutuallyExclusiveKeys: {
+          Keyword.table,
+        },
+      ),
+      ValidateNode(
+        Keyword.extendsClass,
+        valueRestriction: restrictions.validateExtendingClassName,
+      ),
+      ValidateNode(
         Keyword.serverOnly,
         valueRestriction: BooleanValueRestriction().validate,
       ),

--- a/tools/serverpod_cli/lib/src/generator/dart/library_generators/library_generator.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart/library_generators/library_generator.dart
@@ -2320,7 +2320,21 @@ extension on DatabaseDefinition {
 extension on ModelClassDefinition {
   /// Get all child classes and their children, ensuring children before parents.
   List<ModelClassDefinition> get sortedChildClasses => childClasses
-      .whereType<ResolvedInheritanceDefinition>()
+      .whereType<ResolvedInheritanceDefinition<ModelClassDefinition>>()
+      .map(
+        (e) => [
+          ...e.classDefinition.sortedChildClasses,
+          e.classDefinition,
+        ],
+      )
+      .expand((e) => e)
+      .toList();
+}
+
+extension on ExceptionClassDefinition {
+  /// Get all child classes and their children, ensuring children before parents.
+  List<ExceptionClassDefinition> get sortedChildClasses => childClasses
+      .whereType<ResolvedInheritanceDefinition<ExceptionClassDefinition>>()
       .map(
         (e) => [
           ...e.classDefinition.sortedChildClasses,
@@ -2338,6 +2352,12 @@ extension on List<SerializableModelDefinition> {
 
     for (var model in this) {
       if (model is ModelClassDefinition) {
+        for (var subClass in model.sortedChildClasses) {
+          if (contains(subClass) && !sorted.contains(subClass)) {
+            sorted.add(subClass);
+          }
+        }
+      } else if (model is ExceptionClassDefinition) {
         for (var subClass in model.sortedChildClasses) {
           if (contains(subClass) && !sorted.contains(subClass)) {
             sorted.add(subClass);

--- a/tools/serverpod_cli/lib/src/generator/dart/library_generators/model_library_generator.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart/library_generators/model_library_generator.dart
@@ -57,35 +57,59 @@ class SerializableModelLibraryGenerator {
         return _generateExceptionLibrary(classDefinition);
       case ModelClassDefinition():
         return _generateModelClassLibrary(classDefinition);
+      default:
+        throw StateError(
+          'Unhandled ClassDefinition subtype: ${classDefinition.runtimeType}',
+        );
     }
   }
 
   Library _generateExceptionLibrary(ExceptionClassDefinition definition) {
-    var fields = definition.fields;
+    var fields = definition.fieldsIncludingInherited;
     var className = definition.className;
-    var needsUndefinedClass = fields
-        .where((field) => field.shouldIncludeField(serverCode))
-        .any(_fieldUsesUndefinedCopyWithSentinel);
+    var sealedTopNode = definition.sealedTopNode;
 
     return Library(
       (libraryBuilder) {
+        if (definition.isSealedTopNode) {
+          for (var child in definition.descendantClasses) {
+            var childPath = p.relative(
+              child.filePath,
+              from: p.dirname(definition.filePath),
+            );
+            libraryBuilder.directives.add(Directive.part(childPath));
+          }
+        }
+
+        if (!definition.isSealedTopNode && sealedTopNode != null) {
+          var topNodePath = p.relative(
+            sealedTopNode.filePath,
+            from: p.dirname(definition.filePath),
+          );
+          libraryBuilder.directives.add(Directive.partOf(topNodePath));
+        }
         libraryBuilder.body.addAll([
           _buildExceptionClass(
             className,
             definition,
             fields,
           ),
-          if (needsUndefinedClass) _buildUndefinedClass(),
-          _buildModelImplClass(
-            className,
-            null,
-            fields,
-            subDirParts: definition.subDirParts,
-            inheritedFields: [],
-            isParentClass: false,
-            hasImplicitClass: false,
-            isImmutable: false,
-          ),
+                    // We need to generate the implementation class for the copyWith method
+          // to support differentiating between null and undefined values.
+          // https://stackoverflow.com/questions/68009392/dart-custom-copywith-method-with-nullable-properties
+          if (_shouldCreateUndefinedClass(definition, fields)) 
+            _buildUndefinedClass(),
+          if (!definition.isParentClass)
+            _buildModelImplClass(
+              className,
+              null,
+              fields,
+              subDirParts: definition.subDirParts,
+              inheritedFields: [],
+              isParentClass: false,
+              hasImplicitClass: false,
+              isImmutable: false,
+            ),
         ]);
       },
     );
@@ -243,12 +267,27 @@ class SerializableModelLibraryGenerator {
     ExceptionClassDefinition classDefinition,
     List<SerializableModelFieldDefinition> fields,
   ) {
+    var parentClass = classDefinition.parentClass;
     return Class((classBuilder) {
       classBuilder
         ..name = className
         ..docs.addAll(classDefinition.documentation ?? []);
 
-      classBuilder.abstract = true;
+      if (!classDefinition.isParentClass) {
+        classBuilder.abstract = true;
+      }
+
+      if (classDefinition.isSealed) {
+        classBuilder.sealed = true;
+      }
+
+      if (parentClass != null) {
+        classBuilder.extend = parentClass.type.reference(
+          serverCode,
+          subDirParts: classDefinition.subDirParts,
+          config: config,
+        );
+      }
 
       classBuilder.implements.add(
         refer('SerializableException', serverpodUrl(serverCode)),
@@ -278,55 +317,73 @@ class SerializableModelLibraryGenerator {
         _buildModelClassConstructor(
           fields,
           null,
-          isParentClass: false,
+          isParentClass: classDefinition.isParentClass,
           subDirParts: classDefinition.subDirParts,
-          inheritedFields: [],
+          inheritedFields: classDefinition.inheritedFields,
           isImmutable: false,
         ),
-        _buildModelClassFactoryConstructor(
-          className,
-          fields,
-          null,
-          inheritedFields: [],
-          subDirParts: classDefinition.subDirParts,
-          isImmutable: false,
-        ),
-        _buildModelClassFromJsonConstructor(
-          className,
-          fields,
-          null,
-          subDirParts: classDefinition.subDirParts,
-          hasImplicitClass: false,
-          currentSharedPackageName: classDefinition.sharedPackageName,
-        ),
+        if (!classDefinition.isParentClass)
+          _buildModelClassFactoryConstructor(
+            className,
+            fields,
+            null,
+            inheritedFields: classDefinition.inheritedFields,
+            subDirParts: classDefinition.subDirParts,
+            isImmutable: false,
+          ),
+        if (!classDefinition.isSealed)
+          _buildModelClassFromJsonConstructor(
+            className,
+            fields,
+            null,
+            subDirParts: classDefinition.subDirParts,
+            hasImplicitClass: false,
+            currentSharedPackageName: classDefinition.sharedPackageName,
+          ),
       ]);
 
-      classBuilder.methods.add(
-        _buildAbstractCopyWithMethod(
-          className,
-          fields,
-          shouldOverrideAbstractCopyWith: () => false,
-          subDirParts: classDefinition.subDirParts,
-          inheritedFields: [],
-          isIdInherited: false,
-        ),
-      );
-
-      classBuilder.methods.add(
-        _buildModelClassToJsonMethod(
-          fields,
-          className,
-          classDefinition.sharedPackageName,
-          null,
-        ),
-      );
-
-      // Serialization for database and everything
-      if (serverCode) {
+      if (!classDefinition.isParentClass) {
         classBuilder.methods.add(
-          _buildModelClassToJsonForProtocolMethod(
+          _buildAbstractCopyWithMethod(
+            className,
             fields,
-            classDefinition.serverOnly,
+            shouldOverrideAbstractCopyWith: () =>
+                _shouldOverrideAbstractCopyWithMethod(
+                  classDefinition,
+                ),
+            subDirParts: classDefinition.subDirParts,
+            inheritedFields: classDefinition.inheritedFields,
+            isIdInherited: false,
+          ),
+        );
+      } else if (!classDefinition.isSealed) {
+        classBuilder.methods.add(
+          _buildCopyWithMethod(
+            fields,
+            subDirParts: classDefinition.subDirParts,
+            className: className,
+            isParentClass: classDefinition.isParentClass,
+            hasImplicitClass: false,
+            tableName: null,
+            classDefinition: classDefinition,
+          ),
+        );
+      } else if (classDefinition.isSealed && classDefinition.isParentClass) {
+        classBuilder.methods.add(
+          _buildAbstractCopyWithMethod(
+            className,
+            fields,
+            shouldOverrideAbstractCopyWith: () => false,
+            subDirParts: classDefinition.subDirParts,
+            inheritedFields: classDefinition.inheritedFields,
+            isIdInherited: false,
+          ),
+        );
+      }
+      if (!classDefinition.isSealed) {
+        classBuilder.methods.add(
+          _buildModelClassToJsonMethod(
+            fields,
             className,
             classDefinition.sharedPackageName,
             null,
@@ -334,12 +391,28 @@ class SerializableModelLibraryGenerator {
         );
       }
 
-      classBuilder.methods.add(
-        _buildExceptionToStringMethod(
-          className,
-          classDefinition.fields,
-        ),
-      );
+      // Serialization for database and everything
+      if (serverCode) {
+        if (!classDefinition.isSealed) {
+          classBuilder.methods.add(
+            _buildModelClassToJsonForProtocolMethod(
+              fields,
+              classDefinition.serverOnly,
+              className,
+              classDefinition.sharedPackageName,
+              null,
+            ),
+          );
+        }
+      }
+      if (!classDefinition.isSealed) {
+        classBuilder.methods.add(
+          _buildExceptionToStringMethod(
+            className,
+            classDefinition.fields,
+          ),
+        );
+      }
     });
   }
 
@@ -569,8 +642,8 @@ class SerializableModelLibraryGenerator {
     SerializableModelFieldDefinition field,
   ) => field.type.nullable || field.type.className == 'dynamic';
 
-  bool _shouldCreateUndefinedClass(
-    ModelClassDefinition classDefinition,
+  bool _shouldCreateUndefinedClass<T extends InheritanceClassDefinition<T>>(
+    T classDefinition,
     List<SerializableModelFieldDefinition> fields,
   ) {
     if (classDefinition.sealedTopNode == null) {
@@ -785,7 +858,7 @@ class SerializableModelLibraryGenerator {
   }
 
   bool _shouldOverrideAbstractCopyWithMethod(
-    ModelClassDefinition classDefinition,
+    InheritanceClassDefinition classDefinition,
   ) {
     var parentClass = classDefinition.parentClass;
 
@@ -845,7 +918,7 @@ class SerializableModelLibraryGenerator {
     required bool isParentClass,
     required hasImplicitClass,
     String? tableName,
-    ModelClassDefinition? classDefinition,
+    InheritanceClassDefinition? classDefinition,
   }) {
     return Method(
       (m) {

--- a/tools/serverpod_cli/lib/src/generator/dart/library_generators/model_library_generator.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart/library_generators/model_library_generator.dart
@@ -94,10 +94,10 @@ class SerializableModelLibraryGenerator {
             definition,
             fields,
           ),
-                    // We need to generate the implementation class for the copyWith method
+          // We need to generate the implementation class for the copyWith method
           // to support differentiating between null and undefined values.
           // https://stackoverflow.com/questions/68009392/dart-custom-copywith-method-with-nullable-properties
-          if (_shouldCreateUndefinedClass(definition, fields)) 
+          if (_shouldCreateUndefinedClass(definition, fields))
             _buildUndefinedClass(),
           if (!definition.isParentClass)
             _buildModelImplClass(

--- a/tools/serverpod_cli/lib/src/generator/dart/library_generators/util/model_generators_util.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart/library_generators/util/model_generators_util.dart
@@ -91,7 +91,8 @@ class ModelAllocatorContext {
   }
 
   /// Returns all sealed top node classes.
-  static Iterable<T> _getSealedTopNodeClasses<T extends InheritanceClassDefinition<T>>(
+  static Iterable<T>
+  _getSealedTopNodeClasses<T extends InheritanceClassDefinition<T>>(
     List<SerializableModelDefinition> models,
   ) {
     return models.whereType<T>().where(
@@ -101,7 +102,8 @@ class ModelAllocatorContext {
 
   /// Returns a list of sealed hierarchies.
   /// Each hierarchy is represented by a list of classes.
-  static Iterable<Iterable<T>> _getSealedHierarchies<T extends InheritanceClassDefinition<T>>(
+  static Iterable<Iterable<T>>
+  _getSealedHierarchies<T extends InheritanceClassDefinition<T>>(
     List<SerializableModelDefinition> models,
   ) {
     var sealedClasses = _getSealedTopNodeClasses<T>(models);

--- a/tools/serverpod_cli/lib/src/generator/dart/library_generators/util/model_generators_util.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart/library_generators/util/model_generators_util.dart
@@ -37,7 +37,10 @@ class ModelAllocatorContext {
   ) {
     var entries = <ModelAllocatorEntry>[];
 
-    var sealedHierarchies = _getSealedHierarchies(models);
+    var sealedHierarchies = <Iterable<InheritanceClassDefinition>>[
+      ..._getSealedHierarchies<ModelClassDefinition>(models),
+      ..._getSealedHierarchies<ExceptionClassDefinition>(models),
+    ];
 
     for (var sealedHierarchy in sealedHierarchies) {
       var topNode = sealedHierarchy.first.sealedTopNode;
@@ -83,25 +86,25 @@ class ModelAllocatorContext {
     List<SerializableModelDefinition> models,
   ) {
     return models.where(
-      (e) => e is! ModelClassDefinition || e.sealedTopNode == null,
+      (e) => e is! InheritanceClassDefinition || e.sealedTopNode == null,
     );
   }
 
   /// Returns all sealed top node classes.
-  static Iterable<ModelClassDefinition> _getSealedTopNodeClasses(
+  static Iterable<T> _getSealedTopNodeClasses<T extends InheritanceClassDefinition<T>>(
     List<SerializableModelDefinition> models,
   ) {
-    return models.whereType<ModelClassDefinition>().where(
+    return models.whereType<T>().where(
       (element) => element.isSealedTopNode,
     );
   }
 
   /// Returns a list of sealed hierarchies.
   /// Each hierarchy is represented by a list of classes.
-  static Iterable<Iterable<ModelClassDefinition>> _getSealedHierarchies(
+  static Iterable<Iterable<T>> _getSealedHierarchies<T extends InheritanceClassDefinition<T>>(
     List<SerializableModelDefinition> models,
   ) {
-    var sealedClasses = _getSealedTopNodeClasses(models);
+    var sealedClasses = _getSealedTopNodeClasses<T>(models);
 
     return sealedClasses.map(
       (element) {

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/extra_properties_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/extra_properties_test.dart
@@ -289,7 +289,7 @@ void main() {
         var error = collector.errors.first;
         expect(
           error.message,
-          'The "table" property is not allowed for exception type. Valid keys are {exception, serverOnly, fields}.',
+          'The "table" property is not allowed for exception type. Valid keys are {exception, sealed, extends, serverOnly, fields}.',
         );
       },
     );
@@ -449,7 +449,7 @@ void main() {
         var error = collector.errors.first;
         expect(
           error.message,
-          'The "indexes" property is not allowed for exception type. Valid keys are {exception, serverOnly, fields}.',
+          'The "indexes" property is not allowed for exception type. Valid keys are {exception, sealed, extends, serverOnly, fields}.',
         );
       },
     );

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/shared_models_restrictions_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/shared_models_restrictions_test.dart
@@ -221,7 +221,7 @@ fields:
 
       expect(
         collector.errors.first.message,
-        'Can not extend a sealed model from another package.',
+        'Cannot extend a sealed model from another package.',
       );
     },
   );

--- a/tools/serverpod_cli/test/generator/dart/server_code_generator/sealed_exception_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/server_code_generator/sealed_exception_test.dart
@@ -26,7 +26,7 @@ void main() {
       ]);
 
   var serverpodImportPath = 'package:serverpod/serverpod.dart';
-  
+
   group(
     'Given a hierarchy with a sealed parent exception and a normal child, when generating code',
     () {
@@ -370,7 +370,7 @@ void main() {
     },
   );
 
-    group(
+  group(
     'Given a hierarchy with a sealed parent with a nullable field and a child with no nullable fields when generating code',
     () {
       var parent = ExceptionClassDefinitionBuilder()

--- a/tools/serverpod_cli/test/generator/dart/server_code_generator/sealed_exception_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/server_code_generator/sealed_exception_test.dart
@@ -1,0 +1,1289 @@
+import 'package:analyzer/dart/analysis/utilities.dart';
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:path/path.dart' as p;
+import 'package:serverpod_cli/src/analyzer/models/definitions.dart';
+import 'package:serverpod_cli/src/generator/dart/server_code_generator.dart';
+import 'package:test/test.dart';
+
+import '../../../test_util/builders/exception_class_definition_builder.dart';
+import '../../../test_util/builders/generator_config_builder.dart';
+import '../../../test_util/builders/serializable_entity_field_definition_builder.dart';
+import '../../../test_util/builders/type_definition_builder.dart';
+import '../../../test_util/compilation_unit_helpers.dart';
+
+const projectName = 'example_project';
+final config = GeneratorConfigBuilder().withName(projectName).build();
+const generator = DartServerCodeGenerator();
+
+void main() {
+  String getExpectedFilePath(String fileName, {List<String>? subDirParts}) =>
+      p.joinAll([
+        'lib',
+        'src',
+        'generated',
+        ...?subDirParts,
+        '$fileName.dart',
+      ]);
+
+  var serverpodImportPath = 'package:serverpod/serverpod.dart';
+  
+  group(
+    'Given a hierarchy with a sealed parent exception and a normal child, when generating code',
+    () {
+      var parent = ExceptionClassDefinitionBuilder()
+          .withClassName('AppException')
+          .withFileName('app_exception')
+          .withSimpleField('message', 'String')
+          .withIsSealed(true) // <= sealed
+          .build();
+
+      var child = ExceptionClassDefinitionBuilder()
+          .withClassName('NotFoundException')
+          .withFileName('not_found_exception')
+          .withSimpleField('code', 'int')
+          .withExtendsClass(parent)
+          .build();
+
+      parent.childClasses.add(ResolvedInheritanceDefinition(child));
+
+      var models = [
+        parent,
+        child,
+      ];
+
+      var codeMap = generator.generateSerializableModelsCode(
+        models: models,
+        config: config,
+      );
+
+      var parentCompilationUnit = parseString(
+        content: codeMap[getExpectedFilePath(parent.fileName)]!,
+      ).unit;
+      var childCompilationUnit = parseString(
+        content: codeMap[getExpectedFilePath(child.fileName)]!,
+      ).unit;
+
+      group('Then the ${parent.className}', () {
+        var parentClass = CompilationUnitHelpers.tryFindClassDeclaration(
+          parentCompilationUnit,
+          name: parent.className,
+        );
+
+        test('is defined', () {
+          expect(parentClass, isNotNull);
+        });
+
+        test('has a part directive with ${child.className} uri', () {
+          var partDirective = CompilationUnitHelpers.tryFindPartDirective(
+            parentCompilationUnit,
+            uri: '${child.fileName}.dart',
+          );
+
+          expect(
+            partDirective?.uri.stringValue,
+            '${child.fileName}.dart',
+          );
+        });
+
+        test('has import directive for serverpod', () {
+          var serverpodImport = CompilationUnitHelpers.tryFindImportDirective(
+            parentCompilationUnit,
+            uri: serverpodImportPath,
+          );
+
+          expect(serverpodImport, isNotNull);
+        });
+
+        test('does have an abstract copyWith method', () {
+          var copyWithMethod = CompilationUnitHelpers.tryFindMethodDeclaration(
+            parentClass!,
+            name: 'copyWith',
+          );
+
+          expect(copyWithMethod, isNotNull);
+          expect(copyWithMethod!.body, isA<EmptyFunctionBody>());
+        });
+
+        test('does NOT have a toJson method', () {
+          var toJsonMethod = CompilationUnitHelpers.tryFindMethodDeclaration(
+            parentClass!,
+            name: 'toJson',
+          );
+
+          expect(toJsonMethod, isNull);
+        });
+
+        test('does NOT have a toJsonForProtocol method', () {
+          var toJsonForProtocolMethod =
+              CompilationUnitHelpers.tryFindMethodDeclaration(
+                parentClass!,
+                name: 'toJsonForProtocol',
+              );
+
+          expect(toJsonForProtocolMethod, isNull);
+        });
+
+        test('does NOT have a toString method', () {
+          var toStringMethod = CompilationUnitHelpers.tryFindMethodDeclaration(
+            parentClass!,
+            name: 'toString',
+          );
+          expect(toStringMethod, isNull);
+        });
+      });
+
+      group('Then the ${child.className}', () {
+        var childClass = CompilationUnitHelpers.tryFindClassDeclaration(
+          childCompilationUnit,
+          name: child.className,
+        );
+
+        test('is defined', () {
+          expect(childClass, isNotNull);
+        });
+
+        test('has a part-of directive with ${parent.className} uri', () {
+          var partDirectives = CompilationUnitHelpers.tryFindPartOfDirective(
+            childCompilationUnit,
+            uri: '${parent.fileName}.dart',
+          );
+
+          expect(
+            partDirectives?.uri?.stringValue,
+            '${parent.fileName}.dart',
+          );
+        });
+
+        test('does not have import directive for serverpod', () {
+          var importDirective = CompilationUnitHelpers.hasImportDirective(
+            childCompilationUnit,
+            uri: serverpodImportPath,
+          );
+
+          expect(importDirective, false);
+        });
+
+        test('does have a copyWith method', () {
+          var copyWithMethod = CompilationUnitHelpers.tryFindMethodDeclaration(
+            childClass!,
+            name: 'copyWith',
+          );
+
+          expect(copyWithMethod, isNotNull);
+        });
+
+        test('copyWith has @override annotation', () {
+          var copyWithMethod = CompilationUnitHelpers.tryFindMethodDeclaration(
+            childClass!,
+            name: 'copyWith',
+          );
+          var overrideAnnotation = CompilationUnitHelpers.tryFindAnnotation(
+            copyWithMethod!,
+            name: 'override',
+          );
+
+          expect(overrideAnnotation, isNotNull);
+        });
+
+        test('does have a toJson method', () {
+          var toJsonMethod = CompilationUnitHelpers.tryFindMethodDeclaration(
+            childClass!,
+            name: 'toJson',
+          );
+
+          expect(toJsonMethod, isNotNull);
+        });
+
+        test('does have a toJsonForProtocol method', () {
+          var toJsonForProtocolMethod =
+              CompilationUnitHelpers.tryFindMethodDeclaration(
+                childClass!,
+                name: 'toJsonForProtocol',
+              );
+
+          expect(toJsonForProtocolMethod, isNotNull);
+        });
+
+        test('does have a toString method', () {
+          var toStringMethod = CompilationUnitHelpers.tryFindMethodDeclaration(
+            childClass!,
+            name: 'toString',
+          );
+
+          expect(toStringMethod, isNotNull);
+        });
+      });
+    },
+  );
+  group(
+    'Given a hierarchy with a sealed parent exception and two normal children with nullable fields when generating code',
+    () {
+      var parent = ExceptionClassDefinitionBuilder()
+          .withClassName('TransportException')
+          .withFileName('transport_exception')
+          .withSimpleField('message', 'String')
+          .withIsSealed(true) // <= sealed
+          .build();
+
+      var child1 = ExceptionClassDefinitionBuilder()
+          .withClassName('NetworkException')
+          .withFileName('network_excpetion')
+          .withExtendsClass(parent)
+          .build();
+
+      var child2 = ExceptionClassDefinitionBuilder()
+          .withClassName('TimeoutException')
+          .withFileName('timeout_exception')
+          .withSimpleField('code', 'String', nullable: true)
+          .withExtendsClass(parent)
+          .build();
+
+      parent.childClasses.add(ResolvedInheritanceDefinition(child1));
+      parent.childClasses.add(ResolvedInheritanceDefinition(child2));
+
+      var models = [
+        parent,
+        child1,
+        child2,
+      ];
+
+      var codeMap = generator.generateSerializableModelsCode(
+        models: models,
+        config: config,
+      );
+
+      var parentCompilationUnit = parseString(
+        content: codeMap[getExpectedFilePath(parent.fileName)]!,
+      ).unit;
+      var child1CompilationUnit = parseString(
+        content: codeMap[getExpectedFilePath(child1.fileName)]!,
+      ).unit;
+      var child2CompilationUnit = parseString(
+        content: codeMap[getExpectedFilePath(child2.fileName)]!,
+      ).unit;
+
+      test('then ${parent.className} has a _Undefined class', () {
+        var undefinedMethod = CompilationUnitHelpers.tryFindClassDeclaration(
+          parentCompilationUnit,
+          name: '_Undefined',
+        );
+
+        expect(
+          undefinedMethod,
+          isNotNull,
+          reason: '_Undefined class was not created',
+        );
+      });
+
+      test('then ${child1.className} does NOT have a _Undefined class', () {
+        var undefinedClass = CompilationUnitHelpers.tryFindClassDeclaration(
+          child1CompilationUnit,
+          name: '_Undefined',
+        );
+
+        expect(
+          undefinedClass,
+          isNull,
+          reason: '_Undefined class was created in child of a sealed class',
+        );
+      });
+
+      test('then ${child2.className} does NOT have a _Undefined class', () {
+        var undefinedClass = CompilationUnitHelpers.tryFindClassDeclaration(
+          child2CompilationUnit,
+          name: '_Undefined',
+        );
+
+        expect(
+          undefinedClass,
+          isNull,
+          reason: '_Undefined class was created in child of a sealed class',
+        );
+      });
+    },
+  );
+
+  group(
+    'Given a hierarchy with a sealed parent exception with a nullable field and a child with no nullable fields when generating code',
+    () {
+      var parent = ExceptionClassDefinitionBuilder()
+          .withClassName('BaseException')
+          .withFileName('base_exception')
+          .withSimpleField('message', 'String', nullable: true)
+          .withIsSealed(true)
+          .build();
+
+      var child = ExceptionClassDefinitionBuilder()
+          .withClassName('SpecificException')
+          .withFileName('specific_exception')
+          .withExtendsClass(parent)
+          .build();
+
+      parent.childClasses.add(ResolvedInheritanceDefinition(child));
+
+      var models = [
+        parent,
+        child,
+      ];
+
+      var codeMap = generator.generateSerializableModelsCode(
+        models: models,
+        config: config,
+      );
+
+      var parentCompilationUnit = parseString(
+        content: codeMap[getExpectedFilePath(parent.fileName)]!,
+      ).unit;
+      var childCompilationUnit = parseString(
+        content: codeMap[getExpectedFilePath(child.fileName)]!,
+      ).unit;
+
+      test(
+        'then ${parent.className} has a _Undefined class because descendant inherits nullable field',
+        () {
+          var undefinedClass = CompilationUnitHelpers.tryFindClassDeclaration(
+            parentCompilationUnit,
+            name: '_Undefined',
+          );
+
+          expect(
+            undefinedClass,
+            isNotNull,
+            reason:
+                '_Undefined class was not created even though the hierarchy contains a nullable inherited field',
+          );
+        },
+      );
+
+      test('then ${child.className} does NOT have a _Undefined class', () {
+        var undefinedClass = CompilationUnitHelpers.tryFindClassDeclaration(
+          childCompilationUnit,
+          name: '_Undefined',
+        );
+
+        expect(
+          undefinedClass,
+          isNull,
+          reason: '_Undefined class was created in child of a sealed class',
+        );
+      });
+    },
+  );
+
+    group(
+    'Given a hierarchy with a sealed parent with a nullable field and a child with no nullable fields when generating code',
+    () {
+      var parent = ExceptionClassDefinitionBuilder()
+          .withClassName('Event')
+          .withFileName('event')
+          .withSimpleField('description', 'String', nullable: true)
+          .withIsSealed(true)
+          .build();
+
+      var child = ExceptionClassDefinitionBuilder()
+          .withClassName('ClickEvent')
+          .withFileName('click_event')
+          .withSimpleField('elementId', 'String')
+          .withExtendsClass(parent)
+          .build();
+
+      parent.childClasses.add(ResolvedInheritanceDefinition(child));
+
+      var models = [
+        parent,
+        child,
+      ];
+
+      var codeMap = generator.generateSerializableModelsCode(
+        models: models,
+        config: config,
+      );
+
+      var parentCompilationUnit = parseString(
+        content: codeMap[getExpectedFilePath(parent.fileName)]!,
+      ).unit;
+      var childCompilationUnit = parseString(
+        content: codeMap[getExpectedFilePath(child.fileName)]!,
+      ).unit;
+
+      test(
+        'then ${parent.className} has a _Undefined class because descendant inherits nullable field',
+        () {
+          var undefinedClass = CompilationUnitHelpers.tryFindClassDeclaration(
+            parentCompilationUnit,
+            name: '_Undefined',
+          );
+
+          expect(
+            undefinedClass,
+            isNotNull,
+            reason:
+                '_Undefined class was not created even though the hierarchy contains a nullable inherited field',
+          );
+        },
+      );
+
+      test('then ${child.className} does NOT have a _Undefined class', () {
+        var undefinedClass = CompilationUnitHelpers.tryFindClassDeclaration(
+          childCompilationUnit,
+          name: '_Undefined',
+        );
+
+        expect(
+          undefinedClass,
+          isNull,
+          reason: '_Undefined class was created in child of a sealed class',
+        );
+      });
+    },
+  );
+
+  group(
+    'Given a hierarchy with a normal parent exception, a sealed child and a normal grandchild when generating code',
+    () {
+      var grandparent = ExceptionClassDefinitionBuilder()
+          .withClassName('ExampleGrandparentException')
+          .withFileName('example_grandparent_exception')
+          .withSimpleField('name', 'String')
+          .build();
+      var parent = ExceptionClassDefinitionBuilder()
+          .withClassName('ExampleParentException')
+          .withFileName('example_parent_exception')
+          .withSimpleField('name', 'String')
+          .withExtendsClass(grandparent)
+          .withIsSealed(true)
+          .build();
+      var child = ExceptionClassDefinitionBuilder()
+          .withClassName('ExampleChildException')
+          .withFileName('example_child_exception')
+          .withSimpleField('age', 'int', nullable: true)
+          .withExtendsClass(parent)
+          .build();
+
+      grandparent.childClasses.add(ResolvedInheritanceDefinition(parent));
+      parent.childClasses.add(ResolvedInheritanceDefinition(child));
+
+      var models = [
+        grandparent,
+        parent,
+        child,
+      ];
+
+      var codeMap = generator.generateSerializableModelsCode(
+        models: models,
+        config: config,
+      );
+
+      var grandparentCompilationUnit = parseString(
+        content: codeMap[getExpectedFilePath(grandparent.fileName)]!,
+      ).unit;
+      var parentCompilationUnit = parseString(
+        content: codeMap[getExpectedFilePath(parent.fileName)]!,
+      ).unit;
+
+      var childCompilationUnit = parseString(
+        content: codeMap[getExpectedFilePath(child.fileName)]!,
+      ).unit;
+
+      group('then ${grandparent.className}', () {
+        var grandparentClass = CompilationUnitHelpers.tryFindClassDeclaration(
+          grandparentCompilationUnit,
+          name: grandparent.className,
+        );
+
+        test('has a copyWith method', () {
+          var copyWithMethod = CompilationUnitHelpers.tryFindMethodDeclaration(
+            grandparentClass!,
+            name: 'copyWith',
+          );
+          expect(copyWithMethod, isNotNull);
+        });
+
+        test('has an import directive for serverpod', () {
+          var serverpodImport = CompilationUnitHelpers.tryFindImportDirective(
+            grandparentCompilationUnit,
+            uri: serverpodImportPath,
+          );
+
+          expect(serverpodImport, isNotNull);
+        });
+      });
+
+      group('then ${parent.className} ', () {
+        var parentClass = CompilationUnitHelpers.tryFindClassDeclaration(
+          parentCompilationUnit,
+          name: parent.className,
+        );
+
+        test('does have an abstract copyWith method', () {
+          var copyWithMethod = CompilationUnitHelpers.tryFindMethodDeclaration(
+            parentClass!,
+            name: 'copyWith',
+          );
+          expect(copyWithMethod, isNotNull);
+          expect(copyWithMethod!.body, isA<EmptyFunctionBody>());
+        });
+
+        test('has a part directive with ${child.className} uri', () {
+          var partDirective = CompilationUnitHelpers.tryFindPartDirective(
+            parentCompilationUnit,
+            uri: '${child.fileName}.dart',
+          );
+
+          expect(
+            partDirective?.uri.stringValue,
+            '${child.fileName}.dart',
+          );
+        });
+
+        test('has import directive for serverpod', () {
+          var serverpodImport = CompilationUnitHelpers.tryFindImportDirective(
+            parentCompilationUnit,
+            uri: serverpodImportPath,
+          );
+
+          expect(serverpodImport, isNotNull);
+        });
+      });
+
+      group('then ${child.className} has a copyWith method', () {
+        var childClass = CompilationUnitHelpers.tryFindClassDeclaration(
+          childCompilationUnit,
+          name: child.className,
+        );
+
+        var copyWithMethod = CompilationUnitHelpers.tryFindMethodDeclaration(
+          childClass!,
+          name: 'copyWith',
+        );
+
+        test('defined', () {
+          expect(copyWithMethod, isNotNull);
+        });
+
+        test('with the override annotation', () {
+          var overrideAnnotation = CompilationUnitHelpers.tryFindAnnotation(
+            copyWithMethod!,
+            name: 'override',
+          );
+
+          expect(overrideAnnotation, isNotNull);
+        });
+      });
+    },
+  );
+
+  group(
+    'Given a hierarchy: sealed > normal > sealed > normal when generating code',
+    () {
+      var greatGrandparent = ExceptionClassDefinitionBuilder()
+          .withClassName('ExampleGreatGrandparentException')
+          .withFileName('example_great_grandparent_exception')
+          .withSimpleField('name', 'String')
+          .withIsSealed(true)
+          .build();
+      var grandparent = ExceptionClassDefinitionBuilder()
+          .withClassName('ExampleGrandparentException')
+          .withFileName('example_grandparent_exception')
+          .withSimpleField('name', 'String')
+          .withExtendsClass(greatGrandparent)
+          .build();
+      var parent = ExceptionClassDefinitionBuilder()
+          .withClassName('ExampleParentException')
+          .withFileName('example_parent_exception')
+          .withSimpleField('name', 'String')
+          .withExtendsClass(grandparent)
+          .build();
+      var child = ExceptionClassDefinitionBuilder()
+          .withClassName('ExampleChildException')
+          .withFileName('example_child_exception')
+          .withSimpleField('age', 'int', nullable: true)
+          .withExtendsClass(parent)
+          .build();
+
+      greatGrandparent.childClasses.add(
+        ResolvedInheritanceDefinition(grandparent),
+      );
+      grandparent.childClasses.add(ResolvedInheritanceDefinition(parent));
+      parent.childClasses.add(ResolvedInheritanceDefinition(child));
+
+      var models = [
+        greatGrandparent,
+        grandparent,
+        parent,
+        child,
+      ];
+
+      var codeMap = generator.generateSerializableModelsCode(
+        models: models,
+        config: config,
+      );
+
+      var greatGrandparentCompilationUnit = parseString(
+        content: codeMap[getExpectedFilePath(greatGrandparent.fileName)]!,
+      ).unit;
+
+      var grandparentCompilationUnit = parseString(
+        content: codeMap[getExpectedFilePath(grandparent.fileName)]!,
+      ).unit;
+
+      var parentCompilationUnit = parseString(
+        content: codeMap[getExpectedFilePath(parent.fileName)]!,
+      ).unit;
+
+      var childCompilationUnit = parseString(
+        content: codeMap[getExpectedFilePath(child.fileName)]!,
+      ).unit;
+
+      group('then ${greatGrandparent.className}', () {
+        test('has part directives for all children', () {
+          var partDirective = CompilationUnitHelpers.tryFindPartDirective(
+            greatGrandparentCompilationUnit,
+            uri: '${grandparent.fileName}.dart',
+          );
+
+          expect(
+            partDirective?.uri.stringValue,
+            '${grandparent.fileName}.dart',
+          );
+
+          partDirective = CompilationUnitHelpers.tryFindPartDirective(
+            greatGrandparentCompilationUnit,
+            uri: '${parent.fileName}.dart',
+          );
+
+          expect(
+            partDirective?.uri.stringValue,
+            '${parent.fileName}.dart',
+          );
+
+          partDirective = CompilationUnitHelpers.tryFindPartDirective(
+            greatGrandparentCompilationUnit,
+            uri: '${child.fileName}.dart',
+          );
+
+          expect(
+            partDirective?.uri.stringValue,
+            '${child.fileName}.dart',
+          );
+        });
+      });
+
+      group('then ${grandparent.className} has a copyWith method', () {
+        var grandparentClass = CompilationUnitHelpers.tryFindClassDeclaration(
+          grandparentCompilationUnit,
+          name: grandparent.className,
+        );
+
+        var copyWithMethod = CompilationUnitHelpers.tryFindMethodDeclaration(
+          grandparentClass!,
+          name: 'copyWith',
+        );
+
+        test('defined', () {
+          expect(copyWithMethod, isNotNull);
+        });
+
+        test('with the override annotation', () {
+          var overrideAnnotation = CompilationUnitHelpers.tryFindAnnotation(
+            copyWithMethod!,
+            name: 'override',
+          );
+
+          expect(overrideAnnotation, isNotNull);
+        });
+      });
+
+      test(
+        'then ${parent.className} has a part-of directive with ${greatGrandparent.className} uri',
+        () {
+          var partOfDirective = CompilationUnitHelpers.tryFindPartOfDirective(
+            parentCompilationUnit,
+            uri: '${greatGrandparent.fileName}.dart',
+          );
+
+          expect(
+            partOfDirective?.uri?.stringValue,
+            '${greatGrandparent.fileName}.dart',
+          );
+        },
+      );
+
+      group('then ${child.className} ', () {
+        var childClass = CompilationUnitHelpers.tryFindClassDeclaration(
+          childCompilationUnit,
+          name: child.className,
+        );
+
+        var copyWithMethod = CompilationUnitHelpers.tryFindMethodDeclaration(
+          childClass!,
+          name: 'copyWith',
+        );
+
+        group('has a copyWith method', () {
+          test('defined', () {
+            expect(copyWithMethod, isNotNull);
+          });
+
+          test('with the override annotation', () {
+            var overrideAnnotation = CompilationUnitHelpers.tryFindAnnotation(
+              copyWithMethod!,
+              name: 'override',
+            );
+
+            expect(overrideAnnotation, isNotNull);
+          });
+        });
+
+        test(
+          'has a part-of directive with ${greatGrandparent.className} uri',
+          () {
+            var partOfDirective = CompilationUnitHelpers.tryFindPartOfDirective(
+              childCompilationUnit,
+              uri: '${greatGrandparent.fileName}.dart',
+            );
+
+            expect(
+              partOfDirective?.uri?.stringValue,
+              '${greatGrandparent.fileName}.dart',
+            );
+          },
+        );
+      });
+    },
+  );
+
+  group('Given a hierarchy: sealed > sealed > normal when generating code', () {
+    var grandparent = ExceptionClassDefinitionBuilder()
+        .withClassName('ExampleGrandparentException')
+        .withFileName('example_grandparent_exception')
+        .withSimpleField('message', 'String')
+        .withIsSealed(true)
+        .build();
+    var parent = ExceptionClassDefinitionBuilder()
+        .withClassName('ExampleParentException')
+        .withFileName('example_parent_exception')
+        .withSimpleField('name', 'String')
+        .withExtendsClass(grandparent)
+        .withIsSealed(true)
+        .build();
+    var child = ExceptionClassDefinitionBuilder()
+        .withClassName('ExampleChildException')
+        .withFileName('example_child_exception')
+        .withSimpleField('code', 'int', nullable: true)
+        .withExtendsClass(parent)
+        .build();
+
+    grandparent.childClasses.add(ResolvedInheritanceDefinition(parent));
+    parent.childClasses.add(ResolvedInheritanceDefinition(child));
+
+    var models = [
+      grandparent,
+      parent,
+      child,
+    ];
+
+    var codeMap = generator.generateSerializableModelsCode(
+      models: models,
+      config: config,
+    );
+
+    var childCompilationUnit = parseString(
+      content: codeMap[getExpectedFilePath(child.fileName)]!,
+    ).unit;
+
+    group('then ${child.className}', () {
+      var childClass = CompilationUnitHelpers.tryFindClassDeclaration(
+        childCompilationUnit,
+        name: child.className,
+      );
+
+      var copyWithMethod = CompilationUnitHelpers.tryFindMethodDeclaration(
+        childClass!,
+        name: 'copyWith',
+      );
+
+      test('has a copyWith method', () {
+        expect(copyWithMethod, isNotNull);
+      });
+
+      test('with the override annotation', () {
+        var overrideAnnotation = CompilationUnitHelpers.tryFindAnnotation(
+          copyWithMethod!,
+          name: 'override',
+        );
+
+        expect(overrideAnnotation, isNotNull);
+      });
+    });
+  });
+
+  group('Given a sealed class with no children when generating code', () {
+    var parent = ExceptionClassDefinitionBuilder()
+        .withClassName('ExampleParentException')
+        .withFileName('example_parent_exception')
+        .withSimpleField('message', 'String')
+        .withIsSealed(true)
+        .build();
+
+    var models = [
+      parent,
+    ];
+
+    var codeMap = generator.generateSerializableModelsCode(
+      models: models,
+      config: config,
+    );
+
+    var parentCompilationUnit = parseString(
+      content: codeMap[getExpectedFilePath(parent.fileName)]!,
+    ).unit;
+
+    group('then ${parent.className}', () {
+      var parentClass = CompilationUnitHelpers.tryFindClassDeclaration(
+        parentCompilationUnit,
+        name: parent.className,
+      );
+
+      test('is defined', () {
+        expect(parentClass, isNotNull);
+      });
+
+      test('does have an abstract copyWith method', () {
+        var copyWithMethod = CompilationUnitHelpers.tryFindMethodDeclaration(
+          parentClass!,
+          name: 'copyWith',
+        );
+
+        expect(copyWithMethod, isNotNull);
+        expect(copyWithMethod!.body, isA<EmptyFunctionBody>());
+      });
+
+      var directives = parentCompilationUnit.directives;
+
+      test('has only directive which is an import', () {
+        expect(directives.length, 1);
+        expect(directives.first, isA<ImportDirective>());
+      });
+
+      test('does NOT have a part directive', () {
+        expect(directives.first, isNot(isA<PartDirective>()));
+      });
+    });
+  });
+
+  group(
+    'Given a hierarchy: sealed > normal > normal, when the sealed top node is in another directory',
+    () {
+      var grandparent = ExceptionClassDefinitionBuilder()
+          .withClassName('ExampleGrandparentException')
+          .withSubDirParts(['sub_dir'])
+          .withFileName('example_grandparent_exception')
+          .withSimpleField('name', 'String')
+          .withIsSealed(true) // <= sealed
+          .build();
+      var parent = ExceptionClassDefinitionBuilder()
+          .withClassName('ExampleParentException')
+          .withFileName('example_parent_exception')
+          .withSimpleField('name', 'String')
+          .withExtendsClass(grandparent)
+          .build();
+      var child = ExceptionClassDefinitionBuilder()
+          .withClassName('ExampleChildException')
+          .withFileName('example_child_exception')
+          .withSimpleField('code', 'int', nullable: true)
+          .withExtendsClass(parent)
+          .build();
+
+      grandparent.childClasses.add(ResolvedInheritanceDefinition(parent));
+      parent.childClasses.add(ResolvedInheritanceDefinition(child));
+
+      var models = [
+        grandparent,
+        parent,
+        child,
+      ];
+
+      var codeMap = generator.generateSerializableModelsCode(
+        models: models,
+        config: config,
+      );
+
+      var grandparentPath = getExpectedFilePath(
+        grandparent.fileName,
+        subDirParts: ['sub_dir'],
+      );
+      var parentPath = getExpectedFilePath(parent.fileName);
+      var childPath = getExpectedFilePath(child.fileName);
+
+      var grandparentCompilationUnit = parseString(
+        content: codeMap[grandparentPath]!,
+      ).unit;
+      var parentCompilationUnit = parseString(
+        content: codeMap[parentPath]!,
+      ).unit;
+      var childCompilationUnit = parseString(content: codeMap[childPath]!).unit;
+
+      group('then ${grandparent.className}', () {
+        test('has a part directive with ${parent.className} uri', () {
+          var partDirective = CompilationUnitHelpers.tryFindPartDirective(
+            grandparentCompilationUnit,
+            uri: '../${parent.fileName}.dart',
+          );
+
+          expect(
+            partDirective,
+            isNotNull,
+          );
+        });
+
+        test('has a part directive with ${child.className} uri', () {
+          var partDirective = CompilationUnitHelpers.tryFindPartDirective(
+            grandparentCompilationUnit,
+            uri: '../${child.fileName}.dart',
+          );
+          expect(
+            partDirective,
+            isNotNull,
+          );
+        });
+      });
+
+      group('then ${parent.className}', () {
+        test('has a part-of directive with ${grandparent.className} uri', () {
+          var partOfDirective = CompilationUnitHelpers.tryFindPartOfDirective(
+            parentCompilationUnit,
+            uri: 'sub_dir/${grandparent.fileName}.dart',
+          );
+          expect(
+            partOfDirective,
+            isNotNull,
+          );
+        });
+      });
+
+      group('then ${child.className}', () {
+        test('has a part-of directive with ${grandparent.className} uri', () {
+          var partOfDirective = CompilationUnitHelpers.tryFindPartOfDirective(
+            childCompilationUnit,
+            uri: 'sub_dir/${grandparent.fileName}.dart',
+          );
+          expect(
+            partOfDirective,
+            isNotNull,
+          );
+        });
+      });
+    },
+  );
+
+  group(
+    'Given a hierarchy: sealed > normal > normal when the middle node is in another directory',
+    () {
+      var grandparent = ExceptionClassDefinitionBuilder()
+          .withClassName('ExampleGrandparentException')
+          .withFileName('example_grandparent_exception')
+          .withSimpleField('message', 'String')
+          .withIsSealed(true) // <= sealed
+          .build();
+      var parent = ExceptionClassDefinitionBuilder()
+          .withClassName('ExampleParentException')
+          .withFileName('example_parent_exception')
+          .withSubDirParts(['sub_dir'])
+          .withSimpleField('name', 'String')
+          .withExtendsClass(grandparent)
+          .build();
+      var child = ExceptionClassDefinitionBuilder()
+          .withClassName('ExampleChildException')
+          .withFileName('example_child_exception')
+          .withSimpleField('code', 'int', nullable: true)
+          .withExtendsClass(parent)
+          .build();
+
+      grandparent.childClasses.add(ResolvedInheritanceDefinition(parent));
+      parent.childClasses.add(ResolvedInheritanceDefinition(child));
+
+      var models = [
+        grandparent,
+        parent,
+        child,
+      ];
+
+      var codeMap = generator.generateSerializableModelsCode(
+        models: models,
+        config: config,
+      );
+
+      var grandparentPath = getExpectedFilePath(grandparent.fileName);
+      var parentPath = getExpectedFilePath(
+        parent.fileName,
+        subDirParts: ['sub_dir'],
+      );
+      var childPath = getExpectedFilePath(child.fileName);
+
+      var grandparentCompilationUnit = parseString(
+        content: codeMap[grandparentPath]!,
+      ).unit;
+      var parentCompilationUnit = parseString(
+        content: codeMap[parentPath]!,
+      ).unit;
+      var childCompilationUnit = parseString(content: codeMap[childPath]!).unit;
+
+      group('then ${grandparent.className}', () {
+        test('has a part directive with ${parent.className} uri', () {
+          var partDirective = CompilationUnitHelpers.tryFindPartDirective(
+            grandparentCompilationUnit,
+            uri: 'sub_dir/${parent.fileName}.dart',
+          );
+          expect(
+            partDirective,
+            isNotNull,
+          );
+        });
+
+        test('has a part directive with ${child.className} uri', () {
+          var partDirective = CompilationUnitHelpers.tryFindPartDirective(
+            grandparentCompilationUnit,
+            uri: '${child.fileName}.dart',
+          );
+          expect(
+            partDirective,
+            isNotNull,
+          );
+        });
+      });
+
+      group('then ${parent.className}', () {
+        test('has a part-of directive with ${grandparent.className} uri', () {
+          var partOfDirective = CompilationUnitHelpers.tryFindPartOfDirective(
+            parentCompilationUnit,
+            uri: '../${grandparent.fileName}.dart',
+          );
+          expect(
+            partOfDirective,
+            isNotNull,
+          );
+        });
+      });
+
+      group('then ${child.className}', () {
+        test('has a part-of directive with ${grandparent.className} uri', () {
+          var partOfDirective = CompilationUnitHelpers.tryFindPartOfDirective(
+            childCompilationUnit,
+            uri: '${grandparent.fileName}.dart',
+          );
+          expect(
+            partOfDirective,
+            isNotNull,
+          );
+        });
+      });
+    },
+  );
+
+  group(
+    'Given a hierarchy: sealed > normal > normal when the bottom node is in another directory',
+    () {
+      var grandparent = ExceptionClassDefinitionBuilder()
+          .withClassName('ExampleGrandparentException')
+          .withFileName('example_grandparent_exception')
+          .withSimpleField('message', 'String')
+          .withIsSealed(true) // <= sealed
+          .build();
+      var parent = ExceptionClassDefinitionBuilder()
+          .withClassName('ExampleParentException')
+          .withFileName('example_parent_exception')
+          .withSimpleField('name', 'String')
+          .withExtendsClass(grandparent)
+          .build();
+      var child = ExceptionClassDefinitionBuilder()
+          .withClassName('ExampleChildException')
+          .withFileName('example_child_exception')
+          .withSubDirParts(['sub_dir'])
+          .withSimpleField('code', 'int', nullable: true)
+          .withExtendsClass(parent)
+          .build();
+
+      grandparent.childClasses.add(ResolvedInheritanceDefinition(parent));
+      parent.childClasses.add(ResolvedInheritanceDefinition(child));
+
+      var models = [
+        grandparent,
+        parent,
+        child,
+      ];
+
+      var codeMap = generator.generateSerializableModelsCode(
+        models: models,
+        config: config,
+      );
+
+      var grandparentPath = getExpectedFilePath(grandparent.fileName);
+      var parentPath = getExpectedFilePath(parent.fileName);
+      var childPath = getExpectedFilePath(
+        child.fileName,
+        subDirParts: ['sub_dir'],
+      );
+
+      var grandparentCompilationUnit = parseString(
+        content: codeMap[grandparentPath]!,
+      ).unit;
+      var parentCompilationUnit = parseString(
+        content: codeMap[parentPath]!,
+      ).unit;
+      var childCompilationUnit = parseString(content: codeMap[childPath]!).unit;
+
+      group('then ${grandparent.className}', () {
+        test('has a part directive with ${parent.className} uri', () {
+          var partDirective = CompilationUnitHelpers.tryFindPartDirective(
+            grandparentCompilationUnit,
+            uri: '${parent.fileName}.dart',
+          );
+          expect(
+            partDirective,
+            isNotNull,
+          );
+        });
+
+        test('has a part directive with ${child.className} uri', () {
+          var partDirective = CompilationUnitHelpers.tryFindPartDirective(
+            grandparentCompilationUnit,
+            uri: 'sub_dir/${child.fileName}.dart',
+          );
+          expect(
+            partDirective,
+            isNotNull,
+          );
+        });
+      });
+
+      group('then ${parent.className}', () {
+        test('has a part-of directive with ${grandparent.className} uri', () {
+          var partOfDirective = CompilationUnitHelpers.tryFindPartOfDirective(
+            parentCompilationUnit,
+            uri: '${grandparent.fileName}.dart',
+          );
+          expect(
+            partOfDirective,
+            isNotNull,
+          );
+        });
+      });
+
+      group('then ${child.className}', () {
+        test('has a part-of directive with ${grandparent.className} uri', () {
+          var partOfDirective = CompilationUnitHelpers.tryFindPartOfDirective(
+            childCompilationUnit,
+            uri: '../${grandparent.fileName}.dart',
+          );
+          expect(
+            partOfDirective,
+            isNotNull,
+          );
+        });
+      });
+    },
+  );
+
+  group(
+    'Given a model with a sealed exception as a field type when generating code',
+    () {
+      var sealedParent = ExceptionClassDefinitionBuilder()
+          .withClassName('SealedParentException')
+          .withFileName('sealed_parent_exception')
+          .withSimpleField('message', 'String')
+          .withIsSealed(true)
+          .build();
+
+      var sealedChild = ExceptionClassDefinitionBuilder()
+          .withClassName('SealedChildException')
+          .withFileName('sealed_child_exception')
+          .withSimpleField('code', 'int')
+          .withExtendsClass(sealedParent)
+          .build();
+
+      sealedParent.childClasses.add(ResolvedInheritanceDefinition(sealedChild));
+
+      var modelWithSealedField = ExceptionClassDefinitionBuilder()
+          .withClassName('ModelWithSealedField')
+          .withFileName('model_with_sealed_field')
+          .withField(
+            FieldDefinitionBuilder()
+                .withName('sealedField')
+                .withType(
+                  TypeDefinitionBuilder()
+                      .withClassName('SealedParentException')
+                      .withNullable(false)
+                      .build(),
+                )
+                .build(),
+          )
+          .withField(
+            FieldDefinitionBuilder()
+                .withName('nullableSealedField')
+                .withType(
+                  TypeDefinitionBuilder()
+                      .withClassName('SealedParentException')
+                      .withNullable(true)
+                      .build(),
+                )
+                .build(),
+          )
+          .build();
+
+      var models = [
+        sealedParent,
+        sealedChild,
+        modelWithSealedField,
+      ];
+
+      late var codeMap = generator.generateSerializableModelsCode(
+        models: models,
+        config: config,
+      );
+
+      final expectedFileName = getExpectedFilePath(
+        modelWithSealedField.fileName,
+      );
+
+      test('then model file is created.', () {
+        expect(codeMap, contains(expectedFileName));
+      });
+
+      late var compilationUnit = parseString(
+        content: codeMap[expectedFileName]!,
+      ).unit;
+
+      group('then ${modelWithSealedField.className}', () {
+        late var modelClass = CompilationUnitHelpers.tryFindClassDeclaration(
+          compilationUnit,
+          name: modelWithSealedField.className,
+        );
+
+        test('compiles without errors', () {
+          expect(compilationUnit.declarations, isNotEmpty);
+        });
+
+        test('is defined', () {
+          expect(modelClass, isNotNull);
+        });
+
+        test('has a field with sealed class type', () {
+          var field = CompilationUnitHelpers.tryFindFieldDeclaration(
+            modelClass!,
+            name: 'sealedField',
+          );
+          expect(field, isNotNull);
+        });
+
+        test('has a nullable field with sealed class type', () {
+          var field = CompilationUnitHelpers.tryFindFieldDeclaration(
+            modelClass!,
+            name: 'nullableSealedField',
+          );
+          expect(field, isNotNull);
+        });
+      });
+    },
+  );
+}

--- a/tools/serverpod_cli/test/test_util/builders/exception_class_definition_builder.dart
+++ b/tools/serverpod_cli/test/test_util/builders/exception_class_definition_builder.dart
@@ -1,5 +1,6 @@
 import 'package:serverpod_cli/src/analyzer/models/definitions.dart';
 
+import 'serializable_entity_field_definition_builder.dart';
 import 'type_definition_builder.dart';
 
 typedef _FieldBuilder = SerializableModelFieldDefinition Function();
@@ -12,6 +13,9 @@ class ExceptionClassDefinitionBuilder {
   bool _serverOnly;
   List<_FieldBuilder> _fields;
   List<String>? _documentation;
+  bool _isSealed;
+  List<InheritanceDefinition> _childClasses;
+  InheritanceDefinition? _extendsClass;
   String? _sharedPackageName;
   String? _typeUrl;
 
@@ -21,7 +25,9 @@ class ExceptionClassDefinitionBuilder {
       _className = 'Example',
       _fields = [],
       _subDirParts = [],
-      _serverOnly = false;
+      _serverOnly = false,
+      _childClasses = [],
+      _isSealed = false;
 
   ExceptionClassDefinition build() {
     return ExceptionClassDefinition(
@@ -31,6 +37,9 @@ class ExceptionClassDefinitionBuilder {
       fields: _fields.map((f) => f()).toList(),
       subDirParts: _subDirParts,
       serverOnly: _serverOnly,
+      childClasses: _childClasses,
+      extendsClass: _extendsClass,
+      isSealed: _isSealed,
       documentation: _documentation,
       type: TypeDefinitionBuilder()
           .withClassName(_className)
@@ -100,6 +109,50 @@ class ExceptionClassDefinitionBuilder {
 
   ExceptionClassDefinitionBuilder withTypeUrl(String? url) {
     _typeUrl = url;
+    return this;
+  }
+
+  ExceptionClassDefinitionBuilder withSimpleField(
+    String fieldName,
+    String type, {
+    dynamic defaultModelValue,
+    dynamic defaultPersistValue,
+    bool nullable = false,
+  }) {
+    _fields.add(
+      () => FieldDefinitionBuilder()
+          .withName(fieldName)
+          .withTypeDefinition(type, nullable)
+          .withDefaults(
+            defaultModelValue: defaultModelValue,
+            defaultPersistValue: defaultPersistValue,
+          )
+          .build(),
+    );
+    return this;
+  }
+
+  ExceptionClassDefinitionBuilder withChildClasses(
+    List<ExceptionClassDefinition> childClasses,
+  ) {
+    _childClasses = [
+      for (var child in childClasses)
+        ResolvedInheritanceDefinition<ExceptionClassDefinition>(child),
+    ];
+    return this;
+  }
+
+  ExceptionClassDefinitionBuilder withExtendsClass(
+    ExceptionClassDefinition parentClass,
+  ) {
+    _extendsClass = ResolvedInheritanceDefinition<ExceptionClassDefinition>(
+      parentClass,
+    );
+    return this;
+  }
+
+  ExceptionClassDefinitionBuilder withIsSealed(bool isSealed) {
+    _isSealed = isSealed;
     return this;
   }
 }


### PR DESCRIPTION
This PR adds `inheritance` and `sealed` support to exception models, matching the existing capabilities available for regular models.
 
Closes #4249 

Usage:

```yaml
# app_exception.spy.yaml
exception: AppException
sealed: true
fields:
    message: String
```

```yaml
# not_found_exception.spy.yaml
exception: NotFoundException
extends: AppException
fields:
    statusCode: int
```

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

## 1. ExceptionClassDefinition constructor now requires isSealed
```dart
// Before
  ExceptionClassDefinition(
    className: 'BaseException',
    fields: [...],
    fileName: 'base_exception',
    sourceFileName: '...',
    serverOnly: false,
    type: ...,
  );

  // After
  ExceptionClassDefinition(
    className: 'BaseException',
    fields: [...],
    fileName: 'base_exception',
    sourceFileName: '...',
    serverOnly: false,
    type: ..,
    isSealed: false, // <-- now required
  );
```
Existing usages should add isSealed: false, unless the exception is intended to be sealed.

## 2. ResolvedInheritanceDefinition is now generic (internal API)
```dart
 // Before
  class ResolvedInheritanceDefinition extends InheritanceDefinition {
    final ModelClassDefinition classDefinition;
  }

  // After
  class ResolvedInheritanceDefinition<T extends ClassDefinition>
      extends InheritanceDefinition {
    final T classDefinition;
  }
```
This change only affects internal generator APIs, so external consumers should not be impacted. Existing constructor calls such as ResolvedInheritanceDefinition(value) continue to work, but explicit type annotations now require a type argument:

```dart
  // Before
  ResolvedInheritanceDefinition x = ResolvedInheritanceDefinition(value);

  // After
  ResolvedInheritanceDefinition<ModelClassDefinition> x =
      ResolvedInheritanceDefinition(value);
```

## 3. New validation for invalid cross-inheritance
Declaring a standard model that extends an exception model (or an exception model that extends a standard model) previously failed silently. This is now detected during validation and produces a clear error message.
