### PR TITLE
fix: Fixed new project templates for GitHub workflows

### DIFF
--- a/templates/serverpod_templates/github/workflows/analyze.yml
+++ b/templates/serverpod_templates/github/workflows/analyze.yml
@@ -13,13 +13,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: dart-lang/setup-dart@v1
+      - uses: subosito/flutter-action@v2
         with:
-          sdk: 3.10.3
+          flutter-version: '3.38.4'
 
       - name: Install dependencies
         working-directory: projectname_server
-        run: dart pub get
+        run: flutter pub get
 
       - name: Analyze
         working-directory: projectname_server

--- a/templates/serverpod_templates/github/workflows/analyze.yml
+++ b/templates/serverpod_templates/github/workflows/analyze.yml
@@ -18,7 +18,6 @@ jobs:
           flutter-version: '3.38.4'
 
       - name: Install dependencies
-        working-directory: projectname_server
         run: flutter pub get
 
       - name: Analyze

--- a/templates/serverpod_templates/github/workflows/format.yml
+++ b/templates/serverpod_templates/github/workflows/format.yml
@@ -13,13 +13,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: dart-lang/setup-dart@v1
+      - uses: subosito/flutter-action@v2
         with:
-          sdk: 3.10.3
+          flutter-version: '3.38.4'
 
       - name: Install dependencies
         working-directory: projectname_server
-        run: dart pub get
+        run: flutter pub get
 
       - name: Check formatting
         working-directory: projectname_server

--- a/templates/serverpod_templates/github/workflows/format.yml
+++ b/templates/serverpod_templates/github/workflows/format.yml
@@ -18,7 +18,6 @@ jobs:
           flutter-version: '3.38.4'
 
       - name: Install dependencies
-        working-directory: projectname_server
         run: flutter pub get
 
       - name: Check formatting

--- a/templates/serverpod_templates/github/workflows/tests.yml
+++ b/templates/serverpod_templates/github/workflows/tests.yml
@@ -26,11 +26,9 @@ jobs:
         run: docker compose up --quiet-pull --build -d
 
       - name: Install dependencies
-        working-directory: projectname_server
         run: flutter pub get
 
       - name: Install Serverpod CLI
-        working-directory: projectname_server
         run: dart install serverpod_cli $VERSION
 
       - name: Run Serverpod generator

--- a/templates/serverpod_templates/github/workflows/tests.yml
+++ b/templates/serverpod_templates/github/workflows/tests.yml
@@ -19,15 +19,15 @@ jobs:
 
       - uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.32.8'
+          flutter-version: '3.38.4'
 
       - name: Start containers
         working-directory: projectname_server
-        run: docker compose up --quiet-pull --quiet-build --build -d
+        run: docker compose up --quiet-pull --build -d
 
       - name: Install dependencies
         working-directory: projectname_server
-        run: dart pub get
+        run: flutter pub get
 
       - name: Install Serverpod CLI
         working-directory: projectname_server


### PR DESCRIPTION
Fix the templates for GitHub workflows that are included when a new Serverpod project is created.

Since a new Serverpod project by default includes a flutter app and the project is a workspace, `dart pub get` must be replaced with `flutter pub get`. Which also means that the workflows must install flutter rather than just dart.

There was also an issue with the `--quiet-build` flag passed to `docker compose up`, it is not supported by the standard docker version in GitHub (v28). So this flag is removed here.

The flutter version installed in the workflows must match the `pubspec.yaml` in the created flutter package. I attempted to use the `FLUTTER_VERSION` label, but that got replaced by a really old flutter version `3.32.8`. _This might be a separate bug/issue maybe worth looking into._

So here we continue to hardcode with `3.38.4`, same as the flutter package template's pubspec.yaml.

(Note: In the workflow flutter setup action, the flutter version must be distinct, and ^ or range is not supported.)

_List which issues are fixed by this PR. You must list at least one issue._

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

n/a