### PR TITLE
fix: Fix flaky datetime default persist test

### DIFF
--- a/tests/serverpod_test_server/test_integration/database_operations/default/datetime/datetime_default_model_test.dart
+++ b/tests/serverpod_test_server/test_integration/database_operations/default/datetime/datetime_default_model_test.dart
@@ -61,8 +61,9 @@ void main() async {
         expect(
           databaseObject.dateTimeDefaultModelNow
               .difference(DateTime.now())
-              .inSeconds,
-          0,
+              .inSeconds
+              .abs(),
+          lessThanOrEqualTo(1),
         );
       },
     );

--- a/tests/serverpod_test_server/test_integration/database_operations/default/datetime/datetime_default_persist_test.dart
+++ b/tests/serverpod_test_server/test_integration/database_operations/default/datetime/datetime_default_persist_test.dart
@@ -48,8 +48,9 @@ void main() async {
         expect(
           databaseObject.dateTimeDefaultPersistNow!
               .difference(DateTime.now())
-              .inSeconds,
-          0,
+              .inSeconds
+              .abs(),
+          lessThanOrEqualTo(1),
         );
       },
     );
@@ -116,8 +117,9 @@ void main() async {
         expect(
           databaseObject!.dateTimeDefaultPersistNow!
               .difference(DateTime.now())
-              .inSeconds,
-          0,
+              .inSeconds
+              .abs(),
+          lessThanOrEqualTo(1),
         );
       },
     );

--- a/tests/serverpod_test_server/test_integration/database_operations/default/datetime/datetime_default_test.dart
+++ b/tests/serverpod_test_server/test_integration/database_operations/default/datetime/datetime_default_test.dart
@@ -61,8 +61,9 @@ void main() async {
         expect(
           databaseObject.dateTimeDefaultNow
               .difference(DateTime.now())
-              .inSeconds,
-          0,
+              .inSeconds
+              .abs(),
+          lessThanOrEqualTo(1),
         );
       },
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/test_integration/database_operations/default/datetime/datetime_default_model_test.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/test_integration/database_operations/default/datetime/datetime_default_model_test.dart
@@ -61,8 +61,9 @@ void main() async {
         expect(
           databaseObject.dateTimeDefaultModelNow
               .difference(DateTime.now())
-              .inSeconds,
-          0,
+              .inSeconds
+              .abs(),
+          lessThanOrEqualTo(1),
         );
       },
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/test_integration/database_operations/default/datetime/datetime_default_persist_test.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/test_integration/database_operations/default/datetime/datetime_default_persist_test.dart
@@ -48,8 +48,9 @@ void main() async {
         expect(
           databaseObject.dateTimeDefaultPersistNow!
               .difference(DateTime.now())
-              .inSeconds,
-          0,
+              .inSeconds
+              .abs(),
+          lessThanOrEqualTo(1),
         );
       },
     );
@@ -107,8 +108,9 @@ void main() async {
         expect(
           databaseObject!.dateTimeDefaultPersistNow!
               .difference(DateTime.now())
-              .inSeconds,
-          0,
+              .inSeconds
+              .abs(),
+          lessThanOrEqualTo(1),
         );
       },
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/test_integration/database_operations/default/datetime/datetime_default_test.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/test_integration/database_operations/default/datetime/datetime_default_test.dart
@@ -61,8 +61,9 @@ void main() async {
         expect(
           databaseObject.dateTimeDefaultNow
               .difference(DateTime.now())
-              .inSeconds,
-          0,
+              .inSeconds
+              .abs(),
+          lessThanOrEqualTo(1),
         );
       },
     );


### PR DESCRIPTION
Fixes: #5182

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.    
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.