### PR TITLE
feat: Add health endpoints to webserver

### DIFF
--- a/packages/serverpod/lib/src/server/health/health_routes.dart
+++ b/packages/serverpod/lib/src/server/health/health_routes.dart
@@ -1,0 +1,102 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:meta/meta.dart';
+import 'package:serverpod/serverpod.dart';
+import 'package:serverpod/src/server/health_check.dart';
+import 'package:serverpod/src/server/serverpod.dart';
+
+/// Registers the standard Kubernetes-style health probes (`/livez`, `/readyz`,
+/// `/startupz`) on a [RelicRouter]. Mount via [RelicRouter.injectAt] (or call
+/// [injectIn] directly) on any server that should expose probes to an
+/// orchestrator.
+///
+/// The legacy `GET /` health endpoint is intentionally NOT registered by
+/// [injectIn] because it would collide with user-defined homepage routes when
+/// this module is mounted on the web server. Callers that want it (i.e. the
+/// API server) should wire [legacyHealth] explicitly.
+class HealthRoutes implements RouterInjectable {
+  final Serverpod _serverpod;
+
+  /// Creates probes backed by [serverpod]'s [HealthCheckService].
+  HealthRoutes(Serverpod serverpod) : _serverpod = serverpod;
+
+  @override
+  void injectIn(RelicRouter router) {
+    router
+      ..get('/livez', _livez)
+      ..get('/readyz', _readyz)
+      ..get('/startupz', _startupz);
+  }
+
+  /// Legacy `GET /` health endpoint. Returns `200 OK <timestamp>` when all
+  /// metrics are healthy, `503` with a body listing failing metrics otherwise.
+  ///
+  /// Only the API server should wire this up: it would collide with user
+  /// homepage routes on the web server.
+  @internal
+  Future<Result> legacyHealth(Request _) async {
+    final metrics = (await performHealthChecks(_serverpod)).metrics;
+    final issues = metrics.where((m) => !m.isHealthy);
+    final now = DateTime.timestamp();
+    if (issues.isEmpty) return Response.ok(body: Body.fromString('OK $now'));
+    final body = StringBuffer('SADNESS $now\r\n');
+    for (final metric in issues) {
+      body.write('${metric.name}: ${metric.value}\r\n');
+    }
+    return Response(503, body: Body.fromString(body.toString()));
+  }
+
+  Future<Result> _livez(Request request) async {
+    final response = await _serverpod.healthCheckService.checkLiveness();
+    return _healthResponse(request, response);
+  }
+
+  Future<Result> _readyz(Request request) async {
+    final response = await _serverpod.healthCheckService.checkReadiness();
+    return _healthResponse(request, response);
+  }
+
+  Future<Result> _startupz(Request request) async {
+    final response = await _serverpod.healthCheckService.checkStartup();
+    return _healthResponse(request, response);
+  }
+
+  Future<Result> _healthResponse(
+    Request request,
+    HealthResponse response,
+  ) async {
+    final isAuthenticated = await _isAuthenticatedHealthRequest(request);
+
+    if (isAuthenticated) {
+      return Response(
+        response.httpStatusCode,
+        body: Body.fromString(
+          jsonEncode(response.toJson()),
+          mimeType: MimeType.json,
+        ),
+      );
+    }
+    return Response(response.httpStatusCode);
+  }
+
+  Future<bool> _isAuthenticatedHealthRequest(Request request) async {
+    final authHeader = request.getAuthorizationHeaderValue(
+      _serverpod.config.validateHeaders,
+    );
+    if (authHeader == null) return false;
+
+    final authKey = unwrapAuthHeaderValue(authHeader);
+    if (authKey == null) return false;
+
+    final handler = _serverpod.authenticationHandler;
+    if (handler == null) return false;
+
+    try {
+      final authInfo = await handler(_serverpod.internalSession, authKey);
+      return authInfo != null;
+    } catch (e) {
+      return false;
+    }
+  }
+}

--- a/packages/serverpod/lib/src/server/server.dart
+++ b/packages/serverpod/lib/src/server/server.dart
@@ -7,7 +7,7 @@ import 'package:serverpod/serverpod.dart';
 import 'package:serverpod_shared/log.dart';
 import 'package:serverpod/src/cache/caches.dart';
 import 'package:serverpod/src/server/diagnostic_events/diagnostic_events.dart';
-import 'package:serverpod/src/server/health_check.dart';
+import 'package:serverpod/src/server/health/health_routes.dart';
 import 'package:serverpod/src/server/serverpod.dart';
 import 'package:serverpod/src/server/session.dart';
 import 'package:serverpod/src/server/websocket_request_handlers/endpoint_websocket_request_handler.dart';
@@ -140,14 +140,18 @@ class Server implements RouterInjectable {
       router.use('/', _verboseLogging);
     }
 
+    final healthRoutes = HealthRoutes(serverpod);
+
     // Register core middleware first to ensure they wrap all user middleware
     router
       ..use('/', _headers)
       ..use('/', _reportException)
-      ..get('/', _health)
-      ..get('/livez', _livez)
-      ..get('/readyz', _readyz)
-      ..get('/startupz', _startupz)
+      // Legacy `GET /` health endpoint - API/insights only; would collide
+      // with user homepage routes on the web server, so it's wired here
+      // rather than from [HealthRoutes.injectIn].
+      ..get('/', healthRoutes.legacyHealth);
+    healthRoutes.injectIn(router);
+    router
       ..get(
         '/websocket',
         _dispatchWebSocket(EndpointWebsocketRequestHandler.handleWebsocket),
@@ -261,86 +265,6 @@ class Server implements RouterInjectable {
         return Response.internalServerError();
       }
     };
-  }
-
-  Future<Result> _health(Request _) async {
-    final metrics = (await performHealthChecks(serverpod)).metrics;
-    final issues = metrics.where((m) => !m.isHealthy);
-    final ok = issues.isEmpty;
-    final now = DateTime.timestamp();
-    if (ok) return Response.ok(body: Body.fromString('OK $now'));
-    return Response(
-      503,
-      body: Body.fromDataStream(() async* {
-        yield utf8.encode('SADNESS $now\r\n');
-        for (final metric in issues) {
-          yield utf8.encode('${metric.name}: ${metric.value}\r\n');
-        }
-      }()),
-    );
-  }
-
-  /// Liveness probe - always returns healthy if server can respond.
-  Future<Result> _livez(Request request) async {
-    final response = await serverpod.healthCheckService.checkLiveness();
-    return _healthResponse(request, response);
-  }
-
-  /// Readiness probe - checks all readiness indicators.
-  Future<Result> _readyz(Request request) async {
-    final response = await serverpod.healthCheckService.checkReadiness();
-    return _healthResponse(request, response);
-  }
-
-  /// Startup probe - checks if startup is complete.
-  Future<Result> _startupz(Request request) async {
-    final response = await serverpod.healthCheckService.checkStartup();
-    return _healthResponse(request, response);
-  }
-
-  /// Builds the appropriate response based on authentication status.
-  Future<Result> _healthResponse(
-    Request request,
-    HealthResponse response,
-  ) async {
-    final isAuthenticated = await _isAuthenticatedHealthRequest(request);
-
-    if (isAuthenticated) {
-      return Response(
-        response.httpStatusCode,
-        body: Body.fromString(
-          jsonEncode(response.toJson()),
-          mimeType: MimeType.json,
-        ),
-      );
-    } else {
-      // Unauthenticated: status code only, no body
-      return Response(response.httpStatusCode);
-    }
-  }
-
-  /// Checks if the request has valid authentication for detailed health info.
-  Future<bool> _isAuthenticatedHealthRequest(Request request) async {
-    final authHeader = request.getAuthorizationHeaderValue(
-      serverpod.config.validateHeaders,
-    );
-    if (authHeader == null) return false;
-
-    final authKey = unwrapAuthHeaderValue(authHeader);
-    if (authKey == null) return false;
-
-    final handler = serverpod.authenticationHandler;
-    if (handler == null) return false;
-
-    try {
-      final authInfo = await handler(
-        serverpod.internalSession,
-        authKey,
-      );
-      return authInfo != null;
-    } catch (e) {
-      return false;
-    }
   }
 
   Handler _headers(Handler next) {

--- a/packages/serverpod/lib/src/web_server/web_server.dart
+++ b/packages/serverpod/lib/src/web_server/web_server.dart
@@ -7,6 +7,7 @@ import 'package:serverpod/serverpod.dart';
 import 'package:serverpod_shared/log.dart';
 import 'package:serverpod/src/server/dev_auto_refresh_script.dart';
 import 'package:serverpod/src/server/diagnostic_events/diagnostic_events.dart';
+import 'package:serverpod/src/server/health/health_routes.dart';
 import 'package:serverpod/src/server/serverpod.dart';
 import 'package:serverpod/src/server/session.dart';
 
@@ -28,14 +29,19 @@ class WebServer {
 
   RelicApp? _appOrNull;
 
-  // The __dev/version endpoint returns the static change counter in dev mode.
-  // In production mode the handler returns 404, which tells the injected
-  // polling script to stop polling.
-  RelicApp get _app => _appOrNull ??= RelicApp(useHostWhenRouting: true)
-    ..get('*/__dev/version', _devStaticChangeCount)
-    ..use('*/', _devHtmlInjection)
-    ..inject(_ReportExceptionMiddleware(this))
-    ..inject(_SessionMiddleware(serverpod.server));
+  RelicApp get _app {
+    final existing = _appOrNull;
+    if (existing != null) return existing;
+    final healthRoutes = HealthRoutes(serverpod);
+    return _appOrNull = RelicApp(useHostWhenRouting: true)
+      // Returns the static change counter in dev mode
+      ..get('*/__dev/version', _devStaticChangeCount)
+      // Mirrors the probes [Server] exposes on the API/insights ports
+      ..injectAt('*/', healthRoutes)
+      ..use('*/', _devHtmlInjection)
+      ..inject(_ReportExceptionMiddleware(this))
+      ..inject(_SessionMiddleware(serverpod.server));
+  }
 
   /// Security context if the web server is running over https.
   final SecurityContext? _securityContext;

--- a/packages/serverpod/lib/src/web_server/web_server.dart
+++ b/packages/serverpod/lib/src/web_server/web_server.dart
@@ -29,19 +29,14 @@ class WebServer {
 
   RelicApp? _appOrNull;
 
-  RelicApp get _app {
-    final existing = _appOrNull;
-    if (existing != null) return existing;
-    final healthRoutes = HealthRoutes(serverpod);
-    return _appOrNull = RelicApp(useHostWhenRouting: true)
-      // Returns the static change counter in dev mode
-      ..get('*/__dev/version', _devStaticChangeCount)
-      // Mirrors the probes [Server] exposes on the API/insights ports
-      ..injectAt('*/', healthRoutes)
-      ..use('*/', _devHtmlInjection)
-      ..inject(_ReportExceptionMiddleware(this))
-      ..inject(_SessionMiddleware(serverpod.server));
-  }
+  RelicApp get _app => _appOrNull ??= RelicApp(useHostWhenRouting: true)
+    // Returns the static change counter in dev mode
+    ..get('*/__dev/version', _devStaticChangeCount)
+    // Mirrors the probes [Server] exposes on the API/insights ports
+    ..injectAt('*/', HealthRoutes(serverpod))
+    ..use('*/', _devHtmlInjection)
+    ..inject(_ReportExceptionMiddleware(this))
+    ..inject(_SessionMiddleware(serverpod.server));
 
   /// Security context if the web server is running over https.
   final SecurityContext? _securityContext;

--- a/tests/serverpod_test_server/test/web_server_health_endpoints_test.dart
+++ b/tests/serverpod_test_server/test/web_server_health_endpoints_test.dart
@@ -1,0 +1,193 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+import 'package:serverpod/serverpod.dart';
+import 'package:test/test.dart';
+
+import 'package:serverpod_test_server/src/generated/protocol.dart';
+import 'package:serverpod_test_server/src/generated/endpoints.dart';
+import 'package:serverpod_test_server/test_util/fake_health_indicator.dart';
+
+void main() {
+  final portZeroConfig = ServerConfig(
+    port: 0,
+    publicScheme: 'http',
+    publicHost: 'localhost',
+    publicPort: 0,
+  );
+
+  group('Given a running web server with a user-registered route', () {
+    late int port;
+    late http.Client httpClient;
+
+    setUp(() async {
+      final pod = Serverpod(
+        [],
+        Protocol(),
+        Endpoints(),
+        config: ServerpodConfig(
+          apiServer: portZeroConfig,
+          webServer: portZeroConfig,
+        ),
+        authenticationHandler: (session, token) => Future.value(
+          token == 'valid'
+              ? AuthenticationInfo('test-user', {}, authId: 'valid')
+              : null,
+        ),
+      );
+      // Register a user route so the web server's lazy app is initialized
+      // (see Features.enableWebServer + WebServer.hasApp).
+      pod.webServer.addRoute(_FallbackRoute(), '/existing');
+      await pod.start();
+      addTearDown(() => pod.shutdown(exitProcess: false));
+      port = pod.webServer.port!;
+      httpClient = http.Client();
+      addTearDown(httpClient.close);
+    });
+
+    for (final probe in const ['livez', 'readyz', 'startupz']) {
+      test(
+        'when calling GET /$probe '
+        'then response status code is 200',
+        () async {
+          final response = await httpClient.get(
+            Uri.http('localhost:$port', '/$probe'),
+          );
+
+          expect(response.statusCode, 200);
+        },
+      );
+
+      test(
+        'when calling GET /$probe with no authentication '
+        'then response has no body',
+        () async {
+          final response = await httpClient.get(
+            Uri.http('localhost:$port', '/$probe'),
+          );
+
+          expect(response.body, isEmpty);
+        },
+      );
+
+      test(
+        'when calling GET /$probe with valid authentication '
+        'then response is JSON with status pass',
+        () async {
+          final response = await httpClient.get(
+            Uri.http('localhost:$port', '/$probe'),
+            headers: {'Authorization': 'Bearer valid'},
+          );
+
+          expect(response.statusCode, 200);
+          final json = jsonDecode(response.body) as Map<String, dynamic>;
+          expect(json['status'], 'pass');
+        },
+      );
+    }
+  });
+
+  group('Given a web server with a failing readiness indicator', () {
+    late int port;
+    late http.Client httpClient;
+
+    setUp(() async {
+      final pod = Serverpod(
+        [],
+        Protocol(),
+        Endpoints(),
+        config: ServerpodConfig(
+          apiServer: portZeroConfig,
+          webServer: portZeroConfig,
+        ),
+        healthConfig: HealthConfig(
+          additionalReadinessIndicators: [
+            FakeHealthIndicator(
+              name: 'test:service',
+              isHealthy: false,
+              failureMessage: 'Service unavailable',
+            ),
+          ],
+        ),
+      );
+      pod.webServer.addRoute(_FallbackRoute(), '/existing');
+      await pod.start();
+      addTearDown(() => pod.shutdown(exitProcess: false));
+      port = pod.webServer.port!;
+      httpClient = http.Client();
+      addTearDown(httpClient.close);
+    });
+
+    test(
+      'when calling GET /readyz '
+      'then response status code is 503 and reaches the client unmodified',
+      () async {
+        final response = await httpClient.get(
+          Uri.http('localhost:$port', '/readyz'),
+        );
+
+        // Status propagates through _devHtmlInjection / _ReportException /
+        // _SessionMiddleware on the web server without being rewritten.
+        expect(response.statusCode, 503);
+        expect(response.body, isEmpty);
+      },
+    );
+  });
+
+  group('Given a fallback route is configured on the web server', () {
+    late int port;
+    late http.Client httpClient;
+
+    setUp(() async {
+      final pod = Serverpod(
+        [],
+        Protocol(),
+        Endpoints(),
+        config: ServerpodConfig(
+          apiServer: portZeroConfig,
+          webServer: portZeroConfig,
+        ),
+      );
+      pod.webServer.fallbackRoute = _FallbackRoute();
+      await pod.start();
+      addTearDown(() => pod.shutdown(exitProcess: false));
+      port = pod.webServer.port!;
+      httpClient = http.Client();
+      addTearDown(httpClient.close);
+    });
+
+    test(
+      'when calling GET /livez '
+      'then the probe handler responds, not the fallback',
+      () async {
+        final response = await httpClient.get(
+          Uri.http('localhost:$port', '/livez'),
+        );
+
+        expect(response.statusCode, 200);
+        expect(response.body, isEmpty);
+      },
+    );
+
+    test(
+      'when calling an unrelated path '
+      'then the fallback route still handles it',
+      () async {
+        final response = await httpClient.get(
+          Uri.http('localhost:$port', '/something-else'),
+        );
+
+        expect(response.statusCode, 200);
+        expect(response.body, 'fallback');
+      },
+    );
+  });
+}
+
+class _FallbackRoute extends Route {
+  @override
+  FutureOr<Result> handleCall(Session session, Request req) {
+    return Response.ok(body: Body.fromString('fallback'));
+  }
+}


### PR DESCRIPTION
Expose `/livez`, `/readyz`, `/startupz` on the web server in addition to the API/Insights servers, 
so orchestrators can probe the public web port directly.

Probe handlers are extracted into a reusable `HealthRoutes` (`RouterInjectable`) and mounted on each server. 
The legacy `GET /` endpoint stays API-only to avoid colliding with user homepage routes.

Fixes #5147 

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.
