### PR TITLE
feat: Spawn flutter app from serverpod start

### DIFF
--- a/templates/serverpod_templates/vscode/launch.json
+++ b/templates/serverpod_templates/vscode/launch.json
@@ -10,10 +10,8 @@
       "internalConsoleOptions": "neverOpen"
     },
     {
-      // Attaches to the Flutter app that `serverpod start` spawns via
-      // its `--flutter` flag (default on when a Flutter package is
-      // present). Don't launch a second Flutter instance from VS Code -
-      // that would race the spawn for the same web-server port.
+      // Attaches to the Flutter app `serverpod start` spawns. Don't
+      // launch a second instance here - it would race for the port.
       "name": "projectname_flutter",
       "type": "dart",
       "request": "attach",
@@ -26,8 +24,7 @@
     {
       "name": "projectname (full stack)",
       "configurations": ["projectname_server", "projectname_flutter"],
-      // Stop both debug sessions when the user stops one. Without this
-      // the orphan keeps running and the next launch fails to re-attach.
+      // Stopping one session stops both; the orphan blocks re-attach.
       "stopAll": true,
       "presentation": {
         "order": 1

--- a/templates/serverpod_templates/vscode/launch.json
+++ b/templates/serverpod_templates/vscode/launch.json
@@ -2,20 +2,20 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "name": "projectname_server",
-      "type": "dart",
-      "request": "attach",
-      "vmServiceInfoFile": "${workspaceFolder}/projectname_server/.dart_tool/serverpod/vm-service-info.json",
-      "preLaunchTask": "serverpod_start",
-      "internalConsoleOptions": "neverOpen"
-    },
-    {
       // Attaches to the Flutter app `serverpod start` spawns. Don't
       // launch a second instance here - it would race for the port.
       "name": "projectname_flutter",
       "type": "dart",
       "request": "attach",
       "vmServiceInfoFile": "${workspaceFolder}/projectname_server/.dart_tool/serverpod/flutter-vm-service-info.json",
+      "preLaunchTask": "serverpod_start",
+      "internalConsoleOptions": "neverOpen"
+    },
+    {
+      "name": "projectname_server",
+      "type": "dart",
+      "request": "attach",
+      "vmServiceInfoFile": "${workspaceFolder}/projectname_server/.dart_tool/serverpod/vm-service-info.json",
       "preLaunchTask": "serverpod_start",
       "internalConsoleOptions": "neverOpen"
     }

--- a/templates/serverpod_templates/vscode/launch.json
+++ b/templates/serverpod_templates/vscode/launch.json
@@ -2,17 +2,22 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "name": "projectname_flutter",
-      "cwd": "${workspaceFolder}/projectname_flutter",
-      "request": "launch",
-      "type": "dart",
-      "program": "lib/main.dart"
-    },
-    {
       "name": "projectname_server",
       "type": "dart",
       "request": "attach",
       "vmServiceInfoFile": "${workspaceFolder}/projectname_server/.dart_tool/serverpod/vm-service-info.json",
+      "preLaunchTask": "serverpod_start",
+      "internalConsoleOptions": "neverOpen"
+    },
+    {
+      // Attaches to the Flutter app that `serverpod start` spawns via
+      // its `--flutter` flag (default on when a Flutter package is
+      // present). Don't launch a second Flutter instance from VS Code -
+      // that would race the spawn for the same web-server port.
+      "name": "projectname_flutter",
+      "type": "dart",
+      "request": "attach",
+      "vmServiceInfoFile": "${workspaceFolder}/projectname_server/.dart_tool/serverpod/flutter-vm-service-info.json",
       "preLaunchTask": "serverpod_start",
       "internalConsoleOptions": "neverOpen"
     }
@@ -21,6 +26,9 @@
     {
       "name": "projectname (full stack)",
       "configurations": ["projectname_server", "projectname_flutter"],
+      // Stop both debug sessions when the user stops one. Without this
+      // the orphan keeps running and the next launch fails to re-attach.
+      "stopAll": true,
       "presentation": {
         "order": 1
       }

--- a/tools/serverpod_cli/lib/src/commands/messages.dart
+++ b/tools/serverpod_cli/lib/src/commands/messages.dart
@@ -10,3 +10,7 @@ const serverRunning = 'Server running.';
 // Watch command messages
 const serverReloaded = '✓ Server reloaded.';
 const serverRestarted = '✓ Server restarted.';
+const flutterAppReloaded = '✓ Flutter app reloaded.';
+const flutterPackageNotFound =
+    'No Flutter package found; skipping --flutter. '
+    'Pass --no-flutter to silence this notice.';

--- a/tools/serverpod_cli/lib/src/commands/start.dart
+++ b/tools/serverpod_cli/lib/src/commands/start.dart
@@ -159,9 +159,8 @@ class StartCommand extends ServerpodCommand<StartOption> {
     final flutterExtraArgs = List<String>.from(
       commandConfig.value(StartOption.flutterOption) as Iterable,
     );
-    // Flutter's --verbose output arrives as daemon.logMessage events,
-    // which we route to log.debug - so this stays quiet unless the user
-    // also asked serverpod for verbose output.
+    // Flutter --verbose -> daemon.logMessage -> log.debug; stays quiet
+    // unless serverpod itself is verbose.
     final verbose =
         serverpodRunner.globalConfiguration.optionalValue(
           GlobalOption.verbose,

--- a/tools/serverpod_cli/lib/src/commands/start.dart
+++ b/tools/serverpod_cli/lib/src/commands/start.dart
@@ -392,6 +392,7 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
   void Function(String stage)? onFlutterProgress,
   void Function(String url)? onFlutterReady,
   Future<void> Function(ServerProcess server)? onServerStart,
+  Future<void> Function(FlutterProcess flutter)? onFlutterStart,
   List<Object> Function()? mcpGetLogHistory,
 }) async {
   log.info(watch ? 'Starting server in watch mode...' : 'Starting server...');
@@ -615,6 +616,10 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
             'Connecting to Flutter VM service',
             () async {
               await flutterProcess!.connectToVmService();
+              if (flutterProcess.isVmServiceConnected &&
+                  onFlutterStart != null) {
+                await onFlutterStart(flutterProcess);
+              }
               return flutterProcess.isVmServiceConnected;
             },
           ),
@@ -969,6 +974,14 @@ Future<void> _runTuiBackend({
       },
       onServerStart: (server) async {
         final vmService = server.vmService;
+        if (vmService == null) return;
+        await vmService.streamListen('Extension');
+        vmService.onExtensionEvent.listen(
+          (event) => handleServerLogEvent(holder, event),
+        );
+      },
+      onFlutterStart: (flutter) async {
+        final vmService = flutter.vmService;
         if (vmService == null) return;
         await vmService.streamListen('Extension');
         vmService.onExtensionEvent.listen(

--- a/tools/serverpod_cli/lib/src/commands/start.dart
+++ b/tools/serverpod_cli/lib/src/commands/start.dart
@@ -159,6 +159,17 @@ class StartCommand extends ServerpodCommand<StartOption> {
     final flutterExtraArgs = List<String>.from(
       commandConfig.value(StartOption.flutterOption) as Iterable,
     );
+    // Flutter's --verbose output arrives as daemon.logMessage events,
+    // which we route to log.debug - so this stays quiet unless the user
+    // also asked serverpod for verbose output.
+    final verbose =
+        serverpodRunner.globalConfiguration.optionalValue(
+          GlobalOption.verbose,
+        ) ??
+        false;
+    if (verbose && !flutterExtraArgs.contains('--verbose')) {
+      flutterExtraArgs.insert(0, '--verbose');
+    }
 
     // In TUI mode, start the UI immediately and do all setup in onReady.
     // This avoids a visible delay from config loading and Docker checks.

--- a/tools/serverpod_cli/lib/src/commands/start.dart
+++ b/tools/serverpod_cli/lib/src/commands/start.dart
@@ -584,41 +584,36 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
         },
       );
       try {
-        await log.progress(
-          'Launching Flutter app (first run may take 30-60s)',
-          () async {
-            await flutterProcess!.start();
-            // `launched` (not VM service connect): on `-d web-server`
-            // the URI doesn't arrive until a browser attaches, which
-            // the user can't do without seeing the URL first.
-            await flutterProcess.launched;
-            return true;
-          },
-        );
-        final url = flutterProcess.flutterAppUrl;
-        if (url != null) {
-          log.info('Flutter app running at $url');
-          onFlutterReady?.call(url);
-        }
-        // Background tracked op so the TUI shows a parallel spinner.
-        // On `-d web-server` this pends until a browser attaches;
-        // reload is unavailable until it resolves.
-        unawaited(
-          log.progress(
-            'Connecting to Flutter VM service',
-            () async {
-              await flutterProcess!.connectToVmService();
-              if (flutterProcess.isVmServiceConnected &&
-                  onFlutterStart != null) {
-                await onFlutterStart(flutterProcess);
-              }
-              return flutterProcess.isVmServiceConnected;
-            },
-          ),
-        );
+        await flutterProcess.start();
       } on FlutterNotInstalledException catch (e) {
         log.warning(e.message);
         flutterProcess = null;
+      }
+      final fp = flutterProcess;
+      if (fp != null) {
+        // Background: Server-running shouldn't wait on Flutter launch.
+        // On `-d web-server` `launched` pends until a browser attaches.
+        unawaited(() async {
+          await log.progress(
+            'Launching Flutter app (first run may take 30-60s)',
+            () async {
+              await fp.launched;
+              return true;
+            },
+          );
+          final url = fp.flutterAppUrl;
+          if (url != null) {
+            log.info('Flutter app running at $url');
+            onFlutterReady?.call(url);
+          }
+          await log.progress('Connecting to Flutter VM service', () async {
+            await fp.connectToVmService();
+            if (fp.isVmServiceConnected && onFlutterStart != null) {
+              await onFlutterStart(fp);
+            }
+            return fp.isVmServiceConnected;
+          });
+        }());
       }
     }
   }

--- a/tools/serverpod_cli/lib/src/commands/start.dart
+++ b/tools/serverpod_cli/lib/src/commands/start.dart
@@ -154,13 +154,11 @@ class StartCommand extends ServerpodCommand<StartOption> {
     final useTui = commandConfig.value(StartOption.tui) && stdout.hasTerminal;
     final launchFlutterApp = commandConfig.value(StartOption.flutter);
     final flutterDevice = commandConfig.value(StartOption.flutterDevice);
-    // `MultiOption.value()` is typed as `List<dynamic>`; narrow once here so
-    // the rest of the wiring deals in `List<String>`.
+    // Narrow once: MultiOption.value() returns List<dynamic>.
     final flutterExtraArgs = List<String>.from(
       commandConfig.value(StartOption.flutterOption) as Iterable,
     );
-    // Flutter --verbose -> daemon.logMessage -> log.debug; stays quiet
-    // unless serverpod itself is verbose.
+    // Mirror serverpod -v into flutter; output flows via log.debug.
     final verbose =
         serverpodRunner.globalConfiguration.optionalValue(
           GlobalOption.verbose,
@@ -559,25 +557,18 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
     return true;
   });
 
-  // Resolved here so the Flutter spawn can gate on dev mode before
-  // bringing up `flutter run`; WatchSession needs it for the migration
-  // action below.
+  // Needed for the Flutter dev-mode gate and the migration action.
   final runMode = runModeFromServerArgs(serverArgs.value);
 
-  // Start the Flutter app (when requested and the project has one).
-  // hasFlutterPackage gates module/server-only projects so --flutter is
-  // a silent no-op there; FlutterNotInstalledException covers users who
-  // pass --flutter without Flutter on PATH; the runMode gate keeps
-  // production/staging boots from spawning a dev Flutter process.
+  // Production/staging boots skip the dev Flutter spawn. Missing
+  // package = silent no-op; missing Flutter SDK = warning.
   FlutterProcess? flutterProcess;
   if (launchFlutterApp && runMode == 'development') {
     if (!config.hasFlutterPackage) {
       log.info(flutterPackageNotFound);
     } else {
-      // Non-TUI callers don't get a sub-stage spinner from log.progress
-      // (it shows one message). Forward `app.progress` events from the
-      // daemon as `log.info` so users see "Building..." / "Hot
-      // reload..." while the cold compile chews through 30-60s.
+      // Non-TUI: surface daemon progress as log.info during the 30-60s
+      // cold compile; log.progress shows only one line.
       flutterProcess = FlutterProcess(
         flutterPackageDir: p.joinAll(config.flutterPackagePathParts),
         device: flutterDevice,
@@ -597,14 +588,9 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
           'Launching Flutter app (first run may take 30-60s)',
           () async {
             await flutterProcess!.start();
-            // Gate on `launched`, not on VM service connect: on
-            // `-d web-server` the daemon withholds `app.debugPort`
-            // until a browser attaches, so awaiting the VM service
-            // here would hide the served URL behind a 60s+ timeout -
-            // the user can't open the browser they need to open to
-            // unblock the URI publication. Whichever of
-            // `app.webLaunchUrl` / `app.debugPort` arrives first
-            // completes the gate.
+            // `launched` (not VM service connect): on `-d web-server`
+            // the URI doesn't arrive until a browser attaches, which
+            // the user can't do without seeing the URL first.
             await flutterProcess.launched;
             return true;
           },
@@ -614,13 +600,9 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
           log.info('Flutter app running at $url');
           onFlutterReady?.call(url);
         }
-        // Connect to the VM service in the background as its own
-        // tracked operation so the TUI shows a parallel spinner: on
-        // `-d web-server` the VM service URI doesn't arrive until a
-        // browser attaches, so this can pend for an arbitrary time
-        // after launch completes - making that visible matters.
-        // Reload is unavailable until this resolves
-        // (FlutterProcess.reload returns false silently).
+        // Background tracked op so the TUI shows a parallel spinner.
+        // On `-d web-server` this pends until a browser attaches;
+        // reload is unavailable until it resolves.
         unawaited(
           log.progress(
             'Connecting to Flutter VM service',
@@ -697,11 +679,8 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
     mcpSocket = null;
   }
 
-  // File watcher (watch mode only). One watcher covers server lib, shared
-  // models, client lib, web, and - when Flutter is attached - the Flutter
-  // package's lib/. All changes flow through session.handleFileChange so
-  // codegen + server reload + Flutter reload serialize via WatchSession's
-  // _chain. No parallel watcher.
+  // Single watcher across server/shared/client/web/flutter. Changes
+  // serialize through session.handleFileChange via WatchSession._chain.
   StreamSubscription<void>? fileChangeSub;
   if (watch) {
     final watcher = FileWatcher(
@@ -972,7 +951,6 @@ Future<void> _runTuiBackend({
       flutterStdoutSink: flutterStdoutSink,
       flutterStderrSink: flutterStderrSink,
       onFlutterProgress: (stage) {
-        // Show Flutter startup progress in the TUI status area.
         holder.state.flutterStartupStage = stage;
         holder.state.showFlutterOutput = true;
         holder.markDirty();

--- a/tools/serverpod_cli/lib/src/commands/start.dart
+++ b/tools/serverpod_cli/lib/src/commands/start.dart
@@ -582,7 +582,15 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
           'Launching Flutter app (first run may take 30-60s)',
           () async {
             await flutterProcess!.start();
-            await flutterProcess.connectToVmService();
+            // Gate on `launched`, not on VM service connect: on
+            // `-d web-server` the daemon withholds `app.debugPort`
+            // until a browser attaches, so awaiting the VM service
+            // here would hide the served URL behind a 60s+ timeout -
+            // the user can't open the browser they need to open to
+            // unblock the URI publication. Whichever of
+            // `app.webLaunchUrl` / `app.debugPort` arrives first
+            // completes the gate.
+            await flutterProcess.launched;
             return true;
           },
         );
@@ -591,6 +599,11 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
           log.info('Flutter app running at $url');
           onFlutterReady?.call(url);
         }
+        // Connect to the VM service in the background. May pend
+        // indefinitely on `-d web-server` until a browser attaches;
+        // that's expected. Reload is unavailable until it resolves
+        // (FlutterProcess.reload returns false silently).
+        unawaited(flutterProcess.connectToVmService());
       } on FlutterNotInstalledException catch (e) {
         log.warning(e.message);
         flutterProcess = null;

--- a/tools/serverpod_cli/lib/src/commands/start.dart
+++ b/tools/serverpod_cli/lib/src/commands/start.dart
@@ -959,12 +959,12 @@ Future<void> _runTuiBackend({
       onFlutterProgress: (stage) {
         // Show Flutter startup progress in the TUI status area.
         holder.state.flutterStartupStage = stage;
+        holder.state.showFlutterOutput = true;
         holder.markDirty();
       },
       onFlutterReady: (url) {
         holder.state.flutterUrl = url;
         holder.state.flutterReady = true;
-        holder.state.showFlutterOutput = true;
         holder.markDirty();
       },
       onServerStart: (server) async {

--- a/tools/serverpod_cli/lib/src/commands/start.dart
+++ b/tools/serverpod_cli/lib/src/commands/start.dart
@@ -599,11 +599,22 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
           log.info('Flutter app running at $url');
           onFlutterReady?.call(url);
         }
-        // Connect to the VM service in the background. May pend
-        // indefinitely on `-d web-server` until a browser attaches;
-        // that's expected. Reload is unavailable until it resolves
+        // Connect to the VM service in the background as its own
+        // tracked operation so the TUI shows a parallel spinner: on
+        // `-d web-server` the VM service URI doesn't arrive until a
+        // browser attaches, so this can pend for an arbitrary time
+        // after launch completes - making that visible matters.
+        // Reload is unavailable until this resolves
         // (FlutterProcess.reload returns false silently).
-        unawaited(flutterProcess.connectToVmService());
+        unawaited(
+          log.progress(
+            'Connecting to Flutter VM service',
+            () async {
+              await flutterProcess!.connectToVmService();
+              return flutterProcess.isVmServiceConnected;
+            },
+          ),
+        );
       } on FlutterNotInstalledException catch (e) {
         log.warning(e.message);
         flutterProcess = null;

--- a/tools/serverpod_cli/lib/src/commands/start.dart
+++ b/tools/serverpod_cli/lib/src/commands/start.dart
@@ -90,8 +90,12 @@ enum StartOption<V> implements OptionDefinition<V> {
   flutterDevice(
     StringOption(
       argName: 'flutter-device',
-      defaultsTo: 'web-server',
-      helpText: 'Target device for `flutter run -d`. Defaults to web-server.',
+      defaultsTo: 'chrome',
+      helpText:
+          'Target device for `flutter run -d`. Defaults to chrome '
+          '(web-server is headless and triggers a known DWDS hot-reload '
+          'bug: dart-lang/sdk#60289). Pass --flutter-device=web-server '
+          'for CI / headless / remote-attach workflows.',
     ),
   ),
   flutterOption(

--- a/tools/serverpod_cli/lib/src/commands/start.dart
+++ b/tools/serverpod_cli/lib/src/commands/start.dart
@@ -10,6 +10,7 @@ import 'package:serverpod_cli/analyzer.dart';
 import 'package:serverpod_cli/src/commands/generate.dart';
 import 'package:serverpod_cli/src/commands/messages.dart';
 import 'package:serverpod_cli/src/commands/start/file_watcher.dart';
+import 'package:serverpod_cli/src/commands/start/flutter_process.dart';
 import 'package:serverpod_cli/src/commands/start/kernel_compiler.dart';
 import 'package:serverpod_cli/src/commands/start/mcp_server.dart';
 import 'package:serverpod_cli/src/commands/start/mcp_socket.dart';
@@ -76,6 +77,34 @@ enum StartOption<V> implements OptionDefinition<V> {
       helpText: 'Show interactive terminal UI.',
     ),
   ),
+  flutter(
+    FlagOption(
+      argName: 'flutter',
+      defaultsTo: true,
+      helpText:
+          'Launch the project\'s Flutter app alongside the server when a '
+          'companion Flutter package is present. Silently skipped for '
+          'projects without one. Use --no-flutter to disable.',
+    ),
+  ),
+  flutterDevice(
+    StringOption(
+      argName: 'flutter-device',
+      defaultsTo: 'web-server',
+      helpText: 'Target device for `flutter run -d`. Defaults to web-server.',
+    ),
+  ),
+  flutterOption(
+    MultiOption(
+      argName: 'flutter-option',
+      multiParser: MultiParser(StringParser()),
+      helpText:
+          'Extra argument forwarded to `flutter run`. Repeatable, e.g. '
+          '--flutter-option=--web-hostname=0.0.0.0 '
+          '--flutter-option=--web-port=8090.',
+      defaultsTo: [],
+    ),
+  ),
   ;
 
   const StartOption(this.option);
@@ -119,6 +148,13 @@ class StartCommand extends ServerpodCommand<StartOption> {
   ) async {
     final watch = commandConfig.value(StartOption.watch);
     final useTui = commandConfig.value(StartOption.tui) && stdout.hasTerminal;
+    final launchFlutterApp = commandConfig.value(StartOption.flutter);
+    final flutterDevice = commandConfig.value(StartOption.flutterDevice);
+    // `MultiOption.value()` is typed as `List<dynamic>`; narrow once here so
+    // the rest of the wiring deals in `List<String>`.
+    final flutterExtraArgs = List<String>.from(
+      commandConfig.value(StartOption.flutterOption) as Iterable,
+    );
 
     // In TUI mode, start the UI immediately and do all setup in onReady.
     // This avoids a visible delay from config loading and Docker checks.
@@ -137,6 +173,9 @@ class StartCommand extends ServerpodCommand<StartOption> {
       final exitCode = await _runWithTui(
         commandConfig: commandConfig,
         watch: watch,
+        launchFlutterApp: launchFlutterApp,
+        flutterDevice: flutterDevice,
+        flutterExtraArgs: flutterExtraArgs,
         serverArgs: argResults?.rest ?? [],
         config: config,
       );
@@ -186,6 +225,9 @@ class StartCommand extends ServerpodCommand<StartOption> {
         serverArgs: serverArgs,
         watch: watch,
         docker: docker,
+        launchFlutterApp: launchFlutterApp,
+        flutterDevice: flutterDevice,
+        flutterExtraArgs: flutterExtraArgs,
         shutdown: shutdown,
       );
       switch (result) {
@@ -335,9 +377,16 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
   required ServerArgsRef serverArgs,
   required bool watch,
   required bool docker,
+  required bool launchFlutterApp,
+  required String flutterDevice,
+  required List<String> flutterExtraArgs,
   required _ShutdownSignal shutdown,
   IOSink? serverStdoutSink,
   IOSink? serverStderrSink,
+  IOSink? flutterStdoutSink,
+  IOSink? flutterStderrSink,
+  void Function(String stage)? onFlutterProgress,
+  void Function(String url)? onFlutterReady,
   Future<void> Function(ServerProcess server)? onServerStart,
   List<Object> Function()? mcpGetLogHistory,
 }) async {
@@ -495,8 +544,61 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
     return true;
   });
 
-  // Construct the watch session.
+  // Resolved here so the Flutter spawn can gate on dev mode before
+  // bringing up `flutter run`; WatchSession needs it for the migration
+  // action below.
   final runMode = runModeFromServerArgs(serverArgs.value);
+
+  // Start the Flutter app (when requested and the project has one).
+  // hasFlutterPackage gates module/server-only projects so --flutter is
+  // a silent no-op there; FlutterNotInstalledException covers users who
+  // pass --flutter without Flutter on PATH; the runMode gate keeps
+  // production/staging boots from spawning a dev Flutter process.
+  FlutterProcess? flutterProcess;
+  if (launchFlutterApp && runMode == 'development') {
+    if (!config.hasFlutterPackage) {
+      log.info(flutterPackageNotFound);
+    } else {
+      // Non-TUI callers don't get a sub-stage spinner from log.progress
+      // (it shows one message). Forward `app.progress` events from the
+      // daemon as `log.info` so users see "Building..." / "Hot
+      // reload..." while the cold compile chews through 30-60s.
+      flutterProcess = FlutterProcess(
+        flutterPackageDir: p.joinAll(config.flutterPackagePathParts),
+        device: flutterDevice,
+        extraArgs: flutterExtraArgs,
+        vmServiceInfoFile: defaultFlutterVmServiceInfoFile(serverpodToolDir),
+        stdoutSink: flutterStdoutSink,
+        stderrSink: flutterStderrSink,
+        onProgress: (stage) {
+          onFlutterProgress?.call(stage);
+          if (onFlutterProgress == null) {
+            log.info('  Flutter: $stage');
+          }
+        },
+      );
+      try {
+        await log.progress(
+          'Launching Flutter app (first run may take 30-60s)',
+          () async {
+            await flutterProcess!.start();
+            await flutterProcess.connectToVmService();
+            return true;
+          },
+        );
+        final url = flutterProcess.flutterAppUrl;
+        if (url != null) {
+          log.info('Flutter app running at $url');
+          onFlutterReady?.call(url);
+        }
+      } on FlutterNotInstalledException catch (e) {
+        log.warning(e.message);
+        flutterProcess = null;
+      }
+    }
+  }
+
+  // Construct the watch session.
   session = WatchSession(
     compiler: compiler,
     nativeAssetsBuilder: nativeAssetsBuilder,
@@ -512,6 +614,7 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
     createServer: serverProcessFactory,
     initialServer: initialServerProcess,
     generatedDirPaths: config.generatedDirPaths,
+    flutterProcess: flutterProcess,
     applyMigrationsAction: () => _applyMigrationsForSession(
       serverDir: serverDir,
       runMode: runMode,
@@ -551,7 +654,11 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
     mcpSocket = null;
   }
 
-  // File watcher (watch mode only).
+  // File watcher (watch mode only). One watcher covers server lib, shared
+  // models, client lib, web, and - when Flutter is attached - the Flutter
+  // package's lib/. All changes flow through session.handleFileChange so
+  // codegen + server reload + Flutter reload serialize via WatchSession's
+  // _chain. No parallel watcher.
   StreamSubscription<void>? fileChangeSub;
   if (watch) {
     final watcher = FileWatcher(
@@ -562,6 +669,8 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
         p.absolute(
           p.joinAll([...config.serverPackageDirectoryPathParts, 'web']),
         ),
+        if (flutterProcess != null)
+          p.absolute(p.joinAll([...config.flutterPackagePathParts, 'lib'])),
       },
     );
     fileChangeSub = watcher.onFilesChanged
@@ -713,6 +822,9 @@ Future<String?> _checkExistingServer(String infoPath) async {
 Future<int> _runWithTui({
   required Configuration<StartOption> commandConfig,
   required bool watch,
+  required bool launchFlutterApp,
+  required String flutterDevice,
+  required List<String> flutterExtraArgs,
   required List<String> serverArgs,
   required GeneratorConfig config,
 }) async {
@@ -737,6 +849,9 @@ Future<int> _runWithTui({
           holder: h,
           commandConfig: commandConfig,
           watch: watch,
+          launchFlutterApp: launchFlutterApp,
+          flutterDevice: flutterDevice,
+          flutterExtraArgs: flutterExtraArgs,
           serverArgs: serverArgs,
           config: config,
           shutdown: shutdown,
@@ -770,6 +885,9 @@ Future<void> _runTuiBackend({
   required StartAppStateHolder holder,
   required Configuration<StartOption> commandConfig,
   required bool watch,
+  required bool launchFlutterApp,
+  required String flutterDevice,
+  required List<String> flutterExtraArgs,
   required List<String> serverArgs,
   required GeneratorConfig config,
   required _ShutdownSignal shutdown,
@@ -785,8 +903,16 @@ Future<void> _runTuiBackend({
 
     final argsRef = ServerArgsRef(serverArgs);
 
-    final stdoutSink = TuiLogSink(holder);
-    final stderrSink = TuiLogSink(holder);
+    final stdoutSink = TuiLogSink(holder, addLine: holder.state.rawLines.add);
+    final stderrSink = TuiLogSink(holder, addLine: holder.state.rawLines.add);
+    final flutterStdoutSink = TuiLogSink(
+      holder,
+      addLine: holder.state.rawFlutterLines.add,
+    );
+    final flutterStderrSink = TuiLogSink(
+      holder,
+      addLine: holder.state.rawFlutterLines.add,
+    );
 
     final result = await _setupWatchLoop(
       config: config,
@@ -794,9 +920,25 @@ Future<void> _runTuiBackend({
       serverArgs: argsRef,
       watch: watch,
       docker: docker,
+      launchFlutterApp: launchFlutterApp,
+      flutterDevice: flutterDevice,
+      flutterExtraArgs: flutterExtraArgs,
       shutdown: shutdown,
       serverStdoutSink: stdoutSink,
       serverStderrSink: stderrSink,
+      flutterStdoutSink: flutterStdoutSink,
+      flutterStderrSink: flutterStderrSink,
+      onFlutterProgress: (stage) {
+        // Show Flutter startup progress in the TUI status area.
+        holder.state.flutterStartupStage = stage;
+        holder.markDirty();
+      },
+      onFlutterReady: (url) {
+        holder.state.flutterUrl = url;
+        holder.state.flutterReady = true;
+        holder.state.showFlutterOutput = true;
+        holder.markDirty();
+      },
       onServerStart: (server) async {
         final vmService = server.vmService;
         if (vmService == null) return;

--- a/tools/serverpod_cli/lib/src/commands/start/flutter_process.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/flutter_process.dart
@@ -4,9 +4,13 @@ import 'dart:io';
 
 import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
+import 'package:serverpod_cli/src/commands/start/server_process.dart'
+    show vmServiceWsUri;
 import 'package:serverpod_cli/src/util/serverpod_cli_logger.dart';
 import 'package:serverpod_cli/src/vendored/flutter_daemon_protocol.dart';
 import 'package:serverpod_shared/serverpod_shared.dart';
+import 'package:vm_service/vm_service.dart';
+import 'package:vm_service/vm_service_io.dart';
 
 /// Thrown by [FlutterProcess.start] when the `flutter` binary cannot be
 /// launched (typically because Flutter is not installed or not on `PATH`).
@@ -65,6 +69,7 @@ class FlutterProcess {
   FlutterDaemonProtocol? _daemon;
   String? _vmServiceUri;
   String? _flutterAppUrl;
+  VmService? _vmService;
 
   // `null` result means the process exited before publishing a URI.
   final Completer<String?> _vmServiceUriCompleter = Completer<String?>();
@@ -96,16 +101,18 @@ class FlutterProcess {
   /// True between [start] and [stop]/exit.
   bool get isRunning => _process != null;
 
-  /// True once the Flutter daemon has published the VM service URI
-  /// (after which [_vmServiceInfoFile] has been written for IDE attach).
-  bool get isVmServiceConnected => _vmServiceUri != null;
+  /// True once [connectToVmService] resolved the upstream VM service.
+  bool get isVmServiceConnected => _vmService != null;
 
   /// HTTP VM service URI, or `null` before [connectToVmService] resolves.
   String? get vmServiceUri => _vmServiceUri;
 
-  /// HTTP URL the Flutter app is served at (e.g.
-  /// `http://localhost:54321`), or `null` before `--machine` emitted
-  /// `app.webLaunchUrl`.
+  /// Connected `vm_service` client, or `null` before
+  /// [connectToVmService] resolves and after [stop].
+  VmService? get vmService => _vmService;
+
+  /// HTTP URL the Flutter app is served at, or `null` before
+  /// `--machine` emitted `app.webLaunchUrl`.
   String? get flutterAppUrl => _flutterAppUrl;
 
   /// Completes on the first of `app.debugPort`, `app.webLaunchUrl`, or
@@ -180,6 +187,14 @@ class FlutterProcess {
     final stdoutLines = StreamController<String>();
     const lineSplitter = LineSplitter();
     final lineBuffer = StringBuffer();
+    void routeLine(String line) {
+      if (line.startsWith('[')) {
+        stdoutLines.add(line);
+      } else if (line.isNotEmpty) {
+        _stdout.writeln(line);
+      }
+    }
+
     _stdoutBytesSub = process.stdout.listen(
       (data) {
         lineBuffer.write(utf8.decode(data, allowMalformed: true));
@@ -189,23 +204,11 @@ class FlutterProcess {
         final ready = bufferStr.substring(0, lastNewline);
         lineBuffer.clear();
         lineBuffer.write(bufferStr.substring(lastNewline + 1));
-        for (final line in lineSplitter.convert(ready)) {
-          if (line.startsWith('[')) {
-            stdoutLines.add(line);
-          } else if (line.isNotEmpty) {
-            _stdout.writeln(line);
-          }
-        }
+        lineSplitter.convert(ready).forEach(routeLine);
       },
       onDone: () {
         if (lineBuffer.isNotEmpty) {
-          for (final line in lineSplitter.convert(lineBuffer.toString())) {
-            if (line.startsWith('[')) {
-              stdoutLines.add(line);
-            } else if (line.isNotEmpty) {
-              _stdout.writeln(line);
-            }
-          }
+          lineSplitter.convert(lineBuffer.toString()).forEach(routeLine);
           lineBuffer.clear();
         }
         stdoutLines.close();
@@ -233,11 +236,12 @@ class FlutterProcess {
     );
   }
 
-  /// Wait for the VM service URI from `app.debugPort`, then write it
-  /// to [_vmServiceInfoFile] so IDEs can attach. On `-d web-server`
-  /// this pends until a browser attaches.
+  /// Wait for the VM service URI from `app.debugPort`, write it to
+  /// [_vmServiceInfoFile] for IDE attach, then open a `vm_service`
+  /// client. Best-effort. On `-d web-server` this pends until a
+  /// browser attaches.
   Future<void> connectToVmService() async {
-    if (_vmServiceUri != null) return;
+    if (_vmService != null) return;
     _onProgress?.call('connecting');
 
     final maybeUri = await _vmServiceUriCompleter.future;
@@ -251,6 +255,20 @@ class FlutterProcess {
         ).writeAsString(jsonEncode({'uri': maybeUri}));
       } on FileSystemException catch (e) {
         log.warning('Could not write Flutter VM service info file: $e');
+      }
+    }
+
+    final wsUri = vmServiceWsUri(maybeUri);
+    for (var attempt = 0; attempt < 5; attempt++) {
+      try {
+        _vmService = await vmServiceConnectUri(wsUri);
+        return;
+      } on Exception {
+        if (attempt == 4) {
+          log.warning('Could not connect to Flutter VM service at $wsUri');
+          return;
+        }
+        await Future<void>.delayed(const Duration(milliseconds: 200));
       }
     }
   }
@@ -419,6 +437,9 @@ class FlutterProcess {
       _stderrBytesSub = null;
       _machineLinesSub = null;
       _sigtermSub = null;
+
+      await _vmService?.dispose();
+      _vmService = null;
 
       if (_vmServiceInfoFile != null) {
         await File(_vmServiceInfoFile).deleteIfExists();

--- a/tools/serverpod_cli/lib/src/commands/start/flutter_process.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/flutter_process.dart
@@ -12,15 +12,12 @@ import 'package:serverpod_shared/serverpod_shared.dart';
 import 'package:vm_service/vm_service.dart';
 import 'package:vm_service/vm_service_io.dart';
 
-/// Thrown by [FlutterProcess.start] when the `flutter` binary cannot be
-/// launched (typically because Flutter is not installed or not on `PATH`).
-/// Callers should catch this and continue without the Flutter integration
-/// rather than aborting `serverpod start`.
+/// Thrown by [FlutterProcess.start] when `flutter` cannot be launched.
 class FlutterNotInstalledException implements Exception {
-  /// Description of why launching `flutter` failed.
+  /// Reason `flutter` could not be launched.
   final String message;
 
-  /// The underlying [ProcessException] (or other cause) for debug output.
+  /// Underlying [ProcessException] or other cause.
   final Object? cause;
 
   FlutterNotInstalledException(this.message, [this.cause]);
@@ -29,10 +26,9 @@ class FlutterNotInstalledException implements Exception {
   String toString() => 'FlutterNotInstalledException: $message';
 }
 
-/// Manages a `flutter run --machine` subprocess. Mirrors [ServerProcess]
-/// in shape and lifecycle. The VM service URI captured from `app.debugPort`
-/// is written to [vmServiceInfoFile] for IDE attach; reload/restart are
-/// driven over the daemon's stdin via [FlutterDaemonProtocol].
+/// Manages a `flutter run --machine` subprocess. Mirrors [ServerProcess].
+/// VM service URI is written to [vmServiceInfoFile] for IDE attach;
+/// reload/restart go via [FlutterDaemonProtocol] over daemon stdin.
 class FlutterProcess {
   final String _flutterPackageDir;
   final String _flutterExecutable;
@@ -41,22 +37,17 @@ class FlutterProcess {
   final IOSink _stdout;
   final IOSink _stderr;
 
-  /// Path to write the VM service info JSON to once captured. Sibling of
-  /// the pod's `vm-service-info.json` so a single `launch.json` directory
-  /// reference covers both.
+  /// Sibling of the pod's `vm-service-info.json` so one launch.json
+  /// directory reference covers both.
   final String? _vmServiceInfoFile;
 
-  /// Optional callback for surfacing startup-stage progress (e.g. to the
-  /// TUI's tracked-operation indicator or a `log.progress` spinner). Fires
-  /// with `'launching'` on successful spawn, `'connecting'` before the VM
-  /// service connect attempt, `'ready'` after `app.started`, and verbatim
-  /// `app.progress` messages from the Flutter daemon in between.
+  /// Fires `'launching'` on spawn, `'connecting'` before VM-service
+  /// connect, `'ready'` on `app.started`, plus verbatim `app.progress`
+  /// messages in between.
   final void Function(String stage)? _onProgress;
 
-  /// Test-only override of the spawn args. When non-null, replaces the
-  /// default `['run', '--machine', '-d', <device>, ...extraArgs]` list.
-  /// Lets unit tests target a Dart shim that emits hand-crafted machine
-  /// JSON without needing a Flutter SDK on PATH.
+  /// Test-only spawn args override; replaces the default `flutter run`
+  /// arg list when non-null.
   final List<String>? _argsOverrideForTesting;
 
   Process? _process;
@@ -108,28 +99,21 @@ class FlutterProcess {
   /// HTTP VM service URI, or `null` before [connectToVmService] resolves.
   String? get vmServiceUri => _vmServiceUri;
 
-  /// Connected `vm_service` client, or `null` before
-  /// [connectToVmService] resolves and after [stop].
+  /// Connected `vm_service` client; `null` outside connect..[stop].
   VmService? get vmService => _vmService;
 
-  /// HTTP URL the Flutter app is served at, or `null` before
-  /// `--machine` emitted `app.webLaunchUrl`.
+  /// HTTP URL the Flutter app is served at (web targets only).
   String? get flutterAppUrl => _flutterAppUrl;
 
-  /// Completes on the first of `app.debugPort`, `app.webLaunchUrl`, or
-  /// process exit. The right gate for "Flutter is up enough to surface
-  /// to the user"; decoupled from [connectToVmService] because on
-  /// `-d web-server` the daemon withholds `app.debugPort` until a
-  /// browser attaches.
+  /// First of `app.debugPort`, `app.webLaunchUrl`, or process exit.
+  /// Decoupled from [connectToVmService]: on `-d web-server` the
+  /// daemon withholds `app.debugPort` until a browser attaches.
   Future<void> get launched => _launchedCompleter.future;
 
   /// Exit code of the `flutter run` subprocess.
   Future<int> get exitCode => _exitCodeCompleter.future;
 
-  /// Spawn `flutter run --machine -d <device>` in [flutterPackageDir].
-  ///
-  /// Throws [FlutterNotInstalledException] when `flutter` isn't on PATH;
-  /// caller should catch and continue without Flutter.
+  /// Throws [FlutterNotInstalledException] when `flutter` isn't on PATH.
   Future<void> start() async {
     if (_process != null) {
       throw StateError('FlutterProcess is already running.');
@@ -140,20 +124,10 @@ class FlutterProcess {
         <String>['run', '--machine', '-d', _device, ..._extraArgs];
 
     if (_vmServiceInfoFile != null) {
-      // Clear any stale info file from a prior run so consumers (IDE,
-      // launch.json) don't pick up a dead URI before this run publishes
-      // its own.
+      // A stale info file would mislead IDE attach.
       await File(_vmServiceInfoFile).deleteIfExists();
     }
 
-    // Skip every wrapper layer (puro/fvm/asdf shim, the flutter shell
-    // script, even the AOT snapshot) and invoke flutter_tools.dart
-    // through dart directly. That way our `Process.start` child IS
-    // the dart process running flutter_tools - `process.kill` reaches
-    // the daemon, and the simple SIGINT -> SIGKILL chain in [stop] is
-    // sufficient. Falls back to the unresolved executable name when
-    // the direct paths can't be located (e.g. an SDK that hasn't been
-    // bootstrapped yet, where `pub get` on flutter_tools hasn't run).
     final invocation = await _resolveFlutterInvocation(_flutterExecutable);
 
     Process process;
@@ -172,19 +146,16 @@ class FlutterProcess {
     }
     _process = process;
     _daemon = FlutterDaemonProtocol(process);
-    // Spawn succeeded - now signal the caller that startup is under way.
     _onProgress?.call('launching');
 
-    // Forward SIGTERM as SIGINT to the child for graceful shutdown.
+    // Forward SIGTERM as SIGINT for graceful shutdown.
     if (!Platform.isWindows) {
       _sigtermSub = ProcessSignal.sigterm.watch().listen(
         (_) => process.kill(ProcessSignal.sigint),
       );
     }
 
-    // Route `[`-prefixed lines to the machine parser; forward everything
-    // else (including app.log content re-emitted by the parser) as raw
-    // text to _stdout. Keeps the configured sink JSON-noise-free.
+    // `[`-prefixed lines -> machine parser; rest -> _stdout as text.
     final stdoutLines = StreamController<String>();
     const lineSplitter = LineSplitter();
     final lineBuffer = StringBuffer();
@@ -226,8 +197,7 @@ class FlutterProcess {
         if (!_launchedCompleter.isCompleted) {
           _launchedCompleter.complete();
         }
-        // Wake daemon-request awaiters before exitCode so they observe
-        // the failure rather than racing on exitCode resolving first.
+        // Abort before exitCode so request awaiters see the failure.
         _daemon?.abort();
         if (!_exitCodeCompleter.isCompleted) {
           _exitCodeCompleter.complete(code);
@@ -237,10 +207,8 @@ class FlutterProcess {
     );
   }
 
-  /// Wait for the VM service URI from `app.debugPort`, write it to
-  /// [_vmServiceInfoFile] for IDE attach, then open a `vm_service`
-  /// client. Best-effort. On `-d web-server` this pends until a
-  /// browser attaches.
+  /// Wait for `app.debugPort`, write the info file, open a `vm_service`
+  /// client. Best-effort. On `-d web-server` pends until a browser attaches.
   Future<void> connectToVmService() async {
     if (_vmService != null) return;
     _onProgress?.call('connecting');
@@ -295,11 +263,10 @@ class FlutterProcess {
     });
   }
 
-  /// Hot-reload the Flutter app. Returns `true` on daemon-reported
-  /// success; logs and returns `false` otherwise. Never throws.
+  /// Hot reload. Daemon-reported success; never throws.
   Future<bool> reload() => _appRestart(fullRestart: false);
 
-  /// Hot-restart the Flutter app: full app reinit, state lost.
+  /// Hot restart: full app reinit, state lost.
   Future<bool> restart() => _appRestart(fullRestart: true);
 
   Future<bool> _appRestart({required bool fullRestart}) async {
@@ -327,10 +294,8 @@ class FlutterProcess {
     }
   }
 
-  /// SIGINT -> wait -> SIGKILL. Works because [start] resolves the
-  /// real flutter binary path and spawns it directly (see
-  /// [_resolveFlutterBin]) - our child is the flutter_tools dart
-  /// process, not a wrapper, so signals reach the daemon.
+  /// SIGINT -> wait -> SIGKILL. Reaches the daemon because [start]
+  /// spawns flutter_tools directly, bypassing wrappers.
   Future<int> stop({
     Duration timeout = const Duration(seconds: 5),
   }) async {
@@ -362,10 +327,8 @@ class FlutterProcess {
     return exitCode;
   }
 
-  /// Parses one line of `flutter run --machine` output. Most output is
-  /// human-readable; machine events are single-line JSON arrays (the
-  /// daemon prefixes them with `[`). Silently ignores non-JSON lines so
-  /// stdout noise doesn't break startup.
+  /// Parses one `flutter run --machine` line. Machine events are
+  /// `[`-prefixed single-line JSON arrays; other lines are ignored.
   @visibleForTesting
   void handleMachineLine(String line) {
     if (!line.startsWith('[')) return;
@@ -378,14 +341,11 @@ class FlutterProcess {
     }
     if (decoded is! List) return;
 
-    // The daemon usually emits one event per line, but the protocol
-    // allows multiple. Walk the whole array so we don't drop events.
+    // Protocol allows multiple events per line.
     for (final entry in decoded) {
       if (entry is! Map) continue;
 
-      // Daemon responses come back as envelopes with an `id` and no
-      // `event` field. Route them to the matching pending request
-      // before falling through to event dispatch.
+      // Response envelope (`id`, no `event`) -> pending request.
       final envelope = Map<String, Object?>.from(entry);
       if (_daemon?.tryHandleResponse(envelope) ?? false) continue;
 
@@ -395,11 +355,6 @@ class FlutterProcess {
       final params = entry['params'];
       final paramMap = params is Map ? params : const {};
 
-      // Trace every machine event at debug level - the daemon's actual
-      // event ordering on web is opaque (e.g. `app.webLaunchUrl` fires
-      // after the cold compile, not when the dev server binds), and
-      // surprises here are easier to diagnose with a timeline than by
-      // guessing. Cheap: only enabled at debug log level.
       log.debug('flutter[--machine] $event ${jsonEncode(paramMap)}');
 
       switch (event) {
@@ -409,9 +364,7 @@ class FlutterProcess {
         case 'app.debugPort':
           final wsUri = paramMap['wsUri'];
           if (wsUri is String && !_vmServiceUriCompleter.isCompleted) {
-            // `--machine` reports the ws URI; the rest of the code path
-            // (and IDEs) expects the http form. Strip `/ws` and swap
-            // scheme.
+            // IDEs and callers expect the http form.
             _vmServiceUriCompleter.complete(httpFromWs(wsUri));
           }
           if (!_launchedCompleter.isCompleted) _launchedCompleter.complete();
@@ -441,8 +394,7 @@ class FlutterProcess {
   }
 
   Future<void> _cleanup() async {
-    // Mirror ServerProcess._cleanup's completer-guard so concurrent stop
-    // calls and the exit-listener share one cleanup pass.
+    // Completer guard: concurrent stop + exit-listener share one pass.
     if (_cleanupCompleter != null) return _cleanupCompleter!.future;
     if (_process == null) return;
 
@@ -473,29 +425,19 @@ class FlutterProcess {
     }
   }
 
-  /// Cached after first resolution.
   static ({String executable, List<String> baseArgs})? _cachedInvocation;
 
-  /// Resolve a wrapper-free invocation of flutter_tools: probe
-  /// `flutter --version --machine` for `flutterRoot`, then construct
-  /// the direct `dart <flutter_tools.dart>` command. This cuts
-  /// through every layer (puro/fvm/asdf shim, the flutter shell
-  /// script, the AOT snapshot) so our spawned process IS the dart
-  /// process running flutter_tools - signals reach it directly.
-  ///
-  /// Cached after first call. Falls back to invoking
-  /// [flutterExecutable] verbatim if any of the direct paths is
-  /// missing (e.g. an SDK that hasn't been bootstrapped: the flutter
-  /// shell script normally runs `pub get` on flutter_tools the
-  /// first time, which is what creates the package_config.json).
+  /// Probe `flutter --version --machine` for `flutterRoot`, then return
+  /// `dart <flutterRoot>/.../flutter_tools.dart` so signals bypass
+  /// puro/fvm/asdf wrappers and reach the daemon. Falls back to
+  /// invoking [flutterExecutable] verbatim if the SDK paths are missing.
   static Future<({String executable, List<String> baseArgs})>
   _resolveFlutterInvocation(String flutterExecutable) async {
     final cached = _cachedInvocation;
     if (cached != null) return cached;
 
-    // Fallback isn't cached: a failed probe in one context (e.g. a
-    // test with a fake executable) would otherwise poison the cache
-    // for later real callers.
+    // Don't cache the fallback: a fake-executable test probe would
+    // poison the cache for later real callers.
     final fallback = (executable: flutterExecutable, baseArgs: <String>[]);
     try {
       final result = await Process.run(
@@ -545,9 +487,7 @@ class FlutterProcess {
     }
   }
 
-  /// Converts a Flutter daemon `ws://host:port/ws` URI to the http form
-  /// the rest of the code (and IDEs) expect (`http://host:port`).
-  /// Strips a trailing `/ws` path component when present.
+  /// `ws://host:port/ws` -> `http://host:port` (also wss -> https).
   @visibleForTesting
   static String httpFromWs(String wsUri) {
     final uri = Uri.parse(wsUri);
@@ -558,16 +498,6 @@ class FlutterProcess {
   }
 }
 
-/// Default path for the Flutter VM service info file (sibling of the
-/// pod's `vm-service-info.json`). Mirrored in [ServerProcess]'s docs so
-/// a single launch.json directory reference covers both:
-///
-/// ```jsonc
-/// {
-///   "type": "dart",
-///   "request": "attach",
-///   "vmServiceInfoFile": "${workspaceFolder}/.dart_tool/serverpod/flutter-vm-service-info.json"
-/// }
-/// ```
+/// Default Flutter VM-service info file, sibling of the pod's info file.
 String defaultFlutterVmServiceInfoFile(String serverpodToolDir) =>
     p.join(serverpodToolDir, 'flutter-vm-service-info.json');

--- a/tools/serverpod_cli/lib/src/commands/start/flutter_process.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/flutter_process.dart
@@ -64,6 +64,7 @@ class FlutterProcess {
   StreamSubscription<List<int>>? _stdoutBytesSub;
   StreamSubscription<List<int>>? _stderrBytesSub;
   StreamSubscription<String>? _machineLinesSub;
+  StreamSubscription<Event>? _loggingSub;
 
   String? _appId;
   FlutterDaemonProtocol? _daemon;
@@ -262,6 +263,7 @@ class FlutterProcess {
     for (var attempt = 0; attempt < 5; attempt++) {
       try {
         _vmService = await vmServiceConnectUri(wsUri);
+        await _subscribeToLogging(_vmService!);
         return;
       } on Exception {
         if (attempt == 4) {
@@ -271,6 +273,28 @@ class FlutterProcess {
         await Future<void>.delayed(const Duration(milliseconds: 200));
       }
     }
+  }
+
+  /// Subscribe to the Flutter VM's `Logging` stream so `dart:developer.log()`
+  /// calls land in the user-visible output (TUI: Flutter output tab,
+  /// non-TUI: terminal). `--machine` only wraps `print` / stderr into
+  /// `app.log` events; `Logging` is a separate VM-service channel.
+  Future<void> _subscribeToLogging(VmService vmService) async {
+    try {
+      await vmService.streamListen('Logging');
+    } on RPCError catch (e) {
+      log.debug('Could not subscribe to Flutter Logging stream: $e');
+      return;
+    }
+    _loggingSub = vmService.onLoggingEvent.listen((event) {
+      final record = event.logRecord;
+      final message = record?.message?.valueAsString;
+      if (message == null || message.isEmpty) return;
+      final name = record?.loggerName?.valueAsString ?? '';
+      final line = name.isEmpty ? message : '[$name] $message';
+      final level = record?.level ?? 0;
+      (level >= 1000 ? _stderr : _stdout).writeln(line);
+    });
   }
 
   /// Hot-reload the Flutter app. Returns `true` on daemon-reported
@@ -438,6 +462,8 @@ class FlutterProcess {
       _machineLinesSub = null;
       _sigtermSub = null;
 
+      await _loggingSub?.cancel();
+      _loggingSub = null;
       await _vmService?.dispose();
       _vmService = null;
 

--- a/tools/serverpod_cli/lib/src/commands/start/flutter_process.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/flutter_process.dart
@@ -275,10 +275,7 @@ class FlutterProcess {
     }
   }
 
-  /// Subscribe to the Flutter VM's `Logging` stream so `dart:developer.log()`
-  /// calls land in the user-visible output (TUI: Flutter output tab,
-  /// non-TUI: terminal). `--machine` only wraps `print` / stderr into
-  /// `app.log` events; `Logging` is a separate VM-service channel.
+  /// `--machine` doesn't forward `dart:developer.log()`; `Logging` does.
   Future<void> _subscribeToLogging(VmService vmService) async {
     try {
       await vmService.streamListen('Logging');
@@ -286,14 +283,15 @@ class FlutterProcess {
       log.debug('Could not subscribe to Flutter Logging stream: $e');
       return;
     }
+    const severeLevel = 1000;
     _loggingSub = vmService.onLoggingEvent.listen((event) {
       final record = event.logRecord;
       final message = record?.message?.valueAsString;
       if (message == null || message.isEmpty) return;
       final name = record?.loggerName?.valueAsString ?? '';
       final line = name.isEmpty ? message : '[$name] $message';
-      final level = record?.level ?? 0;
-      (level >= 1000 ? _stderr : _stdout).writeln(line);
+      final sink = (record?.level ?? 0) >= severeLevel ? _stderr : _stdout;
+      sink.writeln(line);
     });
   }
 
@@ -457,13 +455,13 @@ class FlutterProcess {
       await _stderrBytesSub?.cancel();
       await _machineLinesSub?.cancel();
       await _sigtermSub?.cancel();
+      await _loggingSub?.cancel();
       _stdoutBytesSub = null;
       _stderrBytesSub = null;
       _machineLinesSub = null;
       _sigtermSub = null;
-
-      await _loggingSub?.cancel();
       _loggingSub = null;
+
       await _vmService?.dispose();
       _vmService = null;
 

--- a/tools/serverpod_cli/lib/src/commands/start/flutter_process.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/flutter_process.dart
@@ -277,14 +277,20 @@ class FlutterProcess {
       log.warning('Flutter $op: daemon not running yet.');
       return false;
     }
+    const requestTimeout = Duration(seconds: 30);
     try {
-      await daemon.sendRequest('app.restart', <String, Object?>{
-        'appId': appId,
-        'fullRestart': fullRestart,
-        'pause': false,
-        'debounce': true,
-      });
+      await daemon
+          .sendRequest('app.restart', <String, Object?>{
+            'appId': appId,
+            'fullRestart': fullRestart,
+            'pause': false,
+            'debounce': true,
+          })
+          .timeout(requestTimeout);
       return true;
+    } on TimeoutException {
+      log.warning('Flutter $op timed out after ${requestTimeout.inSeconds}s.');
+      return false;
     } on FlutterDaemonException catch (e) {
       log.warning('Flutter $op failed: ${e.error}');
       return false;

--- a/tools/serverpod_cli/lib/src/commands/start/flutter_process.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/flutter_process.dart
@@ -65,6 +65,12 @@ class FlutterProcess {
   /// `app.progress` messages from the Flutter daemon in between.
   final void Function(String stage)? _onProgress;
 
+  /// Test-only override of the spawn args. When non-null, replaces the
+  /// default `['run', '--machine', '-d', <device>, ...extraArgs]` list.
+  /// Lets unit tests target a Dart shim that emits hand-crafted machine
+  /// JSON without needing a Flutter SDK on PATH.
+  final List<String>? _argsOverrideForTesting;
+
   Process? _process;
   StreamSubscription<ProcessSignal>? _sigtermSub;
   StreamSubscription<List<int>>? _stdoutBytesSub;
@@ -84,7 +90,11 @@ class FlutterProcess {
   String? _vmServiceUri;
   String? _flutterAppUrl;
 
-  final Completer<String> _vmServiceUriCompleter = Completer<String>();
+  // Completes with the http VM service URI once `app.debugPort` arrives,
+  // or with `null` if the process exits first. Using a nullable result
+  // (rather than completing with an error) keeps the future safely
+  // awaitable even when nothing called connectToVmService().
+  final Completer<String?> _vmServiceUriCompleter = Completer<String?>();
   final Completer<int> _exitCodeCompleter = Completer<int>();
   final Completer<void> _vmServiceReady = Completer<void>();
 
@@ -100,6 +110,7 @@ class FlutterProcess {
     void Function(String stage)? onProgress,
     IOSink? stdoutSink,
     IOSink? stderrSink,
+    @visibleForTesting List<String>? argsOverrideForTesting,
   }) : _flutterPackageDir = flutterPackageDir,
        _flutterExecutable = flutterExecutable,
        _device = device,
@@ -108,7 +119,8 @@ class FlutterProcess {
        _startupTimeout = startupTimeout,
        _onProgress = onProgress,
        _stdout = stdoutSink ?? stdout,
-       _stderr = stderrSink ?? stderr;
+       _stderr = stderrSink ?? stderr,
+       _argsOverrideForTesting = argsOverrideForTesting;
 
   /// True between [start] and [stop]/exit.
   bool get isRunning => _process != null;
@@ -141,7 +153,9 @@ class FlutterProcess {
       throw StateError('FlutterProcess is already running.');
     }
 
-    final args = <String>['run', '--machine', '-d', _device, ..._extraArgs];
+    final args =
+        _argsOverrideForTesting ??
+        <String>['run', '--machine', '-d', _device, ..._extraArgs];
 
     if (_vmServiceInfoFile != null) {
       // Clear any stale info file from a prior run so consumers (IDE,
@@ -181,23 +195,45 @@ class FlutterProcess {
       );
     }
 
-    // Tee raw stdout/stderr bytes to the configured sinks so the TUI's
-    // Flutter tab still gets full output, while a parallel decoded
-    // line-stream feeds the --machine JSON parser.
-    _stdoutBytesSub = process.stdout.listen(_stdout.add);
+    // process.stdout is single-subscription, so fan out from one listen:
+    // forward raw bytes to the configured sink (TUI Flutter tab keeps
+    // full output) AND feed line-wise UTF-8 through the --machine JSON
+    // parser.
+    final stdoutLines = StreamController<String>();
+    const lineSplitter = LineSplitter();
+    final lineBuffer = StringBuffer();
+    _stdoutBytesSub = process.stdout.listen(
+      (data) {
+        _stdout.add(data);
+        lineBuffer.write(utf8.decode(data, allowMalformed: true));
+        // Drain only complete lines; keep the tail in the buffer.
+        final bufferStr = lineBuffer.toString();
+        final lastNewline = bufferStr.lastIndexOf('\n');
+        if (lastNewline == -1) return;
+        final ready = bufferStr.substring(0, lastNewline);
+        lineBuffer.clear();
+        lineBuffer.write(bufferStr.substring(lastNewline + 1));
+        for (final line in lineSplitter.convert(ready)) {
+          stdoutLines.add(line);
+        }
+      },
+      onDone: () {
+        if (lineBuffer.isNotEmpty) {
+          for (final line in lineSplitter.convert(lineBuffer.toString())) {
+            stdoutLines.add(line);
+          }
+          lineBuffer.clear();
+        }
+        stdoutLines.close();
+      },
+    );
+    _machineLinesSub = stdoutLines.stream.listen(handleMachineLine);
     _stderrBytesSub = process.stderr.listen(_stderr.add);
-
-    _machineLinesSub = process.stdout
-        .transform(utf8.decoder)
-        .transform(const LineSplitter())
-        .listen(handleMachineLine);
 
     unawaited(
       process.exitCode.then((code) async {
         if (!_vmServiceUriCompleter.isCompleted) {
-          _vmServiceUriCompleter.completeError(
-            StateError('flutter exited before publishing VM service URI'),
-          );
+          _vmServiceUriCompleter.complete(null);
         }
         if (!_exitCodeCompleter.isCompleted) {
           _exitCodeCompleter.complete(code);
@@ -214,19 +250,22 @@ class FlutterProcess {
   Future<void> connectToVmService() async {
     _onProgress?.call('connecting');
 
-    final String httpUri;
+    final String? maybeUri;
     try {
-      httpUri = await _vmServiceUriCompleter.future.timeout(_startupTimeout);
+      maybeUri = await _vmServiceUriCompleter.future.timeout(_startupTimeout);
     } on TimeoutException {
       log.warning(
         'Flutter did not publish a VM service URI within '
         '${_startupTimeout.inSeconds}s. Reload via VM service is unavailable.',
       );
       return;
-    } catch (e) {
-      log.warning('Flutter VM service URI not available: $e');
+    }
+    if (maybeUri == null) {
+      // Process exited before publishing - silent return, the exit
+      // listener has already wound things down.
       return;
     }
+    final httpUri = maybeUri;
     _vmServiceUri = httpUri;
 
     if (_vmServiceInfoFile != null) {

--- a/tools/serverpod_cli/lib/src/commands/start/flutter_process.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/flutter_process.dart
@@ -1,0 +1,489 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:meta/meta.dart';
+import 'package:path/path.dart' as p;
+import 'package:serverpod_cli/src/commands/start/server_process.dart'
+    show vmServiceWsUri;
+import 'package:serverpod_cli/src/util/serverpod_cli_logger.dart';
+import 'package:serverpod_shared/serverpod_shared.dart';
+import 'package:vm_service/vm_service.dart';
+import 'package:vm_service/vm_service_io.dart';
+
+/// Thrown by [FlutterProcess.start] when the `flutter` binary cannot be
+/// launched (typically because Flutter is not installed or not on `PATH`).
+/// Callers should catch this and continue without the Flutter integration
+/// rather than aborting `serverpod start`.
+class FlutterNotInstalledException implements Exception {
+  /// Description of why launching `flutter` failed.
+  final String message;
+
+  /// The underlying [ProcessException] (or other cause) for debug output.
+  final Object? cause;
+
+  FlutterNotInstalledException(this.message, [this.cause]);
+
+  @override
+  String toString() => 'FlutterNotInstalledException: $message';
+}
+
+/// Manages a `flutter run --machine` subprocess.
+///
+/// Mirrors [ServerProcess] in shape and lifecycle. The VM service URI is
+/// captured from `--machine`'s `app.debugPort` event (Flutter has no
+/// `--write-service-info` flag), and reload is driven through the VM
+/// service rather than stdin keystrokes - giving a real `Future<bool>`
+/// with success/failure semantics. The captured URI is also written to a
+/// file at [vmServiceInfoFile], allowing IDEs to auto-attach via the
+/// `vmServiceInfoFile` field in their launch configuration.
+///
+/// v2 follow-up: a `pubspec.yaml` / asset change watcher can call
+/// `stop()` + `start()` on this class to compose a full process respawn
+/// (level 3 - pubspec / asset bundle changes need a full re-spawn, not
+/// just a hot restart, because the package_config and asset manifest are
+/// read at VM start). The level-2 hot-restart (main isolate only) is
+/// intentionally not exposed here; that lands in a separate change.
+class FlutterProcess {
+  final String _flutterPackageDir;
+  final String _flutterExecutable;
+  final String _device;
+  final List<String> _extraArgs;
+  final IOSink _stdout;
+  final IOSink _stderr;
+  final Duration _startupTimeout;
+
+  /// Path to write the VM service info JSON to once captured. Sibling of
+  /// the pod's `vm-service-info.json` so a single `launch.json` directory
+  /// reference covers both.
+  final String? _vmServiceInfoFile;
+
+  /// Optional callback for surfacing startup-stage progress (e.g. to the
+  /// TUI's tracked-operation indicator or a `log.progress` spinner). Fires
+  /// with `'launching'` on successful spawn, `'connecting'` before the VM
+  /// service connect attempt, `'ready'` after `app.started`, and verbatim
+  /// `app.progress` messages from the Flutter daemon in between.
+  final void Function(String stage)? _onProgress;
+
+  Process? _process;
+  StreamSubscription<ProcessSignal>? _sigtermSub;
+  StreamSubscription<List<int>>? _stdoutBytesSub;
+  StreamSubscription<List<int>>? _stderrBytesSub;
+  StreamSubscription<String>? _machineLinesSub;
+
+  VmService? _vmService;
+  String? _flutterIsolateId;
+
+  /// Service-method prefix used by Flutter to register `hotReload` /
+  /// `hotRestart` on the VM service (e.g. `s0`). Discovered at connect
+  /// time via [VmService.getSupportedProtocols] / probing; `null` when
+  /// the optimized path isn't available and we fall back to
+  /// `reloadSources` + `ext.flutter.reassemble`.
+  String? _flutterServicePrefix;
+
+  String? _vmServiceUri;
+  String? _flutterAppUrl;
+
+  final Completer<String> _vmServiceUriCompleter = Completer<String>();
+  final Completer<int> _exitCodeCompleter = Completer<int>();
+  final Completer<void> _vmServiceReady = Completer<void>();
+
+  Completer<void>? _cleanupCompleter;
+
+  FlutterProcess({
+    required String flutterPackageDir,
+    String flutterExecutable = 'flutter',
+    String device = 'web-server',
+    List<String> extraArgs = const [],
+    String? vmServiceInfoFile,
+    Duration startupTimeout = const Duration(seconds: 60),
+    void Function(String stage)? onProgress,
+    IOSink? stdoutSink,
+    IOSink? stderrSink,
+  }) : _flutterPackageDir = flutterPackageDir,
+       _flutterExecutable = flutterExecutable,
+       _device = device,
+       _extraArgs = extraArgs,
+       _vmServiceInfoFile = vmServiceInfoFile,
+       _startupTimeout = startupTimeout,
+       _onProgress = onProgress,
+       _stdout = stdoutSink ?? stdout,
+       _stderr = stderrSink ?? stderr;
+
+  /// True between [start] and [stop]/exit.
+  bool get isRunning => _process != null;
+
+  /// True once [connectToVmService] resolved the upstream VM service.
+  bool get isVmServiceConnected => _vmService != null;
+
+  /// HTTP VM service URI, or `null` before [connectToVmService] resolves.
+  String? get vmServiceUri => _vmServiceUri;
+
+  /// HTTP URL the Flutter app is served at (e.g.
+  /// `http://localhost:54321`), or `null` before `--machine` emitted
+  /// `app.webLaunchUrl`.
+  String? get flutterAppUrl => _flutterAppUrl;
+
+  /// Completes once the VM service is connected and the Flutter isolate
+  /// id is known. Never completes if startup fails - pair with [exitCode]
+  /// to detect crashes.
+  Future<void> get vmServiceReady => _vmServiceReady.future;
+
+  /// Exit code of the `flutter run` subprocess.
+  Future<int> get exitCode => _exitCodeCompleter.future;
+
+  /// Spawn `flutter run --machine -d <device>` in [flutterPackageDir].
+  ///
+  /// Throws [FlutterNotInstalledException] when `flutter` isn't on PATH;
+  /// caller should catch and continue without Flutter.
+  Future<void> start() async {
+    if (_process != null) {
+      throw StateError('FlutterProcess is already running.');
+    }
+
+    final args = <String>['run', '--machine', '-d', _device, ..._extraArgs];
+
+    if (_vmServiceInfoFile != null) {
+      // Clear any stale info file from a prior run so consumers (IDE,
+      // launch.json) don't pick up a dead URI before this run publishes
+      // its own.
+      await File(_vmServiceInfoFile).deleteIfExists();
+    }
+
+    Process process;
+    try {
+      // `flutter` on Windows is a batch file; Process.start handles `.bat`
+      // resolution when invoking through the shell. Direct invocation
+      // works on POSIX and is the cheaper path. Caveat: with
+      // `runInShell: true`, `Process.kill(SIGINT)` targets the cmd.exe
+      // wrapper rather than the wrapped daemon - the 5s SIGKILL fallback
+      // in `stop()` covers the case where SIGINT doesn't propagate.
+      process = await Process.start(
+        _flutterExecutable,
+        args,
+        workingDirectory: _flutterPackageDir,
+      );
+    } on ProcessException catch (e) {
+      throw FlutterNotInstalledException(
+        'Failed to launch `$_flutterExecutable`: ${e.message}. '
+        'Install Flutter (https://flutter.dev) or pass `--no-flutter`.',
+        e,
+      );
+    }
+    _process = process;
+    // Spawn succeeded - now signal the caller that startup is under way.
+    _onProgress?.call('launching');
+
+    // Forward SIGTERM as SIGINT to the child for graceful shutdown.
+    if (!Platform.isWindows) {
+      _sigtermSub = ProcessSignal.sigterm.watch().listen(
+        (_) => process.kill(ProcessSignal.sigint),
+      );
+    }
+
+    // Tee raw stdout/stderr bytes to the configured sinks so the TUI's
+    // Flutter tab still gets full output, while a parallel decoded
+    // line-stream feeds the --machine JSON parser.
+    _stdoutBytesSub = process.stdout.listen(_stdout.add);
+    _stderrBytesSub = process.stderr.listen(_stderr.add);
+
+    _machineLinesSub = process.stdout
+        .transform(utf8.decoder)
+        .transform(const LineSplitter())
+        .listen(handleMachineLine);
+
+    unawaited(
+      process.exitCode.then((code) async {
+        if (!_vmServiceUriCompleter.isCompleted) {
+          _vmServiceUriCompleter.completeError(
+            StateError('flutter exited before publishing VM service URI'),
+          );
+        }
+        if (!_exitCodeCompleter.isCompleted) {
+          _exitCodeCompleter.complete(code);
+        }
+        await _cleanup();
+      }),
+    );
+  }
+
+  /// Wait for the `--machine` stream to publish the VM service URI, then
+  /// open a `vm_service` connection. Resolves the Flutter isolate id and
+  /// probes the `sN.hotReload` optimization. Best-effort - logs warnings
+  /// and returns when the URI never arrives or the connection fails.
+  Future<void> connectToVmService() async {
+    _onProgress?.call('connecting');
+
+    final String httpUri;
+    try {
+      httpUri = await _vmServiceUriCompleter.future.timeout(_startupTimeout);
+    } on TimeoutException {
+      log.warning(
+        'Flutter did not publish a VM service URI within '
+        '${_startupTimeout.inSeconds}s. Reload via VM service is unavailable.',
+      );
+      return;
+    } catch (e) {
+      log.warning('Flutter VM service URI not available: $e');
+      return;
+    }
+    _vmServiceUri = httpUri;
+
+    if (_vmServiceInfoFile != null) {
+      try {
+        await File(
+          _vmServiceInfoFile,
+        ).writeAsString(jsonEncode({'uri': httpUri}));
+      } on FileSystemException catch (e) {
+        log.warning('Could not write Flutter VM service info file: $e');
+      }
+    }
+
+    final wsUri = vmServiceWsUri(httpUri);
+    const maxRetries = 5;
+    for (var attempt = 0; attempt < maxRetries; attempt++) {
+      try {
+        _vmService = await vmServiceConnectUri(wsUri);
+        break;
+      } on Exception {
+        if (attempt == maxRetries - 1) {
+          log.warning('Could not connect to Flutter VM service at $wsUri');
+          return;
+        }
+        await Future<void>.delayed(const Duration(milliseconds: 200));
+      }
+    }
+
+    final vmService = _vmService;
+    if (vmService == null) return;
+
+    try {
+      final vm = await vmService.getVM();
+      final isolates = vm.isolates ?? const [];
+      if (isolates.isEmpty) {
+        log.warning('Flutter VM has no isolates yet; reload will be limited.');
+        return;
+      }
+      _flutterIsolateId = isolates.first.id;
+      _flutterServicePrefix = await _probeFlutterServicePrefix(vmService);
+    } on RPCError catch (e) {
+      log.warning('Flutter VM service initialization error: $e');
+      return;
+    }
+
+    if (!_vmServiceReady.isCompleted) _vmServiceReady.complete();
+  }
+
+  /// Hot-reload the Flutter app via the VM service.
+  ///
+  /// Prefers `<prefix>.hotReload` (single round-trip, matches what the
+  /// `flutter` CLI itself does) and falls back to `reloadSources` +
+  /// `ext.flutter.reassemble` when that prefix isn't registered.
+  /// Returns `true` on framework-reported success, `false` otherwise.
+  /// Never throws - a disposed connection or any RPC error becomes
+  /// `false` so the caller's chain isn't broken by Flutter-side issues.
+  Future<bool> reload() async {
+    final vmService = _vmService;
+    final isolateId = _flutterIsolateId;
+    if (vmService == null || isolateId == null) return false;
+
+    try {
+      final prefix = _flutterServicePrefix;
+      if (prefix != null) {
+        final res = await vmService.callMethod(
+          '$prefix.hotReload',
+          args: {'isolateId': isolateId, 'pause': false},
+        );
+        // Flutter daemon returns `{ "type": "Success" }` on success.
+        return res.json?['type'] == 'Success';
+      }
+      return await _fallbackReload(vmService, isolateId);
+    } on RPCError {
+      // If the optimized path is no longer registered, try once via
+      // fallback before giving up.
+      try {
+        return await _fallbackReload(vmService, isolateId);
+      } on Exception {
+        return false;
+      }
+    } on Exception {
+      return false;
+    }
+  }
+
+  Future<bool> _fallbackReload(VmService vmService, String isolateId) async {
+    final report = await vmService.reloadSources(isolateId);
+    if (report.success != true) return false;
+    await vmService.callServiceExtension(
+      'ext.flutter.reassemble',
+      isolateId: isolateId,
+    );
+    return true;
+  }
+
+  /// Smart shutdown: SIGINT -> wait -> SIGKILL (mirrors ServerProcess).
+  /// Idempotent; safe to call from multiple paths (signal handler, exit
+  /// listener, watch-session dispose).
+  Future<int> stop({
+    Duration timeout = const Duration(seconds: 5),
+  }) async {
+    final process = _process;
+    if (process == null) return 0;
+
+    await _sigtermSub?.cancel();
+    _sigtermSub = null;
+
+    process.kill(ProcessSignal.sigint);
+
+    final exitCode = await process.exitCode.timeout(
+      timeout,
+      onTimeout: () {
+        log.warning(
+          'Flutter did not stop within ${timeout.inSeconds}s, sending SIGKILL.',
+        );
+        process.kill(ProcessSignal.sigkill);
+        return process.exitCode;
+      },
+    );
+
+    await _cleanup();
+    return exitCode;
+  }
+
+  /// Parses one line of `flutter run --machine` output. Most output is
+  /// human-readable; machine events are single-line JSON arrays (the
+  /// daemon prefixes them with `[`). Silently ignores non-JSON lines so
+  /// stdout noise doesn't break startup.
+  @visibleForTesting
+  void handleMachineLine(String line) {
+    if (!line.startsWith('[')) return;
+
+    final Object? decoded;
+    try {
+      decoded = jsonDecode(line);
+    } on FormatException {
+      return;
+    }
+    if (decoded is! List) return;
+
+    // The daemon usually emits one event per line, but the protocol
+    // allows multiple. Walk the whole array so we don't drop events.
+    for (final entry in decoded) {
+      if (entry is! Map) continue;
+      final event = entry['event'];
+      if (event is! String) continue;
+
+      final params = entry['params'];
+      final paramMap = params is Map ? params : const {};
+
+      switch (event) {
+        case 'app.debugPort':
+          final wsUri = paramMap['wsUri'];
+          if (wsUri is String && !_vmServiceUriCompleter.isCompleted) {
+            // `--machine` reports the ws URI; the rest of the code path
+            // (and IDEs) expects the http form. Strip `/ws` and swap
+            // scheme.
+            _vmServiceUriCompleter.complete(httpFromWs(wsUri));
+          }
+        case 'app.webLaunchUrl':
+          final url = paramMap['url'];
+          if (url is String) {
+            _flutterAppUrl = url;
+          }
+        case 'app.progress':
+          final message = paramMap['message'];
+          if (message is String && message.isNotEmpty) {
+            _onProgress?.call(message);
+          }
+        case 'app.started':
+          _onProgress?.call('ready');
+      }
+    }
+  }
+
+  /// Probes the Flutter daemon's registered service prefix for
+  /// `hotReload` by calling [VmService.getSupportedProtocols] and
+  /// scanning the response. Returns the prefix (typically `s0`) when
+  /// found, `null` otherwise.
+  Future<String?> _probeFlutterServicePrefix(VmService vmService) async {
+    try {
+      final protocols = await vmService.getSupportedProtocols();
+      final entries = protocols.protocols ?? const <Protocol>[];
+      for (final protocol in entries) {
+        final name = protocol.protocolName;
+        // Flutter registers a domain like "DDS" plus per-view domains
+        // such as "s0" or "s1". The hot-reload method lives under the
+        // view domain; we pick the first non-DDS/non-VM protocol.
+        if (name != null &&
+            name != 'VM Service' &&
+            name != 'DDS' &&
+            RegExp(r'^s\d+$').hasMatch(name)) {
+          return name;
+        }
+      }
+    } on RPCError {
+      // Older Flutter or non-standard daemons: fall back gracefully.
+    } on Exception {
+      // Network blip during probe - caller will fall back to
+      // reloadSources + reassemble on the actual reload attempt.
+    }
+    return null;
+  }
+
+  Future<void> _cleanup() async {
+    // Mirror ServerProcess._cleanup's completer-guard so concurrent stop
+    // calls and the exit-listener share one cleanup pass.
+    if (_cleanupCompleter != null) return _cleanupCompleter!.future;
+    if (_process == null) return;
+
+    final completer = Completer<void>();
+    _cleanupCompleter = completer;
+
+    try {
+      _process = null;
+      await _vmService?.dispose();
+      _vmService = null;
+      _flutterIsolateId = null;
+      await _stdoutBytesSub?.cancel();
+      await _stderrBytesSub?.cancel();
+      await _machineLinesSub?.cancel();
+      await _sigtermSub?.cancel();
+      _stdoutBytesSub = null;
+      _stderrBytesSub = null;
+      _machineLinesSub = null;
+      _sigtermSub = null;
+
+      if (_vmServiceInfoFile != null) {
+        await File(_vmServiceInfoFile).deleteIfExists();
+      }
+    } finally {
+      completer.complete();
+    }
+  }
+
+  /// Converts a Flutter daemon `ws://host:port/ws` URI to the http form
+  /// the rest of the code (and IDEs) expect (`http://host:port`).
+  /// Strips a trailing `/ws` path component when present.
+  @visibleForTesting
+  static String httpFromWs(String wsUri) {
+    final uri = Uri.parse(wsUri);
+    final scheme = uri.isScheme('wss') ? 'https' : 'http';
+    var path = uri.path;
+    if (path.endsWith('/ws')) path = path.substring(0, path.length - 3);
+    return uri.replace(scheme: scheme, path: path).toString();
+  }
+}
+
+/// Default path for the Flutter VM service info file (sibling of the
+/// pod's `vm-service-info.json`). Mirrored in [ServerProcess]'s docs so
+/// a single launch.json directory reference covers both:
+///
+/// ```jsonc
+/// {
+///   "type": "dart",
+///   "request": "attach",
+///   "vmServiceInfoFile": "${workspaceFolder}/.dart_tool/serverpod/flutter-vm-service-info.json"
+/// }
+/// ```
+String defaultFlutterVmServiceInfoFile(String serverpodToolDir) =>
+    p.join(serverpodToolDir, 'flutter-vm-service-info.json');

--- a/tools/serverpod_cli/lib/src/commands/start/flutter_process.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/flutter_process.dart
@@ -394,11 +394,15 @@ class FlutterProcess {
     Duration timeout = const Duration(seconds: 5),
   }) async {
     final process = _process;
-    if (process == null) return 0;
+    if (process == null) {
+      log.debug('Flutter stop: no process (already stopped or never started).');
+      return 0;
+    }
 
     await _sigtermSub?.cancel();
     _sigtermSub = null;
 
+    log.debug('Flutter stop: sending SIGINT to PID ${process.pid}');
     process.kill(ProcessSignal.sigint);
 
     final exitCode = await process.exitCode.timeout(
@@ -411,6 +415,7 @@ class FlutterProcess {
         return process.exitCode;
       },
     );
+    log.debug('Flutter stop: PID ${process.pid} exited with $exitCode');
 
     await _cleanup();
     return exitCode;
@@ -441,6 +446,13 @@ class FlutterProcess {
 
       final params = entry['params'];
       final paramMap = params is Map ? params : const {};
+
+      // Trace every machine event at debug level - the daemon's actual
+      // event ordering on web is opaque (e.g. `app.webLaunchUrl` fires
+      // after the cold compile, not when the dev server binds), and
+      // surprises here are easier to diagnose with a timeline than by
+      // guessing. Cheap: only enabled at debug log level.
+      log.debug('flutter[--machine] $event ${jsonEncode(paramMap)}');
 
       switch (event) {
         case 'app.debugPort':

--- a/tools/serverpod_cli/lib/src/commands/start/flutter_process.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/flutter_process.dart
@@ -174,18 +174,15 @@ class FlutterProcess {
       );
     }
 
-    // process.stdout is single-subscription, so fan out from one listen:
-    // forward raw bytes to the configured sink (TUI Flutter tab keeps
-    // full output) AND feed line-wise UTF-8 through the --machine JSON
-    // parser.
+    // Route `[`-prefixed lines to the machine parser; forward everything
+    // else (including app.log content re-emitted by the parser) as raw
+    // text to _stdout. Keeps the configured sink JSON-noise-free.
     final stdoutLines = StreamController<String>();
     const lineSplitter = LineSplitter();
     final lineBuffer = StringBuffer();
     _stdoutBytesSub = process.stdout.listen(
       (data) {
-        _stdout.add(data);
         lineBuffer.write(utf8.decode(data, allowMalformed: true));
-        // Drain only complete lines; keep the tail in the buffer.
         final bufferStr = lineBuffer.toString();
         final lastNewline = bufferStr.lastIndexOf('\n');
         if (lastNewline == -1) return;
@@ -193,13 +190,21 @@ class FlutterProcess {
         lineBuffer.clear();
         lineBuffer.write(bufferStr.substring(lastNewline + 1));
         for (final line in lineSplitter.convert(ready)) {
-          stdoutLines.add(line);
+          if (line.startsWith('[')) {
+            stdoutLines.add(line);
+          } else if (line.isNotEmpty) {
+            _stdout.writeln(line);
+          }
         }
       },
       onDone: () {
         if (lineBuffer.isNotEmpty) {
           for (final line in lineSplitter.convert(lineBuffer.toString())) {
-            stdoutLines.add(line);
+            if (line.startsWith('[')) {
+              stdoutLines.add(line);
+            } else if (line.isNotEmpty) {
+              _stdout.writeln(line);
+            }
           }
           lineBuffer.clear();
         }
@@ -383,6 +388,14 @@ class FlutterProcess {
           }
         case 'app.started':
           _onProgress?.call('ready');
+        case 'app.log':
+          final logText = paramMap['log'];
+          if (logText is! String || logText.isEmpty) break;
+          final sink = paramMap['error'] == true ? _stderr : _stdout;
+          sink.writeln(logText);
+        case 'daemon.logMessage':
+          final message = paramMap['message'];
+          if (message is String) log.debug('flutter[daemon] $message');
       }
     }
   }

--- a/tools/serverpod_cli/lib/src/commands/start/flutter_process.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/flutter_process.dart
@@ -75,8 +75,8 @@ class FlutterProcess {
 
   FlutterProcess({
     required String flutterPackageDir,
+    required String device,
     String flutterExecutable = 'flutter',
-    String device = 'web-server',
     List<String> extraArgs = const [],
     String? vmServiceInfoFile,
     void Function(String stage)? onProgress,

--- a/tools/serverpod_cli/lib/src/commands/start/flutter_process.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/flutter_process.dart
@@ -51,7 +51,6 @@ class FlutterProcess {
   final List<String> _extraArgs;
   final IOSink _stdout;
   final IOSink _stderr;
-  final Duration _startupTimeout;
 
   /// Path to write the VM service info JSON to once captured. Sibling of
   /// the pod's `vm-service-info.json` so a single `launch.json` directory
@@ -98,6 +97,13 @@ class FlutterProcess {
   final Completer<int> _exitCodeCompleter = Completer<int>();
   final Completer<void> _vmServiceReady = Completer<void>();
 
+  // Completes on the first of `app.debugPort` (mobile/desktop, and
+  // `-d chrome` on web) or `app.webLaunchUrl` (web devices). Also
+  // completes when the process exits, so awaiters wake up on failure
+  // - check [isRunning] / [flutterAppUrl] / [vmServiceUri] to see
+  // which signal fired. See [launched].
+  final Completer<void> _launchedCompleter = Completer<void>();
+
   Completer<void>? _cleanupCompleter;
 
   FlutterProcess({
@@ -106,7 +112,6 @@ class FlutterProcess {
     String device = 'web-server',
     List<String> extraArgs = const [],
     String? vmServiceInfoFile,
-    Duration startupTimeout = const Duration(seconds: 60),
     void Function(String stage)? onProgress,
     IOSink? stdoutSink,
     IOSink? stderrSink,
@@ -116,7 +121,6 @@ class FlutterProcess {
        _device = device,
        _extraArgs = extraArgs,
        _vmServiceInfoFile = vmServiceInfoFile,
-       _startupTimeout = startupTimeout,
        _onProgress = onProgress,
        _stdout = stdoutSink ?? stdout,
        _stderr = stderrSink ?? stderr,
@@ -140,6 +144,24 @@ class FlutterProcess {
   /// id is known. Never completes if startup fails - pair with [exitCode]
   /// to detect crashes.
   Future<void> get vmServiceReady => _vmServiceReady.future;
+
+  /// Completes when Flutter has reported a usable state - the first of
+  /// `app.debugPort` (mobile/desktop, `-d chrome`) or `app.webLaunchUrl`
+  /// (web devices) - OR when the process exits.
+  ///
+  /// This is the right gate for "Flutter is up enough to surface to the
+  /// user." It is intentionally decoupled from [connectToVmService] /
+  /// [vmServiceReady]: on `-d web-server` the Flutter daemon withholds
+  /// `app.debugPort` until a browser actually attaches to the served
+  /// URL, so blocking on the VM service URI hides the web URL from the
+  /// user - they'd have nothing to open. Wait on [launched] to log /
+  /// surface the URL, then kick [connectToVmService] off in the
+  /// background.
+  ///
+  /// After this resolves, check [isRunning] (false if the process
+  /// exited before launch) and [flutterAppUrl] / [vmServiceUri] to see
+  /// which signal fired.
+  Future<void> get launched => _launchedCompleter.future;
 
   /// Exit code of the `flutter run` subprocess.
   Future<int> get exitCode => _exitCodeCompleter.future;
@@ -235,6 +257,9 @@ class FlutterProcess {
         if (!_vmServiceUriCompleter.isCompleted) {
           _vmServiceUriCompleter.complete(null);
         }
+        if (!_launchedCompleter.isCompleted) {
+          _launchedCompleter.complete();
+        }
         if (!_exitCodeCompleter.isCompleted) {
           _exitCodeCompleter.complete(code);
         }
@@ -246,20 +271,22 @@ class FlutterProcess {
   /// Wait for the `--machine` stream to publish the VM service URI, then
   /// open a `vm_service` connection. Resolves the Flutter isolate id and
   /// probes the `sN.hotReload` optimization. Best-effort - logs warnings
-  /// and returns when the URI never arrives or the connection fails.
+  /// when the connection itself fails; silent when the URI never arrives
+  /// (the process exits and the completer resolves to `null`).
+  ///
+  /// Returns immediately if already connected, so multiple background
+  /// callers don't race each other.
+  ///
+  /// Waits indefinitely for the URI. On `-d web-server` this may pend
+  /// until a browser connects, which is exactly the right behavior -
+  /// hot reload becomes available the moment DWDS reports a URI, even
+  /// if that's minutes after spawn. Run this unawaited from the caller
+  /// so launch progress isn't gated on it.
   Future<void> connectToVmService() async {
+    if (_vmService != null) return;
     _onProgress?.call('connecting');
 
-    final String? maybeUri;
-    try {
-      maybeUri = await _vmServiceUriCompleter.future.timeout(_startupTimeout);
-    } on TimeoutException {
-      log.warning(
-        'Flutter did not publish a VM service URI within '
-        '${_startupTimeout.inSeconds}s. Reload via VM service is unavailable.',
-      );
-      return;
-    }
+    final maybeUri = await _vmServiceUriCompleter.future;
     if (maybeUri == null) {
       // Process exited before publishing - silent return, the exit
       // listener has already wound things down.
@@ -424,10 +451,12 @@ class FlutterProcess {
             // scheme.
             _vmServiceUriCompleter.complete(httpFromWs(wsUri));
           }
+          if (!_launchedCompleter.isCompleted) _launchedCompleter.complete();
         case 'app.webLaunchUrl':
           final url = paramMap['url'];
           if (url is String) {
             _flutterAppUrl = url;
+            if (!_launchedCompleter.isCompleted) _launchedCompleter.complete();
           }
         case 'app.progress':
           final message = paramMap['message'];

--- a/tools/serverpod_cli/lib/src/commands/start/flutter_process.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/flutter_process.dart
@@ -138,22 +138,26 @@ class FlutterProcess {
       await File(_vmServiceInfoFile).deleteIfExists();
     }
 
+    // Skip every wrapper layer (puro/fvm/asdf shim, the flutter shell
+    // script, even the AOT snapshot) and invoke flutter_tools.dart
+    // through dart directly. That way our `Process.start` child IS
+    // the dart process running flutter_tools - `process.kill` reaches
+    // the daemon, and the simple SIGINT -> SIGKILL chain in [stop] is
+    // sufficient. Falls back to the unresolved executable name when
+    // the direct paths can't be located (e.g. an SDK that hasn't been
+    // bootstrapped yet, where `pub get` on flutter_tools hasn't run).
+    final invocation = await _resolveFlutterInvocation(_flutterExecutable);
+
     Process process;
     try {
-      // `flutter` on Windows is a batch file; Process.start handles `.bat`
-      // resolution when invoking through the shell. Direct invocation
-      // works on POSIX and is the cheaper path. Caveat: with
-      // `runInShell: true`, `Process.kill(SIGINT)` targets the cmd.exe
-      // wrapper rather than the wrapped daemon - the 5s SIGKILL fallback
-      // in `stop()` covers the case where SIGINT doesn't propagate.
       process = await Process.start(
-        _flutterExecutable,
-        args,
+        invocation.executable,
+        [...invocation.baseArgs, ...args],
         workingDirectory: _flutterPackageDir,
       );
     } on ProcessException catch (e) {
       throw FlutterNotInstalledException(
-        'Failed to launch `$_flutterExecutable`: ${e.message}. '
+        'Failed to launch `${invocation.executable}`: ${e.message}. '
         'Install Flutter (https://flutter.dev) or pass `--no-flutter`.',
         e,
       );
@@ -278,15 +282,16 @@ class FlutterProcess {
     }
   }
 
-  /// Smart shutdown: SIGINT -> wait -> SIGKILL (mirrors ServerProcess).
-  /// Idempotent; safe to call from multiple paths (signal handler, exit
-  /// listener, watch-session dispose).
+  /// SIGINT -> wait -> SIGKILL. Works because [start] resolves the
+  /// real flutter binary path and spawns it directly (see
+  /// [_resolveFlutterBin]) - our child is the flutter_tools dart
+  /// process, not a wrapper, so signals reach the daemon.
   Future<int> stop({
     Duration timeout = const Duration(seconds: 5),
   }) async {
     final process = _process;
     if (process == null) {
-      log.debug('Flutter stop: no process (already stopped or never started).');
+      log.debug('Flutter stop: no process.');
       return 0;
     }
 
@@ -407,6 +412,78 @@ class FlutterProcess {
       }
     } finally {
       completer.complete();
+    }
+  }
+
+  /// Cached after first resolution.
+  static ({String executable, List<String> baseArgs})? _cachedInvocation;
+
+  /// Resolve a wrapper-free invocation of flutter_tools: probe
+  /// `flutter --version --machine` for `flutterRoot`, then construct
+  /// the direct `dart <flutter_tools.dart>` command. This cuts
+  /// through every layer (puro/fvm/asdf shim, the flutter shell
+  /// script, the AOT snapshot) so our spawned process IS the dart
+  /// process running flutter_tools - signals reach it directly.
+  ///
+  /// Cached after first call. Falls back to invoking
+  /// [flutterExecutable] verbatim if any of the direct paths is
+  /// missing (e.g. an SDK that hasn't been bootstrapped: the flutter
+  /// shell script normally runs `pub get` on flutter_tools the
+  /// first time, which is what creates the package_config.json).
+  static Future<({String executable, List<String> baseArgs})>
+  _resolveFlutterInvocation(String flutterExecutable) async {
+    final cached = _cachedInvocation;
+    if (cached != null) return cached;
+
+    // Fallback isn't cached: a failed probe in one context (e.g. a
+    // test with a fake executable) would otherwise poison the cache
+    // for later real callers.
+    final fallback = (executable: flutterExecutable, baseArgs: <String>[]);
+    try {
+      final result = await Process.run(
+        flutterExecutable,
+        ['--version', '--machine'],
+        runInShell: Platform.isWindows,
+      );
+      if (result.exitCode != 0) return fallback;
+      final decoded = jsonDecode(result.stdout as String);
+      if (decoded is! Map || decoded['flutterRoot'] is! String) {
+        return fallback;
+      }
+      final root = decoded['flutterRoot'] as String;
+      final dartBin = p.join(
+        root,
+        'bin',
+        'cache',
+        'dart-sdk',
+        'bin',
+        Platform.isWindows ? 'dart.exe' : 'dart',
+      );
+      final packages = p.join(
+        root,
+        'packages',
+        'flutter_tools',
+        '.dart_tool',
+        'package_config.json',
+      );
+      final entry = p.join(
+        root,
+        'packages',
+        'flutter_tools',
+        'bin',
+        'flutter_tools.dart',
+      );
+      if (!File(dartBin).existsSync() ||
+          !File(packages).existsSync() ||
+          !File(entry).existsSync()) {
+        return fallback;
+      }
+      return _cachedInvocation = (
+        executable: dartBin,
+        baseArgs: ['--disable-dart-dev', '--packages=$packages', entry],
+      );
+    } catch (_) {
+      return fallback;
     }
   }
 

--- a/tools/serverpod_cli/lib/src/commands/start/flutter_process.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/flutter_process.dart
@@ -4,12 +4,9 @@ import 'dart:io';
 
 import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
-import 'package:serverpod_cli/src/commands/start/server_process.dart'
-    show vmServiceWsUri;
 import 'package:serverpod_cli/src/util/serverpod_cli_logger.dart';
+import 'package:serverpod_cli/src/vendored/flutter_daemon_protocol.dart';
 import 'package:serverpod_shared/serverpod_shared.dart';
-import 'package:vm_service/vm_service.dart';
-import 'package:vm_service/vm_service_io.dart';
 
 /// Thrown by [FlutterProcess.start] when the `flutter` binary cannot be
 /// launched (typically because Flutter is not installed or not on `PATH`).
@@ -28,22 +25,10 @@ class FlutterNotInstalledException implements Exception {
   String toString() => 'FlutterNotInstalledException: $message';
 }
 
-/// Manages a `flutter run --machine` subprocess.
-///
-/// Mirrors [ServerProcess] in shape and lifecycle. The VM service URI is
-/// captured from `--machine`'s `app.debugPort` event (Flutter has no
-/// `--write-service-info` flag), and reload is driven through the VM
-/// service rather than stdin keystrokes - giving a real `Future<bool>`
-/// with success/failure semantics. The captured URI is also written to a
-/// file at [vmServiceInfoFile], allowing IDEs to auto-attach via the
-/// `vmServiceInfoFile` field in their launch configuration.
-///
-/// v2 follow-up: a `pubspec.yaml` / asset change watcher can call
-/// `stop()` + `start()` on this class to compose a full process respawn
-/// (level 3 - pubspec / asset bundle changes need a full re-spawn, not
-/// just a hot restart, because the package_config and asset manifest are
-/// read at VM start). The level-2 hot-restart (main isolate only) is
-/// intentionally not exposed here; that lands in a separate change.
+/// Manages a `flutter run --machine` subprocess. Mirrors [ServerProcess]
+/// in shape and lifecycle. The VM service URI captured from `app.debugPort`
+/// is written to [vmServiceInfoFile] for IDE attach; reload/restart are
+/// driven over the daemon's stdin via [FlutterDaemonProtocol].
 class FlutterProcess {
   final String _flutterPackageDir;
   final String _flutterExecutable;
@@ -76,32 +61,14 @@ class FlutterProcess {
   StreamSubscription<List<int>>? _stderrBytesSub;
   StreamSubscription<String>? _machineLinesSub;
 
-  VmService? _vmService;
-  String? _flutterIsolateId;
-
-  /// Service-method prefix used by Flutter to register `hotReload` /
-  /// `hotRestart` on the VM service (e.g. `s0`). Discovered at connect
-  /// time via [VmService.getSupportedProtocols] / probing; `null` when
-  /// the optimized path isn't available and we fall back to
-  /// `reloadSources` + `ext.flutter.reassemble`.
-  String? _flutterServicePrefix;
-
+  String? _appId;
+  FlutterDaemonProtocol? _daemon;
   String? _vmServiceUri;
   String? _flutterAppUrl;
 
-  // Completes with the http VM service URI once `app.debugPort` arrives,
-  // or with `null` if the process exits first. Using a nullable result
-  // (rather than completing with an error) keeps the future safely
-  // awaitable even when nothing called connectToVmService().
+  // `null` result means the process exited before publishing a URI.
   final Completer<String?> _vmServiceUriCompleter = Completer<String?>();
   final Completer<int> _exitCodeCompleter = Completer<int>();
-  final Completer<void> _vmServiceReady = Completer<void>();
-
-  // Completes on the first of `app.debugPort` (mobile/desktop, and
-  // `-d chrome` on web) or `app.webLaunchUrl` (web devices). Also
-  // completes when the process exits, so awaiters wake up on failure
-  // - check [isRunning] / [flutterAppUrl] / [vmServiceUri] to see
-  // which signal fired. See [launched].
   final Completer<void> _launchedCompleter = Completer<void>();
 
   Completer<void>? _cleanupCompleter;
@@ -129,8 +96,9 @@ class FlutterProcess {
   /// True between [start] and [stop]/exit.
   bool get isRunning => _process != null;
 
-  /// True once [connectToVmService] resolved the upstream VM service.
-  bool get isVmServiceConnected => _vmService != null;
+  /// True once the Flutter daemon has published the VM service URI
+  /// (after which [_vmServiceInfoFile] has been written for IDE attach).
+  bool get isVmServiceConnected => _vmServiceUri != null;
 
   /// HTTP VM service URI, or `null` before [connectToVmService] resolves.
   String? get vmServiceUri => _vmServiceUri;
@@ -140,27 +108,11 @@ class FlutterProcess {
   /// `app.webLaunchUrl`.
   String? get flutterAppUrl => _flutterAppUrl;
 
-  /// Completes once the VM service is connected and the Flutter isolate
-  /// id is known. Never completes if startup fails - pair with [exitCode]
-  /// to detect crashes.
-  Future<void> get vmServiceReady => _vmServiceReady.future;
-
-  /// Completes when Flutter has reported a usable state - the first of
-  /// `app.debugPort` (mobile/desktop, `-d chrome`) or `app.webLaunchUrl`
-  /// (web devices) - OR when the process exits.
-  ///
-  /// This is the right gate for "Flutter is up enough to surface to the
-  /// user." It is intentionally decoupled from [connectToVmService] /
-  /// [vmServiceReady]: on `-d web-server` the Flutter daemon withholds
-  /// `app.debugPort` until a browser actually attaches to the served
-  /// URL, so blocking on the VM service URI hides the web URL from the
-  /// user - they'd have nothing to open. Wait on [launched] to log /
-  /// surface the URL, then kick [connectToVmService] off in the
-  /// background.
-  ///
-  /// After this resolves, check [isRunning] (false if the process
-  /// exited before launch) and [flutterAppUrl] / [vmServiceUri] to see
-  /// which signal fired.
+  /// Completes on the first of `app.debugPort`, `app.webLaunchUrl`, or
+  /// process exit. The right gate for "Flutter is up enough to surface
+  /// to the user"; decoupled from [connectToVmService] because on
+  /// `-d web-server` the daemon withholds `app.debugPort` until a
+  /// browser attaches.
   Future<void> get launched => _launchedCompleter.future;
 
   /// Exit code of the `flutter run` subprocess.
@@ -207,6 +159,7 @@ class FlutterProcess {
       );
     }
     _process = process;
+    _daemon = FlutterDaemonProtocol(process);
     // Spawn succeeded - now signal the caller that startup is under way.
     _onProgress?.call('launching');
 
@@ -260,6 +213,9 @@ class FlutterProcess {
         if (!_launchedCompleter.isCompleted) {
           _launchedCompleter.complete();
         }
+        // Wake daemon-request awaiters before exitCode so they observe
+        // the failure rather than racing on exitCode resolving first.
+        _daemon?.abort();
         if (!_exitCodeCompleter.isCompleted) {
           _exitCodeCompleter.complete(code);
         }
@@ -268,123 +224,58 @@ class FlutterProcess {
     );
   }
 
-  /// Wait for the `--machine` stream to publish the VM service URI, then
-  /// open a `vm_service` connection. Resolves the Flutter isolate id and
-  /// probes the `sN.hotReload` optimization. Best-effort - logs warnings
-  /// when the connection itself fails; silent when the URI never arrives
-  /// (the process exits and the completer resolves to `null`).
-  ///
-  /// Returns immediately if already connected, so multiple background
-  /// callers don't race each other.
-  ///
-  /// Waits indefinitely for the URI. On `-d web-server` this may pend
-  /// until a browser connects, which is exactly the right behavior -
-  /// hot reload becomes available the moment DWDS reports a URI, even
-  /// if that's minutes after spawn. Run this unawaited from the caller
-  /// so launch progress isn't gated on it.
+  /// Wait for the VM service URI from `app.debugPort`, then write it
+  /// to [_vmServiceInfoFile] so IDEs can attach. On `-d web-server`
+  /// this pends until a browser attaches.
   Future<void> connectToVmService() async {
-    if (_vmService != null) return;
+    if (_vmServiceUri != null) return;
     _onProgress?.call('connecting');
 
     final maybeUri = await _vmServiceUriCompleter.future;
-    if (maybeUri == null) {
-      // Process exited before publishing - silent return, the exit
-      // listener has already wound things down.
-      return;
-    }
-    final httpUri = maybeUri;
-    _vmServiceUri = httpUri;
+    if (maybeUri == null) return;
+    _vmServiceUri = maybeUri;
 
     if (_vmServiceInfoFile != null) {
       try {
         await File(
           _vmServiceInfoFile,
-        ).writeAsString(jsonEncode({'uri': httpUri}));
+        ).writeAsString(jsonEncode({'uri': maybeUri}));
       } on FileSystemException catch (e) {
         log.warning('Could not write Flutter VM service info file: $e');
       }
     }
-
-    final wsUri = vmServiceWsUri(httpUri);
-    const maxRetries = 5;
-    for (var attempt = 0; attempt < maxRetries; attempt++) {
-      try {
-        _vmService = await vmServiceConnectUri(wsUri);
-        break;
-      } on Exception {
-        if (attempt == maxRetries - 1) {
-          log.warning('Could not connect to Flutter VM service at $wsUri');
-          return;
-        }
-        await Future<void>.delayed(const Duration(milliseconds: 200));
-      }
-    }
-
-    final vmService = _vmService;
-    if (vmService == null) return;
-
-    try {
-      final vm = await vmService.getVM();
-      final isolates = vm.isolates ?? const [];
-      if (isolates.isEmpty) {
-        log.warning('Flutter VM has no isolates yet; reload will be limited.');
-        return;
-      }
-      _flutterIsolateId = isolates.first.id;
-      _flutterServicePrefix = await _probeFlutterServicePrefix(vmService);
-    } on RPCError catch (e) {
-      log.warning('Flutter VM service initialization error: $e');
-      return;
-    }
-
-    if (!_vmServiceReady.isCompleted) _vmServiceReady.complete();
   }
 
-  /// Hot-reload the Flutter app via the VM service.
-  ///
-  /// Prefers `<prefix>.hotReload` (single round-trip, matches what the
-  /// `flutter` CLI itself does) and falls back to `reloadSources` +
-  /// `ext.flutter.reassemble` when that prefix isn't registered.
-  /// Returns `true` on framework-reported success, `false` otherwise.
-  /// Never throws - a disposed connection or any RPC error becomes
-  /// `false` so the caller's chain isn't broken by Flutter-side issues.
-  Future<bool> reload() async {
-    final vmService = _vmService;
-    final isolateId = _flutterIsolateId;
-    if (vmService == null || isolateId == null) return false;
+  /// Hot-reload the Flutter app. Returns `true` on daemon-reported
+  /// success; logs and returns `false` otherwise. Never throws.
+  Future<bool> reload() => _appRestart(fullRestart: false);
 
-    try {
-      final prefix = _flutterServicePrefix;
-      if (prefix != null) {
-        final res = await vmService.callMethod(
-          '$prefix.hotReload',
-          args: {'isolateId': isolateId, 'pause': false},
-        );
-        // Flutter daemon returns `{ "type": "Success" }` on success.
-        return res.json?['type'] == 'Success';
-      }
-      return await _fallbackReload(vmService, isolateId);
-    } on RPCError {
-      // If the optimized path is no longer registered, try once via
-      // fallback before giving up.
-      try {
-        return await _fallbackReload(vmService, isolateId);
-      } on Exception {
-        return false;
-      }
-    } on Exception {
+  /// Hot-restart the Flutter app: full app reinit, state lost.
+  Future<bool> restart() => _appRestart(fullRestart: true);
+
+  Future<bool> _appRestart({required bool fullRestart}) async {
+    final op = fullRestart ? 'restart' : 'reload';
+    final daemon = _daemon;
+    final appId = _appId;
+    if (daemon == null || appId == null) {
+      log.warning('Flutter $op: daemon not running yet.');
       return false;
     }
-  }
-
-  Future<bool> _fallbackReload(VmService vmService, String isolateId) async {
-    final report = await vmService.reloadSources(isolateId);
-    if (report.success != true) return false;
-    await vmService.callServiceExtension(
-      'ext.flutter.reassemble',
-      isolateId: isolateId,
-    );
-    return true;
+    try {
+      await daemon.sendRequest('app.restart', <String, Object?>{
+        'appId': appId,
+        'fullRestart': fullRestart,
+        'pause': false,
+        'debounce': true,
+      });
+      return true;
+    } on FlutterDaemonException catch (e) {
+      log.warning('Flutter $op failed: ${e.error}');
+      return false;
+    } catch (e) {
+      log.warning('Flutter $op: unexpected error: $e');
+      return false;
+    }
   }
 
   /// Smart shutdown: SIGINT -> wait -> SIGKILL (mirrors ServerProcess).
@@ -441,6 +332,13 @@ class FlutterProcess {
     // allows multiple. Walk the whole array so we don't drop events.
     for (final entry in decoded) {
       if (entry is! Map) continue;
+
+      // Daemon responses come back as envelopes with an `id` and no
+      // `event` field. Route them to the matching pending request
+      // before falling through to event dispatch.
+      final envelope = Map<String, Object?>.from(entry);
+      if (_daemon?.tryHandleResponse(envelope) ?? false) continue;
+
       final event = entry['event'];
       if (event is! String) continue;
 
@@ -455,6 +353,9 @@ class FlutterProcess {
       log.debug('flutter[--machine] $event ${jsonEncode(paramMap)}');
 
       switch (event) {
+        case 'app.start':
+          final appId = paramMap['appId'];
+          if (appId is String) _appId = appId;
         case 'app.debugPort':
           final wsUri = paramMap['wsUri'];
           if (wsUri is String && !_vmServiceUriCompleter.isCompleted) {
@@ -481,35 +382,6 @@ class FlutterProcess {
     }
   }
 
-  /// Probes the Flutter daemon's registered service prefix for
-  /// `hotReload` by calling [VmService.getSupportedProtocols] and
-  /// scanning the response. Returns the prefix (typically `s0`) when
-  /// found, `null` otherwise.
-  Future<String?> _probeFlutterServicePrefix(VmService vmService) async {
-    try {
-      final protocols = await vmService.getSupportedProtocols();
-      final entries = protocols.protocols ?? const <Protocol>[];
-      for (final protocol in entries) {
-        final name = protocol.protocolName;
-        // Flutter registers a domain like "DDS" plus per-view domains
-        // such as "s0" or "s1". The hot-reload method lives under the
-        // view domain; we pick the first non-DDS/non-VM protocol.
-        if (name != null &&
-            name != 'VM Service' &&
-            name != 'DDS' &&
-            RegExp(r'^s\d+$').hasMatch(name)) {
-          return name;
-        }
-      }
-    } on RPCError {
-      // Older Flutter or non-standard daemons: fall back gracefully.
-    } on Exception {
-      // Network blip during probe - caller will fall back to
-      // reloadSources + reassemble on the actual reload attempt.
-    }
-    return null;
-  }
-
   Future<void> _cleanup() async {
     // Mirror ServerProcess._cleanup's completer-guard so concurrent stop
     // calls and the exit-listener share one cleanup pass.
@@ -521,9 +393,6 @@ class FlutterProcess {
 
     try {
       _process = null;
-      await _vmService?.dispose();
-      _vmService = null;
-      _flutterIsolateId = null;
       await _stdoutBytesSub?.cancel();
       await _stderrBytesSub?.cancel();
       await _machineLinesSub?.cancel();

--- a/tools/serverpod_cli/lib/src/commands/start/server_process.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/server_process.dart
@@ -29,23 +29,10 @@ class ServerProcess {
   final IOSink _stdout;
   final IOSink _stderr;
 
-  /// Path to write the VM service info JSON file to. When set, the file
-  /// is passed to the child via `--write-service-info` and the URI is read
-  /// from the file instead of parsing stdout. IDEs can use this path in
-  /// their `vmServiceInfoFile` launch configuration to auto-attach.
-  ///
-  /// VS Code `launch.json`:
-  /// ```jsonc
-  /// {
-  ///   "name": "Attach to server (serverpod start)",
-  ///   "type": "dart",
-  ///   "request": "attach",
-  ///   "vmServiceInfoFile":
-  ///     "${workspaceFolder}/.dart_tool/serverpod/vm-service-info.json"
-  /// }
-  /// ```
-  /// The companion Flutter-side file lives at `flutter-vm-service-info.json`
-  /// in the same directory (see `FlutterProcess`).
+  /// Path to write the VM service info JSON file to. When set, passed
+  /// to the child via `--write-service-info` and the URI is read from
+  /// the file instead of parsing stdout. IDEs use this path in their
+  /// `vmServiceInfoFile` launch configuration to auto-attach.
   final String? _vmServiceInfoFile;
 
   Process? _process;

--- a/tools/serverpod_cli/lib/src/commands/start/server_process.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/server_process.dart
@@ -33,6 +33,19 @@ class ServerProcess {
   /// is passed to the child via `--write-service-info` and the URI is read
   /// from the file instead of parsing stdout. IDEs can use this path in
   /// their `vmServiceInfoFile` launch configuration to auto-attach.
+  ///
+  /// VS Code `launch.json`:
+  /// ```jsonc
+  /// {
+  ///   "name": "Attach to server (serverpod start)",
+  ///   "type": "dart",
+  ///   "request": "attach",
+  ///   "vmServiceInfoFile":
+  ///     "${workspaceFolder}/.dart_tool/serverpod/vm-service-info.json"
+  /// }
+  /// ```
+  /// The companion Flutter-side file lives at `flutter-vm-service-info.json`
+  /// in the same directory (see `FlutterProcess`).
   final String? _vmServiceInfoFile;
 
   Process? _process;

--- a/tools/serverpod_cli/lib/src/commands/start/tui/app.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/tui/app.dart
@@ -173,8 +173,7 @@ class ServerpodWatchAppState extends ServerpodAppState<ServerpodWatchApp> {
       return true;
     }
 
-    // Tab cycling: Tab and Right cycle forward, Left cycles back. The
-    // Flutter output tab is appended when a Flutter app is attached.
+    // Tab cycling. Flutter tab is appended when attached.
     final tabCount = state.showFlutterOutput ? 3 : 2;
     if (event.logicalKey == LogicalKey.tab ||
         event.logicalKey == LogicalKey.arrowRight) {

--- a/tools/serverpod_cli/lib/src/commands/start/tui/app.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/tui/app.dart
@@ -78,6 +78,7 @@ class ServerpodWatchApp extends ServerpodApp<StartAppStateHolder> {
 class ServerpodWatchAppState extends ServerpodAppState<ServerpodWatchApp> {
   final logScrollController = ScrollController();
   final rawScrollController = ScrollController();
+  final flutterRawScrollController = ScrollController();
   final helpScrollController = ScrollController();
 
   /// Callbacks wired by the backend.
@@ -139,6 +140,7 @@ class ServerpodWatchAppState extends ServerpodAppState<ServerpodWatchApp> {
         showSplash: state.showSplash,
         logScrollController: logScrollController,
         rawScrollController: rawScrollController,
+        flutterRawScrollController: flutterRawScrollController,
         helpScrollController: helpScrollController,
         onToggleHelp: () {
           state.showHelp = !state.showHelp;
@@ -171,8 +173,9 @@ class ServerpodWatchAppState extends ServerpodAppState<ServerpodWatchApp> {
       return true;
     }
 
-    // Tab cycling: Tab and Right cycle forward, Left cycles back.
-    const tabCount = 2;
+    // Tab cycling: Tab and Right cycle forward, Left cycles back. The
+    // Flutter output tab is appended when a Flutter app is attached.
+    final tabCount = state.showFlutterOutput ? 3 : 2;
     if (event.logicalKey == LogicalKey.tab ||
         event.logicalKey == LogicalKey.arrowRight) {
       state.selectedTab = (state.selectedTab + 1) % tabCount;
@@ -194,10 +197,17 @@ class ServerpodWatchAppState extends ServerpodAppState<ServerpodWatchApp> {
       _rebuild();
       return true;
     }
+    if (event.logicalKey == LogicalKey.digit3 && state.showFlutterOutput) {
+      state.selectedTab = 2;
+      _rebuild();
+      return true;
+    }
 
-    final c = state.selectedTab == 0
-        ? logScrollController
-        : rawScrollController;
+    final c = switch (state.selectedTab) {
+      0 => logScrollController,
+      1 => rawScrollController,
+      _ => flutterRawScrollController,
+    };
     return _handleScrollKey(c, event);
   }
 

--- a/tools/serverpod_cli/lib/src/commands/start/tui/main_screen.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/tui/main_screen.dart
@@ -93,11 +93,8 @@ class MainScreen extends StatelessComponent {
     );
   }
 
-  /// Single-line Flutter status surfaced under the tab bar. Returns the
-  /// URL once the app is ready, the current startup stage while it's
-  /// compiling, or null when no Flutter app is attached. The user
-  /// requested this be visible without digging into the Flutter output
-  /// tab.
+  /// URL when ready, startup stage while compiling, `null` when no
+  /// Flutter app is attached.
   String? _flutterStatusLine() {
     if (state.flutterReady) {
       final url = state.flutterUrl;

--- a/tools/serverpod_cli/lib/src/commands/start/tui/main_screen.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/tui/main_screen.dart
@@ -1,4 +1,5 @@
 import 'package:nocterm/nocterm.dart' hide LogEntry;
+import 'package:serverpod_cli/src/commands/tui/bounded_queue_list.dart';
 import 'package:serverpod_cli/src/commands/tui/components/bordered_box.dart';
 import 'package:serverpod_cli/src/commands/tui/components/button.dart';
 import 'package:serverpod_cli/src/commands/tui/components/button_bar.dart';
@@ -26,6 +27,7 @@ class MainScreen extends StatelessComponent {
     this.showSplash = false,
     required this.logScrollController,
     required this.rawScrollController,
+    required this.flutterRawScrollController,
     required this.helpScrollController,
     this.onToggleHelp,
     this.onHotReload,
@@ -39,6 +41,7 @@ class MainScreen extends StatelessComponent {
   final bool showSplash;
   final ScrollController logScrollController;
   final ScrollController rawScrollController;
+  final ScrollController flutterRawScrollController;
   final ScrollController helpScrollController;
   final VoidCallback? onToggleHelp;
   final VoidCallback? onHotReload;
@@ -63,6 +66,11 @@ class MainScreen extends StatelessComponent {
                       padding: const EdgeInsets.only(left: 1),
                       child: _buildTabBar(st),
                     ),
+                    if (_flutterStatusLine() case final line?)
+                      Padding(
+                        padding: const EdgeInsets.only(left: 1),
+                        child: Text(line),
+                      ),
                     Expanded(child: _buildTabContent()),
                     // Pinned active operations
                     if (state.activeOperations.isNotEmpty) ...[
@@ -85,19 +93,42 @@ class MainScreen extends StatelessComponent {
     );
   }
 
+  /// Single-line Flutter status surfaced under the tab bar. Returns the
+  /// URL once the app is ready, the current startup stage while it's
+  /// compiling, or null when no Flutter app is attached. The user
+  /// requested this be visible without digging into the Flutter output
+  /// tab.
+  String? _flutterStatusLine() {
+    if (state.flutterReady) {
+      final url = state.flutterUrl;
+      return url == null ? 'Flutter: ready' : 'Flutter: $url';
+    }
+    final stage = state.flutterStartupStage;
+    if (stage != null) return 'Flutter: $stage';
+    return null;
+  }
+
   Component _buildTabBar(ServerpodThemeData st) {
     return TabBar(
-      labels: const ['Log Messages', 'Raw server output'],
+      labels: [
+        'Log Messages',
+        'Raw server output',
+        if (state.showFlutterOutput) 'Flutter output',
+      ],
       selectedTab: state.selectedTab,
       onTabChanged: onTabChanged,
     );
   }
 
   Component _buildTabContent() {
-    if (state.selectedTab == 0) {
-      return _buildStructuredLogView();
-    }
-    return _buildRawOutputView();
+    return switch (state.selectedTab) {
+      1 => _buildRawOutputView(state.rawLines, rawScrollController),
+      2 => _buildRawOutputView(
+        state.rawFlutterLines,
+        flutterRawScrollController,
+      ),
+      _ => _buildStructuredLogView(),
+    };
   }
 
   Component _buildStructuredLogView() {
@@ -136,18 +167,19 @@ class MainScreen extends StatelessComponent {
     );
   }
 
-  Component _buildRawOutputView() {
-    final lines = state.rawLines;
-
+  Component _buildRawOutputView(
+    BoundedQueueList<String> lines,
+    ScrollController controller,
+  ) {
     return SelectionArea(
       onSelectionCompleted: (text) {
         if (text.isNotEmpty) ClipboardManager.copy(text);
       },
       child: Scrollbar(
-        controller: rawScrollController,
+        controller: controller,
         thumbVisibility: true,
         child: ListView.builder(
-          controller: rawScrollController,
+          controller: controller,
           reverse: true,
           keyboardScrollable: false,
           itemCount: lines.length,

--- a/tools/serverpod_cli/lib/src/commands/start/tui/state.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/tui/state.dart
@@ -14,17 +14,14 @@ class ServerWatchState extends ServerpodState {
   @override
   final rawLines = BoundedQueueList<String>(maxRawLines);
 
-  /// Raw stdout/stderr lines for the "Flutter output" tab. Populated only
-  /// when a [FlutterProcess] is attached; the tab itself is hidden when
-  /// [showFlutterOutput] is false.
+  /// Raw lines for the "Flutter output" tab.
   final rawFlutterLines = BoundedQueueList<String>(maxRawLines);
 
   /// Currently active tracked operations (keyed by ID).
   @override
   final Map<String, TrackedOperation> activeOperations = {};
 
-  /// Currently selected tab index (0 = Log Messages, 1 = Raw server output,
-  /// 2 = Flutter output when [showFlutterOutput] is true).
+  /// Currently selected tab index. 0 = Log, 1 = Raw, 2 = Flutter (if shown).
   int selectedTab = 0;
 
   /// Whether a tracked action (hot reload, migration) is in progress.
@@ -33,18 +30,16 @@ class ServerWatchState extends ServerpodState {
   /// Whether the server is running and ready for actions.
   bool serverReady = false;
 
-  /// Whether the Flutter app is running and the URL has been published.
+  /// Flutter is running and a URL has been published.
   bool flutterReady = false;
 
-  /// Show the "Flutter output" tab in the TUI.
+  /// Whether the "Flutter output" tab is shown.
   bool showFlutterOutput = false;
 
-  /// HTTP URL the Flutter app is served at, surfaced in the TUI status
-  /// area once [flutterReady] flips true.
+  /// HTTP URL the Flutter app is served at.
   String? flutterUrl;
 
-  /// Latest startup-stage message from `flutter run --machine` (e.g.
-  /// `'Launching ...'`, `'Building ...'`). Cleared once Flutter is ready.
+  /// Latest `app.progress` message from the Flutter daemon.
   String? flutterStartupStage;
 
   /// Whether to show the splash overlay. Starts true, set to false

--- a/tools/serverpod_cli/lib/src/commands/start/tui/state.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/tui/state.dart
@@ -14,11 +14,17 @@ class ServerWatchState extends ServerpodState {
   @override
   final rawLines = BoundedQueueList<String>(maxRawLines);
 
+  /// Raw stdout/stderr lines for the "Flutter output" tab. Populated only
+  /// when a [FlutterProcess] is attached; the tab itself is hidden when
+  /// [showFlutterOutput] is false.
+  final rawFlutterLines = BoundedQueueList<String>(maxRawLines);
+
   /// Currently active tracked operations (keyed by ID).
   @override
   final Map<String, TrackedOperation> activeOperations = {};
 
-  /// Currently selected tab index (0 = Log Messages, 1 = Raw server output).
+  /// Currently selected tab index (0 = Log Messages, 1 = Raw server output,
+  /// 2 = Flutter output when [showFlutterOutput] is true).
   int selectedTab = 0;
 
   /// Whether a tracked action (hot reload, migration) is in progress.
@@ -26,6 +32,22 @@ class ServerWatchState extends ServerpodState {
 
   /// Whether the server is running and ready for actions.
   bool serverReady = false;
+
+  /// Whether the Flutter app is running and the URL has been published.
+  bool flutterReady = false;
+
+  /// Show the "Flutter output" tab in the TUI. Toggled true once a Flutter
+  /// process has been started (separately from [flutterReady], which gates
+  /// the URL display).
+  bool showFlutterOutput = false;
+
+  /// HTTP URL the Flutter app is served at, surfaced in the TUI status
+  /// area once [flutterReady] flips true.
+  String? flutterUrl;
+
+  /// Latest startup-stage message from `flutter run --machine` (e.g.
+  /// `'Launching ...'`, `'Building ...'`). Cleared once Flutter is ready.
+  String? flutterStartupStage;
 
   /// Whether to show the splash overlay. Starts true, set to false
   /// after 5 seconds or explicitly by the backend.

--- a/tools/serverpod_cli/lib/src/commands/start/tui/state.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/tui/state.dart
@@ -36,9 +36,7 @@ class ServerWatchState extends ServerpodState {
   /// Whether the Flutter app is running and the URL has been published.
   bool flutterReady = false;
 
-  /// Show the "Flutter output" tab in the TUI. Toggled true once a Flutter
-  /// process has been started (separately from [flutterReady], which gates
-  /// the URL display).
+  /// Show the "Flutter output" tab in the TUI.
   bool showFlutterOutput = false;
 
   /// HTTP URL the Flutter app is served at, surfaced in the TUI status

--- a/tools/serverpod_cli/lib/src/commands/start/watch_session.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/watch_session.dart
@@ -524,6 +524,10 @@ class WatchSession {
   Future<void> _reloadFlutter() async {
     final flutter = _flutterProcess;
     if (flutter == null) return;
+    if (!flutter.isVmServiceConnected) {
+      log.debug('Flutter not ready; skipping reload.');
+      return;
+    }
     final ok = await flutter.reload();
     if (ok) {
       log.info(flutterAppReloaded);

--- a/tools/serverpod_cli/lib/src/commands/start/watch_session.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/watch_session.dart
@@ -278,10 +278,8 @@ class WatchSession {
       dartFiles: allDartChanges,
       packageConfigChanged: event.packageConfigChanged,
     );
-    // Run Flutter reload after the server step regardless of whether the
-    // compile path was a no-op (flutter/lib-only changes hit
-    // _compileAndReload's empty-paths short-circuit) - the Flutter side
-    // still needs to refresh in that case.
+    // Always reload Flutter: flutter/lib-only changes short-circuit
+    // the server compile but still need a Flutter refresh.
     await _reloadFlutter();
   }
 
@@ -424,11 +422,8 @@ class WatchSession {
     }
     return _chain(() async {
       if (_compiler == null) {
-        // Preserve the historical contract: forceReload with no compiler
-        // tries hot reload on the existing pod and surfaces the result
-        // without falling through to a restart. The file-change path
-        // _does_ fall through (via _reloadOrRestart) - those are
-        // different intents.
+        // forceReload doesn't fall through to restart; the file-change
+        // path does (via _reloadOrRestart). Different intents.
         await _reload(null);
       } else {
         await _compileAndReload(
@@ -468,8 +463,7 @@ class WatchSession {
           case MigrationsRequirePodRestart():
             await _restartServer(_compiler?.outputDill);
         }
-        // Schema changes from migrations affect the generated client lib.
-        // Reload Flutter so it picks up the new client surface.
+        // Migrations regen the client lib; refresh Flutter.
         await _reloadFlutter();
       } finally {
         if (_state == SessionState.applyingMigration) {
@@ -514,22 +508,19 @@ class WatchSession {
     }
   }
 
-  /// Disposes the session: stops server and Flutter app, disposes compiler.
-  /// After this returns, [done] is guaranteed to be completed.
+  /// Stops server + Flutter, disposes compiler. Completes [done].
   Future<void> dispose() async {
     _state = SessionState.disposed;
     await _vmServiceUriChangesController.close();
     final code = await _server.stop();
-    // Stop Flutter after the server so any in-flight Flutter reload that's
-    // racing the server's exit doesn't see a half-shut-down VM service.
+    // Stop Flutter after the server: an in-flight Flutter reload
+    // mustn't see a half-shut-down server VM service.
     await _flutterProcess?.stop();
     await _compiler?.dispose();
     if (!_done.isCompleted) _done.complete(code);
   }
 
-  /// Reloads the Flutter app (when one is attached) and logs the outcome.
-  /// Never throws - any RPC error becomes a warning so the surrounding
-  /// chain isn't broken by Flutter-side issues.
+  /// Reloads the Flutter app and logs the outcome. Never throws.
   Future<void> _reloadFlutter() async {
     final flutter = _flutterProcess;
     if (flutter == null) return;

--- a/tools/serverpod_cli/lib/src/commands/start/watch_session.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/watch_session.dart
@@ -5,6 +5,7 @@ import 'package:path/path.dart' as p;
 import 'package:serverpod_cli/src/commands/generate.dart';
 import 'package:serverpod_cli/src/commands/messages.dart';
 import 'package:serverpod_cli/src/commands/start/file_watcher.dart';
+import 'package:serverpod_cli/src/commands/start/flutter_process.dart';
 import 'package:serverpod_cli/src/commands/start/kernel_compiler.dart';
 import 'package:serverpod_cli/src/commands/start/native_assets_builder.dart';
 import 'package:serverpod_cli/src/commands/start/server_process.dart';
@@ -118,6 +119,7 @@ class WatchSession {
   final Set<String> _generatedDirPaths;
   final ProtocolChangeClassifier _classifyProtocolChange;
   final ApplyMigrationsAction _applyMigrationsAction;
+  final FlutterProcess? _flutterProcess;
 
   final Completer<int> _done = Completer<int>();
 
@@ -155,6 +157,7 @@ class WatchSession {
     ProtocolChangeClassifier classifyProtocolChange =
         defaultProtocolChangeClassifier,
     required ApplyMigrationsAction applyMigrationsAction,
+    FlutterProcess? flutterProcess,
   }) : _compiler = compiler,
        _nativeAssetsBuilder = nativeAssetsBuilder,
        _generate = generate,
@@ -162,7 +165,8 @@ class WatchSession {
        _server = initialServer,
        _generatedDirPaths = generatedDirPaths,
        _classifyProtocolChange = classifyProtocolChange,
-       _applyMigrationsAction = applyMigrationsAction {
+       _applyMigrationsAction = applyMigrationsAction,
+       _flutterProcess = flutterProcess {
     assert(
       nativeAssetsBuilder == null || compiler != null,
       'nativeAssetsBuilder requires a compiler.',
@@ -258,6 +262,7 @@ class WatchSession {
     // service instead of the FES pipeline.
     if (_compiler == null) {
       await _reloadOrRestart(null);
+      await _reloadFlutter();
       return;
     }
 
@@ -273,6 +278,11 @@ class WatchSession {
       dartFiles: allDartChanges,
       packageConfigChanged: event.packageConfigChanged,
     );
+    // Run Flutter reload after the server step regardless of whether the
+    // compile path was a no-op (flutter/lib-only changes hit
+    // _compileAndReload's empty-paths short-circuit) - the Flutter side
+    // still needs to refresh in that case.
+    await _reloadFlutter();
   }
 
   /// Returns `true` if [path] is inside a generated directory.
@@ -412,16 +422,18 @@ class WatchSession {
     if (_state == SessionState.disposed) {
       throw StateError('Session has been disposed.');
     }
-    if (_compiler == null) {
-      return _chain(() => _reload(null));
-    }
-    return _chain(
-      () => _compileAndReload(
-        dartFiles: const {},
-        packageConfigChanged: false,
-        forceFullCompile: true,
-      ),
-    );
+    return _chain(() async {
+      if (_compiler == null) {
+        await _reloadOrRestart(null);
+      } else {
+        await _compileAndReload(
+          dartFiles: const {},
+          packageConfigChanged: false,
+          forceFullCompile: true,
+        );
+      }
+      await _reloadFlutter();
+    });
   }
 
   /// Applies pending database migrations.
@@ -451,6 +463,9 @@ class WatchSession {
           case MigrationsRequirePodRestart():
             await _restartServer(_compiler?.outputDill);
         }
+        // Schema changes from migrations affect the generated client lib.
+        // Reload Flutter so it picks up the new client surface.
+        await _reloadFlutter();
       } finally {
         if (_state == SessionState.applyingMigration) {
           _state = SessionState.idle;
@@ -494,14 +509,31 @@ class WatchSession {
     }
   }
 
-  /// Disposes the session: stops server and disposes compiler. After
-  /// this returns, [done] is guaranteed to be completed.
+  /// Disposes the session: stops server and Flutter app, disposes compiler.
+  /// After this returns, [done] is guaranteed to be completed.
   Future<void> dispose() async {
     _state = SessionState.disposed;
     await _vmServiceUriChangesController.close();
     final code = await _server.stop();
+    // Stop Flutter after the server so any in-flight Flutter reload that's
+    // racing the server's exit doesn't see a half-shut-down VM service.
+    await _flutterProcess?.stop();
     await _compiler?.dispose();
     if (!_done.isCompleted) _done.complete(code);
+  }
+
+  /// Reloads the Flutter app (when one is attached) and logs the outcome.
+  /// Never throws - any RPC error becomes a warning so the surrounding
+  /// chain isn't broken by Flutter-side issues.
+  Future<void> _reloadFlutter() async {
+    final flutter = _flutterProcess;
+    if (flutter == null) return;
+    final ok = await flutter.reload();
+    if (ok) {
+      log.info(flutterAppReloaded);
+    } else {
+      log.warning('Flutter reload failed.');
+    }
   }
 
   void _monitorExit(ServerProcess server) {

--- a/tools/serverpod_cli/lib/src/commands/start/watch_session.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/watch_session.dart
@@ -424,7 +424,12 @@ class WatchSession {
     }
     return _chain(() async {
       if (_compiler == null) {
-        await _reloadOrRestart(null);
+        // Preserve the historical contract: forceReload with no compiler
+        // tries hot reload on the existing pod and surfaces the result
+        // without falling through to a restart. The file-change path
+        // _does_ fall through (via _reloadOrRestart) - those are
+        // different intents.
+        await _reload(null);
       } else {
         await _compileAndReload(
           dartFiles: const {},

--- a/tools/serverpod_cli/lib/src/commands/tui/tui_log_sink.dart
+++ b/tools/serverpod_cli/lib/src/commands/tui/tui_log_sink.dart
@@ -4,12 +4,8 @@ import 'dart:io';
 import 'package:serverpod_cli/src/commands/tui/app_state_holder.dart';
 import 'package:serverpod_cli/src/util/strip_ansi.dart';
 
-/// An [IOSink] implementation that captures stdout/stderr output and
-/// appends each line to [addLine].
-///
-/// Generalised so the same sink can route to either the "Raw server output"
-/// or "Flutter output" tab: pass `state.rawLines.add` for the server side,
-/// `state.rawFlutterLines.add` for the Flutter side.
+/// [IOSink] that splits captured stdout/stderr into lines and forwards
+/// each to [addLine] (e.g. `state.rawLines.add`).
 class TuiLogSink implements IOSink {
   TuiLogSink(this._holder, {required this.addLine});
 

--- a/tools/serverpod_cli/lib/src/commands/tui/tui_log_sink.dart
+++ b/tools/serverpod_cli/lib/src/commands/tui/tui_log_sink.dart
@@ -4,12 +4,17 @@ import 'dart:io';
 import 'package:serverpod_cli/src/commands/tui/app_state_holder.dart';
 import 'package:serverpod_cli/src/util/strip_ansi.dart';
 
-/// An [IOSink] implementation that captures server stdout/stderr output
-/// and routes it to the TUI's "Raw server output" tab.
+/// An [IOSink] implementation that captures stdout/stderr output and
+/// appends each line to [addLine].
+///
+/// Generalised so the same sink can route to either the "Raw server output"
+/// or "Flutter output" tab: pass `state.rawLines.add` for the server side,
+/// `state.rawFlutterLines.add` for the Flutter side.
 class TuiLogSink implements IOSink {
-  TuiLogSink(this._holder);
+  TuiLogSink(this._holder, {required this.addLine});
 
   final ServerpodAppStateHolder _holder;
+  final void Function(String) addLine;
   final StringBuffer _lineBuffer = StringBuffer();
 
   @override
@@ -18,7 +23,7 @@ class TuiLogSink implements IOSink {
     for (var i = 0; i < text.length; i++) {
       final char = text[i];
       if (char == '\n') {
-        _holder.state.rawLines.add(stripAnsi(_lineBuffer.toString()));
+        addLine(stripAnsi(_lineBuffer.toString()));
         _lineBuffer.clear();
         _holder.markDirty();
       } else if (char != '\r') {
@@ -42,9 +47,9 @@ class TuiLogSink implements IOSink {
 
   @override
   void addError(Object error, [StackTrace? stackTrace]) {
-    _holder.state.rawLines.add(stripAnsi('ERROR: $error'));
+    addLine(stripAnsi('ERROR: $error'));
     if (stackTrace != null) {
-      _holder.state.rawLines.add(stripAnsi('$stackTrace'));
+      addLine(stripAnsi('$stackTrace'));
     }
     _holder.markDirty();
   }
@@ -58,7 +63,7 @@ class TuiLogSink implements IOSink {
   @override
   Future close() async {
     if (_lineBuffer.isNotEmpty) {
-      _holder.state.rawLines.add(stripAnsi(_lineBuffer.toString()));
+      addLine(stripAnsi(_lineBuffer.toString()));
       _lineBuffer.clear();
       _holder.markDirty();
     }

--- a/tools/serverpod_cli/lib/src/config/config.dart
+++ b/tools/serverpod_cli/lib/src/config/config.dart
@@ -227,21 +227,16 @@ class GeneratorConfig implements ModelLoadConfig {
     ..._relativeDartClientPackagePathParts,
   ];
 
-  /// Path parts from the server package to the Flutter package (when the
-  /// project has one). Defaults to `['..', '${name}_flutter']`.
   final List<String> _relativeFlutterPackagePathParts;
 
-  /// Absolute path parts to the Flutter package. Does not check existence;
-  /// use [hasFlutterPackage] before resolving against the filesystem.
+  /// Absolute path parts to the Flutter package; see [hasFlutterPackage]
+  /// before resolving against the filesystem.
   List<String> get flutterPackagePathParts => [
     ...serverPackageDirectoryPathParts,
     ..._relativeFlutterPackagePathParts,
   ];
 
-  /// True when [flutterPackagePathParts] resolves to a directory that looks
-  /// like a Flutter project (directory exists AND contains a `pubspec.yaml`).
-  /// The pubspec check guards against unrelated directories that happen to
-  /// match the `<name>_flutter` naming convention (e.g. in module projects).
+  /// True when [flutterPackagePathParts] is a directory with `pubspec.yaml`.
   bool get hasFlutterPackage {
     final dirPath = p.joinAll(flutterPackagePathParts);
     if (!Directory(dirPath).existsSync()) return false;

--- a/tools/serverpod_cli/lib/src/config/config.dart
+++ b/tools/serverpod_cli/lib/src/config/config.dart
@@ -87,8 +87,10 @@ class GeneratorConfig implements ModelLoadConfig {
     required this.extraClasses,
     required this.enabledFeatures,
     required this.databaseDialect,
+    required List<String> relativeFlutterPackagePathParts,
     this.experimentalFeatures = const [],
   }) : _relativeDartClientPackagePathParts = relativeDartClientPackagePathParts,
+       _relativeFlutterPackagePathParts = relativeFlutterPackagePathParts,
        _relativeServerTestToolsPathParts = relativeServerTestToolsPathParts,
        _modules = modules;
 
@@ -224,6 +226,27 @@ class GeneratorConfig implements ModelLoadConfig {
     ...serverPackageDirectoryPathParts,
     ..._relativeDartClientPackagePathParts,
   ];
+
+  /// Path parts from the server package to the Flutter package (when the
+  /// project has one). Defaults to `['..', '${name}_flutter']`.
+  final List<String> _relativeFlutterPackagePathParts;
+
+  /// Absolute path parts to the Flutter package. Does not check existence;
+  /// use [hasFlutterPackage] before resolving against the filesystem.
+  List<String> get flutterPackagePathParts => [
+    ...serverPackageDirectoryPathParts,
+    ..._relativeFlutterPackagePathParts,
+  ];
+
+  /// True when [flutterPackagePathParts] resolves to a directory that looks
+  /// like a Flutter project (directory exists AND contains a `pubspec.yaml`).
+  /// The pubspec check guards against unrelated directories that happen to
+  /// match the `<name>_flutter` naming convention (e.g. in module projects).
+  bool get hasFlutterPackage {
+    final dirPath = p.joinAll(flutterPackagePathParts);
+    if (!Directory(dirPath).existsSync()) return false;
+    return File(p.join(dirPath, 'pubspec.yaml')).existsSync();
+  }
 
   final List<String>? _relativeServerTestToolsPathParts;
   static const _defaultRelativeServerTestToolsPathParts = [
@@ -363,6 +386,8 @@ class GeneratorConfig implements ModelLoadConfig {
       );
     }
 
+    final relativeFlutterPackagePathParts = ['..', '${name}_flutter'];
+
     List<String>? relativeServerTestToolsPathParts;
     if (generatorConfig['server_test_tools_path'] != null) {
       relativeServerTestToolsPathParts = p.split(
@@ -489,6 +514,7 @@ class GeneratorConfig implements ModelLoadConfig {
       sharedModelsSourcePathsParts: sharedModelsSourcePathsParts,
       relativeServerTestToolsPathParts: relativeServerTestToolsPathParts,
       relativeDartClientPackagePathParts: relativeDartClientPackagePathParts,
+      relativeFlutterPackagePathParts: relativeFlutterPackagePathParts,
       serializeAsJsonbByDefault: serializeAsJsonbByDefault,
       modules: modules,
       extraClasses: extraClasses,

--- a/tools/serverpod_cli/lib/src/generator/dart/shared_code_generator.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart/shared_code_generator.dart
@@ -85,6 +85,9 @@ class DartSharedCodeGenerator extends CodeGenerator {
           relativeDartClientPackagePathParts: config.clientPackagePathParts
               .skip(config.serverPackageDirectoryPathParts.length)
               .toList(),
+          relativeFlutterPackagePathParts: config.flutterPackagePathParts
+              .skip(config.serverPackageDirectoryPathParts.length)
+              .toList(),
           extraClasses: [],
           enabledFeatures: config.enabledFeatures,
           modules: [],

--- a/tools/serverpod_cli/lib/src/vendored/flutter_daemon_protocol.dart
+++ b/tools/serverpod_cli/lib/src/vendored/flutter_daemon_protocol.dart
@@ -51,9 +51,8 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
-/// Request/response correlator for the `flutter run --machine` daemon
-/// protocol. Create one per [Process]; feed parsed stdout envelopes
-/// through [tryHandleResponse] so matching pending futures resolve.
+/// Request/response correlator for `flutter run --machine`. Feed
+/// stdout envelopes through [tryHandleResponse] to resolve requests.
 class FlutterDaemonProtocol {
   FlutterDaemonProtocol(this._process);
 
@@ -61,8 +60,8 @@ class FlutterDaemonProtocol {
   int _requestId = 0;
   final Map<int, Completer<Object?>> _requestCompleters = {};
 
-  /// Resolves to the response's `result` body, or throws
-  /// [FlutterDaemonException] / [StateError] (process exited).
+  /// Resolves to the response's `result`, or throws
+  /// [FlutterDaemonException] / [StateError].
   Future<Object?> sendRequest(
     String method, [
     Map<String, Object?>? params,
@@ -81,18 +80,17 @@ class FlutterDaemonProtocol {
     return completer.future;
   }
 
-  /// Wire format: single-element JSON array per line. Throws if the
-  /// daemon already closed its stdin.
+  /// Wire format: one JSON array per line. Throws if stdin is closed.
   void _sendMessage(Map<String, Object?> message) {
     _process.stdin.writeln('[${jsonEncode(message)}]');
   }
 
-  /// Returns true and resolves the matching completer if [envelope]
-  /// is a response we're waiting for; false otherwise (caller falls
-  /// through to event dispatch).
+  /// Resolves the matching completer if [envelope] is a response we
+  /// issued; returns `false` otherwise so the caller can event-dispatch.
   bool tryHandleResponse(Map<String, Object?> envelope) {
     final id = envelope['id'];
     if (id is! int) return false;
+    // Reject ids we never issued, in case stray output JSON-decoded.
     if (id < 0 || id >= _requestId) return false;
     final completer = _requestCompleters.remove(id);
     if (completer == null) return false;

--- a/tools/serverpod_cli/lib/src/vendored/flutter_daemon_protocol.dart
+++ b/tools/serverpod_cli/lib/src/vendored/flutter_daemon_protocol.dart
@@ -70,16 +70,21 @@ class FlutterDaemonProtocol {
     final completer = Completer<Object?>();
     final id = _requestId++;
     _requestCompleters[id] = completer;
-    sendMessage({'id': id, 'method': method, 'params': params});
+    try {
+      _sendMessage({'id': id, 'method': method, 'params': params});
+    } catch (e) {
+      _requestCompleters.remove(id);
+      completer.completeError(
+        StateError('Failed to send to Flutter daemon: $e'),
+      );
+    }
     return completer.future;
   }
 
-  void sendMessage(Map<String, Object?> message) {
-    // Wire format: single-element JSON array per line. `writeln` may
-    // throw if the daemon already closed its stdin (shutdown race).
-    try {
-      _process.stdin.writeln('[${jsonEncode(message)}]');
-    } catch (_) {}
+  /// Wire format: single-element JSON array per line. Throws if the
+  /// daemon already closed its stdin.
+  void _sendMessage(Map<String, Object?> message) {
+    _process.stdin.writeln('[${jsonEncode(message)}]');
   }
 
   /// Returns true and resolves the matching completer if [envelope]

--- a/tools/serverpod_cli/lib/src/vendored/flutter_daemon_protocol.dart
+++ b/tools/serverpod_cli/lib/src/vendored/flutter_daemon_protocol.dart
@@ -1,0 +1,119 @@
+/*
+ * This file is adapted from `flutter_tools`' own DAP adapter:
+ *   <flutter>/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter.dart
+ * which is the canonical client for the `flutter run --machine`
+ * daemon protocol. Flutter team maintains it; the protocol itself
+ * has no public stable API of its own.
+ *
+ * Vendored against Flutter 3.41.9 (frameworkRevision 00b0c91f06).
+ * When re-syncing, diff `flutter_adapter.dart` at the matching tag
+ * and update the wire format / request shape if anything changed.
+ * The shape is otherwise stable across recent stable releases.
+ *
+ * The scope of the below license ("Software") is limited to this
+ * file only, which is a derivative work of the original. The license
+ * does not apply to any other part of the codebase.
+ *
+ * Modifications: takes a [Process] from our [FlutterProcess] caller
+ * rather than owning its own spawn; the response router is exposed
+ * for our [FlutterProcess.handleMachineLine] to dispatch into.
+ *
+ * Copyright 2014 The Flutter Authors. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ *       copyright notice, this list of conditions and the following
+ *       disclaimer in the documentation and/or other materials provided
+ *       with the distribution.
+ *     * Neither the name of Google Inc. nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+/// Request/response correlator for the `flutter run --machine` daemon
+/// protocol. Create one per [Process]; feed parsed stdout envelopes
+/// through [tryHandleResponse] so matching pending futures resolve.
+class FlutterDaemonProtocol {
+  FlutterDaemonProtocol(this._process);
+
+  final Process _process;
+  int _requestId = 0;
+  final Map<int, Completer<Object?>> _requestCompleters = {};
+
+  /// Resolves to the response's `result` body, or throws
+  /// [FlutterDaemonException] / [StateError] (process exited).
+  Future<Object?> sendRequest(
+    String method, [
+    Map<String, Object?>? params,
+  ]) {
+    final completer = Completer<Object?>();
+    final id = _requestId++;
+    _requestCompleters[id] = completer;
+    sendMessage({'id': id, 'method': method, 'params': params});
+    return completer.future;
+  }
+
+  void sendMessage(Map<String, Object?> message) {
+    // Wire format: single-element JSON array per line. `writeln` may
+    // throw if the daemon already closed its stdin (shutdown race).
+    try {
+      _process.stdin.writeln('[${jsonEncode(message)}]');
+    } catch (_) {}
+  }
+
+  /// Returns true and resolves the matching completer if [envelope]
+  /// is a response we're waiting for; false otherwise (caller falls
+  /// through to event dispatch).
+  bool tryHandleResponse(Map<String, Object?> envelope) {
+    final id = envelope['id'];
+    if (id is! int) return false;
+    if (id < 0 || id >= _requestId) return false;
+    final completer = _requestCompleters.remove(id);
+    if (completer == null) return false;
+    final error = envelope['error'];
+    if (error != null) {
+      completer.completeError(FlutterDaemonException(error));
+    } else {
+      completer.complete(envelope['result']);
+    }
+    return true;
+  }
+
+  /// Abort in-flight requests. Call from the process-exit listener.
+  void abort([String reason = 'Flutter daemon process exited']) {
+    for (final completer in _requestCompleters.values) {
+      if (!completer.isCompleted) {
+        completer.completeError(StateError(reason));
+      }
+    }
+    _requestCompleters.clear();
+  }
+}
+
+class FlutterDaemonException implements Exception {
+  FlutterDaemonException(this.error);
+  final Object? error;
+  @override
+  String toString() => 'FlutterDaemonException: $error';
+}

--- a/tools/serverpod_cli/test/commands/start/flutter_process_test.dart
+++ b/tools/serverpod_cli/test/commands/start/flutter_process_test.dart
@@ -6,8 +6,7 @@ import 'package:path/path.dart' as p;
 import 'package:serverpod_cli/src/commands/start/flutter_process.dart';
 import 'package:test/test.dart';
 
-/// Resolve a Dart shim path relative to this test file. Tests spawn the
-/// shim via the Dart SDK so they don't need Flutter installed.
+/// Path of a Dart shim under `test/commands/start/flutter_shims/`.
 String _shimPath(String name) => p.join(
   Directory.current.path,
   'test',
@@ -18,25 +17,16 @@ String _shimPath(String name) => p.join(
 );
 
 String _dartExecutable() {
-  // sdkRoot ≈ /usr/local/dart-sdk or similar; Platform.resolvedExecutable
-  // is the dart binary on POSIX and the .exe on Windows.
   return Platform.resolvedExecutable;
 }
 
-/// Bind a throw-away WebSocket server that resembles a VM service well
-/// enough for the connect-and-look-around path. Closes after the first
-/// connection. Returns the `ws://...` URL the shim should advertise.
+/// Minimal WebSocket server that accepts a connect and ignores any RPC.
+/// Enough to populate `vmServiceUri`; do not use for getVM-style calls.
 Future<({HttpServer server, String wsUri})> _startFakeVmService() async {
   final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
   server.transform(WebSocketTransformer()).listen((socket) async {
     socket.listen(
-      (data) {
-        // We don't simulate a real VM service - the connect step is
-        // enough to populate vmServiceUri / kick the retry loop. Any
-        // RPC the resolver tries (getVM, getSupportedProtocols) will
-        // hang here, so tests that need those features should not rely
-        // on this fake.
-      },
+      (data) {},
       onDone: () => socket.close(),
     );
   });
@@ -69,9 +59,8 @@ void main() {
       'when start is called twice while still running '
       'then the second call throws StateError instead of spawning a duplicate process',
       () async {
-        // Use a long-running shim so the first process is still alive when
-        // we attempt the second start - a shim that exits immediately
-        // would clear _process before the second call.
+        // Long-running shim so the first process is still alive when
+        // the second start is attempted.
         final fp = FlutterProcess(
           flutterPackageDir: Directory.current.path,
           device: 'web-server',
@@ -108,8 +97,7 @@ void main() {
         expect(launchedResolved, isFalse);
         expect(connectResolved, isFalse);
 
-        // Stopping the process completes _vmServiceUriCompleter with null
-        // and _launchedCompleter, so both futures resolve quickly.
+        // Stop resolves both completers; the futures unblock.
         await fp.stop(timeout: const Duration(seconds: 1));
         await fp.launched.timeout(const Duration(seconds: 2));
 
@@ -141,10 +129,7 @@ void main() {
         );
 
         await fp.start();
-        // Race against the connect-retry loop: we only need
-        // vmServiceUri (parsed from app.debugPort) to be set; the
-        // actual VM-service ready future will never complete against
-        // our minimal fake.
+        // We only need vmServiceUri set; the fake never replies.
         unawaited(fp.connectToVmService());
 
         // Wait until the URI shows up (the shim emits it ~immediately).
@@ -218,9 +203,8 @@ void main() {
         await fp.start();
         unawaited(fp.connectToVmService());
 
-        // Poll for the file's *contents*, not just existence: writeAsString
-        // creates the inode before flushing, so reading right after
-        // existsSync() can catch the empty intermediate state.
+        // Poll on contents: writeAsString creates the inode before
+        // flushing, so existsSync can catch an empty intermediate.
         final deadline = DateTime.now().add(const Duration(seconds: 5));
         var contents = '';
         while (contents.isEmpty && DateTime.now().isBefore(deadline)) {
@@ -239,8 +223,7 @@ void main() {
 
         await fp.stop(timeout: const Duration(seconds: 1));
 
-        // Cleanup deletes the info file so a subsequent run doesn't read
-        // a stale URI. Poll briefly because the exit listener runs async.
+        // Cleanup runs async via the exit listener; poll briefly.
         final cleanupDeadline = DateTime.now().add(const Duration(seconds: 2));
         while (File(infoPath).existsSync() &&
             DateTime.now().isBefore(cleanupDeadline)) {
@@ -268,8 +251,7 @@ void main() {
     );
 
     test('when the scheme is wss then it swaps to https', () {
-      // Note: Uri.toString() strips the port when it matches the scheme's
-      // default, so 443/https collapses to no explicit port.
+      // Uri.toString() strips the port when it matches the scheme default.
       expect(
         FlutterProcess.httpFromWs('wss://example.com:9443/ws'),
         'https://example.com:9443',
@@ -285,10 +267,8 @@ void main() {
   });
 
   group('Given handleMachineLine', () {
-    /// Probe the parser indirectly: connect a FlutterProcess to a never-
-    /// started state, push synthetic --machine lines through the public
-    /// @visibleForTesting `handleMachineLine`, and assert the visible
-    /// side effects on the FlutterProcess instance.
+    /// FlutterProcess wired only enough to push synthetic lines through
+    /// `handleMachineLine` and assert side effects.
     FlutterProcess bareFp({void Function(String)? onProgress}) =>
         FlutterProcess(
           flutterPackageDir: Directory.systemTemp.path,

--- a/tools/serverpod_cli/test/commands/start/flutter_process_test.dart
+++ b/tools/serverpod_cli/test/commands/start/flutter_process_test.dart
@@ -75,7 +75,6 @@ void main() {
           flutterPackageDir: Directory.current.path,
           flutterExecutable: _dartExecutable(),
           argsOverrideForTesting: [_shimPath('never_publishes_uri.dart')],
-          startupTimeout: const Duration(milliseconds: 50),
         );
         await fp.start();
         expect(fp.start, throwsStateError);
@@ -84,26 +83,35 @@ void main() {
     );
 
     test(
-      'when the shim never publishes app.debugPort then connectToVmService '
-      'returns within the startup timeout and the vmServiceReady future stays '
-      'unresolved (matches "no reload available" semantics)',
+      'when the shim never publishes app.debugPort or app.webLaunchUrl '
+      'then launched and connectToVmService both pend until the process is stopped, '
+      'after which they resolve (matches "no reload available" semantics)',
       () async {
         final fp = FlutterProcess(
           flutterPackageDir: Directory.current.path,
           flutterExecutable: _dartExecutable(),
           argsOverrideForTesting: [_shimPath('never_publishes_uri.dart')],
-          startupTimeout: const Duration(milliseconds: 200),
         );
         await fp.start();
 
-        // connectToVmService should resolve (return) within ~startup
-        // timeout + slack even though no URI was ever published.
-        await fp.connectToVmService().timeout(const Duration(seconds: 5));
+        // While the shim is alive and silent, neither future resolves.
+        var launchedResolved = false;
+        var connectResolved = false;
+        unawaited(fp.launched.then((_) => launchedResolved = true));
+        unawaited(
+          fp.connectToVmService().then((_) => connectResolved = true),
+        );
+        await Future<void>.delayed(const Duration(milliseconds: 200));
+        expect(launchedResolved, isFalse);
+        expect(connectResolved, isFalse);
+
+        // Stopping the process completes _vmServiceUriCompleter with null
+        // and _launchedCompleter, so both futures resolve quickly.
+        await fp.stop(timeout: const Duration(seconds: 1));
+        await fp.launched.timeout(const Duration(seconds: 2));
 
         expect(fp.vmServiceUri, isNull);
         expect(fp.isVmServiceConnected, isFalse);
-
-        await fp.stop(timeout: const Duration(seconds: 1));
       },
     );
   });
@@ -125,7 +133,6 @@ void main() {
             '--ws=${fake.wsUri}',
             '--web-url=http://localhost:54321',
           ],
-          startupTimeout: const Duration(seconds: 5),
           onProgress: progressMessages.add,
         );
 
@@ -199,7 +206,6 @@ void main() {
             '--ws=${fake.wsUri}',
           ],
           vmServiceInfoFile: infoPath,
-          startupTimeout: const Duration(seconds: 5),
         );
 
         await fp.start();
@@ -342,6 +348,43 @@ void main() {
         );
         expect(fp.flutterAppUrl, 'http://localhost:8080');
         expect(progress, containsAllInOrder(['Compiling', 'ready']));
+      },
+    );
+
+    test(
+      'when app.webLaunchUrl arrives before app.debugPort '
+      'then launched completes immediately (web-server gate semantics)',
+      () async {
+        final fp = bareFp();
+        fp.handleMachineLine(
+          jsonEncode([
+            {
+              'event': 'app.webLaunchUrl',
+              'params': {'url': 'http://localhost:54321'},
+            },
+          ]),
+        );
+        await fp.launched.timeout(const Duration(milliseconds: 100));
+        expect(fp.flutterAppUrl, 'http://localhost:54321');
+        expect(fp.vmServiceUri, isNull);
+      },
+    );
+
+    test(
+      'when app.debugPort arrives without app.webLaunchUrl '
+      'then launched completes immediately (mobile/desktop gate semantics)',
+      () async {
+        final fp = bareFp();
+        fp.handleMachineLine(
+          jsonEncode([
+            {
+              'event': 'app.debugPort',
+              'params': {'wsUri': 'ws://127.0.0.1:1111/ws'},
+            },
+          ]),
+        );
+        await fp.launched.timeout(const Duration(milliseconds: 100));
+        expect(fp.flutterAppUrl, isNull);
       },
     );
 

--- a/tools/serverpod_cli/test/commands/start/flutter_process_test.dart
+++ b/tools/serverpod_cli/test/commands/start/flutter_process_test.dart
@@ -1,0 +1,377 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:serverpod_cli/src/commands/start/flutter_process.dart';
+import 'package:test/test.dart';
+
+/// Resolve a Dart shim path relative to this test file. Tests spawn the
+/// shim via the Dart SDK so they don't need Flutter installed.
+String _shimPath(String name) => p.join(
+  Directory.current.path,
+  'test',
+  'commands',
+  'start',
+  'flutter_shims',
+  name,
+);
+
+String _dartExecutable() {
+  // sdkRoot ≈ /usr/local/dart-sdk or similar; Platform.resolvedExecutable
+  // is the dart binary on POSIX and the .exe on Windows.
+  return Platform.resolvedExecutable;
+}
+
+/// Bind a throw-away WebSocket server that resembles a VM service well
+/// enough for the connect-and-look-around path. Closes after the first
+/// connection. Returns the `ws://...` URL the shim should advertise.
+Future<({HttpServer server, String wsUri})> _startFakeVmService() async {
+  final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+  server.transform(WebSocketTransformer()).listen((socket) async {
+    socket.listen(
+      (data) {
+        // We don't simulate a real VM service - the connect step is
+        // enough to populate vmServiceUri / kick the retry loop. Any
+        // RPC the resolver tries (getVM, getSupportedProtocols) will
+        // hang here, so tests that need those features should not rely
+        // on this fake.
+      },
+      onDone: () => socket.close(),
+    );
+  });
+  return (
+    server: server,
+    wsUri: 'ws://127.0.0.1:${server.port}/ws',
+  );
+}
+
+void main() {
+  group('Given a FlutterProcess', () {
+    test(
+      'when the executable is missing '
+      'then FlutterNotInstalledException is thrown so the caller can keep going',
+      () async {
+        final fp = FlutterProcess(
+          flutterPackageDir: Directory.systemTemp.path,
+          flutterExecutable: '/definitely/not/a/real/binary',
+        );
+
+        await expectLater(
+          fp.start,
+          throwsA(isA<FlutterNotInstalledException>()),
+        );
+      },
+    );
+
+    test(
+      'when start is called twice while still running '
+      'then the second call throws StateError instead of spawning a duplicate process',
+      () async {
+        // Use a long-running shim so the first process is still alive when
+        // we attempt the second start; exit_immediately would clear
+        // _process before the second call.
+        final fp = FlutterProcess(
+          flutterPackageDir: Directory.current.path,
+          flutterExecutable: _dartExecutable(),
+          argsOverrideForTesting: [_shimPath('never_publishes_uri.dart')],
+          startupTimeout: const Duration(milliseconds: 50),
+        );
+        await fp.start();
+        expect(fp.start, throwsStateError);
+        await fp.stop(timeout: const Duration(seconds: 1));
+      },
+    );
+
+    test(
+      'when the shim never publishes app.debugPort then connectToVmService '
+      'returns within the startup timeout and the vmServiceReady future stays '
+      'unresolved (matches "no reload available" semantics)',
+      () async {
+        final fp = FlutterProcess(
+          flutterPackageDir: Directory.current.path,
+          flutterExecutable: _dartExecutable(),
+          argsOverrideForTesting: [_shimPath('never_publishes_uri.dart')],
+          startupTimeout: const Duration(milliseconds: 200),
+        );
+        await fp.start();
+
+        // connectToVmService should resolve (return) within ~startup
+        // timeout + slack even though no URI was ever published.
+        await fp.connectToVmService().timeout(const Duration(seconds: 5));
+
+        expect(fp.vmServiceUri, isNull);
+        expect(fp.isVmServiceConnected, isFalse);
+
+        await fp.stop(timeout: const Duration(seconds: 1));
+      },
+    );
+  });
+
+  group('Given a FlutterProcess parsing machine protocol from a shim', () {
+    test(
+      'when the shim emits app.progress, app.webLaunchUrl, app.debugPort, app.started '
+      'then onProgress fires, flutterAppUrl is captured, '
+      'and vmServiceUri is the http form of the daemon\'s wsUri',
+      () async {
+        final fake = await _startFakeVmService();
+        final progressMessages = <String>[];
+
+        final fp = FlutterProcess(
+          flutterPackageDir: Directory.current.path,
+          flutterExecutable: _dartExecutable(),
+          argsOverrideForTesting: [
+            _shimPath('emits_machine_events.dart'),
+            '--ws=${fake.wsUri}',
+            '--web-url=http://localhost:54321',
+          ],
+          startupTimeout: const Duration(seconds: 5),
+          onProgress: progressMessages.add,
+        );
+
+        await fp.start();
+        // Race against the connect-retry loop: we only need
+        // vmServiceUri (parsed from app.debugPort) to be set; the
+        // actual VM-service ready future will never complete against
+        // our minimal fake.
+        unawaited(fp.connectToVmService());
+
+        // Wait until the URI shows up (the shim emits it ~immediately).
+        final deadline = DateTime.now().add(const Duration(seconds: 5));
+        while (fp.vmServiceUri == null && DateTime.now().isBefore(deadline)) {
+          await Future<void>.delayed(const Duration(milliseconds: 20));
+        }
+
+        expect(
+          fp.vmServiceUri,
+          equals('http://127.0.0.1:${fake.server.port}'),
+        );
+        expect(fp.flutterAppUrl, equals('http://localhost:54321'));
+        expect(progressMessages, contains('launching'));
+        expect(progressMessages, contains('Launching ...'));
+        expect(progressMessages, contains('ready'));
+
+        await fp.stop(timeout: const Duration(seconds: 1));
+        await fake.server.close(force: true);
+      },
+      timeout: const Timeout(Duration(seconds: 30)),
+    );
+  });
+
+  group('Given a FlutterProcess that was never started', () {
+    test(
+      'when reload is called then it returns false without throwing',
+      () async {
+        final fp = FlutterProcess(
+          flutterPackageDir: Directory.systemTemp.path,
+        );
+        expect(await fp.reload(), isFalse);
+      },
+    );
+
+    test(
+      'when stop is called '
+      'then it completes with 0 and is idempotent',
+      () async {
+        final fp = FlutterProcess(
+          flutterPackageDir: Directory.systemTemp.path,
+        );
+        expect(await fp.stop(), 0);
+        expect(await fp.stop(), 0);
+      },
+    );
+  });
+
+  group('Given a FlutterProcess with a vmServiceInfoFile configured', () {
+    test(
+      'when the shim publishes a URI '
+      'then the file is written with the http URI, then cleaned up on stop',
+      () async {
+        final fake = await _startFakeVmService();
+        final tmp = Directory.systemTemp.createTempSync('flutter_proc_test_');
+        final infoPath = p.join(tmp.path, 'flutter-vm-service-info.json');
+
+        final fp = FlutterProcess(
+          flutterPackageDir: Directory.current.path,
+          flutterExecutable: _dartExecutable(),
+          argsOverrideForTesting: [
+            _shimPath('emits_machine_events.dart'),
+            '--ws=${fake.wsUri}',
+          ],
+          vmServiceInfoFile: infoPath,
+          startupTimeout: const Duration(seconds: 5),
+        );
+
+        await fp.start();
+        unawaited(fp.connectToVmService());
+
+        // Poll for the file's *contents*, not just existence: writeAsString
+        // creates the inode before flushing, so reading right after
+        // existsSync() can catch the empty intermediate state.
+        final deadline = DateTime.now().add(const Duration(seconds: 5));
+        var contents = '';
+        while (contents.isEmpty && DateTime.now().isBefore(deadline)) {
+          if (File(infoPath).existsSync()) {
+            contents = File(infoPath).readAsStringSync();
+          }
+          if (contents.isEmpty) {
+            await Future<void>.delayed(const Duration(milliseconds: 20));
+          }
+        }
+
+        expect(
+          contents,
+          contains('http://127.0.0.1:${fake.server.port}'),
+        );
+
+        await fp.stop(timeout: const Duration(seconds: 1));
+
+        // Cleanup deletes the info file so a subsequent run doesn't read
+        // a stale URI. Poll briefly because the exit listener runs async.
+        final cleanupDeadline = DateTime.now().add(const Duration(seconds: 2));
+        while (File(infoPath).existsSync() &&
+            DateTime.now().isBefore(cleanupDeadline)) {
+          await Future<void>.delayed(const Duration(milliseconds: 20));
+        }
+        expect(File(infoPath).existsSync(), isFalse);
+
+        await fake.server.close(force: true);
+        tmp.deleteSync(recursive: true);
+      },
+      timeout: const Timeout(Duration(seconds: 30)),
+    );
+  });
+
+  group('Given a ws URI passed to httpFromWs', () {
+    test(
+      'when the URI ends in /ws '
+      'then the scheme swaps to http and the /ws suffix is stripped',
+      () {
+        expect(
+          FlutterProcess.httpFromWs('ws://127.0.0.1:54321/ws'),
+          'http://127.0.0.1:54321',
+        );
+      },
+    );
+
+    test('when the scheme is wss then it swaps to https', () {
+      // Note: Uri.toString() strips the port when it matches the scheme's
+      // default, so 443/https collapses to no explicit port.
+      expect(
+        FlutterProcess.httpFromWs('wss://example.com:9443/ws'),
+        'https://example.com:9443',
+      );
+    });
+
+    test('when the path is not /ws then the path is left alone', () {
+      expect(
+        FlutterProcess.httpFromWs('ws://127.0.0.1:54321/different'),
+        'http://127.0.0.1:54321/different',
+      );
+    });
+  });
+
+  group('Given handleMachineLine', () {
+    /// Probe the parser indirectly: connect a FlutterProcess to a never-
+    /// started state, push synthetic --machine lines through the public
+    /// @visibleForTesting `handleMachineLine`, and assert the visible
+    /// side effects on the FlutterProcess instance.
+    FlutterProcess bareFp({void Function(String)? onProgress}) =>
+        FlutterProcess(
+          flutterPackageDir: Directory.systemTemp.path,
+          onProgress: onProgress,
+        );
+
+    test(
+      'when given a line that does not start with [ '
+      'then the line is ignored',
+      () {
+        final fp = bareFp();
+        fp.handleMachineLine('just some text');
+        fp.handleMachineLine('');
+        expect(fp.vmServiceUri, isNull);
+        expect(fp.flutterAppUrl, isNull);
+      },
+    );
+
+    test(
+      'when given a [-prefixed line containing malformed JSON '
+      'then the line is ignored',
+      () {
+        final fp = bareFp();
+        fp.handleMachineLine('[not-json');
+        expect(fp.vmServiceUri, isNull);
+      },
+    );
+
+    test(
+      'when given an envelope missing the event field '
+      'then the envelope is ignored',
+      () {
+        final fp = bareFp();
+        fp.handleMachineLine(
+          jsonEncode([
+            {'noevent': true},
+          ]),
+        );
+        expect(fp.vmServiceUri, isNull);
+      },
+    );
+
+    test(
+      'when given a line containing multiple events '
+      'then each event is processed in order',
+      () {
+        final progress = <String>[];
+        final fp = bareFp(onProgress: progress.add);
+        fp.handleMachineLine(
+          jsonEncode([
+            {
+              'event': 'app.webLaunchUrl',
+              'params': {'url': 'http://localhost:8080'},
+            },
+            {
+              'event': 'app.progress',
+              'params': {'message': 'Compiling'},
+            },
+            {
+              'event': 'app.started',
+              'params': <String, Object?>{},
+            },
+          ]),
+        );
+        expect(fp.flutterAppUrl, 'http://localhost:8080');
+        expect(progress, containsAllInOrder(['Compiling', 'ready']));
+      },
+    );
+
+    test('first app.debugPort wins; later wsUri events are ignored', () {
+      final fp = bareFp();
+      fp.handleMachineLine(
+        jsonEncode([
+          {
+            'event': 'app.debugPort',
+            'params': {'wsUri': 'ws://127.0.0.1:1111/ws'},
+          },
+        ]),
+      );
+      fp.handleMachineLine(
+        jsonEncode([
+          {
+            'event': 'app.debugPort',
+            'params': {'wsUri': 'ws://127.0.0.1:2222/ws'},
+          },
+        ]),
+      );
+      // The captured URI is only readable once connectToVmService runs;
+      // assert that calling that with an extremely short timeout finds
+      // the first URI in the completer and gives up after the connect
+      // retries.
+      // (We can't connect to a real VM at port 1111 - the connect loop
+      // will exhaust its retries and `connectToVmService` returns with
+      // _vmServiceUri populated from the first wsUri.)
+      // The behavioral check that matters here: the parser didn't
+      // throw and accepted both lines without crashing.
+    });
+  });
+}

--- a/tools/serverpod_cli/test/commands/start/flutter_process_test.dart
+++ b/tools/serverpod_cli/test/commands/start/flutter_process_test.dart
@@ -37,86 +37,118 @@ Future<({HttpServer server, String wsUri})> _startFakeVmService() async {
 }
 
 void main() {
-  group('Given a FlutterProcess', () {
+  group('Given a FlutterProcess missing the executable', () {
+    late FlutterProcess fp;
+
+    setUp(() {
+      fp = FlutterProcess(
+        flutterPackageDir: Directory.systemTemp.path,
+        device: 'web-server',
+        flutterExecutable: '/definitely/not/a/real/binary',
+      );
+    });
+
     test(
-      'when the executable is missing '
+      'when calling start '
       'then FlutterNotInstalledException is thrown so the caller can keep going',
       () async {
-        final fp = FlutterProcess(
-          flutterPackageDir: Directory.systemTemp.path,
-          device: 'web-server',
-          flutterExecutable: '/definitely/not/a/real/binary',
-        );
-
         await expectLater(
           fp.start,
           throwsA(isA<FlutterNotInstalledException>()),
         );
       },
     );
+  });
+
+  group('Given a FlutterProcess running', () {
+    late FlutterProcess fp;
+
+    setUp(() async {
+      // Long-running shim so the first process is still alive when
+      // the second start is attempted.
+      fp = FlutterProcess(
+        flutterPackageDir: Directory.current.path,
+        device: 'web-server',
+        flutterExecutable: _dartExecutable(),
+        argsOverrideForTesting: [_shimPath('never_publishes_uri.dart')],
+      );
+
+      await fp.start();
+    });
+
+    tearDown(() async {
+      await fp.stop();
+    });
 
     test(
-      'when start is called twice while still running '
-      'then the second call throws StateError instead of spawning a duplicate process',
+      'when calling start again while still running '
+      'then it throws StateError instead of spawning a duplicate process',
       () async {
-        // Long-running shim so the first process is still alive when
-        // the second start is attempted.
-        final fp = FlutterProcess(
-          flutterPackageDir: Directory.current.path,
-          device: 'web-server',
-          flutterExecutable: _dartExecutable(),
-          argsOverrideForTesting: [_shimPath('never_publishes_uri.dart')],
-        );
-        await fp.start();
         expect(fp.start, throwsStateError);
-        await fp.stop(timeout: const Duration(seconds: 1));
       },
     );
 
-    test(
-      'when the shim never publishes app.debugPort or app.webLaunchUrl '
-      'then launched and connectToVmService both pend until the process is stopped, '
-      'after which they resolve (matches "no reload available" semantics)',
-      () async {
-        final fp = FlutterProcess(
-          flutterPackageDir: Directory.current.path,
-          device: 'web-server',
-          flutterExecutable: _dartExecutable(),
-          argsOverrideForTesting: [_shimPath('never_publishes_uri.dart')],
+    group(
+      'Given a running FlutterProcess with a shim that never publishes app.debugPort or app.webLaunchUrl',
+      () {
+        late FlutterProcess fp;
+
+        setUp(() async {
+          fp = FlutterProcess(
+            flutterPackageDir: Directory.current.path,
+            device: 'web-server',
+            flutterExecutable: _dartExecutable(),
+            argsOverrideForTesting: [_shimPath('never_publishes_uri.dart')],
+          );
+
+          await fp.start();
+        });
+
+        tearDown(() async {
+          await fp.stop();
+        });
+
+        test(
+          'when awaiting launched and connectToVmService '
+          'then both are only resolved after the process is stopped (matches "no reload available" semantics)',
+          () async {
+            var launchedResolved = false;
+            var connectResolved = false;
+            unawaited(
+              fp.launched.then((_) => launchedResolved = true),
+            );
+            unawaited(
+              fp.connectToVmService().then((_) => connectResolved = true),
+            );
+
+            await Future<void>.delayed(const Duration(milliseconds: 200));
+            expect(launchedResolved, isFalse);
+            expect(connectResolved, isFalse);
+
+            // Stop resolves both completers; the futures unblock.
+            await fp.stop(timeout: const Duration(seconds: 1));
+            await fp.launched.timeout(const Duration(seconds: 2));
+
+            expect(fp.vmServiceUri, isNull);
+            expect(fp.isVmServiceConnected, isFalse);
+          },
         );
-        await fp.start();
-
-        // While the shim is alive and silent, neither future resolves.
-        var launchedResolved = false;
-        var connectResolved = false;
-        unawaited(fp.launched.then((_) => launchedResolved = true));
-        unawaited(
-          fp.connectToVmService().then((_) => connectResolved = true),
-        );
-        await Future<void>.delayed(const Duration(milliseconds: 200));
-        expect(launchedResolved, isFalse);
-        expect(connectResolved, isFalse);
-
-        // Stop resolves both completers; the futures unblock.
-        await fp.stop(timeout: const Duration(seconds: 1));
-        await fp.launched.timeout(const Duration(seconds: 2));
-
-        expect(fp.vmServiceUri, isNull);
-        expect(fp.isVmServiceConnected, isFalse);
       },
     );
   });
 
-  group('Given a FlutterProcess parsing machine protocol from a shim', () {
-    test(
-      'when the shim emits app.progress, app.webLaunchUrl, app.debugPort, app.started '
-      'then onProgress fires, flutterAppUrl is captured, '
-      'and vmServiceUri is the http form of the daemon\'s wsUri',
-      () async {
-        final fake = await _startFakeVmService();
-        final progressMessages = <String>[];
+  group(
+    'Given a running FlutterProcess parsing machine protocol from a shim',
+    () {
+      late FlutterProcess fp;
+      late ({HttpServer server, String wsUri}) fake;
+      late List<String> progressMessages;
 
-        final fp = FlutterProcess(
+      setUp(() async {
+        fake = await _startFakeVmService();
+        progressMessages = <String>[];
+
+        fp = FlutterProcess(
           flutterPackageDir: Directory.current.path,
           device: 'web-server',
           flutterExecutable: _dartExecutable(),
@@ -129,51 +161,69 @@ void main() {
         );
 
         await fp.start();
+
         // We only need vmServiceUri set; the fake never replies.
         unawaited(fp.connectToVmService());
+      });
 
-        // Wait until the URI shows up (the shim emits it ~immediately).
-        final deadline = DateTime.now().add(const Duration(seconds: 5));
-        while (fp.vmServiceUri == null && DateTime.now().isBefore(deadline)) {
-          await Future<void>.delayed(const Duration(milliseconds: 20));
-        }
+      tearDown(() async {
+        await fp.stop();
+      });
 
-        expect(
-          fp.vmServiceUri,
-          equals('http://127.0.0.1:${fake.server.port}'),
-        );
-        expect(fp.flutterAppUrl, equals('http://localhost:54321'));
-        expect(progressMessages, contains('launching'));
-        expect(progressMessages, contains('Launching ...'));
-        expect(progressMessages, contains('ready'));
+      test(
+        'when the shim emits app.progress, app.webLaunchUrl, app.debugPort, app.started '
+        'then onProgress fires, flutterAppUrl is captured, and vmServiceUri is the http form of the daemon\'s wsUri',
+        () async {
+          // Wait until the URI shows up (the shim emits it ~immediately).
+          final deadline = DateTime.now().add(const Duration(seconds: 5));
+          while (fp.vmServiceUri == null && DateTime.now().isBefore(deadline)) {
+            await Future<void>.delayed(const Duration(milliseconds: 20));
+          }
 
-        await fp.stop(timeout: const Duration(seconds: 1));
-        await fake.server.close(force: true);
-      },
-      timeout: const Timeout(Duration(seconds: 30)),
-    );
-  });
+          expect(
+            fp.vmServiceUri,
+            equals('http://127.0.0.1:${fake.server.port}'),
+          );
+          expect(fp.flutterAppUrl, equals('http://localhost:54321'));
+          expect(progressMessages, contains('launching'));
+          expect(progressMessages, contains('Launching ...'));
+          expect(progressMessages, contains('ready'));
+
+          await fp.stop(timeout: const Duration(seconds: 1));
+          await fake.server.close(force: true);
+        },
+        timeout: const Timeout(Duration(seconds: 30)),
+      );
+    },
+  );
 
   group('Given a FlutterProcess that was never started', () {
+    late FlutterProcess fp;
+
+    setUp(() {
+      fp = FlutterProcess(
+        flutterPackageDir: Directory.systemTemp.path,
+        device: 'web-server',
+      );
+    });
+
     test(
       'when reload is called then it returns false without throwing',
       () async {
-        final fp = FlutterProcess(
-          flutterPackageDir: Directory.systemTemp.path,
-          device: 'web-server',
-        );
         expect(await fp.reload(), isFalse);
       },
     );
 
     test(
-      'when stop is called '
-      'then it completes with 0 and is idempotent',
+      'when stop is called then it completes',
       () async {
-        final fp = FlutterProcess(
-          flutterPackageDir: Directory.systemTemp.path,
-          device: 'web-server',
-        );
+        expect(await fp.stop(), 0);
+      },
+    );
+
+    test(
+      'when stop is called multiple times then it completes idempotently',
+      () async {
         expect(await fp.stop(), 0);
         expect(await fp.stop(), 0);
       },
@@ -181,28 +231,45 @@ void main() {
   });
 
   group('Given a FlutterProcess with a vmServiceInfoFile configured', () {
+    late FlutterProcess fp;
+    late ({HttpServer server, String wsUri}) fake;
+    late Directory tmp;
+    late String infoPath;
+
+    setUp(() async {
+      fake = await _startFakeVmService();
+      tmp = Directory.systemTemp.createTempSync('flutter_proc_test_');
+      infoPath = p.join(tmp.path, 'flutter-vm-service-info.json');
+
+      fp = FlutterProcess(
+        flutterPackageDir: Directory.current.path,
+        device: 'web-server',
+        flutterExecutable: _dartExecutable(),
+        argsOverrideForTesting: [
+          _shimPath('emits_machine_events.dart'),
+          '--ws=${fake.wsUri}',
+        ],
+        vmServiceInfoFile: infoPath,
+      );
+
+      await fp.start();
+      unawaited(fp.connectToVmService());
+    });
+
+    tearDown(() async {
+      await fp.stop();
+      await fake.server.close(force: true);
+      try {
+        tmp.deleteSync(recursive: true);
+      } on FileSystemException {
+        // Already gone.
+      }
+    });
+
     test(
       'when the shim publishes a URI '
       'then the file is written with the http URI, then cleaned up on stop',
       () async {
-        final fake = await _startFakeVmService();
-        final tmp = Directory.systemTemp.createTempSync('flutter_proc_test_');
-        final infoPath = p.join(tmp.path, 'flutter-vm-service-info.json');
-
-        final fp = FlutterProcess(
-          flutterPackageDir: Directory.current.path,
-          device: 'web-server',
-          flutterExecutable: _dartExecutable(),
-          argsOverrideForTesting: [
-            _shimPath('emits_machine_events.dart'),
-            '--ws=${fake.wsUri}',
-          ],
-          vmServiceInfoFile: infoPath,
-        );
-
-        await fp.start();
-        unawaited(fp.connectToVmService());
-
         // Poll on contents: writeAsString creates the inode before
         // flushing, so existsSync can catch an empty intermediate.
         final deadline = DateTime.now().add(const Duration(seconds: 5));
@@ -230,57 +297,62 @@ void main() {
           await Future<void>.delayed(const Duration(milliseconds: 20));
         }
         expect(File(infoPath).existsSync(), isFalse);
-
-        await fake.server.close(force: true);
-        tmp.deleteSync(recursive: true);
       },
       timeout: const Timeout(Duration(seconds: 30)),
     );
   });
 
-  group('Given a ws URI passed to httpFromWs', () {
-    test(
-      'when the URI ends in /ws '
-      'then the scheme swaps to http and the /ws suffix is stripped',
-      () {
-        expect(
-          FlutterProcess.httpFromWs('ws://127.0.0.1:54321/ws'),
-          'http://127.0.0.1:54321',
-        );
-      },
+  test(
+    'Given a ws URI ending in /ws'
+    'when getting the http URI '
+    'then the scheme swaps to http and the /ws suffix is stripped',
+    () {
+      expect(
+        FlutterProcess.httpFromWs('ws://127.0.0.1:54321/ws'),
+        'http://127.0.0.1:54321',
+      );
+    },
+  );
+
+  test('Given a wss URI'
+      'when getting the http URI '
+      'then the scheme swaps to https', () {
+    // Uri.toString() strips the port when it matches the scheme default.
+    expect(
+      FlutterProcess.httpFromWs('wss://example.com:9443/ws'),
+      'https://example.com:9443',
     );
-
-    test('when the scheme is wss then it swaps to https', () {
-      // Uri.toString() strips the port when it matches the scheme default.
-      expect(
-        FlutterProcess.httpFromWs('wss://example.com:9443/ws'),
-        'https://example.com:9443',
-      );
-    });
-
-    test('when the path is not /ws then the path is left alone', () {
-      expect(
-        FlutterProcess.httpFromWs('ws://127.0.0.1:54321/different'),
-        'http://127.0.0.1:54321/different',
-      );
-    });
   });
 
-  group('Given handleMachineLine', () {
-    /// FlutterProcess wired only enough to push synthetic lines through
-    /// `handleMachineLine` and assert side effects.
-    FlutterProcess bareFp({void Function(String)? onProgress}) =>
-        FlutterProcess(
-          flutterPackageDir: Directory.systemTemp.path,
-          device: 'web-server',
-          onProgress: onProgress,
-        );
+  test('Given a ws URI with a path other than /ws'
+      'when getting the http URI '
+      'then the path is left alone', () {
+    expect(
+      FlutterProcess.httpFromWs('ws://127.0.0.1:54321/different'),
+      'http://127.0.0.1:54321/different',
+    );
+  });
+
+  group('Given a FlutterProcess receiving machine protocol lines', () {
+    late FlutterProcess fp;
+    late List<String> progressMessages;
+
+    setUp(() async {
+      progressMessages = <String>[];
+
+      /// FlutterProcess wired only enough to push synthetic lines through
+      /// `handleMachineLine` and assert side effects.
+      fp = FlutterProcess(
+        flutterPackageDir: Directory.systemTemp.path,
+        device: 'web-server',
+        onProgress: progressMessages.add,
+      );
+    });
 
     test(
       'when given a line that does not start with [ '
       'then the line is ignored',
       () {
-        final fp = bareFp();
         fp.handleMachineLine('just some text');
         fp.handleMachineLine('');
         expect(fp.vmServiceUri, isNull);
@@ -292,7 +364,6 @@ void main() {
       'when given a [-prefixed line containing malformed JSON '
       'then the line is ignored',
       () {
-        final fp = bareFp();
         fp.handleMachineLine('[not-json');
         expect(fp.vmServiceUri, isNull);
       },
@@ -302,7 +373,6 @@ void main() {
       'when given an envelope missing the event field '
       'then the envelope is ignored',
       () {
-        final fp = bareFp();
         fp.handleMachineLine(
           jsonEncode([
             {'noevent': true},
@@ -316,8 +386,6 @@ void main() {
       'when given a line containing multiple events '
       'then each event is processed in order',
       () {
-        final progress = <String>[];
-        final fp = bareFp(onProgress: progress.add);
         fp.handleMachineLine(
           jsonEncode([
             {
@@ -335,7 +403,7 @@ void main() {
           ]),
         );
         expect(fp.flutterAppUrl, 'http://localhost:8080');
-        expect(progress, containsAllInOrder(['Compiling', 'ready']));
+        expect(progressMessages, containsAllInOrder(['Compiling', 'ready']));
       },
     );
 
@@ -343,7 +411,6 @@ void main() {
       'when app.webLaunchUrl arrives before app.debugPort '
       'then launched completes immediately (web-server gate semantics)',
       () async {
-        final fp = bareFp();
         fp.handleMachineLine(
           jsonEncode([
             {
@@ -362,7 +429,6 @@ void main() {
       'when app.debugPort arrives without app.webLaunchUrl '
       'then launched completes immediately (mobile/desktop gate semantics)',
       () async {
-        final fp = bareFp();
         fp.handleMachineLine(
           jsonEncode([
             {

--- a/tools/serverpod_cli/test/commands/start/flutter_process_test.dart
+++ b/tools/serverpod_cli/test/commands/start/flutter_process_test.dart
@@ -54,6 +54,7 @@ void main() {
       () async {
         final fp = FlutterProcess(
           flutterPackageDir: Directory.systemTemp.path,
+          device: 'web-server',
           flutterExecutable: '/definitely/not/a/real/binary',
         );
 
@@ -73,6 +74,7 @@ void main() {
         // would clear _process before the second call.
         final fp = FlutterProcess(
           flutterPackageDir: Directory.current.path,
+          device: 'web-server',
           flutterExecutable: _dartExecutable(),
           argsOverrideForTesting: [_shimPath('never_publishes_uri.dart')],
         );
@@ -89,6 +91,7 @@ void main() {
       () async {
         final fp = FlutterProcess(
           flutterPackageDir: Directory.current.path,
+          device: 'web-server',
           flutterExecutable: _dartExecutable(),
           argsOverrideForTesting: [_shimPath('never_publishes_uri.dart')],
         );
@@ -127,6 +130,7 @@ void main() {
 
         final fp = FlutterProcess(
           flutterPackageDir: Directory.current.path,
+          device: 'web-server',
           flutterExecutable: _dartExecutable(),
           argsOverrideForTesting: [
             _shimPath('emits_machine_events.dart'),
@@ -171,6 +175,7 @@ void main() {
       () async {
         final fp = FlutterProcess(
           flutterPackageDir: Directory.systemTemp.path,
+          device: 'web-server',
         );
         expect(await fp.reload(), isFalse);
       },
@@ -182,6 +187,7 @@ void main() {
       () async {
         final fp = FlutterProcess(
           flutterPackageDir: Directory.systemTemp.path,
+          device: 'web-server',
         );
         expect(await fp.stop(), 0);
         expect(await fp.stop(), 0);
@@ -200,6 +206,7 @@ void main() {
 
         final fp = FlutterProcess(
           flutterPackageDir: Directory.current.path,
+          device: 'web-server',
           flutterExecutable: _dartExecutable(),
           argsOverrideForTesting: [
             _shimPath('emits_machine_events.dart'),
@@ -285,6 +292,7 @@ void main() {
     FlutterProcess bareFp({void Function(String)? onProgress}) =>
         FlutterProcess(
           flutterPackageDir: Directory.systemTemp.path,
+          device: 'web-server',
           onProgress: onProgress,
         );
 

--- a/tools/serverpod_cli/test/commands/start/flutter_process_test.dart
+++ b/tools/serverpod_cli/test/commands/start/flutter_process_test.dart
@@ -69,8 +69,8 @@ void main() {
       'then the second call throws StateError instead of spawning a duplicate process',
       () async {
         // Use a long-running shim so the first process is still alive when
-        // we attempt the second start; exit_immediately would clear
-        // _process before the second call.
+        // we attempt the second start - a shim that exits immediately
+        // would clear _process before the second call.
         final fp = FlutterProcess(
           flutterPackageDir: Directory.current.path,
           flutterExecutable: _dartExecutable(),
@@ -387,34 +387,5 @@ void main() {
         expect(fp.flutterAppUrl, isNull);
       },
     );
-
-    test('first app.debugPort wins; later wsUri events are ignored', () {
-      final fp = bareFp();
-      fp.handleMachineLine(
-        jsonEncode([
-          {
-            'event': 'app.debugPort',
-            'params': {'wsUri': 'ws://127.0.0.1:1111/ws'},
-          },
-        ]),
-      );
-      fp.handleMachineLine(
-        jsonEncode([
-          {
-            'event': 'app.debugPort',
-            'params': {'wsUri': 'ws://127.0.0.1:2222/ws'},
-          },
-        ]),
-      );
-      // The captured URI is only readable once connectToVmService runs;
-      // assert that calling that with an extremely short timeout finds
-      // the first URI in the completer and gives up after the connect
-      // retries.
-      // (We can't connect to a real VM at port 1111 - the connect loop
-      // will exhaust its retries and `connectToVmService` returns with
-      // _vmServiceUri populated from the first wsUri.)
-      // The behavioral check that matters here: the parser didn't
-      // throw and accepted both lines without crashing.
-    });
   });
 }

--- a/tools/serverpod_cli/test/commands/start/flutter_shims/emits_machine_events.dart
+++ b/tools/serverpod_cli/test/commands/start/flutter_shims/emits_machine_events.dart
@@ -1,11 +1,5 @@
-// Test shim for [FlutterProcess]: emits a sequence of `--machine`
-// JSON events (progress, webLaunchUrl, debugPort, started) over stdout,
-// then waits for SIGINT/SIGTERM so the lifecycle methods can be
-// exercised.
-//
-// The `--ws=<uri>` CLI arg controls the `wsUri` reported in
-// `app.debugPort`; tests provide a URL that points at their fake VM
-// service WebSocket server.
+// Test shim: emits a fixed `--machine` event sequence, then waits for
+// SIGINT/SIGTERM. `--ws=<uri>` overrides the wsUri in app.debugPort.
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
@@ -47,8 +41,6 @@ Future<void> main(List<String> args) async {
 
   final stopper = Completer<void>();
 
-  // Handle SIGINT (and SIGTERM where supported) cleanly so the shim
-  // exits when [FlutterProcess.stop] sends a signal.
   ProcessSignal.sigint.watch().listen((_) {
     if (!stopper.isCompleted) stopper.complete();
   });

--- a/tools/serverpod_cli/test/commands/start/flutter_shims/emits_machine_events.dart
+++ b/tools/serverpod_cli/test/commands/start/flutter_shims/emits_machine_events.dart
@@ -1,0 +1,62 @@
+// Test shim for [FlutterProcess]: emits a sequence of `--machine`
+// JSON events (progress, webLaunchUrl, debugPort, started) over stdout,
+// then waits for SIGINT/SIGTERM so the lifecycle methods can be
+// exercised.
+//
+// The `--ws=<uri>` CLI arg controls the `wsUri` reported in
+// `app.debugPort`; tests provide a URL that points at their fake VM
+// service WebSocket server.
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+Future<void> main(List<String> args) async {
+  final wsUri = args
+      .firstWhere(
+        (a) => a.startsWith('--ws='),
+        orElse: () => '--ws=ws://127.0.0.1:0/ws',
+      )
+      .substring('--ws='.length);
+  final webUrl = args
+      .firstWhere(
+        (a) => a.startsWith('--web-url='),
+        orElse: () => '--web-url=http://localhost:54321',
+      )
+      .substring('--web-url='.length);
+
+  void emit(Map<String, Object?> event) {
+    stdout.writeln(jsonEncode([event]));
+  }
+
+  emit({
+    'event': 'app.progress',
+    'params': {'message': 'Launching ...'},
+  });
+  emit({
+    'event': 'app.webLaunchUrl',
+    'params': {'url': webUrl},
+  });
+  emit({
+    'event': 'app.debugPort',
+    'params': {'wsUri': wsUri, 'port': Uri.parse(wsUri).port},
+  });
+  emit({
+    'event': 'app.started',
+    'params': {},
+  });
+
+  final stopper = Completer<void>();
+
+  // Handle SIGINT (and SIGTERM where supported) cleanly so the shim
+  // exits when [FlutterProcess.stop] sends a signal.
+  ProcessSignal.sigint.watch().listen((_) {
+    if (!stopper.isCompleted) stopper.complete();
+  });
+  if (!Platform.isWindows) {
+    ProcessSignal.sigterm.watch().listen((_) {
+      if (!stopper.isCompleted) stopper.complete();
+    });
+  }
+
+  await stopper.future;
+}

--- a/tools/serverpod_cli/test/commands/start/flutter_shims/exit_immediately.dart
+++ b/tools/serverpod_cli/test/commands/start/flutter_shims/exit_immediately.dart
@@ -1,0 +1,4 @@
+// Test shim for [FlutterProcess]: exits immediately with code 0, never
+// publishing an `app.debugPort` event. Used to exercise the "Flutter
+// exits before VM service URI is published" path.
+void main() {}

--- a/tools/serverpod_cli/test/commands/start/flutter_shims/exit_immediately.dart
+++ b/tools/serverpod_cli/test/commands/start/flutter_shims/exit_immediately.dart
@@ -1,4 +1,0 @@
-// Test shim for [FlutterProcess]: exits immediately with code 0, never
-// publishing an `app.debugPort` event. Used to exercise the "Flutter
-// exits before VM service URI is published" path.
-void main() {}

--- a/tools/serverpod_cli/test/commands/start/flutter_shims/never_publishes_uri.dart
+++ b/tools/serverpod_cli/test/commands/start/flutter_shims/never_publishes_uri.dart
@@ -1,9 +1,6 @@
-// Test shim for [FlutterProcess]: runs forever, emits machine-protocol
-// progress events but never `app.debugPort`. Used to exercise the
-// VM-service-URI startup timeout.
+// Test shim: alive but silent. Exercises the no-URI-arrives path.
 import 'dart:async';
 
 Future<void> main() async {
-  // Keep the process alive long enough for the timeout to fire.
   await Future<void>.delayed(const Duration(minutes: 1));
 }

--- a/tools/serverpod_cli/test/commands/start/flutter_shims/never_publishes_uri.dart
+++ b/tools/serverpod_cli/test/commands/start/flutter_shims/never_publishes_uri.dart
@@ -1,0 +1,9 @@
+// Test shim for [FlutterProcess]: runs forever, emits machine-protocol
+// progress events but never `app.debugPort`. Used to exercise the
+// VM-service-URI startup timeout.
+import 'dart:async';
+
+Future<void> main() async {
+  // Keep the process alive long enough for the timeout to fire.
+  await Future<void>.delayed(const Duration(minutes: 1));
+}

--- a/tools/serverpod_cli/test/commands/tui/tui_log_sink_test.dart
+++ b/tools/serverpod_cli/test/commands/tui/tui_log_sink_test.dart
@@ -13,7 +13,7 @@ void main() {
   setUp(() {
     state = ServerWatchState();
     holder = StartAppStateHolder(state);
-    sink = TuiLogSink(holder);
+    sink = TuiLogSink(holder, addLine: state.rawLines.add);
   });
 
   group('Given a TuiLogSink', () {

--- a/tools/serverpod_cli/test/test_util/builders/generator_config_builder.dart
+++ b/tools/serverpod_cli/test/test_util/builders/generator_config_builder.dart
@@ -23,6 +23,7 @@ class GeneratorConfigBuilder {
   DatabaseDialect _databaseDialect;
   List<ExperimentalFeature> _enabledExperimentalFeatures;
   List<String>? _relativeServerTestToolsPathParts;
+  List<String> _relativeFlutterPackagePathParts;
 
   GeneratorConfigBuilder()
     : _name = _defaultName,
@@ -33,6 +34,7 @@ class GeneratorConfigBuilder {
       _serverPackageDirectoryPathParts = [],
       _sharedModelsSourcePathsParts = {},
       _relativeDartClientPackagePathParts = ['..', 'example_client'],
+      _relativeFlutterPackagePathParts = ['..', 'example_flutter'],
       _modules = [
         ModuleConfig(
           type: PackageType.internal,
@@ -158,6 +160,13 @@ class GeneratorConfigBuilder {
     return this;
   }
 
+  GeneratorConfigBuilder withRelativeFlutterPackagePathParts(
+    List<String> relativeFlutterPackagePathParts,
+  ) {
+    _relativeFlutterPackagePathParts = relativeFlutterPackagePathParts;
+    return this;
+  }
+
   GeneratorConfig build() {
     return GeneratorConfig(
       name: _name,
@@ -168,6 +177,7 @@ class GeneratorConfigBuilder {
       serverPackageDirectoryPathParts: _serverPackageDirectoryPathParts,
       sharedModelsSourcePathsParts: _sharedModelsSourcePathsParts,
       relativeDartClientPackagePathParts: _relativeDartClientPackagePathParts,
+      relativeFlutterPackagePathParts: _relativeFlutterPackagePathParts,
       modules: _modules,
       extraClasses: _extraClasses,
       serializeAsJsonbByDefault: _serializeAsJsonbByDefault,


### PR DESCRIPTION
Auto-launches the project's companion Flutter app alongside the server in `serverpod start`, with coordinated reload and IDE attach for both processes.

- Spawns `flutter run --machine` when a companion package is present; opt out with `--no-flutter`.
- File-watch triggers a single codegen + server-reload + Flutter-reload pass, serialized through `WatchSession._chain`.
- New flags: 
   - `--flutter-device=<device>` (default `chrome`),
   - `--flutter-option=<arg>` (repeatable). 
- `--verbose` propagates to `flutter --verbose`.
- Reload routes through the daemon's `app.restart` over stdin, not `vmService.reloadSources` (the latter skips flutter_tools' recompile and breaks DWDS).
- Daemon protocol client vendored from flutter_tools' DAP adapter.
- `FlutterProcess` spawns `flutter_tools.dart` directly through dart, bypassing puro/fvm/asdf wrappers so signals reach the daemon.
- Project template `launch.json` attaches to (instead of launches) the Flutter app via a new `flutter-vm-service-info.json` sibling of the server's info file; compound config gets `stopAll: true`.
- TUI gains a Flutter output tab and a status line; `app.log` and the VM service's `Logging` stream both feed it.
- `ext.serverpod.log` events from the Flutter VM flow into the structured Log Messages tab via the same handler the server uses.
- Tests use Dart shims (`flutter_shims/`) so CI does not need a Flutter SDK.

Closes #5127 

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else.
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

## Breaking changes

None. Opt-out via `--no-flutter`; silently skipped for projects without a `<name>_flutter` directory containing a `pubspec.yaml`. The template change only affects newly generated projects.
