### PR TITLE
fix: Show global options in command help

### DIFF
--- a/tools/serverpod_cli/lib/src/runner/serverpod_command.dart
+++ b/tools/serverpod_cli/lib/src/runner/serverpod_command.dart
@@ -1,3 +1,4 @@
+import 'package:args/args.dart';
 import 'package:cli_tools/cli_tools.dart';
 import 'package:config/config.dart';
 import 'package:serverpod_cli/src/util/serverpod_cli_logger.dart';
@@ -18,4 +19,36 @@ abstract class ServerpodCommand<O extends OptionDefinition>
   }) : super(
          wrapTextColumn: log.wrapTextColumn,
        );
+
+  /// The global options (e.g. `--no-interactive`) apply to every command, but
+  /// the `args` package only lists a command's own options in its usage and
+  /// merely points to the top-level help for the rest. Append the global
+  /// options to the command usage so they are discoverable directly from
+  /// `serverpod <command> --help`.
+  @override
+  String get usage {
+    final baseUsage = super.usage;
+
+    final runner = this.runner;
+    if (runner is! ServerpodCommandRunner) return baseUsage;
+
+    final globalOptionsParser = ArgParser(
+      usageLineLength: argParser.usageLineLength,
+    );
+    prepareOptionsForParsing(runner.globalOptions, globalOptionsParser);
+    final globalOptionsSection =
+        'Global options:\n${globalOptionsParser.usage}';
+
+    // Replace the `args` note that points to the top-level help with the
+    // global options themselves, falling back to appending them if the note
+    // can no longer be found.
+    final globalOptionsNote = RegExp(
+      r'Run\s+"\S+\s+help"\s+to\s+see\s+global\s+options\.',
+    );
+    if (baseUsage.contains(globalOptionsNote)) {
+      return baseUsage.replaceFirst(globalOptionsNote, globalOptionsSection);
+    }
+
+    return '$baseUsage\n\n$globalOptionsSection';
+  }
 }

--- a/tools/serverpod_cli/lib/src/runner/serverpod_command.dart
+++ b/tools/serverpod_cli/lib/src/runner/serverpod_command.dart
@@ -36,19 +36,7 @@ abstract class ServerpodCommand<O extends OptionDefinition>
       usageLineLength: argParser.usageLineLength,
     );
     prepareOptionsForParsing(runner.globalOptions, globalOptionsParser);
-    final globalOptionsSection =
-        'Global options:\n${globalOptionsParser.usage}';
 
-    // Replace the `args` note that points to the top-level help with the
-    // global options themselves, falling back to appending them if the note
-    // can no longer be found.
-    final globalOptionsNote = RegExp(
-      r'Run\s+"\S+\s+help"\s+to\s+see\s+global\s+options\.',
-    );
-    if (baseUsage.contains(globalOptionsNote)) {
-      return baseUsage.replaceFirst(globalOptionsNote, globalOptionsSection);
-    }
-
-    return '$baseUsage\n\n$globalOptionsSection';
+    return '$baseUsage\n\nGlobal options:\n${globalOptionsParser.usage}';
   }
 }

--- a/tools/serverpod_cli/test/runner/serverpod_command_test.dart
+++ b/tools/serverpod_cli/test/runner/serverpod_command_test.dart
@@ -61,12 +61,5 @@ void main() {
         expect(command.usage, contains('-h, --help'));
       },
     );
-
-    test(
-      'when reading the usage then the top-level help reference note is removed',
-      () {
-        expect(command.usage, isNot(contains('to see global options')));
-      },
-    );
   });
 }

--- a/tools/serverpod_cli/test/runner/serverpod_command_test.dart
+++ b/tools/serverpod_cli/test/runner/serverpod_command_test.dart
@@ -1,0 +1,72 @@
+import 'package:cli_tools/cli_tools.dart';
+import 'package:config/config.dart';
+import 'package:pub_semver/pub_semver.dart';
+import 'package:serverpod_cli/src/runner/serverpod_command.dart';
+import 'package:serverpod_cli/src/runner/serverpod_command_runner.dart';
+import 'package:test/test.dart';
+
+class _TestCommand extends ServerpodCommand<OptionDefinition> {
+  @override
+  final name = 'test-command';
+
+  @override
+  final description = 'Test command used for verifying usage output.';
+
+  _TestCommand() : super(options: const []);
+
+  @override
+  void runWithConfig(Configuration<OptionDefinition> commandConfig) {}
+}
+
+class _MockAnalytics implements Analytics {
+  @override
+  void track({
+    required String event,
+    Map<String, dynamic> properties = const {},
+  }) {}
+
+  @override
+  void cleanUp() {}
+}
+
+void main() {
+  group('Given a Serverpod command registered on the command runner', () {
+    late _TestCommand command;
+
+    setUp(() {
+      var runner = ServerpodCommandRunner.createCommandRunner(
+        _MockAnalytics(),
+        false,
+        Version(1, 1, 0),
+        onBeforeRunCommand: (_) async {},
+      );
+      command = _TestCommand();
+      runner.addCommand(command);
+    });
+
+    test('when reading the usage then the global options are listed', () {
+      expect(command.usage, contains('Global options:'));
+    });
+
+    test(
+      'when reading the usage then the interactive global option is listed',
+      () {
+        expect(command.usage, contains('--[no-]interactive'));
+      },
+    );
+
+    test(
+      'when reading the usage then the command specific options are still listed',
+      () {
+        expect(command.usage, contains('-h, --help'));
+      },
+    );
+
+    test(
+      'when reading the usage then the top-level help reference note is removed',
+      () {
+        expect(command.usage, isNot(contains('to see global options')));
+      },
+    );
+  });
+}


### PR DESCRIPTION
Global options like `--no-interactive`, `--verbose`, and `--analytics` are defined on the command runner and apply to every command. They do work after a subcommand, but the `args` package only lists a command's *own* options in its `--help` output and merely appends a "Run 'serverpod help' to see global options."

This PR overrides `usage` in the shared `ServerpodCommand` base class to render the runner's global options and substitute them in place of that note.

Instead of just fixing this for `--no-interactive` I wen't ahead and appended the global commands to **ALL** subcommands. If this it not desired it's a very easy change.

Running `serverpod create --help`

Before
<img width="1334" height="393" alt="image" src="https://github.com/user-attachments/assets/c904ef8d-078d-4245-be1b-9a86f1ccb4bd" />
After
<img width="1347" height="550" alt="image" src="https://github.com/user-attachments/assets/88171f12-d530-4719-91c4-91e73179e52d" />

Fixes #5228 

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes
None