### PR TITLE
fix: Fix `dynamic` data being serialized as an encoded string

### DIFF
--- a/packages/serverpod_serialization/lib/src/serialization.dart
+++ b/packages/serverpod_serialization/lib/src/serialization.dart
@@ -65,7 +65,7 @@ abstract class SerializationManager {
     if (value is String) return decodeWithType(value);
     if (value is Map<String, dynamic>) return deserializeByClassName(value);
     throw FormatException(
-      'Dynamic fields are serialized as a Map with the type, but got '
+      'Dynamic fields are encoded as a Map with the type, but got '
       '${value.runtimeType} instead.',
     );
   }

--- a/packages/serverpod_serialization/lib/src/serialization.dart
+++ b/packages/serverpod_serialization/lib/src/serialization.dart
@@ -57,19 +57,6 @@ abstract class SerializationManager {
     return deserializeByClassName(jsonDecode(data));
   }
 
-  /// Decodes a value for a `dynamic` model field from protocol or database
-  /// shapes: a JSON [String] from [encodeWithType], or a [Map] when JSON was
-  /// parsed before deserialization.
-  dynamic decodeDynamicFieldValue(Object? value) {
-    if (value == null) return null;
-    if (value is String) return decodeWithType(value);
-    if (value is Map<String, dynamic>) return deserializeByClassName(value);
-    throw FormatException(
-      'Dynamic fields are encoded as a Map with the type, but got '
-      '${value.runtimeType} instead.',
-    );
-  }
-
   bool _isType<T1, T2>(Type t) => t == T1 || t == T2;
 
   bool _isNullableType<T>(Type t) => _isType<T, T?>(t);
@@ -164,39 +151,66 @@ abstract class SerializationManager {
   /// Deserialize the provided json [data] by using the className stored in the [data].
   dynamic deserializeByClassName(Map<String, dynamic> data) {
     var className = data['className'];
+    var raw = data['data'];
     switch (className) {
       case 'null':
         return null;
       case 'int':
-        return deserialize<int>(data['data']);
+        return deserialize<int>(raw);
       case 'double':
-        return deserialize<double>(data['data']);
+        return deserialize<double>(raw);
       case 'String':
-        return deserialize<String>(data['data']);
+        return deserialize<String>(raw);
       case 'bool':
-        return deserialize<bool>(data['data']);
+        return deserialize<bool>(raw);
       case 'DateTime':
-        return deserialize<DateTime>(data['data']);
+        return deserialize<DateTime>(raw);
       case 'ByteData':
-        return deserialize<ByteData>(data['data']);
+        return deserialize<ByteData>(raw);
       case 'Duration':
-        return deserialize<Duration>(data['data']);
+        return deserialize<Duration>(raw);
       case 'UuidValue':
-        return deserialize<UuidValue>(data['data']);
+        return deserialize<UuidValue>(raw);
       case 'Uri':
-        return deserialize<Uri>(data['data']);
+        return deserialize<Uri>(raw);
       case 'BigInt':
-        return deserialize<BigInt>(data['data']);
+        return deserialize<BigInt>(raw);
       case 'Vector':
-        return deserialize<Vector>(data['data']);
+        return deserialize<Vector>(raw);
       case 'HalfVector':
-        return deserialize<HalfVector>(data['data']);
+        return deserialize<HalfVector>(raw);
       case 'SparseVector':
-        return deserialize<SparseVector>(data['data']);
+        return deserialize<SparseVector>(raw);
       case 'Bit':
-        return deserialize<Bit>(data['data']);
+        return deserialize<Bit>(raw);
+      case 'List' when raw is List:
+        return raw.map(deserializeDynamicFieldValue).toList();
+      case 'Set' when raw is List:
+        return raw.map(deserializeDynamicFieldValue).toSet();
+      case 'Map' when raw is Map<String, dynamic>:
+        return raw.map((k, v) => MapEntry(k, deserializeDynamicFieldValue(v)));
+      case 'Map' when raw is List<Map<String, dynamic>>:
+        return Map<dynamic, dynamic>.fromEntries(
+          raw.map(
+            (e) => MapEntry(
+              deserializeDynamicFieldValue(e['k']),
+              deserializeDynamicFieldValue(e['v']),
+            ),
+          ),
+        );
     }
     throw FormatException('No deserialization found for type named $className');
+  }
+
+  /// Decodes a value for a `dynamic` model field: a JSON object ([Map]) with
+  /// `className` and `data` (see [dynamicFieldToJson]).
+  dynamic deserializeDynamicFieldValue(Object? value) {
+    if (value == null) return null;
+    if (value is Map<String, dynamic>) return deserializeByClassName(value);
+    throw FormatException(
+      'Dynamic fields are encoded as a Map with className and data, but got '
+      '${value.runtimeType} instead.',
+    );
   }
 
   /// Wraps serialized data with its class name so that it can be deserialized
@@ -326,6 +340,57 @@ abstract class SerializationManager {
       formatted: formatted,
       encodeForProtocol: true,
     );
+  }
+
+  /// Returns a JSON-encodable structure for a `dynamic` model field.
+  Object? dynamicFieldToJson(Object? object) =>
+      _dynamicFieldValueToJson(object, false);
+
+  /// Same as [dynamicFieldToJson] but uses protocol encoding for nested
+  /// [ProtocolSerialization] values.
+  Object? dynamicFieldToJsonForProtocol(Object? object) =>
+      _dynamicFieldValueToJson(object, true);
+
+  /// Recursively encodes values inside `dynamic` fields so that [List], [Set],
+  /// and [Map] children keep per-element type information.
+  ///
+  /// Does not use [wrapWithClassName] for container types so that
+  /// [getClassNameForObject] is not required to name raw collections.
+  Object? _dynamicFieldValueToJson(Object? object, bool encodeForProtocol) {
+    return switch (object) {
+      List() => {
+        'className': 'List',
+        'data': [
+          for (final e in object)
+            _dynamicFieldValueToJson(e, encodeForProtocol),
+        ],
+      },
+      Set() => {
+        'className': 'Set',
+        'data': [
+          for (final e in object)
+            _dynamicFieldValueToJson(e, encodeForProtocol),
+        ],
+      },
+      Map() when object.keys.every((k) => k is String) => {
+        'className': 'Map',
+        'data': {
+          for (final e in Map<String, dynamic>.from(object).entries)
+            e.key: _dynamicFieldValueToJson(e.value, encodeForProtocol),
+        },
+      },
+      Map() => {
+        'className': 'Map',
+        'data': [
+          for (final e in object.entries)
+            {
+              'k': _dynamicFieldValueToJson(e.key, encodeForProtocol),
+              'v': _dynamicFieldValueToJson(e.value, encodeForProtocol),
+            },
+        ],
+      },
+      _ => _toEncodable(wrapWithClassName(object), encodeForProtocol),
+    };
   }
 }
 

--- a/packages/serverpod_serialization/lib/src/serialization.dart
+++ b/packages/serverpod_serialization/lib/src/serialization.dart
@@ -189,9 +189,9 @@ abstract class SerializationManager {
         return raw.map(deserializeDynamicFieldValue).toSet();
       case 'Map' when raw is Map<String, dynamic>:
         return raw.map((k, v) => MapEntry(k, deserializeDynamicFieldValue(v)));
-      case 'Map' when raw is List<Map<String, dynamic>>:
+      case 'Map' when raw is List:
         return Map<dynamic, dynamic>.fromEntries(
-          raw.map(
+          raw.cast<Map<String, dynamic>>().map(
             (e) => MapEntry(
               deserializeDynamicFieldValue(e['k']),
               deserializeDynamicFieldValue(e['v']),

--- a/packages/serverpod_serialization/lib/src/serialization.dart
+++ b/packages/serverpod_serialization/lib/src/serialization.dart
@@ -372,13 +372,19 @@ abstract class SerializationManager {
             _dynamicFieldValueToJson(e, encodeForProtocol),
         ],
       },
-      Map() when object.keys.every((k) => k is String) => {
-        'className': 'Map',
-        'data': {
-          for (final e in Map<String, dynamic>.from(object).entries)
-            e.key: _dynamicFieldValueToJson(e.value, encodeForProtocol),
+      Map()
+          when object is Map<String, dynamic> ||
+              object.keys.every((k) => k is String) =>
+        {
+          'className': 'Map',
+          'data': {
+            for (final e in object.entries)
+              e.key as String: _dynamicFieldValueToJson(
+                e.value,
+                encodeForProtocol,
+              ),
+          },
         },
-      },
       Map() => {
         'className': 'Map',
         'data': [

--- a/packages/serverpod_serialization/test/dynamic_field_serialization_test.dart
+++ b/packages/serverpod_serialization/test/dynamic_field_serialization_test.dart
@@ -1,0 +1,154 @@
+import 'dart:convert';
+
+import 'package:serverpod_serialization/serverpod_serialization.dart';
+import 'package:test/test.dart';
+
+void main() {
+  var protocol = _TestProtocol();
+
+  group(
+    'Given a map with dynamic keys,',
+    () {
+      final map = {'a': 1, 2: 'two'};
+
+      test(
+        'when converting to json, '
+        'then the data is a list of key-value entries with className and data fields.',
+        () {
+          final encoded = protocol.dynamicFieldToJson(map);
+
+          expect(encoded, {
+            'className': 'Map',
+            'data': [
+              {
+                'k': {'className': 'String', 'data': 'a'},
+                'v': {'className': 'int', 'data': 1},
+              },
+              {
+                'k': {'className': 'int', 'data': 2},
+                'v': {'className': 'String', 'data': 'two'},
+              },
+            ],
+          });
+        },
+      );
+
+      group(
+        'when round-tripping the JSON-converted data through jsonEncode and jsonDecode, ',
+        () {
+          late Map<String, dynamic> jsonDecoded;
+
+          setUp(() {
+            final encoded = protocol.dynamicFieldToJson(map);
+            jsonDecoded = jsonDecode(jsonEncode(encoded));
+          });
+
+          test(
+            'then the decoded data field is a List<dynamic>.',
+            () {
+              final data = jsonDecoded['data'];
+              expect(data, isA<List>());
+              data as List;
+              expect(data[0], isA<Map<String, dynamic>>());
+              expect(data[1], isA<Map<String, dynamic>>());
+            },
+          );
+        },
+      );
+    },
+  );
+
+  group(
+    'Given a map with dynamic keys round-tripped through jsonEncode and jsonDecode,',
+    () {
+      final map = {'a': 1, 2: 'two'};
+
+      late Map<String, dynamic> jsonDecoded;
+
+      setUp(() {
+        final encoded = protocol.dynamicFieldToJson(map);
+        jsonDecoded = jsonDecode(jsonEncode(encoded));
+      });
+
+      test(
+        'when deserializing with deserializeByClassName, '
+        'then the original map is restored.',
+        () {
+          final decoded = protocol.deserializeByClassName(jsonDecoded);
+
+          expect(decoded, isA<Map>());
+          decoded as Map<dynamic, dynamic>;
+          expect(decoded['a'], 1);
+          expect(decoded[2], 'two');
+        },
+      );
+
+      test(
+        'when deserializing with deserializeDynamicFieldValue, '
+        'then the original map is restored.',
+        () {
+          final decoded = protocol.deserializeDynamicFieldValue(
+            jsonDecoded,
+          );
+
+          expect(decoded, isA<Map>());
+          decoded as Map<dynamic, dynamic>;
+          expect(decoded['a'], 1);
+          expect(decoded[2], 'two');
+        },
+      );
+    },
+  );
+
+  group(
+    'Given a dynamic field containing nested maps with dynamic keys, ',
+    () {
+      final value = [
+        {'a': 1, 2: 'two'},
+        {'b': true},
+      ];
+
+      test(
+        'when round-tripping through jsonEncode and jsonDecode, '
+        'then the nested maps are restored correctly.',
+        () {
+          final encoded = protocol.dynamicFieldToJson(value);
+          final jsonDecoded = jsonDecode(jsonEncode(encoded));
+          final decoded = protocol.deserializeDynamicFieldValue(jsonDecoded);
+
+          expect(decoded, isA<List>());
+          decoded as List;
+
+          final first = decoded[0] as Map<dynamic, dynamic>;
+          expect(first['a'], 1);
+          expect(first[2], 'two');
+
+          final second = decoded[1] as Map<dynamic, dynamic>;
+          expect(second['b'], true);
+        },
+      );
+
+      test(
+        'when round-tripping through complete encode/decode cycle, '
+        'then the nested maps are restored correctly.',
+        () {
+          final encoded = protocol.dynamicFieldToJson(value);
+          final jsonDecoded = jsonDecode(jsonEncode(encoded));
+          final decoded = protocol.deserializeDynamicFieldValue(jsonDecoded);
+
+          expect(decoded, isA<List>());
+          decoded as List;
+
+          final first = decoded[0] as Map<dynamic, dynamic>;
+          expect(first['a'], 1);
+          expect(first[2], 'two');
+
+          final second = decoded[1] as Map<dynamic, dynamic>;
+          expect(second['b'], true);
+        },
+      );
+    },
+  );
+}
+
+class _TestProtocol extends SerializationManager {}

--- a/tests/serverpod_test_client/lib/src/protocol/object_with_dynamic.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/object_with_dynamic.dart
@@ -37,10 +37,10 @@ abstract class ObjectWithDynamic implements _i1.SerializableModel {
   factory ObjectWithDynamic.fromJson(Map<String, dynamic> jsonSerialization) {
     return ObjectWithDynamic(
       id: jsonSerialization['id'] as int?,
-      payload: _i2.Protocol().decodeDynamicFieldValue(
+      payload: _i2.Protocol().deserializeDynamicFieldValue(
         jsonSerialization['payload'],
       ),
-      jsonbPayload: _i2.Protocol().decodeDynamicFieldValue(
+      jsonbPayload: _i2.Protocol().deserializeDynamicFieldValue(
         jsonSerialization['jsonbPayload'],
       ),
       payloadList: _i2.Protocol().deserialize<List<dynamic>>(
@@ -93,20 +93,20 @@ abstract class ObjectWithDynamic implements _i1.SerializableModel {
     return {
       '__className__': 'ObjectWithDynamic',
       if (id != null) 'id': id,
-      'payload': _i2.Protocol().encodeWithType(payload),
-      'jsonbPayload': _i2.Protocol().encodeWithType(jsonbPayload),
+      'payload': _i2.Protocol().dynamicFieldToJson(payload),
+      'jsonbPayload': _i2.Protocol().dynamicFieldToJson(jsonbPayload),
       'payloadList': payloadList.toJson(
-        valueToJson: (v) => _i2.Protocol().encodeWithType(v),
+        valueToJson: (v) => _i2.Protocol().dynamicFieldToJson(v),
       ),
       'payloadMap': payloadMap.toJson(
-        valueToJson: (v) => _i2.Protocol().encodeWithType(v),
+        valueToJson: (v) => _i2.Protocol().dynamicFieldToJson(v),
       ),
       'payloadSet': payloadSet.toJson(
-        valueToJson: (v) => _i2.Protocol().encodeWithType(v),
+        valueToJson: (v) => _i2.Protocol().dynamicFieldToJson(v),
       ),
       'payloadMapWithDynamicKeys': payloadMapWithDynamicKeys.toJson(
-        keyToJson: (k) => _i2.Protocol().encodeWithType(k),
-        valueToJson: (v) => _i2.Protocol().encodeWithType(v),
+        keyToJson: (k) => _i2.Protocol().dynamicFieldToJson(k),
+        valueToJson: (v) => _i2.Protocol().dynamicFieldToJson(v),
       ),
     };
   }

--- a/tests/serverpod_test_client/lib/src/protocol/protocol.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/protocol.dart
@@ -2386,7 +2386,7 @@ class Protocol extends _i1.SerializationManager {
           as T;
     }
     if (t == dynamic) {
-      return decodeDynamicFieldValue(data) as T;
+      return deserializeDynamicFieldValue(data) as T;
     }
     if (t == List<dynamic>) {
       return (data as List).map((e) => deserialize<dynamic>(e)).toList() as T;

--- a/tests/serverpod_test_server/lib/src/generated/object_with_dynamic.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_dynamic.dart
@@ -38,10 +38,10 @@ abstract class ObjectWithDynamic
   factory ObjectWithDynamic.fromJson(Map<String, dynamic> jsonSerialization) {
     return ObjectWithDynamic(
       id: jsonSerialization['id'] as int?,
-      payload: _i2.Protocol().decodeDynamicFieldValue(
+      payload: _i2.Protocol().deserializeDynamicFieldValue(
         jsonSerialization['payload'],
       ),
-      jsonbPayload: _i2.Protocol().decodeDynamicFieldValue(
+      jsonbPayload: _i2.Protocol().deserializeDynamicFieldValue(
         jsonSerialization['jsonbPayload'],
       ),
       payloadList: _i2.Protocol().deserialize<List<dynamic>>(
@@ -99,20 +99,20 @@ abstract class ObjectWithDynamic
     return {
       '__className__': 'ObjectWithDynamic',
       if (id != null) 'id': id,
-      'payload': _i2.Protocol().encodeWithType(payload),
-      'jsonbPayload': _i2.Protocol().encodeWithType(jsonbPayload),
+      'payload': _i2.Protocol().dynamicFieldToJson(payload),
+      'jsonbPayload': _i2.Protocol().dynamicFieldToJson(jsonbPayload),
       'payloadList': payloadList.toJson(
-        valueToJson: (v) => _i2.Protocol().encodeWithType(v),
+        valueToJson: (v) => _i2.Protocol().dynamicFieldToJson(v),
       ),
       'payloadMap': payloadMap.toJson(
-        valueToJson: (v) => _i2.Protocol().encodeWithType(v),
+        valueToJson: (v) => _i2.Protocol().dynamicFieldToJson(v),
       ),
       'payloadSet': payloadSet.toJson(
-        valueToJson: (v) => _i2.Protocol().encodeWithType(v),
+        valueToJson: (v) => _i2.Protocol().dynamicFieldToJson(v),
       ),
       'payloadMapWithDynamicKeys': payloadMapWithDynamicKeys.toJson(
-        keyToJson: (k) => _i2.Protocol().encodeWithType(k),
-        valueToJson: (v) => _i2.Protocol().encodeWithType(v),
+        keyToJson: (k) => _i2.Protocol().dynamicFieldToJson(k),
+        valueToJson: (v) => _i2.Protocol().dynamicFieldToJson(v),
       ),
     };
   }
@@ -122,20 +122,22 @@ abstract class ObjectWithDynamic
     return {
       '__className__': 'ObjectWithDynamic',
       if (id != null) 'id': id,
-      'payload': _i2.Protocol().encodeWithTypeForProtocol(payload),
-      'jsonbPayload': _i2.Protocol().encodeWithTypeForProtocol(jsonbPayload),
+      'payload': _i2.Protocol().dynamicFieldToJsonForProtocol(payload),
+      'jsonbPayload': _i2.Protocol().dynamicFieldToJsonForProtocol(
+        jsonbPayload,
+      ),
       'payloadList': payloadList.toJson(
-        valueToJson: (v) => _i2.Protocol().encodeWithTypeForProtocol(v),
+        valueToJson: (v) => _i2.Protocol().dynamicFieldToJsonForProtocol(v),
       ),
       'payloadMap': payloadMap.toJson(
-        valueToJson: (v) => _i2.Protocol().encodeWithTypeForProtocol(v),
+        valueToJson: (v) => _i2.Protocol().dynamicFieldToJsonForProtocol(v),
       ),
       'payloadSet': payloadSet.toJson(
-        valueToJson: (v) => _i2.Protocol().encodeWithTypeForProtocol(v),
+        valueToJson: (v) => _i2.Protocol().dynamicFieldToJsonForProtocol(v),
       ),
       'payloadMapWithDynamicKeys': payloadMapWithDynamicKeys.toJson(
-        keyToJson: (k) => _i2.Protocol().encodeWithTypeForProtocol(k),
-        valueToJson: (v) => _i2.Protocol().encodeWithTypeForProtocol(v),
+        keyToJson: (k) => _i2.Protocol().dynamicFieldToJsonForProtocol(k),
+        valueToJson: (v) => _i2.Protocol().dynamicFieldToJsonForProtocol(v),
       ),
     };
   }

--- a/tests/serverpod_test_server/lib/src/generated/protocol.dart
+++ b/tests/serverpod_test_server/lib/src/generated/protocol.dart
@@ -8277,7 +8277,7 @@ class Protocol extends _i1.DatabaseSerializationManager {
           as T;
     }
     if (t == dynamic) {
-      return decodeDynamicFieldValue(data) as T;
+      return deserializeDynamicFieldValue(data) as T;
     }
     if (t == List<dynamic>) {
       return (data as List).map((e) => deserialize<dynamic>(e)).toList() as T;

--- a/tests/serverpod_test_server/test/dynamic_roundtrip_test.dart
+++ b/tests/serverpod_test_server/test/dynamic_roundtrip_test.dart
@@ -22,11 +22,11 @@ void main() {
         () {
           expect(
             serialized['payload'],
-            '{"className":"int","data":42}',
+            {'className': 'int', 'data': 42},
           );
           expect(
             serialized['jsonbPayload'],
-            '{"className":"double","data":10.23}',
+            {'className': 'double', 'data': 10.23},
           );
         },
       );
@@ -35,16 +35,19 @@ void main() {
         'then the list and set fields are encoded with their type.',
         () {
           expect(serialized['payloadList'], [
-            '{"className":"int","data":1}',
-            '{"className":"String","data":"b"}',
-            '{"className":"SimpleData","data":{"__className__":"SimpleData","num":7}}',
+            {'className': 'int', 'data': 1},
+            {'className': 'String', 'data': 'b'},
+            {
+              'className': 'SimpleData',
+              'data': {'__className__': 'SimpleData', 'num': 7},
+            },
           ]);
 
           expect(serialized['payloadSet'], {
-            '{"className":"int","data":1}',
-            '{"className":"int","data":2}',
-            '{"className":"int","data":3}',
-            '{"className":"String","data":"d"}',
+            {'className': 'int', 'data': 1},
+            {'className': 'int', 'data': 2},
+            {'className': 'int', 'data': 3},
+            {'className': 'String', 'data': 'd'},
           });
         },
       );
@@ -54,13 +57,15 @@ void main() {
         () {
           expect(serialized['payloadMapWithDynamicKeys'], [
             {
-              'k': '{"className":"String","data":"a"}',
-              'v': '{"className":"int","data":1}',
+              'k': {'className': 'String', 'data': 'a'},
+              'v': {'className': 'int', 'data': 1},
             },
             {
-              'k': '{"className":"int","data":2}',
-              'v':
-                  '{"className":"SimpleData","data":{"__className__":"SimpleData","num":1}}',
+              'k': {'className': 'int', 'data': 2},
+              'v': {
+                'className': 'SimpleData',
+                'data': {'__className__': 'SimpleData', 'num': 1},
+              },
             },
           ]);
         },

--- a/tests/serverpod_test_server/test/dynamic_roundtrip_test.dart
+++ b/tests/serverpod_test_server/test/dynamic_roundtrip_test.dart
@@ -226,13 +226,39 @@ void main() {
 
   test(
     'Given a model with a dynamic field, '
-    'when round-tripping the model, '
+    'when round-tripping the model through toJson/fromJson, '
     'then the value roundtrips correctly.',
     () {
       final serialized = object.toJson();
       final deserialized = ObjectWithDynamic.fromJson(serialized);
 
       expect(deserialized, isA<ObjectWithDynamic>());
+      expect(deserialized.payload, object.payload);
+      expect(deserialized.jsonbPayload, object.jsonbPayload);
+      expect(deserialized.payloadList.first, 1);
+      expect(deserialized.payloadList[1], 'b');
+      expect(deserialized.payloadList.last, isA<SimpleData>());
+      expect(deserialized.payloadMap['a'], 1);
+      expect(deserialized.payloadMap['b'], 2);
+      expect(deserialized.payloadMap['c'], isA<SimpleData>());
+      expect((deserialized.payloadMap['c'] as SimpleData).num, 3);
+      expect(deserialized.payloadSet, object.payloadSet);
+      expect(deserialized.payloadMapWithDynamicKeys['a'], 1);
+      expect(deserialized.payloadMapWithDynamicKeys[2], isA<SimpleData>());
+      expect((deserialized.payloadMapWithDynamicKeys[2] as SimpleData).num, 1);
+    },
+  );
+
+  test(
+    'Given a model with a dynamic field, '
+    'when round-tripping the model through complete encode/decode cycle, '
+    'then the value roundtrips correctly.',
+    () {
+      final jsonDecoded = Protocol().encodeWithType(object);
+      final deserialized = Protocol().decodeWithType(jsonDecoded);
+
+      expect(deserialized, isA<ObjectWithDynamic>());
+      deserialized as ObjectWithDynamic;
       expect(deserialized.payload, object.payload);
       expect(deserialized.jsonbPayload, object.jsonbPayload);
       expect(deserialized.payloadList.first, 1);

--- a/tests/serverpod_test_server/test/dynamic_roundtrip_test.dart
+++ b/tests/serverpod_test_server/test/dynamic_roundtrip_test.dart
@@ -1,0 +1,95 @@
+import 'package:serverpod_test_server/src/generated/protocol.dart';
+import 'package:test/test.dart';
+
+void main() {
+  var object = ObjectWithDynamic(
+    payload: 42,
+    jsonbPayload: 10.23,
+    payloadList: [1, 'b', SimpleData(num: 7)],
+    payloadMap: {'a': 1, 'b': 2, 'c': SimpleData(num: 3)},
+    payloadSet: {1, 2, 3, 'd'},
+    payloadMapWithDynamicKeys: {'a': 1, 2: SimpleData(num: 1)},
+  );
+
+  group(
+    'Given a model with a dynamic field, '
+    'when serializing the model,',
+    () {
+      final serialized = object.toJson();
+
+      test(
+        'then the basic fields are encoded with their type.',
+        () {
+          expect(
+            serialized['payload'],
+            '{"className":"int","data":42}',
+          );
+          expect(
+            serialized['jsonbPayload'],
+            '{"className":"double","data":10.23}',
+          );
+        },
+      );
+
+      test(
+        'then the list and set fields are encoded with their type.',
+        () {
+          expect(serialized['payloadList'], [
+            '{"className":"int","data":1}',
+            '{"className":"String","data":"b"}',
+            '{"className":"SimpleData","data":{"__className__":"SimpleData","num":7}}',
+          ]);
+
+          expect(serialized['payloadSet'], {
+            '{"className":"int","data":1}',
+            '{"className":"int","data":2}',
+            '{"className":"int","data":3}',
+            '{"className":"String","data":"d"}',
+          });
+        },
+      );
+
+      test(
+        'then the map dynamic keys has the keys and values encoded with their type.',
+        () {
+          expect(serialized['payloadMapWithDynamicKeys'], [
+            {
+              'k': '{"className":"String","data":"a"}',
+              'v': '{"className":"int","data":1}',
+            },
+            {
+              'k': '{"className":"int","data":2}',
+              'v':
+                  '{"className":"SimpleData","data":{"__className__":"SimpleData","num":1}}',
+            },
+          ]);
+        },
+      );
+    },
+  );
+
+  test(
+    'Given a model with a dynamic field, '
+    'when round-tripping the model, '
+    'then the value roundtrips correctly.',
+    () {
+      final serialized = object.toJson();
+      final deserialized = ObjectWithDynamic.fromJson(serialized);
+
+      expect(deserialized, isA<ObjectWithDynamic>());
+      expect(deserialized.payload, object.payload);
+      expect(deserialized.jsonbPayload, object.jsonbPayload);
+      expect(deserialized.payloadList.first, 1);
+      expect(deserialized.payloadList[1], 'b');
+      expect(deserialized.payloadList.last, isA<SimpleData>());
+      expect(deserialized.payloadMap['a'], 1);
+      expect(deserialized.payloadMap['b'], 2);
+      expect(deserialized.payloadMap['c'], isA<SimpleData>());
+      expect((deserialized.payloadMap['c'] as SimpleData).num, 3);
+      expect(deserialized.payloadSet, object.payloadSet);
+      expect(deserialized.payloadMapWithDynamicKeys['a'], 1);
+      expect(deserialized.payloadMapWithDynamicKeys[2], isA<SimpleData>());
+      expect((deserialized.payloadMapWithDynamicKeys[2] as SimpleData).num, 1);
+    },
+  );
+}

--- a/tests/serverpod_test_server/test/dynamic_roundtrip_test.dart
+++ b/tests/serverpod_test_server/test/dynamic_roundtrip_test.dart
@@ -74,6 +74,157 @@ void main() {
   );
 
   test(
+    'Given a model with a dynamic field having nested container objects, '
+    'when serializing the model, '
+    'then all nested container objects are encoded with their type.',
+    () {
+      var newObject = object.copyWith(
+        payload: [
+          1,
+          2,
+          3,
+          {'a': 1, 'b': 2, 'c': SimpleData(num: 3)},
+          {'a': 1, 2: SimpleData(num: 2)},
+        ],
+        payloadList: [
+          1,
+          'b',
+          SimpleData(num: 7),
+          [1, 2, 3],
+          {'a': 1, 'b': 2},
+          {'a': 1, 2: SimpleData(num: 2)},
+        ],
+        payloadMap: {
+          'a': 1,
+          'b': 2,
+          'c': SimpleData(num: 3),
+          'd': [1, 2, 3],
+          'e': {'a': 1, 'b': 2},
+          'f': {'a': 1, 2: SimpleData(num: 2)},
+        },
+      );
+
+      final serialized = newObject.toJson();
+
+      expect(serialized['payload'], {
+        'className': 'List',
+        'data': [
+          {'className': 'int', 'data': 1},
+          {'className': 'int', 'data': 2},
+          {'className': 'int', 'data': 3},
+          {
+            'className': 'Map',
+            'data': {
+              'a': {'className': 'int', 'data': 1},
+              'b': {'className': 'int', 'data': 2},
+              'c': {
+                'className': 'SimpleData',
+                'data': {'__className__': 'SimpleData', 'num': 3},
+              },
+            },
+          },
+          {
+            'className': 'Map',
+            'data': [
+              {
+                'k': {'className': 'String', 'data': 'a'},
+                'v': {'className': 'int', 'data': 1},
+              },
+              {
+                'k': {'className': 'int', 'data': 2},
+                'v': {
+                  'className': 'SimpleData',
+                  'data': {'__className__': 'SimpleData', 'num': 2},
+                },
+              },
+            ],
+          },
+        ],
+      });
+
+      expect(serialized['payloadList'], [
+        {'className': 'int', 'data': 1},
+        {'className': 'String', 'data': 'b'},
+        {
+          'className': 'SimpleData',
+          'data': {'__className__': 'SimpleData', 'num': 7},
+        },
+        {
+          'className': 'List',
+          'data': [
+            {'className': 'int', 'data': 1},
+            {'className': 'int', 'data': 2},
+            {'className': 'int', 'data': 3},
+          ],
+        },
+        {
+          'className': 'Map',
+          'data': {
+            'a': {'className': 'int', 'data': 1},
+            'b': {'className': 'int', 'data': 2},
+          },
+        },
+        {
+          'className': 'Map',
+          'data': [
+            {
+              'k': {'className': 'String', 'data': 'a'},
+              'v': {'className': 'int', 'data': 1},
+            },
+            {
+              'k': {'className': 'int', 'data': 2},
+              'v': {
+                'className': 'SimpleData',
+                'data': {'__className__': 'SimpleData', 'num': 2},
+              },
+            },
+          ],
+        },
+      ]);
+
+      expect(serialized['payloadMap'], {
+        'a': {'className': 'int', 'data': 1},
+        'b': {'className': 'int', 'data': 2},
+        'c': {
+          'className': 'SimpleData',
+          'data': {'__className__': 'SimpleData', 'num': 3},
+        },
+        'd': {
+          'className': 'List',
+          'data': [
+            {'className': 'int', 'data': 1},
+            {'className': 'int', 'data': 2},
+            {'className': 'int', 'data': 3},
+          ],
+        },
+        'e': {
+          'className': 'Map',
+          'data': {
+            'a': {'className': 'int', 'data': 1},
+            'b': {'className': 'int', 'data': 2},
+          },
+        },
+        'f': {
+          'className': 'Map',
+          'data': [
+            {
+              'k': {'className': 'String', 'data': 'a'},
+              'v': {'className': 'int', 'data': 1},
+            },
+            {
+              'k': {'className': 'int', 'data': 2},
+              'v': {
+                'className': 'SimpleData',
+                'data': {'__className__': 'SimpleData', 'num': 2},
+              },
+            },
+          ],
+        },
+      });
+    },
+  );
+
+  test(
     'Given a model with a dynamic field, '
     'when round-tripping the model, '
     'then the value roundtrips correctly.',

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/object_with_dynamic.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/object_with_dynamic.dart
@@ -37,10 +37,10 @@ abstract class ObjectWithDynamic implements _i1.SerializableModel {
   factory ObjectWithDynamic.fromJson(Map<String, dynamic> jsonSerialization) {
     return ObjectWithDynamic(
       id: jsonSerialization['id'] as int?,
-      payload: _i2.Protocol().decodeDynamicFieldValue(
+      payload: _i2.Protocol().deserializeDynamicFieldValue(
         jsonSerialization['payload'],
       ),
-      jsonbPayload: _i2.Protocol().decodeDynamicFieldValue(
+      jsonbPayload: _i2.Protocol().deserializeDynamicFieldValue(
         jsonSerialization['jsonbPayload'],
       ),
       payloadList: _i2.Protocol().deserialize<List<dynamic>>(
@@ -93,20 +93,20 @@ abstract class ObjectWithDynamic implements _i1.SerializableModel {
     return {
       '__className__': 'ObjectWithDynamic',
       if (id != null) 'id': id,
-      'payload': _i2.Protocol().encodeWithType(payload),
-      'jsonbPayload': _i2.Protocol().encodeWithType(jsonbPayload),
+      'payload': _i2.Protocol().dynamicFieldToJson(payload),
+      'jsonbPayload': _i2.Protocol().dynamicFieldToJson(jsonbPayload),
       'payloadList': payloadList.toJson(
-        valueToJson: (v) => _i2.Protocol().encodeWithType(v),
+        valueToJson: (v) => _i2.Protocol().dynamicFieldToJson(v),
       ),
       'payloadMap': payloadMap.toJson(
-        valueToJson: (v) => _i2.Protocol().encodeWithType(v),
+        valueToJson: (v) => _i2.Protocol().dynamicFieldToJson(v),
       ),
       'payloadSet': payloadSet.toJson(
-        valueToJson: (v) => _i2.Protocol().encodeWithType(v),
+        valueToJson: (v) => _i2.Protocol().dynamicFieldToJson(v),
       ),
       'payloadMapWithDynamicKeys': payloadMapWithDynamicKeys.toJson(
-        keyToJson: (k) => _i2.Protocol().encodeWithType(k),
-        valueToJson: (v) => _i2.Protocol().encodeWithType(v),
+        keyToJson: (k) => _i2.Protocol().dynamicFieldToJson(k),
+        valueToJson: (v) => _i2.Protocol().dynamicFieldToJson(v),
       ),
     };
   }

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/protocol.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/protocol.dart
@@ -2890,7 +2890,7 @@ class Protocol extends _i1.DatabaseSerializationManager {
           as T;
     }
     if (t == dynamic) {
-      return decodeDynamicFieldValue(data) as T;
+      return deserializeDynamicFieldValue(data) as T;
     }
     if (t == List<dynamic>) {
       return (data as List).map((e) => deserialize<dynamic>(e)).toList() as T;

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/object_with_dynamic.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/object_with_dynamic.dart
@@ -39,10 +39,10 @@ abstract class ObjectWithDynamic
   factory ObjectWithDynamic.fromJson(Map<String, dynamic> jsonSerialization) {
     return ObjectWithDynamic(
       id: jsonSerialization['id'] as int?,
-      payload: _i2.Protocol().decodeDynamicFieldValue(
+      payload: _i2.Protocol().deserializeDynamicFieldValue(
         jsonSerialization['payload'],
       ),
-      jsonbPayload: _i2.Protocol().decodeDynamicFieldValue(
+      jsonbPayload: _i2.Protocol().deserializeDynamicFieldValue(
         jsonSerialization['jsonbPayload'],
       ),
       payloadList: _i2.Protocol().deserialize<List<dynamic>>(
@@ -100,20 +100,20 @@ abstract class ObjectWithDynamic
     return {
       '__className__': 'ObjectWithDynamic',
       if (id != null) 'id': id,
-      'payload': _i2.Protocol().encodeWithType(payload),
-      'jsonbPayload': _i2.Protocol().encodeWithType(jsonbPayload),
+      'payload': _i2.Protocol().dynamicFieldToJson(payload),
+      'jsonbPayload': _i2.Protocol().dynamicFieldToJson(jsonbPayload),
       'payloadList': payloadList.toJson(
-        valueToJson: (v) => _i2.Protocol().encodeWithType(v),
+        valueToJson: (v) => _i2.Protocol().dynamicFieldToJson(v),
       ),
       'payloadMap': payloadMap.toJson(
-        valueToJson: (v) => _i2.Protocol().encodeWithType(v),
+        valueToJson: (v) => _i2.Protocol().dynamicFieldToJson(v),
       ),
       'payloadSet': payloadSet.toJson(
-        valueToJson: (v) => _i2.Protocol().encodeWithType(v),
+        valueToJson: (v) => _i2.Protocol().dynamicFieldToJson(v),
       ),
       'payloadMapWithDynamicKeys': payloadMapWithDynamicKeys.toJson(
-        keyToJson: (k) => _i2.Protocol().encodeWithType(k),
-        valueToJson: (v) => _i2.Protocol().encodeWithType(v),
+        keyToJson: (k) => _i2.Protocol().dynamicFieldToJson(k),
+        valueToJson: (v) => _i2.Protocol().dynamicFieldToJson(v),
       ),
     };
   }
@@ -123,20 +123,22 @@ abstract class ObjectWithDynamic
     return {
       '__className__': 'ObjectWithDynamic',
       if (id != null) 'id': id,
-      'payload': _i2.Protocol().encodeWithTypeForProtocol(payload),
-      'jsonbPayload': _i2.Protocol().encodeWithTypeForProtocol(jsonbPayload),
+      'payload': _i2.Protocol().dynamicFieldToJsonForProtocol(payload),
+      'jsonbPayload': _i2.Protocol().dynamicFieldToJsonForProtocol(
+        jsonbPayload,
+      ),
       'payloadList': payloadList.toJson(
-        valueToJson: (v) => _i2.Protocol().encodeWithTypeForProtocol(v),
+        valueToJson: (v) => _i2.Protocol().dynamicFieldToJsonForProtocol(v),
       ),
       'payloadMap': payloadMap.toJson(
-        valueToJson: (v) => _i2.Protocol().encodeWithTypeForProtocol(v),
+        valueToJson: (v) => _i2.Protocol().dynamicFieldToJsonForProtocol(v),
       ),
       'payloadSet': payloadSet.toJson(
-        valueToJson: (v) => _i2.Protocol().encodeWithTypeForProtocol(v),
+        valueToJson: (v) => _i2.Protocol().dynamicFieldToJsonForProtocol(v),
       ),
       'payloadMapWithDynamicKeys': payloadMapWithDynamicKeys.toJson(
-        keyToJson: (k) => _i2.Protocol().encodeWithTypeForProtocol(k),
-        valueToJson: (v) => _i2.Protocol().encodeWithTypeForProtocol(v),
+        keyToJson: (k) => _i2.Protocol().dynamicFieldToJsonForProtocol(k),
+        valueToJson: (v) => _i2.Protocol().dynamicFieldToJsonForProtocol(v),
       ),
     };
   }

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/protocol.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/protocol.dart
@@ -6830,7 +6830,7 @@ class Protocol extends _i1.DatabaseSerializationManager {
           as T;
     }
     if (t == dynamic) {
-      return decodeDynamicFieldValue(data) as T;
+      return deserializeDynamicFieldValue(data) as T;
     }
     if (t == List<dynamic>) {
       return (data as List).map((e) => deserialize<dynamic>(e)).toList() as T;

--- a/tools/serverpod_cli/lib/src/generator/dart/library_generators/model_library_generator.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart/library_generators/model_library_generator.dart
@@ -1625,8 +1625,8 @@ class SerializableModelLibraryGenerator {
     );
     if (fieldType.className == 'dynamic') {
       var encodeMethod = methodName == _toJsonForProtocolMethodName
-          ? 'encodeWithTypeForProtocol'
-          : 'encodeWithType';
+          ? 'dynamicFieldToJsonForProtocol'
+          : 'dynamicFieldToJson';
       return protocolRef.call([]).property(encodeMethod).call([fieldRef]);
     }
     if (fieldType.isRecordType) {

--- a/tools/serverpod_cli/lib/src/generator/dart/library_generators/util/class_generators_util.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart/library_generators/util/class_generators_util.dart
@@ -191,7 +191,7 @@ Expression _buildFromJson(
               currentSharedPackageName: currentSharedPackageName,
             )
             .call([])
-            .property('decodeDynamicFieldValue')
+            .property('deserializeDynamicFieldValue')
             .call([valueExpression])
             .checkIfNull(type, valueExpression: valueExpression)
             .code,

--- a/tools/serverpod_cli/lib/src/generator/types.dart
+++ b/tools/serverpod_cli/lib/src/generator/types.dart
@@ -717,7 +717,7 @@ class TypeDefinition {
       return [
         MapEntry(
           refer('dynamic'),
-          const Code('decodeDynamicFieldValue(data) as T'),
+          const Code('deserializeDynamicFieldValue(data) as T'),
         ),
       ];
     } else if (customClass) {


### PR DESCRIPTION
fixes: #5152

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

This PR is a breaking change since the introduction of the `dynamic` type in `3.5.0-beta.5`, but it is not an issue since it was not released publicly yet.