### PR TITLE
fix: Make the interactive project selector work on Windows

### DIFF
--- a/templates/pubspecs/tools/serverpod_cli/pubspec.yaml
+++ b/templates/pubspecs/tools/serverpod_cli/pubspec.yaml
@@ -28,6 +28,7 @@ dependencies:
   # details, see: https://github.com/dart-lang/dart_style/issues/1785
   dart_style: 3.1.5
   data_assets: '>=0.19.0 <0.20.0'
+  ffi: ^2.1.4
   file: ^7.0.1
   hooks: ^1.0.0
   hooks_runner: ^1.2.1

--- a/templates/pubspecs/tools/serverpod_cli/pubspec.yaml
+++ b/templates/pubspecs/tools/serverpod_cli/pubspec.yaml
@@ -61,6 +61,7 @@ dependencies:
   vm_service: '>=13.0.0 <16.0.0'
   watcher: ^1.0.2
   whiskers: ^0.1.1
+  win32: ^5.13.0
   yaml: ^3.1.2
   yaml_edit: ^2.2.2
 

--- a/tools/serverpod_cli/lib/src/util/cli_tools_select.dart
+++ b/tools/serverpod_cli/lib/src/util/cli_tools_select.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:cli_tools/cli_tools.dart';
+import 'package:serverpod_cli/src/util/windows_console_input.dart';
 
 export 'package:cli_tools/cli_tools.dart' show Option;
 
@@ -33,15 +34,23 @@ Future<Option> select(
 
   bool? originalEchoMode;
   bool? originalLineMode;
+  int? originalWindowsConsoleMode;
   if (hasTerminalInput) {
     originalEchoMode = stdin.echoMode;
     originalLineMode = stdin.lineMode;
     stdin.echoMode = false;
     stdin.lineMode = false;
+    if (Platform.isWindows) {
+      // Windows Terminal/ConPTY delivers arrow keys as character-less key
+      // events that readByteSync drops, so the ESC [ A / ESC [ B parsing below
+      // never sees them. Enabling virtual-terminal input makes the cursor keys
+      // arrive as those escape sequences, exactly as on POSIX terminals.
+      originalWindowsConsoleMode = enableWindowsVirtualTerminalInput();
+    }
   }
 
   try {
-    _renderState(
+    await _renderState(
       selectedIndex: selectedIndex,
       options: options,
       promptMessage: prompt,
@@ -71,44 +80,58 @@ Future<Option> select(
         throw ExitException.error();
       }
 
-      if (keyCode == _KeyCodes.escapeSequenceStart) {
-        var nextByte = stdin.readByteSync();
-        if (nextByte == _KeyCodes.controlSequenceIntroducer) {
-          nextByte = stdin.readByteSync();
-          if (nextByte == _KeyCodes.arrowUp) {
-            selectedIndex =
-                (selectedIndex - 1 + options.length) % options.length;
-          } else if (nextByte == _KeyCodes.arrowDown) {
-            selectedIndex = (selectedIndex + 1) % options.length;
-          } else {
-            continue;
+      // Navigation: arrow keys, plus j/k (vim-style) as aliases. The aliases
+      // matter on terminals/sessions where the cursor keys don't reach stdin
+      // as escape sequences. mason_logger uses the same j/k convention.
+      int? step;
+      if (keyCode == _KeyCodes.k) {
+        step = -1;
+      } else if (keyCode == _KeyCodes.j) {
+        step = 1;
+      } else if (keyCode == _KeyCodes.escapeSequenceStart) {
+        if (stdin.readByteSync() == _KeyCodes.controlSequenceIntroducer) {
+          final arrow = stdin.readByteSync();
+          if (arrow == _KeyCodes.arrowUp) {
+            step = -1;
+          } else if (arrow == _KeyCodes.arrowDown) {
+            step = 1;
           }
-
-          _renderState(
-            selectedIndex: selectedIndex,
-            options: options,
-            promptMessage: prompt,
-            lineCount: lineCount,
-            redraw: true,
-          );
         }
       }
+
+      if (step == null) continue;
+
+      selectedIndex = (selectedIndex + step + options.length) % options.length;
+      await _renderState(
+        selectedIndex: selectedIndex,
+        options: options,
+        promptMessage: prompt,
+        lineCount: lineCount,
+        redraw: true,
+      );
     }
   } finally {
     if (hasTerminalInput) {
-      stdin.echoMode = originalEchoMode!;
+      if (originalWindowsConsoleMode != null) {
+        restoreWindowsConsoleInputMode(originalWindowsConsoleMode);
+      }
+      // Restore lineMode before echoMode: on Windows ENABLE_ECHO_INPUT is only
+      // valid while ENABLE_LINE_INPUT is set, so re-enabling echo while line
+      // mode is still off throws "Error setting terminal echo mode ... errno =
+      // 87". Line-without-echo is a valid intermediate state on every platform.
       stdin.lineMode = originalLineMode!;
+      stdin.echoMode = originalEchoMode!;
     }
   }
 }
 
-void _renderState({
+Future<void> _renderState({
   required int selectedIndex,
   required List<Option> options,
   required String promptMessage,
   required int lineCount,
   required bool redraw,
-}) {
+}) async {
   if (redraw) {
     stdout.write('\x1B[${lineCount}A\x1B[0J');
   }
@@ -124,6 +147,14 @@ void _renderState({
 
   stdout.writeln();
   stdout.writeln('Press [Enter] to confirm.');
+
+  // Drain stdout to the terminal before the caller blocks on
+  // stdin.readByteSync(). A synchronous read parks the isolate without
+  // running the event loop, so anything still buffered in stdout never
+  // reaches a Windows console — the menu renders blank even though key
+  // input keeps working. The previous cli_tools-based path avoided this
+  // by writing from the IsolatedLogWriter's still-spinning isolate.
+  await stdout.flush();
 }
 
 abstract final class _KeyCodes {
@@ -134,6 +165,8 @@ abstract final class _KeyCodes {
   static const enterCR = 13;
   static const enterLF = 10;
   static const q = 113;
+  static const j = 106;
+  static const k = 107;
 }
 
 String _underline(final String text) => '\x1B[4m$text\x1B[0m';

--- a/tools/serverpod_cli/lib/src/util/windows_console_input.dart
+++ b/tools/serverpod_cli/lib/src/util/windows_console_input.dart
@@ -1,0 +1,69 @@
+import 'dart:ffi';
+
+import 'package:ffi/ffi.dart';
+
+/// Enables virtual-terminal input on the Windows console so that special keys
+/// (notably the arrow keys) are delivered to `stdin` as ANSI escape sequences.
+///
+/// Windows Terminal/ConPTY otherwise reports arrow keys as character-less key
+/// events that `stdin.readByteSync()` discards, so an escape-sequence based
+/// prompt never sees them. Enabling this mode makes the cursor keys arrive as
+/// the same `ESC [ A` / `ESC [ B` sequences they do on POSIX terminals.
+///
+/// Returns the previous console mode to hand to
+/// [restoreWindowsConsoleInputMode], or `null` if the mode could not be read
+/// or changed (for example when stdin is not a console).
+///
+/// Only call this on Windows; the `kernel32.dll` bindings are loaded lazily
+/// and are unavailable on other platforms.
+int? enableWindowsVirtualTerminalInput() {
+  final handle = _getStdHandle(_stdInputHandle);
+  final modePointer = calloc<Uint32>();
+  try {
+    if (_getConsoleMode(handle, modePointer) == 0) return null;
+
+    final originalMode = modePointer.value;
+    final result = _setConsoleMode(
+      handle,
+      originalMode | _enableVirtualTerminalInput,
+    );
+    return result == 0 ? null : originalMode;
+  } finally {
+    calloc.free(modePointer);
+  }
+}
+
+/// Restores a console input mode previously captured by
+/// [enableWindowsVirtualTerminalInput].
+void restoreWindowsConsoleInputMode(int mode) {
+  _setConsoleMode(_getStdHandle(_stdInputHandle), mode);
+}
+
+const int _stdInputHandle = -10;
+const int _enableVirtualTerminalInput = 0x0200;
+
+typedef _GetStdHandleC = IntPtr Function(Uint32 nStdHandle);
+typedef _GetStdHandleDart = int Function(int nStdHandle);
+
+typedef _GetConsoleModeC =
+    Int32 Function(
+      IntPtr hConsoleHandle,
+      Pointer<Uint32> lpMode,
+    );
+typedef _GetConsoleModeDart =
+    int Function(
+      int hConsoleHandle,
+      Pointer<Uint32> lpMode,
+    );
+
+typedef _SetConsoleModeC = Int32 Function(IntPtr hConsoleHandle, Uint32 dwMode);
+typedef _SetConsoleModeDart = int Function(int hConsoleHandle, int dwMode);
+
+final DynamicLibrary _kernel32 = DynamicLibrary.open('kernel32.dll');
+
+final _getStdHandle = _kernel32
+    .lookupFunction<_GetStdHandleC, _GetStdHandleDart>('GetStdHandle');
+final _getConsoleMode = _kernel32
+    .lookupFunction<_GetConsoleModeC, _GetConsoleModeDart>('GetConsoleMode');
+final _setConsoleMode = _kernel32
+    .lookupFunction<_SetConsoleModeC, _SetConsoleModeDart>('SetConsoleMode');

--- a/tools/serverpod_cli/lib/src/util/windows_console_input.dart
+++ b/tools/serverpod_cli/lib/src/util/windows_console_input.dart
@@ -1,6 +1,7 @@
 import 'dart:ffi';
 
 import 'package:ffi/ffi.dart';
+import 'package:win32/win32.dart';
 
 /// Enables virtual-terminal input on the Windows console so that special keys
 /// (notably the arrow keys) are delivered to `stdin` as ANSI escape sequences.
@@ -14,18 +15,18 @@ import 'package:ffi/ffi.dart';
 /// [restoreWindowsConsoleInputMode], or `null` if the mode could not be read
 /// or changed (for example when stdin is not a console).
 ///
-/// Only call this on Windows; the `kernel32.dll` bindings are loaded lazily
-/// and are unavailable on other platforms.
+/// Only call this on Windows; the underlying `kernel32.dll` bindings (via
+/// `package:win32`) are unavailable on other platforms.
 int? enableWindowsVirtualTerminalInput() {
-  final handle = _getStdHandle(_stdInputHandle);
+  final handle = GetStdHandle(STD_INPUT_HANDLE);
   final modePointer = calloc<Uint32>();
   try {
-    if (_getConsoleMode(handle, modePointer) == 0) return null;
+    if (GetConsoleMode(handle, modePointer) == 0) return null;
 
     final originalMode = modePointer.value;
-    final result = _setConsoleMode(
+    final result = SetConsoleMode(
       handle,
-      originalMode | _enableVirtualTerminalInput,
+      originalMode | ENABLE_VIRTUAL_TERMINAL_INPUT,
     );
     return result == 0 ? null : originalMode;
   } finally {
@@ -36,34 +37,5 @@ int? enableWindowsVirtualTerminalInput() {
 /// Restores a console input mode previously captured by
 /// [enableWindowsVirtualTerminalInput].
 void restoreWindowsConsoleInputMode(int mode) {
-  _setConsoleMode(_getStdHandle(_stdInputHandle), mode);
+  SetConsoleMode(GetStdHandle(STD_INPUT_HANDLE), mode);
 }
-
-const int _stdInputHandle = -10;
-const int _enableVirtualTerminalInput = 0x0200;
-
-typedef _GetStdHandleC = IntPtr Function(Uint32 nStdHandle);
-typedef _GetStdHandleDart = int Function(int nStdHandle);
-
-typedef _GetConsoleModeC =
-    Int32 Function(
-      IntPtr hConsoleHandle,
-      Pointer<Uint32> lpMode,
-    );
-typedef _GetConsoleModeDart =
-    int Function(
-      int hConsoleHandle,
-      Pointer<Uint32> lpMode,
-    );
-
-typedef _SetConsoleModeC = Int32 Function(IntPtr hConsoleHandle, Uint32 dwMode);
-typedef _SetConsoleModeDart = int Function(int hConsoleHandle, int dwMode);
-
-final DynamicLibrary _kernel32 = DynamicLibrary.open('kernel32.dll');
-
-final _getStdHandle = _kernel32
-    .lookupFunction<_GetStdHandleC, _GetStdHandleDart>('GetStdHandle');
-final _getConsoleMode = _kernel32
-    .lookupFunction<_GetConsoleModeC, _GetConsoleModeDart>('GetConsoleMode');
-final _setConsoleMode = _kernel32
-    .lookupFunction<_SetConsoleModeC, _SetConsoleModeDart>('SetConsoleMode');

--- a/tools/serverpod_cli/pubspec.yaml
+++ b/tools/serverpod_cli/pubspec.yaml
@@ -62,6 +62,7 @@ dependencies:
   vm_service: '>=13.0.0 <16.0.0'
   watcher: ^1.0.2
   whiskers: ^0.1.1
+  win32: ^5.13.0
   yaml: ^3.1.2
   yaml_edit: ^2.2.2
 

--- a/tools/serverpod_cli/pubspec.yaml
+++ b/tools/serverpod_cli/pubspec.yaml
@@ -29,6 +29,7 @@ dependencies:
   # details, see: https://github.com/dart-lang/dart_style/issues/1785
   dart_style: 3.1.5
   data_assets: '>=0.19.0 <0.20.0'
+  ffi: ^2.1.4
   file: ^7.0.1
   hooks: ^1.0.0
   hooks_runner: ^1.2.1


### PR DESCRIPTION
The selector shown when multiple Serverpod servers are detected was broken on Windows: blank screen, arrow keys didn't navigate, and Enter threw StdinException (errno 87).

This keeps the standard terminal prompt and fixes three Windows-specific bugs in cli_tools_select.dart:
- Flush `stdout` after each render so the menu reaches the Windows console before the blocking readByteSync();
- Restore `lineMode` before `echoMode` on exit.
- Enable `ENABLE_VIRTUAL_TERMINAL_INPUT` on Windows so cursor keys arrive as ESC[A/B (Windows Terminal/ConPTY otherwise drops them), restored on exit. Add j/k as navigation aliases, matching `mason_logger`.

Note: There was some discussion about whether or not we should go with the arrow key functionality vs listing each option tied to a number key for selection. Packages like Melos for Windows revert to just using the number approach but several other packages like Mason implement the full support to get arrow keys to render. I went with how Mason implements the support in order to keep it consistent between MacOS and Linux.

Extra Note: I do think long term we should look at using our new `serverpod_tui` for this as there will always be platform/OS edge cases that come up. But this is an easy win for now.

Fixes #5172 

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes
None