### PR TITLE
fix: Update skills documentation so agents know how to add database to existing project

### DIFF
--- a/packages/serverpod/skills/serverpod-database/SKILL.md
+++ b/packages/serverpod/skills/serverpod-database/SKILL.md
@@ -5,7 +5,7 @@ description: Serverpod ORM with PostgreSQL or SQLite — CRUD, filters, sorting,
 
 # Serverpod Database
 
-Serverpod generates ORM code for models with `table` in `.spy.yaml`. PostgreSQL is the default production database; SQLite is also supported for projects/tests that configure the database on `config/<runMode>.yaml` with `database.filePath: <path>`.
+Serverpod generates ORM code for models with `table` in `.spy.yaml`. PostgreSQL is the default production database; SQLite is also supported for projects/tests that configure the database on `config/<runMode>.yaml` with `database.filePath: <path>`. If the project has no database configured, see [Serverpod Upgrading](../serverpod-upgrading/SKILL.md) for how to add one.
 
 ## CRUD
 

--- a/packages/serverpod/skills/serverpod-migrations/SKILL.md
+++ b/packages/serverpod/skills/serverpod-migrations/SKILL.md
@@ -16,7 +16,7 @@ Serverpod has a migration system that generates SQL for changes to models with `
 - Changed relation fields that alter generated foreign keys.
 - Added, removed, or changed indexes.
 
-Migrations are not needed when the project has no database configured (e.g. `config/<runMode>.yaml` with no `database` section).
+Migrations are not needed when the project has no database configured (e.g. `config/<runMode>.yaml` with no `database` section). See [Serverpod Upgrading](../serverpod-upgrading/SKILL.md) to add a database to an existing project.
 
 ## Standard flow
 

--- a/packages/serverpod/skills/serverpod-overview/SKILL.md
+++ b/packages/serverpod/skills/serverpod-overview/SKILL.md
@@ -15,7 +15,7 @@ There can also be packages that share code, e.g., `my_project_shared`.
 
 The server exposes endpoint classes that the client calls via generated RPC client. Add methods to the endpoints, the code generation will recreate them on the client side. Models are defined in YAML and generate Dart classes for both server and client.
 
-Serverpod projects use a Postgres database for persistence and include an ORM, caching, real-time streaming (using Dart streams), file uploads, scheduling (called future calls), logging, and a built-in web server (Relic). Each of these features have specific skills that you can use to get more details.
+Serverpod projects can include a Postgres or SQLite database for persistence (with an ORM), caching, real-time streaming (using Dart streams), file uploads, scheduling (called future calls), logging, and a built-in web server (Relic). Each of these features has a specific skill that you can use to get more details.
 
 ## Running the server
 

--- a/packages/serverpod/skills/serverpod-upgrading/SKILL.md
+++ b/packages/serverpod/skills/serverpod-upgrading/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: serverpod-upgrading
-description: Upgrade Serverpod — minor/patch updates, major upgrade to v3. Use when upgrading Serverpod versions or updating dependencies.
+description: Upgrade Serverpod versions, add a database to a project created without one, or address breaking changes. Use when upgrading Serverpod, updating dependencies, or enabling database support on an existing project.
 ---
 
 # Serverpod minor/patch upgrade
@@ -41,4 +41,22 @@ After following the regular upgrade process, ensure that the following breaking 
 **Auth:** `session.authenticated` is now synchronous. `AuthenticationInfo.authId` non-nullable, `userIdentifier` is `String`. Client: `authenticationKeyManager` → `authKeyProvider`. Custom handlers receive unwrapped Bearer token.
 
 **Deprecated:** Legacy streaming endpoints; use streaming methods.
+
+# Adding a database to a project created without one
+
+Some Serverpod projects are created without a database. Add one by re-running the project creator (`serverpod create .`), which uses an interactive TUI. STOP and ask the user to run it; do not attempt to drive the TUI yourself.
+
+**Detect no-database state:** `config/development.yaml` lacks a `database:` block, or there is no `docker-compose.yaml` at the server package root.
+
+## Steps
+
+1. Ask the user to run `serverpod create .` from inside the server package directory (e.g. `cd my_project_server && serverpod create .`).
+2. Warn the user that the TUI does NOT remember previous project selections. They must re-pick the original options (Flutter, Redis, Auth, Web, Skills) PLUS choose `database: postgres` (or `sqlite`).
+3. After completion, verify it landed: `config/development.yaml` has a `database:` block, `docker-compose.yaml` exists at the server package root, `config/passwords.yaml` has a `database` entry, and a default migration exists under `migrations/`.
+4. Add `table: <table_name>` to any `.spy.yaml` model(s) the user wants persisted. See [Serverpod Models](../serverpod-models/SKILL.md).
+5. Regenerate code: use the MCP `generate` tool if connected, otherwise run `serverpod generate`.
+6. Create a migration: use the MCP if connected, otherwise run `serverpod create-migration`. See [Serverpod Migrations](../serverpod-migrations/SKILL.md).
+7. Ask the user to start the database with `docker compose up -d` (from the server package directory) and apply the migration.
+
+A `Dockerfile` is not added by this flow. It is a separate production deployment artifact, not required for local database support.
 

--- a/packages/serverpod/skills/serverpod-upgrading/SKILL.md
+++ b/packages/serverpod/skills/serverpod-upgrading/SKILL.md
@@ -46,17 +46,17 @@ After following the regular upgrade process, ensure that the following breaking 
 
 Some Serverpod projects are created without a database. Add one by re-running the project creator (`serverpod create .`), which uses an interactive TUI. STOP and ask the user to run it; do not attempt to drive the TUI yourself.
 
-**Detect no-database state:** `config/development.yaml` lacks a `database:` block, or there is no `docker-compose.yaml` at the server package root.
+**Detect no-database state:** `config/development.yaml` lacks a `database:` block.
 
 ## Steps
 
 1. Ask the user to run `serverpod create .` from inside the server package directory (e.g. `cd my_project_server && serverpod create .`).
-2. Warn the user that the TUI does NOT remember previous project selections. They must re-pick the original options (Flutter, Redis, Auth, Web, Skills) PLUS choose `database: postgres` (or `sqlite`).
-3. After completion, verify it landed: `config/development.yaml` has a `database:` block, `docker-compose.yaml` exists at the server package root, `config/passwords.yaml` has a `database` entry, and a default migration exists under `migrations/`.
+2. Tell the user to choose `database: postgres` (or `sqlite`) in the TUI, along with any other features (Flutter, Redis, Auth, Web, Skills) that match their existing project.
+3. After completion, verify it landed: `config/development.yaml` has a `database:` block and a default migration exists under `migrations/`. For Postgres, also verify `docker-compose.yaml` exists at the server package root and `config/passwords.yaml` has a `database` entry. SQLite does not require either.
 4. Add `table: <table_name>` to any `.spy.yaml` model(s) the user wants persisted. See [Serverpod Models](../serverpod-models/SKILL.md).
 5. Regenerate code: use the MCP `generate` tool if connected, otherwise run `serverpod generate`.
 6. Create a migration: use the MCP if connected, otherwise run `serverpod create-migration`. See [Serverpod Migrations](../serverpod-migrations/SKILL.md).
-7. Ask the user to start the database with `docker compose up -d` (from the server package directory) and apply the migration.
+7. If the user chose Postgres, ask them to start the database with `docker compose up -d` from the server package directory. SQLite does not need Docker. For either, apply the migration using the workflow in [Serverpod Migrations](../serverpod-migrations/SKILL.md).
 
 A `Dockerfile` is not added by this flow. It is a separate production deployment artifact, not required for local database support.
 


### PR DESCRIPTION
Updates the skills documentation so that agents can understand how to upgrade a project to use a database when it was setup without one.

Fixed #5129 

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes
None