### PR TITLE
fix: Call endpoints passing the method on the route instead of the body

### DIFF
--- a/packages/serverpod_client/lib/src/serverpod_client_shared.dart
+++ b/packages/serverpod_client/lib/src/serverpod_client_shared.dart
@@ -558,8 +558,10 @@ abstract class ServerpodClientShared extends EndpointCaller {
       var authenticationValue = authenticated
           ? await authKeyProvider?.authHeaderValue
           : null;
-      var body = formatArgs(args, method);
-      var url = Uri.parse('$host$endpoint');
+      var body = formatArgs(args);
+      var url = method.isEmpty
+          ? Uri.parse('$host$endpoint')
+          : Uri.parse('$host$endpoint/$method');
 
       var data = await _requestDelegate.serverRequest(
         url,

--- a/packages/serverpod_client/lib/src/serverpod_client_shared_private.dart
+++ b/packages/serverpod_client/lib/src/serverpod_client_shared_private.dart
@@ -7,10 +7,7 @@ import 'http/http_status.dart';
 /// Encodes arguments for serialization.
 String formatArgs(
   Map<String, dynamic> args,
-  String method,
 ) {
-  args['method'] = method;
-
   return SerializationManager.encode(args);
 }
 

--- a/tests/serverpod_test_server/test_e2e/http_codes_test.dart
+++ b/tests/serverpod_test_server/test_e2e/http_codes_test.dart
@@ -8,10 +8,6 @@ import 'package:uuid/uuid.dart';
 
 void main() {
   group('Given an HTTP client invoking a serverpod endpoint method', () {
-    setUpAll(() async {});
-
-    tearDownAll(() async {});
-
     test('when calling an endpoint method with correct parameters '
         'then it should respond with 200 ok', () async {
       var response = await http.post(

--- a/tests/serverpod_test_server/test_integration/diagnostics/diagnostic_events_test.dart
+++ b/tests/serverpod_test_server/test_integration/diagnostics/diagnostic_events_test.dart
@@ -185,7 +185,10 @@ void main() {
           contains('sessionId'),
           containsPair('userAuthInfo', null),
           contains('remoteInfo'),
-          containsPair('uri', 'http://localhost:8080/exceptionTest'),
+          containsPair(
+            'uri',
+            'http://localhost:8080/exceptionTest/throwNormalException',
+          ),
           containsPair('endpoint', 'exceptionTest'),
           containsPair('methodName', 'throwNormalException'),
         ]),


### PR DESCRIPTION
Complimentary work for the changes done at #2676.
One small step towards #591.
Closes #5229.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None, we're only changing the default behavior to explicitly passing the method name on the route instead of the body, as it was already supported since #2676.