### PR TITLE
fix(cli): Add timeout to Flutter VM service connect

### DIFF
--- a/tools/serverpod_cli/lib/src/commands/start.dart
+++ b/tools/serverpod_cli/lib/src/commands/start.dart
@@ -635,7 +635,12 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
         onFlutterReady?.call(url);
       }
       await log.progress('Connecting to Flutter VM service', () async {
-        await fp.connectToVmService();
+        // `-d web-server` requires a human to open the URL, so the wait is unbounded.
+        await fp.connectToVmService(
+          timeout: flutterDevice == flutterDeviceWebServer
+              ? null
+              : const Duration(seconds: 30),
+        );
         if (fp.isVmServiceConnected && onFlutterStart != null) {
           await onFlutterStart(fp);
         }

--- a/tools/serverpod_cli/lib/src/commands/start/flutter_process.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/flutter_process.dart
@@ -14,6 +14,10 @@ import 'package:serverpod_cli/src/vm_proxy/proxy.dart';
 import 'package:vm_service/vm_service.dart';
 import 'package:vm_service/vm_service_io.dart';
 
+/// Flutter's headless web device; serves the app but never opens a
+/// browser, so a VM service attach waits for a human to open the URL.
+const flutterDeviceWebServer = 'web-server';
+
 const flutterDeviceWebServerWithBrowser = 'web-server-launch-browser';
 
 /// Thrown by [FlutterProcess.start] when `flutter` cannot be launched.
@@ -144,7 +148,7 @@ class FlutterProcess {
       throw StateError('FlutterProcess is already running.');
     }
 
-    final device = _launchBrowser ? 'web-server' : _device;
+    final device = _launchBrowser ? flutterDeviceWebServer : _device;
     final args =
         _argsOverrideForTesting ??
         <String>['run', '--machine', '-d', device, ..._extraArgs];
@@ -228,14 +232,28 @@ class FlutterProcess {
     );
   }
 
-  /// Wait for `app.debugPort`, bind [flutterProxy] upstream so IDE
-  /// clients can attach, open a `vm_service` client. Best-effort.
-  /// On `-d web-server` pends until a browser attaches.
-  Future<void> connectToVmService() async {
+  /// Connects to the Flutter VM service.
+  ///
+  /// When set [timeout] caps the wait for the daemon to publish URI.
+  ///
+  /// Waits for `app.debugPort`, binds [flutterProxy] upstream so IDE
+  /// clients can attach, then opens a `vm_service` client.
+  Future<void> connectToVmService({Duration? timeout}) async {
     if (_vmService != null) return;
     _onProgress?.call('connecting');
 
-    final maybeUri = await _vmServiceUriCompleter.future;
+    final String? maybeUri;
+    try {
+      final pending = _vmServiceUriCompleter.future;
+      maybeUri = await (timeout == null ? pending : pending.timeout(timeout));
+    } on TimeoutException {
+      log.warning(
+        'Flutter VM service did not publish within ${timeout!.inSeconds}s; '
+        'continuing without an attached VM service. '
+        '(Hot reload from the CLI/IDE for the Flutter app will be unavailable.)',
+      );
+      return;
+    }
     if (maybeUri == null) return;
     _vmServiceUri = maybeUri;
 

--- a/tools/serverpod_cli/test/commands/start/flutter_process_test.dart
+++ b/tools/serverpod_cli/test/commands/start/flutter_process_test.dart
@@ -135,6 +135,23 @@ void main() {
             expect(fp.isVmServiceConnected, isFalse);
           },
         );
+
+        test(
+          'when connectToVmService is called with a short timeout '
+          'then it gives up without throwing so the caller can proceed',
+          () async {
+            // Mirrors the chrome-tab-closed-quickly bug:
+            // https://github.com/serverpod/serverpod/issues/5173
+            // app.debugPort "never" arrives
+            await fp
+                .connectToVmService(
+                  timeout: const Duration(milliseconds: 200),
+                )
+                .timeout(const Duration(seconds: 2));
+            expect(fp.isVmServiceConnected, isFalse);
+            expect(fp.vmServiceUri, isNull);
+          },
+        );
       },
     );
   });


### PR DESCRIPTION
If the Flutter app's browser tab is closed before DWDS attaches,
`app.debugPort` never fires. Hence `connectToVmService` now timeout after 30s.
Unless using `-d web_server`, which requires the url to be opened manually.

Fixes: #5173

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None