### PR TITLE
feat: Make Ctrl-C in the TUI copy the selection or exit on a second press

### DIFF
--- a/tools/serverpod_cli/lib/src/commands/create.dart
+++ b/tools/serverpod_cli/lib/src/commands/create.dart
@@ -243,6 +243,7 @@ class CreateCommand extends ServerpodCommand<CreateOption> {
 
     await runServerpodApp(
       backend: backend,
+      routeSigintThroughApp: true,
       ServerpodCreateApp(
         name: name,
         holder: holder,

--- a/tools/serverpod_cli/lib/src/commands/create/tui/app.dart
+++ b/tools/serverpod_cli/lib/src/commands/create/tui/app.dart
@@ -23,16 +23,21 @@ class ServerpodCreateApp extends ServerpodApp<CreateAppStateHolder> {
   ServerpodAppState createState() => ServerpodCreateAppState();
 }
 
-class ServerpodCreateAppState extends ServerpodAppState<ServerpodCreateApp> {
+class ServerpodCreateAppState extends ServerpodAppState<ServerpodCreateApp>
+    with CtrlCExitHandler<ServerpodCreateApp> {
   final _scrollController = ScrollController();
   final _logScrollController = ScrollController();
 
   @override
   void dispose() {
+    disposeCtrlC();
     _scrollController.dispose();
     _logScrollController.dispose();
     super.dispose();
   }
+
+  @override
+  void onCtrlCQuit() => component.onQuit();
 
   @override
   Component buildApp(BuildContext context) {
@@ -51,6 +56,8 @@ class ServerpodCreateAppState extends ServerpodAppState<ServerpodCreateApp> {
   }
 
   bool _handleKeyEvent(KeyboardEvent event) {
+    if (handleCtrlC(event)) return true;
+
     if (event.logicalKey == LogicalKey.keyS) {
       component.onSkipFlutterBuild();
       return true;

--- a/tools/serverpod_cli/lib/src/commands/create/tui/main_screen.dart
+++ b/tools/serverpod_cli/lib/src/commands/create/tui/main_screen.dart
@@ -49,8 +49,19 @@ class MainScreen extends StatelessComponent {
             ),
           ),
         ),
+        if (state.ctrlCHint case final hint?) _buildHintLine(theme, hint),
         _buildButtonBar(theme),
       ],
+    );
+  }
+
+  Component _buildHintLine(ServerpodThemeData theme, String hint) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 1),
+      child: Text(
+        hint,
+        style: TextStyle(color: theme.brightText, fontWeight: FontWeight.bold),
+      ),
     );
   }
 

--- a/tools/serverpod_cli/lib/src/commands/start.dart
+++ b/tools/serverpod_cli/lib/src/commands/start.dart
@@ -984,6 +984,7 @@ Future<int> _runWithTui({
   await runServerpodApp(
     ServerpodWatchApp(holder: holder, onReady: onReady),
     onShutdownSignal: () => shutdown.complete(0),
+    routeSigintThroughApp: true,
   );
 
   // runServerpodApp returned, so shutdownServerpodApp ran, so the listener fired,

--- a/tools/serverpod_cli/lib/src/commands/start/tui/app.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/tui/app.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:nocterm/nocterm.dart';
 import 'package:serverpod_cli/src/commands/tui/app.dart';
 import 'package:serverpod_cli/src/commands/tui/app_state_holder.dart';
+import 'package:serverpod_cli/src/commands/tui/run_app.dart';
 
 import 'main_screen.dart';
 
@@ -89,7 +90,8 @@ class ServerpodWatchApp extends ServerpodApp<StartAppStateHolder> {
   ServerpodAppState createState() => ServerpodWatchAppState();
 }
 
-class ServerpodWatchAppState extends ServerpodAppState<ServerpodWatchApp> {
+class ServerpodWatchAppState extends ServerpodAppState<ServerpodWatchApp>
+    with CtrlCExitHandler<ServerpodWatchApp> {
   final logScrollController = ScrollController();
   final rawScrollController = ScrollController();
   final flutterRawScrollController = ScrollController();
@@ -121,6 +123,7 @@ class ServerpodWatchAppState extends ServerpodAppState<ServerpodWatchApp> {
 
   @override
   void dispose() {
+    disposeCtrlC();
     component.holder.detach(this);
     super.dispose();
   }
@@ -172,6 +175,7 @@ class ServerpodWatchAppState extends ServerpodAppState<ServerpodWatchApp> {
         },
         onTabChanged: (index) {
           state.selectedTab = index;
+          state.selectedText = '';
           _rebuild();
         },
         onHotReload: onHotReload,
@@ -184,8 +188,19 @@ class ServerpodWatchAppState extends ServerpodAppState<ServerpodWatchApp> {
     );
   }
 
+  @override
+  void onCtrlCQuit() {
+    if (onQuit != null) {
+      onQuit!.call();
+    } else {
+      shutdownServerpodApp(0);
+    }
+  }
+
   bool _handleKeyEvent(KeyboardEvent event) {
     final state = component.holder.state;
+
+    if (handleCtrlC(event)) return true;
 
     if (state.showHelp) {
       if (event.logicalKey == LogicalKey.escape) {

--- a/tools/serverpod_cli/lib/src/commands/start/tui/main_screen.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/tui/main_screen.dart
@@ -129,6 +129,7 @@ class MainScreen extends StatelessComponent {
                 ),
               ),
             ),
+            if (state.ctrlCHint case final hint?) _buildHintLine(st, hint),
             _buildButtonBar(),
           ],
         ),
@@ -232,9 +233,7 @@ class MainScreen extends StatelessComponent {
     final items = state.logHistory;
 
     return SelectionArea(
-      onSelectionCompleted: (text) {
-        if (text.isNotEmpty) ClipboardManager.copy(text);
-      },
+      onSelectionChanged: (text) => state.selectedText = text,
       child: Scrollbar(
         controller: logScrollController,
         thumbVisibility: true,
@@ -269,9 +268,7 @@ class MainScreen extends StatelessComponent {
     ScrollController controller,
   ) {
     return SelectionArea(
-      onSelectionCompleted: (text) {
-        if (text.isNotEmpty) ClipboardManager.copy(text);
-      },
+      onSelectionChanged: (text) => state.selectedText = text,
       child: Scrollbar(
         controller: controller,
         thumbVisibility: true,
@@ -285,6 +282,16 @@ class MainScreen extends StatelessComponent {
             return Text(line, key: ValueKey(index));
           },
         ),
+      ),
+    );
+  }
+
+  Component _buildHintLine(ServerpodThemeData st, String hint) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 1),
+      child: Text(
+        hint,
+        style: TextStyle(color: st.brightText, fontWeight: FontWeight.bold),
       ),
     );
   }

--- a/tools/serverpod_cli/lib/src/commands/tui/app.dart
+++ b/tools/serverpod_cli/lib/src/commands/tui/app.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:meta/meta.dart';
 import 'package:nocterm/nocterm.dart';
 import 'package:serverpod_cli/src/commands/tui/app_state_holder.dart';
@@ -62,5 +64,79 @@ abstract class ServerpodAppState<S extends ServerpodApp> extends State<S> {
         },
       ),
     );
+  }
+}
+
+/// Ctrl-C handling shared by the Serverpod TUIs: copy the current selection if
+/// there is one, otherwise require a second press within [_exitArmWindow] to
+/// quit. Reads and writes [ServerpodState.selectedText] and
+/// [ServerpodState.ctrlCHint].
+mixin CtrlCExitHandler<S extends ServerpodApp> on ServerpodAppState<S> {
+  static const _exitArmWindow = Duration(seconds: 2);
+
+  bool _exitArmed = false;
+  Timer? _exitArmTimer;
+  Timer? _hintClearTimer;
+
+  /// Runs the graceful shutdown when a second Ctrl-C confirms exit.
+  void onCtrlCQuit();
+
+  /// Handles [event] when it is Ctrl-C, returning true so callers can
+  /// `if (handleCtrlC(event)) return true;` from their key handler.
+  ///
+  /// Always returns true for Ctrl-C so nocterm's signal handler never falls
+  /// back to its abrupt default shutdown, which would bypass backend cleanup.
+  /// Exit goes through [onCtrlCQuit].
+  bool handleCtrlC(KeyboardEvent event) {
+    if (event.logicalKey != LogicalKey.keyC || !event.isControlPressed) {
+      return false;
+    }
+
+    final state = component.holder.state;
+
+    if (state.selectedText.isNotEmpty) {
+      ClipboardManager.copy(state.selectedText);
+      _disarmExit();
+      _showHint('Copied to clipboard', autoClear: true);
+      return true;
+    }
+
+    if (_exitArmed) {
+      _disarmExit();
+      onCtrlCQuit();
+      return true;
+    }
+
+    _exitArmed = true;
+    _showHint('Press Ctrl-C again to exit', autoClear: false);
+    _exitArmTimer?.cancel();
+    _exitArmTimer = Timer(_exitArmWindow, () {
+      _exitArmed = false;
+      _clearHint();
+    });
+    return true;
+  }
+
+  /// Cancels pending timers. Call from the host state's [dispose].
+  void disposeCtrlC() {
+    _exitArmTimer?.cancel();
+    _hintClearTimer?.cancel();
+  }
+
+  void _showHint(String message, {required bool autoClear}) {
+    component.holder.state.ctrlCHint = message;
+    _hintClearTimer?.cancel();
+    if (autoClear) _hintClearTimer = Timer(_exitArmWindow, _clearHint);
+    rebuild();
+  }
+
+  void _clearHint() {
+    component.holder.state.ctrlCHint = null;
+    rebuild();
+  }
+
+  void _disarmExit() {
+    _exitArmed = false;
+    _exitArmTimer?.cancel();
   }
 }

--- a/tools/serverpod_cli/lib/src/commands/tui/components/help_overlay.dart
+++ b/tools/serverpod_cli/lib/src/commands/tui/components/help_overlay.dart
@@ -52,6 +52,7 @@ class _HelpOverlayState extends State<HelpOverlay> {
         ('M / Shift+M', 'Create migration (⇧ = force)'),
         ('P / Shift+P', 'Repair migration (⇧ = force)'),
         ('A', 'Apply migrations'),
+        ('Ctrl+C', 'Copy selection, or quit'),
         ('Q', 'Quit'),
       ],
     ),

--- a/tools/serverpod_cli/lib/src/commands/tui/components/log_viewer.dart
+++ b/tools/serverpod_cli/lib/src/commands/tui/components/log_viewer.dart
@@ -29,9 +29,7 @@ class LogViewerWidget extends StatelessComponent {
           children: [
             Expanded(
               child: SelectionArea(
-                onSelectionCompleted: (text) {
-                  if (text.isNotEmpty) ClipboardManager.copy(text);
-                },
+                onSelectionChanged: (text) => state.selectedText = text,
                 child: Scrollbar(
                   controller: scrollController,
                   thumbVisibility: true,

--- a/tools/serverpod_cli/lib/src/commands/tui/run_app.dart
+++ b/tools/serverpod_cli/lib/src/commands/tui/run_app.dart
@@ -37,11 +37,17 @@ void _restoreServerpodTerminal() {
 /// When [onShutdownSignal] is provided, signals invoke that callback instead.
 /// The caller is then responsible for running cleanup and eventually calling
 /// `shutdownServerpodApp(...)` to tear down the nocterm renderer.
+///
+/// When [routeSigintThroughApp] is true, SIGINT is not handled here. The
+/// nocterm backend converts it into a Ctrl-C keyboard event routed through the
+/// component tree, letting the app intercept it (e.g. to copy a selection or
+/// require a second press before exiting). SIGTERM is still handled here.
 Future<void> runServerpodApp(
   Component app, {
   bool enableHotReload = true,
   TerminalBackend? backend,
   void Function()? onShutdownSignal,
+  bool routeSigintThroughApp = false,
 }) async {
   _captureTerminalState();
 
@@ -58,7 +64,9 @@ Future<void> runServerpodApp(
       ? onShutDownSignalDefault
       : onShutDownSignalDelegated;
 
-  ProcessSignal.sigint.watch().listen(handler);
+  if (!routeSigintThroughApp) {
+    ProcessSignal.sigint.watch().listen(handler);
+  }
   if (!Platform.isWindows) {
     ProcessSignal.sigterm.watch().listen(handler);
   }

--- a/tools/serverpod_cli/lib/src/commands/tui/state.dart
+++ b/tools/serverpod_cli/lib/src/commands/tui/state.dart
@@ -52,4 +52,14 @@ abstract class ServerpodState {
 
   /// Whether the help overlay is visible.
   bool showHelp = false;
+
+  /// The text currently highlighted in a log view, or empty when there is no
+  /// selection. Updated as the user drags a selection and read when Ctrl-C is
+  /// pressed so the selection can be copied to the clipboard.
+  String selectedText = '';
+
+  /// Transient message shown above the button bar, e.g. "Copied to clipboard"
+  /// after a copy or "Press Ctrl-C again to exit" while exit is armed. Null
+  /// when nothing should be shown.
+  String? ctrlCHint;
 }

--- a/tools/serverpod_cli/test/commands/create/tui/ctrl_c_test.dart
+++ b/tools/serverpod_cli/test/commands/create/tui/ctrl_c_test.dart
@@ -1,0 +1,79 @@
+import 'package:nocterm/nocterm.dart';
+import 'package:serverpod_cli/src/commands/create/tui/app.dart';
+import 'package:serverpod_cli/src/commands/create/tui/state.dart';
+import 'package:serverpod_cli/src/commands/create/tui/state_holder.dart';
+import 'package:serverpod_cli/src/create/create.dart';
+import 'package:test/test.dart';
+
+Future<void> _sendCtrlC(NoctermTester tester) {
+  return tester.sendKeyEvent(
+    const KeyboardEvent(
+      logicalKey: LogicalKey.keyC,
+      modifiers: ModifierKeys(ctrl: true),
+    ),
+  );
+}
+
+void main() {
+  late NoctermTester tester;
+  late CreateConfigState state;
+  late CreateAppStateHolder holder;
+  late bool quit;
+
+  setUp(() async {
+    state = CreateConfigState(ServerpodTemplateType.server);
+    holder = CreateAppStateHolder(state);
+    quit = false;
+    tester = await NoctermTester.create(size: const Size(80, 24));
+    await tester.pumpComponent(
+      ServerpodCreateApp(
+        name: 'my_project',
+        holder: holder,
+        onCreate: () {},
+        onQuit: () => quit = true,
+        onSkipFlutterBuild: () {},
+      ),
+    );
+  });
+
+  tearDown(() async {
+    tester.dispose();
+    await holder.dispose();
+  });
+
+  group('Given text is selected during project creation', () {
+    setUp(() {
+      state.selectedText = 'a selected log line';
+    });
+
+    test(
+      'when Ctrl-C is pressed then the selection is copied without exiting',
+      () async {
+        await _sendCtrlC(tester);
+
+        expect(ClipboardManager.paste(), 'a selected log line');
+        expect(state.ctrlCHint, 'Copied to clipboard');
+        expect(quit, isFalse);
+      },
+    );
+  });
+
+  group('Given nothing is selected', () {
+    test(
+      'when Ctrl-C is pressed once then exit is armed without exiting',
+      () async {
+        await _sendCtrlC(tester);
+
+        expect(state.ctrlCHint, 'Press Ctrl-C again to exit');
+        expect(quit, isFalse);
+      },
+    );
+
+    test('when Ctrl-C is pressed twice then the app quits', () async {
+      await _sendCtrlC(tester);
+      await _sendCtrlC(tester);
+
+      expect(quit, isTrue);
+    });
+  });
+}

--- a/tools/serverpod_cli/test/commands/start/tui/ctrl_c_test.dart
+++ b/tools/serverpod_cli/test/commands/start/tui/ctrl_c_test.dart
@@ -1,0 +1,72 @@
+import 'package:nocterm/nocterm.dart';
+import 'package:serverpod_cli/src/commands/start/tui/app.dart';
+import 'package:serverpod_cli/src/commands/start/tui/state.dart';
+import 'package:test/test.dart';
+
+Future<void> _sendCtrlC(NoctermTester tester) {
+  return tester.sendKeyEvent(
+    const KeyboardEvent(
+      logicalKey: LogicalKey.keyC,
+      modifiers: ModifierKeys(ctrl: true),
+    ),
+  );
+}
+
+void main() {
+  late NoctermTester tester;
+  late ServerWatchState state;
+  late StartAppStateHolder holder;
+  late bool quit;
+
+  setUp(() async {
+    state = ServerWatchState();
+    holder = StartAppStateHolder(state);
+    quit = false;
+    tester = await NoctermTester.create(size: const Size(80, 24));
+    await tester.pumpComponent(
+      ServerpodWatchApp(holder: holder, onReady: (_) {}),
+    );
+    holder.onQuit = () => quit = true;
+  });
+
+  tearDown(() async {
+    tester.dispose();
+    await holder.dispose();
+  });
+
+  group('Given text is selected in a log view', () {
+    setUp(() {
+      state.selectedText = 'a selected log line';
+    });
+
+    test(
+      'when Ctrl-C is pressed then the selection is copied without exiting',
+      () async {
+        await _sendCtrlC(tester);
+
+        expect(ClipboardManager.paste(), 'a selected log line');
+        expect(state.ctrlCHint, 'Copied to clipboard');
+        expect(quit, isFalse);
+      },
+    );
+  });
+
+  group('Given nothing is selected', () {
+    test(
+      'when Ctrl-C is pressed once then exit is armed without exiting',
+      () async {
+        await _sendCtrlC(tester);
+
+        expect(state.ctrlCHint, 'Press Ctrl-C again to exit');
+        expect(quit, isFalse);
+      },
+    );
+
+    test('when Ctrl-C is pressed twice then the app quits', () async {
+      await _sendCtrlC(tester);
+      await _sendCtrlC(tester);
+
+      expect(quit, isTrue);
+    });
+  });
+}


### PR DESCRIPTION
Ctrl-C in the `serverpod start` / `serverpod create` TUIs previously killed the process immediately.

This changes Ctrl-C to behave like other terminal apps (Claude Code CLI):
- If text is selected, Ctrl-C copies it to the clipboard and the process keeps running.
- If nothing is selected, the first Ctrl-C shows "Press Ctrl-C again to exit" and a second press within 2s exits gracefully. The hint clears on timeout.

Note: This fix is in place to support Windows, MacOS, and Linux but currently is only working on MacOS and Linux while we wait for a Nocterm upstream PR to be merged.

Fixes #5170 

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes
One "breaking" change is the previous behavior had highlighting text automatically copy the highlighted portion on mouse release. This behavior replaces that one. We can have both if that's desired.