### PR TITLE
feat(auth): Add 'kid' to JWT header for ES512 tokens and update tests

### DIFF
--- a/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_server/lib/src/jwt/business/jwt_util.dart
+++ b/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_server/lib/src/jwt/business/jwt_util.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:crypto/crypto.dart';
 import 'package:dart_jsonwebtoken/dart_jsonwebtoken.dart' as dart_jsonwebtoken;
 import 'package:serverpod/serverpod.dart';
 
@@ -70,20 +71,32 @@ class JwtUtil {
     final (
       dart_jsonwebtoken.JWTKey key,
       dart_jsonwebtoken.JWTAlgorithm algorithm,
+      String? kid,
     ) = switch (_algorithm) {
       HmacSha256JwtAlgorithmConfiguration(:final key) => (
         key,
         dart_jsonwebtoken.JWTAlgorithm.HS256,
+        null,
       ),
       HmacSha512JwtAlgorithmConfiguration(:final key) => (
         key,
         dart_jsonwebtoken.JWTAlgorithm.HS512,
+        null,
       ),
-      EcdsaSha512JwtAlgorithmConfiguration(:final privateKey) => (
-        privateKey,
-        dart_jsonwebtoken.JWTAlgorithm.ES512,
-      ),
+      EcdsaSha512JwtAlgorithmConfiguration(
+        :final privateKey,
+        :final publicKey,
+      ) =>
+        (
+          privateKey,
+          dart_jsonwebtoken.JWTAlgorithm.ES512,
+          _computeKid(publicKey),
+        ),
     };
+
+    if (kid != null) {
+      jwt.header = {'kid': kid};
+    }
 
     return jwt.sign(
       key,
@@ -191,6 +204,23 @@ class JwtUtil {
     }
 
     throw firstError!;
+  }
+
+  /// Computes an RFC 7638 JWK Thumbprint for an EC public key.
+  ///
+  /// Used as the `kid` value in JWT headers for ES512 tokens so that
+  /// consumers can efficiently select the correct key from a JWKS endpoint.
+  static String _computeKid(final dart_jsonwebtoken.ECPublicKey publicKey) {
+    final jwk = publicKey.toJWK();
+    // RFC 7638 members in lexicographic order, no whitespace.
+    final input = jsonEncode({
+      'crv': jwk['crv'],
+      'kty': 'EC',
+      'x': jwk['x'],
+      'y': jwk['y'],
+    });
+    final digest = sha256.convert(utf8.encode(input));
+    return base64Url.encode(digest.bytes).replaceAll('=', '');
   }
 
   /// Registered claims as per https://datatracker.ietf.org/doc/html/rfc7519#section-4.1

--- a/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_server/test/jwt/jwt_util_test.dart
+++ b/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_server/test/jwt/jwt_util_test.dart
@@ -696,12 +696,23 @@ void main() {
       );
 
       test(
-        'when the JWT is decoded, then it names ES512 as its `alg`.',
+        'when the JWT is decoded, then it names ES512 as its `alg` and includes a `kid`.',
         () {
-          expect(
-            dart_jsonwebtoken.JWT.decode(jwtToken).header,
-            equals({'alg': 'ES512', 'typ': 'JWT'}),
-          );
+          final header = dart_jsonwebtoken.JWT.decode(jwtToken).header!;
+          expect(header['alg'], equals('ES512'));
+          expect(header['typ'], equals('JWT'));
+          expect(header['kid'], isA<String>());
+          expect(header['kid'], isNotEmpty);
+        },
+      );
+
+      test(
+        'when two JWTs are created with the same key, then they share the same `kid`.',
+        () {
+          final jwt2 = jwtUtil.createJwt(refreshToken);
+          final kid1 = dart_jsonwebtoken.JWT.decode(jwtToken).header!['kid'];
+          final kid2 = dart_jsonwebtoken.JWT.decode(jwt2).header!['kid'];
+          expect(kid1, equals(kid2));
         },
       );
 


### PR DESCRIPTION
This PR adds `kid` in JWT header. The `kid` is optional param but it is recommended RFC 7638 JWK Thumbprint for an EC public key. When the server support multiple EC pair, then `kid` helps to optimize validation by `JWKS` by selecting the right key by `kid`. 

Fixes https://github.com/serverpod/serverpod/issues/5269

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

No breaking changes