### PR TITLE
fix: Fix error when closing method stream command with error after already closed

### DIFF
--- a/packages/serverpod_client/lib/src/client_method_stream_manager.dart
+++ b/packages/serverpod_client/lib/src/client_method_stream_manager.dart
@@ -385,7 +385,8 @@ final class ClientMethodStreamManager {
     // a close message to the server.
     inboundStreamContext.controller.onCancel = null;
 
-    if (reason == CloseReason.error) {
+    if (reason == CloseReason.error &&
+        !inboundStreamContext.controller.isClosed) {
       inboundStreamContext.controller.addError(
         const ConnectionClosedException(),
       );

--- a/packages/serverpod_client/lib/src/client_method_stream_manager.dart
+++ b/packages/serverpod_client/lib/src/client_method_stream_manager.dart
@@ -229,6 +229,7 @@ final class ClientMethodStreamManager {
 
     if (exception != null) {
       for (var c in inputControllers) {
+        if (c.isClosed) continue;
         c.addError(exception);
       }
     }
@@ -445,7 +446,8 @@ final class ClientMethodStreamManager {
     );
 
     var inboundStreamContext = _inboundStreams[inboundStreamKey];
-    if (inboundStreamContext == null) {
+    if (inboundStreamContext == null ||
+        inboundStreamContext.controller.isClosed) {
       return false;
     }
 
@@ -481,7 +483,9 @@ final class ClientMethodStreamManager {
       return;
     }
 
-    inboundStreamContext.controller.addError(message.exception);
+    if (!inboundStreamContext.controller.isClosed) {
+      inboundStreamContext.controller.addError(message.exception);
+    }
     await _closeControllers([inboundStreamContext.controller]);
   }
 

--- a/packages/serverpod_client/lib/src/serverpod_client_shared.dart
+++ b/packages/serverpod_client/lib/src/serverpod_client_shared.dart
@@ -622,7 +622,9 @@ abstract class ServerpodClientShared extends EndpointCaller {
         error = e;
       }
 
-      connectionDetails.outputController.addError(error);
+      if (!connectionDetails.outputController.isClosed) {
+        connectionDetails.outputController.addError(error);
+      }
       connectionDetails.outputController.close();
     });
 

--- a/packages/serverpod_client/test/integration/method_stream_manager_connection_test.dart
+++ b/packages/serverpod_client/test/integration/method_stream_manager_connection_test.dart
@@ -485,6 +485,87 @@ void main() async {
     );
   });
 
+  group('Given a connected method stream with a closed output controller,', () {
+    Completer<Uri> callbackUrlFuture;
+    late RelicWebSocket testWebSocket;
+    late OpenMethodStreamCommand openMethodStreamCommand;
+    late Completer<void> webSocketClosed;
+    late Future<void> Function() closeServer;
+    late MethodStreamConnectionDetails streamConnectionDetails;
+    setUp(() async {
+      webSocketClosed = Completer<void>();
+      callbackUrlFuture = Completer<Uri>();
+      closeServer = await TestWebSocketServer.startServer(
+        webSocketHandler: (webSocket) {
+          testWebSocket = webSocket;
+          webSocket.textEvents.listen(
+            (event) {
+              var message = WebSocketMessage.fromJsonString(
+                event,
+                TestSerializationManager(),
+              );
+              if (message is PingCommand) {
+                webSocket.sendText(PongCommand.buildMessage());
+              } else if (message is OpenMethodStreamCommand) {
+                openMethodStreamCommand = message;
+                webSocket.sendText(
+                  OpenMethodStreamResponse.buildMessage(
+                    connectionId: message.connectionId,
+                    endpoint: message.endpoint,
+                    method: message.method,
+                    responseType: OpenMethodStreamResponseType.success,
+                  ),
+                );
+              }
+            },
+            onDone: () {
+              webSocketClosed.complete();
+            },
+          );
+        },
+        onConnected: (host) {
+          callbackUrlFuture.complete(host);
+        },
+      );
+
+      var webSocketHost = await callbackUrlFuture.future;
+      var streamManager = ClientMethodStreamManager(
+        connectionTimeout: const Duration(milliseconds: 100),
+        webSocketHost: webSocketHost,
+        serializationManager: TestSerializationManager(),
+      );
+
+      streamConnectionDetails = MethodStreamConnectionDetailsBuilder().build();
+      await streamManager.openMethodStream(streamConnectionDetails);
+
+      // The controller has no listener, so the close future never completes.
+      // It is still marked closed synchronously, which is the state under test.
+      unawaited(streamConnectionDetails.outputController.close());
+    });
+
+    tearDown(() async => await closeServer());
+
+    test(
+      'when the server closes the method stream command with error reason, '
+      'then the websocket connection is closed without an exception.',
+      () async {
+        testWebSocket.sendText(
+          CloseMethodStreamCommand.buildMessage(
+            endpoint: openMethodStreamCommand.endpoint,
+            connectionId: openMethodStreamCommand.connectionId,
+            method: openMethodStreamCommand.method,
+            reason: CloseReason.error,
+          ),
+        );
+
+        await expectLater(
+          webSocketClosed.future.timeout(const Duration(seconds: 1)),
+          completes,
+        );
+      },
+    );
+  });
+
   group('Given idle method stream connection', () {
     Completer<Uri> callbackUrlFuture;
     late Future<void> Function() closeServer;

--- a/packages/serverpod_client/test/integration/method_stream_manager_connection_test.dart
+++ b/packages/serverpod_client/test/integration/method_stream_manager_connection_test.dart
@@ -15,7 +15,23 @@ import 'websocket_extensions.dart';
 import '../test_utils/method_stream_connection_details_builder.dart';
 import '../test_utils/test_web_socket_server.dart';
 
-class TestSerializationManager extends SerializationManager {}
+class TestSerializationManager extends SerializationManager {
+  @override
+  String? getClassNameForObject(Object? data) {
+    if (data is TestSerializableException) return 'TestSerializableException';
+    return super.getClassNameForObject(data);
+  }
+
+  @override
+  dynamic deserializeByClassName(Map<String, dynamic> data) {
+    if (data['className'] == 'TestSerializableException') {
+      return TestSerializableException();
+    }
+    return super.deserializeByClassName(data);
+  }
+}
+
+class TestSerializableException extends SerializableException {}
 
 void main() async {
   test(
@@ -491,6 +507,7 @@ void main() async {
     late OpenMethodStreamCommand openMethodStreamCommand;
     late Completer<void> webSocketClosed;
     late Future<void> Function() closeServer;
+    late ClientMethodStreamManager streamManager;
     late MethodStreamConnectionDetails streamConnectionDetails;
     setUp(() async {
       webSocketClosed = Completer<void>();
@@ -529,7 +546,7 @@ void main() async {
       );
 
       var webSocketHost = await callbackUrlFuture.future;
-      var streamManager = ClientMethodStreamManager(
+      streamManager = ClientMethodStreamManager(
         connectionTimeout: const Duration(milliseconds: 100),
         webSocketHost: webSocketHost,
         serializationManager: TestSerializationManager(),
@@ -562,6 +579,36 @@ void main() async {
           webSocketClosed.future.timeout(const Duration(seconds: 1)),
           completes,
         );
+      },
+    );
+
+    test(
+      'when all connections are closed with an exception, '
+      'then closing completes without an exception.',
+      () async {
+        await expectLater(
+          streamManager.closeAllConnections(const ConnectionClosedException()),
+          completes,
+        );
+      },
+    );
+
+    test(
+      'when the server sends a serializable exception, '
+      'then closing all connections completes without an exception.',
+      () async {
+        testWebSocket.sendText(
+          MethodStreamSerializableException.buildMessage(
+            endpoint: openMethodStreamCommand.endpoint,
+            connectionId: openMethodStreamCommand.connectionId,
+            method: openMethodStreamCommand.method,
+            object: TestSerializableException(),
+            serializationManager: TestSerializationManager(),
+          ),
+        );
+
+        await Future<void>.delayed(const Duration(milliseconds: 20));
+        await expectLater(streamManager.closeAllConnections(), completes);
       },
     );
   });


### PR DESCRIPTION
Fixes: #4948

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.