### PR TITLE
fix: Add the missing shift+tab action to navigate backwards on `start` tabs

### DIFF
--- a/tools/serverpod_cli/lib/src/commands/start/tui/app.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/tui/app.dart
@@ -152,6 +152,17 @@ class ServerpodWatchAppState extends ServerpodAppState<ServerpodWatchApp> {
     }
   }
 
+  void _cycleTab(int delta) {
+    final state = component.holder.state;
+    if (state.useSideBySideLayout) {
+      state.selectedTab = state.selectedTab == 0 ? 2 : 0;
+    } else {
+      final tabCount = state.showFlutterOutput ? 3 : 2;
+      state.selectedTab = (state.selectedTab + delta + tabCount) % tabCount;
+    }
+    _rebuild();
+  }
+
   @override
   Component buildApp(BuildContext context) {
     final state = component.holder.state;
@@ -202,25 +213,14 @@ class ServerpodWatchAppState extends ServerpodAppState<ServerpodWatchApp> {
     final sideBySide = state.useSideBySideLayout;
 
     // Tab cycling. In side-by-side mode, only server tabs are selectable.
-    if (event.logicalKey == LogicalKey.tab ||
+    if (event.matches(LogicalKey.tab, shift: false) ||
         event.logicalKey == LogicalKey.arrowRight) {
-      if (sideBySide) {
-        state.selectedTab = state.selectedTab == 0 ? 2 : 0;
-      } else {
-        final tabCount = state.showFlutterOutput ? 3 : 2;
-        state.selectedTab = (state.selectedTab + 1) % tabCount;
-      }
-      _rebuild();
+      _cycleTab(1);
       return true;
     }
-    if (event.logicalKey == LogicalKey.arrowLeft) {
-      if (sideBySide) {
-        state.selectedTab = state.selectedTab == 0 ? 2 : 0;
-      } else {
-        final tabCount = state.showFlutterOutput ? 3 : 2;
-        state.selectedTab = (state.selectedTab - 1 + tabCount) % tabCount;
-      }
-      _rebuild();
+    if (event.matches(LogicalKey.tab, shift: true) ||
+        event.logicalKey == LogicalKey.arrowLeft) {
+      _cycleTab(-1);
       return true;
     }
     if (event.logicalKey == LogicalKey.digit1) {

--- a/tools/serverpod_cli/lib/src/commands/tui/components/help_overlay.dart
+++ b/tools/serverpod_cli/lib/src/commands/tui/components/help_overlay.dart
@@ -40,7 +40,7 @@ class _HelpOverlayState extends State<HelpOverlay> {
       'Tabs',
       [
         ('Tab / →', 'Next tab'),
-        ('←', 'Previous tab'),
+        ('Shift+Tab / ←', 'Previous tab'),
         ('1', 'Log Messages'),
         ('2', 'Raw server output'),
       ],


### PR DESCRIPTION
Fixes: #5207

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.