### PR TITLE
feat: Expose L key to clear logs on serverpod start

### DIFF
--- a/tools/serverpod_cli/lib/src/commands/start/tui/app.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/tui/app.dart
@@ -189,6 +189,10 @@ class ServerpodWatchAppState extends TuiAppState<ServerpodWatchApp> {
         onCreateMigration: onCreateMigration,
         onCreateRepairMigration: onCreateRepairMigration,
         onApplyMigration: onApplyMigration,
+        onClearLogs: () {
+          state.clearLogs();
+          _rebuild();
+        },
         onQuit: onQuit,
       ),
     );

--- a/tools/serverpod_cli/lib/src/commands/start/tui/main_screen.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/tui/main_screen.dart
@@ -26,6 +26,7 @@ class MainScreen extends StatelessComponent {
     this.onCreateMigration,
     this.onCreateRepairMigration,
     this.onApplyMigration,
+    this.onClearLogs,
     this.onQuit,
   });
 
@@ -42,6 +43,7 @@ class MainScreen extends StatelessComponent {
   final void Function({bool force})? onCreateMigration;
   final void Function({bool force})? onCreateRepairMigration;
   final VoidCallback? onApplyMigration;
+  final VoidCallback? onClearLogs;
   final VoidCallback? onQuit;
 
   static const _helpBindings = [
@@ -76,6 +78,7 @@ class MainScreen extends StatelessComponent {
         ('M / Shift+M', 'Create migration (⇧ = force)'),
         ('P / Shift+P', 'Repair migration (⇧ = force)'),
         ('A', 'Apply migrations'),
+        ('L', 'Clear logs'),
         ('Q', 'Quit'),
       ],
     ),
@@ -356,6 +359,13 @@ class MainScreen extends StatelessComponent {
           activationKeys: const [LogicalKey.keyA],
           onActivate: (_) => onApplyMigration?.call(),
           enabled: actionsEnabled && onApplyMigration != null,
+        ),
+        Button(
+          name: 'Clear logs',
+          activationChar: 'L',
+          activationKeys: const [LogicalKey.keyL],
+          onActivate: (_) => onClearLogs?.call(),
+          enabled: onClearLogs != null,
         ),
         Button(
           name: 'Help',

--- a/tools/serverpod_cli/lib/src/commands/start/tui/state.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/tui/state.dart
@@ -67,4 +67,14 @@ class ServerWatchState extends TuiState {
 
   /// Maximum number of raw lines to keep.
   static const maxRawLines = 10000;
+
+  /// Drops all server, raw server, and Flutter log entries.
+  ///
+  /// In-progress [activeOperations] are kept so a running hot reload or
+  /// migration still renders its pinned spinner after the buffers are cleared.
+  void clearLogs() {
+    logHistory.clear();
+    rawLines.clear();
+    rawFlutterLines.clear();
+  }
 }

--- a/tools/serverpod_cli/test/commands/start/tui/state_test.dart
+++ b/tools/serverpod_cli/test/commands/start/tui/state_test.dart
@@ -1,4 +1,5 @@
 import 'package:serverpod_cli/src/commands/start/tui/state.dart';
+import 'package:serverpod_tui/serverpod_tui.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -20,4 +21,47 @@ void main() {
       expect(state.showHelp, isFalse);
     });
   });
+
+  group('Given a ServerWatchState with entries in every log buffer', () {
+    late ServerWatchState state;
+
+    setUp(() {
+      state = ServerWatchState();
+      state.logHistory.add('server entry');
+      state.rawLines.add('raw server line');
+      state.rawFlutterLines.add('raw flutter line');
+    });
+
+    test('when clearLogs is called then every log buffer is emptied', () {
+      state.clearLogs();
+
+      expect(state.logHistory, isEmpty);
+      expect(state.rawLines, isEmpty);
+      expect(state.rawFlutterLines, isEmpty);
+    });
+  });
+
+  group(
+    'Given a ServerWatchState with in-progress operations and log entries',
+    () {
+      late ServerWatchState state;
+      late TrackedOperation operation;
+
+      setUp(() {
+        state = ServerWatchState();
+        operation = TrackedOperation(id: 'hot-reload', label: 'Hot reload');
+        state.activeOperations[operation.id] = operation;
+        state.logHistory.add('server entry');
+        state.rawLines.add('raw server line');
+        state.rawFlutterLines.add('raw flutter line');
+      });
+
+      test('when clearLogs is called then activeOperations are preserved', () {
+        state.clearLogs();
+
+        expect(state.activeOperations, hasLength(1));
+        expect(state.activeOperations[operation.id], same(operation));
+      });
+    },
+  );
 }


### PR DESCRIPTION
Adds an `L` button to the `serverpod start` TUI button bar that empties every log buffer in one keystroke, structured server log history, raw server stdout/stderr, and Flutter stdout/stderr.

I went with the behavior to clear logs across **ALL** tabs as the split pain makes it a bit difficult to understand which logs the user would want to clear, but if we would rather it just clear the current active tab it would be a very simple change. It's just then we would need to decide if the TUI has the side-by-side layout with server logs & raw server logs and then the right side is **always** flutter logs, what's the "active" tab?

Fixes #5199 

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes
None