### PR TITLE
feat: Wire Ctrl-C copy-or-exit through serverpod start and create

### DIFF
--- a/tools/serverpod_cli/lib/src/commands/create/tui/app.dart
+++ b/tools/serverpod_cli/lib/src/commands/create/tui/app.dart
@@ -35,6 +35,9 @@ class ServerpodCreateAppState extends TuiAppState<ServerpodCreateApp> {
   }
 
   @override
+  void onExit() => component.onQuit();
+
+  @override
   Component buildApp(BuildContext context) {
     return Focusable(
       focused: true,

--- a/tools/serverpod_cli/lib/src/commands/start/tui/app.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/tui/app.dart
@@ -163,6 +163,16 @@ class ServerpodWatchAppState extends TuiAppState<ServerpodWatchApp> {
   }
 
   @override
+  void onExit() {
+    final quit = onQuit;
+    if (quit != null) {
+      quit();
+    } else {
+      super.onExit();
+    }
+  }
+
+  @override
   Component buildApp(BuildContext context) {
     final state = component.holder.state;
 
@@ -202,6 +212,10 @@ class ServerpodWatchAppState extends TuiAppState<ServerpodWatchApp> {
         state.showHelp = false;
         _rebuild();
         return true;
+      }
+      // Let Ctrl-C bubble to the base TuiAppState so copy/exit still work.
+      if (event.logicalKey == LogicalKey.keyC && event.isControlPressed) {
+        return false;
       }
       // Route navigation keys to the help overlay's controller; absorb the
       // rest so they don't fall through to tab/scroll handling underneath.

--- a/tools/serverpod_cli/test/commands/create/tui/app_test.dart
+++ b/tools/serverpod_cli/test/commands/create/tui/app_test.dart
@@ -15,33 +15,33 @@ Future<void> _sendCtrlC(NoctermTester tester) {
 }
 
 void main() {
-  late NoctermTester tester;
-  late CreateConfigState state;
-  late CreateAppStateHolder holder;
-  late int quitCalls;
-
-  setUp(() async {
-    state = CreateConfigState(ServerpodTemplateType.server);
-    holder = CreateAppStateHolder(state);
-    quitCalls = 0;
-    tester = await NoctermTester.create(size: const Size(80, 24));
-    await tester.pumpComponent(
-      ServerpodCreateApp(
-        holder: holder,
-        name: 'test_project',
-        onCreate: () {},
-        onQuit: () => quitCalls++,
-        onSkipFlutterBuild: () {},
-      ),
-    );
-  });
-
-  tearDown(() async {
-    tester.dispose();
-    await holder.dispose();
-  });
-
   group('Given the create TUI', () {
+    late NoctermTester tester;
+    late CreateConfigState state;
+    late CreateAppStateHolder holder;
+    late int quitCalls;
+
+    setUp(() async {
+      state = CreateConfigState(ServerpodTemplateType.server);
+      holder = CreateAppStateHolder(state);
+      quitCalls = 0;
+      tester = await NoctermTester.create(size: const Size(80, 24));
+      await tester.pumpComponent(
+        ServerpodCreateApp(
+          holder: holder,
+          name: 'test_project',
+          onCreate: () {},
+          onQuit: () => quitCalls++,
+          onSkipFlutterBuild: () {},
+        ),
+      );
+    });
+
+    tearDown(() async {
+      tester.dispose();
+      await holder.dispose();
+    });
+
     test(
       'when Ctrl-C is pressed twice without a selection then onQuit is invoked',
       () async {

--- a/tools/serverpod_cli/test/commands/create/tui/app_test.dart
+++ b/tools/serverpod_cli/test/commands/create/tui/app_test.dart
@@ -1,0 +1,55 @@
+import 'package:nocterm/nocterm.dart';
+import 'package:serverpod_cli/src/commands/create/tui/app.dart';
+import 'package:serverpod_cli/src/commands/create/tui/state.dart';
+import 'package:serverpod_cli/src/commands/create/tui/state_holder.dart';
+import 'package:serverpod_cli/src/create/create.dart';
+import 'package:test/test.dart';
+
+Future<void> _sendCtrlC(NoctermTester tester) {
+  return tester.sendKeyEvent(
+    const KeyboardEvent(
+      logicalKey: LogicalKey.keyC,
+      modifiers: ModifierKeys(ctrl: true),
+    ),
+  );
+}
+
+void main() {
+  late NoctermTester tester;
+  late CreateConfigState state;
+  late CreateAppStateHolder holder;
+  late int quitCalls;
+
+  setUp(() async {
+    state = CreateConfigState(ServerpodTemplateType.server);
+    holder = CreateAppStateHolder(state);
+    quitCalls = 0;
+    tester = await NoctermTester.create(size: const Size(80, 24));
+    await tester.pumpComponent(
+      ServerpodCreateApp(
+        holder: holder,
+        name: 'test_project',
+        onCreate: () {},
+        onQuit: () => quitCalls++,
+        onSkipFlutterBuild: () {},
+      ),
+    );
+  });
+
+  tearDown(() async {
+    tester.dispose();
+    await holder.dispose();
+  });
+
+  group('Given the create TUI', () {
+    test(
+      'when Ctrl-C is pressed twice without a selection then onQuit is invoked',
+      () async {
+        await _sendCtrlC(tester);
+        await _sendCtrlC(tester);
+
+        expect(quitCalls, 1);
+      },
+    );
+  });
+}

--- a/tools/serverpod_cli/test/commands/start/tui/app_test.dart
+++ b/tools/serverpod_cli/test/commands/start/tui/app_test.dart
@@ -1,0 +1,67 @@
+import 'package:nocterm/nocterm.dart';
+import 'package:serverpod_cli/src/commands/start/tui/app.dart';
+import 'package:serverpod_cli/src/commands/start/tui/state.dart';
+import 'package:test/test.dart';
+
+Future<void> _sendCtrlC(NoctermTester tester) {
+  return tester.sendKeyEvent(
+    const KeyboardEvent(
+      logicalKey: LogicalKey.keyC,
+      modifiers: ModifierKeys(ctrl: true),
+    ),
+  );
+}
+
+void main() {
+  late NoctermTester tester;
+  late ServerWatchState state;
+  late StartAppStateHolder holder;
+
+  setUp(() async {
+    state = ServerWatchState();
+    holder = StartAppStateHolder(state);
+    tester = await NoctermTester.create(size: const Size(80, 24));
+    await tester.pumpComponent(
+      ServerpodWatchApp(holder: holder, onReady: (_) {}),
+    );
+  });
+
+  tearDown(() async {
+    tester.dispose();
+    await holder.dispose();
+  });
+
+  group('Given onQuit is wired', () {
+    late int quitCalls;
+
+    setUp(() {
+      quitCalls = 0;
+      holder.onQuit = () => quitCalls++;
+    });
+
+    test(
+      'when Ctrl-C is pressed twice without a selection then onQuit is invoked',
+      () async {
+        await _sendCtrlC(tester);
+        await _sendCtrlC(tester);
+
+        expect(quitCalls, 1);
+      },
+    );
+  });
+
+  group('Given the help overlay is open', () {
+    setUp(() {
+      state.showHelp = true;
+    });
+
+    test(
+      'when Ctrl-C is pressed then exit is armed (it bubbles past the help-mode key absorber)',
+      () async {
+        await _sendCtrlC(tester);
+
+        expect(state.ctrlCHint, 'Press Ctrl-C again to exit');
+      },
+    );
+  });
+}

--- a/tools/serverpod_cli/test/commands/start/tui/app_test.dart
+++ b/tools/serverpod_cli/test/commands/start/tui/app_test.dart
@@ -31,7 +31,7 @@ void main() {
     await holder.dispose();
   });
 
-  group('Given onQuit is wired', () {
+  group('Given a running TUI start app with onQuit callback wired', () {
     late int quitCalls;
 
     setUp(() {
@@ -50,13 +50,13 @@ void main() {
     );
   });
 
-  group('Given the help overlay is open', () {
+  group('Given a running TUI start app with the help overlay open', () {
     setUp(() {
       state.showHelp = true;
     });
 
     test(
-      'when Ctrl-C is pressed then exit is armed (it bubbles past the help-mode key absorber)',
+      'when Ctrl-C is pressed then it bubbles past the help-mode key absorber and exit is armed',
       () async {
         await _sendCtrlC(tester);
 


### PR DESCRIPTION
Wiring for the new Ctrl-C handler in serverpod_tui 0.1.0-rc.4. Routes the second Ctrl-C through each app's existing quit path (onQuit) so server tear-down still runs in serverpod start and the create wizard exits with the same code 1 as 'Q'. Also lets Ctrl-C bubble out of the start app's help-overlay, so copy/exit still work while help is open.

Fixes #5170 

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes
None