### PR TITLE
fix: McpCommand lost McpOption in the fray

### DIFF
--- a/tools/serverpod_cli/lib/src/commands/mcp.dart
+++ b/tools/serverpod_cli/lib/src/commands/mcp.dart
@@ -43,7 +43,7 @@ enum McpOption<V> implements OptionDefinition<V> {
 /// transparently if the runner restarts. There is no `connect`/`spawn`
 /// surface - one bridge per server project, configured per entry in the
 /// agent's MCP config.
-class McpCommand extends ServerpodCommand {
+class McpCommand extends ServerpodCommand<McpOption> {
   @override
   final name = 'mcp';
 
@@ -55,8 +55,10 @@ class McpCommand extends ServerpodCommand {
   @override
   String get invocation => 'serverpod mcp';
 
+  McpCommand() : super(options: McpOption.values);
+
   @override
-  Future<void> runWithConfig(Configuration commandConfig) async {
+  Future<void> runWithConfig(Configuration<McpOption> commandConfig) async {
     if (!hasUnixSocketSupport()) {
       log.error(
         'The serverpod MCP bridge requires Unix domain socket support, '

--- a/tools/serverpod_cli/lib/src/commands/start/mcp_server.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/mcp_server.dart
@@ -69,9 +69,9 @@ base class ServerpodMcpServer extends MCPServer
       ) {
     registerTool(applyMigrationsTool, _applyMigrations);
     registerTool(createMigrationTool, _createMigration);
-    registerTool(_createRepairMigrationTool, _createRepairMigration);
+    registerTool(createRepairMigrationTool, _createRepairMigration);
     registerTool(hotReloadTool, _hotReload);
-    registerTool(_hotRestartTool, _hotRestart);
+    registerTool(hotRestartTool, _hotRestart);
     registerTool(tailLogsTool, _tailLogs);
 
     addResource(vmServiceResource, _readVmService);
@@ -142,35 +142,6 @@ base class ServerpodMcpServer extends MCPServer
     }
   }
 
-  static final _createRepairMigrationTool = Tool(
-    name: 'create_repair_migration',
-    description:
-        'Create a repair migration that brings the live database in line '
-        'with the target migration version (default: latest). Connects to '
-        'the running server to read the live schema, diffs it against the '
-        'target, and writes a `.sql` repair file. Use when a migration was '
-        'partially applied or the database drifted out of sync. Does not '
-        'apply the migration; follow up with `apply_migrations`.',
-    inputSchema: Schema.object(
-      properties: {
-        'tag': Schema.string(
-          description:
-              'Optional tag appended to the repair migration version name.',
-        ),
-        'force': Schema.bool(
-          description:
-              'Create the repair migration even when warnings are present '
-              'or when no schema drift is detected (data may be destroyed).',
-        ),
-        'version': Schema.string(
-          description:
-              'Optional target migration version to repair against. '
-              'Defaults to the latest migration version.',
-        ),
-      },
-    ),
-  );
-
   Future<CallToolResult> _createRepairMigration(CallToolRequest request) async {
     final callback = onCreateRepairMigration;
     if (callback == null) {
@@ -224,16 +195,6 @@ base class ServerpodMcpServer extends MCPServer
       );
     }
   }
-
-  static final _hotRestartTool = Tool(
-    name: 'hot_restart',
-    description:
-        'Recompile from scratch and restart the server process. Clears all '
-        'in-memory state (singletons, connection pools, caches). Use when '
-        'hot_reload is not enough - for example, to reset state that '
-        'survives source reloads.',
-    inputSchema: Schema.object(),
-  );
 
   Future<CallToolResult> _hotRestart(CallToolRequest request) async {
     final callback = onHotRestart;

--- a/tools/serverpod_cli/lib/src/generated/completion_script_carapace.dart
+++ b/tools/serverpod_cli/lib/src/generated/completion_script_carapace.dart
@@ -75,6 +75,8 @@ commands:
       - [stdio, no-stdio]
 
   - name: mcp
+    flags:
+      -s, --server-dir=: "Path to the server project directory (the package that contains a `serverpod` dependency). Auto-detected from the current working directory if omitted. Pass this flag explicitly in monorepos with multiple server projects."
 
   - name: create-migration
     flags:

--- a/tools/serverpod_cli/lib/src/mcp/runner_surface.dart
+++ b/tools/serverpod_cli/lib/src/mcp/runner_surface.dart
@@ -31,6 +31,35 @@ final Tool createMigrationTool = Tool(
   ),
 );
 
+final Tool createRepairMigrationTool = Tool(
+  name: 'create_repair_migration',
+  description:
+      'Create a repair migration that brings the live database in line '
+      'with the target migration version (default: latest). Connects to '
+      'the running server to read the live schema, diffs it against the '
+      'target, and writes a `.sql` repair file. Use when a migration was '
+      'partially applied or the database drifted out of sync. Does not '
+      'apply the migration; follow up with `apply_migrations`.',
+  inputSchema: Schema.object(
+    properties: {
+      'tag': Schema.string(
+        description:
+            'Optional tag appended to the repair migration version name.',
+      ),
+      'force': Schema.bool(
+        description:
+            'Create the repair migration even when warnings are present '
+            'or when no schema drift is detected (data may be destroyed).',
+      ),
+      'version': Schema.string(
+        description:
+            'Optional target migration version to repair against. '
+            'Defaults to the latest migration version.',
+      ),
+    },
+  ),
+);
+
 final Tool hotReloadTool = Tool(
   name: 'hot_reload',
   description:
@@ -79,6 +108,7 @@ final Resource vmServiceResource = Resource(
 final List<Tool> runnerStaticTools = [
   applyMigrationsTool,
   createMigrationTool,
+  createRepairMigrationTool,
   hotReloadTool,
   hotRestartTool,
   tailLogsTool,

--- a/tools/serverpod_cli/test/commands/mcp_command_test.dart
+++ b/tools/serverpod_cli/test/commands/mcp_command_test.dart
@@ -1,0 +1,72 @@
+import 'package:serverpod_cli/src/commands/mcp.dart';
+import 'package:serverpod_cli/src/util/serverpod_cli_logger.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Given an McpCommand', () {
+    late McpCommand command;
+
+    setUp(() {
+      command = McpCommand();
+    });
+
+    tearDownAll(closeLogger);
+
+    test(
+      'when parsing configuration with no args, '
+      'then there are no errors',
+      () {
+        final argResults = command.argParser.parse([]);
+        final config = command.resolveConfiguration(argResults);
+
+        expect(config.errors, isEmpty);
+      },
+    );
+
+    test(
+      'when parsing configuration with no --server-dir, '
+      'then server-dir is null',
+      () {
+        final argResults = command.argParser.parse([]);
+        final config = command.resolveConfiguration(argResults);
+
+        expect(config.optionalValue(McpOption.serverDir), isNull);
+      },
+    );
+
+    test(
+      'when parsing configuration with --server-dir=path, '
+      'then server-dir is the path',
+      () {
+        final argResults = command.argParser.parse([
+          '--server-dir=packages/my_server',
+        ]);
+        final config = command.resolveConfiguration(argResults);
+
+        expect(config.errors, isEmpty);
+        expect(
+          config.optionalValue(McpOption.serverDir),
+          equals('packages/my_server'),
+        );
+      },
+    );
+
+    test(
+      'when parsing configuration with -s path, '
+      'then server-dir is the path',
+      () {
+        final argResults = command.argParser.parse([
+          '-s',
+          'packages/my_server',
+        ]);
+        final config = command.resolveConfiguration(argResults);
+
+        expect(config.errors, isEmpty);
+        expect(
+          config.optionalValue(McpOption.serverDir),
+          equals('packages/my_server'),
+        );
+      },
+    );
+  });
+}

--- a/tools/serverpod_cli/test/mcp/bridge_mcp_server_test.dart
+++ b/tools/serverpod_cli/test/mcp/bridge_mcp_server_test.dart
@@ -64,6 +64,7 @@ void main() {
             containsAll(<String>{
               'apply_migrations',
               'create_migration',
+              'create_repair_migration',
               'hot_reload',
               'hot_restart',
               'tail_logs',
@@ -132,6 +133,7 @@ void main() {
             containsAll(<String>{
               'apply_migrations',
               'create_migration',
+              'create_repair_migration',
               'hot_reload',
               'hot_restart',
               'tail_logs',


### PR DESCRIPTION
- Fix `serverpod mcp --server-dir` regression. 
- Rebase didn't expose the new `createRepairMigration` as a mcp tool.
- Adds tests.