### PR TITLE
fix: Throw eagerly if invalid chars are used as migration tag name

### DIFF
--- a/tools/serverpod_cli/lib/src/migrations/generator.dart
+++ b/tools/serverpod_cli/lib/src/migrations/generator.dart
@@ -34,7 +34,7 @@ class MigrationGenerator {
     var fmt = DateFormat('yyyyMMddHHmmssSSS');
     var versionName = fmt.format(now);
     if (tag != null && tag.isNotEmpty) {
-      if (RegExp(r'[/\\:*?"<>|\x00-\x1f]').hasMatch(tag)) {
+      if (!RegExp(r'^[a-zA-Z0-9_-\s.]+$').hasMatch(tag)) {
         throw FormatException(
           'Invalid migration tag: "$tag". Only characters that are supported '
           'in file names are allowed.',

--- a/tools/serverpod_cli/lib/src/migrations/generator.dart
+++ b/tools/serverpod_cli/lib/src/migrations/generator.dart
@@ -33,7 +33,13 @@ class MigrationGenerator {
     var now = DateTime.now().toUtc();
     var fmt = DateFormat('yyyyMMddHHmmssSSS');
     var versionName = fmt.format(now);
-    if (tag != null) {
+    if (tag != null && tag.isNotEmpty) {
+      if (RegExp(r'[/\\:*?"<>|\x00-\x1f]').hasMatch(tag)) {
+        throw FormatException(
+          'Invalid migration tag: "$tag". Only characters that are supported '
+          'in file names are allowed.',
+        );
+      }
       versionName += '-$tag';
     }
     return versionName;

--- a/tools/serverpod_cli/test/migrations/generator_test.dart
+++ b/tools/serverpod_cli/test/migrations/generator_test.dart
@@ -1,0 +1,65 @@
+import 'package:serverpod_cli/src/migrations/generator.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test(
+    'Given a migration version name with no tag, '
+    'when creating a version name, '
+    'then it returns a timestamp-based version name.',
+    () {
+      final versionName = MigrationGenerator.createVersionName(null);
+
+      expect(versionName, matches(RegExp(r'^\d{17}$')));
+    },
+  );
+
+  test(
+    'Given a migration version name with a tag containing spaces, '
+    'when creating a version name, '
+    'then the tag is included with the spaces.',
+    () {
+      const tag = 'foo bar';
+      final versionName = MigrationGenerator.createVersionName(tag);
+
+      final tagPart = versionName.split('-').last;
+      expect(tagPart, 'foo bar');
+    },
+  );
+
+  test(
+    'Given a migration version name with a tag containing dots, '
+    'when creating a version name, '
+    'then the dots are preserved.',
+    () {
+      const tag = 'foo..bar';
+      final versionName = MigrationGenerator.createVersionName(tag);
+
+      final tagPart = versionName.split('-').last;
+      expect(tagPart, 'foo..bar');
+    },
+  );
+
+  test(
+    'Given a migration version name with a tag containing path separators, '
+    'when creating a version name, '
+    'then a FormatException is thrown.',
+    () {
+      expect(
+        () => MigrationGenerator.createVersionName('foo/bar'),
+        throwsA(isA<FormatException>()),
+      );
+    },
+  );
+
+  test(
+    'Given a migration version name with a tag containing unsupported path characters, '
+    'when creating a version name, '
+    'then a FormatException is thrown.',
+    () {
+      expect(
+        () => MigrationGenerator.createVersionName(r'foo*bar:"<>|'),
+        throwsA(isA<FormatException>()),
+      );
+    },
+  );
+}


### PR DESCRIPTION
Closes: #5029

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.