### PR TITLE
feat: Expose the Flutter process DTD on a `get_flutter_app_dtd` MCP tool

### DIFF
--- a/tools/serverpod_cli/lib/src/commands/start.dart
+++ b/tools/serverpod_cli/lib/src/commands/start.dart
@@ -706,6 +706,7 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
       getLogHistory: mcpGetLogHistory,
       getFlutterLogHistory: mcpGetFlutterLogHistory,
       getVmServiceUri: () => proxy?.httpUri.toString(),
+      getFlutterDtdUri: () => flutterProcess?.dtdUri,
       vmServiceUriChanges: session.vmServiceUriChanges,
     );
     log.info('MCP server listening on ${mcpSocket.socketPath}');

--- a/tools/serverpod_cli/lib/src/commands/start/flutter_process.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/flutter_process.dart
@@ -66,6 +66,7 @@ class FlutterProcess {
   FlutterDaemonProtocol? _daemon;
   String? _vmServiceUri;
   String? _flutterAppUrl;
+  String? _dtdUri;
   VmService? _vmService;
 
   // `null` result means the process exited before publishing a URI.
@@ -109,6 +110,9 @@ class FlutterProcess {
 
   /// HTTP URL the Flutter app is served at (web targets only).
   String? get flutterAppUrl => _flutterAppUrl;
+
+  /// DTD URI from the daemon's `app.dtd` event.
+  String? get dtdUri => _dtdUri;
 
   /// First of `app.debugPort`, `app.webLaunchUrl`, or process exit.
   /// Decoupled from [connectToVmService]: on `-d web-server` the
@@ -416,6 +420,11 @@ class FlutterProcess {
             _flutterAppUrl = url;
             if (!_launchedCompleter.isCompleted) _launchedCompleter.complete();
           }
+        case 'app.dtd':
+          final uri = paramMap['uri'];
+          if (uri is String && uri.isNotEmpty) {
+            _dtdUri = uri;
+          }
         case 'app.progress':
           final message = paramMap['message'];
           if (message is String && message.isNotEmpty) {
@@ -484,6 +493,7 @@ class FlutterProcess {
       await _vmService?.dispose();
       _vmService = null;
       _vmServiceUri = null;
+      _dtdUri = null;
 
       await _flutterProxy?.setUpstream(null);
     } finally {

--- a/tools/serverpod_cli/lib/src/commands/start/mcp_server.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/mcp_server.dart
@@ -58,6 +58,9 @@ base class ServerpodMcpServer extends MCPServer
   /// Returns the current HTTP VM service URI, or `null` if not yet available.
   String? Function()? getVmServiceUri;
 
+  /// Returns the current Flutter app DTD URI, or `null` if not yet available.
+  String? Function()? getFlutterDtdUri;
+
   StreamSubscription<void>? _vmServiceUriSub;
 
   ServerpodMcpServer(super.channel)
@@ -77,6 +80,7 @@ base class ServerpodMcpServer extends MCPServer
     registerTool(hotRestartTool, _hotRestart);
     registerTool(tailLogsTool, _tailLogs);
     registerTool(tailFlutterLogsTool, _tailFlutterLogs);
+    registerTool(getFlutterAppDtdTool, _getFlutterAppDtd);
 
     addResource(vmServiceResource, _readVmService);
   }
@@ -252,6 +256,21 @@ base class ServerpodMcpServer extends MCPServer
     final tail = all.length <= limit ? all : all.sublist(all.length - limit);
     return CallToolResult(
       content: [TextContent(text: jsonEncode(tail))],
+    );
+  }
+
+  Future<CallToolResult> _getFlutterAppDtd(CallToolRequest request) async {
+    final get = getFlutterDtdUri;
+    if (get == null) {
+      return CallToolResult(
+        content: [TextContent(text: 'Flutter DTD not available.')],
+        isError: true,
+      );
+    }
+    return CallToolResult(
+      content: [
+        TextContent(text: jsonEncode({'uri': get()})),
+      ],
     );
   }
 }

--- a/tools/serverpod_cli/lib/src/commands/start/mcp_socket.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/mcp_socket.dart
@@ -39,6 +39,7 @@ class McpSocketServer {
   List<Object> Function()? _getLogHistory;
   List<String> Function()? _getFlutterLogHistory;
   String? Function()? _getVmServiceUri;
+  String? Function()? _getFlutterDtdUri;
   Stream<void>? _vmServiceUriChanges;
 
   McpSocketServer({required String serverDir})
@@ -70,6 +71,7 @@ class McpSocketServer {
     List<Object> Function()? getLogHistory,
     List<String> Function()? getFlutterLogHistory,
     String? Function()? getVmServiceUri,
+    String? Function()? getFlutterDtdUri,
     Stream<void>? vmServiceUriChanges,
   }) {
     _onApplyMigration = onApplyMigration;
@@ -80,6 +82,7 @@ class McpSocketServer {
     _getLogHistory = getLogHistory;
     _getFlutterLogHistory = getFlutterLogHistory;
     _getVmServiceUri = getVmServiceUri;
+    _getFlutterDtdUri = getFlutterDtdUri;
     _vmServiceUriChanges = vmServiceUriChanges;
     final server = _mcpServer;
     if (server != null) {
@@ -91,6 +94,7 @@ class McpSocketServer {
       server.getLogHistory = getLogHistory;
       server.getFlutterLogHistory = getFlutterLogHistory;
       server.getVmServiceUri = getVmServiceUri;
+      server.getFlutterDtdUri = getFlutterDtdUri;
       server.vmServiceUriChanges = vmServiceUriChanges;
     }
   }
@@ -149,6 +153,7 @@ class McpSocketServer {
     server.getLogHistory = _getLogHistory;
     server.getFlutterLogHistory = _getFlutterLogHistory;
     server.getVmServiceUri = _getVmServiceUri;
+    server.getFlutterDtdUri = _getFlutterDtdUri;
     server.vmServiceUriChanges = _vmServiceUriChanges;
 
     // Clean up on disconnect.

--- a/tools/serverpod_cli/lib/src/mcp/runner_surface.dart
+++ b/tools/serverpod_cli/lib/src/mcp/runner_surface.dart
@@ -111,6 +111,15 @@ final Tool tailFlutterLogsTool = Tool(
   ),
 );
 
+final Tool getFlutterAppDtdTool = Tool(
+  name: 'get_flutter_app_dtd',
+  description:
+      'Return the Dart Tooling Daemon (DTD) URI for the Flutter app started '
+      'from `serverpod start`. The URI is null until the app has published '
+      'its DTD endpoint.',
+  inputSchema: Schema.object(),
+);
+
 final Resource vmServiceResource = Resource(
   uri: 'serverpod://vm-service',
   name: 'VM service',
@@ -129,6 +138,7 @@ final List<Tool> runnerStaticTools = [
   hotRestartTool,
   tailLogsTool,
   tailFlutterLogsTool,
+  getFlutterAppDtdTool,
 ];
 
 final List<Resource> runnerStaticResources = [vmServiceResource];

--- a/tools/serverpod_cli/test/commands/start/flutter_process_test.dart
+++ b/tools/serverpod_cli/test/commands/start/flutter_process_test.dart
@@ -173,8 +173,8 @@ void main() {
       });
 
       test(
-        'when the shim emits app.progress, app.webLaunchUrl, app.debugPort, app.started '
-        'then onProgress fires, flutterAppUrl is captured, and vmServiceUri is the http form of the daemon\'s wsUri',
+        'when the shim emits app.progress, app.webLaunchUrl, app.debugPort, app.dtd, app.started '
+        'then onProgress fires, flutterAppUrl is captured, dtdUri is captured, and vmServiceUri is the http form of the daemon\'s wsUri',
         () async {
           // Wait until the URI shows up (the shim emits it ~immediately).
           final deadline = DateTime.now().add(const Duration(seconds: 5));
@@ -187,6 +187,7 @@ void main() {
             equals('http://127.0.0.1:${fake.server.port}'),
           );
           expect(fp.flutterAppUrl, equals('http://localhost:54321'));
+          expect(fp.dtdUri, equals('ws://127.0.0.1:9100/ws'));
           expect(progressMessages, contains(flutterAppLaunching));
           expect(progressMessages, contains('Launching ...'));
           expect(progressMessages, contains('ready'));
@@ -397,6 +398,22 @@ void main() {
         );
         expect(fp.flutterAppUrl, 'http://localhost:8080');
         expect(progressMessages, containsAllInOrder(['Compiling', 'ready']));
+      },
+    );
+
+    test(
+      'when given app.dtd then dtdUri is captured',
+      () {
+        fp.handleMachineLine(
+          jsonEncode([
+            {
+              'event': 'app.dtd',
+              'params': {'uri': 'ws://127.0.0.1:9100/ws'},
+            },
+          ]),
+        );
+
+        expect(fp.dtdUri, 'ws://127.0.0.1:9100/ws');
       },
     );
 

--- a/tools/serverpod_cli/test/commands/start/flutter_shims/emits_machine_events.dart
+++ b/tools/serverpod_cli/test/commands/start/flutter_shims/emits_machine_events.dart
@@ -35,6 +35,10 @@ Future<void> main(List<String> args) async {
     'params': {'wsUri': wsUri, 'port': Uri.parse(wsUri).port},
   });
   emit({
+    'event': 'app.dtd',
+    'params': {'uri': 'ws://127.0.0.1:9100/ws'},
+  });
+  emit({
     'event': 'app.started',
     'params': {},
   });

--- a/tools/serverpod_cli/test/commands/start/mcp_server_test.dart
+++ b/tools/serverpod_cli/test/commands/start/mcp_server_test.dart
@@ -71,6 +71,7 @@ void main() {
             'hot_restart',
             'tail_server_logs',
             'tail_flutter_logs',
+            'get_flutter_app_dtd',
           ]),
         );
       },
@@ -152,6 +153,22 @@ void main() {
           expect(
             (result.content.first as TextContent).text,
             contains('Flutter log history not available'),
+          );
+        },
+      );
+
+      test(
+        'when calling get_flutter_app_dtd without a callback, '
+        'then it returns an error',
+        () async {
+          final result = await connection.callTool(
+            CallToolRequest(name: 'get_flutter_app_dtd'),
+          );
+
+          expect(result.isError, isTrue);
+          expect(
+            (result.content.first as TextContent).text,
+            contains('Flutter DTD not available'),
           );
         },
       );
@@ -485,6 +502,42 @@ void main() {
                   )
                   as List<dynamic>;
           expect(lines, ['line 2', 'line 3']);
+        },
+      );
+
+      test(
+        'when calling get_flutter_app_dtd with a callback, '
+        'then it returns the URI as JSON',
+        () async {
+          server.getFlutterDtdUri = () => 'ws://127.0.0.1:9100/ws';
+
+          final result = await connection.callTool(
+            CallToolRequest(name: 'get_flutter_app_dtd'),
+          );
+
+          expect(result.isError, isNull);
+          expect(
+            jsonDecode((result.content.first as TextContent).text),
+            {'uri': 'ws://127.0.0.1:9100/ws'},
+          );
+        },
+      );
+
+      test(
+        'when calling get_flutter_app_dtd before the app publishes DTD, '
+        'then it returns a null URI',
+        () async {
+          server.getFlutterDtdUri = () => null;
+
+          final result = await connection.callTool(
+            CallToolRequest(name: 'get_flutter_app_dtd'),
+          );
+
+          expect(result.isError, isNull);
+          expect(
+            jsonDecode((result.content.first as TextContent).text),
+            {'uri': null},
+          );
         },
       );
     });

--- a/tools/serverpod_cli/test/mcp/bridge_mcp_server_test.dart
+++ b/tools/serverpod_cli/test/mcp/bridge_mcp_server_test.dart
@@ -19,7 +19,8 @@ import 'package:test/test.dart';
 ///
 /// The bridge auto-connects on the first tool/resource call. The runner's
 /// static surface (apply_migrations, create_migration, hot_reload, hot_restart,
-/// tail_server_logs, tail_flutter_logs, serverpod://vm-service) is advertised
+/// tail_server_logs, tail_flutter_logs, get_flutter_app_dtd,
+/// serverpod://vm-service) is advertised
 /// upfront regardless of whether the runner is currently up.
 void main() {
   group(
@@ -69,6 +70,7 @@ void main() {
               'hot_restart',
               'tail_server_logs',
               'tail_flutter_logs',
+              'get_flutter_app_dtd',
             }),
           );
           expect(names, isNot(contains('connect')));
@@ -139,6 +141,7 @@ void main() {
               'hot_restart',
               'tail_server_logs',
               'tail_flutter_logs',
+              'get_flutter_app_dtd',
             }),
           );
         },


### PR DESCRIPTION
This was a missing piece to allow agents to use the Dart MCP on the running Flutter app started by `serverpod start`.

Now we can do something like "Get the widget tree of the running app started with Serverpod".

Response example of an agent that was given the exact prompt above:

> **Connection:** Serverpod MCP → `get_flutter_app_dtd` → `ws://127.0.0.1:46151/N5yiaqN38DI=` → Dart MCP `connect_dart_tooling_daemon` → `get_widget_tree`.
>
> ...[tree and a ton of lines]...
> 
> Retrieved the widget tree from the Flutter app started via `serverpod start` (Chrome at http://localhost:45181).

The Dart MCP also gives agents access to:

- `hot_reload` / `hot_restart` (redundant, bundled in our `hot_restart` tool)
- **`get_widget_tree`**
- **`get_runtime_errors`**
- `get_app_logs` (might be redundant with our `tail_flutter_logs`)
- **`flutter_driver` (tap, scroll, screenshot, etc.)**
- **`set_widget_selection_mode`** / **`get_selected_widget`**


## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.