### PR TITLE
fix: Fix `copyWith` method on `dynamic` fields

### DIFF
--- a/tests/serverpod_test_client/lib/src/protocol/object_with_dynamic.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/object_with_dynamic.dart
@@ -153,8 +153,8 @@ class _ObjectWithDynamicImpl extends ObjectWithDynamic {
   }) {
     return ObjectWithDynamic(
       id: id is int? ? id : this.id,
-      payload: payload is! _Undefined ? payload : this.payload,
-      jsonbPayload: jsonbPayload is! _Undefined
+      payload: payload != _Undefined ? payload : this.payload,
+      jsonbPayload: jsonbPayload != _Undefined
           ? jsonbPayload
           : this.jsonbPayload,
       payloadList: payloadList ?? this.payloadList.map((e0) => e0).toList(),

--- a/tests/serverpod_test_client/test/dynamic_copy_with_test.dart
+++ b/tests/serverpod_test_client/test/dynamic_copy_with_test.dart
@@ -1,0 +1,59 @@
+import 'package:serverpod_test_client/src/protocol/object_with_dynamic.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Given a model with dynamic fields', () {
+    final model = ObjectWithDynamic(
+      id: 1,
+      payload: 'test',
+      jsonbPayload: 1,
+      payloadList: [1, 2, 3],
+      payloadMap: {'a': 1, 'b': 2},
+      payloadSet: {1, 2, 3},
+      payloadMapWithDynamicKeys: {},
+    );
+
+    test(
+      'when calling copyWith changing a non-dynamic field, '
+      'then dynamic fields remain unchanged.',
+      () {
+        final updated = model.copyWith(id: 2);
+
+        expect(updated.id, 2);
+        expect(updated.payload, model.payload);
+        expect(updated.jsonbPayload, model.jsonbPayload);
+        expect(updated.payloadList, model.payloadList);
+        expect(updated.payloadMap, model.payloadMap);
+        expect(updated.payloadSet, model.payloadSet);
+      },
+    );
+
+    test(
+      'when calling copyWith changing a dynamic field to null, '
+      'then only the changed dynamic field is nulled.',
+      () {
+        final cleared = model.copyWith(payload: null);
+
+        expect(cleared.payload, isNull);
+        expect(cleared.jsonbPayload, model.jsonbPayload);
+        expect(cleared.payloadList, model.payloadList);
+        expect(cleared.payloadMap, model.payloadMap);
+        expect(cleared.payloadSet, model.payloadSet);
+      },
+    );
+
+    test(
+      'when calling copyWith changing a dynamic field to a new value, '
+      'then only the changed dynamic field is updated.',
+      () {
+        final updated = model.copyWith(payload: 2);
+
+        expect(updated.payload, 2);
+        expect(updated.jsonbPayload, model.jsonbPayload);
+        expect(updated.payloadList, model.payloadList);
+        expect(updated.payloadMap, model.payloadMap);
+        expect(updated.payloadSet, model.payloadSet);
+      },
+    );
+  });
+}

--- a/tests/serverpod_test_server/lib/src/generated/object_with_dynamic.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_dynamic.dart
@@ -208,8 +208,8 @@ class _ObjectWithDynamicImpl extends ObjectWithDynamic {
   }) {
     return ObjectWithDynamic(
       id: id is int? ? id : this.id,
-      payload: payload is! _Undefined ? payload : this.payload,
-      jsonbPayload: jsonbPayload is! _Undefined
+      payload: payload != _Undefined ? payload : this.payload,
+      jsonbPayload: jsonbPayload != _Undefined
           ? jsonbPayload
           : this.jsonbPayload,
       payloadList: payloadList ?? this.payloadList.map((e0) => e0).toList(),

--- a/tests/serverpod_test_server/test/dynamic_copy_with_test.dart
+++ b/tests/serverpod_test_server/test/dynamic_copy_with_test.dart
@@ -1,0 +1,59 @@
+import 'package:serverpod_test_server/src/generated/protocol.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Given a model with dynamic fields', () {
+    final model = ObjectWithDynamic(
+      id: 1,
+      payload: 'test',
+      jsonbPayload: 1,
+      payloadList: [1, 2, 3],
+      payloadMap: {'a': 1, 'b': 2},
+      payloadSet: {1, 2, 3},
+      payloadMapWithDynamicKeys: {},
+    );
+
+    test(
+      'when calling copyWith changing a non-dynamic field, '
+      'then dynamic fields remain unchanged.',
+      () {
+        final updated = model.copyWith(id: 2);
+
+        expect(updated.id, 2);
+        expect(updated.payload, model.payload);
+        expect(updated.jsonbPayload, model.jsonbPayload);
+        expect(updated.payloadList, model.payloadList);
+        expect(updated.payloadMap, model.payloadMap);
+        expect(updated.payloadSet, model.payloadSet);
+      },
+    );
+
+    test(
+      'when calling copyWith changing a dynamic field to null, '
+      'then only the changed dynamic field is nulled.',
+      () {
+        final cleared = model.copyWith(payload: null);
+
+        expect(cleared.payload, isNull);
+        expect(cleared.jsonbPayload, model.jsonbPayload);
+        expect(cleared.payloadList, model.payloadList);
+        expect(cleared.payloadMap, model.payloadMap);
+        expect(cleared.payloadSet, model.payloadSet);
+      },
+    );
+
+    test(
+      'when calling copyWith changing a dynamic field to a new value, '
+      'then only the changed dynamic field is updated.',
+      () {
+        final updated = model.copyWith(payload: 2);
+
+        expect(updated.payload, 2);
+        expect(updated.jsonbPayload, model.jsonbPayload);
+        expect(updated.payloadList, model.payloadList);
+        expect(updated.payloadMap, model.payloadMap);
+        expect(updated.payloadSet, model.payloadSet);
+      },
+    );
+  });
+}

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/object_with_dynamic.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/object_with_dynamic.dart
@@ -153,8 +153,8 @@ class _ObjectWithDynamicImpl extends ObjectWithDynamic {
   }) {
     return ObjectWithDynamic(
       id: id is int? ? id : this.id,
-      payload: payload is! _Undefined ? payload : this.payload,
-      jsonbPayload: jsonbPayload is! _Undefined
+      payload: payload != _Undefined ? payload : this.payload,
+      jsonbPayload: jsonbPayload != _Undefined
           ? jsonbPayload
           : this.jsonbPayload,
       payloadList: payloadList ?? this.payloadList.map((e0) => e0).toList(),

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/object_with_dynamic.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/object_with_dynamic.dart
@@ -209,8 +209,8 @@ class _ObjectWithDynamicImpl extends ObjectWithDynamic {
   }) {
     return ObjectWithDynamic(
       id: id is int? ? id : this.id,
-      payload: payload is! _Undefined ? payload : this.payload,
-      jsonbPayload: jsonbPayload is! _Undefined
+      payload: payload != _Undefined ? payload : this.payload,
+      jsonbPayload: jsonbPayload != _Undefined
           ? jsonbPayload
           : this.jsonbPayload,
       payloadList: payloadList ?? this.payloadList.map((e0) => e0).toList(),

--- a/tools/serverpod_cli/lib/src/generator/dart/library_generators/model_library_generator.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart/library_generators/model_library_generator.dart
@@ -944,7 +944,7 @@ class SerializableModelLibraryGenerator {
         // Since `dynamic` also covers `_Undefined`, the check for `param`
         // must be inverted to explicitly not be `_Undefined`.
         valueDefinition = refer(field.name)
-            .isNotA(refer('_Undefined'))
+            .notEqualTo(refer('_Undefined'))
             .conditional(
               refer(field.name),
               assignment,


### PR DESCRIPTION
Fixes: #5145

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.