### PR TITLE
fix: Add the missing `--empty` flag to `create-migration`

### DIFF
--- a/tests/serverpod_cli_e2e_test/test/create_migration_exit_code_test.dart
+++ b/tests/serverpod_cli_e2e_test/test/create_migration_exit_code_test.dart
@@ -56,6 +56,35 @@ void main() async {
           );
         },
       );
+
+      test(
+        'when create-migration is called with --empty then an empty migration is created.',
+        () async {
+          var migrationsDirectory = Directory(
+            path.join(serverDir, 'migrations'),
+          );
+          var migrationsBefore = migrationsDirectory
+              .listSync()
+              .whereType<Directory>()
+              .length;
+
+          var result = await runServerpod(
+            ['create-migration', '--empty'],
+            workingDirectory: serverDir,
+          );
+
+          expect(
+            result.exitCode,
+            equals(0),
+            reason: 'Empty migration should be created with exit code 0',
+          );
+          expect(
+            migrationsDirectory.listSync().whereType<Directory>().length,
+            equals(migrationsBefore + 1),
+            reason: 'Should create an additional empty migration directory',
+          );
+        },
+      );
     },
   );
 

--- a/tools/serverpod_cli/lib/src/commands/create_migration.dart
+++ b/tools/serverpod_cli/lib/src/commands/create_migration.dart
@@ -11,6 +11,7 @@ import 'package:serverpod_cli/src/util/serverpod_cli_logger.dart';
 import 'package:serverpod_cli/src/util/string_validators.dart';
 
 enum CreateMigrationOption<V> implements OptionDefinition<V> {
+  empty(CreateMigrationCommand.emptyOption),
   force(CreateMigrationCommand.forceOption),
   tag(CreateMigrationCommand.tagOption),
   ;
@@ -22,6 +23,13 @@ enum CreateMigrationOption<V> implements OptionDefinition<V> {
 }
 
 class CreateMigrationCommand extends ServerpodCommand<CreateMigrationOption> {
+  static const emptyOption = FlagOption(
+    argName: 'empty',
+    negatable: false,
+    defaultsTo: false,
+    helpText: 'Creates the migration even if there are no database changes.',
+  );
+
   static const forceOption = FlagOption(
     argName: 'force',
     argAbbrev: 'f',
@@ -60,6 +68,7 @@ class CreateMigrationCommand extends ServerpodCommand<CreateMigrationOption> {
   Future<void> runWithConfig(
     final Configuration<CreateMigrationOption> commandConfig,
   ) async {
+    final empty = commandConfig.value(CreateMigrationOption.empty);
     final force = commandConfig.value(CreateMigrationOption.force);
     final tag = commandConfig.optionalValue(CreateMigrationOption.tag);
 
@@ -81,6 +90,7 @@ class CreateMigrationCommand extends ServerpodCommand<CreateMigrationOption> {
       outcome = await createMigrationAction(
         config: config,
         tag: tag,
+        empty: empty,
         force: force,
       );
       return outcome.success;

--- a/tools/serverpod_cli/lib/src/generated/completion_script_carapace.dart
+++ b/tools/serverpod_cli/lib/src/generated/completion_script_carapace.dart
@@ -82,6 +82,7 @@ commands:
 
   - name: create-migration
     flags:
+      --empty: "Creates the migration even if there are no database changes."
       -f, --force: "Creates the migration even if there are warnings or information that may be destroyed."
       -t, --tag=: "Add a tag to the revision to easier identify it."
 

--- a/tools/serverpod_cli/lib/src/migrations/create_migration_action.dart
+++ b/tools/serverpod_cli/lib/src/migrations/create_migration_action.dart
@@ -78,6 +78,7 @@ extension MigrationOutcomeExtension on CreateMigrationOutcome {
 Future<CreateMigrationOutcome> createMigrationAction({
   required GeneratorConfig config,
   String? tag,
+  bool empty = false,
   bool force = false,
 }) async {
   if (!config.isFeatureEnabled(ServerpodFeature.database)) {
@@ -126,6 +127,7 @@ Future<CreateMigrationOutcome> createMigrationAction({
 
   final results = await Future.wait([
     _createMigration(
+      empty: empty,
       force: force,
       config: config,
       precomputedVersion: precomputedVersion,
@@ -135,6 +137,7 @@ Future<CreateMigrationOutcome> createMigrationAction({
     if (hasClientMigrations)
       _createMigration(
         config: config,
+        empty: empty,
         force: force,
         precomputedVersion: precomputedVersion,
         generator: clientGenerator!,
@@ -155,6 +158,7 @@ Future<CreateMigrationOutcome> createMigrationAction({
 Future<CreateMigrationOutcome> _createMigration({
   required MigrationGenerator generator,
   required GeneratorConfig config,
+  required bool empty,
   required bool force,
   required MigrationGenerationContext context,
   required String precomputedVersion,
@@ -162,6 +166,7 @@ Future<CreateMigrationOutcome> _createMigration({
   MigrationVersionArtifacts? migration;
   try {
     migration = await generator.createMigration(
+      empty: empty,
       force: force,
       config: config,
       context: context,

--- a/tools/serverpod_cli/lib/src/migrations/generator.dart
+++ b/tools/serverpod_cli/lib/src/migrations/generator.dart
@@ -47,6 +47,8 @@ class MigrationGenerator {
   /// If [tag] is specified, the migration will be tagged with the given name.
   /// If [force] is true, the migration will be created even if there are
   /// warnings.
+  /// If [empty] is true, the migration will be created even if there are no
+  /// database changes.
   /// If [write] is false, the migration will not be written to disk.
   ///
   /// A [precomputedVersion] can be provided to skip the version name creation.
@@ -62,6 +64,7 @@ class MigrationGenerator {
   Future<MigrationVersionArtifacts?> createMigration({
     String? tag,
     String? precomputedVersion,
+    bool empty = false,
     required bool force,
     required GeneratorConfig config,
     MigrationGenerationContext? context,
@@ -115,7 +118,7 @@ class MigrationGenerator {
       throw const MigrationAbortedException();
     }
 
-    if (migration.isEmpty) {
+    if (migration.isEmpty && !empty) {
       return null;
     }
 

--- a/tools/serverpod_cli/test/integration/migrations/migration_generator_exceptions_test.dart
+++ b/tools/serverpod_cli/test/integration/migrations/migration_generator_exceptions_test.dart
@@ -281,6 +281,20 @@ fields:
       );
       expect(result, isNull);
     });
+
+    test(
+      'when creating migration with empty `true` then an empty migration is returned.',
+      () async {
+        var result = await generator.createMigration(
+          empty: true,
+          force: false,
+          config: config,
+          write: false,
+        );
+        expect(result, isNotNull);
+        expect(result!.migration.isEmpty, isTrue);
+      },
+    );
   });
 }
 


### PR DESCRIPTION
Closes: #4999

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.