### PR TITLE
fix: Surface serverpod start crashes to the terminal on exit

### DIFF
--- a/tools/serverpod_cli/lib/src/commands/start.dart
+++ b/tools/serverpod_cli/lib/src/commands/start.dart
@@ -31,6 +31,7 @@ import 'package:serverpod_cli/src/migrations/create_migration_action.dart';
 import 'package:serverpod_cli/src/migrations/create_repair_migration_action.dart';
 import 'package:serverpod_cli/src/runner/serverpod_command.dart';
 import 'package:serverpod_cli/src/runner/serverpod_command_runner.dart';
+import 'package:serverpod_cli/src/util/internal_error.dart';
 import 'package:serverpod_cli/src/util/serverpod_cli_logger.dart';
 import 'package:serverpod_cli/src/vm_proxy/proxy.dart';
 import 'package:serverpod_cli/src/vm_proxy/serverpod_hooks.dart';
@@ -943,9 +944,20 @@ Future<int> _runWithTui({
   // Shared shutdown signal
   final shutdown = _ShutdownSignal(listenForSignals: false);
 
+  // Captured on a fatal crash so it can be replayed to the real terminal in
+  // [preExit], after the TUI has released the alternate screen. The TUI routes
+  // logs into an in-memory history that is discarded when we leave the
+  // alternate screen, so a crash would otherwise vanish without ever reaching
+  // the user's scrollback.
+  ({Object error, StackTrace stackTrace})? fatalCrash;
+  void recordFatalCrash(Object error, StackTrace stackTrace) {
+    fatalCrash ??= (error: error, stackTrace: stackTrace);
+    shutdown.complete(ExitException.codeError);
+  }
+
   // Captured so the renderer tear-down listener can wait for the
   // backend's cleanup (ctx.dispose) to finish before calling
-  // shutdownServerpodApp. Default to a no-op so the listener is safe to invoke
+  // shutdownTuiApp. Default to a no-op so the listener is safe to invoke
   // even if SIGINT arrives before onReady fires.
   Future<void> backendFuture = Future.value();
 
@@ -953,25 +965,34 @@ Future<int> _runWithTui({
     if (backendStarted) return;
     backendStarted = true;
 
-    backendFuture =
-        _runTuiBackend(
-          holder: h,
-          commandConfig: commandConfig,
-          watch: watch,
-          launchFlutterApp: launchFlutterApp,
-          flutterDevice: flutterDevice,
-          flutterExtraArgs: flutterExtraArgs,
-          serverArgs: serverArgs,
-          config: config,
-          shutdown: shutdown,
-        ).catchError((Object e, StackTrace st) {
-          // Show the error in the TUI.
-          // The TUI stays open until Ctrl-C / Quit completes shutdown.
-          log.error('Fatal error: $e', stackTrace: st);
-        });
+    backendFuture = _runTuiBackend(
+      holder: h,
+      commandConfig: commandConfig,
+      watch: watch,
+      launchFlutterApp: launchFlutterApp,
+      flutterDevice: flutterDevice,
+      flutterExtraArgs: flutterExtraArgs,
+      serverArgs: serverArgs,
+      config: config,
+      shutdown: shutdown,
+      onFatalError: recordFatalCrash,
+    ).catchError((Object e, StackTrace st) => recordFatalCrash(e, st));
   }
 
-  // Wait for the backend's dispose to finish before calling shutdownServerpodApp
+  // Runs after the TUI tears down (alternate screen restored) but before the
+  // process exits. Restores the stdout logger and replays any captured crash
+  // so it survives in the user's scrollback - mirrors how `serverpod create`
+  // flushes its errors to the terminal on exit.
+  Future<void> preExit() async {
+    final crash = fatalCrash;
+    if (crash == null) return;
+    await closeLogger();
+    initializeLogger();
+    printInternalError(crash.error, crash.stackTrace);
+    await log.flush();
+  }
+
+  // Wait for the backend's dispose to finish before calling shutdownTuiApp
   unawaited(
     shutdown.future.then((code) async {
       await backendFuture;
@@ -981,6 +1002,7 @@ Future<int> _runWithTui({
 
   await runTuiApp(
     ServerpodWatchApp(holder: holder, onReady: onReady),
+    backend: ServerpodTerminalBackend(preExit: preExit),
     onShutdownSignal: () => shutdown.complete(0),
   );
 
@@ -1000,6 +1022,7 @@ Future<void> _runTuiBackend({
   required List<String> serverArgs,
   required GeneratorConfig config,
   required _ShutdownSignal shutdown,
+  required void Function(Object error, StackTrace stackTrace) onFatalError,
 }) async {
   try {
     // Replace the CLI logger with a TUI-backed logger.
@@ -1122,10 +1145,10 @@ Future<void> _runTuiBackend({
         await ctx.dispose();
     }
   } catch (e, st) {
-    // Show the error in the TUI; let the user read it. Quitting still
-    // works via the Ctrl-C signal handler routed through shutdown.
-    holder.state.showSplash = false;
-    log.error('$e', stackTrace: st);
+    // Capture the crash and tear the TUI down so it can be replayed to the
+    // terminal in [_runWithTui]; otherwise it dies with the in-memory TUI log
+    // history when we leave the alternate screen.
+    onFatalError(e, st);
   }
 }
 

--- a/tools/serverpod_cli/lib/src/commands/start.dart
+++ b/tools/serverpod_cli/lib/src/commands/start.dart
@@ -945,14 +945,13 @@ Future<int> _runWithTui({
   final shutdown = _ShutdownSignal(listenForSignals: false);
 
   // Captured on a fatal crash so it can be replayed to the real terminal in
-  // [preExit], after the TUI has released the alternate screen. The TUI routes
-  // logs into an in-memory history that is discarded when we leave the
-  // alternate screen, so a crash would otherwise vanish without ever reaching
-  // the user's scrollback.
+  // [preExit] when the user quits. The crash is also shown inside the TUI, but
+  // that copy lives in an in-memory log history that is discarded once we leave
+  // the alternate screen - so without this capture it would never reach the
+  // user's scrollback. First crash wins.
   ({Object error, StackTrace stackTrace})? fatalCrash;
   void recordFatalCrash(Object error, StackTrace stackTrace) {
     fatalCrash ??= (error: error, stackTrace: stackTrace);
-    shutdown.complete(ExitException.codeError);
   }
 
   // Captured so the renderer tear-down listener can wait for the
@@ -986,6 +985,9 @@ Future<int> _runWithTui({
   Future<void> preExit() async {
     final crash = fatalCrash;
     if (crash == null) return;
+    // Swap the TUI-backed logger (whose output went to the now-gone alternate
+    // screen) for a fresh stdout-backed one, so the replayed crash actually
+    // reaches the terminal.
     await closeLogger();
     initializeLogger();
     printInternalError(crash.error, crash.stackTrace);
@@ -1029,6 +1031,10 @@ Future<void> _runTuiBackend({
     final tuiWriter = TuiLogWriter();
     initializeLoggerWith(ServerpodCliLogger(tuiWriter));
     tuiWriter.attach(holder);
+
+    // TEMP(#5217 verification): force a backend crash to exercise the
+    // crash-replay path. Remove before committing.
+    throw StateError('Simulated start crash for #5217');
 
     final serverDir = p.joinAll(config.serverPackageDirectoryPathParts);
     final docker = commandConfig.value(StartOption.docker);
@@ -1145,9 +1151,12 @@ Future<void> _runTuiBackend({
         await ctx.dispose();
     }
   } catch (e, st) {
-    // Capture the crash and tear the TUI down so it can be replayed to the
-    // terminal in [_runWithTui]; otherwise it dies with the in-memory TUI log
-    // history when we leave the alternate screen.
+    // Surface the crash in the TUI (left open so it stays visible alongside the
+    // preceding logs), and capture it via [onFatalError] so it is also replayed
+    // to the terminal in [_runWithTui] when the user quits - the in-TUI copy is
+    // lost when we leave the alternate screen.
+    holder.state.showSplash = false;
+    log.error('$e', stackTrace: st);
     onFatalError(e, st);
   }
 }

--- a/tools/serverpod_cli/lib/src/commands/start.dart
+++ b/tools/serverpod_cli/lib/src/commands/start.dart
@@ -1032,10 +1032,6 @@ Future<void> _runTuiBackend({
     initializeLoggerWith(ServerpodCliLogger(tuiWriter));
     tuiWriter.attach(holder);
 
-    // TEMP(#5217 verification): force a backend crash to exercise the
-    // crash-replay path. Remove before committing.
-    throw StateError('Simulated start crash for #5217');
-
     final serverDir = p.joinAll(config.serverPackageDirectoryPathParts);
     final docker = commandConfig.value(StartOption.docker);
 


### PR DESCRIPTION
When `serverpod start` crashed while running in TUI mode, nothing was printed to the terminal.

This change captures the fatal error and stack trace, tears the TUI down so we leave the alternate screen, and then replays the crash to the restored `stdout` logger via a `ServerpodTerminalBackend` `preExit` hook.

This mirrors the strategy `serverpod create` already uses to flush errors to the console after exiting the alternate screen, so the crash survives in the user's scrollback.

Fixes #5217 

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes
None