### PR TITLE
feat: Implement a `cloud` Serverpod CLI command to forward to `scloud`

### DIFF
--- a/templates/pubspecs/tools/serverpod_cli/pubspec.yaml
+++ b/templates/pubspecs/tools/serverpod_cli/pubspec.yaml
@@ -20,6 +20,7 @@ dependencies:
   code_builder: ^4.5.0
   collection: ^1.18.0
   config: ^0.8.4
+  dart_data_home: ^0.1.0
   dart_mcp: '>=0.4.1 <0.6.0'
   # Dart style must be pinned to 3.1.5 until we bump the minimum Dart version
   # to 3.12 due to a bug on the formatter that was fixed in 3.1.6, but only

--- a/tools/serverpod_cli/bin/serverpod_cli.dart
+++ b/tools/serverpod_cli/bin/serverpod_cli.dart
@@ -5,6 +5,7 @@ import 'package:cli_tools/cli_tools.dart';
 import 'package:config/config.dart';
 import 'package:pub_semver/pub_semver.dart';
 import 'package:serverpod_cli/src/commands/analyze_pubspecs.dart';
+import 'package:serverpod_cli/src/commands/cloud.dart';
 import 'package:serverpod_cli/src/commands/create.dart';
 import 'package:serverpod_cli/src/commands/create_migration.dart';
 import 'package:serverpod_cli/src/commands/create_repair_migration.dart';
@@ -113,6 +114,7 @@ ServerpodCommandRunner buildCommandRunner() {
     version,
   )..addCommands([
     AnalyzePubspecsCommand(),
+    CloudCommand(),
     CreateCommand(),
     QuickstartCommand(),
     GenerateCommand(),

--- a/tools/serverpod_cli/lib/src/commands/cloud.dart
+++ b/tools/serverpod_cli/lib/src/commands/cloud.dart
@@ -6,6 +6,7 @@ import 'package:args/args.dart';
 import 'package:async/async.dart';
 import 'package:cli_tools/cli_tools.dart';
 import 'package:config/config.dart';
+import 'package:dart_data_home/dart_data_home.dart';
 import 'package:path/path.dart' as p;
 import 'package:serverpod_cli/src/runner/serverpod_command.dart';
 import 'package:serverpod_cli/src/util/sdk_path.dart';
@@ -96,18 +97,28 @@ Future<Process> _startScloudProcess(
   List<String> args, {
   required bool installIfMissing,
 }) async {
-  try {
-    return await Process.start(
-      'scloud',
-      args,
-      workingDirectory: Directory.current.path,
-    );
-  } on ProcessException catch (exception) {
+  final scloudExecutable = getScloudExecutablePath();
+
+  if (!File(scloudExecutable).existsSync()) {
     if (installIfMissing) {
       await _installScloud();
       return _startScloudProcess(args, installIfMissing: false);
     }
 
+    log.error(
+      'Failed to start Serverpod Cloud CLI: '
+      'executable not found at $scloudExecutable',
+    );
+    throw ExitException(ServerpodCommand.commandInvokedCannotExecute);
+  }
+
+  try {
+    return await Process.start(
+      scloudExecutable,
+      args,
+      workingDirectory: Directory.current.path,
+    );
+  } on ProcessException catch (exception) {
     log.error(
       'Failed to start Serverpod Cloud CLI: ${exception.message}',
     );
@@ -146,4 +157,44 @@ Future<void> _closeProcessStdin(IOSink sink) async {
   } on IOException {
     // Ignore broken pipe errors during shutdown.
   }
+}
+
+/// Resolves the full path to the Serverpod Cloud CLI (`scloud`) executable.
+///
+/// Tries in order:
+/// 1. The `dart install` bin directory (where `_installScloud` places it)
+/// 2. The legacy pub-cache bin directory
+///
+/// Returns the preferred `dart install` path even when the executable is
+/// missing so callers can trigger installation.
+String getScloudExecutablePath() {
+  final name = Platform.isWindows ? 'scloud.bat' : 'scloud';
+
+  final dartInstallPath = p.join(getDartDataHome('install'), 'bin', name);
+  if (File(dartInstallPath).existsSync()) {
+    return dartInstallPath;
+  }
+
+  final pubCachePath = p.join(_resolvePubCacheBinDirectory(), name);
+  if (File(pubCachePath).existsSync()) {
+    return pubCachePath;
+  }
+
+  return dartInstallPath;
+}
+
+String _resolvePubCacheBinDirectory() {
+  final pubCache = Platform.environment['PUB_CACHE'];
+  if (pubCache != null && pubCache.isNotEmpty) {
+    return p.join(pubCache, 'bin');
+  }
+
+  if (Platform.isWindows) {
+    final localAppData = Platform.environment['LOCALAPPDATA'];
+    if (localAppData != null && localAppData.isNotEmpty) {
+      return p.join(localAppData, 'Pub', 'Cache', 'bin');
+    }
+  }
+
+  return p.join(Platform.environment['HOME'] ?? '', '.pub-cache', 'bin');
 }

--- a/tools/serverpod_cli/lib/src/commands/cloud.dart
+++ b/tools/serverpod_cli/lib/src/commands/cloud.dart
@@ -1,0 +1,141 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:args/args.dart';
+import 'package:async/async.dart';
+import 'package:cli_tools/cli_tools.dart';
+import 'package:config/config.dart';
+import 'package:path/path.dart' as p;
+import 'package:serverpod_cli/src/runner/serverpod_command.dart';
+import 'package:serverpod_cli/src/util/sdk_path.dart';
+import 'package:serverpod_cli/src/util/serverpod_cli_logger.dart';
+
+/// Forwards to the Serverpod Cloud CLI (`scloud`).
+class CloudCommand extends ServerpodCommand {
+  CloudCommand() : super(options: []);
+
+  final ArgParser _cloudArgParser = ArgParser.allowAnything();
+
+  @override
+  ArgParser get argParser => _cloudArgParser;
+
+  @override
+  final name = 'cloud';
+
+  @override
+  final description =
+      'Manage Serverpod Cloud projects through the Serverpod Cloud.';
+
+  @override
+  String get invocation => 'serverpod cloud <scloud-args>';
+
+  @override
+  Configuration resolveConfiguration(ArgResults? argResults) {
+    return Configuration.resolveNoExcept(
+      options: options,
+      argResults: argResults,
+      env: envVariables,
+      ignoreUnexpectedPositionalArgs: true,
+    );
+  }
+
+  @override
+  Future<void> runWithConfig(Configuration commandConfig) async {
+    final scloudArgs = argResults?.rest ?? [];
+
+    final process = await _startScloudProcess(
+      scloudArgs,
+      installIfMissing: true,
+    );
+
+    final sigSubscription =
+        StreamGroup.merge(
+          [
+            ProcessSignal.sigint,
+            if (!Platform.isWindows) ProcessSignal.sigterm,
+          ].map((signal) => signal.watch()),
+        ).listen((signal) {
+          process.kill(signal);
+        });
+
+    StreamSubscription<List<int>>? stdinSubscription;
+    stdinSubscription = stdin.listen(
+      (data) {
+        try {
+          process.stdin.add(data);
+        } on StateError {
+          stdinSubscription?.cancel();
+        } on IOException {
+          stdinSubscription?.cancel();
+        }
+      },
+      cancelOnError: true,
+      onError: (_) {},
+    );
+
+    try {
+      await Future.wait([
+        stdout.addStream(process.stdout),
+        stderr.addStream(process.stderr),
+      ]);
+    } finally {
+      await stdinSubscription.cancel();
+      await _closeProcessStdin(process.stdin);
+      await sigSubscription.cancel();
+    }
+
+    final exitCode = await process.exitCode;
+    if (exitCode != 0) {
+      throw ExitException(exitCode);
+    }
+  }
+}
+
+Future<Process> _startScloudProcess(
+  List<String> args, {
+  required bool installIfMissing,
+}) async {
+  try {
+    return await Process.start(
+      'scloud',
+      args,
+      workingDirectory: Directory.current.path,
+    );
+  } on ProcessException catch (exception) {
+    if (installIfMissing) {
+      await _installScloud();
+      return _startScloudProcess(args, installIfMissing: false);
+    }
+
+    log.error(
+      'Failed to start Serverpod Cloud CLI: ${exception.message}',
+    );
+    throw ExitException(ServerpodCommand.commandInvokedCannotExecute);
+  }
+}
+
+Future<void> _installScloud() async {
+  final dartExecutable = p.join(getSdkPath(), 'bin', 'dart');
+  log.info('Installing Serverpod Cloud CLI...');
+  final installProcess = await Process.start(dartExecutable, [
+    'install',
+    'serverpod_cloud_cli',
+  ]);
+  installProcess.stdout.transform(const Utf8Decoder()).listen(log.debug);
+  installProcess.stderr.transform(const Utf8Decoder()).listen(log.error);
+  if (await installProcess.exitCode != 0) {
+    log.error('Failed to install Serverpod Cloud CLI.');
+    throw ExitException(ServerpodCommand.commandInvokedCannotExecute);
+  }
+}
+
+Future<void> _closeProcessStdin(IOSink sink) async {
+  try {
+    await sink.close();
+  } on StateError {
+    // The child may already have closed stdin.
+  } on IOException {
+    // Ignore broken pipe errors during shutdown.
+  }
+}

--- a/tools/serverpod_cli/lib/src/commands/cloud.dart
+++ b/tools/serverpod_cli/lib/src/commands/cloud.dart
@@ -76,8 +76,8 @@ class CloudCommand extends ServerpodCommand {
 
     try {
       await Future.wait([
-        stdout.addStream(process.stdout),
-        stderr.addStream(process.stderr),
+        stdout.addStream(_replaceScloudInOutput(process.stdout)),
+        stderr.addStream(_replaceScloudInOutput(process.stderr)),
       ]);
     } finally {
       await stdinSubscription.cancel();
@@ -128,6 +128,14 @@ Future<void> _installScloud() async {
     log.error('Failed to install Serverpod Cloud CLI.');
     throw ExitException(ServerpodCommand.commandInvokedCannotExecute);
   }
+}
+
+/// Rewrites [scloud] branding in child process output for the parent CLI.
+Stream<List<int>> _replaceScloudInOutput(Stream<List<int>> stream) {
+  return stream
+      .transform(utf8.decoder)
+      .map((text) => text.replaceAll('scloud', 'serverpod cloud'))
+      .transform(utf8.encoder);
 }
 
 Future<void> _closeProcessStdin(IOSink sink) async {

--- a/tools/serverpod_cli/lib/src/commands/cloud.dart
+++ b/tools/serverpod_cli/lib/src/commands/cloud.dart
@@ -60,35 +60,13 @@ class CloudCommand extends ServerpodCommand {
           process.kill(signal);
         });
 
-    StreamSubscription<List<int>>? stdinSubscription;
-    stdinSubscription = stdin.listen(
-      (data) {
-        try {
-          process.stdin.add(data);
-        } on StateError {
-          stdinSubscription?.cancel();
-        } on IOException {
-          stdinSubscription?.cancel();
-        }
-      },
-      cancelOnError: true,
-      onError: (_) {},
-    );
-
     try {
-      await Future.wait([
-        stdout.addStream(_replaceScloudInOutput(process.stdout)),
-        stderr.addStream(_replaceScloudInOutput(process.stderr)),
-      ]);
+      final exitCode = await process.exitCode;
+      if (exitCode != 0) {
+        throw ExitException(exitCode);
+      }
     } finally {
-      await stdinSubscription.cancel();
-      await _closeProcessStdin(process.stdin);
       await sigSubscription.cancel();
-    }
-
-    final exitCode = await process.exitCode;
-    if (exitCode != 0) {
-      throw ExitException(exitCode);
     }
   }
 }
@@ -117,6 +95,7 @@ Future<Process> _startScloudProcess(
       scloudExecutable,
       args,
       workingDirectory: Directory.current.path,
+      mode: ProcessStartMode.inheritStdio,
     );
   } on ProcessException catch (exception) {
     log.error(
@@ -146,47 +125,6 @@ Future<void> _installScloud() async {
   if (!success) {
     log.error('Failed to install Serverpod Cloud CLI.');
     throw ExitException(ServerpodCommand.commandInvokedCannotExecute);
-  }
-}
-
-/// Rewrites [scloud] branding in child process output for the parent CLI.
-Stream<List<int>> _replaceScloudInOutput(Stream<List<int>> stream) async* {
-  var pending = '';
-
-  await for (final chunk in stream.transform(const Utf8Decoder())) {
-    pending += chunk;
-
-    final lastSpace = pending.lastIndexOf(' ');
-    if (lastSpace == -1) {
-      continue;
-    }
-
-    final emit = pending.substring(0, lastSpace + 1);
-    pending = pending.substring(lastSpace + 1);
-    yield _encodeReplacingScloudInText(emit);
-  }
-
-  if (pending.isNotEmpty) {
-    yield _encodeReplacingScloudInText(pending);
-  }
-}
-
-List<int> _encodeReplacingScloudInText(String text) {
-  return utf8.encode(
-    text.replaceAllMapped(
-      RegExp(r'''(["' ])scloud(["' ])?'''),
-      (match) => '${match.group(1)}serverpod cloud${match.group(2) ?? ''}',
-    ),
-  );
-}
-
-Future<void> _closeProcessStdin(IOSink sink) async {
-  try {
-    await sink.close();
-  } on StateError {
-    // The child may already have closed stdin.
-  } on IOException {
-    // Ignore broken pipe errors during shutdown.
   }
 }
 

--- a/tools/serverpod_cli/lib/src/commands/cloud.dart
+++ b/tools/serverpod_cli/lib/src/commands/cloud.dart
@@ -128,14 +128,22 @@ Future<Process> _startScloudProcess(
 
 Future<void> _installScloud() async {
   final dartExecutable = p.join(getSdkPath(), 'bin', 'dart');
-  log.info('Installing Serverpod Cloud CLI...');
+  final success = await log.progress(
+    'Installing Serverpod Cloud CLI...',
+    () async {
   final installProcess = await Process.start(dartExecutable, [
     'install',
     'serverpod_cloud_cli',
   ]);
+
   installProcess.stdout.transform(const Utf8Decoder()).listen(log.debug);
   installProcess.stderr.transform(const Utf8Decoder()).listen(log.error);
-  if (await installProcess.exitCode != 0) {
+
+      return (await installProcess.exitCode) == 0;
+    },
+  );
+
+  if (!success) {
     log.error('Failed to install Serverpod Cloud CLI.');
     throw ExitException(ServerpodCommand.commandInvokedCannotExecute);
   }

--- a/tools/serverpod_cli/lib/src/commands/cloud.dart
+++ b/tools/serverpod_cli/lib/src/commands/cloud.dart
@@ -131,13 +131,13 @@ Future<void> _installScloud() async {
   final success = await log.progress(
     'Installing Serverpod Cloud CLI...',
     () async {
-  final installProcess = await Process.start(dartExecutable, [
-    'install',
-    'serverpod_cloud_cli',
-  ]);
+      final installProcess = await Process.start(dartExecutable, [
+        'install',
+        'serverpod_cloud_cli',
+      ]);
 
-  installProcess.stdout.transform(const Utf8Decoder()).listen(log.debug);
-  installProcess.stderr.transform(const Utf8Decoder()).listen(log.error);
+      installProcess.stdout.transform(const Utf8Decoder()).listen(log.debug);
+      installProcess.stderr.transform(const Utf8Decoder()).listen(log.error);
 
       return (await installProcess.exitCode) == 0;
     },
@@ -150,11 +150,34 @@ Future<void> _installScloud() async {
 }
 
 /// Rewrites [scloud] branding in child process output for the parent CLI.
-Stream<List<int>> _replaceScloudInOutput(Stream<List<int>> stream) {
-  return stream
-      .transform(utf8.decoder)
-      .map((text) => text.replaceAll('scloud', 'serverpod cloud'))
-      .transform(utf8.encoder);
+Stream<List<int>> _replaceScloudInOutput(Stream<List<int>> stream) async* {
+  var pending = '';
+
+  await for (final chunk in stream.transform(const Utf8Decoder())) {
+    pending += chunk;
+
+    final lastSpace = pending.lastIndexOf(' ');
+    if (lastSpace == -1) {
+      continue;
+    }
+
+    final emit = pending.substring(0, lastSpace + 1);
+    pending = pending.substring(lastSpace + 1);
+    yield _encodeReplacingScloudInText(emit);
+  }
+
+  if (pending.isNotEmpty) {
+    yield _encodeReplacingScloudInText(pending);
+  }
+}
+
+List<int> _encodeReplacingScloudInText(String text) {
+  return utf8.encode(
+    text.replaceAllMapped(
+      RegExp(r'''(["' ])scloud(["' ])?'''),
+      (match) => '${match.group(1)}serverpod cloud${match.group(2) ?? ''}',
+    ),
+  );
 }
 
 Future<void> _closeProcessStdin(IOSink sink) async {

--- a/tools/serverpod_cli/lib/src/generated/completion_script_carapace.dart
+++ b/tools/serverpod_cli/lib/src/generated/completion_script_carapace.dart
@@ -43,6 +43,8 @@ commands:
             tool: ["completely", "carapace"]
             write-dir: ["$directories"]
 
+  - name: cloud
+
   - name: create
     flags:
       -f, --force: "Create the project even if there are issues that prevent it from running out of the box."

--- a/tools/serverpod_cli/pubspec.yaml
+++ b/tools/serverpod_cli/pubspec.yaml
@@ -21,6 +21,7 @@ dependencies:
   code_builder: ^4.5.0
   collection: ^1.18.0
   config: ^0.8.4
+  dart_data_home: ^0.1.0
   dart_mcp: '>=0.4.1 <0.6.0'
   # Dart style must be pinned to 3.1.5 until we bump the minimum Dart version
   # to 3.12 due to a bug on the formatter that was fixed in 3.1.6, but only

--- a/tools/serverpod_cli/test/commands/cloud_command_test.dart
+++ b/tools/serverpod_cli/test/commands/cloud_command_test.dart
@@ -1,0 +1,44 @@
+import 'package:serverpod_cli/src/commands/cloud.dart';
+import 'package:serverpod_cli/src/util/serverpod_cli_logger.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Given a CloudCommand', () {
+    late CloudCommand command;
+
+    setUp(() {
+      command = CloudCommand();
+    });
+
+    tearDownAll(closeLogger);
+
+    test(
+      'when parsing configuration with no args, '
+      'then there are no errors',
+      () {
+        final argResults = command.argParser.parse([]);
+        final config = command.resolveConfiguration(argResults);
+
+        expect(config.errors, isEmpty);
+      },
+    );
+
+    group('when parsing configuration with scloud args, ', () {
+      late final argResults = command.argParser.parse([
+        'deploy',
+        '--project',
+        'my-project',
+      ]);
+
+      test('then there are no errors', () {
+        final config = command.resolveConfiguration(argResults);
+
+        expect(config.errors, isEmpty);
+      });
+
+      test('then args are forwarded via argResults.rest', () {
+        expect(argResults.rest, ['deploy', '--project', 'my-project']);
+      });
+    });
+  });
+}


### PR DESCRIPTION
Closes: #5202

~When invoked through `serverpod cloud`, all occurrences of `scloud` are also replaced for consistency:~
> <img width="570" height="230" alt="image" src="https://github.com/user-attachments/assets/9745fa00-f039-4d2f-9be3-cb2fd9bfede4" />

> Revoked at https://github.com/serverpod/serverpod/pull/5203/commits/d8c33cd856f14d3c65b82a5752019310e8024d74 due to the issues that it would bring when `scloud` features a TUI.
## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.