### PR TITLE
feat: Spawn flutter app on demand on attach

### DIFF
--- a/tools/serverpod_cli/lib/src/commands/start.dart
+++ b/tools/serverpod_cli/lib/src/commands/start.dart
@@ -537,7 +537,7 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
   // IDE-facing Flutter VM-service proxy. Bound now so the info file
   // exists at session start regardless of whether `--flutter` was
   // passed; the upstream is set later when FlutterProcess connects.
-  late final Future<void> Function() spawnFlutterAppIfNeeded;
+  Future<void> Function() spawnFlutterAppIfNeeded = () async {};
   final flutterProxy = await _bindFlutterProxy(
     infoFile: flutterVmServiceInfoFile,
     onWaitingClientArrived: () => spawnFlutterAppIfNeeded(),

--- a/tools/serverpod_cli/lib/src/commands/start.dart
+++ b/tools/serverpod_cli/lib/src/commands/start.dart
@@ -760,7 +760,7 @@ Future<VmServiceProxy?> _mountOrRetargetProxy({
   final podWs = Uri.parse(vmServiceWsUri(podHttp));
 
   if (existing != null) {
-    await existing.retarget(podWs);
+    await existing.setUpstream(podWs);
     return existing;
   }
 

--- a/tools/serverpod_cli/lib/src/commands/start.dart
+++ b/tools/serverpod_cli/lib/src/commands/start.dart
@@ -417,6 +417,10 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
   // user-facing vm-service-info.json receives the proxy URI written by
   // _mountOrRetargetProxy.
   final podInfoFile = p.join(serverpodToolDir, 'vm-service-info.pod.json');
+  final flutterVmServiceInfoFile = p.join(
+    serverpodToolDir,
+    'flutter-vm-service-info.json',
+  );
 
   // If a server is already running, abort so the IDE can attach to the
   // existing instance via the unchanged info file. Cheap local check; runs
@@ -530,6 +534,13 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
     dartExecutable = localCompiler.dartExecutable;
   }
 
+  // IDE-facing Flutter VM-service proxy. Bound now so the info file
+  // exists at session start regardless of whether `--flutter` was
+  // passed; the upstream is set later when FlutterProcess connects.
+  final flutterProxy = await _bindFlutterProxy(
+    infoFile: flutterVmServiceInfoFile,
+  );
+
   // Server process factory. Invoked for the initial start and for each
   // subsequent restart driven by the WatchSession
   late final WatchSession session;
@@ -579,7 +590,7 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
         flutterPackageDir: p.joinAll(config.flutterPackagePathParts),
         device: flutterDevice,
         extraArgs: flutterExtraArgs,
-        vmServiceInfoFile: defaultFlutterVmServiceInfoFile(serverpodToolDir),
+        flutterProxy: flutterProxy,
         stdoutSink: flutterStdoutSink,
         stderrSink: flutterStderrSink,
         onProgress: (stage) {
@@ -718,11 +729,13 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
     WatchLoopContext(
       session: session,
       proxy: proxy,
+      flutterProxy: flutterProxy,
       mcpSocket: mcpSocket,
       fileChangeSub: fileChangeSub,
       closeAnalyzers: closeAnalyzers,
       stopDocker: startedDocker ? () => _stopDockerServices(serverDir) : null,
       vmServiceInfoFile: vmServiceInfoFile,
+      flutterVmServiceInfoFile: flutterVmServiceInfoFile,
     ),
   );
 }
@@ -742,6 +755,22 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
 /// Returns the (possibly retargeted) proxy on success, or [existing] when
 /// the pod hasn't published a VM service URI - the watch session keeps
 /// running without an attachable proxy in that case.
+/// Binds a `VmServiceProxy` that the Flutter app's vm-service will be
+/// attached to once it comes up, and writes [infoFile] with the proxy's
+/// stable URI so launch.json's `vmServiceInfoFile` reference resolves
+/// immediately. The proxy starts upstream-less so it works for
+/// `--no-flutter` (IDE attach holds in a waiting queue rather than
+/// hanging on a never-published info file).
+Future<VmServiceProxy> _bindFlutterProxy({required String infoFile}) async {
+  final proxy = VmServiceProxy(upstreamWs: null);
+  await proxy.bind();
+  await File(infoFile).writeAsString(
+    jsonEncode({'uri': proxy.httpUri.toString()}),
+  );
+  log.info('Flutter VM service proxy listening on ${proxy.httpUri}');
+  return proxy;
+}
+
 Future<VmServiceProxy?> _mountOrRetargetProxy({
   required ServerProcess serverProcess,
   required VmServiceProxy? existing,

--- a/tools/serverpod_cli/lib/src/commands/start.dart
+++ b/tools/serverpod_cli/lib/src/commands/start.dart
@@ -537,8 +537,10 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
   // IDE-facing Flutter VM-service proxy. Bound now so the info file
   // exists at session start regardless of whether `--flutter` was
   // passed; the upstream is set later when FlutterProcess connects.
+  late final Future<void> Function() spawnFlutterAppIfNeeded;
   final flutterProxy = await _bindFlutterProxy(
     infoFile: flutterVmServiceInfoFile,
+    onWaitingClientArrived: () => spawnFlutterAppIfNeeded(),
   );
 
   // Server process factory. Invoked for the initial start and for each
@@ -577,62 +579,76 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
   // Needed for the Flutter dev-mode gate and the migration action.
   final runMode = runModeFromServerArgs(serverArgs.value);
 
-  // Production/staging boots skip the dev Flutter spawn. Missing
-  // package = silent no-op; missing Flutter SDK = warning.
+  // Spawn the Flutter app subprocess.
+  //
+  // Calling while previous instance is still running is a no-op.
   FlutterProcess? flutterProcess;
-  if (launchFlutterApp && runMode == 'development') {
+  var spawnInFlight = false;
+  spawnFlutterAppIfNeeded = () async {
+    if (runMode != 'development') return;
     if (!config.hasFlutterPackage) {
       log.info(flutterPackageNotFound);
-    } else {
-      // Non-TUI: surface daemon progress as log.info during the 30-60s
-      // cold compile; log.progress shows only one line.
-      flutterProcess = FlutterProcess(
-        flutterPackageDir: p.joinAll(config.flutterPackagePathParts),
-        device: flutterDevice,
-        extraArgs: flutterExtraArgs,
-        flutterProxy: flutterProxy,
-        stdoutSink: flutterStdoutSink,
-        stderrSink: flutterStderrSink,
-        onProgress: (stage) {
-          onFlutterProgress?.call(stage);
-          if (onFlutterProgress == null) {
-            log.info('  Flutter: $stage');
-          }
+      return;
+    }
+    final existing = flutterProcess;
+    if (existing != null && existing.isRunning) return;
+    if (spawnInFlight) return;
+    spawnInFlight = true;
+
+    final fp = FlutterProcess(
+      flutterPackageDir: p.joinAll(config.flutterPackagePathParts),
+      device: flutterDevice,
+      extraArgs: flutterExtraArgs,
+      flutterProxy: flutterProxy,
+      stdoutSink: flutterStdoutSink,
+      stderrSink: flutterStderrSink,
+      onProgress: (stage) {
+        onFlutterProgress?.call(stage);
+        if (onFlutterProgress == null) {
+          log.info('  Flutter: $stage');
+        }
+      },
+    );
+    try {
+      await fp.start();
+    } on FlutterNotInstalledException catch (e) {
+      log.warning(e.message);
+      spawnInFlight = false;
+      return;
+    } catch (_) {
+      spawnInFlight = false;
+      rethrow;
+    }
+    flutterProcess = fp;
+    spawnInFlight = false;
+
+    // Background: Server-running shouldn't wait on Flutter launch.
+    // On `-d web-server` `launched` pends until a browser attaches.
+    unawaited(() async {
+      await log.progress(
+        'Launching Flutter app (first run may take 30-60s)',
+        () async {
+          await fp.launched;
+          return true;
         },
       );
-      try {
-        await flutterProcess.start();
-      } on FlutterNotInstalledException catch (e) {
-        log.warning(e.message);
-        flutterProcess = null;
+      final url = fp.flutterAppUrl;
+      if (url != null) {
+        log.info('Flutter app running at $url');
+        onFlutterReady?.call(url);
       }
-      final fp = flutterProcess;
-      if (fp != null) {
-        // Background: Server-running shouldn't wait on Flutter launch.
-        // On `-d web-server` `launched` pends until a browser attaches.
-        unawaited(() async {
-          await log.progress(
-            'Launching Flutter app (first run may take 30-60s)',
-            () async {
-              await fp.launched;
-              return true;
-            },
-          );
-          final url = fp.flutterAppUrl;
-          if (url != null) {
-            log.info('Flutter app running at $url');
-            onFlutterReady?.call(url);
-          }
-          await log.progress('Connecting to Flutter VM service', () async {
-            await fp.connectToVmService();
-            if (fp.isVmServiceConnected && onFlutterStart != null) {
-              await onFlutterStart(fp);
-            }
-            return fp.isVmServiceConnected;
-          });
-        }());
-      }
-    }
+      await log.progress('Connecting to Flutter VM service', () async {
+        await fp.connectToVmService();
+        if (fp.isVmServiceConnected && onFlutterStart != null) {
+          await onFlutterStart(fp);
+        }
+        return fp.isVmServiceConnected;
+      });
+    }());
+  };
+
+  if (launchFlutterApp) {
+    await spawnFlutterAppIfNeeded();
   }
 
   // Construct the watch session.
@@ -651,7 +667,7 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
     createServer: serverProcessFactory,
     initialServer: initialServerProcess,
     generatedDirPaths: config.generatedDirPaths,
-    flutterProcess: flutterProcess,
+    flutterProcessProvider: () => flutterProcess,
     applyMigrationsAction: () => _applyMigrationsForSession(
       serverDir: serverDir,
       runMode: runMode,
@@ -716,7 +732,7 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
         p.absolute(
           p.joinAll([...config.serverPackageDirectoryPathParts, 'web']),
         ),
-        if (flutterProcess != null)
+        if (config.hasFlutterPackage)
           p.absolute(p.joinAll([...config.flutterPackagePathParts, 'lib'])),
       },
     );
@@ -740,6 +756,29 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
   );
 }
 
+/// Binds a [VmServiceProxy] that the Flutter app's vm-service will be
+/// attached to once it comes up.
+///
+/// Writes [infoFile] with the proxy's stable URI.
+///
+/// [onWaitingClientArrived] fires the first time a client connects
+/// while no upstream is bound.
+Future<VmServiceProxy> _bindFlutterProxy({
+  required String infoFile,
+  FutureOr<void> Function()? onWaitingClientArrived,
+}) async {
+  final proxy = VmServiceProxy(
+    upstreamWs: null,
+    onWaitingClientArrived: onWaitingClientArrived,
+  );
+  await proxy.bind();
+  await File(infoFile).writeAsString(
+    jsonEncode({'uri': proxy.httpUri.toString()}),
+  );
+  log.info('Flutter VM service proxy listening on ${proxy.httpUri}');
+  return proxy;
+}
+
 /// Mounts a fresh [VmServiceProxy] in front of [serverProcess] (writing
 /// the proxy's URI to [userInfoFile]), or retargets [existing] in place
 /// when called for a subsequent pod restart so the published proxy URI
@@ -755,22 +794,6 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
 /// Returns the (possibly retargeted) proxy on success, or [existing] when
 /// the pod hasn't published a VM service URI - the watch session keeps
 /// running without an attachable proxy in that case.
-/// Binds a `VmServiceProxy` that the Flutter app's vm-service will be
-/// attached to once it comes up, and writes [infoFile] with the proxy's
-/// stable URI so launch.json's `vmServiceInfoFile` reference resolves
-/// immediately. The proxy starts upstream-less so it works for
-/// `--no-flutter` (IDE attach holds in a waiting queue rather than
-/// hanging on a never-published info file).
-Future<VmServiceProxy> _bindFlutterProxy({required String infoFile}) async {
-  final proxy = VmServiceProxy(upstreamWs: null);
-  await proxy.bind();
-  await File(infoFile).writeAsString(
-    jsonEncode({'uri': proxy.httpUri.toString()}),
-  );
-  log.info('Flutter VM service proxy listening on ${proxy.httpUri}');
-  return proxy;
-}
-
 Future<VmServiceProxy?> _mountOrRetargetProxy({
   required ServerProcess serverProcess,
   required VmServiceProxy? existing,

--- a/tools/serverpod_cli/lib/src/commands/start/flutter_process.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/flutter_process.dart
@@ -59,6 +59,7 @@ class FlutterProcess {
   StreamSubscription<List<int>>? _stderrBytesSub;
   StreamSubscription<String>? _machineLinesSub;
   StreamSubscription<Event>? _loggingSub;
+  Timer? _vmServiceHeartbeat;
 
   String? _appId;
   FlutterDaemonProtocol? _daemon;
@@ -221,8 +222,10 @@ class FlutterProcess {
 
     for (var attempt = 0; attempt < 5; attempt++) {
       try {
-        _vmService = await vmServiceConnectUri(wsUri);
-        await _subscribeToLogging(_vmService!);
+        final vm = await vmServiceConnectUri(wsUri);
+        _vmService = vm;
+        await _subscribeToLogging(vm);
+        _startVmServiceHeartbeat(vm);
         return;
       } on Exception {
         if (attempt == 4) {
@@ -232,6 +235,47 @@ class FlutterProcess {
         await Future<void>.delayed(const Duration(milliseconds: 200));
       }
     }
+  }
+
+  /// Periodic `getVM()` against the [vm].
+  ///
+  /// Belt-and-suspenders companion to the daemon `app.stop` event
+  /// (missing on flutter web).
+  void _startVmServiceHeartbeat(VmService vm) {
+    _vmServiceHeartbeat?.cancel();
+    // Tight loop because DWDS won't tell us when a browser tab
+    // detaches (its keep-alive is hardcoded to ~3000 days). 2s
+    // interval + 1s timeout lets us notice within ~3s.
+    //
+    // Hot restart briefly empties the isolate list - require two
+    // consecutive empty reads (~4s window at 2s interval) so we
+    // don't race-kill a healthy restart.
+    var emptyReads = 0;
+    _vmServiceHeartbeat = Timer.periodic(const Duration(seconds: 2), (
+      timer,
+    ) async {
+      if (_vmService != vm) {
+        timer.cancel();
+        return;
+      }
+      try {
+        final vmInfo = await vm.getVM().timeout(const Duration(seconds: 1));
+        if (vmInfo.isolates?.isEmpty ?? true) {
+          emptyReads++;
+          if (emptyReads >= 2) {
+            timer.cancel();
+            log.info('Flutter heartbeat: no isolates; tearing down.');
+            await _onAppStop();
+          }
+        } else {
+          emptyReads = 0;
+        }
+      } catch (e) {
+        timer.cancel();
+        log.info('Flutter heartbeat failed ($e); tearing down.');
+        await _onAppStop();
+      }
+    });
   }
 
   /// `--machine` doesn't forward `dart:developer.log()`; `Logging` does.
@@ -378,6 +422,9 @@ class FlutterProcess {
           }
         case 'app.started':
           _onProgress?.call('ready');
+        case 'app.stop':
+          log.debug('Flutter daemon emitted app.stop; tearing down.');
+          unawaited(_onAppStop());
         case 'app.log':
           final logText = paramMap['log'];
           if (logText is! String || logText.isEmpty) break;
@@ -388,6 +435,26 @@ class FlutterProcess {
           if (message is String) log.debug('flutter[daemon] $message');
       }
     }
+  }
+
+  bool _appStopHandled = false;
+  Future<void> _onAppStop() async {
+    if (_appStopHandled) return;
+    _appStopHandled = true;
+    log.debug('Flutter teardown begin.');
+    await _flutterProxy?.setUpstream(null);
+    final process = _process;
+    if (process == null) return;
+    process.kill(ProcessSignal.sigint);
+    await process.exitCode.timeout(
+      const Duration(seconds: 3),
+      onTimeout: () {
+        log.debug('Flutter did not exit on SIGINT; sending SIGKILL.');
+        process.kill(ProcessSignal.sigkill);
+        return process.exitCode;
+      },
+    );
+    log.debug('Flutter teardown end.');
   }
 
   Future<void> _cleanup() async {
@@ -405,17 +472,18 @@ class FlutterProcess {
       await _machineLinesSub?.cancel();
       await _sigtermSub?.cancel();
       await _loggingSub?.cancel();
+      _vmServiceHeartbeat?.cancel();
       _stdoutBytesSub = null;
       _stderrBytesSub = null;
       _machineLinesSub = null;
       _sigtermSub = null;
       _loggingSub = null;
+      _vmServiceHeartbeat = null;
 
       await _vmService?.dispose();
       _vmService = null;
+      _vmServiceUri = null;
 
-      // Unbind upstream so the IDE side sees a disconnect rather than
-      // forwarding requests at a dead VM service.
       await _flutterProxy?.setUpstream(null);
     } finally {
       completer.complete();

--- a/tools/serverpod_cli/lib/src/commands/start/flutter_process.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/flutter_process.dart
@@ -8,7 +8,7 @@ import 'package:serverpod_cli/src/commands/start/server_process.dart'
     show vmServiceWsUri;
 import 'package:serverpod_cli/src/util/serverpod_cli_logger.dart';
 import 'package:serverpod_cli/src/vendored/flutter_daemon_protocol.dart';
-import 'package:serverpod_shared/serverpod_shared.dart';
+import 'package:serverpod_cli/src/vm_proxy/proxy.dart';
 import 'package:vm_service/vm_service.dart';
 import 'package:vm_service/vm_service_io.dart';
 
@@ -27,7 +27,8 @@ class FlutterNotInstalledException implements Exception {
 }
 
 /// Manages a `flutter run --machine` subprocess. Mirrors [ServerProcess].
-/// VM service URI is written to [vmServiceInfoFile] for IDE attach;
+/// IDE attach flows through [flutterProxy] (which owns the stable
+/// vm-service URI and the `flutter-vm-service-info.json` file);
 /// reload/restart go via [FlutterDaemonProtocol] over daemon stdin.
 class FlutterProcess {
   final String _flutterPackageDir;
@@ -37,9 +38,11 @@ class FlutterProcess {
   final IOSink _stdout;
   final IOSink _stderr;
 
-  /// Sibling of the pod's `vm-service-info.json` so one launch.json
-  /// directory reference covers both.
-  final String? _vmServiceInfoFile;
+  /// IDE-facing proxy. When non-null, the process binds upstream on
+  /// VM-service connect and unbinds on shutdown so the IDE sees a
+  /// stable attach point regardless of whether the Flutter app is
+  /// currently running.
+  final VmServiceProxy? _flutterProxy;
 
   /// Fires `'launching'` on spawn, `'connecting'` before VM-service
   /// connect, `'ready'` on `app.started`, plus verbatim `app.progress`
@@ -75,7 +78,7 @@ class FlutterProcess {
     required String device,
     String flutterExecutable = 'flutter',
     List<String> extraArgs = const [],
-    String? vmServiceInfoFile,
+    VmServiceProxy? flutterProxy,
     void Function(String stage)? onProgress,
     IOSink? stdoutSink,
     IOSink? stderrSink,
@@ -84,7 +87,7 @@ class FlutterProcess {
        _flutterExecutable = flutterExecutable,
        _device = device,
        _extraArgs = extraArgs,
-       _vmServiceInfoFile = vmServiceInfoFile,
+       _flutterProxy = flutterProxy,
        _onProgress = onProgress,
        _stdout = stdoutSink ?? stdout,
        _stderr = stderrSink ?? stderr,
@@ -122,11 +125,6 @@ class FlutterProcess {
     final args =
         _argsOverrideForTesting ??
         <String>['run', '--machine', '-d', _device, ..._extraArgs];
-
-    if (_vmServiceInfoFile != null) {
-      // A stale info file would mislead IDE attach.
-      await File(_vmServiceInfoFile).deleteIfExists();
-    }
 
     final invocation = await _resolveFlutterInvocation(_flutterExecutable);
 
@@ -207,8 +205,9 @@ class FlutterProcess {
     );
   }
 
-  /// Wait for `app.debugPort`, write the info file, open a `vm_service`
-  /// client. Best-effort. On `-d web-server` pends until a browser attaches.
+  /// Wait for `app.debugPort`, bind [flutterProxy] upstream so IDE
+  /// clients can attach, open a `vm_service` client. Best-effort.
+  /// On `-d web-server` pends until a browser attaches.
   Future<void> connectToVmService() async {
     if (_vmService != null) return;
     _onProgress?.call('connecting');
@@ -217,17 +216,9 @@ class FlutterProcess {
     if (maybeUri == null) return;
     _vmServiceUri = maybeUri;
 
-    if (_vmServiceInfoFile != null) {
-      try {
-        await File(
-          _vmServiceInfoFile,
-        ).writeAsString(jsonEncode({'uri': maybeUri}));
-      } on FileSystemException catch (e) {
-        log.warning('Could not write Flutter VM service info file: $e');
-      }
-    }
-
     final wsUri = vmServiceWsUri(maybeUri);
+    await _flutterProxy?.setUpstream(Uri.parse(wsUri));
+
     for (var attempt = 0; attempt < 5; attempt++) {
       try {
         _vmService = await vmServiceConnectUri(wsUri);
@@ -423,9 +414,9 @@ class FlutterProcess {
       await _vmService?.dispose();
       _vmService = null;
 
-      if (_vmServiceInfoFile != null) {
-        await File(_vmServiceInfoFile).deleteIfExists();
-      }
+      // Unbind upstream so the IDE side sees a disconnect rather than
+      // forwarding requests at a dead VM service.
+      await _flutterProxy?.setUpstream(null);
     } finally {
       completer.complete();
     }
@@ -503,7 +494,3 @@ class FlutterProcess {
     return uri.replace(scheme: scheme, path: path).toString();
   }
 }
-
-/// Default Flutter VM-service info file, sibling of the pod's info file.
-String defaultFlutterVmServiceInfoFile(String serverpodToolDir) =>
-    p.join(serverpodToolDir, 'flutter-vm-service-info.json');

--- a/tools/serverpod_cli/lib/src/commands/start/watch_loop.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/watch_loop.dart
@@ -32,21 +32,25 @@ final class WatchLoopAborted extends WatchLoopSetupResult {
 class WatchLoopContext {
   final WatchSession session;
   final VmServiceProxy? proxy;
+  final VmServiceProxy flutterProxy;
   final McpSocketServer? mcpSocket;
   final StreamSubscription<void>? fileChangeSub;
   final Future<void> Function() closeAnalyzers;
   final Future<void> Function()? stopDocker;
   final String vmServiceInfoFile;
+  final String flutterVmServiceInfoFile;
   bool _disposed = false;
 
   WatchLoopContext({
     required this.session,
     required this.proxy,
+    required this.flutterProxy,
     required this.mcpSocket,
     required this.fileChangeSub,
     required this.closeAnalyzers,
     required this.stopDocker,
     required this.vmServiceInfoFile,
+    required this.flutterVmServiceInfoFile,
   });
 
   /// Whether [dispose] has been called.
@@ -60,7 +64,9 @@ class WatchLoopContext {
     await closeAnalyzers();
     await session.dispose();
     await proxy?.close();
+    await flutterProxy.close();
     await File(vmServiceInfoFile).deleteIfExists();
+    await File(flutterVmServiceInfoFile).deleteIfExists();
     await stopDocker?.call();
   }
 }

--- a/tools/serverpod_cli/lib/src/commands/start/watch_session.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/watch_session.dart
@@ -119,7 +119,9 @@ class WatchSession {
   final Set<String> _generatedDirPaths;
   final ProtocolChangeClassifier _classifyProtocolChange;
   final ApplyMigrationsAction _applyMigrationsAction;
-  final FlutterProcess? _flutterProcess;
+
+  final FlutterProcess? Function() _flutterProcessProvider;
+  FlutterProcess? get _flutterProcess => _flutterProcessProvider();
 
   final Completer<int> _done = Completer<int>();
 
@@ -157,7 +159,7 @@ class WatchSession {
     ProtocolChangeClassifier classifyProtocolChange =
         defaultProtocolChangeClassifier,
     required ApplyMigrationsAction applyMigrationsAction,
-    FlutterProcess? flutterProcess,
+    FlutterProcess? Function()? flutterProcessProvider,
   }) : _compiler = compiler,
        _nativeAssetsBuilder = nativeAssetsBuilder,
        _generate = generate,
@@ -166,7 +168,7 @@ class WatchSession {
        _generatedDirPaths = generatedDirPaths,
        _classifyProtocolChange = classifyProtocolChange,
        _applyMigrationsAction = applyMigrationsAction,
-       _flutterProcess = flutterProcess {
+       _flutterProcessProvider = flutterProcessProvider ?? (() => null) {
     assert(
       nativeAssetsBuilder == null || compiler != null,
       'nativeAssetsBuilder requires a compiler.',

--- a/tools/serverpod_cli/lib/src/vm_proxy/proxy.dart
+++ b/tools/serverpod_cli/lib/src/vm_proxy/proxy.dart
@@ -169,7 +169,6 @@ class VmServiceProxy {
     );
     wc.timer = Timer(_waitingClientTimeout, () async {
       if (_waitingClients.remove(wc)) {
-        await wc.sub?.cancel();
         await downstream.close(
           WebSocketStatus.normalClosure,
           'no upstream available',
@@ -212,11 +211,11 @@ class VmServiceProxy {
     for (final wc in waiting) {
       wc.timer?.cancel();
     }
+    // Don't cancel waiting subs explicitly.
+    // Their onDone handlers run when ws.close completes and cleans up.
     await [
-      for (final wc in waiting) ...[
-        ?wc.sub?.cancel(),
+      for (final wc in waiting)
         wc.ws.close(WebSocketStatus.normalClosure, 'proxy shutting down'),
-      ],
       ?liveServer?.close(force: true),
       for (final p in List.of(_pairs)) p.close(),
     ].wait;

--- a/tools/serverpod_cli/lib/src/vm_proxy/proxy.dart
+++ b/tools/serverpod_cli/lib/src/vm_proxy/proxy.dart
@@ -78,7 +78,11 @@ class VmServiceProxy {
       _waitingClients.clear();
       for (final wc in waiting) {
         wc.timer?.cancel();
-        await _attachUpstream(wc.ws, upstreamWs);
+        await _attachUpstream(
+          wc.ws,
+          upstreamWs,
+          existingDownSub: wc.sub,
+        );
       }
     }
   }
@@ -135,29 +139,36 @@ class VmServiceProxy {
   void _enqueueWaitingClient(WebSocket downstream) {
     final wc = _WaitingClient(downstream);
     _waitingClients.add(wc);
-    wc.timer = Timer(_waitingClientTimeout, () {
+    wc.sub = downstream.listen(
+      (_) {},
+      onDone: () {
+        if (_waitingClients.remove(wc)) wc.timer?.cancel();
+      },
+      onError: (_) {},
+    );
+    wc.timer = Timer(_waitingClientTimeout, () async {
       if (_waitingClients.remove(wc)) {
-        downstream.close(
-          WebSocketStatus.normalClosure,
-          'no upstream available',
+        await wc.sub?.cancel();
+        unawaited(
+          downstream.close(
+            WebSocketStatus.normalClosure,
+            'no upstream available',
+          ),
         );
       }
     });
-    // ws.done completes when the WS closes from either side. We use it
-    // (instead of ws.listen) so the client's frame buffer isn't consumed
-    // - the _Pair attaches its own listener when we pair up later.
-    unawaited(
-      downstream.done.whenComplete(() {
-        if (_waitingClients.remove(wc)) wc.timer?.cancel();
-      }),
-    );
   }
 
-  Future<void> _attachUpstream(WebSocket downstream, Uri upstreamWs) async {
+  Future<void> _attachUpstream(
+    WebSocket downstream,
+    Uri upstreamWs, {
+    StreamSubscription<dynamic>? existingDownSub,
+  }) async {
     WebSocket upstream;
     try {
       upstream = await WebSocket.connect(upstreamWs.toString());
     } catch (_) {
+      await existingDownSub?.cancel();
       await downstream.close(WebSocketStatus.internalServerError);
       return;
     }
@@ -166,6 +177,7 @@ class VmServiceProxy {
       upstream,
       () => _interceptor,
       _interceptDirections,
+      existingDownSub: existingDownSub,
     );
     _pairs.add(pair);
     unawaited(pair.done.whenComplete(() => _pairs.remove(pair)));
@@ -180,6 +192,7 @@ class VmServiceProxy {
     _waitingClients.clear();
     for (final wc in waiting) {
       wc.timer?.cancel();
+      await wc.sub?.cancel();
       unawaited(
         wc.ws.close(WebSocketStatus.normalClosure, 'proxy shutting down'),
       );
@@ -208,18 +221,29 @@ class _Pair {
     this._down,
     this._up,
     this._resolveInterceptor,
-    this._interceptDirections,
-  );
+    this._interceptDirections, {
+    StreamSubscription<dynamic>? existingDownSub,
+  }) : _downSub = existingDownSub;
 
   Future<void> get done => _done.future;
 
   void start() {
-    _downSub = _down.listen(
-      (data) => _onFrame(Direction.clientToServer, data),
-      onDone: _close,
-      onError: (_) => _close(),
-      cancelOnError: false,
-    );
+    final existing = _downSub;
+    if (existing != null) {
+      // Re-aim the handlers on the pre-existing subscription from the
+      // waiting-client phase. WebSocket is single-subscription so we
+      // can't listen again.
+      existing.onData((data) => _onFrame(Direction.clientToServer, data));
+      existing.onDone(_close);
+      existing.onError((_) => _close());
+    } else {
+      _downSub = _down.listen(
+        (data) => _onFrame(Direction.clientToServer, data),
+        onDone: _close,
+        onError: (_) => _close(),
+        cancelOnError: false,
+      );
+    }
     _upSub = _up.listen(
       (data) => _onFrame(Direction.serverToClient, data),
       onDone: _close,
@@ -284,9 +308,16 @@ class _Pair {
   }
 }
 
-/// A client socket waiting for an upstream to become available.
+/// A client socket waiting for an upstream to become available. We
+/// hold an active subscription during the wait so dart:io's WebSocket
+/// can process control frames (close, ping) - otherwise our own
+/// timeout-close never completes the handshake. On pair-up, the
+/// subscription's handlers are re-aimed by [_Pair] via the
+/// `onData` / `onDone` / `onError` setters; the underlying single-
+/// subscription stream is never re-listened.
 class _WaitingClient {
   _WaitingClient(this.ws);
   final WebSocket ws;
+  StreamSubscription<dynamic>? sub;
   Timer? timer;
 }

--- a/tools/serverpod_cli/lib/src/vm_proxy/proxy.dart
+++ b/tools/serverpod_cli/lib/src/vm_proxy/proxy.dart
@@ -13,17 +13,22 @@ import 'package:serverpod_shared/serverpod_shared.dart';
 /// are decoded as JSON-RPC where possible and dispatched to the
 /// [RpcInterceptor]. Non-JSON / binary frames are forwarded verbatim.
 ///
+/// Upstream is mutable via [setUpstream] - the proxy survives upstream
+/// restarts (pod hot restart, Flutter hot restart) without changing its
+/// own URI.
+///
+/// Upstream may also be `null`, in which case new client connections are
+/// held in a waiting queue until [setUpstream] is called with a non-null
+/// URI.
+///
 /// The proxy mints a per-instance token and accepts WebSocket upgrades only
 /// on `/<token>=/ws`, mirroring how the Dart VM service authenticates its
 /// own URI - this preserves the existing "anyone on loopback can connect
 /// only if they know the token" property when the proxy replaces the
 /// pod-side VM service URI in `vm-service-info.json`.
 class VmServiceProxy {
-  /// Upstream WebSocket URI (typically the pod's DDS `ws://.../<token>=/ws`).
-  /// Mutable so the proxy can survive pod restarts ([retarget]) without
-  /// changing its own URI - existing clients reconnect at the same
-  /// proxy URL after they observe their connection drop.
-  Uri _upstreamWs;
+  /// Upstream WebSocket URI, or `null` when no upstream is currently available.
+  Uri? _upstreamWs;
   RpcInterceptor _interceptor;
 
   /// Directions whose frames are JSON-decoded and dispatched to
@@ -35,31 +40,47 @@ class VmServiceProxy {
   /// Random token guarding the WS upgrade path.
   final String _token;
 
+  /// How long a client may wait before the proxy closes its WS.
+  final Duration _waitingClientTimeout;
+
   HttpServer? _server;
   final Set<_Pair> _pairs = {};
+  final Set<_WaitingClient> _waitingClients = {};
 
   VmServiceProxy({
-    required Uri upstreamWs,
+    Uri? upstreamWs,
     RpcInterceptor? interceptor,
     Set<Direction> interceptDirections = const {Direction.clientToServer},
     String? token,
+    Duration waitingClientTimeout = const Duration(minutes: 2),
   }) : _upstreamWs = upstreamWs,
        _interceptor = interceptor ?? passthroughInterceptor,
        _interceptDirections = interceptDirections,
-       _token = token ?? _mintToken();
+       _token = token ?? _mintToken(),
+       _waitingClientTimeout = waitingClientTimeout;
 
   /// Replace the live interceptor. The next frame uses the new hook.
   @visibleForTesting
   set interceptor(RpcInterceptor i) => _interceptor = i;
 
-  /// Point future client connections at a different upstream WS URI and
-  /// drop any pairs that are still live - they belong to a now-dead pod.
-  /// Clients reconnect on their own; the proxy's published URI is stable.
-  Future<void> retarget(Uri upstreamWs) async {
+  /// The current upstream URI, or `null` if no upstream is bound.
+  Uri? get upstreamWs => _upstreamWs;
+
+  /// Point future client connections at [upstreamWs]
+  /// (or unbind by passing `null`)
+  Future<void> setUpstream(Uri? upstreamWs) async {
     _upstreamWs = upstreamWs;
     final live = List.of(_pairs);
     _pairs.clear();
     await [for (final p in live) p.close()].wait;
+    if (upstreamWs != null) {
+      final waiting = List.of(_waitingClients);
+      _waitingClients.clear();
+      for (final wc in waiting) {
+        wc.timer?.cancel();
+        await _attachUpstream(wc.ws, upstreamWs);
+      }
+    }
   }
 
   /// HTTP base URI of the proxy (e.g. `http://127.0.0.1:NNNN/<token>=/`).
@@ -100,14 +121,46 @@ class VmServiceProxy {
       return;
     }
 
+    final upstreamWs = _upstreamWs;
+    if (upstreamWs == null) {
+      _enqueueWaitingClient(downstream);
+      return;
+    }
+    await _attachUpstream(downstream, upstreamWs);
+  }
+
+  /// Holds [downstream] in the waiting queue until either [setUpstream]
+  /// is called with a non-null upstream, the client disconnects, or
+  /// [_waitingClientTimeout] elapses.
+  void _enqueueWaitingClient(WebSocket downstream) {
+    final wc = _WaitingClient(downstream);
+    _waitingClients.add(wc);
+    wc.timer = Timer(_waitingClientTimeout, () {
+      if (_waitingClients.remove(wc)) {
+        downstream.close(
+          WebSocketStatus.normalClosure,
+          'no upstream available',
+        );
+      }
+    });
+    // ws.done completes when the WS closes from either side. We use it
+    // (instead of ws.listen) so the client's frame buffer isn't consumed
+    // - the _Pair attaches its own listener when we pair up later.
+    unawaited(
+      downstream.done.whenComplete(() {
+        if (_waitingClients.remove(wc)) wc.timer?.cancel();
+      }),
+    );
+  }
+
+  Future<void> _attachUpstream(WebSocket downstream, Uri upstreamWs) async {
     WebSocket upstream;
     try {
-      upstream = await WebSocket.connect(_upstreamWs.toString());
+      upstream = await WebSocket.connect(upstreamWs.toString());
     } catch (_) {
       await downstream.close(WebSocketStatus.internalServerError);
       return;
     }
-
     final pair = _Pair(
       downstream,
       upstream,
@@ -119,10 +172,18 @@ class VmServiceProxy {
     pair.start();
   }
 
-  /// Closes the proxy and tears down all live pairs.
+  /// Closes the proxy, tears down all live pairs, drops waiting clients.
   Future<void> close() async {
     final liveServer = _server;
     _server = null;
+    final waiting = List.of(_waitingClients);
+    _waitingClients.clear();
+    for (final wc in waiting) {
+      wc.timer?.cancel();
+      unawaited(
+        wc.ws.close(WebSocketStatus.normalClosure, 'proxy shutting down'),
+      );
+    }
     await [
       ?liveServer?.close(force: true),
       ...[for (final p in List.of(_pairs)) p.close()],
@@ -221,4 +282,11 @@ class _Pair {
       // Either side may already be closed by its peer
     }
   }
+}
+
+/// A client socket waiting for an upstream to become available.
+class _WaitingClient {
+  _WaitingClient(this.ws);
+  final WebSocket ws;
+  Timer? timer;
 }

--- a/tools/serverpod_cli/lib/src/vm_proxy/proxy.dart
+++ b/tools/serverpod_cli/lib/src/vm_proxy/proxy.dart
@@ -47,17 +47,27 @@ class VmServiceProxy {
   final Set<_Pair> _pairs = {};
   final Set<_WaitingClient> _waitingClients = {};
 
+  /// Fired the first time a client lands in the waiting queue while no
+  /// upstream is bound. Callers use it to demand-start whatever process
+  /// would provide that upstream (e.g. a Flutter app spawn triggered by
+  /// IDE attach). Fires again if the waiting queue drains to empty and
+  /// a new client arrives, so a second IDE attach after a Flutter exit
+  /// can re-spawn. Never fires while an upstream is bound.
+  final FutureOr<void> Function()? _onWaitingClientArrived;
+
   VmServiceProxy({
     Uri? upstreamWs,
     RpcInterceptor? interceptor,
     Set<Direction> interceptDirections = const {Direction.clientToServer},
     String? token,
     Duration waitingClientTimeout = const Duration(minutes: 2),
+    FutureOr<void> Function()? onWaitingClientArrived,
   }) : _upstreamWs = upstreamWs,
        _interceptor = interceptor ?? passthroughInterceptor,
        _interceptDirections = interceptDirections,
        _token = token ?? _mintToken(),
-       _waitingClientTimeout = waitingClientTimeout;
+       _waitingClientTimeout = waitingClientTimeout,
+       _onWaitingClientArrived = onWaitingClientArrived;
 
   /// Replace the live interceptor. The next frame uses the new hook.
   @visibleForTesting
@@ -66,9 +76,10 @@ class VmServiceProxy {
   /// The current upstream URI, or `null` if no upstream is bound.
   Uri? get upstreamWs => _upstreamWs;
 
-  /// Point future client connections at [upstreamWs]
-  /// (or unbind by passing `null`)
+  /// Point future client connections at [upstreamWs] (or unbind by passing `null`).
+  /// A re-bind to the same URI is a no-op.
   Future<void> setUpstream(Uri? upstreamWs) async {
+    if (_upstreamWs == upstreamWs) return;
     _upstreamWs = upstreamWs;
     final live = List.of(_pairs);
     _pairs.clear();
@@ -78,12 +89,11 @@ class VmServiceProxy {
       _waitingClients.clear();
       for (final wc in waiting) {
         wc.timer?.cancel();
-        await _attachUpstream(
-          wc.ws,
-          upstreamWs,
-          existingDownSub: wc.sub,
-        );
       }
+      await [
+        for (final wc in waiting)
+          _attachUpstream(wc.ws, upstreamWs, existingDownSub: wc.sub),
+      ].wait;
     }
   }
 
@@ -137,8 +147,19 @@ class VmServiceProxy {
   /// is called with a non-null upstream, the client disconnects, or
   /// [_waitingClientTimeout] elapses.
   void _enqueueWaitingClient(WebSocket downstream) {
+    final wasEmpty = _waitingClients.isEmpty;
     final wc = _WaitingClient(downstream);
     _waitingClients.add(wc);
+    final cb = _onWaitingClientArrived;
+    if (wasEmpty && cb != null) {
+      // Fire-and-forget: don't block the handler on the callback's
+      // future (which may include a Flutter spawn taking 30+ seconds).
+      // The proxy keeps holding the WS; pairing happens when the
+      // callback eventually calls setUpstream. Errors are swallowed
+      // here so a failing spawn can't crash the proxy listener; the
+      // callback owns its own error reporting.
+      unawaited(Future(cb).catchError((Object _, StackTrace _) {}));
+    }
     wc.sub = downstream.listen(
       (_) {},
       onDone: () {
@@ -149,11 +170,9 @@ class VmServiceProxy {
     wc.timer = Timer(_waitingClientTimeout, () async {
       if (_waitingClients.remove(wc)) {
         await wc.sub?.cancel();
-        unawaited(
-          downstream.close(
-            WebSocketStatus.normalClosure,
-            'no upstream available',
-          ),
+        await downstream.close(
+          WebSocketStatus.normalClosure,
+          'no upstream available',
         );
       }
     });
@@ -192,14 +211,14 @@ class VmServiceProxy {
     _waitingClients.clear();
     for (final wc in waiting) {
       wc.timer?.cancel();
-      await wc.sub?.cancel();
-      unawaited(
-        wc.ws.close(WebSocketStatus.normalClosure, 'proxy shutting down'),
-      );
     }
     await [
+      for (final wc in waiting) ...[
+        ?wc.sub?.cancel(),
+        wc.ws.close(WebSocketStatus.normalClosure, 'proxy shutting down'),
+      ],
       ?liveServer?.close(force: true),
-      ...[for (final p in List.of(_pairs)) p.close()],
+      for (final p in List.of(_pairs)) p.close(),
     ].wait;
   }
 

--- a/tools/serverpod_cli/test/commands/start/flutter_process_test.dart
+++ b/tools/serverpod_cli/test/commands/start/flutter_process_test.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 
 import 'package:path/path.dart' as p;
 import 'package:serverpod_cli/src/commands/start/flutter_process.dart';
+import 'package:serverpod_cli/src/vm_proxy/proxy.dart';
 import 'package:test/test.dart';
 
 /// Path of a Dart shim under `test/commands/start/flutter_shims/`.
@@ -230,17 +231,18 @@ void main() {
     );
   });
 
-  group('Given a FlutterProcess with a vmServiceInfoFile configured', () {
+  group('Given a FlutterProcess wired to a VmServiceProxy', () {
     late FlutterProcess fp;
     late ({HttpServer server, String wsUri}) fake;
-    late Directory tmp;
-    late String infoPath;
+    late VmServiceProxy proxy;
 
     setUp(() async {
       fake = await _startFakeVmService();
-      tmp = Directory.systemTemp.createTempSync('flutter_proc_test_');
-      infoPath = p.join(tmp.path, 'flutter-vm-service-info.json');
-
+      proxy = VmServiceProxy(
+        upstreamWs: null,
+        waitingClientTimeout: const Duration(seconds: 10),
+      );
+      await proxy.bind();
       fp = FlutterProcess(
         flutterPackageDir: Directory.current.path,
         device: 'web-server',
@@ -249,7 +251,7 @@ void main() {
           _shimPath('emits_machine_events.dart'),
           '--ws=${fake.wsUri}',
         ],
-        vmServiceInfoFile: infoPath,
+        flutterProxy: proxy,
       );
 
       await fp.start();
@@ -258,45 +260,35 @@ void main() {
 
     tearDown(() async {
       await fp.stop();
+      await proxy.close();
       await fake.server.close(force: true);
-      try {
-        tmp.deleteSync(recursive: true);
-      } on FileSystemException {
-        // Already gone.
-      }
     });
 
     test(
       'when the shim publishes a URI '
-      'then the file is written with the http URI, then cleaned up on stop',
+      'then the proxy upstream becomes the WS form of that URI, '
+      'and is cleared on stop',
       () async {
-        // Poll on contents: writeAsString creates the inode before
-        // flushing, so existsSync can catch an empty intermediate.
+        // Poll until the proxy observes the upstream bind.
         final deadline = DateTime.now().add(const Duration(seconds: 5));
-        var contents = '';
-        while (contents.isEmpty && DateTime.now().isBefore(deadline)) {
-          if (File(infoPath).existsSync()) {
-            contents = File(infoPath).readAsStringSync();
-          }
-          if (contents.isEmpty) {
-            await Future<void>.delayed(const Duration(milliseconds: 20));
-          }
+        while (proxy.upstreamWs == null && DateTime.now().isBefore(deadline)) {
+          await Future<void>.delayed(const Duration(milliseconds: 20));
         }
 
         expect(
-          contents,
-          contains('http://127.0.0.1:${fake.server.port}'),
+          proxy.upstreamWs?.toString(),
+          equals(fake.wsUri),
         );
 
         await fp.stop(timeout: const Duration(seconds: 1));
 
-        // Cleanup runs async via the exit listener; poll briefly.
-        final cleanupDeadline = DateTime.now().add(const Duration(seconds: 2));
-        while (File(infoPath).existsSync() &&
-            DateTime.now().isBefore(cleanupDeadline)) {
+        // Cleanup runs async via the exit listener.
+        final clearDeadline = DateTime.now().add(const Duration(seconds: 2));
+        while (proxy.upstreamWs != null &&
+            DateTime.now().isBefore(clearDeadline)) {
           await Future<void>.delayed(const Duration(milliseconds: 20));
         }
-        expect(File(infoPath).existsSync(), isFalse);
+        expect(proxy.upstreamWs, isNull);
       },
       timeout: const Timeout(Duration(seconds: 30)),
     );

--- a/tools/serverpod_cli/test/commands/start/watch_loop_test.dart
+++ b/tools/serverpod_cli/test/commands/start/watch_loop_test.dart
@@ -156,11 +156,14 @@ void main() {
     late StreamSubscription<void> fileSub;
     late Directory tempDir;
     late String vmServiceInfoFile;
+    late String flutterVmServiceInfoFile;
+    late _FakeProxy flutterProxy;
 
     setUp(() {
       compiler = _FakeCompiler();
       server = _FakeServer();
       proxy = _FakeProxy();
+      flutterProxy = _FakeProxy();
       mcp = _FakeMcpSocket();
       closeAnalyzersCalls = 0;
       stopDockerCalls = 0;
@@ -176,7 +179,12 @@ void main() {
 
       tempDir = Directory.systemTemp.createTempSync('watch_loop_test_');
       vmServiceInfoFile = p.join(tempDir.path, 'vm-service-info.json');
+      flutterVmServiceInfoFile = p.join(
+        tempDir.path,
+        'flutter-vm-service-info.json',
+      );
       File(vmServiceInfoFile).writeAsStringSync('{}');
+      File(flutterVmServiceInfoFile).writeAsStringSync('{}');
     });
 
     tearDown(() {
@@ -191,6 +199,7 @@ void main() {
       return WatchLoopContext(
         session: _buildSession(compiler, server),
         proxy: proxy,
+        flutterProxy: flutterProxy,
         mcpSocket: mcp,
         fileChangeSub: fileSub,
         closeAnalyzers: () async {
@@ -202,6 +211,7 @@ void main() {
               }
             : null,
         vmServiceInfoFile: vmServiceInfoFile,
+        flutterVmServiceInfoFile: flutterVmServiceInfoFile,
       );
     }
 
@@ -285,6 +295,7 @@ void main() {
         final ctx = WatchLoopContext(
           session: _buildSession(compiler, server),
           proxy: null,
+          flutterProxy: flutterProxy,
           mcpSocket: null,
           fileChangeSub: null,
           closeAnalyzers: () async {
@@ -292,6 +303,7 @@ void main() {
           },
           stopDocker: null,
           vmServiceInfoFile: vmServiceInfoFile,
+          flutterVmServiceInfoFile: flutterVmServiceInfoFile,
         );
 
         await ctx.dispose();

--- a/tools/serverpod_cli/test/commands/start/watch_session_test.dart
+++ b/tools/serverpod_cli/test/commands/start/watch_session_test.dart
@@ -191,7 +191,7 @@ void main() {
           applyMigrationsAction ?? () async => const MigrationsApplied(),
       classifyProtocolChange:
           classifyProtocolChange ?? defaultProtocolChangeClassifier,
-      flutterProcess: flutterProcess,
+      flutterProcessProvider: () => flutterProcess,
     );
   }
 

--- a/tools/serverpod_cli/test/vm_proxy/proxy_test.dart
+++ b/tools/serverpod_cli/test/vm_proxy/proxy_test.dart
@@ -340,6 +340,55 @@ void main() {
       },
     );
   });
+
+  group('Given a VmServiceProxy with onWaitingClientArrived', () {
+    test(
+      'when the first client connects with no upstream '
+      'then the callback fires exactly once '
+      'and again only after the waiting queue drains and refills',
+      () async {
+        var fired = 0;
+        final proxy = VmServiceProxy(
+          upstreamWs: null,
+          onWaitingClientArrived: () => fired++,
+          waitingClientTimeout: const Duration(seconds: 2),
+        );
+        await proxy.bind();
+        addTearDown(proxy.close);
+
+        // First connect: fires.
+        final client1 = await _connectClient(proxy);
+        await Future<void>.delayed(const Duration(milliseconds: 20));
+        expect(fired, 1);
+
+        // Second concurrent connect while queue still has client1:
+        // does NOT re-fire (we don't want to re-spawn for every tab).
+        final client2 = await _connectClient(proxy);
+        await Future<void>.delayed(const Duration(milliseconds: 20));
+        expect(fired, 1);
+
+        // Pair both up with an upstream; queue empties.
+        final upstream = await _FakeUpstream.start();
+        addTearDown(upstream.close);
+        await proxy.setUpstream(upstream.wsUri);
+        await Future<void>.delayed(const Duration(milliseconds: 20));
+        expect(fired, 1, reason: 'set-upstream must not fire the callback');
+
+        // Clear upstream (existing pairs close). A fresh client arrives
+        // and finds an empty queue + no upstream: fires again.
+        await proxy.setUpstream(null);
+        await client1.close();
+        await client2.close();
+        await Future<void>.delayed(const Duration(milliseconds: 20));
+
+        final client3 = await _connectClient(proxy);
+        addTearDown(client3.close);
+        await Future<void>.delayed(const Duration(milliseconds: 20));
+        expect(fired, 2);
+      },
+      timeout: const Timeout(Duration(seconds: 10)),
+    );
+  });
 }
 
 Future<WebSocket> _connectClient(VmServiceProxy proxy) async {

--- a/tools/serverpod_cli/test/vm_proxy/proxy_test.dart
+++ b/tools/serverpod_cli/test/vm_proxy/proxy_test.dart
@@ -235,6 +235,111 @@ void main() {
       },
     );
   });
+
+  group('Given a VmServiceProxy bound with no upstream', () {
+    late VmServiceProxy proxy;
+
+    setUp(() async {
+      proxy = VmServiceProxy(
+        upstreamWs: null,
+        waitingClientTimeout: const Duration(seconds: 2),
+      );
+      await proxy.bind();
+    });
+
+    tearDown(() async {
+      await proxy.close();
+    });
+
+    test(
+      'when a client connects '
+      'then the WS upgrade succeeds and the socket stays open '
+      'until an upstream is set',
+      () async {
+        final client = await _connectClient(proxy);
+        addTearDown(client.close);
+        // The socket should be open; ws.readyState reflects that.
+        expect(client.readyState, WebSocket.open);
+      },
+    );
+
+    test(
+      'when an upstream is set after a client is already waiting '
+      'then a round-trip flows through the just-paired upstream',
+      () async {
+        final upstream = await _FakeUpstream.start();
+        addTearDown(upstream.close);
+
+        final client = await _connectClient(proxy);
+        addTearDown(client.close);
+        final responses = StreamController<Map<String, Object?>>();
+        client.listen(
+          (data) =>
+              responses.add(jsonDecode(data as String) as Map<String, Object?>),
+          onDone: responses.close,
+        );
+
+        await proxy.setUpstream(upstream.wsUri);
+        await upstream.connectionAttached;
+
+        client.add(
+          jsonEncode({
+            'jsonrpc': '2.0',
+            'id': 11,
+            'method': 'getVersion',
+            'params': <String, Object?>{},
+          }),
+        );
+
+        final response = await responses.stream.first;
+        expect(response['id'], 11);
+        expect((response['result'] as Map)['method'], 'getVersion');
+      },
+    );
+
+    test(
+      'when a client waits past the timeout with no upstream ever set '
+      'then the WS is closed cleanly so the IDE attach surfaces an error '
+      'instead of hanging forever',
+      () async {
+        final client = await _connectClient(proxy);
+        final closed = Completer<void>();
+        client.listen((_) {}, onDone: closed.complete);
+        await closed.future.timeout(const Duration(seconds: 5));
+        expect(client.readyState, WebSocket.closed);
+      },
+      timeout: const Timeout(Duration(seconds: 10)),
+    );
+
+    test(
+      'when setUpstream(null) is called while pairs are active '
+      'then existing client sockets are closed and new connections wait',
+      () async {
+        final upstream = await _FakeUpstream.start();
+        addTearDown(upstream.close);
+
+        await proxy.setUpstream(upstream.wsUri);
+
+        final client1 = await _connectClient(proxy);
+        final closed = Completer<void>();
+        client1.listen((_) {}, onDone: closed.complete);
+        await upstream.connectionAttached;
+
+        // Ensure pair is registered before we clear the upstream.
+        await Future<void>.delayed(const Duration(milliseconds: 20));
+
+        // Clear the upstream; the active client's WS should close.
+        await proxy.setUpstream(null);
+        await closed.future.timeout(const Duration(seconds: 5));
+        expect(client1.readyState, WebSocket.closed);
+
+        // A fresh client now waits rather than failing.
+        final client2 = await _connectClient(proxy);
+        addTearDown(client2.close);
+        expect(client2.readyState, WebSocket.open);
+      },
+    );
+  });
 }
 
 Future<WebSocket> _connectClient(VmServiceProxy proxy) async {

--- a/tools/serverpod_cli/test/vm_proxy/proxy_test.dart
+++ b/tools/serverpod_cli/test/vm_proxy/proxy_test.dart
@@ -198,7 +198,7 @@ void main() {
         await upstream.connectionAttached;
 
         final preRetargetHttpUri = proxy.httpUri;
-        await proxy.retarget(upstream2.wsUri);
+        await proxy.setUpstream(upstream2.wsUri);
 
         // The proxy's published URI is stable across retarget so consumers
         // can simply reconnect without re-reading vm-service-info.json.


### PR DESCRIPTION
Use augmented `VmServiceProxy` to allow `start` to spawn flutter app, and late-bind vm service, on demand.

Fixes: #5162 