### PR TITLE
chore: Update win32 to 6.x in serverpod_shared

### DIFF
--- a/packages/serverpod_shared/lib/src/utils/process_alive.dart
+++ b/packages/serverpod_shared/lib/src/utils/process_alive.dart
@@ -58,12 +58,16 @@ String? _readWindowsImagePath(int pid) {
   return _withProcessHandle(pid, (handle) {
     // 32768 wide chars covers the extended-path limit (Win10+).
     const capacity = 32768;
-    final buffer = calloc<Uint16>(capacity).cast<Utf16>();
+    final buffer = win32.PWSTR(calloc<Uint16>(capacity).cast());
     final sizePtr = calloc<Uint32>()..value = capacity;
     try {
-      if (win32.QueryFullProcessImageName(handle, 0, buffer, sizePtr) == 0) {
-        return null;
-      }
+      final win32.Win32Result(value: success) = win32.QueryFullProcessImageName(
+        handle,
+        win32.PROCESS_NAME_WIN32,
+        buffer,
+        sizePtr,
+      );
+      if (!success) return null;
       return buffer.toDartString(length: sizePtr.value);
     } finally {
       calloc
@@ -76,13 +80,13 @@ String? _readWindowsImagePath(int pid) {
 /// Opens a `PROCESS_QUERY_LIMITED_INFORMATION` handle to [pid], runs [body]
 /// with it, and closes the handle. Returns null when the PID is unassigned.
 /// Windows-only.
-T? _withProcessHandle<T>(int pid, T? Function(int handle) body) {
-  final handle = win32.OpenProcess(
+T? _withProcessHandle<T>(int pid, T? Function(win32.HANDLE handle) body) {
+  final win32.Win32Result(value: handle) = win32.OpenProcess(
     win32.PROCESS_QUERY_LIMITED_INFORMATION,
-    win32.FALSE,
+    false,
     pid,
   );
-  if (handle == 0) return null;
+  if (!handle.isValid) return null;
   try {
     return body(handle);
   } finally {

--- a/packages/serverpod_shared/pubspec.yaml
+++ b/packages/serverpod_shared/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   meta: ^1.15.0
   path: ^1.8.3
   super_string: ^1.0.3
-  win32: ^5.13.0
+  win32: ^6.0.0
   yaml: ^3.1.2
 
 dev_dependencies:

--- a/templates/pubspecs/packages/serverpod_shared/pubspec.yaml
+++ b/templates/pubspecs/packages/serverpod_shared/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   meta: ^1.15.0
   path: ^1.8.3
   super_string: ^1.0.3
-  win32: ^5.13.0
+  win32: ^6.0.0
   yaml: ^3.1.2
 
 dev_dependencies:

--- a/templates/pubspecs/tools/serverpod_cli/pubspec.yaml
+++ b/templates/pubspecs/tools/serverpod_cli/pubspec.yaml
@@ -63,7 +63,7 @@ dependencies:
   vm_service: '>=13.0.0 <16.0.0'
   watcher: ^1.0.2
   whiskers: ^0.1.1
-  win32: ^5.13.0
+  win32: ^6.0.0
   yaml: ^3.1.2
   yaml_edit: ^2.2.2
 

--- a/tools/serverpod_cli/lib/src/util/windows_console_input.dart
+++ b/tools/serverpod_cli/lib/src/util/windows_console_input.dart
@@ -18,17 +18,18 @@ import 'package:win32/win32.dart';
 /// Only call this on Windows; the underlying `kernel32.dll` bindings (via
 /// `package:win32`) are unavailable on other platforms.
 int? enableWindowsVirtualTerminalInput() {
-  final handle = GetStdHandle(STD_INPUT_HANDLE);
+  final Win32Result(value: handle) = GetStdHandle(STD_INPUT_HANDLE);
   final modePointer = calloc<Uint32>();
   try {
-    if (GetConsoleMode(handle, modePointer) == 0) return null;
+    final Win32Result(value: modeRead) = GetConsoleMode(handle, modePointer);
+    if (!modeRead) return null;
 
     final originalMode = modePointer.value;
-    final result = SetConsoleMode(
+    final Win32Result(value: modeSet) = SetConsoleMode(
       handle,
-      originalMode | ENABLE_VIRTUAL_TERMINAL_INPUT,
+      CONSOLE_MODE(originalMode | ENABLE_VIRTUAL_TERMINAL_INPUT),
     );
-    return result == 0 ? null : originalMode;
+    return modeSet ? originalMode : null;
   } finally {
     calloc.free(modePointer);
   }
@@ -37,5 +38,6 @@ int? enableWindowsVirtualTerminalInput() {
 /// Restores a console input mode previously captured by
 /// [enableWindowsVirtualTerminalInput].
 void restoreWindowsConsoleInputMode(int mode) {
-  SetConsoleMode(GetStdHandle(STD_INPUT_HANDLE), mode);
+  final Win32Result(value: handle) = GetStdHandle(STD_INPUT_HANDLE);
+  SetConsoleMode(handle, CONSOLE_MODE(mode));
 }

--- a/tools/serverpod_cli/pubspec.yaml
+++ b/tools/serverpod_cli/pubspec.yaml
@@ -64,7 +64,7 @@ dependencies:
   vm_service: '>=13.0.0 <16.0.0'
   watcher: ^1.0.2
   whiskers: ^0.1.1
-  win32: ^5.13.0
+  win32: ^6.0.0
   yaml: ^3.1.2
   yaml_edit: ^2.2.2
 


### PR DESCRIPTION
Bump win32 from ^5.13.0 to ^6.0.0 so `serverpod_shared` no longer conflicts with packages that already require win32 6.x.

Fixed #5224 

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes
No breaking changes to public API