### PR TITLE
fix: Fix `cursor` skills deferring to `.agents` instead of `.cursor`

### DIFF
--- a/tests/bootstrap_project/test/module_quickstart_test.dart
+++ b/tests/bootstrap_project/test/module_quickstart_test.dart
@@ -357,6 +357,12 @@ void main() {
             ).existsSync(),
             isTrue,
           );
+          expect(
+            Directory(
+              path.join(tempPath, projectName, '.cursor', 'skills'),
+            ).existsSync(),
+            isTrue,
+          );
         });
 
         group('has Serverpod and Dart MCP servers configured', () {

--- a/tests/bootstrap_project/test/module_test.dart
+++ b/tests/bootstrap_project/test/module_test.dart
@@ -412,6 +412,12 @@ void main() {
             ).existsSync(),
             isTrue,
           );
+          expect(
+            Directory(
+              path.join(tempPath, projectName, '.cursor', 'skills'),
+            ).existsSync(),
+            isTrue,
+          );
         });
 
         group('has Serverpod and Dart MCP servers configured', () {

--- a/tests/bootstrap_project/test/project_mini_test.dart
+++ b/tests/bootstrap_project/test/project_mini_test.dart
@@ -345,6 +345,12 @@ void main() async {
             ).existsSync(),
             isTrue,
           );
+          expect(
+            Directory(
+              path.join(tempPath, projectName, '.cursor', 'skills'),
+            ).existsSync(),
+            isTrue,
+          );
         });
 
         group('has Serverpod and Dart MCP servers configured', () {

--- a/tests/bootstrap_project/test/project_quickstart_test.dart
+++ b/tests/bootstrap_project/test/project_quickstart_test.dart
@@ -474,6 +474,12 @@ void main() async {
                 ).existsSync(),
                 isTrue,
               );
+              expect(
+                Directory(
+                  path.join(tempPath, projectName, '.cursor', 'skills'),
+                ).existsSync(),
+                isTrue,
+              );
             });
 
             group('has Serverpod and Dart MCP servers configured', () {

--- a/tests/bootstrap_project/test/project_test.dart
+++ b/tests/bootstrap_project/test/project_test.dart
@@ -771,6 +771,12 @@ void main() async {
             ).existsSync(),
             isTrue,
           );
+          expect(
+            Directory(
+              path.join(tempPath, projectName, '.cursor', 'skills'),
+            ).existsSync(),
+            isTrue,
+          );
         });
 
         group('has Serverpod and Dart MCP servers configured', () {

--- a/tests/bootstrap_project/test_perform_create/ide_test.dart
+++ b/tests/bootstrap_project/test_perform_create/ide_test.dart
@@ -59,6 +59,10 @@ void main() {
           isTrue,
         );
         expect(
+          Directory(p.join(projectName, '.cursor', 'skills')).existsSync(),
+          isTrue,
+        );
+        expect(
           Directory(p.join(projectName, '.opencode', 'skills')).existsSync(),
           isTrue,
         );

--- a/tools/serverpod_cli/lib/src/create/create.dart
+++ b/tools/serverpod_cli/lib/src/create/create.dart
@@ -65,6 +65,7 @@ extension TemplateIdeExtension on List<TemplateIde> {
     return map((templateIde) {
       return switch (templateIde) {
         TemplateIde.claude => Ide.claude,
+        TemplateIde.cursor => Ide.cursor,
         TemplateIde.openCode => Ide.opencode,
         _ => Ide.generic,
       };
@@ -342,15 +343,17 @@ Future<String?> performCreate(
         final agentDir = Directory(
           p.join(serverpodDirs.projectDir.path, '.agent'),
         );
-        final agentsDir = Directory(
-          p.join(serverpodDirs.projectDir.path, '.agents'),
-        );
+        if (await agentDir.exists()) {
+          final agentsDir = Directory(
+            p.join(serverpodDirs.projectDir.path, '.agents'),
+          );
 
-        try {
-          await _moveDirectoryContents(agentDir, agentsDir);
-          await agentDir.delete();
-        } on FileSystemException {
-          //
+          try {
+            await _moveDirectoryContents(agentDir, agentsDir);
+            await agentDir.delete();
+          } on FileSystemException {
+            //
+          }
         }
       } catch (_) {
         _logError('Failed to install agent skills');


### PR DESCRIPTION
Fixes Cursor skills not being placed under `.cursor`.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.