### PR TITLE
fix: Fix serialization/deserialization of project models on `dynamic` fields of module models

### DIFF
--- a/examples/auth/auth_client/lib/src/protocol/protocol.dart
+++ b/examples/auth/auth_client/lib/src/protocol/protocol.dart
@@ -23,9 +23,9 @@ export 'client.dart';
 class Protocol extends _i1.SerializationManager {
   Protocol._();
 
-  factory Protocol() => _instance.._registerHostProtocols();
+  factory Protocol() => _instance;
 
-  static final Protocol _instance = Protocol._();
+  static final Protocol _instance = Protocol._().._registerHostProtocols();
 
   static String? getClassNameFromObjectJson(dynamic data) {
     if (data is! Map) return null;

--- a/examples/auth/auth_client/lib/src/protocol/protocol.dart
+++ b/examples/auth/auth_client/lib/src/protocol/protocol.dart
@@ -23,7 +23,7 @@ export 'client.dart';
 class Protocol extends _i1.SerializationManager {
   Protocol._();
 
-  factory Protocol() => _instance;
+  factory Protocol() => _instance.._registerHostProtocols();
 
   static final Protocol _instance = Protocol._();
 
@@ -100,11 +100,15 @@ class Protocol extends _i1.SerializationManager {
     }
     className = _i4.Protocol().getClassNameForObject(data);
     if (className != null) {
-      return 'serverpod_auth_idp.$className';
+      return className.contains('.')
+          ? className
+          : 'serverpod_auth_idp.$className';
     }
     className = _i5.Protocol().getClassNameForObject(data);
     if (className != null) {
-      return 'serverpod_auth_core.$className';
+      return className.contains('.')
+          ? className
+          : 'serverpod_auth_core.$className';
     }
     return null;
   }
@@ -127,6 +131,11 @@ class Protocol extends _i1.SerializationManager {
       return _i5.Protocol().deserializeByClassName(data);
     }
     return super.deserializeByClassName(data);
+  }
+
+  void _registerHostProtocols() {
+    _i4.Protocol().registerHostProtocol('auth', this);
+    _i5.Protocol().registerHostProtocol('auth', this);
   }
 
   /// Maps any `Record`s known to this [Protocol] to their JSON representation

--- a/examples/auth/auth_server/lib/src/generated/protocol.dart
+++ b/examples/auth/auth_server/lib/src/generated/protocol.dart
@@ -23,9 +23,9 @@ export 'greeting.dart';
 class Protocol extends _i1.DatabaseSerializationManager {
   Protocol._();
 
-  factory Protocol() => _instance.._registerHostProtocols();
+  factory Protocol() => _instance;
 
-  static final Protocol _instance = Protocol._();
+  static final Protocol _instance = Protocol._().._registerHostProtocols();
 
   static final List<_i2.TableDefinition> targetTableDefinitions = [
     ..._i3.Protocol.targetTableDefinitions,

--- a/examples/auth/auth_server/lib/src/generated/protocol.dart
+++ b/examples/auth/auth_server/lib/src/generated/protocol.dart
@@ -23,7 +23,7 @@ export 'greeting.dart';
 class Protocol extends _i1.DatabaseSerializationManager {
   Protocol._();
 
-  factory Protocol() => _instance;
+  factory Protocol() => _instance.._registerHostProtocols();
 
   static final Protocol _instance = Protocol._();
 
@@ -107,17 +107,21 @@ class Protocol extends _i1.DatabaseSerializationManager {
       case _i5.Greeting():
         return 'Greeting';
     }
-    className = _i2.Protocol().getClassNameForObject(data);
-    if (className != null) {
-      return 'serverpod.$className';
-    }
     className = _i3.Protocol().getClassNameForObject(data);
     if (className != null) {
-      return 'serverpod_auth_idp.$className';
+      return className.contains('.')
+          ? className
+          : 'serverpod_auth_idp.$className';
     }
     className = _i4.Protocol().getClassNameForObject(data);
     if (className != null) {
-      return 'serverpod_auth_core.$className';
+      return className.contains('.')
+          ? className
+          : 'serverpod_auth_core.$className';
+    }
+    className = _i2.Protocol().getClassNameForObject(data);
+    if (className != null) {
+      return className.contains('.') ? className : 'serverpod.$className';
     }
     return null;
   }
@@ -131,10 +135,6 @@ class Protocol extends _i1.DatabaseSerializationManager {
     if (dataClassName == 'Greeting') {
       return deserialize<_i5.Greeting>(data['data']);
     }
-    if (dataClassName.startsWith('serverpod.')) {
-      data['className'] = dataClassName.substring(10);
-      return _i2.Protocol().deserializeByClassName(data);
-    }
     if (dataClassName.startsWith('serverpod_auth_idp.')) {
       data['className'] = dataClassName.substring(19);
       return _i3.Protocol().deserializeByClassName(data);
@@ -143,7 +143,16 @@ class Protocol extends _i1.DatabaseSerializationManager {
       data['className'] = dataClassName.substring(20);
       return _i4.Protocol().deserializeByClassName(data);
     }
+    if (dataClassName.startsWith('serverpod.')) {
+      data['className'] = dataClassName.substring(10);
+      return _i2.Protocol().deserializeByClassName(data);
+    }
     return super.deserializeByClassName(data);
+  }
+
+  void _registerHostProtocols() {
+    _i3.Protocol().registerHostProtocol('auth', this);
+    _i4.Protocol().registerHostProtocol('auth', this);
   }
 
   @override

--- a/examples/legacy/auth_example/auth_example_client/lib/src/protocol/protocol.dart
+++ b/examples/legacy/auth_example/auth_example_client/lib/src/protocol/protocol.dart
@@ -19,9 +19,9 @@ export 'client.dart';
 class Protocol extends _i1.SerializationManager {
   Protocol._();
 
-  factory Protocol() => _instance.._registerHostProtocols();
+  factory Protocol() => _instance;
 
-  static final Protocol _instance = Protocol._();
+  static final Protocol _instance = Protocol._().._registerHostProtocols();
 
   static String? getClassNameFromObjectJson(dynamic data) {
     if (data is! Map) return null;

--- a/examples/legacy/auth_example/auth_example_client/lib/src/protocol/protocol.dart
+++ b/examples/legacy/auth_example/auth_example_client/lib/src/protocol/protocol.dart
@@ -19,7 +19,7 @@ export 'client.dart';
 class Protocol extends _i1.SerializationManager {
   Protocol._();
 
-  factory Protocol() => _instance;
+  factory Protocol() => _instance.._registerHostProtocols();
 
   static final Protocol _instance = Protocol._();
 
@@ -87,7 +87,7 @@ class Protocol extends _i1.SerializationManager {
     }
     className = _i3.Protocol().getClassNameForObject(data);
     if (className != null) {
-      return 'serverpod_auth.$className';
+      return className.contains('.') ? className : 'serverpod_auth.$className';
     }
     return null;
   }
@@ -106,6 +106,10 @@ class Protocol extends _i1.SerializationManager {
       return _i3.Protocol().deserializeByClassName(data);
     }
     return super.deserializeByClassName(data);
+  }
+
+  void _registerHostProtocols() {
+    _i3.Protocol().registerHostProtocol('auth_example', this);
   }
 
   /// Maps any `Record`s known to this [Protocol] to their JSON representation

--- a/examples/legacy/auth_example/auth_example_server/lib/src/generated/protocol.dart
+++ b/examples/legacy/auth_example/auth_example_server/lib/src/generated/protocol.dart
@@ -19,9 +19,9 @@ export 'example.dart';
 class Protocol extends _i1.DatabaseSerializationManager {
   Protocol._();
 
-  factory Protocol() => _instance.._registerHostProtocols();
+  factory Protocol() => _instance;
 
-  static final Protocol _instance = Protocol._();
+  static final Protocol _instance = Protocol._().._registerHostProtocols();
 
   static final List<_i2.TableDefinition> targetTableDefinitions = [
     ..._i3.Protocol.targetTableDefinitions,

--- a/examples/legacy/auth_example/auth_example_server/lib/src/generated/protocol.dart
+++ b/examples/legacy/auth_example/auth_example_server/lib/src/generated/protocol.dart
@@ -19,7 +19,7 @@ export 'example.dart';
 class Protocol extends _i1.DatabaseSerializationManager {
   Protocol._();
 
-  factory Protocol() => _instance;
+  factory Protocol() => _instance.._registerHostProtocols();
 
   static final Protocol _instance = Protocol._();
 
@@ -93,13 +93,13 @@ class Protocol extends _i1.DatabaseSerializationManager {
       case _i4.Example():
         return 'Example';
     }
-    className = _i2.Protocol().getClassNameForObject(data);
-    if (className != null) {
-      return 'serverpod.$className';
-    }
     className = _i3.Protocol().getClassNameForObject(data);
     if (className != null) {
-      return 'serverpod_auth.$className';
+      return className.contains('.') ? className : 'serverpod_auth.$className';
+    }
+    className = _i2.Protocol().getClassNameForObject(data);
+    if (className != null) {
+      return className.contains('.') ? className : 'serverpod.$className';
     }
     return null;
   }
@@ -113,15 +113,19 @@ class Protocol extends _i1.DatabaseSerializationManager {
     if (dataClassName == 'Example') {
       return deserialize<_i4.Example>(data['data']);
     }
-    if (dataClassName.startsWith('serverpod.')) {
-      data['className'] = dataClassName.substring(10);
-      return _i2.Protocol().deserializeByClassName(data);
-    }
     if (dataClassName.startsWith('serverpod_auth.')) {
       data['className'] = dataClassName.substring(15);
       return _i3.Protocol().deserializeByClassName(data);
     }
+    if (dataClassName.startsWith('serverpod.')) {
+      data['className'] = dataClassName.substring(10);
+      return _i2.Protocol().deserializeByClassName(data);
+    }
     return super.deserializeByClassName(data);
+  }
+
+  void _registerHostProtocols() {
+    _i3.Protocol().registerHostProtocol('auth_example', this);
   }
 
   @override

--- a/examples/legacy/chat/chat_client/lib/src/protocol/protocol.dart
+++ b/examples/legacy/chat/chat_client/lib/src/protocol/protocol.dart
@@ -21,7 +21,7 @@ export 'client.dart';
 class Protocol extends _i1.SerializationManager {
   Protocol._();
 
-  factory Protocol() => _instance;
+  factory Protocol() => _instance.._registerHostProtocols();
 
   static final Protocol _instance = Protocol._();
 
@@ -93,11 +93,11 @@ class Protocol extends _i1.SerializationManager {
     }
     className = _i4.Protocol().getClassNameForObject(data);
     if (className != null) {
-      return 'serverpod_auth.$className';
+      return className.contains('.') ? className : 'serverpod_auth.$className';
     }
     className = _i5.Protocol().getClassNameForObject(data);
     if (className != null) {
-      return 'serverpod_chat.$className';
+      return className.contains('.') ? className : 'serverpod_chat.$className';
     }
     return null;
   }
@@ -120,6 +120,11 @@ class Protocol extends _i1.SerializationManager {
       return _i5.Protocol().deserializeByClassName(data);
     }
     return super.deserializeByClassName(data);
+  }
+
+  void _registerHostProtocols() {
+    _i4.Protocol().registerHostProtocol('chat', this);
+    _i5.Protocol().registerHostProtocol('chat', this);
   }
 
   /// Maps any `Record`s known to this [Protocol] to their JSON representation

--- a/examples/legacy/chat/chat_client/lib/src/protocol/protocol.dart
+++ b/examples/legacy/chat/chat_client/lib/src/protocol/protocol.dart
@@ -21,9 +21,9 @@ export 'client.dart';
 class Protocol extends _i1.SerializationManager {
   Protocol._();
 
-  factory Protocol() => _instance.._registerHostProtocols();
+  factory Protocol() => _instance;
 
-  static final Protocol _instance = Protocol._();
+  static final Protocol _instance = Protocol._().._registerHostProtocols();
 
   static String? getClassNameFromObjectJson(dynamic data) {
     if (data is! Map) return null;

--- a/examples/legacy/chat/chat_server/lib/src/generated/protocol.dart
+++ b/examples/legacy/chat/chat_server/lib/src/generated/protocol.dart
@@ -21,9 +21,9 @@ export 'channel.dart';
 class Protocol extends _i1.DatabaseSerializationManager {
   Protocol._();
 
-  factory Protocol() => _instance.._registerHostProtocols();
+  factory Protocol() => _instance;
 
-  static final Protocol _instance = Protocol._();
+  static final Protocol _instance = Protocol._().._registerHostProtocols();
 
   static final List<_i2.TableDefinition> targetTableDefinitions = [
     _i2.TableDefinition(

--- a/examples/legacy/chat/chat_server/lib/src/generated/protocol.dart
+++ b/examples/legacy/chat/chat_server/lib/src/generated/protocol.dart
@@ -21,7 +21,7 @@ export 'channel.dart';
 class Protocol extends _i1.DatabaseSerializationManager {
   Protocol._();
 
-  factory Protocol() => _instance;
+  factory Protocol() => _instance.._registerHostProtocols();
 
   static final Protocol _instance = Protocol._();
 
@@ -130,17 +130,17 @@ class Protocol extends _i1.DatabaseSerializationManager {
       case _i5.Channel():
         return 'Channel';
     }
-    className = _i2.Protocol().getClassNameForObject(data);
-    if (className != null) {
-      return 'serverpod.$className';
-    }
     className = _i3.Protocol().getClassNameForObject(data);
     if (className != null) {
-      return 'serverpod_auth.$className';
+      return className.contains('.') ? className : 'serverpod_auth.$className';
     }
     className = _i4.Protocol().getClassNameForObject(data);
     if (className != null) {
-      return 'serverpod_chat.$className';
+      return className.contains('.') ? className : 'serverpod_chat.$className';
+    }
+    className = _i2.Protocol().getClassNameForObject(data);
+    if (className != null) {
+      return className.contains('.') ? className : 'serverpod.$className';
     }
     return null;
   }
@@ -154,10 +154,6 @@ class Protocol extends _i1.DatabaseSerializationManager {
     if (dataClassName == 'Channel') {
       return deserialize<_i5.Channel>(data['data']);
     }
-    if (dataClassName.startsWith('serverpod.')) {
-      data['className'] = dataClassName.substring(10);
-      return _i2.Protocol().deserializeByClassName(data);
-    }
     if (dataClassName.startsWith('serverpod_auth.')) {
       data['className'] = dataClassName.substring(15);
       return _i3.Protocol().deserializeByClassName(data);
@@ -166,7 +162,16 @@ class Protocol extends _i1.DatabaseSerializationManager {
       data['className'] = dataClassName.substring(15);
       return _i4.Protocol().deserializeByClassName(data);
     }
+    if (dataClassName.startsWith('serverpod.')) {
+      data['className'] = dataClassName.substring(10);
+      return _i2.Protocol().deserializeByClassName(data);
+    }
     return super.deserializeByClassName(data);
+  }
+
+  void _registerHostProtocols() {
+    _i3.Protocol().registerHostProtocol('chat', this);
+    _i4.Protocol().registerHostProtocol('chat', this);
   }
 
   @override

--- a/examples/middleware/middleware_server/lib/src/generated/protocol.dart
+++ b/examples/middleware/middleware_server/lib/src/generated/protocol.dart
@@ -87,7 +87,7 @@ class Protocol extends _i1.DatabaseSerializationManager {
     }
     className = _i2.Protocol().getClassNameForObject(data);
     if (className != null) {
-      return 'serverpod.$className';
+      return className.contains('.') ? className : 'serverpod.$className';
     }
     return null;
   }

--- a/modules/legacy/serverpod_auth/serverpod_auth_client/lib/src/protocol/protocol.dart
+++ b/modules/legacy/serverpod_auth/serverpod_auth_client/lib/src/protocol/protocol.dart
@@ -48,6 +48,15 @@ class Protocol extends _i1.SerializationManager {
 
   static final Protocol _instance = Protocol._();
 
+  final Map<String, _i1.SerializationManager> _hostProtocols = {};
+
+  void registerHostProtocol(
+    String projectName,
+    _i1.SerializationManager protocol,
+  ) {
+    _hostProtocols[projectName] = protocol;
+  }
+
   static String? getClassNameFromObjectJson(dynamic data) {
     if (data is! Map) return null;
     final className = data['__className__'] as String?;
@@ -288,6 +297,61 @@ class Protocol extends _i1.SerializationManager {
       return deserialize<_i15.UserSettingsConfig>(data['data']);
     }
     return super.deserializeByClassName(data);
+  }
+
+  @override
+  Object? dynamicFieldToJson(
+    Object? object, {
+    bool forProtocol = false,
+  }) {
+    if ((object is List || object is Set || object is Map) ||
+        getClassNameForObject(object) != null) {
+      return super.dynamicFieldToJson(object, forProtocol: forProtocol);
+    }
+    for (final MapEntry(key: host, value: protocol) in _hostProtocols.entries) {
+      final className = protocol.getClassNameForObject(object);
+      if (className == null) continue;
+      final wrapped = {
+        'className': className.contains('.') ? className : '$host.$className',
+        'data': object,
+      };
+      return forProtocol
+          ? _i1.SerializationManager.toEncodableForProtocol(wrapped)
+          : _i1.SerializationManager.toEncodable(wrapped);
+    }
+    return super.dynamicFieldToJson(object, forProtocol: forProtocol);
+  }
+
+  @override
+  dynamic deserializeDynamicFieldValue(Object? value) {
+    if (value == null) return null;
+    if (value is! Map<String, dynamic> || value['className'] is! String) {
+      throw FormatException(
+        'Dynamic fields are encoded as a Map with className and data, but got '
+        '${value.runtimeType} instead.',
+      );
+    }
+    final className = value['className'] as String;
+    for (final MapEntry(key: host, value: protocol) in _hostProtocols.entries) {
+      final hostPrefix = '$host.';
+      if (className.startsWith(hostPrefix)) {
+        final strippedClassName = className.substring(hostPrefix.length);
+        if (strippedClassName.contains('.')) {
+          throw FormatException(
+            'Dynamic field className must not use multiple prefixes: $className',
+          );
+        }
+        final hostData = Map<String, dynamic>.from(value);
+        hostData['className'] = strippedClassName;
+        return protocol.deserializeByClassName(hostData);
+      }
+    }
+    if (className.contains('.')) {
+      for (final protocol in _hostProtocols.values) {
+        return protocol.deserializeByClassName(value);
+      }
+    }
+    return deserializeByClassName(value);
   }
 
   /// Maps any `Record`s known to this [Protocol] to their JSON representation

--- a/modules/legacy/serverpod_auth/serverpod_auth_client/lib/src/protocol/protocol.dart
+++ b/modules/legacy/serverpod_auth/serverpod_auth_client/lib/src/protocol/protocol.dart
@@ -348,7 +348,9 @@ class Protocol extends _i1.SerializationManager {
     }
     if (className.contains('.')) {
       for (final protocol in _hostProtocols.values) {
-        return protocol.deserializeByClassName(value);
+        try {
+          return protocol.deserializeByClassName(value);
+        } on FormatException catch (_) {}
       }
     }
     return deserializeByClassName(value);

--- a/modules/legacy/serverpod_auth/serverpod_auth_server/lib/src/generated/protocol.dart
+++ b/modules/legacy/serverpod_auth/serverpod_auth_server/lib/src/generated/protocol.dart
@@ -517,6 +517,15 @@ class Protocol extends _i1.DatabaseSerializationManager {
     ),
   ];
 
+  final Map<String, _i1.SerializationManager> _hostProtocols = {};
+
+  void registerHostProtocol(
+    String projectName,
+    _i1.SerializationManager protocol,
+  ) {
+    _hostProtocols[projectName] = protocol;
+  }
+
   static String? getClassNameFromObjectJson(dynamic data) {
     if (data is! Map) return null;
     final className = data['__className__'] as String?;
@@ -711,7 +720,7 @@ class Protocol extends _i1.DatabaseSerializationManager {
     }
     className = _i2.Protocol().getClassNameForObject(data);
     if (className != null) {
-      return 'serverpod.$className';
+      return className.contains('.') ? className : 'serverpod.$className';
     }
     return null;
   }
@@ -769,6 +778,61 @@ class Protocol extends _i1.DatabaseSerializationManager {
       return _i2.Protocol().deserializeByClassName(data);
     }
     return super.deserializeByClassName(data);
+  }
+
+  @override
+  Object? dynamicFieldToJson(
+    Object? object, {
+    bool forProtocol = false,
+  }) {
+    if ((object is List || object is Set || object is Map) ||
+        getClassNameForObject(object) != null) {
+      return super.dynamicFieldToJson(object, forProtocol: forProtocol);
+    }
+    for (final MapEntry(key: host, value: protocol) in _hostProtocols.entries) {
+      final className = protocol.getClassNameForObject(object);
+      if (className == null) continue;
+      final wrapped = {
+        'className': className.contains('.') ? className : '$host.$className',
+        'data': object,
+      };
+      return forProtocol
+          ? _i1.SerializationManager.toEncodableForProtocol(wrapped)
+          : _i1.SerializationManager.toEncodable(wrapped);
+    }
+    return super.dynamicFieldToJson(object, forProtocol: forProtocol);
+  }
+
+  @override
+  dynamic deserializeDynamicFieldValue(Object? value) {
+    if (value == null) return null;
+    if (value is! Map<String, dynamic> || value['className'] is! String) {
+      throw FormatException(
+        'Dynamic fields are encoded as a Map with className and data, but got '
+        '${value.runtimeType} instead.',
+      );
+    }
+    final className = value['className'] as String;
+    for (final MapEntry(key: host, value: protocol) in _hostProtocols.entries) {
+      final hostPrefix = '$host.';
+      if (className.startsWith(hostPrefix)) {
+        final strippedClassName = className.substring(hostPrefix.length);
+        if (strippedClassName.contains('.')) {
+          throw FormatException(
+            'Dynamic field className must not use multiple prefixes: $className',
+          );
+        }
+        final hostData = Map<String, dynamic>.from(value);
+        hostData['className'] = strippedClassName;
+        return protocol.deserializeByClassName(hostData);
+      }
+    }
+    if (className.contains('.')) {
+      for (final protocol in _hostProtocols.values) {
+        return protocol.deserializeByClassName(value);
+      }
+    }
+    return deserializeByClassName(value);
   }
 
   @override

--- a/modules/legacy/serverpod_auth/serverpod_auth_server/lib/src/generated/protocol.dart
+++ b/modules/legacy/serverpod_auth/serverpod_auth_server/lib/src/generated/protocol.dart
@@ -829,7 +829,9 @@ class Protocol extends _i1.DatabaseSerializationManager {
     }
     if (className.contains('.')) {
       for (final protocol in _hostProtocols.values) {
-        return protocol.deserializeByClassName(value);
+        try {
+          return protocol.deserializeByClassName(value);
+        } on FormatException catch (_) {}
       }
     }
     return deserializeByClassName(value);

--- a/modules/legacy/serverpod_chat/serverpod_chat_client/lib/src/protocol/protocol.dart
+++ b/modules/legacy/serverpod_chat/serverpod_chat_client/lib/src/protocol/protocol.dart
@@ -43,6 +43,15 @@ class Protocol extends _i1.SerializationManager {
 
   static final Protocol _instance = Protocol._();
 
+  final Map<String, _i1.SerializationManager> _hostProtocols = {};
+
+  void registerHostProtocol(
+    String projectName,
+    _i1.SerializationManager protocol,
+  ) {
+    _hostProtocols[projectName] = protocol;
+  }
+
   static String? getClassNameFromObjectJson(dynamic data) {
     if (data is! Map) return null;
     final className = data['__className__'] as String?;
@@ -222,10 +231,6 @@ class Protocol extends _i1.SerializationManager {
       case _i12.ChatRequestMessageChunk():
         return 'ChatRequestMessageChunk';
     }
-    className = _i13.Protocol().getClassNameForObject(data);
-    if (className != null) {
-      return 'serverpod_auth.$className';
-    }
     return null;
   }
 
@@ -270,11 +275,62 @@ class Protocol extends _i1.SerializationManager {
     if (dataClassName == 'ChatRequestMessageChunk') {
       return deserialize<_i12.ChatRequestMessageChunk>(data['data']);
     }
-    if (dataClassName.startsWith('serverpod_auth.')) {
-      data['className'] = dataClassName.substring(15);
-      return _i13.Protocol().deserializeByClassName(data);
-    }
     return super.deserializeByClassName(data);
+  }
+
+  @override
+  Object? dynamicFieldToJson(
+    Object? object, {
+    bool forProtocol = false,
+  }) {
+    if ((object is List || object is Set || object is Map) ||
+        getClassNameForObject(object) != null) {
+      return super.dynamicFieldToJson(object, forProtocol: forProtocol);
+    }
+    for (final MapEntry(key: host, value: protocol) in _hostProtocols.entries) {
+      final className = protocol.getClassNameForObject(object);
+      if (className == null) continue;
+      final wrapped = {
+        'className': className.contains('.') ? className : '$host.$className',
+        'data': object,
+      };
+      return forProtocol
+          ? _i1.SerializationManager.toEncodableForProtocol(wrapped)
+          : _i1.SerializationManager.toEncodable(wrapped);
+    }
+    return super.dynamicFieldToJson(object, forProtocol: forProtocol);
+  }
+
+  @override
+  dynamic deserializeDynamicFieldValue(Object? value) {
+    if (value == null) return null;
+    if (value is! Map<String, dynamic> || value['className'] is! String) {
+      throw FormatException(
+        'Dynamic fields are encoded as a Map with className and data, but got '
+        '${value.runtimeType} instead.',
+      );
+    }
+    final className = value['className'] as String;
+    for (final MapEntry(key: host, value: protocol) in _hostProtocols.entries) {
+      final hostPrefix = '$host.';
+      if (className.startsWith(hostPrefix)) {
+        final strippedClassName = className.substring(hostPrefix.length);
+        if (strippedClassName.contains('.')) {
+          throw FormatException(
+            'Dynamic field className must not use multiple prefixes: $className',
+          );
+        }
+        final hostData = Map<String, dynamic>.from(value);
+        hostData['className'] = strippedClassName;
+        return protocol.deserializeByClassName(hostData);
+      }
+    }
+    if (className.contains('.')) {
+      for (final protocol in _hostProtocols.values) {
+        return protocol.deserializeByClassName(value);
+      }
+    }
+    return deserializeByClassName(value);
   }
 
   /// Maps any `Record`s known to this [Protocol] to their JSON representation

--- a/modules/legacy/serverpod_chat/serverpod_chat_client/lib/src/protocol/protocol.dart
+++ b/modules/legacy/serverpod_chat/serverpod_chat_client/lib/src/protocol/protocol.dart
@@ -327,7 +327,9 @@ class Protocol extends _i1.SerializationManager {
     }
     if (className.contains('.')) {
       for (final protocol in _hostProtocols.values) {
-        return protocol.deserializeByClassName(value);
+        try {
+          return protocol.deserializeByClassName(value);
+        } on FormatException catch (_) {}
       }
     }
     return deserializeByClassName(value);

--- a/modules/legacy/serverpod_chat/serverpod_chat_server/lib/src/generated/protocol.dart
+++ b/modules/legacy/serverpod_chat/serverpod_chat_server/lib/src/generated/protocol.dart
@@ -169,6 +169,15 @@ class Protocol extends _i1.DatabaseSerializationManager {
     ..._i3.Protocol.targetTableDefinitions,
   ];
 
+  final Map<String, _i1.SerializationManager> _hostProtocols = {};
+
+  void registerHostProtocol(
+    String projectName,
+    _i1.SerializationManager protocol,
+  ) {
+    _hostProtocols[projectName] = protocol;
+  }
+
   static String? getClassNameFromObjectJson(dynamic data) {
     if (data is! Map) return null;
     final className = data['__className__'] as String?;
@@ -353,11 +362,7 @@ class Protocol extends _i1.DatabaseSerializationManager {
     }
     className = _i2.Protocol().getClassNameForObject(data);
     if (className != null) {
-      return 'serverpod.$className';
-    }
-    className = _i3.Protocol().getClassNameForObject(data);
-    if (className != null) {
-      return 'serverpod_auth.$className';
+      return className.contains('.') ? className : 'serverpod.$className';
     }
     return null;
   }
@@ -407,11 +412,62 @@ class Protocol extends _i1.DatabaseSerializationManager {
       data['className'] = dataClassName.substring(10);
       return _i2.Protocol().deserializeByClassName(data);
     }
-    if (dataClassName.startsWith('serverpod_auth.')) {
-      data['className'] = dataClassName.substring(15);
-      return _i3.Protocol().deserializeByClassName(data);
-    }
     return super.deserializeByClassName(data);
+  }
+
+  @override
+  Object? dynamicFieldToJson(
+    Object? object, {
+    bool forProtocol = false,
+  }) {
+    if ((object is List || object is Set || object is Map) ||
+        getClassNameForObject(object) != null) {
+      return super.dynamicFieldToJson(object, forProtocol: forProtocol);
+    }
+    for (final MapEntry(key: host, value: protocol) in _hostProtocols.entries) {
+      final className = protocol.getClassNameForObject(object);
+      if (className == null) continue;
+      final wrapped = {
+        'className': className.contains('.') ? className : '$host.$className',
+        'data': object,
+      };
+      return forProtocol
+          ? _i1.SerializationManager.toEncodableForProtocol(wrapped)
+          : _i1.SerializationManager.toEncodable(wrapped);
+    }
+    return super.dynamicFieldToJson(object, forProtocol: forProtocol);
+  }
+
+  @override
+  dynamic deserializeDynamicFieldValue(Object? value) {
+    if (value == null) return null;
+    if (value is! Map<String, dynamic> || value['className'] is! String) {
+      throw FormatException(
+        'Dynamic fields are encoded as a Map with className and data, but got '
+        '${value.runtimeType} instead.',
+      );
+    }
+    final className = value['className'] as String;
+    for (final MapEntry(key: host, value: protocol) in _hostProtocols.entries) {
+      final hostPrefix = '$host.';
+      if (className.startsWith(hostPrefix)) {
+        final strippedClassName = className.substring(hostPrefix.length);
+        if (strippedClassName.contains('.')) {
+          throw FormatException(
+            'Dynamic field className must not use multiple prefixes: $className',
+          );
+        }
+        final hostData = Map<String, dynamic>.from(value);
+        hostData['className'] = strippedClassName;
+        return protocol.deserializeByClassName(hostData);
+      }
+    }
+    if (className.contains('.')) {
+      for (final protocol in _hostProtocols.values) {
+        return protocol.deserializeByClassName(value);
+      }
+    }
+    return deserializeByClassName(value);
   }
 
   @override

--- a/modules/legacy/serverpod_chat/serverpod_chat_server/lib/src/generated/protocol.dart
+++ b/modules/legacy/serverpod_chat/serverpod_chat_server/lib/src/generated/protocol.dart
@@ -464,7 +464,9 @@ class Protocol extends _i1.DatabaseSerializationManager {
     }
     if (className.contains('.')) {
       for (final protocol in _hostProtocols.values) {
-        return protocol.deserializeByClassName(value);
+        try {
+          return protocol.deserializeByClassName(value);
+        } on FormatException catch (_) {}
       }
     }
     return deserializeByClassName(value);

--- a/modules/serverpod_auth/serverpod_auth_bridge/serverpod_auth_bridge_client/lib/src/protocol/protocol.dart
+++ b/modules/serverpod_auth/serverpod_auth_bridge/serverpod_auth_bridge_client/lib/src/protocol/protocol.dart
@@ -32,6 +32,15 @@ class Protocol extends _i1.SerializationManager {
 
   static final Protocol _instance = Protocol._();
 
+  final Map<String, _i1.SerializationManager> _hostProtocols = {};
+
+  void registerHostProtocol(
+    String projectName,
+    _i1.SerializationManager protocol,
+  ) {
+    _hostProtocols[projectName] = protocol;
+  }
+
   static String? getClassNameFromObjectJson(dynamic data) {
     if (data is! Map) return null;
     final className = data['__className__'] as String?;
@@ -136,14 +145,6 @@ class Protocol extends _i1.SerializationManager {
       case _i5.LegacyUserSettingsConfig():
         return 'LegacyUserSettingsConfig';
     }
-    className = _i6.Protocol().getClassNameForObject(data);
-    if (className != null) {
-      return 'serverpod_auth_core.$className';
-    }
-    className = _i7.Protocol().getClassNameForObject(data);
-    if (className != null) {
-      return 'serverpod_auth_idp.$className';
-    }
     return null;
   }
 
@@ -165,15 +166,62 @@ class Protocol extends _i1.SerializationManager {
     if (dataClassName == 'LegacyUserSettingsConfig') {
       return deserialize<_i5.LegacyUserSettingsConfig>(data['data']);
     }
-    if (dataClassName.startsWith('serverpod_auth_core.')) {
-      data['className'] = dataClassName.substring(20);
-      return _i6.Protocol().deserializeByClassName(data);
-    }
-    if (dataClassName.startsWith('serverpod_auth_idp.')) {
-      data['className'] = dataClassName.substring(19);
-      return _i7.Protocol().deserializeByClassName(data);
-    }
     return super.deserializeByClassName(data);
+  }
+
+  @override
+  Object? dynamicFieldToJson(
+    Object? object, {
+    bool forProtocol = false,
+  }) {
+    if ((object is List || object is Set || object is Map) ||
+        getClassNameForObject(object) != null) {
+      return super.dynamicFieldToJson(object, forProtocol: forProtocol);
+    }
+    for (final MapEntry(key: host, value: protocol) in _hostProtocols.entries) {
+      final className = protocol.getClassNameForObject(object);
+      if (className == null) continue;
+      final wrapped = {
+        'className': className.contains('.') ? className : '$host.$className',
+        'data': object,
+      };
+      return forProtocol
+          ? _i1.SerializationManager.toEncodableForProtocol(wrapped)
+          : _i1.SerializationManager.toEncodable(wrapped);
+    }
+    return super.dynamicFieldToJson(object, forProtocol: forProtocol);
+  }
+
+  @override
+  dynamic deserializeDynamicFieldValue(Object? value) {
+    if (value == null) return null;
+    if (value is! Map<String, dynamic> || value['className'] is! String) {
+      throw FormatException(
+        'Dynamic fields are encoded as a Map with className and data, but got '
+        '${value.runtimeType} instead.',
+      );
+    }
+    final className = value['className'] as String;
+    for (final MapEntry(key: host, value: protocol) in _hostProtocols.entries) {
+      final hostPrefix = '$host.';
+      if (className.startsWith(hostPrefix)) {
+        final strippedClassName = className.substring(hostPrefix.length);
+        if (strippedClassName.contains('.')) {
+          throw FormatException(
+            'Dynamic field className must not use multiple prefixes: $className',
+          );
+        }
+        final hostData = Map<String, dynamic>.from(value);
+        hostData['className'] = strippedClassName;
+        return protocol.deserializeByClassName(hostData);
+      }
+    }
+    if (className.contains('.')) {
+      for (final protocol in _hostProtocols.values) {
+        return protocol.deserializeByClassName(value);
+      }
+    }
+    return deserializeByClassName(value);
   }
 
   /// Maps any `Record`s known to this [Protocol] to their JSON representation

--- a/modules/serverpod_auth/serverpod_auth_bridge/serverpod_auth_bridge_client/lib/src/protocol/protocol.dart
+++ b/modules/serverpod_auth/serverpod_auth_bridge/serverpod_auth_bridge_client/lib/src/protocol/protocol.dart
@@ -218,7 +218,9 @@ class Protocol extends _i1.SerializationManager {
     }
     if (className.contains('.')) {
       for (final protocol in _hostProtocols.values) {
-        return protocol.deserializeByClassName(value);
+        try {
+          return protocol.deserializeByClassName(value);
+        } on FormatException catch (_) {}
       }
     }
     return deserializeByClassName(value);

--- a/modules/serverpod_auth/serverpod_auth_bridge/serverpod_auth_bridge_server/lib/src/generated/protocol.dart
+++ b/modules/serverpod_auth/serverpod_auth_bridge/serverpod_auth_bridge_server/lib/src/generated/protocol.dart
@@ -448,7 +448,9 @@ class Protocol extends _i1.DatabaseSerializationManager {
     }
     if (className.contains('.')) {
       for (final protocol in _hostProtocols.values) {
-        return protocol.deserializeByClassName(value);
+        try {
+          return protocol.deserializeByClassName(value);
+        } on FormatException catch (_) {}
       }
     }
     return deserializeByClassName(value);

--- a/modules/serverpod_auth/serverpod_auth_bridge/serverpod_auth_bridge_server/lib/src/generated/protocol.dart
+++ b/modules/serverpod_auth/serverpod_auth_bridge/serverpod_auth_bridge_server/lib/src/generated/protocol.dart
@@ -206,6 +206,15 @@ class Protocol extends _i1.DatabaseSerializationManager {
     ..._i4.Protocol.targetTableDefinitions,
   ];
 
+  final Map<String, _i1.SerializationManager> _hostProtocols = {};
+
+  void registerHostProtocol(
+    String projectName,
+    _i1.SerializationManager protocol,
+  ) {
+    _hostProtocols[projectName] = protocol;
+  }
+
   static String? getClassNameFromObjectJson(dynamic data) {
     if (data is! Map) return null;
     final className = data['__className__'] as String?;
@@ -351,15 +360,7 @@ class Protocol extends _i1.DatabaseSerializationManager {
     }
     className = _i2.Protocol().getClassNameForObject(data);
     if (className != null) {
-      return 'serverpod.$className';
-    }
-    className = _i3.Protocol().getClassNameForObject(data);
-    if (className != null) {
-      return 'serverpod_auth_core.$className';
-    }
-    className = _i4.Protocol().getClassNameForObject(data);
-    if (className != null) {
-      return 'serverpod_auth_idp.$className';
+      return className.contains('.') ? className : 'serverpod.$className';
     }
     return null;
   }
@@ -395,15 +396,62 @@ class Protocol extends _i1.DatabaseSerializationManager {
       data['className'] = dataClassName.substring(10);
       return _i2.Protocol().deserializeByClassName(data);
     }
-    if (dataClassName.startsWith('serverpod_auth_core.')) {
-      data['className'] = dataClassName.substring(20);
-      return _i3.Protocol().deserializeByClassName(data);
-    }
-    if (dataClassName.startsWith('serverpod_auth_idp.')) {
-      data['className'] = dataClassName.substring(19);
-      return _i4.Protocol().deserializeByClassName(data);
-    }
     return super.deserializeByClassName(data);
+  }
+
+  @override
+  Object? dynamicFieldToJson(
+    Object? object, {
+    bool forProtocol = false,
+  }) {
+    if ((object is List || object is Set || object is Map) ||
+        getClassNameForObject(object) != null) {
+      return super.dynamicFieldToJson(object, forProtocol: forProtocol);
+    }
+    for (final MapEntry(key: host, value: protocol) in _hostProtocols.entries) {
+      final className = protocol.getClassNameForObject(object);
+      if (className == null) continue;
+      final wrapped = {
+        'className': className.contains('.') ? className : '$host.$className',
+        'data': object,
+      };
+      return forProtocol
+          ? _i1.SerializationManager.toEncodableForProtocol(wrapped)
+          : _i1.SerializationManager.toEncodable(wrapped);
+    }
+    return super.dynamicFieldToJson(object, forProtocol: forProtocol);
+  }
+
+  @override
+  dynamic deserializeDynamicFieldValue(Object? value) {
+    if (value == null) return null;
+    if (value is! Map<String, dynamic> || value['className'] is! String) {
+      throw FormatException(
+        'Dynamic fields are encoded as a Map with className and data, but got '
+        '${value.runtimeType} instead.',
+      );
+    }
+    final className = value['className'] as String;
+    for (final MapEntry(key: host, value: protocol) in _hostProtocols.entries) {
+      final hostPrefix = '$host.';
+      if (className.startsWith(hostPrefix)) {
+        final strippedClassName = className.substring(hostPrefix.length);
+        if (strippedClassName.contains('.')) {
+          throw FormatException(
+            'Dynamic field className must not use multiple prefixes: $className',
+          );
+        }
+        final hostData = Map<String, dynamic>.from(value);
+        hostData['className'] = strippedClassName;
+        return protocol.deserializeByClassName(hostData);
+      }
+    }
+    if (className.contains('.')) {
+      for (final protocol in _hostProtocols.values) {
+        return protocol.deserializeByClassName(value);
+      }
+    }
+    return deserializeByClassName(value);
   }
 
   @override

--- a/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_client/lib/src/protocol/protocol.dart
+++ b/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_client/lib/src/protocol/protocol.dart
@@ -54,6 +54,15 @@ class Protocol extends _i1.SerializationManager {
 
   static final Protocol _instance = Protocol._();
 
+  final Map<String, _i1.SerializationManager> _hostProtocols = {};
+
+  void registerHostProtocol(
+    String projectName,
+    _i1.SerializationManager protocol,
+  ) {
+    _hostProtocols[projectName] = protocol;
+  }
+
   static String? getClassNameFromObjectJson(dynamic data) {
     if (data is! Map) return null;
     final className = data['__className__'] as String?;
@@ -341,6 +350,61 @@ class Protocol extends _i1.SerializationManager {
       return deserialize<_i18.ServerSideSessionInfo>(data['data']);
     }
     return super.deserializeByClassName(data);
+  }
+
+  @override
+  Object? dynamicFieldToJson(
+    Object? object, {
+    bool forProtocol = false,
+  }) {
+    if ((object is List || object is Set || object is Map) ||
+        getClassNameForObject(object) != null) {
+      return super.dynamicFieldToJson(object, forProtocol: forProtocol);
+    }
+    for (final MapEntry(key: host, value: protocol) in _hostProtocols.entries) {
+      final className = protocol.getClassNameForObject(object);
+      if (className == null) continue;
+      final wrapped = {
+        'className': className.contains('.') ? className : '$host.$className',
+        'data': object,
+      };
+      return forProtocol
+          ? _i1.SerializationManager.toEncodableForProtocol(wrapped)
+          : _i1.SerializationManager.toEncodable(wrapped);
+    }
+    return super.dynamicFieldToJson(object, forProtocol: forProtocol);
+  }
+
+  @override
+  dynamic deserializeDynamicFieldValue(Object? value) {
+    if (value == null) return null;
+    if (value is! Map<String, dynamic> || value['className'] is! String) {
+      throw FormatException(
+        'Dynamic fields are encoded as a Map with className and data, but got '
+        '${value.runtimeType} instead.',
+      );
+    }
+    final className = value['className'] as String;
+    for (final MapEntry(key: host, value: protocol) in _hostProtocols.entries) {
+      final hostPrefix = '$host.';
+      if (className.startsWith(hostPrefix)) {
+        final strippedClassName = className.substring(hostPrefix.length);
+        if (strippedClassName.contains('.')) {
+          throw FormatException(
+            'Dynamic field className must not use multiple prefixes: $className',
+          );
+        }
+        final hostData = Map<String, dynamic>.from(value);
+        hostData['className'] = strippedClassName;
+        return protocol.deserializeByClassName(hostData);
+      }
+    }
+    if (className.contains('.')) {
+      for (final protocol in _hostProtocols.values) {
+        return protocol.deserializeByClassName(value);
+      }
+    }
+    return deserializeByClassName(value);
   }
 
   /// Maps any `Record`s known to this [Protocol] to their JSON representation

--- a/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_client/lib/src/protocol/protocol.dart
+++ b/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_client/lib/src/protocol/protocol.dart
@@ -401,7 +401,9 @@ class Protocol extends _i1.SerializationManager {
     }
     if (className.contains('.')) {
       for (final protocol in _hostProtocols.values) {
-        return protocol.deserializeByClassName(value);
+        try {
+          return protocol.deserializeByClassName(value);
+        } on FormatException catch (_) {}
       }
     }
     return deserializeByClassName(value);

--- a/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_server/lib/src/generated/protocol.dart
+++ b/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_server/lib/src/generated/protocol.dart
@@ -425,6 +425,15 @@ class Protocol extends _i1.DatabaseSerializationManager {
     ),
   ];
 
+  final Map<String, _i1.SerializationManager> _hostProtocols = {};
+
+  void registerHostProtocol(
+    String projectName,
+    _i1.SerializationManager protocol,
+  ) {
+    _hostProtocols[projectName] = protocol;
+  }
+
   static String? getClassNameFromObjectJson(dynamic data) {
     if (data is! Map) return null;
     final className = data['__className__'] as String?;
@@ -674,7 +683,7 @@ class Protocol extends _i1.DatabaseSerializationManager {
     }
     className = _i2.Protocol().getClassNameForObject(data);
     if (className != null) {
-      return 'serverpod.$className';
+      return className.contains('.') ? className : 'serverpod.$className';
     }
     return null;
   }
@@ -747,6 +756,61 @@ class Protocol extends _i1.DatabaseSerializationManager {
       return _i2.Protocol().deserializeByClassName(data);
     }
     return super.deserializeByClassName(data);
+  }
+
+  @override
+  Object? dynamicFieldToJson(
+    Object? object, {
+    bool forProtocol = false,
+  }) {
+    if ((object is List || object is Set || object is Map) ||
+        getClassNameForObject(object) != null) {
+      return super.dynamicFieldToJson(object, forProtocol: forProtocol);
+    }
+    for (final MapEntry(key: host, value: protocol) in _hostProtocols.entries) {
+      final className = protocol.getClassNameForObject(object);
+      if (className == null) continue;
+      final wrapped = {
+        'className': className.contains('.') ? className : '$host.$className',
+        'data': object,
+      };
+      return forProtocol
+          ? _i1.SerializationManager.toEncodableForProtocol(wrapped)
+          : _i1.SerializationManager.toEncodable(wrapped);
+    }
+    return super.dynamicFieldToJson(object, forProtocol: forProtocol);
+  }
+
+  @override
+  dynamic deserializeDynamicFieldValue(Object? value) {
+    if (value == null) return null;
+    if (value is! Map<String, dynamic> || value['className'] is! String) {
+      throw FormatException(
+        'Dynamic fields are encoded as a Map with className and data, but got '
+        '${value.runtimeType} instead.',
+      );
+    }
+    final className = value['className'] as String;
+    for (final MapEntry(key: host, value: protocol) in _hostProtocols.entries) {
+      final hostPrefix = '$host.';
+      if (className.startsWith(hostPrefix)) {
+        final strippedClassName = className.substring(hostPrefix.length);
+        if (strippedClassName.contains('.')) {
+          throw FormatException(
+            'Dynamic field className must not use multiple prefixes: $className',
+          );
+        }
+        final hostData = Map<String, dynamic>.from(value);
+        hostData['className'] = strippedClassName;
+        return protocol.deserializeByClassName(hostData);
+      }
+    }
+    if (className.contains('.')) {
+      for (final protocol in _hostProtocols.values) {
+        return protocol.deserializeByClassName(value);
+      }
+    }
+    return deserializeByClassName(value);
   }
 
   @override

--- a/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_server/lib/src/generated/protocol.dart
+++ b/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_server/lib/src/generated/protocol.dart
@@ -807,7 +807,9 @@ class Protocol extends _i1.DatabaseSerializationManager {
     }
     if (className.contains('.')) {
       for (final protocol in _hostProtocols.values) {
-        return protocol.deserializeByClassName(value);
+        try {
+          return protocol.deserializeByClassName(value);
+        } on FormatException catch (_) {}
       }
     }
     return deserializeByClassName(value);

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_client/lib/src/protocol/protocol.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_client/lib/src/protocol/protocol.dart
@@ -75,6 +75,15 @@ class Protocol extends _i1.SerializationManager {
 
   static final Protocol _instance = Protocol._();
 
+  final Map<String, _i1.SerializationManager> _hostProtocols = {};
+
+  void registerHostProtocol(
+    String projectName,
+    _i1.SerializationManager protocol,
+  ) {
+    _hostProtocols[projectName] = protocol;
+  }
+
   static String? getClassNameFromObjectJson(dynamic data) {
     if (data is! Map) return null;
     final className = data['__className__'] as String?;
@@ -367,10 +376,6 @@ class Protocol extends _i1.SerializationManager {
       case _i19.PasskeyRegistrationRequest():
         return 'PasskeyRegistrationRequest';
     }
-    className = _i21.Protocol().getClassNameForObject(data);
-    if (className != null) {
-      return 'serverpod_auth_core.$className';
-    }
     return null;
   }
 
@@ -446,11 +451,62 @@ class Protocol extends _i1.SerializationManager {
     if (dataClassName == 'PasskeyRegistrationRequest') {
       return deserialize<_i19.PasskeyRegistrationRequest>(data['data']);
     }
-    if (dataClassName.startsWith('serverpod_auth_core.')) {
-      data['className'] = dataClassName.substring(20);
-      return _i21.Protocol().deserializeByClassName(data);
-    }
     return super.deserializeByClassName(data);
+  }
+
+  @override
+  Object? dynamicFieldToJson(
+    Object? object, {
+    bool forProtocol = false,
+  }) {
+    if ((object is List || object is Set || object is Map) ||
+        getClassNameForObject(object) != null) {
+      return super.dynamicFieldToJson(object, forProtocol: forProtocol);
+    }
+    for (final MapEntry(key: host, value: protocol) in _hostProtocols.entries) {
+      final className = protocol.getClassNameForObject(object);
+      if (className == null) continue;
+      final wrapped = {
+        'className': className.contains('.') ? className : '$host.$className',
+        'data': object,
+      };
+      return forProtocol
+          ? _i1.SerializationManager.toEncodableForProtocol(wrapped)
+          : _i1.SerializationManager.toEncodable(wrapped);
+    }
+    return super.dynamicFieldToJson(object, forProtocol: forProtocol);
+  }
+
+  @override
+  dynamic deserializeDynamicFieldValue(Object? value) {
+    if (value == null) return null;
+    if (value is! Map<String, dynamic> || value['className'] is! String) {
+      throw FormatException(
+        'Dynamic fields are encoded as a Map with className and data, but got '
+        '${value.runtimeType} instead.',
+      );
+    }
+    final className = value['className'] as String;
+    for (final MapEntry(key: host, value: protocol) in _hostProtocols.entries) {
+      final hostPrefix = '$host.';
+      if (className.startsWith(hostPrefix)) {
+        final strippedClassName = className.substring(hostPrefix.length);
+        if (strippedClassName.contains('.')) {
+          throw FormatException(
+            'Dynamic field className must not use multiple prefixes: $className',
+          );
+        }
+        final hostData = Map<String, dynamic>.from(value);
+        hostData['className'] = strippedClassName;
+        return protocol.deserializeByClassName(hostData);
+      }
+    }
+    if (className.contains('.')) {
+      for (final protocol in _hostProtocols.values) {
+        return protocol.deserializeByClassName(value);
+      }
+    }
+    return deserializeByClassName(value);
   }
 
   /// Maps any `Record`s known to this [Protocol] to their JSON representation

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_client/lib/src/protocol/protocol.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_client/lib/src/protocol/protocol.dart
@@ -503,7 +503,9 @@ class Protocol extends _i1.SerializationManager {
     }
     if (className.contains('.')) {
       for (final protocol in _hostProtocols.values) {
-        return protocol.deserializeByClassName(value);
+        try {
+          return protocol.deserializeByClassName(value);
+        } on FormatException catch (_) {}
       }
     }
     return deserializeByClassName(value);

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/generated/protocol.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/generated/protocol.dart
@@ -1691,7 +1691,9 @@ class Protocol extends _i1.DatabaseSerializationManager {
     }
     if (className.contains('.')) {
       for (final protocol in _hostProtocols.values) {
-        return protocol.deserializeByClassName(value);
+        try {
+          return protocol.deserializeByClassName(value);
+        } on FormatException catch (_) {}
       }
     }
     return deserializeByClassName(value);

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/generated/protocol.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/generated/protocol.dart
@@ -1061,6 +1061,15 @@ class Protocol extends _i1.DatabaseSerializationManager {
     ..._i3.Protocol.targetTableDefinitions,
   ];
 
+  final Map<String, _i1.SerializationManager> _hostProtocols = {};
+
+  void registerHostProtocol(
+    String projectName,
+    _i1.SerializationManager protocol,
+  ) {
+    _hostProtocols[projectName] = protocol;
+  }
+
   static String? getClassNameFromObjectJson(dynamic data) {
     if (data is! Map) return null;
     final className = data['__className__'] as String?;
@@ -1507,11 +1516,7 @@ class Protocol extends _i1.DatabaseSerializationManager {
     }
     className = _i2.Protocol().getClassNameForObject(data);
     if (className != null) {
-      return 'serverpod.$className';
-    }
-    className = _i3.Protocol().getClassNameForObject(data);
-    if (className != null) {
-      return 'serverpod_auth_core.$className';
+      return className.contains('.') ? className : 'serverpod.$className';
     }
     return null;
   }
@@ -1634,11 +1639,62 @@ class Protocol extends _i1.DatabaseSerializationManager {
       data['className'] = dataClassName.substring(10);
       return _i2.Protocol().deserializeByClassName(data);
     }
-    if (dataClassName.startsWith('serverpod_auth_core.')) {
-      data['className'] = dataClassName.substring(20);
-      return _i3.Protocol().deserializeByClassName(data);
-    }
     return super.deserializeByClassName(data);
+  }
+
+  @override
+  Object? dynamicFieldToJson(
+    Object? object, {
+    bool forProtocol = false,
+  }) {
+    if ((object is List || object is Set || object is Map) ||
+        getClassNameForObject(object) != null) {
+      return super.dynamicFieldToJson(object, forProtocol: forProtocol);
+    }
+    for (final MapEntry(key: host, value: protocol) in _hostProtocols.entries) {
+      final className = protocol.getClassNameForObject(object);
+      if (className == null) continue;
+      final wrapped = {
+        'className': className.contains('.') ? className : '$host.$className',
+        'data': object,
+      };
+      return forProtocol
+          ? _i1.SerializationManager.toEncodableForProtocol(wrapped)
+          : _i1.SerializationManager.toEncodable(wrapped);
+    }
+    return super.dynamicFieldToJson(object, forProtocol: forProtocol);
+  }
+
+  @override
+  dynamic deserializeDynamicFieldValue(Object? value) {
+    if (value == null) return null;
+    if (value is! Map<String, dynamic> || value['className'] is! String) {
+      throw FormatException(
+        'Dynamic fields are encoded as a Map with className and data, but got '
+        '${value.runtimeType} instead.',
+      );
+    }
+    final className = value['className'] as String;
+    for (final MapEntry(key: host, value: protocol) in _hostProtocols.entries) {
+      final hostPrefix = '$host.';
+      if (className.startsWith(hostPrefix)) {
+        final strippedClassName = className.substring(hostPrefix.length);
+        if (strippedClassName.contains('.')) {
+          throw FormatException(
+            'Dynamic field className must not use multiple prefixes: $className',
+          );
+        }
+        final hostData = Map<String, dynamic>.from(value);
+        hostData['className'] = strippedClassName;
+        return protocol.deserializeByClassName(hostData);
+      }
+    }
+    if (className.contains('.')) {
+      for (final protocol in _hostProtocols.values) {
+        return protocol.deserializeByClassName(value);
+      }
+    }
+    return deserializeByClassName(value);
   }
 
   @override

--- a/modules/serverpod_auth/serverpod_auth_migration/serverpod_auth_migration_client/lib/src/protocol/protocol.dart
+++ b/modules/serverpod_auth/serverpod_auth_migration/serverpod_auth_migration_client/lib/src/protocol/protocol.dart
@@ -159,7 +159,9 @@ class Protocol extends _i1.SerializationManager {
     }
     if (className.contains('.')) {
       for (final protocol in _hostProtocols.values) {
-        return protocol.deserializeByClassName(value);
+        try {
+          return protocol.deserializeByClassName(value);
+        } on FormatException catch (_) {}
       }
     }
     return deserializeByClassName(value);

--- a/modules/serverpod_auth/serverpod_auth_migration/serverpod_auth_migration_client/lib/src/protocol/protocol.dart
+++ b/modules/serverpod_auth/serverpod_auth_migration/serverpod_auth_migration_client/lib/src/protocol/protocol.dart
@@ -27,6 +27,15 @@ class Protocol extends _i1.SerializationManager {
 
   static final Protocol _instance = Protocol._();
 
+  final Map<String, _i1.SerializationManager> _hostProtocols = {};
+
+  void registerHostProtocol(
+    String projectName,
+    _i1.SerializationManager protocol,
+  ) {
+    _hostProtocols[projectName] = protocol;
+  }
+
   static String? getClassNameFromObjectJson(dynamic data) {
     if (data is! Map) return null;
     final className = data['__className__'] as String?;
@@ -89,22 +98,6 @@ class Protocol extends _i1.SerializationManager {
       );
     }
 
-    className = _i2.Protocol().getClassNameForObject(data);
-    if (className != null) {
-      return 'serverpod_auth_bridge.$className';
-    }
-    className = _i3.Protocol().getClassNameForObject(data);
-    if (className != null) {
-      return 'serverpod_auth_core.$className';
-    }
-    className = _i4.Protocol().getClassNameForObject(data);
-    if (className != null) {
-      return 'serverpod_auth_idp.$className';
-    }
-    className = _i5.Protocol().getClassNameForObject(data);
-    if (className != null) {
-      return 'serverpod_auth.$className';
-    }
     return null;
   }
 
@@ -114,23 +107,62 @@ class Protocol extends _i1.SerializationManager {
     if (dataClassName is! String) {
       return super.deserializeByClassName(data);
     }
-    if (dataClassName.startsWith('serverpod_auth_bridge.')) {
-      data['className'] = dataClassName.substring(22);
-      return _i2.Protocol().deserializeByClassName(data);
-    }
-    if (dataClassName.startsWith('serverpod_auth_core.')) {
-      data['className'] = dataClassName.substring(20);
-      return _i3.Protocol().deserializeByClassName(data);
-    }
-    if (dataClassName.startsWith('serverpod_auth_idp.')) {
-      data['className'] = dataClassName.substring(19);
-      return _i4.Protocol().deserializeByClassName(data);
-    }
-    if (dataClassName.startsWith('serverpod_auth.')) {
-      data['className'] = dataClassName.substring(15);
-      return _i5.Protocol().deserializeByClassName(data);
-    }
     return super.deserializeByClassName(data);
+  }
+
+  @override
+  Object? dynamicFieldToJson(
+    Object? object, {
+    bool forProtocol = false,
+  }) {
+    if ((object is List || object is Set || object is Map) ||
+        getClassNameForObject(object) != null) {
+      return super.dynamicFieldToJson(object, forProtocol: forProtocol);
+    }
+    for (final MapEntry(key: host, value: protocol) in _hostProtocols.entries) {
+      final className = protocol.getClassNameForObject(object);
+      if (className == null) continue;
+      final wrapped = {
+        'className': className.contains('.') ? className : '$host.$className',
+        'data': object,
+      };
+      return forProtocol
+          ? _i1.SerializationManager.toEncodableForProtocol(wrapped)
+          : _i1.SerializationManager.toEncodable(wrapped);
+    }
+    return super.dynamicFieldToJson(object, forProtocol: forProtocol);
+  }
+
+  @override
+  dynamic deserializeDynamicFieldValue(Object? value) {
+    if (value == null) return null;
+    if (value is! Map<String, dynamic> || value['className'] is! String) {
+      throw FormatException(
+        'Dynamic fields are encoded as a Map with className and data, but got '
+        '${value.runtimeType} instead.',
+      );
+    }
+    final className = value['className'] as String;
+    for (final MapEntry(key: host, value: protocol) in _hostProtocols.entries) {
+      final hostPrefix = '$host.';
+      if (className.startsWith(hostPrefix)) {
+        final strippedClassName = className.substring(hostPrefix.length);
+        if (strippedClassName.contains('.')) {
+          throw FormatException(
+            'Dynamic field className must not use multiple prefixes: $className',
+          );
+        }
+        final hostData = Map<String, dynamic>.from(value);
+        hostData['className'] = strippedClassName;
+        return protocol.deserializeByClassName(hostData);
+      }
+    }
+    if (className.contains('.')) {
+      for (final protocol in _hostProtocols.values) {
+        return protocol.deserializeByClassName(value);
+      }
+    }
+    return deserializeByClassName(value);
   }
 
   /// Maps any `Record`s known to this [Protocol] to their JSON representation

--- a/modules/serverpod_auth/serverpod_auth_migration/serverpod_auth_migration_server/lib/src/generated/protocol.dart
+++ b/modules/serverpod_auth/serverpod_auth_migration/serverpod_auth_migration_server/lib/src/generated/protocol.dart
@@ -114,6 +114,15 @@ class Protocol extends _i1.DatabaseSerializationManager {
     ..._i6.Protocol.targetTableDefinitions,
   ];
 
+  final Map<String, _i1.SerializationManager> _hostProtocols = {};
+
+  void registerHostProtocol(
+    String projectName,
+    _i1.SerializationManager protocol,
+  ) {
+    _hostProtocols[projectName] = protocol;
+  }
+
   static String? getClassNameFromObjectJson(dynamic data) {
     if (data is! Map) return null;
     final className = data['__className__'] as String?;
@@ -192,23 +201,7 @@ class Protocol extends _i1.DatabaseSerializationManager {
     }
     className = _i2.Protocol().getClassNameForObject(data);
     if (className != null) {
-      return 'serverpod.$className';
-    }
-    className = _i3.Protocol().getClassNameForObject(data);
-    if (className != null) {
-      return 'serverpod_auth_bridge.$className';
-    }
-    className = _i4.Protocol().getClassNameForObject(data);
-    if (className != null) {
-      return 'serverpod_auth_core.$className';
-    }
-    className = _i5.Protocol().getClassNameForObject(data);
-    if (className != null) {
-      return 'serverpod_auth_idp.$className';
-    }
-    className = _i6.Protocol().getClassNameForObject(data);
-    if (className != null) {
-      return 'serverpod_auth.$className';
+      return className.contains('.') ? className : 'serverpod.$className';
     }
     return null;
   }
@@ -226,23 +219,62 @@ class Protocol extends _i1.DatabaseSerializationManager {
       data['className'] = dataClassName.substring(10);
       return _i2.Protocol().deserializeByClassName(data);
     }
-    if (dataClassName.startsWith('serverpod_auth_bridge.')) {
-      data['className'] = dataClassName.substring(22);
-      return _i3.Protocol().deserializeByClassName(data);
-    }
-    if (dataClassName.startsWith('serverpod_auth_core.')) {
-      data['className'] = dataClassName.substring(20);
-      return _i4.Protocol().deserializeByClassName(data);
-    }
-    if (dataClassName.startsWith('serverpod_auth_idp.')) {
-      data['className'] = dataClassName.substring(19);
-      return _i5.Protocol().deserializeByClassName(data);
-    }
-    if (dataClassName.startsWith('serverpod_auth.')) {
-      data['className'] = dataClassName.substring(15);
-      return _i6.Protocol().deserializeByClassName(data);
-    }
     return super.deserializeByClassName(data);
+  }
+
+  @override
+  Object? dynamicFieldToJson(
+    Object? object, {
+    bool forProtocol = false,
+  }) {
+    if ((object is List || object is Set || object is Map) ||
+        getClassNameForObject(object) != null) {
+      return super.dynamicFieldToJson(object, forProtocol: forProtocol);
+    }
+    for (final MapEntry(key: host, value: protocol) in _hostProtocols.entries) {
+      final className = protocol.getClassNameForObject(object);
+      if (className == null) continue;
+      final wrapped = {
+        'className': className.contains('.') ? className : '$host.$className',
+        'data': object,
+      };
+      return forProtocol
+          ? _i1.SerializationManager.toEncodableForProtocol(wrapped)
+          : _i1.SerializationManager.toEncodable(wrapped);
+    }
+    return super.dynamicFieldToJson(object, forProtocol: forProtocol);
+  }
+
+  @override
+  dynamic deserializeDynamicFieldValue(Object? value) {
+    if (value == null) return null;
+    if (value is! Map<String, dynamic> || value['className'] is! String) {
+      throw FormatException(
+        'Dynamic fields are encoded as a Map with className and data, but got '
+        '${value.runtimeType} instead.',
+      );
+    }
+    final className = value['className'] as String;
+    for (final MapEntry(key: host, value: protocol) in _hostProtocols.entries) {
+      final hostPrefix = '$host.';
+      if (className.startsWith(hostPrefix)) {
+        final strippedClassName = className.substring(hostPrefix.length);
+        if (strippedClassName.contains('.')) {
+          throw FormatException(
+            'Dynamic field className must not use multiple prefixes: $className',
+          );
+        }
+        final hostData = Map<String, dynamic>.from(value);
+        hostData['className'] = strippedClassName;
+        return protocol.deserializeByClassName(hostData);
+      }
+    }
+    if (className.contains('.')) {
+      for (final protocol in _hostProtocols.values) {
+        return protocol.deserializeByClassName(value);
+      }
+    }
+    return deserializeByClassName(value);
   }
 
   @override

--- a/modules/serverpod_auth/serverpod_auth_migration/serverpod_auth_migration_server/lib/src/generated/protocol.dart
+++ b/modules/serverpod_auth/serverpod_auth_migration/serverpod_auth_migration_server/lib/src/generated/protocol.dart
@@ -271,7 +271,9 @@ class Protocol extends _i1.DatabaseSerializationManager {
     }
     if (className.contains('.')) {
       for (final protocol in _hostProtocols.values) {
-        return protocol.deserializeByClassName(value);
+        try {
+          return protocol.deserializeByClassName(value);
+        } on FormatException catch (_) {}
       }
     }
     return deserializeByClassName(value);

--- a/packages/serverpod/lib/src/generated/protocol.dart
+++ b/packages/serverpod/lib/src/generated/protocol.dart
@@ -86,9 +86,9 @@ export 'session_log_result.dart';
 class Protocol extends _i1.DatabaseSerializationManager {
   Protocol._();
 
-  factory Protocol() => _instance.._registerHostProtocols();
+  factory Protocol() => _instance;
 
-  static final Protocol _instance = Protocol._();
+  static final Protocol _instance = Protocol._().._registerHostProtocols();
 
   static final List<_i2.TableDefinition> targetTableDefinitions = [
     _i2.TableDefinition(

--- a/packages/serverpod/lib/src/generated/protocol.dart
+++ b/packages/serverpod/lib/src/generated/protocol.dart
@@ -86,7 +86,7 @@ export 'session_log_result.dart';
 class Protocol extends _i1.DatabaseSerializationManager {
   Protocol._();
 
-  factory Protocol() => _instance;
+  factory Protocol() => _instance.._registerHostProtocols();
 
   static final Protocol _instance = Protocol._();
 
@@ -1671,6 +1671,12 @@ class Protocol extends _i1.DatabaseSerializationManager {
       case _i36.SessionLogResult():
         return 'SessionLogResult';
     }
+    className = _i38.Protocol().getClassNameForObject(data);
+    if (className != null) {
+      return className.contains('.')
+          ? className
+          : 'serverpod_database.$className';
+    }
     return null;
   }
 
@@ -1785,7 +1791,15 @@ class Protocol extends _i1.DatabaseSerializationManager {
     if (dataClassName == 'SessionLogResult') {
       return deserialize<_i36.SessionLogResult>(data['data']);
     }
+    if (dataClassName.startsWith('serverpod_database.')) {
+      data['className'] = dataClassName.substring(19);
+      return _i38.Protocol().deserializeByClassName(data);
+    }
     return super.deserializeByClassName(data);
+  }
+
+  void _registerHostProtocols() {
+    _i38.Protocol().registerHostProtocol('serverpod', this);
   }
 
   @override

--- a/packages/serverpod_database/lib/src/generated/protocol.dart
+++ b/packages/serverpod_database/lib/src/generated/protocol.dart
@@ -78,6 +78,15 @@ class Protocol extends _i1.SerializationManager {
 
   static final Protocol _instance = Protocol._();
 
+  final Map<String, _i1.SerializationManager> _hostProtocols = {};
+
+  void registerHostProtocol(
+    String projectName,
+    _i1.SerializationManager protocol,
+  ) {
+    _hostProtocols[projectName] = protocol;
+  }
+
   static String? getClassNameFromObjectJson(dynamic data) {
     if (data is! Map) return null;
     final className = data['__className__'] as String?;
@@ -594,6 +603,61 @@ class Protocol extends _i1.SerializationManager {
       return deserialize<_i30.VectorDistanceFunction>(data['data']);
     }
     return super.deserializeByClassName(data);
+  }
+
+  @override
+  Object? dynamicFieldToJson(
+    Object? object, {
+    bool forProtocol = false,
+  }) {
+    if ((object is List || object is Set || object is Map) ||
+        getClassNameForObject(object) != null) {
+      return super.dynamicFieldToJson(object, forProtocol: forProtocol);
+    }
+    for (final MapEntry(key: host, value: protocol) in _hostProtocols.entries) {
+      final className = protocol.getClassNameForObject(object);
+      if (className == null) continue;
+      final wrapped = {
+        'className': className.contains('.') ? className : '$host.$className',
+        'data': object,
+      };
+      return forProtocol
+          ? _i1.SerializationManager.toEncodableForProtocol(wrapped)
+          : _i1.SerializationManager.toEncodable(wrapped);
+    }
+    return super.dynamicFieldToJson(object, forProtocol: forProtocol);
+  }
+
+  @override
+  dynamic deserializeDynamicFieldValue(Object? value) {
+    if (value == null) return null;
+    if (value is! Map<String, dynamic> || value['className'] is! String) {
+      throw FormatException(
+        'Dynamic fields are encoded as a Map with className and data, but got '
+        '${value.runtimeType} instead.',
+      );
+    }
+    final className = value['className'] as String;
+    for (final MapEntry(key: host, value: protocol) in _hostProtocols.entries) {
+      final hostPrefix = '$host.';
+      if (className.startsWith(hostPrefix)) {
+        final strippedClassName = className.substring(hostPrefix.length);
+        if (strippedClassName.contains('.')) {
+          throw FormatException(
+            'Dynamic field className must not use multiple prefixes: $className',
+          );
+        }
+        final hostData = Map<String, dynamic>.from(value);
+        hostData['className'] = strippedClassName;
+        return protocol.deserializeByClassName(hostData);
+      }
+    }
+    if (className.contains('.')) {
+      for (final protocol in _hostProtocols.values) {
+        return protocol.deserializeByClassName(value);
+      }
+    }
+    return deserializeByClassName(value);
   }
 
   /// Maps any `Record`s known to this [Protocol] to their JSON representation

--- a/packages/serverpod_database/lib/src/generated/protocol.dart
+++ b/packages/serverpod_database/lib/src/generated/protocol.dart
@@ -654,7 +654,9 @@ class Protocol extends _i1.SerializationManager {
     }
     if (className.contains('.')) {
       for (final protocol in _hostProtocols.values) {
-        return protocol.deserializeByClassName(value);
+        try {
+          return protocol.deserializeByClassName(value);
+        } on FormatException catch (_) {}
       }
     }
     return deserializeByClassName(value);

--- a/packages/serverpod_serialization/lib/src/serialization.dart
+++ b/packages/serverpod_serialization/lib/src/serialization.dart
@@ -343,33 +343,32 @@ abstract class SerializationManager {
   }
 
   /// Returns a JSON-encodable structure for a `dynamic` model field.
-  Object? dynamicFieldToJson(Object? object) =>
-      _dynamicFieldValueToJson(object, false);
-
-  /// Same as [dynamicFieldToJson] but uses protocol encoding for nested
-  /// [ProtocolSerialization] values.
-  Object? dynamicFieldToJsonForProtocol(Object? object) =>
-      _dynamicFieldValueToJson(object, true);
-
-  /// Recursively encodes values inside `dynamic` fields so that [List], [Set],
-  /// and [Map] children keep per-element type information.
   ///
-  /// Does not use [wrapWithClassName] for container types so that
-  /// [getClassNameForObject] is not required to name raw collections.
-  Object? _dynamicFieldValueToJson(Object? object, bool encodeForProtocol) {
+  /// Recursively encodes [List], [Set], and [Map] children so each element
+  /// keeps type information via `className` / `data` wrappers.
+  ///
+  /// When [forProtocol] is true, nested [ProtocolSerialization] values use
+  /// [ProtocolSerialization.toJsonForProtocol].
+  ///
+  /// Module and shared package protocols override this method to resolve host
+  /// project types via registered host protocols.
+  Object? dynamicFieldToJson(
+    Object? object, {
+    bool forProtocol = false,
+  }) {
     return switch (object) {
       List() => {
         'className': 'List',
         'data': [
           for (final e in object)
-            _dynamicFieldValueToJson(e, encodeForProtocol),
+            dynamicFieldToJson(e, forProtocol: forProtocol),
         ],
       },
       Set() => {
         'className': 'Set',
         'data': [
           for (final e in object)
-            _dynamicFieldValueToJson(e, encodeForProtocol),
+            dynamicFieldToJson(e, forProtocol: forProtocol),
         ],
       },
       Map()
@@ -379,9 +378,9 @@ abstract class SerializationManager {
           'className': 'Map',
           'data': {
             for (final e in object.entries)
-              e.key as String: _dynamicFieldValueToJson(
+              e.key as String: dynamicFieldToJson(
                 e.value,
-                encodeForProtocol,
+                forProtocol: forProtocol,
               ),
           },
         },
@@ -390,12 +389,12 @@ abstract class SerializationManager {
         'data': [
           for (final e in object.entries)
             {
-              'k': _dynamicFieldValueToJson(e.key, encodeForProtocol),
-              'v': _dynamicFieldValueToJson(e.value, encodeForProtocol),
+              'k': dynamicFieldToJson(e.key, forProtocol: forProtocol),
+              'v': dynamicFieldToJson(e.value, forProtocol: forProtocol),
             },
         ],
       },
-      _ => _toEncodable(wrapWithClassName(object), encodeForProtocol),
+      _ => _toEncodable(wrapWithClassName(object), forProtocol),
     };
   }
 }

--- a/packages/serverpod_service_client/lib/src/protocol/protocol.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/protocol.dart
@@ -80,7 +80,7 @@ export 'client.dart';
 class Protocol extends _i1.SerializationManager {
   Protocol._();
 
-  factory Protocol() => _instance;
+  factory Protocol() => _instance.._registerHostProtocols();
 
   static final Protocol _instance = Protocol._();
 
@@ -532,6 +532,12 @@ class Protocol extends _i1.SerializationManager {
       case _i32.SessionLogResult():
         return 'SessionLogResult';
     }
+    className = _i34.Protocol().getClassNameForObject(data);
+    if (className != null) {
+      return className.contains('.')
+          ? className
+          : 'serverpod_database.$className';
+    }
     return null;
   }
 
@@ -637,7 +643,15 @@ class Protocol extends _i1.SerializationManager {
     if (dataClassName == 'SessionLogResult') {
       return deserialize<_i32.SessionLogResult>(data['data']);
     }
+    if (dataClassName.startsWith('serverpod_database.')) {
+      data['className'] = dataClassName.substring(19);
+      return _i34.Protocol().deserializeByClassName(data);
+    }
     return super.deserializeByClassName(data);
+  }
+
+  void _registerHostProtocols() {
+    _i34.Protocol().registerHostProtocol('serverpod', this);
   }
 
   /// Maps any `Record`s known to this [Protocol] to their JSON representation

--- a/packages/serverpod_service_client/lib/src/protocol/protocol.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/protocol.dart
@@ -80,9 +80,9 @@ export 'client.dart';
 class Protocol extends _i1.SerializationManager {
   Protocol._();
 
-  factory Protocol() => _instance.._registerHostProtocols();
+  factory Protocol() => _instance;
 
-  static final Protocol _instance = Protocol._();
+  static final Protocol _instance = Protocol._().._registerHostProtocols();
 
   static String? getClassNameFromObjectJson(dynamic data) {
     if (data is! Map) return null;

--- a/tests/serverpod_auth_test/serverpod_auth_test_client/lib/src/protocol/protocol.dart
+++ b/tests/serverpod_auth_test/serverpod_auth_test_client/lib/src/protocol/protocol.dart
@@ -28,9 +28,9 @@ export 'client.dart';
 class Protocol extends _i1.SerializationManager {
   Protocol._();
 
-  factory Protocol() => _instance.._registerHostProtocols();
+  factory Protocol() => _instance;
 
-  static final Protocol _instance = Protocol._();
+  static final Protocol _instance = Protocol._().._registerHostProtocols();
 
   static String? getClassNameFromObjectJson(dynamic data) {
     if (data is! Map) return null;

--- a/tests/serverpod_auth_test/serverpod_auth_test_client/lib/src/protocol/protocol.dart
+++ b/tests/serverpod_auth_test/serverpod_auth_test_client/lib/src/protocol/protocol.dart
@@ -28,7 +28,7 @@ export 'client.dart';
 class Protocol extends _i1.SerializationManager {
   Protocol._();
 
-  factory Protocol() => _instance;
+  factory Protocol() => _instance.._registerHostProtocols();
 
   static final Protocol _instance = Protocol._();
 
@@ -120,23 +120,31 @@ class Protocol extends _i1.SerializationManager {
     }
     className = _i4.Protocol().getClassNameForObject(data);
     if (className != null) {
-      return 'serverpod_auth_bridge.$className';
+      return className.contains('.')
+          ? className
+          : 'serverpod_auth_bridge.$className';
     }
     className = _i5.Protocol().getClassNameForObject(data);
     if (className != null) {
-      return 'serverpod_auth_core.$className';
+      return className.contains('.')
+          ? className
+          : 'serverpod_auth_core.$className';
     }
     className = _i6.Protocol().getClassNameForObject(data);
     if (className != null) {
-      return 'serverpod_auth_idp.$className';
+      return className.contains('.')
+          ? className
+          : 'serverpod_auth_idp.$className';
     }
     className = _i7.Protocol().getClassNameForObject(data);
     if (className != null) {
-      return 'serverpod_auth_migration.$className';
+      return className.contains('.')
+          ? className
+          : 'serverpod_auth_migration.$className';
     }
     className = _i8.Protocol().getClassNameForObject(data);
     if (className != null) {
-      return 'serverpod_auth.$className';
+      return className.contains('.') ? className : 'serverpod_auth.$className';
     }
     return null;
   }
@@ -171,6 +179,14 @@ class Protocol extends _i1.SerializationManager {
       return _i8.Protocol().deserializeByClassName(data);
     }
     return super.deserializeByClassName(data);
+  }
+
+  void _registerHostProtocols() {
+    _i4.Protocol().registerHostProtocol('serverpod_auth_test', this);
+    _i5.Protocol().registerHostProtocol('serverpod_auth_test', this);
+    _i6.Protocol().registerHostProtocol('serverpod_auth_test', this);
+    _i7.Protocol().registerHostProtocol('serverpod_auth_test', this);
+    _i8.Protocol().registerHostProtocol('serverpod_auth_test', this);
   }
 
   /// Maps any `Record`s known to this [Protocol] to their JSON representation

--- a/tests/serverpod_auth_test/serverpod_auth_test_server/lib/src/generated/protocol.dart
+++ b/tests/serverpod_auth_test/serverpod_auth_test_server/lib/src/generated/protocol.dart
@@ -34,9 +34,9 @@ export 'user_data.dart';
 class Protocol extends _i1.DatabaseSerializationManager {
   Protocol._();
 
-  factory Protocol() => _instance.._registerHostProtocols();
+  factory Protocol() => _instance;
 
-  static final Protocol _instance = Protocol._();
+  static final Protocol _instance = Protocol._().._registerHostProtocols();
 
   static final List<_i2.TableDefinition> targetTableDefinitions = [
     _i2.TableDefinition(

--- a/tests/serverpod_auth_test/serverpod_auth_test_server/lib/src/generated/protocol.dart
+++ b/tests/serverpod_auth_test/serverpod_auth_test_server/lib/src/generated/protocol.dart
@@ -34,7 +34,7 @@ export 'user_data.dart';
 class Protocol extends _i1.DatabaseSerializationManager {
   Protocol._();
 
-  factory Protocol() => _instance;
+  factory Protocol() => _instance.._registerHostProtocols();
 
   static final Protocol _instance = Protocol._();
 
@@ -431,29 +431,37 @@ class Protocol extends _i1.DatabaseSerializationManager {
       case _i11.UserData():
         return 'UserData';
     }
-    className = _i2.Protocol().getClassNameForObject(data);
-    if (className != null) {
-      return 'serverpod.$className';
-    }
     className = _i3.Protocol().getClassNameForObject(data);
     if (className != null) {
-      return 'serverpod_auth_bridge.$className';
+      return className.contains('.')
+          ? className
+          : 'serverpod_auth_bridge.$className';
     }
     className = _i4.Protocol().getClassNameForObject(data);
     if (className != null) {
-      return 'serverpod_auth_core.$className';
+      return className.contains('.')
+          ? className
+          : 'serverpod_auth_core.$className';
     }
     className = _i5.Protocol().getClassNameForObject(data);
     if (className != null) {
-      return 'serverpod_auth_idp.$className';
+      return className.contains('.')
+          ? className
+          : 'serverpod_auth_idp.$className';
     }
     className = _i6.Protocol().getClassNameForObject(data);
     if (className != null) {
-      return 'serverpod_auth_migration.$className';
+      return className.contains('.')
+          ? className
+          : 'serverpod_auth_migration.$className';
     }
     className = _i7.Protocol().getClassNameForObject(data);
     if (className != null) {
-      return 'serverpod_auth.$className';
+      return className.contains('.') ? className : 'serverpod_auth.$className';
+    }
+    className = _i2.Protocol().getClassNameForObject(data);
+    if (className != null) {
+      return className.contains('.') ? className : 'serverpod.$className';
     }
     return null;
   }
@@ -476,10 +484,6 @@ class Protocol extends _i1.DatabaseSerializationManager {
     if (dataClassName == 'UserData') {
       return deserialize<_i11.UserData>(data['data']);
     }
-    if (dataClassName.startsWith('serverpod.')) {
-      data['className'] = dataClassName.substring(10);
-      return _i2.Protocol().deserializeByClassName(data);
-    }
     if (dataClassName.startsWith('serverpod_auth_bridge.')) {
       data['className'] = dataClassName.substring(22);
       return _i3.Protocol().deserializeByClassName(data);
@@ -500,7 +504,19 @@ class Protocol extends _i1.DatabaseSerializationManager {
       data['className'] = dataClassName.substring(15);
       return _i7.Protocol().deserializeByClassName(data);
     }
+    if (dataClassName.startsWith('serverpod.')) {
+      data['className'] = dataClassName.substring(10);
+      return _i2.Protocol().deserializeByClassName(data);
+    }
     return super.deserializeByClassName(data);
+  }
+
+  void _registerHostProtocols() {
+    _i3.Protocol().registerHostProtocol('serverpod_auth_test', this);
+    _i4.Protocol().registerHostProtocol('serverpod_auth_test', this);
+    _i5.Protocol().registerHostProtocol('serverpod_auth_test', this);
+    _i6.Protocol().registerHostProtocol('serverpod_auth_test', this);
+    _i7.Protocol().registerHostProtocol('serverpod_auth_test', this);
   }
 
   @override

--- a/tests/serverpod_test_client/lib/src/protocol/protocol.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/protocol.dart
@@ -444,7 +444,7 @@ export 'client.dart';
 class Protocol extends _i1.SerializationManager {
   Protocol._();
 
-  factory Protocol() => _instance;
+  factory Protocol() => _instance.._registerHostProtocols();
 
   static final Protocol _instance = Protocol._();
 
@@ -6470,14 +6470,6 @@ class Protocol extends _i1.SerializationManager {
       case _i204.UpsertTestModel():
         return 'UpsertTestModel';
     }
-    className = _i210.Protocol().getClassNameForObject(data);
-    if (className != null) {
-      return 'serverpod_auth.$className';
-    }
-    className = _i205.Protocol().getClassNameForObject(data);
-    if (className != null) {
-      return 'serverpod_test_module.$className';
-    }
     if (data is List<int>) {
       return 'List<int>';
     }
@@ -6536,6 +6528,22 @@ class Protocol extends _i1.SerializationManager {
     }
     if (data is List<(String, int)>?) {
       return 'List<(String,int)>?';
+    }
+    className = _i210.Protocol().getClassNameForObject(data);
+    if (className != null) {
+      return className.contains('.') ? className : 'serverpod_auth.$className';
+    }
+    className = _i205.Protocol().getClassNameForObject(data);
+    if (className != null) {
+      return className.contains('.')
+          ? className
+          : 'serverpod_test_module.$className';
+    }
+    className = _i207.Protocol().getClassNameForObject(data);
+    if (className != null) {
+      return className.contains('.')
+          ? className
+          : 'serverpod_test_shared.$className';
     }
     return null;
   }
@@ -7201,6 +7209,10 @@ class Protocol extends _i1.SerializationManager {
       data['className'] = dataClassName.substring(22);
       return _i205.Protocol().deserializeByClassName(data);
     }
+    if (dataClassName.startsWith('serverpod_test_shared.')) {
+      data['className'] = dataClassName.substring(22);
+      return _i207.Protocol().deserializeByClassName(data);
+    }
     if (dataClassName == 'List<int>') {
       return deserialize<List<int>>(data['data']);
     }
@@ -7260,6 +7272,12 @@ class Protocol extends _i1.SerializationManager {
       return deserialize<List<(String, int)>?>(data['data']);
     }
     return super.deserializeByClassName(data);
+  }
+
+  void _registerHostProtocols() {
+    _i210.Protocol().registerHostProtocol('serverpod_test', this);
+    _i205.Protocol().registerHostProtocol('serverpod_test', this);
+    _i207.Protocol().registerHostProtocol('serverpod_test', this);
   }
 
   /// Wraps serialized data with its class name so that it can be deserialized

--- a/tests/serverpod_test_client/lib/src/protocol/protocol.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/protocol.dart
@@ -444,9 +444,9 @@ export 'client.dart';
 class Protocol extends _i1.SerializationManager {
   Protocol._();
 
-  factory Protocol() => _instance.._registerHostProtocols();
+  factory Protocol() => _instance;
 
-  static final Protocol _instance = Protocol._();
+  static final Protocol _instance = Protocol._().._registerHostProtocols();
 
   static String? getClassNameFromObjectJson(dynamic data) {
     if (data is! Map) return null;

--- a/tests/serverpod_test_client/test/dynamic_on_module_test.dart
+++ b/tests/serverpod_test_client/test/dynamic_on_module_test.dart
@@ -6,6 +6,11 @@ import 'package:test/test.dart';
 void main() {
   final moduleProtocol = module.Protocol();
 
+  // Registers this project as a host on module protocols for dynamic fields.
+  // This will always be called for real projects, since the client protocol
+  // is used on the generated `Client` class.
+  client.Protocol();
+
   group(
     'Given a model from a module with a dynamic field and a project model as data,',
     () {

--- a/tests/serverpod_test_client/test/dynamic_on_module_test.dart
+++ b/tests/serverpod_test_client/test/dynamic_on_module_test.dart
@@ -1,0 +1,117 @@
+import 'package:serverpod_test_client/src/protocol/protocol.dart' as client;
+import 'package:serverpod_test_module_client/serverpod_test_module_client.dart'
+    as module;
+import 'package:test/test.dart';
+
+void main() {
+  final moduleProtocol = module.Protocol();
+
+  group(
+    'Given a model from a module with a dynamic field and a project model as data,',
+    () {
+      final simpleData = client.SimpleData(num: 1);
+      final model = module.DynamicOnModule(
+        name: 'test',
+        data: simpleData,
+      );
+
+      test(
+        'when serializing the model, '
+        'then it returns the payload with the correct class name and data.',
+        () {
+          final serialized = model.toJson();
+
+          expect(
+            serialized,
+            {
+              '__className__': 'serverpod_test_module.DynamicOnModule',
+              'name': 'test',
+              'data': {
+                'className': 'serverpod_test.SimpleData',
+                'data': simpleData.toJson(),
+              },
+            },
+          );
+        },
+      );
+
+      test(
+        'when wrapping the model with className, '
+        'then it returns the model with the correct class name and data.',
+        () {
+          final wrapped = moduleProtocol.wrapWithClassName(model);
+
+          expect(
+            wrapped,
+            {
+              'className': 'DynamicOnModule',
+              'data': model,
+            },
+          );
+        },
+      );
+    },
+  );
+
+  group(
+    'Given a serialized model from a module with a dynamic field and a project model as data,',
+    () {
+      final simpleData = client.SimpleData(num: 1);
+
+      final payload = {
+        '__className__': 'serverpod_test_module.DynamicOnModule',
+        'name': 'test',
+        'data': {
+          'className': 'serverpod_test.SimpleData',
+          'data': simpleData.toJson(),
+        },
+      };
+
+      test(
+        'when deserializing the payload, '
+        'then it returns the model with the correct class name and data.',
+        () {
+          final decoded = module.DynamicOnModule.fromJson(payload);
+
+          expect(decoded, isA<module.DynamicOnModule>());
+          expect(
+            decoded.data,
+            isA<client.SimpleData>().having((data) => data.num, 'num', 1),
+          );
+        },
+      );
+    },
+  );
+
+  group(
+    'Given a serialized model from a module with a dynamic field and a project model as data wrapped with className,',
+    () {
+      final simpleData = client.SimpleData(num: 1);
+
+      final payload = {
+        'className': 'DynamicOnModule',
+        'data': {
+          'name': 'test',
+          'data': {
+            'className': 'serverpod_test.SimpleData',
+            'data': simpleData.toJson(),
+          },
+        },
+      };
+
+      test(
+        'when deserializing the payload, '
+        'then it returns the model with the correct class name and data.',
+        () {
+          final decoded = moduleProtocol.deserializeByClassName(payload);
+
+          expect(decoded, isA<module.DynamicOnModule>());
+          expect(
+            (decoded as module.DynamicOnModule).data,
+            isA<client.SimpleData>().having((data) => data.num, 'num', 1),
+          );
+        },
+      );
+    },
+  );
+}

--- a/tests/serverpod_test_client/test/dynamic_on_shared_test.dart
+++ b/tests/serverpod_test_client/test/dynamic_on_shared_test.dart
@@ -5,6 +5,11 @@ import 'package:test/test.dart';
 void main() {
   final sharedProtocol = shared.Protocol();
 
+  // Registers this project as a host on shared protocols for dynamic fields.
+  // This will always be called for real projects, since the client protocol
+  // is used on the generated `Client` class.
+  client.Protocol();
+
   group(
     'Given a shared model with a dynamic field and a project model as data,',
     () {

--- a/tests/serverpod_test_client/test/dynamic_on_shared_test.dart
+++ b/tests/serverpod_test_client/test/dynamic_on_shared_test.dart
@@ -1,0 +1,116 @@
+import 'package:serverpod_test_client/src/protocol/protocol.dart' as client;
+import 'package:serverpod_test_shared/serverpod_test_shared.dart' as shared;
+import 'package:test/test.dart';
+
+void main() {
+  final sharedProtocol = shared.Protocol();
+
+  group(
+    'Given a shared model with a dynamic field and a project model as data,',
+    () {
+      final simpleData = client.SimpleData(num: 1);
+      final model = shared.DynamicOnShared(
+        name: 'test',
+        data: simpleData,
+      );
+
+      test(
+        'when serializing the model, '
+        'then it returns the payload with the correct class name and data.',
+        () {
+          final serialized = model.toJson();
+
+          expect(
+            serialized,
+            {
+              '__className__': 'DynamicOnShared',
+              'name': 'test',
+              'data': {
+                'className': 'serverpod_test.SimpleData',
+                'data': simpleData.toJson(),
+              },
+            },
+          );
+        },
+      );
+
+      test(
+        'when wrapping the model with className, '
+        'then it returns the model with the correct class name and data.',
+        () {
+          final wrapped = sharedProtocol.wrapWithClassName(model);
+
+          expect(
+            wrapped,
+            {
+              'className': 'DynamicOnShared',
+              'data': model,
+            },
+          );
+        },
+      );
+    },
+  );
+
+  group(
+    'Given a serialized shared model with a dynamic field and a project model as data,',
+    () {
+      final simpleData = client.SimpleData(num: 1);
+
+      final payload = {
+        '__className__': 'DynamicOnShared',
+        'name': 'test',
+        'data': {
+          'className': 'serverpod_test.SimpleData',
+          'data': simpleData.toJson(),
+        },
+      };
+
+      test(
+        'when deserializing the payload, '
+        'then it returns the model with the correct class name and data.',
+        () {
+          final decoded = shared.DynamicOnShared.fromJson(payload);
+
+          expect(decoded, isA<shared.DynamicOnShared>());
+          expect(
+            decoded.data,
+            isA<client.SimpleData>().having((data) => data.num, 'num', 1),
+          );
+        },
+      );
+    },
+  );
+
+  group(
+    'Given a serialized shared model with a dynamic field and a project model as data wrapped with className,',
+    () {
+      final simpleData = client.SimpleData(num: 1);
+
+      final payload = {
+        'className': 'DynamicOnShared',
+        'data': {
+          'name': 'test',
+          'data': {
+            'className': 'serverpod_test.SimpleData',
+            'data': simpleData.toJson(),
+          },
+        },
+      };
+
+      test(
+        'when deserializing the payload, '
+        'then it returns the model with the correct class name and data.',
+        () {
+          final decoded = sharedProtocol.deserializeByClassName(payload);
+
+          expect(decoded, isA<shared.DynamicOnShared>());
+          expect(
+            (decoded as shared.DynamicOnShared).data,
+            isA<client.SimpleData>().having((data) => data.num, 'num', 1),
+          );
+        },
+      );
+    },
+  );
+}

--- a/tests/serverpod_test_client/test/dynamic_shared_in_module_test.dart
+++ b/tests/serverpod_test_client/test/dynamic_shared_in_module_test.dart
@@ -5,6 +5,11 @@ import 'package:serverpod_test_shared/serverpod_test_shared.dart' as shared;
 import 'package:test/test.dart';
 
 void main() {
+  // Registers this project as a host on both shared and module protocols for
+  // dynamic fields. This will always be called for real projects, since the
+  // client protocol is used on the generated `Client` class.
+  client.Protocol();
+
   group(
     'Given a module model with a dynamic field and a shared model as data,',
     () {

--- a/tests/serverpod_test_client/test/dynamic_shared_in_module_test.dart
+++ b/tests/serverpod_test_client/test/dynamic_shared_in_module_test.dart
@@ -1,0 +1,51 @@
+import 'package:serverpod_test_client/src/protocol/protocol.dart' as client;
+import 'package:serverpod_test_module_client/serverpod_test_module_client.dart'
+    as module;
+import 'package:serverpod_test_shared/serverpod_test_shared.dart' as shared;
+import 'package:test/test.dart';
+
+void main() {
+  group(
+    'Given a module model with a dynamic field and a shared model as data,',
+    () {
+      final sharedModel = shared.SharedModel(name: 'test', data: 42);
+      final model = module.DynamicOnModule(
+        name: 'test',
+        data: sharedModel,
+      );
+
+      test(
+        'when serializing the model, '
+        'then it returns the payload with the correct class name and data.',
+        () {
+          final serialized = model.toJson();
+
+          expect(
+            serialized,
+            {
+              '__className__': 'serverpod_test_module.DynamicOnModule',
+              'name': 'test',
+              'data': {
+                'className': 'serverpod_test_shared.SharedModel',
+                'data': sharedModel.toJson(),
+              },
+            },
+          );
+        },
+      );
+
+      test(
+        'when deserializing the payload, '
+        'then it returns the shared model.',
+        () {
+          final decoded = module.DynamicOnModule.fromJson(model.toJson());
+
+          expect(decoded.data, isA<shared.SharedModel>());
+          final data = decoded.data as shared.SharedModel;
+          expect(data.name, 'test');
+          expect(data.data, 42);
+        },
+      );
+    },
+  );
+}

--- a/tests/serverpod_test_client/test/dynamic_shared_in_project_test.dart
+++ b/tests/serverpod_test_client/test/dynamic_shared_in_project_test.dart
@@ -4,6 +4,11 @@ import 'package:serverpod_test_shared/serverpod_test_shared.dart' as shared;
 import 'package:test/test.dart';
 
 void main() {
+  // Registers this project as a host on shared protocols for dynamic fields.
+  // This will always be called for real projects, since the client protocol
+  // is used on the generated `Client` class.
+  client.Protocol();
+
   group('Given a project model with a shared model in payload,', () {
     final sharedModel = shared.SharedModel(name: 'test', data: 42);
     final object = client.ObjectWithDynamic(

--- a/tests/serverpod_test_client/test/dynamic_shared_in_project_test.dart
+++ b/tests/serverpod_test_client/test/dynamic_shared_in_project_test.dart
@@ -1,0 +1,50 @@
+import 'package:serverpod_test_client/src/protocol/object_with_dynamic.dart';
+import 'package:serverpod_test_client/src/protocol/protocol.dart' as client;
+import 'package:serverpod_test_shared/serverpod_test_shared.dart' as shared;
+import 'package:test/test.dart';
+
+void main() {
+  group('Given a project model with a shared model in payload,', () {
+    final sharedModel = shared.SharedModel(name: 'test', data: 42);
+    final object = client.ObjectWithDynamic(
+      payload: sharedModel,
+      jsonbPayload: null,
+      payloadList: [sharedModel],
+      payloadMap: {sharedModel.name: sharedModel},
+      payloadSet: {},
+      payloadMapWithDynamicKeys: {},
+    );
+
+    test(
+      'when serializing the model, '
+      'then the dynamic field uses the shared package class name.',
+      () {
+        final serialized = object.toJson();
+
+        final expectedModelPayload = {
+          'className': 'serverpod_test_shared.SharedModel',
+          'data': sharedModel.toJson(),
+        };
+
+        expect(serialized['payload'], expectedModelPayload);
+        expect(serialized['payloadList'], [expectedModelPayload]);
+        expect(serialized['payloadMap'], {
+          sharedModel.name: expectedModelPayload,
+        });
+      },
+    );
+
+    test(
+      'when deserializing the payload, '
+      'then it returns the shared model.',
+      () {
+        final decoded = ObjectWithDynamic.fromJson(object.toJson());
+
+        expect(decoded.payload, isA<shared.SharedModel>());
+        final payload = decoded.payload as shared.SharedModel;
+        expect(payload.name, 'test');
+        expect(payload.data, 42);
+      },
+    );
+  });
+}

--- a/tests/serverpod_test_module/serverpod_test_module_client/lib/src/protocol/dynamic_on_module.dart
+++ b/tests/serverpod_test_module/serverpod_test_module_client/lib/src/protocol/dynamic_on_module.dart
@@ -1,0 +1,86 @@
+/* AUTOMATICALLY GENERATED CODE DO NOT MODIFY */
+/*   To generate run: "serverpod generate"    */
+
+// ignore_for_file: implementation_imports
+// ignore_for_file: library_private_types_in_public_api
+// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: public_member_api_docs
+// ignore_for_file: type_literal_in_constant_pattern
+// ignore_for_file: use_super_parameters
+// ignore_for_file: invalid_use_of_internal_member
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:serverpod_test_module_client/src/protocol/protocol.dart' as _i2;
+
+abstract class DynamicOnModule implements _i1.SerializableModel {
+  DynamicOnModule._({
+    required this.name,
+    required this.data,
+  });
+
+  factory DynamicOnModule({
+    required String name,
+    required dynamic data,
+  }) = _DynamicOnModuleImpl;
+
+  factory DynamicOnModule.fromJson(Map<String, dynamic> jsonSerialization) {
+    return DynamicOnModule(
+      name: jsonSerialization['name'] as String,
+      data: _i2.Protocol().deserializeDynamicFieldValue(
+        jsonSerialization['data'],
+      ),
+    );
+  }
+
+  String name;
+
+  dynamic data;
+
+  /// Returns a shallow copy of this [DynamicOnModule]
+  /// with some or all fields replaced by the given arguments.
+  @_i1.useResult
+  DynamicOnModule copyWith({
+    String? name,
+    dynamic data,
+  });
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      '__className__': 'serverpod_test_module.DynamicOnModule',
+      'name': name,
+      'data': _i2.Protocol().dynamicFieldToJson(data),
+    };
+  }
+
+  @override
+  String toString() {
+    return _i1.SerializationManager.encode(this);
+  }
+}
+
+class _Undefined {}
+
+class _DynamicOnModuleImpl extends DynamicOnModule {
+  _DynamicOnModuleImpl({
+    required String name,
+    required dynamic data,
+  }) : super._(
+         name: name,
+         data: data,
+       );
+
+  /// Returns a shallow copy of this [DynamicOnModule]
+  /// with some or all fields replaced by the given arguments.
+  @_i1.useResult
+  @override
+  DynamicOnModule copyWith({
+    String? name,
+    Object? data = _Undefined,
+  }) {
+    return DynamicOnModule(
+      name: name ?? this.name,
+      data: data != _Undefined ? data : this.data,
+    );
+  }
+}

--- a/tests/serverpod_test_module/serverpod_test_module_client/lib/src/protocol/protocol.dart
+++ b/tests/serverpod_test_module/serverpod_test_module_client/lib/src/protocol/protocol.dart
@@ -38,6 +38,15 @@ class Protocol extends _i1.SerializationManager {
 
   static final Protocol _instance = Protocol._();
 
+  final Map<String, _i1.SerializationManager> _hostProtocols = {};
+
+  void registerHostProtocol(
+    String projectName,
+    _i1.SerializationManager protocol,
+  ) {
+    _hostProtocols[projectName] = protocol;
+  }
+
   static String? getClassNameFromObjectJson(dynamic data) {
     if (data is! Map) return null;
     final className = data['__className__'] as String?;
@@ -245,6 +254,61 @@ class Protocol extends _i1.SerializationManager {
       return deserialize<(int?, _i10.ModuleStreamingClass?)>(data['data']);
     }
     return super.deserializeByClassName(data);
+  }
+
+  @override
+  Object? dynamicFieldToJson(
+    Object? object, {
+    bool forProtocol = false,
+  }) {
+    if ((object is List || object is Set || object is Map) ||
+        getClassNameForObject(object) != null) {
+      return super.dynamicFieldToJson(object, forProtocol: forProtocol);
+    }
+    for (final MapEntry(key: host, value: protocol) in _hostProtocols.entries) {
+      final className = protocol.getClassNameForObject(object);
+      if (className == null) continue;
+      final wrapped = {
+        'className': className.contains('.') ? className : '$host.$className',
+        'data': object,
+      };
+      return forProtocol
+          ? _i1.SerializationManager.toEncodableForProtocol(wrapped)
+          : _i1.SerializationManager.toEncodable(wrapped);
+    }
+    return super.dynamicFieldToJson(object, forProtocol: forProtocol);
+  }
+
+  @override
+  dynamic deserializeDynamicFieldValue(Object? value) {
+    if (value == null) return null;
+    if (value is! Map<String, dynamic> || value['className'] is! String) {
+      throw FormatException(
+        'Dynamic fields are encoded as a Map with className and data, but got '
+        '${value.runtimeType} instead.',
+      );
+    }
+    final className = value['className'] as String;
+    for (final MapEntry(key: host, value: protocol) in _hostProtocols.entries) {
+      final hostPrefix = '$host.';
+      if (className.startsWith(hostPrefix)) {
+        final strippedClassName = className.substring(hostPrefix.length);
+        if (strippedClassName.contains('.')) {
+          throw FormatException(
+            'Dynamic field className must not use multiple prefixes: $className',
+          );
+        }
+        final hostData = Map<String, dynamic>.from(value);
+        hostData['className'] = strippedClassName;
+        return protocol.deserializeByClassName(hostData);
+      }
+    }
+    if (className.contains('.')) {
+      for (final protocol in _hostProtocols.values) {
+        return protocol.deserializeByClassName(value);
+      }
+    }
+    return deserializeByClassName(value);
   }
 
   /// Wraps serialized data with its class name so that it can be deserialized

--- a/tests/serverpod_test_module/serverpod_test_module_client/lib/src/protocol/protocol.dart
+++ b/tests/serverpod_test_module/serverpod_test_module_client/lib/src/protocol/protocol.dart
@@ -305,7 +305,9 @@ class Protocol extends _i1.SerializationManager {
     }
     if (className.contains('.')) {
       for (final protocol in _hostProtocols.values) {
-        return protocol.deserializeByClassName(value);
+        try {
+          return protocol.deserializeByClassName(value);
+        } on FormatException catch (_) {}
       }
     }
     return deserializeByClassName(value);

--- a/tests/serverpod_test_module/serverpod_test_module_client/lib/src/protocol/protocol.dart
+++ b/tests/serverpod_test_module/serverpod_test_module_client/lib/src/protocol/protocol.dart
@@ -11,15 +11,17 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
-import 'generated/polymorphism/grandchild.dart' as _i2;
-import 'generated/polymorphism/child.dart' as _i3;
-import 'generated/polymorphism/parent.dart' as _i4;
-import 'module_class.dart' as _i5;
-import 'module_feature/models/my_feature_model.dart' as _i6;
-import 'module_streaming_class.dart' as _i7;
-import 'project_streaming_class.dart' as _i8;
+import 'dynamic_on_module.dart' as _i2;
+import 'generated/polymorphism/grandchild.dart' as _i3;
+import 'generated/polymorphism/child.dart' as _i4;
+import 'generated/polymorphism/parent.dart' as _i5;
+import 'module_class.dart' as _i6;
+import 'module_feature/models/my_feature_model.dart' as _i7;
+import 'module_streaming_class.dart' as _i8;
+import 'project_streaming_class.dart' as _i9;
 import 'package:serverpod_test_module_client/src/protocol/module_streaming_class.dart'
-    as _i9;
+    as _i10;
+export 'dynamic_on_module.dart';
 export 'generated/polymorphism/grandchild.dart';
 export 'generated/polymorphism/child.dart';
 export 'generated/polymorphism/parent.dart';
@@ -65,69 +67,78 @@ class Protocol extends _i1.SerializationManager {
       }
     }
 
-    if (t == _i2.ModulePolymorphicGrandChild) {
-      return _i2.ModulePolymorphicGrandChild.fromJson(data) as T;
+    if (t == _i2.DynamicOnModule) {
+      return _i2.DynamicOnModule.fromJson(data) as T;
     }
-    if (t == _i3.ModulePolymorphicChild) {
-      return _i3.ModulePolymorphicChild.fromJson(data) as T;
+    if (t == _i3.ModulePolymorphicGrandChild) {
+      return _i3.ModulePolymorphicGrandChild.fromJson(data) as T;
     }
-    if (t == _i4.ModulePolymorphicParent) {
-      return _i4.ModulePolymorphicParent.fromJson(data) as T;
+    if (t == _i4.ModulePolymorphicChild) {
+      return _i4.ModulePolymorphicChild.fromJson(data) as T;
     }
-    if (t == _i5.ModuleClass) {
-      return _i5.ModuleClass.fromJson(data) as T;
+    if (t == _i5.ModulePolymorphicParent) {
+      return _i5.ModulePolymorphicParent.fromJson(data) as T;
     }
-    if (t == _i6.MyModuleFeatureModel) {
-      return _i6.MyModuleFeatureModel.fromJson(data) as T;
+    if (t == _i6.ModuleClass) {
+      return _i6.ModuleClass.fromJson(data) as T;
     }
-    if (t == _i7.ModuleStreamingClass) {
-      return _i7.ModuleStreamingClass.fromJson(data) as T;
+    if (t == _i7.MyModuleFeatureModel) {
+      return _i7.MyModuleFeatureModel.fromJson(data) as T;
     }
-    if (t == _i8.ProjectStreamingClass) {
-      return _i8.ProjectStreamingClass.fromJson(data) as T;
+    if (t == _i8.ModuleStreamingClass) {
+      return _i8.ModuleStreamingClass.fromJson(data) as T;
     }
-    if (t == _i1.getType<_i2.ModulePolymorphicGrandChild?>()) {
+    if (t == _i9.ProjectStreamingClass) {
+      return _i9.ProjectStreamingClass.fromJson(data) as T;
+    }
+    if (t == _i1.getType<_i2.DynamicOnModule?>()) {
+      return (data != null ? _i2.DynamicOnModule.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i3.ModulePolymorphicGrandChild?>()) {
       return (data != null
-              ? _i2.ModulePolymorphicGrandChild.fromJson(data)
+              ? _i3.ModulePolymorphicGrandChild.fromJson(data)
               : null)
           as T;
     }
-    if (t == _i1.getType<_i3.ModulePolymorphicChild?>()) {
-      return (data != null ? _i3.ModulePolymorphicChild.fromJson(data) : null)
+    if (t == _i1.getType<_i4.ModulePolymorphicChild?>()) {
+      return (data != null ? _i4.ModulePolymorphicChild.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i4.ModulePolymorphicParent?>()) {
-      return (data != null ? _i4.ModulePolymorphicParent.fromJson(data) : null)
+    if (t == _i1.getType<_i5.ModulePolymorphicParent?>()) {
+      return (data != null ? _i5.ModulePolymorphicParent.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i5.ModuleClass?>()) {
-      return (data != null ? _i5.ModuleClass.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i6.ModuleClass?>()) {
+      return (data != null ? _i6.ModuleClass.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i6.MyModuleFeatureModel?>()) {
-      return (data != null ? _i6.MyModuleFeatureModel.fromJson(data) : null)
+    if (t == _i1.getType<_i7.MyModuleFeatureModel?>()) {
+      return (data != null ? _i7.MyModuleFeatureModel.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i7.ModuleStreamingClass?>()) {
-      return (data != null ? _i7.ModuleStreamingClass.fromJson(data) : null)
+    if (t == _i1.getType<_i8.ModuleStreamingClass?>()) {
+      return (data != null ? _i8.ModuleStreamingClass.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i8.ProjectStreamingClass?>()) {
-      return (data != null ? _i8.ProjectStreamingClass.fromJson(data) : null)
+    if (t == _i1.getType<_i9.ProjectStreamingClass?>()) {
+      return (data != null ? _i9.ProjectStreamingClass.fromJson(data) : null)
           as T;
+    }
+    if (t == dynamic) {
+      return deserializeDynamicFieldValue(data) as T;
     }
     if (t == _i1.getType<(bool,)?>()) {
       return (data == null)
           ? null as T
           : (deserialize<bool>(((data as Map)['p'] as List)[0]),) as T;
     }
-    if (t == _i1.getType<(int?, _i9.ModuleStreamingClass?)>()) {
+    if (t == _i1.getType<(int?, _i10.ModuleStreamingClass?)>()) {
       return (
             ((data as Map)['p'] as List)[0] == null
                 ? null
                 : deserialize<int>(data['p'][0]),
             ((data)['p'] as List)[1] == null
                 ? null
-                : deserialize<_i9.ModuleStreamingClass>(data['p'][1]),
+                : deserialize<_i10.ModuleStreamingClass>(data['p'][1]),
           )
           as T;
     }
@@ -136,14 +147,14 @@ class Protocol extends _i1.SerializationManager {
           ? null as T
           : (deserialize<bool>(((data as Map)['p'] as List)[0]),) as T;
     }
-    if (t == _i1.getType<(int?, _i9.ModuleStreamingClass?)>()) {
+    if (t == _i1.getType<(int?, _i10.ModuleStreamingClass?)>()) {
       return (
             ((data as Map)['p'] as List)[0] == null
                 ? null
                 : deserialize<int>(data['p'][0]),
             ((data)['p'] as List)[1] == null
                 ? null
-                : deserialize<_i9.ModuleStreamingClass>(data['p'][1]),
+                : deserialize<_i10.ModuleStreamingClass>(data['p'][1]),
           )
           as T;
     }
@@ -152,13 +163,14 @@ class Protocol extends _i1.SerializationManager {
 
   static String? getClassNameForType(Type type) {
     return switch (type) {
-      _i2.ModulePolymorphicGrandChild => 'ModulePolymorphicGrandChild',
-      _i3.ModulePolymorphicChild => 'ModulePolymorphicChild',
-      _i4.ModulePolymorphicParent => 'ModulePolymorphicParent',
-      _i5.ModuleClass => 'ModuleClass',
-      _i6.MyModuleFeatureModel => 'MyModuleFeatureModel',
-      _i7.ModuleStreamingClass => 'ModuleStreamingClass',
-      _i8.ProjectStreamingClass => 'ProjectStreamingClass',
+      _i2.DynamicOnModule => 'DynamicOnModule',
+      _i3.ModulePolymorphicGrandChild => 'ModulePolymorphicGrandChild',
+      _i4.ModulePolymorphicChild => 'ModulePolymorphicChild',
+      _i5.ModulePolymorphicParent => 'ModulePolymorphicParent',
+      _i6.ModuleClass => 'ModuleClass',
+      _i7.MyModuleFeatureModel => 'MyModuleFeatureModel',
+      _i8.ModuleStreamingClass => 'ModuleStreamingClass',
+      _i9.ProjectStreamingClass => 'ProjectStreamingClass',
       _ => null,
     };
   }
@@ -176,22 +188,24 @@ class Protocol extends _i1.SerializationManager {
     }
 
     switch (data) {
-      case _i2.ModulePolymorphicGrandChild():
+      case _i2.DynamicOnModule():
+        return 'DynamicOnModule';
+      case _i3.ModulePolymorphicGrandChild():
         return 'ModulePolymorphicGrandChild';
-      case _i3.ModulePolymorphicChild():
+      case _i4.ModulePolymorphicChild():
         return 'ModulePolymorphicChild';
-      case _i4.ModulePolymorphicParent():
+      case _i5.ModulePolymorphicParent():
         return 'ModulePolymorphicParent';
-      case _i5.ModuleClass():
+      case _i6.ModuleClass():
         return 'ModuleClass';
-      case _i6.MyModuleFeatureModel():
+      case _i7.MyModuleFeatureModel():
         return 'MyModuleFeatureModel';
-      case _i7.ModuleStreamingClass():
+      case _i8.ModuleStreamingClass():
         return 'ModuleStreamingClass';
-      case _i8.ProjectStreamingClass():
+      case _i9.ProjectStreamingClass():
         return 'ProjectStreamingClass';
     }
-    if (data is (int?, _i9.ModuleStreamingClass?)) {
+    if (data is (int?, _i10.ModuleStreamingClass?)) {
       return '(int?,ModuleStreamingClass?)';
     }
     return null;
@@ -203,29 +217,32 @@ class Protocol extends _i1.SerializationManager {
     if (dataClassName is! String) {
       return super.deserializeByClassName(data);
     }
+    if (dataClassName == 'DynamicOnModule') {
+      return deserialize<_i2.DynamicOnModule>(data['data']);
+    }
     if (dataClassName == 'ModulePolymorphicGrandChild') {
-      return deserialize<_i2.ModulePolymorphicGrandChild>(data['data']);
+      return deserialize<_i3.ModulePolymorphicGrandChild>(data['data']);
     }
     if (dataClassName == 'ModulePolymorphicChild') {
-      return deserialize<_i3.ModulePolymorphicChild>(data['data']);
+      return deserialize<_i4.ModulePolymorphicChild>(data['data']);
     }
     if (dataClassName == 'ModulePolymorphicParent') {
-      return deserialize<_i4.ModulePolymorphicParent>(data['data']);
+      return deserialize<_i5.ModulePolymorphicParent>(data['data']);
     }
     if (dataClassName == 'ModuleClass') {
-      return deserialize<_i5.ModuleClass>(data['data']);
+      return deserialize<_i6.ModuleClass>(data['data']);
     }
     if (dataClassName == 'MyModuleFeatureModel') {
-      return deserialize<_i6.MyModuleFeatureModel>(data['data']);
+      return deserialize<_i7.MyModuleFeatureModel>(data['data']);
     }
     if (dataClassName == 'ModuleStreamingClass') {
-      return deserialize<_i7.ModuleStreamingClass>(data['data']);
+      return deserialize<_i8.ModuleStreamingClass>(data['data']);
     }
     if (dataClassName == 'ProjectStreamingClass') {
-      return deserialize<_i8.ProjectStreamingClass>(data['data']);
+      return deserialize<_i9.ProjectStreamingClass>(data['data']);
     }
     if (dataClassName == '(int?,ModuleStreamingClass?)') {
-      return deserialize<(int?, _i9.ModuleStreamingClass?)>(data['data']);
+      return deserialize<(int?, _i10.ModuleStreamingClass?)>(data['data']);
     }
     return super.deserializeByClassName(data);
   }
@@ -261,7 +278,7 @@ class Protocol extends _i1.SerializationManager {
     if (record == null) {
       return null;
     }
-    if (record is (int?, _i9.ModuleStreamingClass?)) {
+    if (record is (int?, _i10.ModuleStreamingClass?)) {
       return {
         "p": [
           record.$1,

--- a/tests/serverpod_test_module/serverpod_test_module_server/lib/src/generated/dynamic_on_module.dart
+++ b/tests/serverpod_test_module/serverpod_test_module_server/lib/src/generated/dynamic_on_module.dart
@@ -60,7 +60,10 @@ abstract class DynamicOnModule
     return {
       '__className__': 'serverpod_test_module.DynamicOnModule',
       'name': name,
-      'data': _i2.Protocol().dynamicFieldToJsonForProtocol(data),
+      'data': _i2.Protocol().dynamicFieldToJson(
+        data,
+        forProtocol: true,
+      ),
     };
   }
 

--- a/tests/serverpod_test_module/serverpod_test_module_server/lib/src/generated/dynamic_on_module.dart
+++ b/tests/serverpod_test_module/serverpod_test_module_server/lib/src/generated/dynamic_on_module.dart
@@ -1,0 +1,97 @@
+/* AUTOMATICALLY GENERATED CODE DO NOT MODIFY */
+/*   To generate run: "serverpod generate"    */
+
+// ignore_for_file: implementation_imports
+// ignore_for_file: library_private_types_in_public_api
+// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: public_member_api_docs
+// ignore_for_file: type_literal_in_constant_pattern
+// ignore_for_file: use_super_parameters
+// ignore_for_file: invalid_use_of_internal_member
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:serverpod_test_module_server/src/generated/protocol.dart'
+    as _i2;
+
+abstract class DynamicOnModule
+    implements _i1.SerializableModel, _i1.ProtocolSerialization {
+  DynamicOnModule._({
+    required this.name,
+    required this.data,
+  });
+
+  factory DynamicOnModule({
+    required String name,
+    required dynamic data,
+  }) = _DynamicOnModuleImpl;
+
+  factory DynamicOnModule.fromJson(Map<String, dynamic> jsonSerialization) {
+    return DynamicOnModule(
+      name: jsonSerialization['name'] as String,
+      data: _i2.Protocol().deserializeDynamicFieldValue(
+        jsonSerialization['data'],
+      ),
+    );
+  }
+
+  String name;
+
+  dynamic data;
+
+  /// Returns a shallow copy of this [DynamicOnModule]
+  /// with some or all fields replaced by the given arguments.
+  @_i1.useResult
+  DynamicOnModule copyWith({
+    String? name,
+    dynamic data,
+  });
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      '__className__': 'serverpod_test_module.DynamicOnModule',
+      'name': name,
+      'data': _i2.Protocol().dynamicFieldToJson(data),
+    };
+  }
+
+  @override
+  Map<String, dynamic> toJsonForProtocol() {
+    return {
+      '__className__': 'serverpod_test_module.DynamicOnModule',
+      'name': name,
+      'data': _i2.Protocol().dynamicFieldToJsonForProtocol(data),
+    };
+  }
+
+  @override
+  String toString() {
+    return _i1.SerializationManager.encode(this);
+  }
+}
+
+class _Undefined {}
+
+class _DynamicOnModuleImpl extends DynamicOnModule {
+  _DynamicOnModuleImpl({
+    required String name,
+    required dynamic data,
+  }) : super._(
+         name: name,
+         data: data,
+       );
+
+  /// Returns a shallow copy of this [DynamicOnModule]
+  /// with some or all fields replaced by the given arguments.
+  @_i1.useResult
+  @override
+  DynamicOnModule copyWith({
+    String? name,
+    Object? data = _Undefined,
+  }) {
+    return DynamicOnModule(
+      name: name ?? this.name,
+      data: data != _Undefined ? data : this.data,
+    );
+  }
+}

--- a/tests/serverpod_test_module/serverpod_test_module_server/lib/src/generated/protocol.dart
+++ b/tests/serverpod_test_module/serverpod_test_module_server/lib/src/generated/protocol.dart
@@ -318,7 +318,9 @@ class Protocol extends _i1.DatabaseSerializationManager {
     }
     if (className.contains('.')) {
       for (final protocol in _hostProtocols.values) {
-        return protocol.deserializeByClassName(value);
+        try {
+          return protocol.deserializeByClassName(value);
+        } on FormatException catch (_) {}
       }
     }
     return deserializeByClassName(value);

--- a/tests/serverpod_test_module/serverpod_test_module_server/lib/src/generated/protocol.dart
+++ b/tests/serverpod_test_module/serverpod_test_module_server/lib/src/generated/protocol.dart
@@ -40,6 +40,15 @@ class Protocol extends _i1.DatabaseSerializationManager {
 
   static final List<_i2.TableDefinition> targetTableDefinitions = [];
 
+  final Map<String, _i1.SerializationManager> _hostProtocols = {};
+
+  void registerHostProtocol(
+    String projectName,
+    _i1.SerializationManager protocol,
+  ) {
+    _hostProtocols[projectName] = protocol;
+  }
+
   static String? getClassNameFromObjectJson(dynamic data) {
     if (data is! Map) return null;
     final className = data['__className__'] as String?;
@@ -210,12 +219,12 @@ class Protocol extends _i1.DatabaseSerializationManager {
       case _i10.ProjectStreamingClass():
         return 'ProjectStreamingClass';
     }
-    className = _i2.Protocol().getClassNameForObject(data);
-    if (className != null) {
-      return 'serverpod.$className';
-    }
     if (data is (int?, _i11.ModuleStreamingClass?)) {
       return '(int?,ModuleStreamingClass?)';
+    }
+    className = _i2.Protocol().getClassNameForObject(data);
+    if (className != null) {
+      return className.contains('.') ? className : 'serverpod.$className';
     }
     return null;
   }
@@ -258,6 +267,61 @@ class Protocol extends _i1.DatabaseSerializationManager {
       return deserialize<(int?, _i11.ModuleStreamingClass?)>(data['data']);
     }
     return super.deserializeByClassName(data);
+  }
+
+  @override
+  Object? dynamicFieldToJson(
+    Object? object, {
+    bool forProtocol = false,
+  }) {
+    if ((object is List || object is Set || object is Map) ||
+        getClassNameForObject(object) != null) {
+      return super.dynamicFieldToJson(object, forProtocol: forProtocol);
+    }
+    for (final MapEntry(key: host, value: protocol) in _hostProtocols.entries) {
+      final className = protocol.getClassNameForObject(object);
+      if (className == null) continue;
+      final wrapped = {
+        'className': className.contains('.') ? className : '$host.$className',
+        'data': object,
+      };
+      return forProtocol
+          ? _i1.SerializationManager.toEncodableForProtocol(wrapped)
+          : _i1.SerializationManager.toEncodable(wrapped);
+    }
+    return super.dynamicFieldToJson(object, forProtocol: forProtocol);
+  }
+
+  @override
+  dynamic deserializeDynamicFieldValue(Object? value) {
+    if (value == null) return null;
+    if (value is! Map<String, dynamic> || value['className'] is! String) {
+      throw FormatException(
+        'Dynamic fields are encoded as a Map with className and data, but got '
+        '${value.runtimeType} instead.',
+      );
+    }
+    final className = value['className'] as String;
+    for (final MapEntry(key: host, value: protocol) in _hostProtocols.entries) {
+      final hostPrefix = '$host.';
+      if (className.startsWith(hostPrefix)) {
+        final strippedClassName = className.substring(hostPrefix.length);
+        if (strippedClassName.contains('.')) {
+          throw FormatException(
+            'Dynamic field className must not use multiple prefixes: $className',
+          );
+        }
+        final hostData = Map<String, dynamic>.from(value);
+        hostData['className'] = strippedClassName;
+        return protocol.deserializeByClassName(hostData);
+      }
+    }
+    if (className.contains('.')) {
+      for (final protocol in _hostProtocols.values) {
+        return protocol.deserializeByClassName(value);
+      }
+    }
+    return deserializeByClassName(value);
   }
 
   @override

--- a/tests/serverpod_test_module/serverpod_test_module_server/lib/src/generated/protocol.dart
+++ b/tests/serverpod_test_module/serverpod_test_module_server/lib/src/generated/protocol.dart
@@ -12,15 +12,17 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'package:serverpod/protocol.dart' as _i2;
-import 'generated/polymorphism/grandchild.dart' as _i3;
-import 'generated/polymorphism/child.dart' as _i4;
-import 'generated/polymorphism/parent.dart' as _i5;
-import 'module_class.dart' as _i6;
-import 'module_feature/models/my_feature_model.dart' as _i7;
-import 'module_streaming_class.dart' as _i8;
-import 'project_streaming_class.dart' as _i9;
+import 'dynamic_on_module.dart' as _i3;
+import 'generated/polymorphism/grandchild.dart' as _i4;
+import 'generated/polymorphism/child.dart' as _i5;
+import 'generated/polymorphism/parent.dart' as _i6;
+import 'module_class.dart' as _i7;
+import 'module_feature/models/my_feature_model.dart' as _i8;
+import 'module_streaming_class.dart' as _i9;
+import 'project_streaming_class.dart' as _i10;
 import 'package:serverpod_test_module_server/src/generated/module_streaming_class.dart'
-    as _i10;
+    as _i11;
+export 'dynamic_on_module.dart';
 export 'generated/polymorphism/grandchild.dart';
 export 'generated/polymorphism/child.dart';
 export 'generated/polymorphism/parent.dart';
@@ -67,69 +69,78 @@ class Protocol extends _i1.DatabaseSerializationManager {
       }
     }
 
-    if (t == _i3.ModulePolymorphicGrandChild) {
-      return _i3.ModulePolymorphicGrandChild.fromJson(data) as T;
+    if (t == _i3.DynamicOnModule) {
+      return _i3.DynamicOnModule.fromJson(data) as T;
     }
-    if (t == _i4.ModulePolymorphicChild) {
-      return _i4.ModulePolymorphicChild.fromJson(data) as T;
+    if (t == _i4.ModulePolymorphicGrandChild) {
+      return _i4.ModulePolymorphicGrandChild.fromJson(data) as T;
     }
-    if (t == _i5.ModulePolymorphicParent) {
-      return _i5.ModulePolymorphicParent.fromJson(data) as T;
+    if (t == _i5.ModulePolymorphicChild) {
+      return _i5.ModulePolymorphicChild.fromJson(data) as T;
     }
-    if (t == _i6.ModuleClass) {
-      return _i6.ModuleClass.fromJson(data) as T;
+    if (t == _i6.ModulePolymorphicParent) {
+      return _i6.ModulePolymorphicParent.fromJson(data) as T;
     }
-    if (t == _i7.MyModuleFeatureModel) {
-      return _i7.MyModuleFeatureModel.fromJson(data) as T;
+    if (t == _i7.ModuleClass) {
+      return _i7.ModuleClass.fromJson(data) as T;
     }
-    if (t == _i8.ModuleStreamingClass) {
-      return _i8.ModuleStreamingClass.fromJson(data) as T;
+    if (t == _i8.MyModuleFeatureModel) {
+      return _i8.MyModuleFeatureModel.fromJson(data) as T;
     }
-    if (t == _i9.ProjectStreamingClass) {
-      return _i9.ProjectStreamingClass.fromJson(data) as T;
+    if (t == _i9.ModuleStreamingClass) {
+      return _i9.ModuleStreamingClass.fromJson(data) as T;
     }
-    if (t == _i1.getType<_i3.ModulePolymorphicGrandChild?>()) {
+    if (t == _i10.ProjectStreamingClass) {
+      return _i10.ProjectStreamingClass.fromJson(data) as T;
+    }
+    if (t == _i1.getType<_i3.DynamicOnModule?>()) {
+      return (data != null ? _i3.DynamicOnModule.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i4.ModulePolymorphicGrandChild?>()) {
       return (data != null
-              ? _i3.ModulePolymorphicGrandChild.fromJson(data)
+              ? _i4.ModulePolymorphicGrandChild.fromJson(data)
               : null)
           as T;
     }
-    if (t == _i1.getType<_i4.ModulePolymorphicChild?>()) {
-      return (data != null ? _i4.ModulePolymorphicChild.fromJson(data) : null)
+    if (t == _i1.getType<_i5.ModulePolymorphicChild?>()) {
+      return (data != null ? _i5.ModulePolymorphicChild.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i5.ModulePolymorphicParent?>()) {
-      return (data != null ? _i5.ModulePolymorphicParent.fromJson(data) : null)
+    if (t == _i1.getType<_i6.ModulePolymorphicParent?>()) {
+      return (data != null ? _i6.ModulePolymorphicParent.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i6.ModuleClass?>()) {
-      return (data != null ? _i6.ModuleClass.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i7.ModuleClass?>()) {
+      return (data != null ? _i7.ModuleClass.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i7.MyModuleFeatureModel?>()) {
-      return (data != null ? _i7.MyModuleFeatureModel.fromJson(data) : null)
+    if (t == _i1.getType<_i8.MyModuleFeatureModel?>()) {
+      return (data != null ? _i8.MyModuleFeatureModel.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i8.ModuleStreamingClass?>()) {
-      return (data != null ? _i8.ModuleStreamingClass.fromJson(data) : null)
+    if (t == _i1.getType<_i9.ModuleStreamingClass?>()) {
+      return (data != null ? _i9.ModuleStreamingClass.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i9.ProjectStreamingClass?>()) {
-      return (data != null ? _i9.ProjectStreamingClass.fromJson(data) : null)
+    if (t == _i1.getType<_i10.ProjectStreamingClass?>()) {
+      return (data != null ? _i10.ProjectStreamingClass.fromJson(data) : null)
           as T;
+    }
+    if (t == dynamic) {
+      return deserializeDynamicFieldValue(data) as T;
     }
     if (t == _i1.getType<(bool,)?>()) {
       return (data == null)
           ? null as T
           : (deserialize<bool>(((data as Map)['p'] as List)[0]),) as T;
     }
-    if (t == _i1.getType<(int?, _i10.ModuleStreamingClass?)>()) {
+    if (t == _i1.getType<(int?, _i11.ModuleStreamingClass?)>()) {
       return (
             ((data as Map)['p'] as List)[0] == null
                 ? null
                 : deserialize<int>(data['p'][0]),
             ((data)['p'] as List)[1] == null
                 ? null
-                : deserialize<_i10.ModuleStreamingClass>(data['p'][1]),
+                : deserialize<_i11.ModuleStreamingClass>(data['p'][1]),
           )
           as T;
     }
@@ -138,14 +149,14 @@ class Protocol extends _i1.DatabaseSerializationManager {
           ? null as T
           : (deserialize<bool>(((data as Map)['p'] as List)[0]),) as T;
     }
-    if (t == _i1.getType<(int?, _i10.ModuleStreamingClass?)>()) {
+    if (t == _i1.getType<(int?, _i11.ModuleStreamingClass?)>()) {
       return (
             ((data as Map)['p'] as List)[0] == null
                 ? null
                 : deserialize<int>(data['p'][0]),
             ((data)['p'] as List)[1] == null
                 ? null
-                : deserialize<_i10.ModuleStreamingClass>(data['p'][1]),
+                : deserialize<_i11.ModuleStreamingClass>(data['p'][1]),
           )
           as T;
     }
@@ -157,13 +168,14 @@ class Protocol extends _i1.DatabaseSerializationManager {
 
   static String? getClassNameForType(Type type) {
     return switch (type) {
-      _i3.ModulePolymorphicGrandChild => 'ModulePolymorphicGrandChild',
-      _i4.ModulePolymorphicChild => 'ModulePolymorphicChild',
-      _i5.ModulePolymorphicParent => 'ModulePolymorphicParent',
-      _i6.ModuleClass => 'ModuleClass',
-      _i7.MyModuleFeatureModel => 'MyModuleFeatureModel',
-      _i8.ModuleStreamingClass => 'ModuleStreamingClass',
-      _i9.ProjectStreamingClass => 'ProjectStreamingClass',
+      _i3.DynamicOnModule => 'DynamicOnModule',
+      _i4.ModulePolymorphicGrandChild => 'ModulePolymorphicGrandChild',
+      _i5.ModulePolymorphicChild => 'ModulePolymorphicChild',
+      _i6.ModulePolymorphicParent => 'ModulePolymorphicParent',
+      _i7.ModuleClass => 'ModuleClass',
+      _i8.MyModuleFeatureModel => 'MyModuleFeatureModel',
+      _i9.ModuleStreamingClass => 'ModuleStreamingClass',
+      _i10.ProjectStreamingClass => 'ProjectStreamingClass',
       _ => null,
     };
   }
@@ -181,26 +193,28 @@ class Protocol extends _i1.DatabaseSerializationManager {
     }
 
     switch (data) {
-      case _i3.ModulePolymorphicGrandChild():
+      case _i3.DynamicOnModule():
+        return 'DynamicOnModule';
+      case _i4.ModulePolymorphicGrandChild():
         return 'ModulePolymorphicGrandChild';
-      case _i4.ModulePolymorphicChild():
+      case _i5.ModulePolymorphicChild():
         return 'ModulePolymorphicChild';
-      case _i5.ModulePolymorphicParent():
+      case _i6.ModulePolymorphicParent():
         return 'ModulePolymorphicParent';
-      case _i6.ModuleClass():
+      case _i7.ModuleClass():
         return 'ModuleClass';
-      case _i7.MyModuleFeatureModel():
+      case _i8.MyModuleFeatureModel():
         return 'MyModuleFeatureModel';
-      case _i8.ModuleStreamingClass():
+      case _i9.ModuleStreamingClass():
         return 'ModuleStreamingClass';
-      case _i9.ProjectStreamingClass():
+      case _i10.ProjectStreamingClass():
         return 'ProjectStreamingClass';
     }
     className = _i2.Protocol().getClassNameForObject(data);
     if (className != null) {
       return 'serverpod.$className';
     }
-    if (data is (int?, _i10.ModuleStreamingClass?)) {
+    if (data is (int?, _i11.ModuleStreamingClass?)) {
       return '(int?,ModuleStreamingClass?)';
     }
     return null;
@@ -212,33 +226,36 @@ class Protocol extends _i1.DatabaseSerializationManager {
     if (dataClassName is! String) {
       return super.deserializeByClassName(data);
     }
+    if (dataClassName == 'DynamicOnModule') {
+      return deserialize<_i3.DynamicOnModule>(data['data']);
+    }
     if (dataClassName == 'ModulePolymorphicGrandChild') {
-      return deserialize<_i3.ModulePolymorphicGrandChild>(data['data']);
+      return deserialize<_i4.ModulePolymorphicGrandChild>(data['data']);
     }
     if (dataClassName == 'ModulePolymorphicChild') {
-      return deserialize<_i4.ModulePolymorphicChild>(data['data']);
+      return deserialize<_i5.ModulePolymorphicChild>(data['data']);
     }
     if (dataClassName == 'ModulePolymorphicParent') {
-      return deserialize<_i5.ModulePolymorphicParent>(data['data']);
+      return deserialize<_i6.ModulePolymorphicParent>(data['data']);
     }
     if (dataClassName == 'ModuleClass') {
-      return deserialize<_i6.ModuleClass>(data['data']);
+      return deserialize<_i7.ModuleClass>(data['data']);
     }
     if (dataClassName == 'MyModuleFeatureModel') {
-      return deserialize<_i7.MyModuleFeatureModel>(data['data']);
+      return deserialize<_i8.MyModuleFeatureModel>(data['data']);
     }
     if (dataClassName == 'ModuleStreamingClass') {
-      return deserialize<_i8.ModuleStreamingClass>(data['data']);
+      return deserialize<_i9.ModuleStreamingClass>(data['data']);
     }
     if (dataClassName == 'ProjectStreamingClass') {
-      return deserialize<_i9.ProjectStreamingClass>(data['data']);
+      return deserialize<_i10.ProjectStreamingClass>(data['data']);
     }
     if (dataClassName.startsWith('serverpod.')) {
       data['className'] = dataClassName.substring(10);
       return _i2.Protocol().deserializeByClassName(data);
     }
     if (dataClassName == '(int?,ModuleStreamingClass?)') {
-      return deserialize<(int?, _i10.ModuleStreamingClass?)>(data['data']);
+      return deserialize<(int?, _i11.ModuleStreamingClass?)>(data['data']);
     }
     return super.deserializeByClassName(data);
   }
@@ -292,7 +309,7 @@ class Protocol extends _i1.DatabaseSerializationManager {
     if (record == null) {
       return null;
     }
-    if (record is (int?, _i10.ModuleStreamingClass?)) {
+    if (record is (int?, _i11.ModuleStreamingClass?)) {
       return {
         "p": [
           record.$1,

--- a/tests/serverpod_test_module/serverpod_test_module_server/lib/src/models/dynamic_on_module.spy.yaml
+++ b/tests/serverpod_test_module/serverpod_test_module_server/lib/src/models/dynamic_on_module.spy.yaml
@@ -1,0 +1,4 @@
+class: DynamicOnModule
+fields:
+  name: String
+  data: dynamic

--- a/tests/serverpod_test_nonvector/serverpod_test_nonvector_server/lib/src/generated/protocol.dart
+++ b/tests/serverpod_test_nonvector/serverpod_test_nonvector_server/lib/src/generated/protocol.dart
@@ -126,7 +126,7 @@ class Protocol extends _i1.DatabaseSerializationManager {
     }
     className = _i2.Protocol().getClassNameForObject(data);
     if (className != null) {
-      return 'serverpod.$className';
+      return className.contains('.') ? className : 'serverpod.$className';
     }
     return null;
   }

--- a/tests/serverpod_test_server/lib/src/generated/object_with_dynamic.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_dynamic.dart
@@ -122,22 +122,41 @@ abstract class ObjectWithDynamic
     return {
       '__className__': 'ObjectWithDynamic',
       if (id != null) 'id': id,
-      'payload': _i2.Protocol().dynamicFieldToJsonForProtocol(payload),
-      'jsonbPayload': _i2.Protocol().dynamicFieldToJsonForProtocol(
+      'payload': _i2.Protocol().dynamicFieldToJson(
+        payload,
+        forProtocol: true,
+      ),
+      'jsonbPayload': _i2.Protocol().dynamicFieldToJson(
         jsonbPayload,
+        forProtocol: true,
       ),
       'payloadList': payloadList.toJson(
-        valueToJson: (v) => _i2.Protocol().dynamicFieldToJsonForProtocol(v),
+        valueToJson: (v) => _i2.Protocol().dynamicFieldToJson(
+          v,
+          forProtocol: true,
+        ),
       ),
       'payloadMap': payloadMap.toJson(
-        valueToJson: (v) => _i2.Protocol().dynamicFieldToJsonForProtocol(v),
+        valueToJson: (v) => _i2.Protocol().dynamicFieldToJson(
+          v,
+          forProtocol: true,
+        ),
       ),
       'payloadSet': payloadSet.toJson(
-        valueToJson: (v) => _i2.Protocol().dynamicFieldToJsonForProtocol(v),
+        valueToJson: (v) => _i2.Protocol().dynamicFieldToJson(
+          v,
+          forProtocol: true,
+        ),
       ),
       'payloadMapWithDynamicKeys': payloadMapWithDynamicKeys.toJson(
-        keyToJson: (k) => _i2.Protocol().dynamicFieldToJsonForProtocol(k),
-        valueToJson: (v) => _i2.Protocol().dynamicFieldToJsonForProtocol(v),
+        keyToJson: (k) => _i2.Protocol().dynamicFieldToJson(
+          k,
+          forProtocol: true,
+        ),
+        valueToJson: (v) => _i2.Protocol().dynamicFieldToJson(
+          v,
+          forProtocol: true,
+        ),
       ),
     };
   }

--- a/tests/serverpod_test_server/lib/src/generated/protocol.dart
+++ b/tests/serverpod_test_server/lib/src/generated/protocol.dart
@@ -468,9 +468,9 @@ export 'upsert_test_model.dart';
 class Protocol extends _i1.DatabaseSerializationManager {
   Protocol._();
 
-  factory Protocol() => _instance.._registerHostProtocols();
+  factory Protocol() => _instance;
 
-  static final Protocol _instance = Protocol._();
+  static final Protocol _instance = Protocol._().._registerHostProtocols();
 
   static final List<_i2.TableDefinition> targetTableDefinitions = [
     _i2.TableDefinition(

--- a/tests/serverpod_test_server/lib/src/generated/protocol.dart
+++ b/tests/serverpod_test_server/lib/src/generated/protocol.dart
@@ -468,7 +468,7 @@ export 'upsert_test_model.dart';
 class Protocol extends _i1.DatabaseSerializationManager {
   Protocol._();
 
-  factory Protocol() => _instance;
+  factory Protocol() => _instance.._registerHostProtocols();
 
   static final Protocol _instance = Protocol._();
 
@@ -12439,18 +12439,6 @@ class Protocol extends _i1.DatabaseSerializationManager {
       case _i219.UpsertTestModel():
         return 'UpsertTestModel';
     }
-    className = _i2.Protocol().getClassNameForObject(data);
-    if (className != null) {
-      return 'serverpod.$className';
-    }
-    className = _i3.Protocol().getClassNameForObject(data);
-    if (className != null) {
-      return 'serverpod_auth.$className';
-    }
-    className = _i4.Protocol().getClassNameForObject(data);
-    if (className != null) {
-      return 'serverpod_test_module.$className';
-    }
     if (data is List<int>) {
       return 'List<int>';
     }
@@ -12509,6 +12497,26 @@ class Protocol extends _i1.DatabaseSerializationManager {
     }
     if (data is List<(String, int)>?) {
       return 'List<(String,int)>?';
+    }
+    className = _i3.Protocol().getClassNameForObject(data);
+    if (className != null) {
+      return className.contains('.') ? className : 'serverpod_auth.$className';
+    }
+    className = _i4.Protocol().getClassNameForObject(data);
+    if (className != null) {
+      return className.contains('.')
+          ? className
+          : 'serverpod_test_module.$className';
+    }
+    className = _i221.Protocol().getClassNameForObject(data);
+    if (className != null) {
+      return className.contains('.')
+          ? className
+          : 'serverpod_test_shared.$className';
+    }
+    className = _i2.Protocol().getClassNameForObject(data);
+    if (className != null) {
+      return className.contains('.') ? className : 'serverpod.$className';
     }
     return null;
   }
@@ -13204,10 +13212,6 @@ class Protocol extends _i1.DatabaseSerializationManager {
     if (dataClassName == 'UpsertTestModel') {
       return deserialize<_i219.UpsertTestModel>(data['data']);
     }
-    if (dataClassName.startsWith('serverpod.')) {
-      data['className'] = dataClassName.substring(10);
-      return _i2.Protocol().deserializeByClassName(data);
-    }
     if (dataClassName.startsWith('serverpod_auth.')) {
       data['className'] = dataClassName.substring(15);
       return _i3.Protocol().deserializeByClassName(data);
@@ -13215,6 +13219,14 @@ class Protocol extends _i1.DatabaseSerializationManager {
     if (dataClassName.startsWith('serverpod_test_module.')) {
       data['className'] = dataClassName.substring(22);
       return _i4.Protocol().deserializeByClassName(data);
+    }
+    if (dataClassName.startsWith('serverpod_test_shared.')) {
+      data['className'] = dataClassName.substring(22);
+      return _i221.Protocol().deserializeByClassName(data);
+    }
+    if (dataClassName.startsWith('serverpod.')) {
+      data['className'] = dataClassName.substring(10);
+      return _i2.Protocol().deserializeByClassName(data);
     }
     if (dataClassName == 'List<int>') {
       return deserialize<List<int>>(data['data']);
@@ -13275,6 +13287,12 @@ class Protocol extends _i1.DatabaseSerializationManager {
       return deserialize<List<(String, int)>?>(data['data']);
     }
     return super.deserializeByClassName(data);
+  }
+
+  void _registerHostProtocols() {
+    _i3.Protocol().registerHostProtocol('serverpod_test', this);
+    _i4.Protocol().registerHostProtocol('serverpod_test', this);
+    _i221.Protocol().registerHostProtocol('serverpod_test', this);
   }
 
   @override

--- a/tests/serverpod_test_server/test/dynamic_on_module_test.dart
+++ b/tests/serverpod_test_server/test/dynamic_on_module_test.dart
@@ -6,6 +6,11 @@ import 'package:test/test.dart';
 void main() {
   final moduleProtocol = module.Protocol();
 
+  // Registers this project as a host on module protocols for dynamic fields.
+  // This will always be called for real projects, since the server protocol
+  // is passed to the `Serverpod` constructor.
+  server.Protocol();
+
   group(
     'Given a model from a module with a dynamic field and a project model as data,',
     () {

--- a/tests/serverpod_test_server/test/dynamic_on_module_test.dart
+++ b/tests/serverpod_test_server/test/dynamic_on_module_test.dart
@@ -1,0 +1,117 @@
+import 'package:serverpod_test_server/src/generated/protocol.dart' as server;
+import 'package:serverpod_test_module_server/serverpod_test_module_server.dart'
+    as module;
+import 'package:test/test.dart';
+
+void main() {
+  final moduleProtocol = module.Protocol();
+
+  group(
+    'Given a model from a module with a dynamic field and a project model as data,',
+    () {
+      final simpleData = server.SimpleData(num: 1);
+      final model = module.DynamicOnModule(
+        name: 'test',
+        data: simpleData,
+      );
+
+      test(
+        'when serializing the model, '
+        'then it returns the payload with the correct class name and data.',
+        () {
+          final serialized = model.toJson();
+
+          expect(
+            serialized,
+            {
+              '__className__': 'serverpod_test_module.DynamicOnModule',
+              'name': 'test',
+              'data': {
+                'className': 'serverpod_test.SimpleData',
+                'data': simpleData.toJson(),
+              },
+            },
+          );
+        },
+      );
+
+      test(
+        'when wrapping the model with className, '
+        'then it returns the model with the correct class name and data.',
+        () {
+          final wrapped = moduleProtocol.wrapWithClassName(model);
+
+          expect(
+            wrapped,
+            {
+              'className': 'DynamicOnModule',
+              'data': model,
+            },
+          );
+        },
+      );
+    },
+  );
+
+  group(
+    'Given a serialized model from a module with a dynamic field and a project model as data,',
+    () {
+      final simpleData = server.SimpleData(num: 1);
+
+      final payload = {
+        '__className__': 'serverpod_test_module.DynamicOnModule',
+        'name': 'test',
+        'data': {
+          'className': 'serverpod_test.SimpleData',
+          'data': simpleData.toJson(),
+        },
+      };
+
+      test(
+        'when deserializing the payload, '
+        'then it returns the model with the correct class name and data.',
+        () {
+          final decoded = module.DynamicOnModule.fromJson(payload);
+
+          expect(decoded, isA<module.DynamicOnModule>());
+          expect(
+            decoded.data,
+            isA<server.SimpleData>().having((data) => data.num, 'num', 1),
+          );
+        },
+      );
+    },
+  );
+
+  group(
+    'Given a serialized model from a module with a dynamic field and a project model as data wrapped with className,',
+    () {
+      final simpleData = server.SimpleData(num: 1);
+
+      final payload = {
+        'className': 'DynamicOnModule',
+        'data': {
+          'name': 'test',
+          'data': {
+            'className': 'serverpod_test.SimpleData',
+            'data': simpleData.toJson(),
+          },
+        },
+      };
+
+      test(
+        'when deserializing the payload, '
+        'then it returns the model with the correct class name and data.',
+        () {
+          final decoded = moduleProtocol.deserializeByClassName(payload);
+
+          expect(decoded, isA<module.DynamicOnModule>());
+          expect(
+            (decoded as module.DynamicOnModule).data,
+            isA<server.SimpleData>().having((data) => data.num, 'num', 1),
+          );
+        },
+      );
+    },
+  );
+}

--- a/tests/serverpod_test_server/test/dynamic_on_shared_test.dart
+++ b/tests/serverpod_test_server/test/dynamic_on_shared_test.dart
@@ -5,6 +5,11 @@ import 'package:test/test.dart';
 void main() {
   final sharedProtocol = shared.Protocol();
 
+  // Registers this project as a host on shared protocols for dynamic fields.
+  // This will always be called for real projects, since the server protocol
+  // is passed to the `Serverpod` constructor.
+  server.Protocol();
+
   group(
     'Given a shared model with a dynamic field and a project model as data,',
     () {

--- a/tests/serverpod_test_server/test/dynamic_on_shared_test.dart
+++ b/tests/serverpod_test_server/test/dynamic_on_shared_test.dart
@@ -1,0 +1,116 @@
+import 'package:serverpod_test_server/src/generated/protocol.dart' as server;
+import 'package:serverpod_test_shared/serverpod_test_shared.dart' as shared;
+import 'package:test/test.dart';
+
+void main() {
+  final sharedProtocol = shared.Protocol();
+
+  group(
+    'Given a shared model with a dynamic field and a project model as data,',
+    () {
+      final simpleData = server.SimpleData(num: 1);
+      final model = shared.DynamicOnShared(
+        name: 'test',
+        data: simpleData,
+      );
+
+      test(
+        'when serializing the model, '
+        'then it returns the payload with the correct class name and data.',
+        () {
+          final serialized = model.toJson();
+
+          expect(
+            serialized,
+            {
+              '__className__': 'DynamicOnShared',
+              'name': 'test',
+              'data': {
+                'className': 'serverpod_test.SimpleData',
+                'data': simpleData.toJson(),
+              },
+            },
+          );
+        },
+      );
+
+      test(
+        'when wrapping the model with className, '
+        'then it returns the model with the correct class name and data.',
+        () {
+          final wrapped = sharedProtocol.wrapWithClassName(model);
+
+          expect(
+            wrapped,
+            {
+              'className': 'DynamicOnShared',
+              'data': model,
+            },
+          );
+        },
+      );
+    },
+  );
+
+  group(
+    'Given a serialized shared model with a dynamic field and a project model as data,',
+    () {
+      final simpleData = server.SimpleData(num: 1);
+
+      final payload = {
+        '__className__': 'DynamicOnShared',
+        'name': 'test',
+        'data': {
+          'className': 'serverpod_test.SimpleData',
+          'data': simpleData.toJson(),
+        },
+      };
+
+      test(
+        'when deserializing the payload, '
+        'then it returns the model with the correct class name and data.',
+        () {
+          final decoded = shared.DynamicOnShared.fromJson(payload);
+
+          expect(decoded, isA<shared.DynamicOnShared>());
+          expect(
+            decoded.data,
+            isA<server.SimpleData>().having((data) => data.num, 'num', 1),
+          );
+        },
+      );
+    },
+  );
+
+  group(
+    'Given a serialized shared model with a dynamic field and a project model as data wrapped with className,',
+    () {
+      final simpleData = server.SimpleData(num: 1);
+
+      final payload = {
+        'className': 'DynamicOnShared',
+        'data': {
+          'name': 'test',
+          'data': {
+            'className': 'serverpod_test.SimpleData',
+            'data': simpleData.toJson(),
+          },
+        },
+      };
+
+      test(
+        'when deserializing the payload, '
+        'then it returns the model with the correct class name and data.',
+        () {
+          final decoded = sharedProtocol.deserializeByClassName(payload);
+
+          expect(decoded, isA<shared.DynamicOnShared>());
+          expect(
+            (decoded as shared.DynamicOnShared).data,
+            isA<server.SimpleData>().having((data) => data.num, 'num', 1),
+          );
+        },
+      );
+    },
+  );
+}

--- a/tests/serverpod_test_server/test/dynamic_shared_in_module_test.dart
+++ b/tests/serverpod_test_server/test/dynamic_shared_in_module_test.dart
@@ -5,6 +5,11 @@ import 'package:serverpod_test_shared/serverpod_test_shared.dart' as shared;
 import 'package:test/test.dart';
 
 void main() {
+  // Registers this project as a host on both shared and module protocols for
+  // dynamic fields. This will always be called for real projects, since the
+  // server protocol is passed to the `Serverpod` constructor.
+  server.Protocol();
+
   group(
     'Given a module model with a dynamic field and a shared model as data,',
     () {

--- a/tests/serverpod_test_server/test/dynamic_shared_in_module_test.dart
+++ b/tests/serverpod_test_server/test/dynamic_shared_in_module_test.dart
@@ -1,0 +1,51 @@
+import 'package:serverpod_test_module_server/serverpod_test_module_server.dart'
+    as module;
+import 'package:serverpod_test_server/src/generated/protocol.dart' as server;
+import 'package:serverpod_test_shared/serverpod_test_shared.dart' as shared;
+import 'package:test/test.dart';
+
+void main() {
+  group(
+    'Given a module model with a dynamic field and a shared model as data,',
+    () {
+      final sharedModel = shared.SharedModel(name: 'test', data: 42);
+      final model = module.DynamicOnModule(
+        name: 'test',
+        data: sharedModel,
+      );
+
+      test(
+        'when serializing the model, '
+        'then it returns the payload with the correct class name and data.',
+        () {
+          final serialized = model.toJson();
+
+          expect(
+            serialized,
+            {
+              '__className__': 'serverpod_test_module.DynamicOnModule',
+              'name': 'test',
+              'data': {
+                'className': 'serverpod_test_shared.SharedModel',
+                'data': sharedModel.toJson(),
+              },
+            },
+          );
+        },
+      );
+
+      test(
+        'when deserializing the payload, '
+        'then it returns the shared model.',
+        () {
+          final decoded = module.DynamicOnModule.fromJson(model.toJson());
+
+          expect(decoded.data, isA<shared.SharedModel>());
+          final data = decoded.data as shared.SharedModel;
+          expect(data.name, 'test');
+          expect(data.data, 42);
+        },
+      );
+    },
+  );
+}

--- a/tests/serverpod_test_server/test/dynamic_shared_in_project_test.dart
+++ b/tests/serverpod_test_server/test/dynamic_shared_in_project_test.dart
@@ -3,6 +3,11 @@ import 'package:serverpod_test_shared/serverpod_test_shared.dart' as shared;
 import 'package:test/test.dart';
 
 void main() {
+  // Registers this project as a host on shared protocols for dynamic fields.
+  // This will always be called for real projects, since the server protocol
+  // is passed to the `Serverpod` constructor.
+  server.Protocol();
+
   group('Given a project model with a shared model in payload,', () {
     final sharedModel = shared.SharedModel(name: 'test', data: 42);
     final object = server.ObjectWithDynamic(

--- a/tests/serverpod_test_server/test/dynamic_shared_in_project_test.dart
+++ b/tests/serverpod_test_server/test/dynamic_shared_in_project_test.dart
@@ -1,0 +1,49 @@
+import 'package:serverpod_test_server/src/generated/protocol.dart' as server;
+import 'package:serverpod_test_shared/serverpod_test_shared.dart' as shared;
+import 'package:test/test.dart';
+
+void main() {
+  group('Given a project model with a shared model in payload,', () {
+    final sharedModel = shared.SharedModel(name: 'test', data: 42);
+    final object = server.ObjectWithDynamic(
+      payload: sharedModel,
+      jsonbPayload: null,
+      payloadList: [sharedModel],
+      payloadMap: {sharedModel.name: sharedModel},
+      payloadSet: {},
+      payloadMapWithDynamicKeys: {},
+    );
+
+    test(
+      'when serializing the model, '
+      'then the dynamic field uses the shared package class name.',
+      () {
+        final serialized = object.toJson();
+
+        final expectedModelPayload = {
+          'className': 'serverpod_test_shared.SharedModel',
+          'data': sharedModel.toJson(),
+        };
+
+        expect(serialized['payload'], expectedModelPayload);
+        expect(serialized['payloadList'], [expectedModelPayload]);
+        expect(serialized['payloadMap'], {
+          sharedModel.name: expectedModelPayload,
+        });
+      },
+    );
+
+    test(
+      'when deserializing the payload, '
+      'then it returns the shared model.',
+      () {
+        final decoded = server.ObjectWithDynamic.fromJson(object.toJson());
+
+        expect(decoded.payload, isA<shared.SharedModel>());
+        final payload = decoded.payload as shared.SharedModel;
+        expect(payload.name, 'test');
+        expect(payload.data, 42);
+      },
+    );
+  });
+}

--- a/tests/serverpod_test_shared/lib/src/generated/protocol.dart
+++ b/tests/serverpod_test_shared/lib/src/generated/protocol.dart
@@ -33,6 +33,15 @@ class Protocol extends _i1.SerializationManager {
 
   static final Protocol _instance = Protocol._();
 
+  final Map<String, _i1.SerializationManager> _hostProtocols = {};
+
+  void registerHostProtocol(
+    String projectName,
+    _i1.SerializationManager protocol,
+  ) {
+    _hostProtocols[projectName] = protocol;
+  }
+
   static String? getClassNameFromObjectJson(dynamic data) {
     if (data is! Map) return null;
     final className = data['__className__'] as String?;
@@ -180,6 +189,61 @@ class Protocol extends _i1.SerializationManager {
       return deserialize<_i8.SharedSealedChild>(data['data']);
     }
     return super.deserializeByClassName(data);
+  }
+
+  @override
+  Object? dynamicFieldToJson(
+    Object? object, {
+    bool forProtocol = false,
+  }) {
+    if ((object is List || object is Set || object is Map) ||
+        getClassNameForObject(object) != null) {
+      return super.dynamicFieldToJson(object, forProtocol: forProtocol);
+    }
+    for (final MapEntry(key: host, value: protocol) in _hostProtocols.entries) {
+      final className = protocol.getClassNameForObject(object);
+      if (className == null) continue;
+      final wrapped = {
+        'className': className.contains('.') ? className : '$host.$className',
+        'data': object,
+      };
+      return forProtocol
+          ? _i1.SerializationManager.toEncodableForProtocol(wrapped)
+          : _i1.SerializationManager.toEncodable(wrapped);
+    }
+    return super.dynamicFieldToJson(object, forProtocol: forProtocol);
+  }
+
+  @override
+  dynamic deserializeDynamicFieldValue(Object? value) {
+    if (value == null) return null;
+    if (value is! Map<String, dynamic> || value['className'] is! String) {
+      throw FormatException(
+        'Dynamic fields are encoded as a Map with className and data, but got '
+        '${value.runtimeType} instead.',
+      );
+    }
+    final className = value['className'] as String;
+    for (final MapEntry(key: host, value: protocol) in _hostProtocols.entries) {
+      final hostPrefix = '$host.';
+      if (className.startsWith(hostPrefix)) {
+        final strippedClassName = className.substring(hostPrefix.length);
+        if (strippedClassName.contains('.')) {
+          throw FormatException(
+            'Dynamic field className must not use multiple prefixes: $className',
+          );
+        }
+        final hostData = Map<String, dynamic>.from(value);
+        hostData['className'] = strippedClassName;
+        return protocol.deserializeByClassName(hostData);
+      }
+    }
+    if (className.contains('.')) {
+      for (final protocol in _hostProtocols.values) {
+        return protocol.deserializeByClassName(value);
+      }
+    }
+    return deserializeByClassName(value);
   }
 
   /// Maps any `Record`s known to this [Protocol] to their JSON representation

--- a/tests/serverpod_test_shared/lib/src/generated/protocol.dart
+++ b/tests/serverpod_test_shared/lib/src/generated/protocol.dart
@@ -240,7 +240,9 @@ class Protocol extends _i1.SerializationManager {
     }
     if (className.contains('.')) {
       for (final protocol in _hostProtocols.values) {
-        return protocol.deserializeByClassName(value);
+        try {
+          return protocol.deserializeByClassName(value);
+        } on FormatException catch (_) {}
       }
     }
     return deserializeByClassName(value);

--- a/tests/serverpod_test_shared/lib/src/generated/protocol.dart
+++ b/tests/serverpod_test_shared/lib/src/generated/protocol.dart
@@ -12,12 +12,14 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_serialization/serverpod_serialization.dart' as _i1;
 import 'shared/container.dart' as _i2;
-import 'shared/enum.dart' as _i3;
-import 'shared/exception.dart' as _i4;
-import 'shared/subclass.dart' as _i5;
-import 'shared/model.dart' as _i6;
-import 'shared/sealed/parent.dart' as _i7;
+import 'shared/dynamic_on_shared.dart' as _i3;
+import 'shared/enum.dart' as _i4;
+import 'shared/exception.dart' as _i5;
+import 'shared/subclass.dart' as _i6;
+import 'shared/model.dart' as _i7;
+import 'shared/sealed/parent.dart' as _i8;
 export 'shared/container.dart';
+export 'shared/dynamic_on_shared.dart';
 export 'shared/enum.dart';
 export 'shared/exception.dart';
 export 'shared/subclass.dart';
@@ -61,38 +63,47 @@ class Protocol extends _i1.SerializationManager {
     if (t == _i2.SharedContainer) {
       return _i2.SharedContainer.fromJson(data) as T;
     }
-    if (t == _i3.SharedEnum) {
-      return _i3.SharedEnum.fromJson(data) as T;
+    if (t == _i3.DynamicOnShared) {
+      return _i3.DynamicOnShared.fromJson(data) as T;
     }
-    if (t == _i4.SharedException) {
-      return _i4.SharedException.fromJson(data) as T;
+    if (t == _i4.SharedEnum) {
+      return _i4.SharedEnum.fromJson(data) as T;
     }
-    if (t == _i5.SharedSubclass) {
-      return _i5.SharedSubclass.fromJson(data) as T;
+    if (t == _i5.SharedException) {
+      return _i5.SharedException.fromJson(data) as T;
     }
-    if (t == _i6.SharedModel) {
-      return _i6.SharedModel.fromJson(data) as T;
+    if (t == _i6.SharedSubclass) {
+      return _i6.SharedSubclass.fromJson(data) as T;
     }
-    if (t == _i7.SharedSealedChild) {
-      return _i7.SharedSealedChild.fromJson(data) as T;
+    if (t == _i7.SharedModel) {
+      return _i7.SharedModel.fromJson(data) as T;
+    }
+    if (t == _i8.SharedSealedChild) {
+      return _i8.SharedSealedChild.fromJson(data) as T;
     }
     if (t == _i1.getType<_i2.SharedContainer?>()) {
       return (data != null ? _i2.SharedContainer.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i3.SharedEnum?>()) {
-      return (data != null ? _i3.SharedEnum.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i3.DynamicOnShared?>()) {
+      return (data != null ? _i3.DynamicOnShared.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i4.SharedException?>()) {
-      return (data != null ? _i4.SharedException.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i4.SharedEnum?>()) {
+      return (data != null ? _i4.SharedEnum.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i5.SharedSubclass?>()) {
-      return (data != null ? _i5.SharedSubclass.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i5.SharedException?>()) {
+      return (data != null ? _i5.SharedException.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i6.SharedModel?>()) {
-      return (data != null ? _i6.SharedModel.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i6.SharedSubclass?>()) {
+      return (data != null ? _i6.SharedSubclass.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i7.SharedSealedChild?>()) {
-      return (data != null ? _i7.SharedSealedChild.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i7.SharedModel?>()) {
+      return (data != null ? _i7.SharedModel.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i8.SharedSealedChild?>()) {
+      return (data != null ? _i8.SharedSealedChild.fromJson(data) : null) as T;
+    }
+    if (t == dynamic) {
+      return deserializeDynamicFieldValue(data) as T;
     }
     return super.deserialize<T>(data, t);
   }
@@ -100,11 +111,12 @@ class Protocol extends _i1.SerializationManager {
   static String? getClassNameForType(Type type) {
     return switch (type) {
       _i2.SharedContainer => 'SharedContainer',
-      _i3.SharedEnum => 'SharedEnum',
-      _i4.SharedException => 'SharedException',
-      _i5.SharedSubclass => 'SharedSubclass',
-      _i6.SharedModel => 'SharedModel',
-      _i7.SharedSealedChild => 'SharedSealedChild',
+      _i3.DynamicOnShared => 'DynamicOnShared',
+      _i4.SharedEnum => 'SharedEnum',
+      _i5.SharedException => 'SharedException',
+      _i6.SharedSubclass => 'SharedSubclass',
+      _i7.SharedModel => 'SharedModel',
+      _i8.SharedSealedChild => 'SharedSealedChild',
       _ => null,
     };
   }
@@ -124,15 +136,17 @@ class Protocol extends _i1.SerializationManager {
     switch (data) {
       case _i2.SharedContainer():
         return 'SharedContainer';
-      case _i3.SharedEnum():
+      case _i3.DynamicOnShared():
+        return 'DynamicOnShared';
+      case _i4.SharedEnum():
         return 'SharedEnum';
-      case _i4.SharedException():
+      case _i5.SharedException():
         return 'SharedException';
-      case _i5.SharedSubclass():
+      case _i6.SharedSubclass():
         return 'SharedSubclass';
-      case _i6.SharedModel():
+      case _i7.SharedModel():
         return 'SharedModel';
-      case _i7.SharedSealedChild():
+      case _i8.SharedSealedChild():
         return 'SharedSealedChild';
     }
     return null;
@@ -147,20 +161,23 @@ class Protocol extends _i1.SerializationManager {
     if (dataClassName == 'SharedContainer') {
       return deserialize<_i2.SharedContainer>(data['data']);
     }
+    if (dataClassName == 'DynamicOnShared') {
+      return deserialize<_i3.DynamicOnShared>(data['data']);
+    }
     if (dataClassName == 'SharedEnum') {
-      return deserialize<_i3.SharedEnum>(data['data']);
+      return deserialize<_i4.SharedEnum>(data['data']);
     }
     if (dataClassName == 'SharedException') {
-      return deserialize<_i4.SharedException>(data['data']);
+      return deserialize<_i5.SharedException>(data['data']);
     }
     if (dataClassName == 'SharedSubclass') {
-      return deserialize<_i5.SharedSubclass>(data['data']);
+      return deserialize<_i6.SharedSubclass>(data['data']);
     }
     if (dataClassName == 'SharedModel') {
-      return deserialize<_i6.SharedModel>(data['data']);
+      return deserialize<_i7.SharedModel>(data['data']);
     }
     if (dataClassName == 'SharedSealedChild') {
-      return deserialize<_i7.SharedSealedChild>(data['data']);
+      return deserialize<_i8.SharedSealedChild>(data['data']);
     }
     return super.deserializeByClassName(data);
   }

--- a/tests/serverpod_test_shared/lib/src/generated/shared/dynamic_on_shared.dart
+++ b/tests/serverpod_test_shared/lib/src/generated/shared/dynamic_on_shared.dart
@@ -1,0 +1,86 @@
+/* AUTOMATICALLY GENERATED CODE DO NOT MODIFY */
+/*   To generate run: "serverpod generate"    */
+
+// ignore_for_file: implementation_imports
+// ignore_for_file: library_private_types_in_public_api
+// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: public_member_api_docs
+// ignore_for_file: type_literal_in_constant_pattern
+// ignore_for_file: use_super_parameters
+// ignore_for_file: invalid_use_of_internal_member
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:serverpod_serialization/serverpod_serialization.dart' as _i1;
+import 'package:serverpod_test_shared/serverpod_test_shared.dart' as _i2;
+
+abstract class DynamicOnShared implements _i1.SerializableModel {
+  DynamicOnShared._({
+    required this.name,
+    required this.data,
+  });
+
+  factory DynamicOnShared({
+    required String name,
+    required dynamic data,
+  }) = _DynamicOnSharedImpl;
+
+  factory DynamicOnShared.fromJson(Map<String, dynamic> jsonSerialization) {
+    return DynamicOnShared(
+      name: jsonSerialization['name'] as String,
+      data: _i2.Protocol().deserializeDynamicFieldValue(
+        jsonSerialization['data'],
+      ),
+    );
+  }
+
+  String name;
+
+  dynamic data;
+
+  /// Returns a shallow copy of this [DynamicOnShared]
+  /// with some or all fields replaced by the given arguments.
+  @_i1.useResult
+  DynamicOnShared copyWith({
+    String? name,
+    dynamic data,
+  });
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      '__className__': 'DynamicOnShared',
+      'name': name,
+      'data': _i2.Protocol().dynamicFieldToJson(data),
+    };
+  }
+
+  @override
+  String toString() {
+    return _i1.SerializationManager.encode(this);
+  }
+}
+
+class _Undefined {}
+
+class _DynamicOnSharedImpl extends DynamicOnShared {
+  _DynamicOnSharedImpl({
+    required String name,
+    required dynamic data,
+  }) : super._(
+         name: name,
+         data: data,
+       );
+
+  /// Returns a shallow copy of this [DynamicOnShared]
+  /// with some or all fields replaced by the given arguments.
+  @_i1.useResult
+  @override
+  DynamicOnShared copyWith({
+    String? name,
+    Object? data = _Undefined,
+  }) {
+    return DynamicOnShared(
+      name: name ?? this.name,
+      data: data != _Undefined ? data : this.data,
+    );
+  }
+}

--- a/tests/serverpod_test_shared/lib/src/shared/dynamic_on_shared.spy.yaml
+++ b/tests/serverpod_test_shared/lib/src/shared/dynamic_on_shared.spy.yaml
@@ -1,0 +1,4 @@
+class: DynamicOnShared
+fields:
+  name: String
+  data: dynamic

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/object_with_dynamic.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/object_with_dynamic.dart
@@ -123,22 +123,41 @@ abstract class ObjectWithDynamic
     return {
       '__className__': 'ObjectWithDynamic',
       if (id != null) 'id': id,
-      'payload': _i2.Protocol().dynamicFieldToJsonForProtocol(payload),
-      'jsonbPayload': _i2.Protocol().dynamicFieldToJsonForProtocol(
+      'payload': _i2.Protocol().dynamicFieldToJson(
+        payload,
+        forProtocol: true,
+      ),
+      'jsonbPayload': _i2.Protocol().dynamicFieldToJson(
         jsonbPayload,
+        forProtocol: true,
       ),
       'payloadList': payloadList.toJson(
-        valueToJson: (v) => _i2.Protocol().dynamicFieldToJsonForProtocol(v),
+        valueToJson: (v) => _i2.Protocol().dynamicFieldToJson(
+          v,
+          forProtocol: true,
+        ),
       ),
       'payloadMap': payloadMap.toJson(
-        valueToJson: (v) => _i2.Protocol().dynamicFieldToJsonForProtocol(v),
+        valueToJson: (v) => _i2.Protocol().dynamicFieldToJson(
+          v,
+          forProtocol: true,
+        ),
       ),
       'payloadSet': payloadSet.toJson(
-        valueToJson: (v) => _i2.Protocol().dynamicFieldToJsonForProtocol(v),
+        valueToJson: (v) => _i2.Protocol().dynamicFieldToJson(
+          v,
+          forProtocol: true,
+        ),
       ),
       'payloadMapWithDynamicKeys': payloadMapWithDynamicKeys.toJson(
-        keyToJson: (k) => _i2.Protocol().dynamicFieldToJsonForProtocol(k),
-        valueToJson: (v) => _i2.Protocol().dynamicFieldToJsonForProtocol(v),
+        keyToJson: (k) => _i2.Protocol().dynamicFieldToJson(
+          k,
+          forProtocol: true,
+        ),
+        valueToJson: (v) => _i2.Protocol().dynamicFieldToJson(
+          v,
+          forProtocol: true,
+        ),
       ),
     };
   }

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/protocol.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/protocol.dart
@@ -7641,7 +7641,7 @@ class Protocol extends _i1.DatabaseSerializationManager {
     }
     className = _i2.Protocol().getClassNameForObject(data);
     if (className != null) {
-      return 'serverpod.$className';
+      return className.contains('.') ? className : 'serverpod.$className';
     }
     return null;
   }

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/test/dynamic_host_protocol_delegation_test.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/test/dynamic_host_protocol_delegation_test.dart
@@ -1,0 +1,66 @@
+import 'package:serverpod_test_module_server/serverpod_test_module_server.dart'
+    as module;
+import 'package:serverpod_test_server/src/generated/protocol.dart' as server;
+import 'package:serverpod_test_shared/serverpod_test_shared.dart' as shared;
+import 'package:serverpod_test_sqlite_server/src/generated/protocol.dart'
+    as sqlite;
+import 'package:test/test.dart';
+
+void main() {
+  group(
+    'Given a module protocol holding an object from an unknown project,',
+    () {
+      late final moduleProtocol = module.Protocol()
+        ..registerHostProtocol('serverpod_test_sqlite', sqlite.Protocol());
+      // The `serverpod_test` is the owner of the class and is not registered.
+
+      test(
+        'when deserializing a qualified className unknown to the module, '
+        'then a FormatException is thrown.',
+        () {
+          final sharedModel = shared.SharedModel(name: 'test', data: 42);
+          final payload = {
+            'className': 'serverpod_test_shared.SharedModel',
+            'data': sharedModel.toJson(),
+          };
+
+          expect(
+            () => moduleProtocol.deserializeDynamicFieldValue(payload),
+            throwsA(isA<FormatException>()),
+          );
+        },
+      );
+    },
+  );
+
+  // NOTE: This test must come after the previous, since registering a host
+  // protocol can not be undone. Otherwise, the test would not throw because
+  // the previous registration would leak to the next test.
+  group(
+    'Given a module protocol with two registered host protocols,',
+    () {
+      late final moduleProtocol = module.Protocol()
+        ..registerHostProtocol('serverpod_test_sqlite', sqlite.Protocol())
+        ..registerHostProtocol('serverpod_test', server.Protocol());
+
+      test(
+        'when deserializing a qualified className only known to the second host, '
+        'then the first host failure is caught and deserialization succeeds.',
+        () {
+          final sharedModel = shared.SharedModel(name: 'test', data: 42);
+          final payload = {
+            'className': 'serverpod_test_shared.SharedModel',
+            'data': sharedModel.toJson(),
+          };
+
+          final decoded = moduleProtocol.deserializeDynamicFieldValue(payload);
+
+          expect(decoded, isA<shared.SharedModel>());
+          final model = decoded as shared.SharedModel;
+          expect(model.name, 'test');
+          expect(model.data, 42);
+        },
+      );
+    },
+  );
+}

--- a/tools/serverpod_cli/lib/src/generator/dart/library_generators/library_generator.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart/library_generators/library_generator.dart
@@ -113,11 +113,7 @@ class LibraryGenerator {
       Constructor(
         (c) => c
           ..factory = true
-          ..body = _shouldRegisterHostProtocols
-              ? refer(
-                  '_instance',
-                ).cascade('_registerHostProtocols').call([]).code
-              : refer('_instance').code,
+          ..body = refer('_instance').code,
       ),
     ]);
 
@@ -133,7 +129,9 @@ class LibraryGenerator {
           ..static = true
           ..type = refer('Protocol')
           ..modifier = FieldModifier.final$
-          ..assignment = const Code('Protocol._()'),
+          ..assignment = _shouldRegisterHostProtocols
+              ? const Code('Protocol._().._registerHostProtocols()')
+              : const Code('Protocol._()'),
       ),
       if (serverCode || hasDatabaseTablesForCurrentSide)
         Field(

--- a/tools/serverpod_cli/lib/src/generator/dart/library_generators/library_generator.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart/library_generators/library_generator.dart
@@ -780,7 +780,9 @@ for (final MapEntry(key: host, value: protocol) in _hostProtocols.entries) {
 }
 if (className.contains('.')) {
   for (final protocol in _hostProtocols.values) {
-    return protocol.deserializeByClassName(value);
+    try {
+      return protocol.deserializeByClassName(value);
+    } on FormatException catch (_) {}
   }
 }
 return deserializeByClassName(value);

--- a/tools/serverpod_cli/lib/src/generator/dart/library_generators/library_generator.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart/library_generators/library_generator.dart
@@ -33,6 +33,21 @@ class LibraryGenerator {
     required this.config,
   });
 
+  /// Whether this package supports delegating serialization to a host protocol.
+  ///
+  /// Will be `true` modules and shared packages.
+  bool get _supportsHostProtocols =>
+      config.type == PackageType.module || sharedPackage;
+
+  /// Whether the host protocols should be registered for this package.
+  ///
+  /// Will be `true` for projects that have modules or shared models.
+  bool get _shouldRegisterHostProtocols =>
+      !sharedPackage &&
+      config.type != PackageType.module &&
+      (config.modules.isNotEmpty ||
+          config.sharedModelsSourcePathsParts.isNotEmpty);
+
   /// Generate the protocol library.
   Library generateProtocol() {
     var library = LibraryBuilder();
@@ -98,7 +113,11 @@ class LibraryGenerator {
       Constructor(
         (c) => c
           ..factory = true
-          ..body = refer('_instance').code,
+          ..body = _shouldRegisterHostProtocols
+              ? refer(
+                  '_instance',
+                ).cascade('_registerHostProtocols').call([]).code
+              : refer('_instance').code,
       ),
     ]);
 
@@ -171,6 +190,21 @@ class LibraryGenerator {
                         ],
                 ),
         ),
+      if (_supportsHostProtocols)
+        Field(
+          (f) => f
+            ..name = '_hostProtocols'
+            ..type = TypeReference(
+              (t) => t
+                ..symbol = 'Map'
+                ..types.addAll([
+                  refer('String'),
+                  refer('SerializationManager', serverpodUrl(serverCode)),
+                ]),
+            )
+            ..modifier = FieldModifier.final$
+            ..assignment = literalMap({}).code,
+        ),
     ]);
 
     final allFieldsToGenerateSerialization = unsealedModels
@@ -180,6 +214,7 @@ class LibraryGenerator {
         .distinct();
 
     protocol.methods.addAll([
+      if (_supportsHostProtocols) ..._buildModuleHostProtocolMethods(),
       Method(
         (m) => m
           ..static = true
@@ -402,16 +437,6 @@ class LibraryGenerator {
                 ),
               const Code('}'),
             ],
-            if (config.name != 'serverpod' && serverCode)
-              _buildGetClassNameForObjectDelegation(
-                serverpodProtocolUrl(serverCode),
-                'serverpod',
-              ),
-            for (var module in config.modules)
-              _buildGetClassNameForObjectDelegation(
-                module.dartImportUrl(serverCode),
-                module.name,
-              ),
             for (var containerType in nonModelStreamTypes)
               Block.of([
                 const Code('if(data is '),
@@ -422,6 +447,26 @@ class LibraryGenerator {
                 ),
                 const Code('}'),
               ]),
+            if (config.type != PackageType.module)
+              for (var module in config.modules)
+                _buildGetClassNameForObjectDelegation(
+                  module.dartImportUrl(serverCode),
+                  module.name,
+                ),
+            if (!sharedPackage)
+              for (var packageName in config.sharedModelsSourcePathsParts.keys)
+                _buildGetClassNameForObjectDelegation(
+                  packageName == 'serverpod_database' &&
+                          config.name != 'serverpod'
+                      ? serverpodDatabaseUrl(serverCode)
+                      : 'package:$packageName/$packageName.dart',
+                  packageName,
+                ),
+            if (config.name != 'serverpod' && serverCode)
+              _buildGetClassNameForObjectDelegation(
+                serverpodProtocolUrl(serverCode),
+                'serverpod',
+              ),
             const Code('return null;'),
           ]),
       ),
@@ -455,15 +500,25 @@ class LibraryGenerator {
                     'if(dataClassName == \'${classInfo.className}\'){'
                     'return deserialize<${a(refer(classInfo.className, TypeDefinition.getRef(classInfo)))}>(data[\'data\']);}',
               ),
+            if (config.type != PackageType.module)
+              for (var module in config.modules)
+                _buildDeserializeByClassNameDelegation(
+                  module.dartImportUrl(serverCode),
+                  module.name,
+                ),
+            if (!sharedPackage)
+              for (var packageName in config.sharedModelsSourcePathsParts.keys)
+                _buildDeserializeByClassNameDelegation(
+                  packageName == 'serverpod_database' &&
+                          config.name != 'serverpod'
+                      ? serverpodDatabaseUrl(serverCode)
+                      : 'package:$packageName/$packageName.dart',
+                  packageName,
+                ),
             if (config.name != 'serverpod' && serverCode)
               _buildDeserializeByClassNameDelegation(
                 serverpodProtocolUrl(serverCode),
                 'serverpod',
-              ),
-            for (var module in config.modules)
-              _buildDeserializeByClassNameDelegation(
-                module.dartImportUrl(serverCode),
-                module.name,
               ),
             for (final containerType in nonModelStreamTypes) ...[
               Code(
@@ -477,6 +532,8 @@ class LibraryGenerator {
             const Code('return super.deserializeByClassName(data);'),
           ]),
       ),
+      if (_supportsHostProtocols) ..._buildDynamicFieldHostMethods(),
+      if (_shouldRegisterHostProtocols) _buildRegisterHostProtocolsMethod(),
       if (serverCode || hasDatabaseTablesForCurrentSide)
         Method(
           (m) => m
@@ -614,7 +671,9 @@ class LibraryGenerator {
         (a) =>
             'className = ${a(refer('Protocol', protocolImportPath))}().getClassNameForObject(data);',
       ),
-      Code('if(className != null){return \'$projectName.\$className\';}'),
+      Code(
+        'if(className != null){return className.contains(\'.\') ? className : \'$projectName.\$className\';}',
+      ),
     ]);
   }
 
@@ -633,6 +692,149 @@ class LibraryGenerator {
       ),
       const Code('}'),
     ]);
+  }
+
+  List<Method> _buildDynamicFieldHostMethods() {
+    return [
+      Method(
+        (m) => m
+          ..annotations.add(refer('override'))
+          ..name = 'dynamicFieldToJson'
+          ..returns = refer('Object?')
+          ..requiredParameters.add(
+            Parameter(
+              (p) => p
+                ..name = 'object'
+                ..type = refer('Object?'),
+            ),
+          )
+          ..optionalParameters.add(
+            Parameter(
+              (p) => p
+                ..name = 'forProtocol'
+                ..named = true
+                ..type = refer('bool')
+                ..defaultTo = literalFalse.code,
+            ),
+          )
+          ..body = Code.scope(
+            (a) {
+              final serializationManager = a(
+                refer('SerializationManager', serverpodUrl(serverCode)),
+              );
+              return '''
+if ((object is List || object is Set || object is Map) ||
+    getClassNameForObject(object) != null) {
+  return super.dynamicFieldToJson(object, forProtocol: forProtocol);
+}
+for (final MapEntry(key: host, value: protocol) in _hostProtocols.entries) {
+  final className = protocol.getClassNameForObject(object);
+  if (className == null) continue;
+  final wrapped = {
+    'className': className.contains('.') ? className : '\$host.\$className',
+    'data': object,
+  };
+  return forProtocol
+    ? $serializationManager.toEncodableForProtocol(wrapped)
+    : $serializationManager.toEncodable(wrapped);
+}
+return super.dynamicFieldToJson(object, forProtocol: forProtocol);
+''';
+            },
+          ),
+      ),
+      Method(
+        (m) => m
+          ..annotations.add(refer('override'))
+          ..name = 'deserializeDynamicFieldValue'
+          ..returns = refer('dynamic')
+          ..requiredParameters.add(
+            Parameter(
+              (p) => p
+                ..name = 'value'
+                ..type = refer('Object?'),
+            ),
+          )
+          ..body = const Code('''
+if (value == null) return null;
+if (value is! Map<String, dynamic> || value['className'] is! String) {
+  throw FormatException(
+    'Dynamic fields are encoded as a Map with className and data, but got '
+    '\${value.runtimeType} instead.',
+  );
+}
+final className = value['className'] as String;
+for (final MapEntry(key: host, value: protocol) in _hostProtocols.entries) {
+  final hostPrefix = '\$host.';
+  if (className.startsWith(hostPrefix)) {
+    final strippedClassName = className.substring(hostPrefix.length);
+    if (strippedClassName.contains('.')) {
+      throw FormatException(
+        'Dynamic field className must not use multiple prefixes: \$className',
+      );
+    }
+    final hostData = Map<String, dynamic>.from(value);
+    hostData['className'] = strippedClassName;
+    return protocol.deserializeByClassName(hostData);
+  }
+}
+if (className.contains('.')) {
+  for (final protocol in _hostProtocols.values) {
+    return protocol.deserializeByClassName(value);
+  }
+}
+return deserializeByClassName(value);
+'''),
+      ),
+    ];
+  }
+
+  List<Method> _buildModuleHostProtocolMethods() {
+    return [
+      Method(
+        (m) => m
+          ..returns = refer('void')
+          ..name = 'registerHostProtocol'
+          ..requiredParameters.addAll([
+            Parameter(
+              (p) => p
+                ..name = 'projectName'
+                ..type = refer('String'),
+            ),
+            Parameter(
+              (p) => p
+                ..name = 'protocol'
+                ..type = refer(
+                  'SerializationManager',
+                  serverpodUrl(serverCode),
+                ),
+            ),
+          ])
+          ..body = const Code('_hostProtocols[projectName] = protocol;'),
+      ),
+    ];
+  }
+
+  Method _buildRegisterHostProtocolsMethod() {
+    return Method(
+      (m) => m
+        ..name = '_registerHostProtocols'
+        ..returns = refer('void')
+        ..body = Block.of([
+          for (var module in config.modules)
+            Code.scope(
+              (a) =>
+                  '${a(refer('Protocol', module.dartImportUrl(serverCode)))}()'
+                  '.registerHostProtocol(\'${config.name}\', this);',
+            ),
+          for (var packageName in config.sharedModelsSourcePathsParts.keys)
+            Code.scope(
+              (a) =>
+                  '${a(refer('Protocol', 'package:$packageName/$packageName.dart'))}()'
+                  '.registerHostProtocol(\'${config.name}\', this);',
+            ),
+        ]),
+    );
   }
 
   /// Generates the EndpointDispatch for the server side.

--- a/tools/serverpod_cli/lib/src/generator/dart/library_generators/model_library_generator.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart/library_generators/model_library_generator.dart
@@ -1624,10 +1624,10 @@ class SerializableModelLibraryGenerator {
       currentSharedPackageName: currentSharedPackageName,
     );
     if (fieldType.className == 'dynamic') {
-      var encodeMethod = methodName == _toJsonForProtocolMethodName
-          ? 'dynamicFieldToJsonForProtocol'
-          : 'dynamicFieldToJson';
-      return protocolRef.call([]).property(encodeMethod).call([fieldRef]);
+      final methodToJson = protocolRef.call([]).property('dynamicFieldToJson');
+      return (methodName == _toJsonForProtocolMethodName)
+          ? methodToJson.call([fieldRef], {'forProtocol': literal(true)})
+          : methodToJson.call([fieldRef]);
     }
     if (fieldType.isRecordType) {
       return protocolRef.call([]).property(mapRecordToJsonFuncName).call(

--- a/tools/serverpod_cli/test/generator/dart/client_code_generator/protocol/module_host_protocol_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/client_code_generator/protocol/module_host_protocol_test.dart
@@ -1,0 +1,143 @@
+import 'package:path/path.dart' as path;
+import 'package:serverpod_cli/analyzer.dart';
+import 'package:serverpod_cli/src/generator/dart/client_code_generator.dart';
+import 'package:test/test.dart';
+
+import '../../../../test_util/builders/generator_config_builder.dart';
+import '../../../../test_util/builders/module_config_builder.dart';
+
+const _moduleName = 'example_module';
+const _projectName = 'example_project';
+
+void main() {
+  group('Given a module protocol when generating code', () {
+    late final moduleConfig = GeneratorConfigBuilder()
+        .withName(_moduleName)
+        .withPackageType(PackageType.module)
+        .build();
+
+    const protocolDefinition = ProtocolDefinition(
+      endpoints: [],
+      models: [],
+      futureCalls: [],
+    );
+
+    late final codeMap = const DartClientCodeGenerator().generateProtocolCode(
+      protocolDefinition: protocolDefinition,
+      config: moduleConfig,
+    );
+
+    late final protocolSource =
+        codeMap[path.join(
+          '..',
+          '${_moduleName}_client',
+          'lib',
+          'src',
+          'protocol',
+          'protocol.dart',
+        )]!;
+
+    test('then it defines a host protocol registry', () {
+      expect(protocolSource, contains('_hostProtocols'));
+    });
+
+    test('then it defines registerHostProtocol', () {
+      expect(
+        protocolSource,
+        contains('void registerHostProtocol('),
+      );
+    });
+
+    test('then it assigns the protocol to the registry', () {
+      expect(
+        protocolSource,
+        contains('_hostProtocols[projectName] = protocol'),
+      );
+    });
+
+    test('then it overrides dynamicFieldToJson', () {
+      expect(
+        protocolSource,
+        contains('''
+  @override
+  Object? dynamicFieldToJson('''),
+      );
+    });
+
+    test(
+      'then it overrides deserializeDynamicFieldValue',
+      () {
+        expect(
+          protocolSource,
+          contains('''
+  @override
+  dynamic deserializeDynamicFieldValue('''),
+        );
+      },
+    );
+
+    test(
+      'then getClassNameForObject does not delegate to registered hosts',
+      () {
+        expect(
+          protocolSource,
+          contains('factory Protocol() => _instance;'),
+        );
+      },
+    );
+  });
+
+  group(
+    'Given a project protocol with a module dependency when generating code',
+    () {
+      late final projectConfig = GeneratorConfigBuilder()
+          .withName(_projectName)
+          .withModules([
+            ModuleConfigBuilder(_moduleName).build(),
+          ])
+          .build();
+
+      const protocolDefinition = ProtocolDefinition(
+        endpoints: [],
+        models: [],
+        futureCalls: [],
+      );
+
+      late final codeMap = const DartClientCodeGenerator().generateProtocolCode(
+        protocolDefinition: protocolDefinition,
+        config: projectConfig,
+      );
+
+      late final protocolSource =
+          codeMap[path.join(
+            '..',
+            '${_projectName}_client',
+            'lib',
+            'src',
+            'protocol',
+            'protocol.dart',
+          )]!;
+
+      test('then Protocol() registers the project as a module host', () {
+        expect(
+          protocolSource,
+          contains(
+            'factory Protocol() => _instance.._registerHostProtocols();',
+          ),
+        );
+        expect(
+          protocolSource,
+          contains("registerHostProtocol('$_projectName', this)"),
+        );
+      });
+
+      test('then it does not override dynamicFieldToJson', () {
+        expect(protocolSource, isNot(contains('dynamicFieldToJson')));
+      });
+
+      test('then it does not override deserializeDynamicFieldValue', () {
+        expect(protocolSource, isNot(contains('deserializeDynamicFieldValue')));
+      });
+    },
+  );
+}

--- a/tools/serverpod_cli/test/generator/dart/client_code_generator/protocol/module_host_protocol_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/client_code_generator/protocol/module_host_protocol_test.dart
@@ -118,18 +118,21 @@ void main() {
             'protocol.dart',
           )]!;
 
-      test('then Protocol() registers the project as a module host', () {
-        expect(
-          protocolSource,
-          contains(
-            'factory Protocol() => _instance.._registerHostProtocols();',
-          ),
-        );
-        expect(
-          protocolSource,
-          contains("registerHostProtocol('$_projectName', this)"),
-        );
-      });
+      test(
+        'then Protocol() registers the project as a module host on the singleton instance',
+        () {
+          expect(
+            protocolSource,
+            contains(
+              'static final Protocol _instance = Protocol._().._registerHostProtocols();',
+            ),
+          );
+          expect(
+            protocolSource,
+            contains("registerHostProtocol('$_projectName', this)"),
+          );
+        },
+      );
 
       test('then it does not override dynamicFieldToJson', () {
         expect(protocolSource, isNot(contains('dynamicFieldToJson')));

--- a/tools/serverpod_cli/test/generator/dart/server_code_generator/protocol/module_host_protocol_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/server_code_generator/protocol/module_host_protocol_test.dart
@@ -114,18 +114,21 @@ void main() {
             'protocol.dart',
           )]!;
 
-      test('then Protocol() registers the project as a module host', () {
-        expect(
-          protocolSource,
-          contains(
-            'factory Protocol() => _instance.._registerHostProtocols();',
-          ),
-        );
-        expect(
-          protocolSource,
-          contains("registerHostProtocol('$_projectName', this)"),
-        );
-      });
+      test(
+        'then Protocol() registers the project as a module host on the singleton instance',
+        () {
+          expect(
+            protocolSource,
+            contains(
+              'static final Protocol _instance = Protocol._().._registerHostProtocols();',
+            ),
+          );
+          expect(
+            protocolSource,
+            contains("registerHostProtocol('$_projectName', this)"),
+          );
+        },
+      );
 
       test('then it does not override dynamicFieldToJson', () {
         expect(protocolSource, isNot(contains('dynamicFieldToJson')));

--- a/tools/serverpod_cli/test/generator/dart/server_code_generator/protocol/module_host_protocol_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/server_code_generator/protocol/module_host_protocol_test.dart
@@ -1,0 +1,139 @@
+import 'package:path/path.dart' as path;
+import 'package:serverpod_cli/analyzer.dart';
+import 'package:serverpod_cli/src/generator/dart/server_code_generator.dart';
+import 'package:test/test.dart';
+
+import '../../../../test_util/builders/generator_config_builder.dart';
+import '../../../../test_util/builders/module_config_builder.dart';
+
+const _moduleName = 'example_module';
+const _projectName = 'example_project';
+
+void main() {
+  group('Given a module protocol when generating code', () {
+    late final moduleConfig = GeneratorConfigBuilder()
+        .withName(_moduleName)
+        .withPackageType(PackageType.module)
+        .build();
+
+    const protocolDefinition = ProtocolDefinition(
+      endpoints: [],
+      models: [],
+      futureCalls: [],
+    );
+
+    late final codeMap = const DartServerCodeGenerator().generateProtocolCode(
+      protocolDefinition: protocolDefinition,
+      config: moduleConfig,
+    );
+
+    late final protocolSource =
+        codeMap[path.join(
+          'lib',
+          'src',
+          'generated',
+          'protocol.dart',
+        )]!;
+
+    test('then it defines a host protocol registry', () {
+      expect(protocolSource, contains('_hostProtocols'));
+    });
+
+    test('then it defines registerHostProtocol', () {
+      expect(
+        protocolSource,
+        contains('void registerHostProtocol('),
+      );
+    });
+
+    test('then it assigns the protocol to the registry', () {
+      expect(
+        protocolSource,
+        contains('_hostProtocols[projectName] = protocol'),
+      );
+    });
+
+    test('then it overrides dynamicFieldToJson', () {
+      expect(
+        protocolSource,
+        contains('''
+  @override
+  Object? dynamicFieldToJson('''),
+      );
+    });
+
+    test(
+      'then it overrides deserializeDynamicFieldValue',
+      () {
+        expect(
+          protocolSource,
+          contains('''
+  @override
+  dynamic deserializeDynamicFieldValue('''),
+        );
+      },
+    );
+
+    test(
+      'then getClassNameForObject does not delegate to registered hosts',
+      () {
+        expect(
+          protocolSource,
+          contains('factory Protocol() => _instance;'),
+        );
+      },
+    );
+  });
+
+  group(
+    'Given a project protocol with a module dependency when generating code',
+    () {
+      late final projectConfig = GeneratorConfigBuilder()
+          .withName(_projectName)
+          .withModules([
+            ModuleConfigBuilder(_moduleName).build(),
+          ])
+          .build();
+
+      const protocolDefinition = ProtocolDefinition(
+        endpoints: [],
+        models: [],
+        futureCalls: [],
+      );
+
+      late final codeMap = const DartServerCodeGenerator().generateProtocolCode(
+        protocolDefinition: protocolDefinition,
+        config: projectConfig,
+      );
+
+      late final protocolSource =
+          codeMap[path.join(
+            'lib',
+            'src',
+            'generated',
+            'protocol.dart',
+          )]!;
+
+      test('then Protocol() registers the project as a module host', () {
+        expect(
+          protocolSource,
+          contains(
+            'factory Protocol() => _instance.._registerHostProtocols();',
+          ),
+        );
+        expect(
+          protocolSource,
+          contains("registerHostProtocol('$_projectName', this)"),
+        );
+      });
+
+      test('then it does not override dynamicFieldToJson', () {
+        expect(protocolSource, isNot(contains('dynamicFieldToJson')));
+      });
+
+      test('then it does not override deserializeDynamicFieldValue', () {
+        expect(protocolSource, isNot(contains('deserializeDynamicFieldValue')));
+      });
+    },
+  );
+}

--- a/tools/serverpod_cli/test/generator/dart/shared_code_generator/protocol/shared_host_protocol_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/shared_code_generator/protocol/shared_host_protocol_test.dart
@@ -1,0 +1,151 @@
+import 'package:path/path.dart' as path;
+import 'package:serverpod_cli/analyzer.dart';
+import 'package:serverpod_cli/src/generator/dart/client_code_generator.dart';
+import 'package:serverpod_cli/src/generator/dart/shared_code_generator.dart';
+import 'package:test/test.dart';
+
+import '../../../../test_util/builders/generator_config_builder.dart';
+import '../../../../test_util/builders/model_class_definition_builder.dart';
+
+const _sharedPackageName = 'example_shared';
+const _projectName = 'example_project';
+
+void main() {
+  group('Given a shared package protocol when generating code', () {
+    late final sharedConfig = GeneratorConfigBuilder()
+        .withName(_projectName)
+        .withSharedModelsSourcePathsParts({
+          _sharedPackageName: ['..', _sharedPackageName],
+        })
+        .build();
+
+    late final protocolDefinition = ProtocolDefinition(
+      endpoints: [],
+      models: [
+        ModelClassDefinitionBuilder()
+            .withClassName('Example')
+            .withSharedPackageName(_sharedPackageName)
+            .build(),
+      ],
+      futureCalls: [],
+    );
+
+    late final codeMap = const DartSharedCodeGenerator().generateProtocolCode(
+      protocolDefinition: protocolDefinition,
+      config: sharedConfig,
+    );
+
+    late final protocolSource =
+        codeMap[path.join(
+          '..',
+          _sharedPackageName,
+          'lib',
+          'src',
+          'generated',
+          'protocol.dart',
+        )]!;
+
+    test('then it defines a host protocol registry', () {
+      expect(protocolSource, contains('_hostProtocols'));
+    });
+
+    test('then it defines registerHostProtocol', () {
+      expect(
+        protocolSource,
+        contains('void registerHostProtocol('),
+      );
+    });
+
+    test('then it assigns the protocol to the registry', () {
+      expect(
+        protocolSource,
+        contains('_hostProtocols[projectName] = protocol'),
+      );
+    });
+
+    test('then it overrides dynamicFieldToJson', () {
+      expect(
+        protocolSource,
+        contains('''
+  @override
+  Object? dynamicFieldToJson('''),
+      );
+    });
+
+    test(
+      'then it overrides deserializeDynamicFieldValue',
+      () {
+        expect(
+          protocolSource,
+          contains('''
+  @override
+  dynamic deserializeDynamicFieldValue('''),
+        );
+      },
+    );
+
+    test(
+      'then getClassNameForObject does not delegate to registered hosts',
+      () {
+        expect(
+          protocolSource,
+          contains('factory Protocol() => _instance;'),
+        );
+      },
+    );
+  });
+
+  group(
+    'Given a project protocol with a shared package when generating code',
+    () {
+      late final projectConfig = GeneratorConfigBuilder()
+          .withName(_projectName)
+          .withSharedModelsSourcePathsParts({
+            _sharedPackageName: ['..', _sharedPackageName],
+          })
+          .build();
+
+      const protocolDefinition = ProtocolDefinition(
+        endpoints: [],
+        models: [],
+        futureCalls: [],
+      );
+
+      late final codeMap = const DartClientCodeGenerator().generateProtocolCode(
+        protocolDefinition: protocolDefinition,
+        config: projectConfig,
+      );
+
+      late final protocolSource =
+          codeMap[path.join(
+            '..',
+            '${_projectName}_client',
+            'lib',
+            'src',
+            'protocol',
+            'protocol.dart',
+          )]!;
+
+      test('then Protocol() registers the project as a module host', () {
+        expect(
+          protocolSource,
+          contains(
+            'factory Protocol() => _instance.._registerHostProtocols();',
+          ),
+        );
+        expect(
+          protocolSource,
+          contains("registerHostProtocol('$_projectName', this)"),
+        );
+      });
+
+      test('then it does not override dynamicFieldToJson', () {
+        expect(protocolSource, isNot(contains('dynamicFieldToJson')));
+      });
+
+      test('then it does not override deserializeDynamicFieldValue', () {
+        expect(protocolSource, isNot(contains('deserializeDynamicFieldValue')));
+      });
+    },
+  );
+}

--- a/tools/serverpod_cli/test/generator/dart/shared_code_generator/protocol/shared_host_protocol_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/shared_code_generator/protocol/shared_host_protocol_test.dart
@@ -126,18 +126,21 @@ void main() {
             'protocol.dart',
           )]!;
 
-      test('then Protocol() registers the project as a module host', () {
-        expect(
-          protocolSource,
-          contains(
-            'factory Protocol() => _instance.._registerHostProtocols();',
-          ),
-        );
-        expect(
-          protocolSource,
-          contains("registerHostProtocol('$_projectName', this)"),
-        );
-      });
+      test(
+        'then Protocol() registers the project as a module host on the singleton instance',
+        () {
+          expect(
+            protocolSource,
+            contains(
+              'static final Protocol _instance = Protocol._().._registerHostProtocols();',
+            ),
+          );
+          expect(
+            protocolSource,
+            contains("registerHostProtocol('$_projectName', this)"),
+          );
+        },
+      );
 
       test('then it does not override dynamicFieldToJson', () {
         expect(protocolSource, isNot(contains('dynamicFieldToJson')));


### PR DESCRIPTION
Fixes: #5156

The fix goes beyond the issue to also fix a missing delegation to the shared protocol for the `getClassNameForObject` and `deserializeByClassName` methods. This is required for complete `dynamic` support, but also needed for streaming serialization of shared models.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.