### PR TITLE
feat: Remove the need for the raw server logs tab in serverpod start

### DIFF
--- a/tools/serverpod_cli/lib/src/commands/start/tui/app.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/tui/app.dart
@@ -146,19 +146,17 @@ class ServerpodWatchAppState extends TuiAppState<ServerpodWatchApp> {
 
   void _normalizeSelectedTab() {
     final state = component.holder.state;
-    if (state.useSideBySideLayout && state.selectedTab == 1) {
+    if (state.selectedTab == 1 &&
+        (state.useSideBySideLayout || !state.showFlutterOutput)) {
       state.selectedTab = 0;
     }
   }
 
   void _cycleTab(int delta) {
     final state = component.holder.state;
-    if (state.useSideBySideLayout) {
-      state.selectedTab = state.selectedTab == 0 ? 2 : 0;
-    } else {
-      final tabCount = state.showFlutterOutput ? 3 : 2;
-      state.selectedTab = (state.selectedTab + delta + tabCount) % tabCount;
-    }
+    if (state.useSideBySideLayout) return;
+    final tabCount = state.showFlutterOutput ? 2 : 1;
+    state.selectedTab = (state.selectedTab + delta + tabCount) % tabCount;
     _rebuild();
   }
 
@@ -227,9 +225,22 @@ class ServerpodWatchAppState extends TuiAppState<ServerpodWatchApp> {
       return true;
     }
 
+    if (state.showRawServerLogs) {
+      if (event.logicalKey == LogicalKey.escape ||
+          event.logicalKey == LogicalKey.backquote) {
+        state.showRawServerLogs = false;
+        _rebuild();
+        return true;
+      }
+      if (event.logicalKey == LogicalKey.keyC && event.isControlPressed) {
+        return false;
+      }
+      _handleScrollKey(rawScrollController, event);
+      return true;
+    }
+
     final sideBySide = state.useSideBySideLayout;
 
-    // Tab cycling. In side-by-side mode, only server tabs are selectable.
     if (event.matches(LogicalKey.tab, shift: false) ||
         event.logicalKey == LogicalKey.arrowRight) {
       _cycleTab(1);
@@ -245,30 +256,29 @@ class ServerpodWatchAppState extends TuiAppState<ServerpodWatchApp> {
       _rebuild();
       return true;
     }
-    if (event.logicalKey == LogicalKey.digit2) {
-      state.selectedTab = sideBySide ? 2 : 1;
-      _rebuild();
-      return true;
-    }
-    if (event.logicalKey == LogicalKey.digit3 &&
+    if (event.logicalKey == LogicalKey.digit2 &&
         !sideBySide &&
         state.showFlutterOutput) {
-      state.selectedTab = 2;
+      state.selectedTab = 1;
       _rebuild();
       return true;
     }
 
-    // Expand / collapse inline stack traces on the structured log tab.
     if (event.logicalKey == LogicalKey.keyE && state.selectedTab == 0) {
       state.expandStackTraces = !state.expandStackTraces;
       _rebuild();
       return true;
     }
 
+    if (event.logicalKey == LogicalKey.backquote) {
+      state.showRawServerLogs = true;
+      _rebuild();
+      return true;
+    }
+
     final c = switch (state.selectedTab) {
-      0 => logScrollController,
       1 => flutterRawScrollController,
-      _ => rawScrollController,
+      _ => logScrollController,
     };
     return _handleScrollKey(c, event);
   }

--- a/tools/serverpod_cli/lib/src/commands/start/tui/app.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/tui/app.dart
@@ -258,6 +258,13 @@ class ServerpodWatchAppState extends TuiAppState<ServerpodWatchApp> {
       return true;
     }
 
+    // Expand / collapse inline stack traces on the structured log tab.
+    if (event.logicalKey == LogicalKey.keyE && state.selectedTab == 0) {
+      state.expandStackTraces = !state.expandStackTraces;
+      _rebuild();
+      return true;
+    }
+
     final c = switch (state.selectedTab) {
       0 => logScrollController,
       1 => flutterRawScrollController,

--- a/tools/serverpod_cli/lib/src/commands/start/tui/app.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/tui/app.dart
@@ -227,7 +227,8 @@ class ServerpodWatchAppState extends TuiAppState<ServerpodWatchApp> {
 
     if (state.showRawServerLogs) {
       if (event.logicalKey == LogicalKey.escape ||
-          event.logicalKey == LogicalKey.backquote) {
+          event.logicalKey == LogicalKey.backquote ||
+          event.logicalKey == LogicalKey.period) {
         state.showRawServerLogs = false;
         _rebuild();
         return true;
@@ -270,7 +271,8 @@ class ServerpodWatchAppState extends TuiAppState<ServerpodWatchApp> {
       return true;
     }
 
-    if (event.logicalKey == LogicalKey.backquote) {
+    if (event.logicalKey == LogicalKey.backquote ||
+        event.logicalKey == LogicalKey.period) {
       state.showRawServerLogs = true;
       _rebuild();
       return true;

--- a/tools/serverpod_cli/lib/src/commands/start/tui/event_handler.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/tui/event_handler.dart
@@ -17,6 +17,7 @@ void handleServerLogEvent(TuiAppStateHolder holder, Event event) {
   final type = data['type'] as String?;
   switch (type) {
     case 'log':
+      final stackTrace = data['stackTrace'] as String?;
       state.logHistory.add(
         LogEntry(
           level: parseLogLevel(data['level'] as String? ?? 'info'),
@@ -26,6 +27,9 @@ void handleServerLogEvent(TuiAppStateHolder holder, Event event) {
           message: data['message'] as String? ?? '',
           scope: LogScope.root('server'),
           error: data['error']?.toString(),
+          stackTrace: stackTrace != null && stackTrace.isNotEmpty
+              ? StackTrace.fromString(stackTrace)
+              : null,
         ),
       );
 

--- a/tools/serverpod_cli/lib/src/commands/start/tui/main_screen.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/tui/main_screen.dart
@@ -78,6 +78,7 @@ class MainScreen extends StatelessComponent {
         ('M / Shift+M', 'Create migration (⇧ = force)'),
         ('P / Shift+P', 'Repair migration (⇧ = force)'),
         ('A', 'Apply migrations'),
+        ('e', 'Expand / collapse stack traces'),
         ('L', 'Clear logs'),
         ('Q', 'Quit'),
       ],
@@ -281,10 +282,7 @@ class MainScreen extends StatelessComponent {
           itemBuilder: (context, index) {
             final item = items[items.length - 1 - index];
             if (item is LogEntry) {
-              return LogMessageWidget(
-                key: ValueKey(index),
-                entry: item,
-              );
+              return _buildLogEntry(context, item, index);
             }
             if (item is CompletedOperation) {
               return CompletedOperationWidget(
@@ -296,6 +294,35 @@ class MainScreen extends StatelessComponent {
           },
         ),
       ),
+    );
+  }
+
+  /// Renders a single [LogEntry], appending its stack trace - or a collapsed
+  /// affordance hinting that one exists - when the entry carries one.
+  Component _buildLogEntry(BuildContext context, LogEntry entry, int index) {
+    final message = LogMessageWidget(key: ValueKey(index), entry: entry);
+    final stackTrace = entry.stackTrace?.toString().trimRight();
+    if (stackTrace == null || stackTrace.isEmpty) return message;
+
+    final st = ServerpodTheme.of(context);
+    final dim = TextStyle(color: st.debugLevel, fontWeight: FontWeight.dim);
+
+    final trailing = state.expandStackTraces
+        ? Text(stackTrace, style: dim)
+        : Text(
+            '▸ ${stackTrace.split('\n').length}-line stack trace (press e)',
+            style: dim,
+          );
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        message,
+        Padding(
+          padding: const EdgeInsets.only(left: 6),
+          child: trailing,
+        ),
+      ],
     );
   }
 

--- a/tools/serverpod_cli/lib/src/commands/start/tui/main_screen.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/tui/main_screen.dart
@@ -67,8 +67,8 @@ class MainScreen extends StatelessComponent {
       [
         ('Tab / →', 'Next tab'),
         ('Shift+Tab / ←', 'Previous tab'),
-        ('1', 'Log Messages'),
-        ('2', 'Raw server output'),
+        ('1', 'Server logs'),
+        ('2', 'Flutter logs'),
       ],
     ),
     (
@@ -79,6 +79,7 @@ class MainScreen extends StatelessComponent {
         ('P / Shift+P', 'Repair migration (⇧ = force)'),
         ('A', 'Apply migrations'),
         ('e', 'Expand / collapse stack traces'),
+        ('`', 'Show raw server logs'),
         ('L', 'Clear logs'),
         ('Q', 'Quit'),
       ],
@@ -96,69 +97,71 @@ class MainScreen extends StatelessComponent {
           children: [
             Expanded(
               child: BorderedBox(
-                child: LayoutBuilder(
-                  builder: (context, constraints) {
-                    state.contentWidth = constraints.maxWidth;
-                    final showSideBySide = state.useSideBySideLayout;
+                child: state.showRawServerLogs
+                    ? _buildRawServerLogsPanel(st)
+                    : LayoutBuilder(
+                        builder: (context, constraints) {
+                          state.contentWidth = constraints.maxWidth;
+                          final showSideBySide = state.useSideBySideLayout;
 
-                    return Column(
-                      children: [
-                        Padding(
-                          padding: const EdgeInsets.only(left: 1),
-                          child: _buildTabBar(st, showSideBySide),
-                        ),
-                        if (!showSideBySide) ?_buildFlutterStatusLine(st),
-                        Expanded(
-                          child: !showSideBySide
-                              ? _buildTabContent(state.selectedTab)
-                              : Row(
-                                  crossAxisAlignment:
-                                      CrossAxisAlignment.stretch,
-                                  children: [
-                                    Expanded(
-                                      child: Column(
+                          return Column(
+                            children: [
+                              Padding(
+                                padding: const EdgeInsets.only(left: 1),
+                                child: _buildTabBar(st, showSideBySide),
+                              ),
+                              if (!showSideBySide) ?_buildFlutterStatusLine(st),
+                              Expanded(
+                                child: !showSideBySide
+                                    ? _buildTabContent(state.selectedTab)
+                                    : Row(
+                                        crossAxisAlignment:
+                                            CrossAxisAlignment.stretch,
                                         children: [
                                           Expanded(
-                                            child: _buildTabContent(
-                                              state.selectedTab,
+                                            child: Column(
+                                              children: [
+                                                Expanded(
+                                                  child: _buildTabContent(
+                                                    state.selectedTab,
+                                                  ),
+                                                ),
+                                              ],
+                                            ),
+                                          ),
+                                          VerticalDivider(
+                                            color: st.subtleDivider,
+                                            width: 1,
+                                            thickness: 1,
+                                          ),
+                                          Expanded(
+                                            child: Column(
+                                              children: [
+                                                ?_buildFlutterStatusLine(
+                                                  st,
+                                                  withTitle: false,
+                                                ),
+                                                Expanded(
+                                                  child: _buildTabContent(1),
+                                                ),
+                                              ],
                                             ),
                                           ),
                                         ],
                                       ),
-                                    ),
-                                    VerticalDivider(
-                                      color: st.subtleDivider,
-                                      width: 1,
-                                      thickness: 1,
-                                    ),
-                                    Expanded(
-                                      child: Column(
-                                        children: [
-                                          ?_buildFlutterStatusLine(
-                                            st,
-                                            withTitle: false,
-                                          ),
-                                          Expanded(
-                                            child: _buildTabContent(1),
-                                          ),
-                                        ],
-                                      ),
-                                    ),
-                                  ],
-                                ),
-                        ),
+                              ),
 
-                        if (state.activeOperations.isNotEmpty)
-                          ...state.activeOperations.values.map(
-                            (op) => TrackedOperationWidget(
-                              key: ValueKey(op.id),
-                              operation: op,
-                            ),
-                          ),
-                      ],
-                    );
-                  },
-                ),
+                              if (state.activeOperations.isNotEmpty)
+                                ...state.activeOperations.values.map(
+                                  (op) => TrackedOperationWidget(
+                                    key: ValueKey(op.id),
+                                    operation: op,
+                                  ),
+                                ),
+                            ],
+                          );
+                        },
+                      ),
               ),
             ),
             _buildButtonBar(),
@@ -220,7 +223,6 @@ class MainScreen extends StatelessComponent {
 
   Component _buildTabBar(ServerpodThemeData st, bool sideBySide) {
     const serverLogs = 'Server logs';
-    const rawServerLogs = 'Raw server logs';
     const flutterLogs = 'Flutter logs';
 
     return !sideBySide
@@ -228,7 +230,6 @@ class MainScreen extends StatelessComponent {
             labels: [
               serverLogs,
               if (state.showFlutterOutput) flutterLogs,
-              rawServerLogs,
             ],
             selectedTab: state.selectedTab,
             onTabChanged: onTabChanged,
@@ -237,9 +238,9 @@ class MainScreen extends StatelessComponent {
             children: [
               Expanded(
                 child: TabBar(
-                  labels: const [serverLogs, rawServerLogs],
-                  selectedTab: state.selectedTab == 2 ? 1 : 0,
-                  onTabChanged: (index) => onTabChanged(index == 0 ? 0 : 2),
+                  labels: const [serverLogs],
+                  selectedTab: 0,
+                  onTabChanged: (_) {},
                 ),
               ),
               Expanded(
@@ -259,9 +260,39 @@ class MainScreen extends StatelessComponent {
         state.rawFlutterLines,
         flutterRawScrollController,
       ),
-      2 => _buildRawOutputView(state.rawLines, rawScrollController),
       _ => _buildStructuredLogView(),
     };
+  }
+
+  /// The raw server logs "dev console", shown as a full-area overlay when
+  /// toggled via the backtick (`` ` ``) shortcut.
+  Component _buildRawServerLogsPanel(ServerpodThemeData st) {
+    return Column(
+      children: [
+        Padding(
+          padding: const EdgeInsets.only(left: 1),
+          child: Row(
+            children: [
+              Text(
+                'Raw server logs',
+                style: TextStyle(
+                  color: st.primary,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+              const Text(
+                '  press ` or Esc to close',
+                style: TextStyle(fontWeight: FontWeight.dim),
+              ),
+            ],
+          ),
+        ),
+        Divider(color: st.subtleDivider),
+        Expanded(
+          child: _buildRawOutputView(state.rawLines, rawScrollController),
+        ),
+      ],
+    );
   }
 
   Component _buildStructuredLogView() {

--- a/tools/serverpod_cli/lib/src/commands/start/tui/main_screen.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/tui/main_screen.dart
@@ -79,7 +79,7 @@ class MainScreen extends StatelessComponent {
         ('P / Shift+P', 'Repair migration (⇧ = force)'),
         ('A', 'Apply migrations'),
         ('e', 'Expand / collapse stack traces'),
-        ('`', 'Show raw server logs'),
+        ('` / .', 'Show raw server logs'),
         ('L', 'Clear logs'),
         ('Q', 'Quit'),
       ],
@@ -281,7 +281,7 @@ class MainScreen extends StatelessComponent {
                 ),
               ),
               const Text(
-                '  press ` or Esc to close',
+                '  press ` / . or Esc to close',
                 style: TextStyle(fontWeight: FontWeight.dim),
               ),
             ],

--- a/tools/serverpod_cli/lib/src/commands/start/tui/state.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/tui/state.dart
@@ -23,8 +23,7 @@ class ServerWatchState extends TuiState {
   /// Currently selected tab index.
   ///
   /// - 0 = structured server logs
-  /// - 1 = Flutter logs (narrow layout only)
-  /// - 2 = raw server logs
+  /// - 1 = Flutter logs (only when [showFlutterOutput])
   int selectedTab = 0;
 
   /// Latest measured content width from the main log area.
@@ -67,6 +66,12 @@ class ServerWatchState extends TuiState {
   /// When false, an error entry that carries a trace shows a compact
   /// affordance instead; toggled with `e` on the structured log tab.
   bool expandStackTraces = false;
+
+  /// Whether the raw server logs overlay (the "dev console") is visible.
+  ///
+  /// Raw server stdout/stderr is hidden from the default tabs and reached
+  /// on demand via the backtick (`` ` ``) shortcut.
+  bool showRawServerLogs = false;
 
   /// Maximum number of log entries to keep.
   static const maxLogEntries = 10000;

--- a/tools/serverpod_cli/lib/src/commands/start/tui/state.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/tui/state.dart
@@ -9,11 +9,12 @@ class ServerWatchState extends TuiState {
   @override
   final logHistory = BoundedQueueList<Object>(maxLogEntries);
 
-  /// Raw stdout/stderr lines for the "Raw server output" tab.
+  /// Raw stdout/stderr lines shown in the raw server logs overlay
+  /// (toggled with the backtick shortcut).
   @override
   final rawLines = BoundedQueueList<String>(maxRawLines);
 
-  /// Raw lines for the "Flutter output" tab.
+  /// Raw lines for the "Flutter logs" tab.
   final rawFlutterLines = BoundedQueueList<String>(maxRawLines);
 
   /// Currently active tracked operations (keyed by ID).

--- a/tools/serverpod_cli/lib/src/commands/start/tui/state.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/tui/state.dart
@@ -10,7 +10,7 @@ class ServerWatchState extends TuiState {
   final logHistory = BoundedQueueList<Object>(maxLogEntries);
 
   /// Raw stdout/stderr lines shown in the raw server logs overlay
-  /// (toggled with the backtick shortcut).
+  /// (toggled with the backtick or `.` shortcut).
   @override
   final rawLines = BoundedQueueList<String>(maxRawLines);
 
@@ -71,7 +71,7 @@ class ServerWatchState extends TuiState {
   /// Whether the raw server logs overlay (the "dev console") is visible.
   ///
   /// Raw server stdout/stderr is hidden from the default tabs and reached
-  /// on demand via the backtick (`` ` ``) shortcut.
+  /// on demand via the backtick or `.` shortcut.
   bool showRawServerLogs = false;
 
   /// Maximum number of log entries to keep.

--- a/tools/serverpod_cli/lib/src/commands/start/tui/state.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/tui/state.dart
@@ -62,6 +62,12 @@ class ServerWatchState extends TuiState {
   /// Whether the help overlay is visible.
   bool showHelp = false;
 
+  /// Whether stack traces attached to log entries are shown inline.
+  ///
+  /// When false, an error entry that carries a trace shows a compact
+  /// affordance instead; toggled with `e` on the structured log tab.
+  bool expandStackTraces = false;
+
   /// Maximum number of log entries to keep.
   static const maxLogEntries = 10000;
 

--- a/tools/serverpod_cli/test/commands/start/tui/app_test.dart
+++ b/tools/serverpod_cli/test/commands/start/tui/app_test.dart
@@ -1,6 +1,7 @@
-import 'package:nocterm/nocterm.dart';
+import 'package:nocterm/nocterm.dart' hide LogEntry;
 import 'package:serverpod_cli/src/commands/start/tui/app.dart';
 import 'package:serverpod_cli/src/commands/start/tui/state.dart';
+import 'package:serverpod_shared/log.dart';
 import 'package:test/test.dart';
 
 Future<void> _sendCtrlC(NoctermTester tester) {
@@ -10,6 +11,10 @@ Future<void> _sendCtrlC(NoctermTester tester) {
       modifiers: ModifierKeys(ctrl: true),
     ),
   );
+}
+
+Future<void> _sendKey(NoctermTester tester, LogicalKey key) {
+  return tester.sendKeyEvent(KeyboardEvent(logicalKey: key));
 }
 
 void main() {
@@ -48,6 +53,39 @@ void main() {
         expect(quitCalls, 1);
       },
     );
+  });
+
+  group('Given a structured log tab with a stack-traced error entry', () {
+    setUp(() {
+      state.logHistory.add(
+        LogEntry(
+          time: DateTime(2026),
+          level: LogLevel.error,
+          message: 'boom',
+          scope: LogScope.root('server'),
+          error: 'Exception: boom',
+          stackTrace: StackTrace.fromString('#0 a\n#1 b'),
+        ),
+      );
+    });
+
+    test('when e is pressed then stack traces expand and collapse', () async {
+      expect(state.expandStackTraces, isFalse);
+
+      await _sendKey(tester, LogicalKey.keyE);
+      expect(state.expandStackTraces, isTrue);
+
+      await _sendKey(tester, LogicalKey.keyE);
+      expect(state.expandStackTraces, isFalse);
+    });
+
+    test('when e is pressed on a raw output tab then traces do not toggle', () async {
+      state.selectedTab = 2;
+
+      await _sendKey(tester, LogicalKey.keyE);
+
+      expect(state.expandStackTraces, isFalse);
+    });
   });
 
   group('Given a running TUI start app with the help overlay open', () {

--- a/tools/serverpod_cli/test/commands/start/tui/app_test.dart
+++ b/tools/serverpod_cli/test/commands/start/tui/app_test.dart
@@ -79,12 +79,38 @@ void main() {
       expect(state.expandStackTraces, isFalse);
     });
 
-    test('when e is pressed on a raw output tab then traces do not toggle', () async {
-      state.selectedTab = 2;
+    test(
+      'when e is pressed on the Flutter logs tab then traces do not toggle',
+      () async {
+        state.showFlutterOutput = true;
+        state.selectedTab = 1;
 
-      await _sendKey(tester, LogicalKey.keyE);
+        await _sendKey(tester, LogicalKey.keyE);
 
-      expect(state.expandStackTraces, isFalse);
+        expect(state.expandStackTraces, isFalse);
+      },
+    );
+
+    test('when backtick is pressed then the raw server logs open', () async {
+      expect(state.showRawServerLogs, isFalse);
+
+      await _sendKey(tester, LogicalKey.backquote);
+      expect(state.showRawServerLogs, isTrue);
+
+      await _sendKey(tester, LogicalKey.backquote);
+      expect(state.showRawServerLogs, isFalse);
+    });
+  });
+
+  group('Given the raw server logs overlay is open', () {
+    setUp(() {
+      state.showRawServerLogs = true;
+    });
+
+    test('when Esc is pressed then it closes', () async {
+      await _sendKey(tester, LogicalKey.escape);
+
+      expect(state.showRawServerLogs, isFalse);
     });
   });
 

--- a/tools/serverpod_cli/test/commands/start/tui/app_test.dart
+++ b/tools/serverpod_cli/test/commands/start/tui/app_test.dart
@@ -100,6 +100,16 @@ void main() {
       await _sendKey(tester, LogicalKey.backquote);
       expect(state.showRawServerLogs, isFalse);
     });
+
+    test('when period is pressed then the raw server logs open', () async {
+      expect(state.showRawServerLogs, isFalse);
+
+      await _sendKey(tester, LogicalKey.period);
+      expect(state.showRawServerLogs, isTrue);
+
+      await _sendKey(tester, LogicalKey.period);
+      expect(state.showRawServerLogs, isFalse);
+    });
   });
 
   group('Given the raw server logs overlay is open', () {
@@ -109,6 +119,12 @@ void main() {
 
     test('when Esc is pressed then it closes', () async {
       await _sendKey(tester, LogicalKey.escape);
+
+      expect(state.showRawServerLogs, isFalse);
+    });
+
+    test('when period is pressed then it closes', () async {
+      await _sendKey(tester, LogicalKey.period);
 
       expect(state.showRawServerLogs, isFalse);
     });

--- a/tools/serverpod_cli/test/commands/start/tui/event_handler_test.dart
+++ b/tools/serverpod_cli/test/commands/start/tui/event_handler_test.dart
@@ -89,7 +89,10 @@ void main() {
         'registered but it is not found in the project files.',
       );
       expect(entry.stackTrace, isNotNull);
-      expect(entry.stackTrace.toString(), '#0      fake (file:///fake.dart:1:1)');
+      expect(
+        entry.stackTrace.toString(),
+        '#0      fake (file:///fake.dart:1:1)',
+      );
     });
   });
 

--- a/tools/serverpod_cli/test/commands/start/tui/event_handler_test.dart
+++ b/tools/serverpod_cli/test/commands/start/tui/event_handler_test.dart
@@ -66,33 +66,48 @@ void main() {
   });
 
   group('Given an error log event with error details and stackTrace', () {
-    test(
-      'when dispatched then stores the error text but not the stack trace',
-      () {
-        handleServerLogEvent(
-          holder,
-          _logEvent({
-            'type': 'log',
-            'level': 'error',
-            'message': 'Failed to apply database migrations.',
-            'error':
-                'Exception: DB has migration version 20260428173453748 '
-                'registered but it is not found in the project files.',
-            'stackTrace': '#0      fake (file:///fake.dart:1:1)',
-          }),
-        );
+    test('when dispatched then stores the error text and stack trace', () {
+      handleServerLogEvent(
+        holder,
+        _logEvent({
+          'type': 'log',
+          'level': 'error',
+          'message': 'Failed to apply database migrations.',
+          'error':
+              'Exception: DB has migration version 20260428173453748 '
+              'registered but it is not found in the project files.',
+          'stackTrace': '#0      fake (file:///fake.dart:1:1)',
+        }),
+      );
 
-        final entry = state.logHistory.first as LogEntry;
-        expect(entry.level, LogLevel.error);
-        expect(entry.message, 'Failed to apply database migrations.');
-        expect(
-          entry.error,
-          'Exception: DB has migration version 20260428173453748 '
-          'registered but it is not found in the project files.',
-        );
-        expect(entry.stackTrace, isNull);
-      },
-    );
+      final entry = state.logHistory.first as LogEntry;
+      expect(entry.level, LogLevel.error);
+      expect(entry.message, 'Failed to apply database migrations.');
+      expect(
+        entry.error,
+        'Exception: DB has migration version 20260428173453748 '
+        'registered but it is not found in the project files.',
+      );
+      expect(entry.stackTrace, isNotNull);
+      expect(entry.stackTrace.toString(), '#0      fake (file:///fake.dart:1:1)');
+    });
+  });
+
+  group('Given an error log event with an empty stackTrace', () {
+    test('when dispatched then leaves the stack trace null', () {
+      handleServerLogEvent(
+        holder,
+        _logEvent({
+          'type': 'log',
+          'level': 'error',
+          'message': 'Something failed.',
+          'stackTrace': '',
+        }),
+      );
+
+      final entry = state.logHistory.first as LogEntry;
+      expect(entry.stackTrace, isNull);
+    });
   });
 
   group('Given a scope_start event', () {


### PR DESCRIPTION
Removes the raw server logs tab from the serverpod start TUI now that stack traces surface in the structured view.

- Attaches stackTrace from ext.serverpod.log events to the log entry and renders it in the Server logs tab collapsed to a ▸ N-line stack trace affordance, toggled inline with e.
- Moves raw server logs from a tab to a backtick (`) overlay, Esc or ` closes it, listed in the help panel.
- Collapses the tabs to Server logs + Flutter logs, which also fixes the empty buffer on no Flutter raw tab and the two swapped scroll controllers.

<img width="1716" height="1218" alt="20260601-2138-44 8035054" src="https://github.com/user-attachments/assets/e24b9478-146c-4a1b-875b-431ab2d482e5" />

Fixes #5223 

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes
None