### PR TITLE
fix: Refresh the web page on Dart code changes in serverpod start

### DIFF
--- a/tools/serverpod_cli/lib/src/commands/start/watch_session.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/watch_session.dart
@@ -185,8 +185,7 @@ class WatchSession {
         event.modelFiles.isNotEmpty ||
         event.packageConfigChanged;
 
-    // Static-only changes (HTML, JS, CSS, templates): no compilation needed,
-    // just refresh the browser.
+    // Static-only changes (HTML, JS, CSS, templates): no compilation needed.
     if (!hasDartChanges) {
       log.debug('Static files changed.');
       await _notifyBrowserRefresh();

--- a/tools/serverpod_cli/lib/src/commands/start/watch_session.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/watch_session.dart
@@ -187,7 +187,6 @@ class WatchSession {
 
     // Static-only changes (HTML, JS, CSS, templates): no compilation needed.
     if (!hasDartChanges) {
-      log.debug('Static files changed.');
       await _notifyBrowserRefresh();
       return;
     }

--- a/tools/serverpod_cli/lib/src/commands/start/watch_session.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/watch_session.dart
@@ -185,9 +185,11 @@ class WatchSession {
         event.modelFiles.isNotEmpty ||
         event.packageConfigChanged;
 
-    // Static-only changes (HTML, JS, CSS, templates): no compilation needed.
+    // Static-only changes (HTML, JS, CSS, templates): no compilation needed,
+    // just refresh the browser.
     if (!hasDartChanges) {
-      await _handleStaticChange();
+      log.debug('Static files changed.');
+      await _notifyBrowserRefresh();
       return;
     }
 
@@ -247,8 +249,9 @@ class WatchSession {
     // Without a compiler, drive a reload through the VM's own kernel
     // service instead of the FES pipeline.
     if (_compiler == null) {
-      await _reloadOrRestart(null);
+      final reloaded = await _reloadOrRestart(null);
       await _reloadFlutter();
+      if (reloaded) await _notifyBrowserRefresh();
       return;
     }
 
@@ -260,30 +263,43 @@ class WatchSession {
       ...generatedDartFiles,
     };
 
-    await _compileAndReload(
+    final reloaded = await _compileAndReload(
       dartFiles: allDartChanges,
       packageConfigChanged: event.packageConfigChanged,
     );
     // Always reload Flutter: flutter/lib-only changes short-circuit
     // the server compile but still need a Flutter refresh.
     await _reloadFlutter();
+    if (reloaded) await _notifyBrowserRefresh();
   }
 
   /// Returns `true` if [path] is inside a generated directory.
   bool _isGenerated(String path) =>
       _generatedDirPaths.any((prefix) => p.isWithin(prefix, path));
 
-  /// Notifies the server of static file changes for browser refresh.
-  Future<void> _handleStaticChange() async {
-    if (_server.isVmServiceConnected) {
-      log.debug('Static files changed, notifying server.');
+  /// Triggers a refresh of any connected browsers by bumping the server's
+  /// static change counter, which the dev auto-refresh script polls. Called
+  /// both for static file changes and after the server reloads new Dart code,
+  /// so server-rendered web pages stay in sync.
+  Future<void> _notifyBrowserRefresh() async {
+    if (!_server.isVmServiceConnected) {
+      log.debug('Server VM service not connected; skipping browser refresh.');
+      return;
+    }
+    try {
       await _server.notifyStaticChange();
       log.info('Browser refresh triggered.');
+    } catch (e) {
+      log.warning('Browser refresh failed: $e');
     }
   }
 
   /// Compiles changed files and hot-reloads or restarts the server.
-  Future<void> _compileAndReload({
+  ///
+  /// Returns `true` if the server is now running the new code, `false` if
+  /// generation, native build hooks, or compilation failed (or there was
+  /// nothing to compile).
+  Future<bool> _compileAndReload({
     required Set<String> dartFiles,
     required bool packageConfigChanged,
     bool forceFullCompile = false,
@@ -307,7 +323,7 @@ class WatchSession {
         case NativeAssetsApplyFailure(:final message):
           log.error('$message Server not reloaded.');
           if (changedPaths.isNotEmpty) _pendingPaths.addAll(changedPaths);
-          return;
+          return false;
         case NativeAssetsApplySuccess(:final restarted):
           if (restarted) {
             compilerRestartedByHooks = true;
@@ -345,25 +361,28 @@ class WatchSession {
       );
     } else {
       // No changes to compile.
-      return;
+      return false;
     }
 
     if (result == null) {
       // Compilation failed - remember which paths need re-invalidation.
       _pendingPaths.addAll(changedPaths);
-      return;
+      return false;
     }
 
     _pendingPaths.clear();
     compiler.accept();
 
-    await _reloadOrRestart(result);
+    return _reloadOrRestart(result);
   }
 
   /// Attempts hot reload; falls back to a server restart if reload fails.
-  Future<void> _reloadOrRestart(CompileResult? result) async {
-    if (await _reload(result?.dillOutput)) return;
-    await _fullCompileAndRestart();
+  ///
+  /// Returns `true` if the server is now running the new code (via a
+  /// successful hot reload or restart), `false` otherwise.
+  Future<bool> _reloadOrRestart(CompileResult? result) async {
+    if (await _reload(result?.dillOutput)) return true;
+    return _fullCompileAndRestart();
   }
 
   /// Resets the compiler, produces a fresh full dill, and restarts the server.
@@ -406,18 +425,20 @@ class WatchSession {
       throw StateError('Session has been disposed.');
     }
     return _chain(() async {
+      final bool reloaded;
       if (_compiler == null) {
         // forceReload doesn't fall through to restart; the file-change
         // path does (via _reloadOrRestart). Different intents.
-        await _reload(null);
+        reloaded = await _reload(null);
       } else {
-        await _compileAndReload(
+        reloaded = await _compileAndReload(
           dartFiles: const {},
           packageConfigChanged: false,
           forceFullCompile: true,
         );
       }
       await _reloadFlutter();
+      if (reloaded) await _notifyBrowserRefresh();
     });
   }
 
@@ -434,6 +455,7 @@ class WatchSession {
     return _chain(() async {
       if (await _fullCompileAndRestart()) {
         await _restartFlutter();
+        await _notifyBrowserRefresh();
       }
     });
   }

--- a/tools/serverpod_cli/test/commands/start/watch_session_test.dart
+++ b/tools/serverpod_cli/test/commands/start/watch_session_test.dart
@@ -266,7 +266,23 @@ void main() {
           'compile(changed):[/lib/a.dart]',
           'accept',
         ]);
-        expect(server.calls, ['reload:/out.dill']);
+        expect(server.calls, ['reload:/out.dill', 'notifyStaticChange']);
+      },
+    );
+
+    test(
+      'when the server hot reloads, '
+      'then the browser is refreshed after the reload',
+      () async {
+        final event = FileChangeEvent(
+          dartFiles: {'/lib/a.dart'},
+        );
+
+        await session.handleFileChange(event);
+
+        // The browser refresh must follow the reload so the page re-fetches
+        // the newly loaded server code.
+        expect(server.calls, ['reload:/out.dill', 'notifyStaticChange']);
       },
     );
   });
@@ -362,7 +378,7 @@ void main() {
           'compile(changed):[/lib/endpoint.dart, /lib/other.dart]',
           'accept',
         ]);
-        expect(server.calls, ['reload:/out.dill']);
+        expect(server.calls, ['reload:/out.dill', 'notifyStaticChange']);
       },
     );
   });
@@ -391,7 +407,7 @@ void main() {
           'compile(changed):[/generated/user.dart]',
           'accept',
         ]);
-        expect(server.calls, ['reload:/out.dill']);
+        expect(server.calls, ['reload:/out.dill', 'notifyStaticChange']);
       },
     );
   });
@@ -441,7 +457,7 @@ void main() {
           'compile(changed):[/generated/protocol.dart]',
           'accept',
         ]);
-        expect(server.calls, ['reload:/out.dill']);
+        expect(server.calls, ['reload:/out.dill', 'notifyStaticChange']);
       },
     );
   });
@@ -470,7 +486,7 @@ void main() {
           'compile(changed):[/generated/protocol.dart, /generated/user.dart, /lib/endpoint.dart]',
           'accept',
         ]);
-        expect(server.calls, ['reload:/out.dill']);
+        expect(server.calls, ['reload:/out.dill', 'notifyStaticChange']);
       },
     );
   });
@@ -596,7 +612,7 @@ void main() {
         // Old server should have no new calls.
         expect(server.calls, isEmpty);
         // New server should receive the reload.
-        expect(factoryServer.calls, ['reload:/out.dill']);
+        expect(factoryServer.calls, ['reload:/out.dill', 'notifyStaticChange']);
       },
     );
   });
@@ -1087,7 +1103,10 @@ void main() {
             'compile(changed):[/lib/helper.dart]',
             'accept',
           ]);
-          expect(classifierServer.calls, ['reload:/out.dill']);
+          expect(classifierServer.calls, [
+            'reload:/out.dill',
+            'notifyStaticChange',
+          ]);
         },
       );
 
@@ -1289,7 +1308,7 @@ class Counter {
         expect(noCompilerGenerateCalls, [
           {'/lib/a.dart'},
         ]);
-        expect(noCompilerServer.calls, ['reload:null']);
+        expect(noCompilerServer.calls, ['reload:null', 'notifyStaticChange']);
       },
     );
 
@@ -1315,7 +1334,7 @@ class Counter {
       () async {
         await noCompilerSession.forceReload();
 
-        expect(noCompilerServer.calls, ['reload:null']);
+        expect(noCompilerServer.calls, ['reload:null', 'notifyStaticChange']);
       },
     );
 
@@ -1408,7 +1427,7 @@ class Counter {
       () async {
         await noFactorySession.forceReload();
 
-        expect(noFactoryServer.calls, ['reload:null']);
+        expect(noFactoryServer.calls, ['reload:null', 'notifyStaticChange']);
       },
     );
 

--- a/tools/serverpod_cli/test/commands/start/watch_session_test.dart
+++ b/tools/serverpod_cli/test/commands/start/watch_session_test.dart
@@ -842,6 +842,10 @@ void main() {
       test('then it creates a new server with the fresh full dill.', () {
         expect(factoryCalls, ['createServer:/out.dill']);
       });
+
+      test('then it refreshes the browser on the new server.', () {
+        expect(factoryServer.calls, contains('notifyStaticChange'));
+      });
     },
   );
 


### PR DESCRIPTION
In `serverpod start` watch mode, the browser was only auto-refreshed when a static file (HTML, CSS, JS, or template) changed. A change to Dart code hot-reloaded the server but left any open server-rendered web page showing stale content until it was manually reloaded.

This wires the existing browser-refresh mechanism into the Dart-change path, which now refreshes for *any* server change, not just static-file changes.

The refresh only fires when the server actually reloaded, code generation or compilation failures don't trigger a refresh to a stale page.

Fixes #5222 

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes
None