### PR TITLE
fix: Pressing Q should cancel new TUI on Windows

### DIFF
--- a/tools/serverpod_cli/lib/src/commands/tui/run_app.dart
+++ b/tools/serverpod_cli/lib/src/commands/tui/run_app.dart
@@ -20,8 +20,11 @@ void _captureTerminalState() {
 /// Safe to call multiple times.
 void _restoreServerpodTerminal() {
   if (!_terminalStateCaptured || _terminalStateRestored) return;
-  stdin.echoMode = _originalEchoMode;
+  // On Windows, ENABLE_ECHO_INPUT requires ENABLE_LINE_INPUT to be set, or
+  // SetConsoleMode rejects with ERROR_INVALID_PARAMETER. Restore lineMode
+  // first so echoMode is allowed to follow.
   stdin.lineMode = _originalLineMode;
+  stdin.echoMode = _originalEchoMode;
   _terminalStateRestored = true;
 }
 


### PR DESCRIPTION
This fixes the issue with being unable to cancel/quit the new TUI on windows by pressing `Q`.

Note: Until the upstream Nocterm [PR](https://github.com/Norbert515/nocterm/pull/74) get's merged the new TUI will still have freezing issues on Windows. I've tested this by overriding the dependencies to use the fork of Nocterm allowing me to use the TUI.

Fixes only partially #5181 

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes
None