### PR TITLE
feat: Add `tail_flutter_logs` MCP tool

### DIFF
--- a/docs/design/mcp_server.md
+++ b/docs/design/mcp_server.md
@@ -4,7 +4,7 @@ This document describes the MCP (Model Context Protocol) integration for `server
 
 The integration has two parts:
 
-- A small **per-runner MCP server** that lives inside each `serverpod start --watch` process and exposes dev operations against that instance (currently: `apply_migrations`, `create_migration`, `hot_reload`, `tail_logs`).
+- A small **per-runner MCP server** that lives inside each `serverpod start --watch` process and exposes dev operations against that instance (currently: `apply_migrations`, `create_migration`, `hot_reload`, `tail_server_logs`).
 - A long-lived **bridge MCP server** (`serverpod mcp`) that sits on stdio between the AI client and the runners. It discovers running instances by scanning a shared socket directory, connects to one at a time, and forwards tool calls. The bridge survives runner restarts.
 
 The per-runner server runs inside the CLI process, alongside the compiler, file watcher, and watch session. It is not part of the server subprocess (the Serverpod application). This keeps dev tooling concerns out of the framework itself - the `serverpod` package should not impose an MCP dependency or dev-time features on the application server. It also means the MCP server has access to the CLI's internal state (the incremental compiler, the server process handle, the restart lifecycle) which the server subprocess does not.
@@ -95,7 +95,7 @@ Native resource (always present):
 | ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `serverpod://instances` | JSON list of `{pid, project, socketPath, connected}` for each live runner. Updated when the socket directory changes or when the bridge connects/disconnects. |
 
-Currently auto-forwarded from the runner once connected: the tools `apply_migrations`, `create_migration`, `hot_reload`, `tail_logs`, and the resource `serverpod://vm-service`. Adding a new tool or resource on the runner side requires no bridge changes - it appears in the AI client automatically on the next `connect`. Names that collide with a native bridge tool (`connect`/`disconnect`/`spawn`/`stop`) or URI (`serverpod://instances`) are skipped to keep the bridge's surface authoritative.
+Currently auto-forwarded from the runner once connected: the tools `apply_migrations`, `create_migration`, `hot_reload`, `tail_server_logs`, and the resource `serverpod://vm-service`. Adding a new tool or resource on the runner side requires no bridge changes - it appears in the AI client automatically on the next `connect`. Names that collide with a native bridge tool (`connect`/`disconnect`/`spawn`/`stop`) or URI (`serverpod://instances`) are skipped to keep the bridge's surface authoritative.
 
 For per-resource updates, the bridge subscribes to each forwarded resource on `connect` and re-emits `notifications/resources/updated` upstream. Resources that don't support subscription are silently skipped (reads still work).
 
@@ -125,7 +125,7 @@ The runner's MCP socket survives the server-subprocess restart because the socke
 
 `McpSocketServer({required project})` derives its socket path from the current `pid` and the sanitized project. `start()` ensures the shared dir exists, binds the `ServerSocket`, and accepts at most one client at a time. `close()` shuts down the active MCP server, destroys the client socket, and unlinks the socket file. New connections wait for any in-flight shutdown to settle and are rejected once `close()` has been called.
 
-`ServerpodMcpServer` (`lib/src/commands/start/mcp_server.dart`) extends `MCPServer` with `ToolsSupport` and `ResourcesSupport`. It registers `apply_migrations`, `create_migration`, `hot_reload`, and `tail_logs` tools against callbacks wired by `start.dart` (`WatchSession.applyMigration`, a `createMigrationAction`-backed closure, `WatchSession.forceReload`, and a log-history getter respectively). It also exposes the `serverpod://vm-service` resource.
+`ServerpodMcpServer` (`lib/src/commands/start/mcp_server.dart`) extends `MCPServer` with `ToolsSupport` and `ResourcesSupport`. It registers `apply_migrations`, `create_migration`, `hot_reload`, and `tail_server_logs` tools against callbacks wired by `start.dart` (`WatchSession.applyMigration`, a `createMigrationAction`-backed closure, `WatchSession.forceReload`, and a log-history getter respectively). It also exposes the `serverpod://vm-service` resource.
 
 ### Bridge side (`lib/src/mcp/`)
 
@@ -138,7 +138,7 @@ Validates Unix socket support, instantiates `ServerpodMcpBridge`, scans + starts
 
 ### Integration with watch mode
 
-In `_startWatchSession()` and `_runTuiBackend()` (`start.dart`), the runner-side `McpSocketServer` is constructed with `project: config.name`. The `apply_migrations` callback is wired to `WatchSession.applyMigration`; the `create_migration` callback is a closure over `createMigrationAction(config: ...)` (the shared helper also used by the `serverpod create-migration` CLI command and the TUI "Create Migration" button); `hot_reload` is `WatchSession.forceReload`; `tail_logs` reads from `holder.state.logHistory` in the TUI path. The socket is closed on shutdown (signal, TUI quit, or session exit), which removes the file from the shared dir.
+In `_startWatchSession()` and `_runTuiBackend()` (`start.dart`), the runner-side `McpSocketServer` is constructed with `project: config.name`. The `apply_migrations` callback is wired to `WatchSession.applyMigration`; the `create_migration` callback is a closure over `createMigrationAction(config: ...)` (the shared helper also used by the `serverpod create-migration` CLI command and the TUI "Create Migration" button); `hot_reload` is `WatchSession.forceReload`; `tail_server_logs` reads from `holder.state.logHistory` in the TUI path. The socket is closed on shutdown (signal, TUI quit, or session exit), which removes the file from the shared dir.
 
 ### Live migration apply
 
@@ -163,7 +163,7 @@ Forwarding to one runner at a time keeps tool semantics unambiguous - the client
 Any operation that the AI agent reaches for mid-session against a running dev environment belongs on the MCP server, whether or not it strictly needs the CLI's in-memory state. Keeping those operations behind the socket gives agents a stable, discoverable interface tied to the specific running instance (no ambiguity about which project directory the action lands in) and avoids forcing the agent to shell out with the right flags and working directory each time.
 
 - Operations that need the CLI's in-memory state (compiler, server lifecycle) - `apply_migrations`, `hot_reload` - must live here.
-- Operations that are conceptually per-instance but don't strictly need in-memory state - `create_migration`, `tail_logs` - are exposed here too. The alternative (shelling out to `serverpod create-migration`) forces a context switch, adds a failure mode where the agent runs in the wrong directory, and makes tool discovery dependent on a shipped skill file.
+- Operations that are conceptually per-instance but don't strictly need in-memory state - `create_migration`, `tail_server_logs` - are exposed here too. The alternative (shelling out to `serverpod create-migration`) forces a context switch, adds a failure mode where the agent runs in the wrong directory, and makes tool discovery dependent on a shipped skill file.
 
 Commands that are project-setup / one-shot / infrastructure (`serverpod create`, `serverpod generate` outside watch mode, `serverpod mcp` itself) stay as CLI commands. They don't belong to a running instance and don't benefit from being forwarded through a socket.
 

--- a/packages/serverpod/skills/serverpod-overview/SKILL.md
+++ b/packages/serverpod/skills/serverpod-overview/SKILL.md
@@ -24,7 +24,7 @@ Most likely the server is already running with hot reload and `serverpod generat
 ALWAYS use the MCP server instead of the command line. Use the MCP server to:
 
 - `create_migration` and `apply_migrations` for database (after you change data models).
-- `tail_logs` to read logs from the server.
+- `tail_server_logs` to read logs from the server.
 - `tail_flutter_logs` to read raw stdout/stderr from the Flutter app.
 - `hot_restart` will reload the server and the Flutter app. ALWAYS call it after doing changes in the Flutter app that may not work with normal hot reload (which is automatically applied).
 

--- a/packages/serverpod/skills/serverpod-overview/SKILL.md
+++ b/packages/serverpod/skills/serverpod-overview/SKILL.md
@@ -25,6 +25,7 @@ ALWAYS use the MCP server instead of the command line. Use the MCP server to:
 
 - `create_migration` and `apply_migrations` for database (after you change data models).
 - `tail_logs` to read logs from the server.
+- `tail_flutter_logs` to read raw stdout/stderr from the Flutter app.
 - `hot_restart` will reload the server and the Flutter app. ALWAYS call it after doing changes in the Flutter app that may not work with normal hot reload (which is automatically applied).
 
 ## Working on the project with no running instance

--- a/tools/serverpod_cli/lib/src/commands/start.dart
+++ b/tools/serverpod_cli/lib/src/commands/start.dart
@@ -408,6 +408,7 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
   Future<void> Function(ServerProcess server)? onServerStart,
   Future<void> Function(FlutterProcess flutter)? onFlutterStart,
   List<Object> Function()? mcpGetLogHistory,
+  List<String> Function()? mcpGetFlutterLogHistory,
 }) async {
   log.info(watch ? 'Starting server in watch mode...' : 'Starting server...');
 
@@ -711,6 +712,7 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
       onHotReload: session.forceReload,
       onHotRestart: session.forceRestart,
       getLogHistory: mcpGetLogHistory,
+      getFlutterLogHistory: mcpGetFlutterLogHistory,
       getVmServiceUri: () => proxy?.httpUri.toString(),
       vmServiceUriChanges: session.vmServiceUriChanges,
     );
@@ -1071,6 +1073,7 @@ Future<void> _runTuiBackend({
         );
       },
       mcpGetLogHistory: () => holder.state.logHistory.toList(),
+      mcpGetFlutterLogHistory: () => holder.state.rawFlutterLines.toList(),
     );
 
     switch (result) {

--- a/tools/serverpod_cli/lib/src/commands/start/mcp_server.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/mcp_server.dart
@@ -52,6 +52,9 @@ base class ServerpodMcpServer extends MCPServer
   /// Returns the current log history snapshot.
   List<Object> Function()? getLogHistory;
 
+  /// Returns the current Flutter raw log line snapshot.
+  List<String> Function()? getFlutterLogHistory;
+
   /// Returns the current HTTP VM service URI, or `null` if not yet available.
   String? Function()? getVmServiceUri;
 
@@ -73,6 +76,7 @@ base class ServerpodMcpServer extends MCPServer
     registerTool(hotReloadTool, _hotReload);
     registerTool(hotRestartTool, _hotRestart);
     registerTool(tailLogsTool, _tailLogs);
+    registerTool(tailFlutterLogsTool, _tailFlutterLogs);
 
     addResource(vmServiceResource, _readVmService);
   }
@@ -222,11 +226,7 @@ base class ServerpodMcpServer extends MCPServer
         isError: true,
       );
     }
-    final limitArg = request.arguments?['limit'];
-    final limit = switch (limitArg) {
-      int v => v.clamp(1, 10000),
-      _ => 200,
-    };
+    final limit = _tailLimit(request);
     final all = get();
     final tail = all.length <= limit ? all : all.sublist(all.length - limit);
     final encoded = tail.map(_encodeLogHistoryItem).toList();
@@ -238,6 +238,30 @@ base class ServerpodMcpServer extends MCPServer
       ],
     );
   }
+
+  Future<CallToolResult> _tailFlutterLogs(CallToolRequest request) async {
+    final get = getFlutterLogHistory;
+    if (get == null) {
+      return CallToolResult(
+        content: [TextContent(text: 'Flutter log history not available.')],
+        isError: true,
+      );
+    }
+    final limit = _tailLimit(request);
+    final all = get();
+    final tail = all.length <= limit ? all : all.sublist(all.length - limit);
+    return CallToolResult(
+      content: [TextContent(text: jsonEncode(tail))],
+    );
+  }
+}
+
+int _tailLimit(CallToolRequest request) {
+  final limitArg = request.arguments?['limit'];
+  return switch (limitArg) {
+    int v => v.clamp(1, 10000),
+    _ => 200,
+  };
 }
 
 /// Returns the standard error response for tools whose callback is unset

--- a/tools/serverpod_cli/lib/src/commands/start/mcp_socket.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/mcp_socket.dart
@@ -37,6 +37,7 @@ class McpSocketServer {
   Future<void> Function()? _onHotReload;
   Future<void> Function()? _onHotRestart;
   List<Object> Function()? _getLogHistory;
+  List<String> Function()? _getFlutterLogHistory;
   String? Function()? _getVmServiceUri;
   Stream<void>? _vmServiceUriChanges;
 
@@ -67,6 +68,7 @@ class McpSocketServer {
     Future<void> Function()? onHotReload,
     Future<void> Function()? onHotRestart,
     List<Object> Function()? getLogHistory,
+    List<String> Function()? getFlutterLogHistory,
     String? Function()? getVmServiceUri,
     Stream<void>? vmServiceUriChanges,
   }) {
@@ -76,6 +78,7 @@ class McpSocketServer {
     _onHotReload = onHotReload;
     _onHotRestart = onHotRestart;
     _getLogHistory = getLogHistory;
+    _getFlutterLogHistory = getFlutterLogHistory;
     _getVmServiceUri = getVmServiceUri;
     _vmServiceUriChanges = vmServiceUriChanges;
     final server = _mcpServer;
@@ -86,6 +89,7 @@ class McpSocketServer {
       server.onHotReload = onHotReload;
       server.onHotRestart = onHotRestart;
       server.getLogHistory = getLogHistory;
+      server.getFlutterLogHistory = getFlutterLogHistory;
       server.getVmServiceUri = getVmServiceUri;
       server.vmServiceUriChanges = vmServiceUriChanges;
     }
@@ -143,6 +147,7 @@ class McpSocketServer {
     server.onHotReload = _onHotReload;
     server.onHotRestart = _onHotRestart;
     server.getLogHistory = _getLogHistory;
+    server.getFlutterLogHistory = _getFlutterLogHistory;
     server.getVmServiceUri = _getVmServiceUri;
     server.vmServiceUriChanges = _vmServiceUriChanges;
 

--- a/tools/serverpod_cli/lib/src/mcp/runner_surface.dart
+++ b/tools/serverpod_cli/lib/src/mcp/runner_surface.dart
@@ -95,6 +95,23 @@ final Tool tailLogsTool = Tool(
   ),
 );
 
+final Tool tailFlutterLogsTool = Tool(
+  name: 'tail_flutter_logs',
+  description:
+      'Return recent raw stdout/stderr lines from the running Flutter app. '
+      'Newest last. Only available when Flutter was launched by '
+      '`serverpod start`.',
+  inputSchema: Schema.object(
+    properties: {
+      'limit': Schema.int(
+        description: 'Max lines to return (default 200, max 10000).',
+        minimum: 1,
+        maximum: 10000,
+      ),
+    },
+  ),
+);
+
 final Resource vmServiceResource = Resource(
   uri: 'serverpod://vm-service',
   name: 'VM service',
@@ -112,6 +129,7 @@ final List<Tool> runnerStaticTools = [
   hotReloadTool,
   hotRestartTool,
   tailLogsTool,
+  tailFlutterLogsTool,
 ];
 
 final List<Resource> runnerStaticResources = [vmServiceResource];

--- a/tools/serverpod_cli/lib/src/mcp/runner_surface.dart
+++ b/tools/serverpod_cli/lib/src/mcp/runner_surface.dart
@@ -80,7 +80,7 @@ final Tool hotRestartTool = Tool(
 );
 
 final Tool tailLogsTool = Tool(
-  name: 'tail_logs',
+  name: 'tail_server_logs',
   description:
       'Return recent log entries from the running server '
       '(structured log entries plus completed operations). Newest last.',
@@ -98,9 +98,8 @@ final Tool tailLogsTool = Tool(
 final Tool tailFlutterLogsTool = Tool(
   name: 'tail_flutter_logs',
   description:
-      'Return recent raw stdout/stderr lines from the running Flutter app. '
-      'Newest last. Only available when Flutter was launched by '
-      '`serverpod start`.',
+      'Return recent raw stdout/stderr lines from the running Flutter app '
+      'started from `serverpod start`. Newest last.',
   inputSchema: Schema.object(
     properties: {
       'limit': Schema.int(

--- a/tools/serverpod_cli/test/commands/start/mcp_server_test.dart
+++ b/tools/serverpod_cli/test/commands/start/mcp_server_test.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:convert';
 
 import 'package:dart_mcp/client.dart';
 import 'package:serverpod_cli/src/commands/start/mcp_server.dart';
@@ -69,6 +70,7 @@ void main() {
             'hot_reload',
             'hot_restart',
             'tail_logs',
+            'tail_flutter_logs',
           ]),
         );
       },
@@ -135,6 +137,21 @@ void main() {
           expect(
             (result.content.first as TextContent).text,
             contains('not connected'),
+          );
+        },
+      );
+      test(
+        'when calling tail_flutter_logs without a callback, '
+        'then it returns an error',
+        () async {
+          final result = await connection.callTool(
+            CallToolRequest(name: 'tail_flutter_logs'),
+          );
+
+          expect(result.isError, isTrue);
+          expect(
+            (result.content.first as TextContent).text,
+            contains('Flutter log history not available'),
           );
         },
       );
@@ -442,6 +459,32 @@ void main() {
             (result.content.first as TextContent).text,
             contains('live db unreachable'),
           );
+        },
+      );
+      test(
+        'when calling tail_flutter_logs with a callback, '
+        'then it returns the most recent lines as JSON',
+        () async {
+          server.getFlutterLogHistory = () => [
+            'line 1',
+            'line 2',
+            'line 3',
+          ];
+
+          final result = await connection.callTool(
+            CallToolRequest(
+              name: 'tail_flutter_logs',
+              arguments: {'limit': 2},
+            ),
+          );
+
+          expect(result.isError, isNull);
+          final lines =
+              jsonDecode(
+                    (result.content.first as TextContent).text,
+                  )
+                  as List<dynamic>;
+          expect(lines, ['line 2', 'line 3']);
         },
       );
     });

--- a/tools/serverpod_cli/test/commands/start/mcp_server_test.dart
+++ b/tools/serverpod_cli/test/commands/start/mcp_server_test.dart
@@ -69,7 +69,7 @@ void main() {
             'create_repair_migration',
             'hot_reload',
             'hot_restart',
-            'tail_logs',
+            'tail_server_logs',
             'tail_flutter_logs',
           ]),
         );

--- a/tools/serverpod_cli/test/mcp/bridge_mcp_server_test.dart
+++ b/tools/serverpod_cli/test/mcp/bridge_mcp_server_test.dart
@@ -18,8 +18,8 @@ import 'package:test/test.dart';
 ///   McpSocketServer  (with apply_migrations callback)
 ///
 /// The bridge auto-connects on the first tool/resource call. The runner's
-/// static surface (apply_migrations, create_migration, hot_reload,
-/// hot_restart, tail_logs, serverpod://vm-service) is advertised upfront
+/// static surface (apply_migrations, create_migration, hot_reload, hot_restart,
+/// tail_logs, tail_flutter_logs, serverpod://vm-service) is advertised upfront
 /// regardless of whether the runner is currently up.
 void main() {
   group(
@@ -68,6 +68,7 @@ void main() {
               'hot_reload',
               'hot_restart',
               'tail_logs',
+              'tail_flutter_logs',
             }),
           );
           expect(names, isNot(contains('connect')));
@@ -137,6 +138,7 @@ void main() {
               'hot_reload',
               'hot_restart',
               'tail_logs',
+              'tail_flutter_logs',
             }),
           );
         },

--- a/tools/serverpod_cli/test/mcp/bridge_mcp_server_test.dart
+++ b/tools/serverpod_cli/test/mcp/bridge_mcp_server_test.dart
@@ -19,8 +19,8 @@ import 'package:test/test.dart';
 ///
 /// The bridge auto-connects on the first tool/resource call. The runner's
 /// static surface (apply_migrations, create_migration, hot_reload, hot_restart,
-/// tail_logs, tail_flutter_logs, serverpod://vm-service) is advertised upfront
-/// regardless of whether the runner is currently up.
+/// tail_server_logs, tail_flutter_logs, serverpod://vm-service) is advertised
+/// upfront regardless of whether the runner is currently up.
 void main() {
   group(
     'Given a BridgeMcpServer wired to a running runner socket',
@@ -67,7 +67,7 @@ void main() {
               'create_repair_migration',
               'hot_reload',
               'hot_restart',
-              'tail_logs',
+              'tail_server_logs',
               'tail_flutter_logs',
             }),
           );
@@ -137,7 +137,7 @@ void main() {
               'create_repair_migration',
               'hot_reload',
               'hot_restart',
-              'tail_logs',
+              'tail_server_logs',
               'tail_flutter_logs',
             }),
           );


### PR DESCRIPTION
Add the missing tool to allow agents to read back what is happening in the running Flutter app.

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.