### PR TITLE
chore: Ignore `scloud` related paths on project template

### DIFF
--- a/templates/serverpod_templates/projectname/gitignore
+++ b/templates/serverpod_templates/projectname/gitignore
@@ -14,3 +14,6 @@ pubspec_overrides.yaml
 .vscode/mcp.json
 .codex/
 .mcp.json
+
+# Serverpod Cloud CLI
+.scloud/

--- a/tests/bootstrap_project/test/project_mini_test.dart
+++ b/tests/bootstrap_project/test/project_mini_test.dart
@@ -295,13 +295,19 @@ void main() async {
           expect(content, contains('${projectName}_flutter'));
         });
 
-        test('has a root .gitignore that ignores workspace .dart_tool', () {
-          final rootGitignore = File(
-            path.join(tempPath, projectName, '.gitignore'),
-          );
-          expect(rootGitignore.existsSync(), isTrue);
-          expect(rootGitignore.readAsStringSync(), contains('.dart_tool/'));
-        });
+        test(
+          'has a root .gitignore that ignores workspace .dart_tool and .scloud',
+          () {
+            final rootGitignore = File(
+              path.join(tempPath, projectName, '.gitignore'),
+            );
+            expect(rootGitignore.existsSync(), isTrue);
+
+            final content = rootGitignore.readAsStringSync();
+            expect(content, contains('.dart_tool/'));
+            expect(content, contains('.scloud/'));
+          },
+        );
 
         test('server pubspec.yaml has resolution: workspace', () {
           final content = File(

--- a/tests/bootstrap_project/test/project_test.dart
+++ b/tests/bootstrap_project/test/project_test.dart
@@ -658,13 +658,19 @@ void main() async {
           expect(content, contains('${projectName}_flutter'));
         });
 
-        test('has a root .gitignore that ignores workspace .dart_tool', () {
-          final rootGitignore = File(
-            path.join(tempPath, projectName, '.gitignore'),
-          );
-          expect(rootGitignore.existsSync(), isTrue);
-          expect(rootGitignore.readAsStringSync(), contains('.dart_tool/'));
-        });
+        test(
+          'has a root .gitignore that ignores workspace .dart_tool and .scloud',
+          () {
+            final rootGitignore = File(
+              path.join(tempPath, projectName, '.gitignore'),
+            );
+            expect(rootGitignore.existsSync(), isTrue);
+
+            final content = rootGitignore.readAsStringSync();
+            expect(content, contains('.dart_tool/'));
+            expect(content, contains('.scloud/'));
+          },
+        );
 
         test('server pubspec.yaml has resolution: workspace', () {
           final content = File(


### PR DESCRIPTION
Fixes: #5205

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.