### PR TITLE
refactor: Replace project-tree walk with explicit paths in TemplateRenderer

### DIFF
--- a/tools/serverpod_cli/lib/src/create/copier.dart
+++ b/tools/serverpod_cli/lib/src/create/copier.dart
@@ -19,6 +19,8 @@ class Copier {
 
   bool processUncommentMarker;
 
+  final List<String> _writtenPaths = [];
+
   Copier({
     required this.srcDir,
     required this.dstDir,
@@ -32,8 +34,11 @@ class Copier {
          // the Serverpod repository when using a local built CLI.
          ..addAll(['pubspec.lock', 'pubspec_overrides.yaml']);
 
-  void copyFiles() {
+  /// Copies the template tree into [dstDir] and returns the absolute
+  /// paths of every file written.
+  List<String> copyFiles() {
     _copyDirectory(srcDir, '');
+    return _writtenPaths;
   }
 
   void _copyDirectory(Directory dir, String relativePath) {
@@ -77,6 +82,7 @@ class Copier {
     }
     dstFile.createSync(recursive: true);
     dstFile.writeAsStringSync(contents);
+    _writtenPaths.add(dstFile.path);
   }
 
   String _replace(String str, List<Replacement> replacements) {

--- a/tools/serverpod_cli/lib/src/create/create.dart
+++ b/tools/serverpod_cli/lib/src/create/create.dart
@@ -163,54 +163,59 @@ Future<String?> performCreate(
     newParagraph: true,
   );
 
+  final writtenPaths = <String>{};
+
   if (template == ServerpodTemplateType.server ||
       template == ServerpodTemplateType.mini) {
     success &= await log.progress(
       'Writing project files.',
       () async {
-        _copyServerTemplates(
-          serverpodDirs,
-          name: name,
-          customServerpodPath: productionMode ? null : serverpodHome,
+        writtenPaths.addAll(
+          _copyServerTemplates(
+            serverpodDirs,
+            name: name,
+            customServerpodPath: productionMode ? null : serverpodHome,
+          ),
         );
         return true;
       },
     );
   } else if (template == ServerpodTemplateType.module) {
-    success &= await log.progress(
-      'Writing project files.',
-      () => Future(() {
+    success &= await log.progress('Writing project files.', () async {
+      writtenPaths.addAll(
         _copyModuleTemplates(
           serverpodDirs,
           name: name,
           customServerpodPath: productionMode ? null : serverpodHome,
-        );
-        return true;
-      }),
-    );
+        ),
+      );
+      return true;
+    });
   }
 
   if (template == ServerpodTemplateType.server) {
     success &= await log.progress(
       'Writing additional project files.',
       () async {
-        await _copyServerUpgrade(
-          serverpodDirs,
-          name: name,
-          isUpgrade: false,
-          customServerpodPath: productionMode ? null : serverpodHome,
-        );
-        await _copyFlutterUpgrade(
-          serverpodDirs,
-          name: name,
-          customServerpodPath: productionMode ? null : serverpodHome,
-        );
+        writtenPaths.addAll([
+          ...await _copyServerUpgrade(
+            serverpodDirs,
+            name: name,
+            isUpgrade: false,
+            customServerpodPath: productionMode ? null : serverpodHome,
+          ),
+          ...await _copyFlutterUpgrade(
+            serverpodDirs,
+            name: name,
+            customServerpodPath: productionMode ? null : serverpodHome,
+          ),
+        ]);
         return true;
       },
     );
   }
 
-  success &= await _renderTemplates(serverpodDirs.projectDir, context);
+  success &= await _renderTemplates(writtenPaths, context);
 
   success &= await log.progress('Getting workspace dependencies.', () {
     return CommandLineTools.dartPubGet(serverpodDirs.projectDir);
@@ -468,21 +473,24 @@ Future<String?> _performUpgrade({
     projectDir: serverDir.parent,
   );
 
+  final writtenPaths = <String>{};
   var success = true;
   success &= await log.progress(
     'Upgrading project.',
     () async {
-      await _copyServerUpgrade(
-        serverpodDir,
-        name: name,
-        isUpgrade: true,
-        customServerpodPath: productionMode ? null : serverpodHome,
+      writtenPaths.addAll(
+        await _copyServerUpgrade(
+          serverpodDir,
+          name: name,
+          isUpgrade: true,
+          customServerpodPath: productionMode ? null : serverpodHome,
+        ),
       );
       return true;
     },
   );
 
-  success &= await _renderTemplates(serverpodDir.projectDir, context);
+  success &= await _renderTemplates(writtenPaths, context);
 
   success &= await _runGenerate(
     serverpodDir.serverDir,
@@ -512,10 +520,13 @@ Future<String?> _performUpgrade({
   return null;
 }
 
-/// Parses and renders the template files in the given directory.
-Future<bool> _renderTemplates(Directory dir, TemplateContext context) async {
+/// Renders Mustache directives in the file paths the copiers just wrote.
+Future<bool> _renderTemplates(
+  Iterable<String> paths,
+  TemplateContext context,
+) async {
   return await log.progress('Applying template options', () async {
-    await TemplateRenderer(dir: dir).render(context);
+    await const TemplateRenderer().renderPaths(paths, context);
     return true;
   });
 }
@@ -633,7 +644,7 @@ void _createDirectory(Directory dir) {
   dir.createSync();
 }
 
-Future<void> _copyFlutterUpgrade(
+Future<List<String>> _copyFlutterUpgrade(
   ServerpodDirectories serverpodDirs, {
   required String name,
   String? customServerpodPath,
@@ -656,7 +667,7 @@ Future<void> _copyFlutterUpgrade(
     fileNameReplacements: const [],
     ignoreFileNames: const [],
   );
-  copier.copyFiles();
+  final writtenPaths = [...copier.copyFiles()];
 
   log.debug('Adding auth dependencies to Flutter pubspec', newParagraph: true);
   _addDependenciesToPubspec(
@@ -729,9 +740,10 @@ Future<void> _copyFlutterUpgrade(
       ],
     );
   }
+  return writtenPaths;
 }
 
-Future<void> _copyServerUpgrade(
+Future<List<String>> _copyServerUpgrade(
   ServerpodDirectories serverpodDirs, {
   required String name,
   required bool isUpgrade,
@@ -880,7 +892,7 @@ Future<void> _copyServerUpgrade(
       ],
     ],
   );
-  copier.copyFiles();
+  final writtenPaths = [...copier.copyFiles()];
 
   log.debug('Copying .github files', newParagraph: true);
   copier = Copier(
@@ -914,7 +926,7 @@ Future<void> _copyServerUpgrade(
     ],
     fileNameReplacements: [],
   );
-  copier.copyFiles();
+  writtenPaths.addAll(copier.copyFiles());
 
   if (!isUpgrade) {
     log.debug('Copying .vscode files', newParagraph: true);
@@ -935,7 +947,7 @@ Future<void> _copyServerUpgrade(
       ],
       fileNameReplacements: [],
     );
-    copier.copyFiles();
+    writtenPaths.addAll(copier.copyFiles());
   }
 
   if (!isUpgrade) {
@@ -984,6 +996,7 @@ Future<void> _copyServerUpgrade(
       );
     }
   }
+  return writtenPaths;
 }
 
 void _enableWorkspaceInRootPubspec({
@@ -1010,11 +1023,12 @@ void _addDependenciesToPubspec({
   pubspecFile.writeAsStringSync(contents);
 }
 
-void _copyServerTemplates(
+List<String> _copyServerTemplates(
   ServerpodDirectories serverpodDirs, {
   required String name,
   String? customServerpodPath,
 }) {
+  final writtenPaths = <String>[];
   log.debug('Copying root workspace pubspec');
   var rootCopier = Copier(
     srcDir: Directory(
@@ -1045,7 +1059,7 @@ void _copyServerTemplates(
     ],
     ignoreFileNames: const [],
   );
-  rootCopier.copyFiles();
+  writtenPaths.addAll(rootCopier.copyFiles());
 
   log.debug('Copying server files');
   var copier = Copier(
@@ -1075,7 +1089,7 @@ void _copyServerTemplates(
       ),
     ],
   );
-  copier.copyFiles();
+  writtenPaths.addAll(copier.copyFiles());
 
   log.debug('Copying client files', newParagraph: true);
   copier = Copier(
@@ -1105,7 +1119,7 @@ void _copyServerTemplates(
       ),
     ],
   );
-  copier.copyFiles();
+  writtenPaths.addAll(copier.copyFiles());
 
   log.debug('Copying Flutter files', newParagraph: true);
   copier = Copier(
@@ -1142,7 +1156,7 @@ void _copyServerTemplates(
       'build',
     ],
   );
-  copier.copyFiles();
+  writtenPaths.addAll(copier.copyFiles());
 
   log.debug('Enabling workspace configuration', newParagraph: true);
   _enableWorkspaceInRootPubspec(
@@ -1155,13 +1169,15 @@ void _copyServerTemplates(
       '${name}_flutter',
     ],
   );
+  return writtenPaths;
 }
 
-void _copyModuleTemplates(
+List<String> _copyModuleTemplates(
   ServerpodDirectories serverpodDirs, {
   required String name,
   String? customServerpodPath,
 }) {
+  final writtenPaths = <String>[];
   log.debug('Copying root workspace pubspec');
   var rootCopier = Copier(
     srcDir: Directory(
@@ -1192,7 +1208,7 @@ void _copyModuleTemplates(
     ],
     ignoreFileNames: const [],
   );
-  rootCopier.copyFiles();
+  writtenPaths.addAll(rootCopier.copyFiles());
 
   log.debug('Copying server files', newParagraph: true);
   var copier = Copier(
@@ -1222,7 +1238,7 @@ void _copyModuleTemplates(
       ),
     ],
   );
-  copier.copyFiles();
+  writtenPaths.addAll(copier.copyFiles());
 
   log.debug('Copying client files', newParagraph: true);
   copier = Copier(
@@ -1252,7 +1268,7 @@ void _copyModuleTemplates(
       ),
     ],
   );
-  copier.copyFiles();
+  writtenPaths.addAll(copier.copyFiles());
 
   log.debug('Enabling workspace configuration', newParagraph: true);
   _enableWorkspaceInRootPubspec(
@@ -1264,6 +1280,7 @@ void _copyModuleTemplates(
       '${name}_server',
     ],
   );
+  return writtenPaths;
 }
 
 Future<bool> _runGenerate(

--- a/tools/serverpod_cli/lib/src/create/template_renderer.dart
+++ b/tools/serverpod_cli/lib/src/create/template_renderer.dart
@@ -6,24 +6,27 @@ import 'package:pub_semver/pub_semver.dart';
 import 'package:serverpod_cli/src/create/template_context.dart';
 import 'package:whiskers/whiskers.dart';
 
-/// Responsible for rendering template files in a directory using provided context.
-/// It processes both file contents and directory names,
-/// allowing for dynamic project structures.
+/// Renders Mustache `{{...}}` directives in a known set of file paths
+/// (typically the files [Copier] just wrote) and their ancestor
+/// directory names.
+///
+/// Operating on an explicit path list - rather than walking the project
+/// tree - guarantees the renderer never reads or rewrites a file the
+/// caller didn't ask for, sidestepping any question of "should we have
+/// entered `.dart_tool` / `build` / `.git`".
 class TemplateRenderer {
-  static const Set<String> _defaultExcludedDirNames = <String>{
-    '.git',
-    '.dart_tool',
-    '.idea',
-    '.github',
-    'node_modules',
-    'Pods',
-    // Dart/Flutter build output.
-    'build',
-    '.symlinks',
-    // Serverpod runtime artefacts.
-    'sqlite_data',
-    'migrations',
-    '.serverpod',
+  /// File extensions whose contents the renderer is allowed to read and
+  /// rewrite. Serverpod templates only produce text files in this set;
+  /// anything else is left untouched as a defensive sanity guard.
+  static const Set<String> _renderableExtensions = <String>{
+    '.dart',
+    '.yaml',
+    '.yml',
+    '.json',
+    '.html',
+    '.css',
+    '.md',
+    '.svg',
   };
 
   static final DartFormatter _dartFormatter = DartFormatter(
@@ -32,93 +35,135 @@ class TemplateRenderer {
     trailingCommas: TrailingCommas.preserve,
   );
 
-  /// Creates a [TemplateRenderer].
+  const TemplateRenderer();
+
+  /// Renders [paths] under [context]:
   ///
-  /// [excludedDirNames] may be passed to override the default set of
-  /// directory basenames that are skipped during traversal.
-  TemplateRenderer({
-    required this.dir,
-    Set<String>? excludedDirNames,
-  }) : excludedDirNames = excludedDirNames ?? _defaultExcludedDirNames;
-
-  /// The target directory containing the template files to be rendered.
-  final Directory dir;
-
-  /// Directory basenames to skip while recursing.
-  final Set<String> excludedDirNames;
-
-  /// Renders the templates in the target directory using [context].
-  Future<void> render(TemplateContext context) async {
-    try {
-      await _renderDirectory(dir, context);
-    } on FileSystemException {
-      // Directory gone.
+  /// 1. Each ancestor directory whose basename contains a Mustache
+  ///    directive is renamed (deepest first). A directive that renders
+  ///    to empty deletes the directory recursively. A pre-existing
+  ///    target directory triggers a recursive merge instead of a
+  ///    rename, so a second upgrade run doesn't leave literal `{{...}}`
+  ///    directories behind on disk.
+  /// 2. Each surviving file's basename is rendered (renaming or
+  ///    deleting the file).
+  /// 3. Each surviving file's contents are rendered, and reformatted
+  ///    in-process via [DartFormatter] when the extension is `.dart`.
+  Future<void> renderPaths(
+    Iterable<String> paths,
+    TemplateContext context,
+  ) async {
+    final pathList = paths.toList();
+    await _renameAncestors(pathList, context);
+    for (final original in pathList) {
+      final current = _translateDirSegments(original, context);
+      if (current == null) continue;
+      final file = File(current);
+      if (!await file.exists()) continue;
+      await _renderFile(file, context);
     }
   }
 
-  /// Recursively renders all files and directories within the specified directory.
-  Future<void> _renderDirectory(
-    Directory dir,
+  /// Renames every ancestor directory of any path in [paths] whose
+  /// basename carries a Mustache directive. Deduplicated, deepest first
+  /// so each rename sees its parents under their original names.
+  Future<void> _renameAncestors(
+    List<String> paths,
     TemplateContext context,
   ) async {
-    await for (final entity in dir.list(recursive: false, followLinks: false)) {
-      if (entity is File) {
-        await _renderFile(entity, context);
-      } else if (entity is Directory) {
-        final basename = p.basename(entity.path);
-        if (excludedDirNames.contains(basename)) continue;
-        await _handleDirectoryRendering(entity, context);
+    final byDepth = <int, Set<String>>{};
+    for (final filePath in paths) {
+      var dir = p.dirname(filePath);
+      // `p.dirname` of a filesystem root returns itself.
+      while (dir != p.dirname(dir)) {
+        if (_hasTemplateMarker(p.basename(dir))) {
+          byDepth.putIfAbsent(p.split(dir).length, () => {}).add(dir);
+        }
+        dir = p.dirname(dir);
+      }
+    }
+    final depths = byDepth.keys.toList()..sort((a, b) => b.compareTo(a));
+    for (final depth in depths) {
+      for (final dirPath in byDepth[depth]!) {
+        await _renameAncestor(dirPath, context);
       }
     }
   }
 
-  Future<void> _handleDirectoryRendering(
-    Directory directory,
+  Future<void> _renameAncestor(
+    String dirPath,
     TemplateContext context,
   ) async {
+    final source = Directory(dirPath);
+    if (!await source.exists()) return;
+    final renderedName = _renderFileSystemEntityName(
+      p.basename(dirPath),
+      context,
+    );
     try {
-      final basename = p.basename(directory.path);
-
-      // Fast path! directory names without template directives can't be renamed,
-      // so just recurse without invoking the Mustache parser.
-      if (!_hasTemplateMarker(basename)) {
-        await _renderDirectory(directory, context);
+      if (renderedName.isEmpty) {
+        await source.delete(recursive: true);
         return;
       }
-
-      final renderedName = _renderFileSystemEntityName(basename, context);
-      final newPath = p.join(p.dirname(directory.path), renderedName);
-
-      if (renderedName.isEmpty) {
-        await directory.delete(recursive: true);
-      } else if (newPath != directory.path) {
-        await directory.rename(newPath);
-        await _renderDirectory(Directory(newPath), context);
+      final destPath = p.join(p.dirname(dirPath), renderedName);
+      if (destPath == dirPath) return;
+      final dest = Directory(destPath);
+      if (await dest.exists()) {
+        await _mergeIntoDirectory(source, dest);
       } else {
-        await _renderDirectory(directory, context);
+        await source.rename(destPath);
       }
     } on FileSystemException {
-      // Directory gone.
+      // Source vanished mid-flight (e.g. an outer rename already moved
+      // it). Best-effort: skip.
     }
   }
 
-  String _renderTemplate(String content, TemplateContext context) {
-    try {
-      var template = Template(content, lenient: true);
-      return template.renderString(
-        context.toMustacheMap(),
-        onMissingVariable: (name, context) {
-          return '{{$name}}';
-        },
-      );
-    } catch (_) {
-      return content;
+  /// Computes [original]'s path after [_renameAncestors] has run, by
+  /// re-rendering every *directory* segment. Returns `null` if any
+  /// ancestor segment renders to empty (the file's parent was deleted).
+  /// The file basename is preserved verbatim - [_renderFileName]
+  /// handles that separately once we open the file.
+  String? _translateDirSegments(String original, TemplateContext context) {
+    final segments = p.split(original);
+    final out = <String>[];
+    for (var i = 0; i < segments.length; i++) {
+      final seg = segments[i];
+      final isFileBasename = i == segments.length - 1;
+      if (!isFileBasename && _hasTemplateMarker(seg)) {
+        final rendered = _renderFileSystemEntityName(seg, context);
+        if (rendered.isEmpty) return null;
+        out.add(rendered);
+      } else {
+        out.add(seg);
+      }
     }
+    return p.joinAll(out);
   }
 
-  /// Renders template directives in [file]'s base name and content.
-  /// Rewrites [file] with the rendering result.
-  /// If the [file] name or its content is empty after rendering, the [file] is deleted.
+  /// Recursively moves [source]'s contents into [destination],
+  /// overwriting on file collision and merging on directory collision.
+  /// [source] is deleted once empty.
+  Future<void> _mergeIntoDirectory(
+    Directory source,
+    Directory destination,
+  ) async {
+    await for (final entity in source.list(followLinks: false)) {
+      final destPath = p.join(destination.path, p.basename(entity.path));
+      if (entity is File) {
+        await entity.rename(destPath);
+      } else if (entity is Directory) {
+        final destDir = Directory(destPath);
+        if (await destDir.exists()) {
+          await _mergeIntoDirectory(entity, destDir);
+        } else {
+          await entity.rename(destPath);
+        }
+      }
+    }
+    await source.delete();
+  }
+
   Future<void> _renderFile(File file, TemplateContext context) async {
     try {
       final renderedFile = await _renderFileName(file, context);
@@ -126,16 +171,15 @@ class TemplateRenderer {
     } on FileSystemException {
       // File gone.
     } on FormatException {
-      // Non-UTF8 content (binary asset?). Skip silently!
+      // Non-UTF8 content. The extension allowlist already filters known
+      // binary types; this is defence-in-depth for malformed text files.
     }
   }
 
-  /// Renders template directives in [file]'s base name.
-  /// If rendering results in an empty file name (excluding extension), the file is deleted.
+  /// Renames [file] if its basename carries a Mustache directive.
+  /// Deletes the file if the directive renders to empty.
   Future<File?> _renderFileName(File file, TemplateContext context) async {
     final fileName = p.basename(file.path);
-
-    // Fast path! File names without template directives can't be renamed.
     if (!_hasTemplateMarker(fileName)) return file;
 
     final renderedFileName = _renderFileSystemEntityName(fileName, context);
@@ -156,12 +200,11 @@ class TemplateRenderer {
     return await file.rename(p.join(p.dirname(file.path), renderedFileName));
   }
 
-  /// Renders template directives in [file]'s content.
-  /// If rendering results in a file with empty content, the file is deleted.
   Future<void> _renderFileContent(File file, TemplateContext context) async {
-    final content = await file.readAsString();
+    final extension = p.extension(file.path);
+    if (!_renderableExtensions.contains(extension.toLowerCase())) return;
 
-    // Fast path! Bail before invoking expensive regex preprocessor and Mustache parser.
+    final content = await file.readAsString();
     if (!_hasTemplateMarker(content)) return;
 
     final processedContent = _preprocessContent(content);
@@ -173,42 +216,52 @@ class TemplateRenderer {
     }
     if (renderedContent == content) return;
 
-    var toWrite = renderedContent;
-    if (p.extension(file.path) == '.dart') {
+    String toWrite;
+    if (extension == '.dart') {
       try {
         toWrite = _dartFormatter.format(renderedContent);
       } on FormatterException {
-        // Rendered output isn't valid Dart!
-        // Write the unformatted content rather than failing the render.
+        // Rendered output isn't valid Dart - leave the file untouched
+        // rather than persisting a broken intermediate (which would
+        // also touch the file's mtime).
+        return;
       }
+    } else {
+      toWrite = renderedContent;
     }
     await file.writeAsString(toWrite);
   }
 
-  /// Cheap test for the presence of a Mustache opening delimiter.
   static bool _hasTemplateMarker(String s) => s.contains('{{');
 
-  /// Preprocesses the content by removing comment markers from template directives.
-  /// The comment markers allow template directives to be included in the source
-  /// files without affecting the syntax of the code.
-  /// For example, `// {{#enableAuth}}` will be transformed to `{{#enableAuth}}`.
+  String _renderTemplate(String content, TemplateContext context) {
+    try {
+      var template = Template(content, lenient: true);
+      return template.renderString(
+        context.toMustacheMap(),
+        onMissingVariable: (name, context) => '{{$name}}',
+      );
+    } catch (_) {
+      return content;
+    }
+  }
+
+  /// Preprocesses [content] by stripping `// ` / `# ` comment prefixes
+  /// from Mustache directives, so that templates can embed directives
+  /// inside otherwise-valid source files.
   String _preprocessContent(String content) {
     var result = content;
-
     result = result.replaceAllMapped(
       RegExp(r'//\s*(\{\{[^}]+\}\})'),
       (match) => match.group(1)!,
     );
-
     result = result.replaceAllMapped(
       RegExp(r'#\s*(\{\{[^}]+\}\})'),
       (match) => match.group(1)!,
     );
-
     return result;
   }
 
-  /// Formats the file/directory name as a template and returns the rendered name.
   String _renderFileSystemEntityName(String name, TemplateContext context) {
     return _renderTemplate(
       name.replaceAll(r'{{!', '{{/'),

--- a/tools/serverpod_cli/lib/src/create/template_renderer.dart
+++ b/tools/serverpod_cli/lib/src/create/template_renderer.dart
@@ -15,20 +15,6 @@ import 'package:whiskers/whiskers.dart';
 /// caller didn't ask for, sidestepping any question of "should we have
 /// entered `.dart_tool` / `build` / `.git`".
 class TemplateRenderer {
-  /// File extensions whose contents the renderer is allowed to read and
-  /// rewrite. Serverpod templates only produce text files in this set;
-  /// anything else is left untouched as a defensive sanity guard.
-  static const Set<String> _renderableExtensions = <String>{
-    '.dart',
-    '.yaml',
-    '.yml',
-    '.json',
-    '.html',
-    '.css',
-    '.md',
-    '.svg',
-  };
-
   static final DartFormatter _dartFormatter = DartFormatter(
     // update in concert with `code_generator.dart`
     languageVersion: Version(3, 10, 0),
@@ -171,8 +157,7 @@ class TemplateRenderer {
     } on FileSystemException {
       // File gone.
     } on FormatException {
-      // Non-UTF8 content. The extension allowlist already filters known
-      // binary types; this is defence-in-depth for malformed text files.
+      // A binary file slipped into the path list. Skip it!
     }
   }
 
@@ -202,7 +187,6 @@ class TemplateRenderer {
 
   Future<void> _renderFileContent(File file, TemplateContext context) async {
     final extension = p.extension(file.path);
-    if (!_renderableExtensions.contains(extension.toLowerCase())) return;
 
     final content = await file.readAsString();
     if (!_hasTemplateMarker(content)) return;

--- a/tools/serverpod_cli/test/commands/create/template_renderer/directory_test.dart
+++ b/tools/serverpod_cli/test/commands/create/template_renderer/directory_test.dart
@@ -5,13 +5,34 @@ import 'package:serverpod_cli/src/create/template_context.dart';
 import 'package:serverpod_cli/src/create/template_renderer.dart';
 import 'package:test/test.dart';
 
+/// The renderer renames ancestor dirs of the file paths it's given.
+/// Tests that exercise dir renaming need at least one file inside the
+/// dir to anchor that ancestor. [_sentinel] is the placeholder used.
+const _sentinel = '.template_sentinel';
+
 void main() {
   late Directory testDir;
-  late TemplateRenderer templateRenderer;
+  const renderer = TemplateRenderer();
+
+  /// Renders every file currently under [testDir] - mirrors how the
+  /// production caller passes the set of files just written by [Copier].
+  Future<void> renderTestDir(TemplateContext context) async {
+    final paths = <String>[];
+    await for (final entity in testDir.list(
+      recursive: true,
+      followLinks: false,
+    )) {
+      if (entity is File) paths.add(entity.path);
+    }
+    await renderer.renderPaths(paths, context);
+  }
+
+  Future<void> addSentinel(Directory dir) async {
+    await File(p.join(dir.path, _sentinel)).create(recursive: true);
+  }
 
   setUp(() async {
     testDir = await Directory.systemTemp.createTemp('template_test_');
-    templateRenderer = TemplateRenderer(dir: testDir);
   });
 
   tearDown(() async {
@@ -26,13 +47,14 @@ void main() {
       setUp(() async {
         dir = Directory(p.join(testDir.path, '{{#web}}web{{!web}}'));
         await dir.create();
+        await addSentinel(dir);
       });
 
       test(
         'when rendering the template with a true context value, '
         'then the directory name is formatted to remove the template directives',
         () async {
-          await templateRenderer.render(TemplateContext(web: true));
+          await renderTestDir(TemplateContext(web: true));
 
           await expectLater(
             Directory(p.join(testDir.path, '{{#web}}web{{!web}}')).exists(),
@@ -49,7 +71,7 @@ void main() {
         'when rendering the template with a false context value, '
         'then the directory is deleted',
         () async {
-          await templateRenderer.render(TemplateContext(web: false));
+          await renderTestDir(TemplateContext(web: false));
 
           await expectLater(
             Directory(p.join(testDir.path, '{{#web}}web{{!web}}')).exists(),
@@ -66,7 +88,7 @@ void main() {
         'when rendering the template with empty context, '
         'then the directory is deleted',
         () async {
-          await templateRenderer.render(TemplateContext());
+          await renderTestDir(TemplateContext());
 
           await expectLater(
             Directory(p.join(testDir.path, '{{#web}}web{{!web}}')).exists(),
@@ -89,13 +111,14 @@ void main() {
       setUp(() async {
         dir = Directory(p.join(testDir.path, '{{#web}}web{{+web}}'));
         await dir.create();
+        await addSentinel(dir);
       });
 
       test(
         'when rendering the template with a true context value, '
         'then the directory name is not formatted to remove the template directive',
         () async {
-          await templateRenderer.render(TemplateContext(web: true));
+          await renderTestDir(TemplateContext(web: true));
 
           await expectLater(
             Directory(p.join(testDir.path, '{{#web}}web{{+web}}')).exists(),
@@ -112,7 +135,7 @@ void main() {
         'when rendering the template with a false context value, '
         'then the directory name is not formatted to remove the template directive',
         () async {
-          await templateRenderer.render(TemplateContext(web: false));
+          await renderTestDir(TemplateContext(web: false));
 
           await expectLater(
             Directory(p.join(testDir.path, '{{#web}}web{{+web}}')).exists(),
@@ -129,7 +152,7 @@ void main() {
         'when rendering the template with empty context, '
         'then the directory name is not formatted to remove the template directive',
         () async {
-          await templateRenderer.render(TemplateContext(web: true));
+          await renderTestDir(TemplateContext(web: true));
 
           await expectLater(
             Directory(p.join(testDir.path, '{{#web}}web{{+web}}')).exists(),
@@ -151,13 +174,15 @@ void main() {
     () async {
       final webDir = Directory(p.join(testDir.path, '{{#web}}web{{!web}}'));
       await webDir.create();
+      await addSentinel(webDir);
 
       final redisDir = Directory(
         p.join(testDir.path, '{{#redis}}redis{{!redis}}'),
       );
       await redisDir.create();
+      await addSentinel(redisDir);
 
-      await templateRenderer.render(TemplateContext(redis: false, web: true));
+      await renderTestDir(TemplateContext(redis: false, web: true));
 
       await expectLater(
         Directory(p.join(testDir.path, 'web')).exists(),
@@ -186,13 +211,14 @@ void main() {
           ),
         );
         await nestedDir.create(recursive: true);
+        await addSentinel(nestedDir);
       });
 
       test(
         'when rendering templates with true context values, '
         'then the nested directories are not deleted',
         () async {
-          await templateRenderer.render(
+          await renderTestDir(
             TemplateContext(postgres: true, web: true, redis: true),
           );
 
@@ -209,7 +235,7 @@ void main() {
         'when rendering templates with a false context value for the parent directory '
         'then the nested directories are deleted',
         () async {
-          await templateRenderer.render(
+          await renderTestDir(
             TemplateContext(web: false, redis: true, postgres: true),
           );
 
@@ -226,7 +252,7 @@ void main() {
         'when rendering templates with a false context value for a nested directory, '
         'then only the nested directory is deleted',
         () async {
-          await templateRenderer.render(
+          await renderTestDir(
             TemplateContext(redis: false, postgres: true, web: true),
           );
 

--- a/tools/serverpod_cli/test/commands/create/template_renderer/file_test.dart
+++ b/tools/serverpod_cli/test/commands/create/template_renderer/file_test.dart
@@ -7,11 +7,23 @@ import 'package:test/test.dart';
 
 void main() {
   late Directory testDir;
-  late TemplateRenderer templateRenderer;
+  const renderer = TemplateRenderer();
+
+  /// Renders every file currently under [testDir] - mirrors how the
+  /// production caller passes the set of files just written by [Copier].
+  Future<void> renderTestDir(TemplateContext context) async {
+    final paths = <String>[];
+    await for (final entity in testDir.list(
+      recursive: true,
+      followLinks: false,
+    )) {
+      if (entity is File) paths.add(entity.path);
+    }
+    await renderer.renderPaths(paths, context);
+  }
 
   setUp(() async {
     testDir = await Directory.systemTemp.createTemp('template_test_');
-    templateRenderer = TemplateRenderer(dir: testDir);
   });
 
   tearDown(() async {
@@ -31,7 +43,7 @@ void main() {
         'when rendering the template with a true context value, '
         'then the file name is formatted to remove the template directives',
         () async {
-          await templateRenderer.render(TemplateContext(web: true));
+          await renderTestDir(TemplateContext(web: true));
 
           await expectLater(file.exists(), completion(false));
           await expectLater(
@@ -45,7 +57,7 @@ void main() {
         'when rendering the template with a false context value, '
         'then the file is deleted',
         () async {
-          await templateRenderer.render(TemplateContext(web: false));
+          await renderTestDir(TemplateContext(web: false));
 
           await expectLater(file.exists(), completion(false));
           await expectLater(
@@ -59,7 +71,7 @@ void main() {
         'when rendering the template with empty context, '
         'then the file is deleted',
         () async {
-          await templateRenderer.render(TemplateContext());
+          await renderTestDir(TemplateContext());
 
           await expectLater(file.exists(), completion(false));
           await expectLater(
@@ -84,7 +96,7 @@ void main() {
         'when rendering the template with a true context value, '
         'then the file name is not formatted to remove the template directives',
         () async {
-          await templateRenderer.render(TemplateContext(web: true));
+          await renderTestDir(TemplateContext(web: true));
 
           await expectLater(file.exists(), completion(true));
           await expectLater(
@@ -98,7 +110,7 @@ void main() {
         'when rendering the template with a false context value, '
         'then the file name is not formatted to remove the template directives',
         () async {
-          await templateRenderer.render(TemplateContext(web: false));
+          await renderTestDir(TemplateContext(web: false));
 
           await expectLater(file.exists(), completion(true));
           await expectLater(
@@ -112,7 +124,7 @@ void main() {
         'when rendering the template with empty context, '
         'then the file name is not formatted to remove the template directives',
         () async {
-          await templateRenderer.render(TemplateContext());
+          await renderTestDir(TemplateContext());
 
           await expectLater(file.exists(), completion(true));
           await expectLater(
@@ -144,7 +156,7 @@ development:
         'when rendering the template with a true context value, '
         'then the template directives are processed correctly',
         () async {
-          await templateRenderer.render(TemplateContext(redis: true));
+          await renderTestDir(TemplateContext(redis: true));
           final content = await file.readAsString();
 
           expect(
@@ -162,7 +174,7 @@ development:
         'when rendering the template with a false context value, '
         'then the template directives are processed correctly',
         () async {
-          await templateRenderer.render(TemplateContext(redis: false));
+          await renderTestDir(TemplateContext(redis: false));
           final content = await file.readAsString();
 
           expect(
@@ -208,9 +220,7 @@ void main() {
         'when rendering the template with true context values, '
         'then all the sections with conditional directives are retained in the file',
         () async {
-          await templateRenderer.render(
-            TemplateContext(web: true, postgres: true),
-          );
+          await renderTestDir(TemplateContext(web: true, postgres: true));
           final content = await file.readAsString();
           expect(
             content,
@@ -232,9 +242,7 @@ void main() {
         'when rendering the template with a mix of true and false context values, '
         'then only the sections with true conditional directives are retained in the file',
         () async {
-          await templateRenderer.render(
-            TemplateContext(postgres: true, web: false),
-          );
+          await renderTestDir(TemplateContext(postgres: true, web: false));
           final content = await file.readAsString();
           expect(
             content,
@@ -254,7 +262,7 @@ void main() {
         'when rendering the template with empty context, '
         'then all conditional sections are removed from the file',
         () async {
-          await templateRenderer.render(TemplateContext());
+          await renderTestDir(TemplateContext());
           final content = await file.readAsString();
           expect(
             content,
@@ -298,7 +306,7 @@ void main() {
 }
 ''');
 
-      await templateRenderer.render(TemplateContext());
+      await renderTestDir(TemplateContext());
       final content = await file.readAsString();
       expect(
         content,
@@ -326,7 +334,7 @@ import 'auth.web';
 // {{/web}}
 ''');
 
-      await templateRenderer.render(TemplateContext());
+      await renderTestDir(TemplateContext());
       await expectLater(file.exists(), completion(false));
     },
   );


### PR DESCRIPTION
The old `TemplateRenderer`  took a _directory_ and walked the entire project tree, rendering everything it found. 

To avoid clobbering files it shouldn't touch and improve performance a recent change #5177 carried a hardcoded blocklist, 
but  that is still a fragile design. 

The new design flips it. `Copier` now records the exact paths it wrote (`copyFiles()` returns them), and the renderer is handed *only that explicit list* via `renderPaths(paths, context)`. It can only ever touch files the copiers actually produced.

The renderer also gained directory-rename + merge logic so a second upgrade run doesn't leave literal `{{...}}` directories on disk.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.