### PR TITLE
feat: Replace the default Flutter device by a special `web-server` that launches the browser

### DIFF
--- a/tools/serverpod_cli/lib/src/commands/start.dart
+++ b/tools/serverpod_cli/lib/src/commands/start.dart
@@ -93,12 +93,10 @@ enum StartOption<V> implements OptionDefinition<V> {
   flutterDevice(
     StringOption(
       argName: 'flutter-device',
-      defaultsTo: 'chrome',
+      defaultsTo: flutterDeviceWebServerWithBrowser,
       helpText:
-          'Target device for `flutter run -d`. Defaults to chrome '
-          '(web-server is headless and triggers a known DWDS hot-reload '
-          'bug: dart-lang/sdk#60289). Pass --flutter-device=web-server '
-          'for CI / headless / remote-attach workflows.',
+          'Target device for `flutter run -d`. Defaults to "web-server" '
+          'and launches the default browser as soon as the app is ready.',
     ),
   ),
   flutterOption(

--- a/tools/serverpod_cli/lib/src/commands/start/flutter_process.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/flutter_process.dart
@@ -80,7 +80,7 @@ class FlutterProcess {
   String? _flutterAppUrl;
   String? _dtdUri;
   VmService? _vmService;
-  bool _browserOpened = false;
+  bool _browserOpening = false;
 
   // `null` result means the process exited before publishing a URI.
   final Completer<String?> _vmServiceUriCompleter = Completer<String?>();
@@ -501,15 +501,15 @@ class FlutterProcess {
   }
 
   Future<void> _openBrowser(Uri url) async {
-    if (_browserOpened) return;
-    _browserOpened = true;
+    if (_browserOpening) return;
+    _browserOpening = true;
     final open = _openBrowserForTesting ?? BrowserLauncher.openUrl;
     if (!await open(url)) {
       log.warning('Could not open browser at $url');
     }
 
     // Reset the flag so we can open the browser again if the app is restarted.
-    _browserOpened = false;
+    _browserOpening = false;
   }
 
   bool _appStopHandled = false;

--- a/tools/serverpod_cli/lib/src/commands/start/flutter_process.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/flutter_process.dart
@@ -7,11 +7,14 @@ import 'package:path/path.dart' as p;
 import 'package:serverpod_cli/src/commands/messages.dart';
 import 'package:serverpod_cli/src/commands/start/server_process.dart'
     show vmServiceWsUri;
+import 'package:serverpod_cli/src/util/browser_launcher.dart';
 import 'package:serverpod_cli/src/util/serverpod_cli_logger.dart';
 import 'package:serverpod_cli/src/vendored/flutter_daemon_protocol.dart';
 import 'package:serverpod_cli/src/vm_proxy/proxy.dart';
 import 'package:vm_service/vm_service.dart';
 import 'package:vm_service/vm_service_io.dart';
+
+const flutterDeviceWebServerWithBrowser = 'web-server-launch-browser';
 
 /// Thrown by [FlutterProcess.start] when `flutter` cannot be launched.
 class FlutterNotInstalledException implements Exception {
@@ -50,9 +53,16 @@ class FlutterProcess {
   /// messages in between.
   final void Function(String stage)? _onProgress;
 
+  /// When true, open [flutterAppUrl] in the default browser once it is
+  /// published by the daemon (`app.webLaunchUrl`).
+  final bool _launchBrowser;
+
   /// Test-only spawn args override; replaces the default `flutter run`
   /// arg list when non-null.
   final List<String>? _argsOverrideForTesting;
+
+  /// Test-only override for [BrowserLauncher.openUrl].
+  final Future<bool> Function(Uri url)? _openBrowserForTesting;
 
   Process? _process;
   StreamSubscription<ProcessSignal>? _sigtermSub;
@@ -70,6 +80,7 @@ class FlutterProcess {
   String? _flutterAppUrl;
   String? _dtdUri;
   VmService? _vmService;
+  bool _browserOpened = false;
 
   // `null` result means the process exited before publishing a URI.
   final Completer<String?> _vmServiceUriCompleter = Completer<String?>();
@@ -88,6 +99,7 @@ class FlutterProcess {
     IOSink? stdoutSink,
     IOSink? stderrSink,
     @visibleForTesting List<String>? argsOverrideForTesting,
+    @visibleForTesting Future<bool> Function(Uri url)? openBrowserForTesting,
   }) : _flutterPackageDir = flutterPackageDir,
        _flutterExecutable = flutterExecutable,
        _device = device,
@@ -96,7 +108,9 @@ class FlutterProcess {
        _onProgress = onProgress,
        _stdout = stdoutSink ?? stdout,
        _stderr = stderrSink ?? stderr,
-       _argsOverrideForTesting = argsOverrideForTesting;
+       _launchBrowser = device == flutterDeviceWebServerWithBrowser,
+       _argsOverrideForTesting = argsOverrideForTesting,
+       _openBrowserForTesting = openBrowserForTesting;
 
   /// True between [start] and [stop]/exit.
   bool get isRunning => _process != null;
@@ -130,9 +144,10 @@ class FlutterProcess {
       throw StateError('FlutterProcess is already running.');
     }
 
+    final device = _launchBrowser ? 'web-server' : _device;
     final args =
         _argsOverrideForTesting ??
-        <String>['run', '--machine', '-d', _device, ..._extraArgs];
+        <String>['run', '--machine', '-d', device, ..._extraArgs];
 
     final invocation = await _resolveFlutterInvocation(_flutterExecutable);
 
@@ -459,6 +474,9 @@ class FlutterProcess {
           if (url is String) {
             _flutterAppUrl = url;
             if (!_launchedCompleter.isCompleted) _launchedCompleter.complete();
+            if (_launchBrowser) {
+              unawaited(_openBrowser(Uri.parse(url)));
+            }
           }
         case 'app.dtd':
           final uri = paramMap['uri'];
@@ -480,6 +498,18 @@ class FlutterProcess {
           if (message is String) log.debug('flutter[daemon] $message');
       }
     }
+  }
+
+  Future<void> _openBrowser(Uri url) async {
+    if (_browserOpened) return;
+    _browserOpened = true;
+    final open = _openBrowserForTesting ?? BrowserLauncher.openUrl;
+    if (!await open(url)) {
+      log.warning('Could not open browser at $url');
+    }
+
+    // Reset the flag so we can open the browser again if the app is restarted.
+    _browserOpened = false;
   }
 
   bool _appStopHandled = false;

--- a/tools/serverpod_cli/lib/src/util/browser_launcher.dart
+++ b/tools/serverpod_cli/lib/src/util/browser_launcher.dart
@@ -12,6 +12,11 @@ abstract final class BrowserLauncher {
         commandWithArgs.first,
         [...commandWithArgs.sublist(1), url.toString()],
         runInShell: true,
+        // WSL invokes Windows cmd.exe, which may emit CP1252 stderr (e.g.
+        // UNC-path warnings). Default UTF-8 decoding then throws even when
+        // the browser actually opened.
+        stdoutEncoding: null,
+        stderrEncoding: null,
       );
       return result.exitCode == 0;
     } catch (_) {

--- a/tools/serverpod_cli/test/commands/start/flutter_process_test.dart
+++ b/tools/serverpod_cli/test/commands/start/flutter_process_test.dart
@@ -436,6 +436,58 @@ void main() {
     );
 
     test(
+      'when device is "web-server-launch-browser" and app.webLaunchUrl arrives '
+      'then the browser launcher is invoked with that URL',
+      () async {
+        Uri? openedUrl;
+        fp = FlutterProcess(
+          flutterPackageDir: Directory.systemTemp.path,
+          device: flutterDeviceWebServerWithBrowser,
+          openBrowserForTesting: (url) async {
+            openedUrl = url;
+            return true;
+          },
+        );
+        fp.handleMachineLine(
+          jsonEncode([
+            {
+              'event': 'app.webLaunchUrl',
+              'params': {'url': 'http://localhost:54321'},
+            },
+          ]),
+        );
+        await Future<void>.delayed(Duration.zero);
+        expect(openedUrl, Uri.parse('http://localhost:54321'));
+      },
+    );
+
+    test(
+      'when device is "web-server" and app.webLaunchUrl arrives '
+      'then the browser launcher is not invoked',
+      () async {
+        var browserLaunchCount = 0;
+        fp = FlutterProcess(
+          flutterPackageDir: Directory.systemTemp.path,
+          device: 'web-server',
+          openBrowserForTesting: (_) async {
+            browserLaunchCount++;
+            return true;
+          },
+        );
+        fp.handleMachineLine(
+          jsonEncode([
+            {
+              'event': 'app.webLaunchUrl',
+              'params': {'url': 'http://localhost:54321'},
+            },
+          ]),
+        );
+        await Future<void>.delayed(Duration.zero);
+        expect(browserLaunchCount, 0);
+      },
+    );
+
+    test(
       'when app.debugPort arrives without app.webLaunchUrl '
       'then launched completes immediately (mobile/desktop gate semantics)',
       () async {


### PR DESCRIPTION
Closes #5226 by replacing the default `chrome` device with a special `web-server` that launches automatically in the default browser when the app is started. Automatic launch is opt-out by passing `--flutter-device=web-server` to `serverpod start`.

Also lower the priority of #5167 - which proves very hard to do properly - because the browser is no longer a responsibility of the `serverpod start` command.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.