### PR TITLE
feat: Improves the Flutter UX on the TUI with split-screen and a smaller breadcrumb

### DIFF
--- a/tools/serverpod_cli/lib/src/commands/messages.dart
+++ b/tools/serverpod_cli/lib/src/commands/messages.dart
@@ -15,3 +15,6 @@ const flutterAppRestarted = '✓ Flutter app restarted.';
 const flutterPackageNotFound =
     'No Flutter package found; skipping --flutter. '
     'Pass --no-flutter to silence this notice.';
+
+// Flutter process messages
+const flutterAppLaunching = 'Launching Flutter app...';

--- a/tools/serverpod_cli/lib/src/commands/start/flutter_process.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/flutter_process.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 
 import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
+import 'package:serverpod_cli/src/commands/messages.dart';
 import 'package:serverpod_cli/src/commands/start/server_process.dart'
     show vmServiceWsUri;
 import 'package:serverpod_cli/src/util/serverpod_cli_logger.dart';
@@ -146,7 +147,7 @@ class FlutterProcess {
     }
     _process = process;
     _daemon = FlutterDaemonProtocol(process);
-    _onProgress?.call('launching');
+    _onProgress?.call(flutterAppLaunching);
 
     // Forward SIGTERM as SIGINT for graceful shutdown.
     if (!Platform.isWindows) {

--- a/tools/serverpod_cli/lib/src/commands/start/tui/app.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/tui/app.dart
@@ -141,7 +141,15 @@ class ServerpodWatchAppState extends ServerpodAppState<ServerpodWatchApp> {
   void _rebuild() {
     if (!mounted) return;
     _tryDismissSplash();
+    _normalizeSelectedTab();
     setState(() {});
+  }
+
+  void _normalizeSelectedTab() {
+    final state = component.holder.state;
+    if (state.useSideBySideLayout && state.selectedTab == 1) {
+      state.selectedTab = 0;
+    }
   }
 
   @override
@@ -191,16 +199,27 @@ class ServerpodWatchAppState extends ServerpodAppState<ServerpodWatchApp> {
       return true;
     }
 
-    // Tab cycling. Flutter tab is appended when attached.
-    final tabCount = state.showFlutterOutput ? 3 : 2;
+    final sideBySide = state.useSideBySideLayout;
+
+    // Tab cycling. In side-by-side mode, only server tabs are selectable.
     if (event.logicalKey == LogicalKey.tab ||
         event.logicalKey == LogicalKey.arrowRight) {
-      state.selectedTab = (state.selectedTab + 1) % tabCount;
+      if (sideBySide) {
+        state.selectedTab = state.selectedTab == 0 ? 2 : 0;
+      } else {
+        final tabCount = state.showFlutterOutput ? 3 : 2;
+        state.selectedTab = (state.selectedTab + 1) % tabCount;
+      }
       _rebuild();
       return true;
     }
     if (event.logicalKey == LogicalKey.arrowLeft) {
-      state.selectedTab = (state.selectedTab - 1 + tabCount) % tabCount;
+      if (sideBySide) {
+        state.selectedTab = state.selectedTab == 0 ? 2 : 0;
+      } else {
+        final tabCount = state.showFlutterOutput ? 3 : 2;
+        state.selectedTab = (state.selectedTab - 1 + tabCount) % tabCount;
+      }
       _rebuild();
       return true;
     }
@@ -210,11 +229,13 @@ class ServerpodWatchAppState extends ServerpodAppState<ServerpodWatchApp> {
       return true;
     }
     if (event.logicalKey == LogicalKey.digit2) {
-      state.selectedTab = 1;
+      state.selectedTab = sideBySide ? 2 : 1;
       _rebuild();
       return true;
     }
-    if (event.logicalKey == LogicalKey.digit3 && state.showFlutterOutput) {
+    if (event.logicalKey == LogicalKey.digit3 &&
+        !sideBySide &&
+        state.showFlutterOutput) {
       state.selectedTab = 2;
       _rebuild();
       return true;
@@ -222,8 +243,8 @@ class ServerpodWatchAppState extends ServerpodAppState<ServerpodWatchApp> {
 
     final c = switch (state.selectedTab) {
       0 => logScrollController,
-      1 => rawScrollController,
-      _ => flutterRawScrollController,
+      1 => flutterRawScrollController,
+      _ => rawScrollController,
     };
     return _handleScrollKey(c, event);
   }

--- a/tools/serverpod_cli/lib/src/commands/start/tui/main_screen.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/tui/main_screen.dart
@@ -64,23 +64,68 @@ class MainScreen extends StatelessComponent {
           children: [
             Expanded(
               child: BorderedBox(
-                child: Column(
-                  children: [
-                    Padding(
-                      padding: const EdgeInsets.only(left: 1),
-                      child: _buildTabBar(st),
-                    ),
-                    ?_buildFlutterStatusLine(st),
-                    Expanded(child: _buildTabContent()),
-                    // Pinned active operations
-                    if (state.activeOperations.isNotEmpty) ...[
-                      for (final op in state.activeOperations.values)
-                        TrackedOperationWidget(
-                          key: ValueKey(op.id),
-                          operation: op,
+                child: LayoutBuilder(
+                  builder: (context, constraints) {
+                    state.contentWidth = constraints.maxWidth;
+                    final showSideBySide = state.useSideBySideLayout;
+
+                    return Column(
+                      children: [
+                        Padding(
+                          padding: const EdgeInsets.only(left: 1),
+                          child: _buildTabBar(st, showSideBySide),
                         ),
-                    ],
-                  ],
+                        if (!showSideBySide) ?_buildFlutterStatusLine(st),
+                        Expanded(
+                          child: !showSideBySide
+                              ? _buildTabContent(state.selectedTab)
+                              : Row(
+                                  crossAxisAlignment:
+                                      CrossAxisAlignment.stretch,
+                                  children: [
+                                    Expanded(
+                                      child: Column(
+                                        children: [
+                                          Expanded(
+                                            child: _buildTabContent(
+                                              state.selectedTab,
+                                            ),
+                                          ),
+                                        ],
+                                      ),
+                                    ),
+                                    VerticalDivider(
+                                      color: st.subtleDivider,
+                                      width: 1,
+                                      thickness: 1,
+                                    ),
+                                    Expanded(
+                                      child: Column(
+                                        children: [
+                                          ?_buildFlutterStatusLine(
+                                            st,
+                                            withTitle: false,
+                                          ),
+                                          Expanded(
+                                            child: _buildTabContent(1),
+                                          ),
+                                        ],
+                                      ),
+                                    ),
+                                  ],
+                                ),
+                        ),
+
+                        if (state.activeOperations.isNotEmpty)
+                          ...state.activeOperations.values.map(
+                            (op) => TrackedOperationWidget(
+                              key: ValueKey(op.id),
+                              operation: op,
+                            ),
+                          ),
+                      ],
+                    );
+                  },
                 ),
               ),
             ),
@@ -97,7 +142,10 @@ class MainScreen extends StatelessComponent {
   /// label, vertical divider, and value.
   ///
   /// Returns `null` when no Flutter app is running or starting.
-  Component? _buildFlutterStatusLine(ServerpodThemeData st) {
+  Component? _buildFlutterStatusLine(
+    ServerpodThemeData st, {
+    bool withTitle = true,
+  }) {
     final mutedText = TextStyle(
       color: st.debugLevel,
       fontWeight: FontWeight.dim,
@@ -121,8 +169,10 @@ class MainScreen extends StatelessComponent {
           padding: const EdgeInsets.only(left: 1),
           child: Row(
             children: [
-              Text(' Flutter app', style: mutedText),
-              Text(' │ ', style: separatorStyle),
+              if (withTitle) ...[
+                Text(' Flutter app', style: mutedText),
+                Text(' │ ', style: separatorStyle),
+              ],
               Text(value, style: mutedText),
             ],
           ),
@@ -132,20 +182,43 @@ class MainScreen extends StatelessComponent {
     );
   }
 
-  Component _buildTabBar(ServerpodThemeData st) {
-    return TabBar(
-      labels: [
-        'Server logs',
-        if (state.showFlutterOutput) 'Flutter logs',
-        'Raw server logs',
-      ],
-      selectedTab: state.selectedTab,
-      onTabChanged: onTabChanged,
-    );
+  Component _buildTabBar(ServerpodThemeData st, bool sideBySide) {
+    const serverLogs = 'Server logs';
+    const rawServerLogs = 'Raw server logs';
+    const flutterLogs = 'Flutter logs';
+
+    return !sideBySide
+        ? TabBar(
+            labels: [
+              serverLogs,
+              if (state.showFlutterOutput) flutterLogs,
+              rawServerLogs,
+            ],
+            selectedTab: state.selectedTab,
+            onTabChanged: onTabChanged,
+          )
+        : Row(
+            children: [
+              Expanded(
+                child: TabBar(
+                  labels: const [serverLogs, rawServerLogs],
+                  selectedTab: state.selectedTab == 2 ? 1 : 0,
+                  onTabChanged: (index) => onTabChanged(index == 0 ? 0 : 2),
+                ),
+              ),
+              Expanded(
+                child: TabBar(
+                  labels: const [flutterLogs],
+                  selectedTab: 0,
+                  onTabChanged: (_) {},
+                ),
+              ),
+            ],
+          );
   }
 
-  Component _buildTabContent() {
-    return switch (state.selectedTab) {
+  Component _buildTabContent(int index) {
+    return switch (index) {
       1 => _buildRawOutputView(
         state.rawFlutterLines,
         flutterRawScrollController,

--- a/tools/serverpod_cli/lib/src/commands/start/tui/main_screen.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/tui/main_screen.dart
@@ -117,12 +117,11 @@ class MainScreen extends StatelessComponent {
 
     return Column(
       children: [
-        Divider(color: st.subtleDivider),
         Padding(
           padding: const EdgeInsets.only(left: 1),
           child: Row(
             children: [
-              Text('Flutter app', style: mutedText),
+              Text(' Flutter app', style: mutedText),
               Text(' │ ', style: separatorStyle),
               Text(value, style: mutedText),
             ],

--- a/tools/serverpod_cli/lib/src/commands/start/tui/state.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/tui/state.dart
@@ -21,8 +21,22 @@ class ServerWatchState extends ServerpodState {
   @override
   final Map<String, TrackedOperation> activeOperations = {};
 
-  /// Currently selected tab index. 0 = Log, 1 = Raw, 2 = Flutter (if shown).
+  /// Currently selected tab index.
+  ///
+  /// - 0 = structured server logs
+  /// - 1 = Flutter logs (narrow layout only)
+  /// - 2 = raw server logs
   int selectedTab = 0;
+
+  /// Latest measured content width from the main log area.
+  double? contentWidth;
+
+  /// Minimum width for showing server and Flutter logs side by side.
+  final sideBySideMinWidth = 160.0;
+
+  /// Whether the main log area should use a side-by-side layout.
+  bool get useSideBySideLayout =>
+      showFlutterOutput && (contentWidth ?? 0) >= sideBySideMinWidth;
 
   /// Whether a tracked action (hot reload, migration) is in progress.
   bool actionBusy = false;

--- a/tools/serverpod_cli/lib/src/commands/tui/components/checkbox.dart
+++ b/tools/serverpod_cli/lib/src/commands/tui/components/checkbox.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:nocterm/nocterm.dart';
 
 /// A check box component
@@ -13,10 +15,15 @@ class Checkbox extends StatelessComponent {
   final bool value;
   final bool focused;
 
+  String get indicator {
+    if (Platform.isWindows || Platform.isLinux) {
+      return value ? '🞕' : '🞎';
+    }
+    return value ? '■' : '□';
+  }
+
   @override
   Component build(BuildContext context) {
-    final indicator = value ? '■' : '□';
-
     return Text(
       '$indicator $label',
       style: TextStyle(color: Color.defaultColor, reverse: focused),

--- a/tools/serverpod_cli/test/commands/start/flutter_process_test.dart
+++ b/tools/serverpod_cli/test/commands/start/flutter_process_test.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:path/path.dart' as p;
+import 'package:serverpod_cli/src/commands/messages.dart';
 import 'package:serverpod_cli/src/commands/start/flutter_process.dart';
 import 'package:test/test.dart';
 
@@ -185,7 +186,7 @@ void main() {
             equals('http://127.0.0.1:${fake.server.port}'),
           );
           expect(fp.flutterAppUrl, equals('http://localhost:54321'));
-          expect(progressMessages, contains('launching'));
+          expect(progressMessages, contains(flutterAppLaunching));
           expect(progressMessages, contains('Launching ...'));
           expect(progressMessages, contains('ready'));
 


### PR DESCRIPTION
Also changes the checkbox icons to use a better alternative on Linux and Windows - shame that Mac does not support it...

The changes to implement split-screen are not in ideal shape and a refactor should follow up. The ideal is to group the tab specifications with their titles and navigation so that we only need to branch on the layout once.

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.