### PR TITLE
perf(cli): Speed up serverpod create template rendering

### DIFF
--- a/tools/serverpod_cli/lib/src/create/template_renderer.dart
+++ b/tools/serverpod_cli/lib/src/create/template_renderer.dart
@@ -14,7 +14,6 @@ class TemplateRenderer {
     '.git',
     '.dart_tool',
     '.idea',
-    '.vscode',
     '.github',
     'node_modules',
     'Pods',

--- a/tools/serverpod_cli/lib/src/create/template_renderer.dart
+++ b/tools/serverpod_cli/lib/src/create/template_renderer.dart
@@ -1,19 +1,52 @@
 import 'dart:io';
 
+import 'package:dart_style/dart_style.dart';
 import 'package:path/path.dart' as p;
+import 'package:pub_semver/pub_semver.dart';
 import 'package:serverpod_cli/src/create/template_context.dart';
-import 'package:serverpod_cli/src/util/command_line_tools.dart';
 import 'package:whiskers/whiskers.dart';
 
 /// Responsible for rendering template files in a directory using provided context.
 /// It processes both file contents and directory names,
 /// allowing for dynamic project structures.
 class TemplateRenderer {
+  static const Set<String> _defaultExcludedDirNames = <String>{
+    '.git',
+    '.dart_tool',
+    '.idea',
+    '.vscode',
+    '.github',
+    'node_modules',
+    'Pods',
+    // Dart/Flutter build output.
+    'build',
+    '.symlinks',
+    // Serverpod runtime artefacts.
+    'sqlite_data',
+    'migrations',
+    '.serverpod',
+  };
+
+  static final DartFormatter _dartFormatter = DartFormatter(
+    // update in concert with `code_generator.dart`
+    languageVersion: Version(3, 10, 0),
+    trailingCommas: TrailingCommas.preserve,
+  );
+
   /// Creates a [TemplateRenderer].
-  TemplateRenderer({required this.dir});
+  ///
+  /// [excludedDirNames] may be passed to override the default set of
+  /// directory basenames that are skipped during traversal.
+  TemplateRenderer({
+    required this.dir,
+    Set<String>? excludedDirNames,
+  }) : excludedDirNames = excludedDirNames ?? _defaultExcludedDirNames;
 
   /// The target directory containing the template files to be rendered.
   final Directory dir;
+
+  /// Directory basenames to skip while recursing.
+  final Set<String> excludedDirNames;
 
   /// Renders the templates in the target directory using [context].
   Future<void> render(TemplateContext context) async {
@@ -33,6 +66,8 @@ class TemplateRenderer {
       if (entity is File) {
         await _renderFile(entity, context);
       } else if (entity is Directory) {
+        final basename = p.basename(entity.path);
+        if (excludedDirNames.contains(basename)) continue;
         await _handleDirectoryRendering(entity, context);
       }
     }
@@ -43,10 +78,16 @@ class TemplateRenderer {
     TemplateContext context,
   ) async {
     try {
-      final renderedName = _renderFileSystemEntityName(
-        p.basename(directory.path),
-        context,
-      );
+      final basename = p.basename(directory.path);
+
+      // Fast path! directory names without template directives can't be renamed,
+      // so just recurse without invoking the Mustache parser.
+      if (!_hasTemplateMarker(basename)) {
+        await _renderDirectory(directory, context);
+        return;
+      }
+
+      final renderedName = _renderFileSystemEntityName(basename, context);
       final newPath = p.join(p.dirname(directory.path), renderedName);
 
       if (renderedName.isEmpty) {
@@ -84,7 +125,9 @@ class TemplateRenderer {
       final renderedFile = await _renderFileName(file, context);
       if (renderedFile != null) await _renderFileContent(renderedFile, context);
     } on FileSystemException {
-      // File gone or not decodable.
+      // File gone.
+    } on FormatException {
+      // Non-UTF8 content (binary asset?). Skip silently!
     }
   }
 
@@ -92,6 +135,10 @@ class TemplateRenderer {
   /// If rendering results in an empty file name (excluding extension), the file is deleted.
   Future<File?> _renderFileName(File file, TemplateContext context) async {
     final fileName = p.basename(file.path);
+
+    // Fast path! File names without template directives can't be renamed.
+    if (!_hasTemplateMarker(fileName)) return file;
+
     final renderedFileName = _renderFileSystemEntityName(fileName, context);
     late final extension = p.extension(fileName);
 
@@ -114,19 +161,33 @@ class TemplateRenderer {
   /// If rendering results in a file with empty content, the file is deleted.
   Future<void> _renderFileContent(File file, TemplateContext context) async {
     final content = await file.readAsString();
+
+    // Fast path! Bail before invoking expensive regex preprocessor and Mustache parser.
+    if (!_hasTemplateMarker(content)) return;
+
     final processedContent = _preprocessContent(content);
     final renderedContent = _renderTemplate(processedContent, context);
 
     if (renderedContent.trim().isEmpty) {
       await file.delete();
-    } else if (renderedContent != content) {
-      await file.writeAsString(renderedContent);
-
-      // Format rendered dart files
-      final extension = p.extension(p.basename(file.path));
-      if (extension == '.dart') await CommandLineTools.dartFormat(file);
+      return;
     }
+    if (renderedContent == content) return;
+
+    var toWrite = renderedContent;
+    if (p.extension(file.path) == '.dart') {
+      try {
+        toWrite = _dartFormatter.format(renderedContent);
+      } on FormatterException {
+        // Rendered output isn't valid Dart!
+        // Write the unformatted content rather than failing the render.
+      }
+    }
+    await file.writeAsString(toWrite);
   }
+
+  /// Cheap test for the presence of a Mustache opening delimiter.
+  static bool _hasTemplateMarker(String s) => s.contains('{{');
 
   /// Preprocesses the content by removing comment markers from template directives.
   /// The comment markers allow template directives to be included in the source

--- a/tools/serverpod_cli/lib/src/util/command_line_tools.dart
+++ b/tools/serverpod_cli/lib/src/util/command_line_tools.dart
@@ -67,22 +67,6 @@ class CommandLineTools {
     );
     return exitCode == 0;
   }
-
-  static Future<bool> dartFormat(File file) async {
-    log.debug('Running `dart format ${file.path}`', newParagraph: true);
-
-    var exitCode = await _runProcessWithDefaultLogger(
-      executable: 'dart',
-      arguments: ['format', file.path],
-    );
-
-    if (exitCode != 0) {
-      _logError('Failed to run `dart format ${file.path}`');
-      return false;
-    }
-
-    return true;
-  }
 }
 
 Future<int> _runProcessWithDefaultLogger({


### PR DESCRIPTION
The current code in `tools/serverpod_cli/lib/src/create/template_renderer.dart` traverses way too many files, invoking expensive operations like mustache rendering, or per-file subprocesses for dart formatting. This PR fixes the worst offenders.

- format Dart files in-process with DartFormatter instead of spawning `dart format` per file,
- skip heavy directories (`.git`, `.dart_tool`, `build`, ...) when traversing,
- and bail early on names/contents without `{{`.

In one example this makes `serverpod create .` (ie. upgrade) run go down from 10m37s to 2s, so 318x faster.

The PR does not fix the fact that blocking operations are run on the nocterm render thread, but the staggering obviously becomes much less pronounced.