### PR TITLE
fix: Fix flaky `flutterAppUrl` expect on `flutter_process_test`

### DIFF
--- a/tools/serverpod_cli/lib/src/commands/start/flutter_process.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/flutter_process.dart
@@ -122,7 +122,7 @@ class FlutterProcess {
   /// True once [connectToVmService] resolved the upstream VM service.
   bool get isVmServiceConnected => _vmService != null;
 
-  /// HTTP VM service URI, or `null` before [connectToVmService] resolves.
+  /// HTTP VM service URI published by the daemon, or `null` before publication.
   String? get vmServiceUri => _vmServiceUri;
 
   /// Connected `vm_service` client; `null` outside connect..[stop].
@@ -255,7 +255,6 @@ class FlutterProcess {
       return;
     }
     if (maybeUri == null) return;
-    _vmServiceUri = maybeUri;
 
     final wsUri = vmServiceWsUri(maybeUri);
     await _flutterProxy?.setUpstream(Uri.parse(wsUri));
@@ -484,7 +483,9 @@ class FlutterProcess {
           final wsUri = paramMap['wsUri'];
           if (wsUri is String && !_vmServiceUriCompleter.isCompleted) {
             // IDEs and callers expect the http form.
-            _vmServiceUriCompleter.complete(httpFromWs(wsUri));
+            final httpUri = httpFromWs(wsUri);
+            _vmServiceUri = httpUri;
+            _vmServiceUriCompleter.complete(httpUri);
           }
           if (!_launchedCompleter.isCompleted) _launchedCompleter.complete();
         case 'app.webLaunchUrl':

--- a/tools/serverpod_cli/test/commands/start/flutter_process_test.dart
+++ b/tools/serverpod_cli/test/commands/start/flutter_process_test.dart
@@ -162,10 +162,12 @@ void main() {
       late FlutterProcess fp;
       late ({HttpServer server, String wsUri}) fake;
       late List<String> progressMessages;
+      late Completer<void> ready;
 
       setUp(() async {
         fake = await _startFakeVmService();
         progressMessages = <String>[];
+        ready = Completer<void>();
 
         fp = FlutterProcess(
           flutterPackageDir: Directory.current.path,
@@ -176,7 +178,10 @@ void main() {
             '--ws=${fake.wsUri}',
             '--web-url=http://localhost:54321',
           ],
-          onProgress: progressMessages.add,
+          onProgress: (message) {
+            progressMessages.add(message);
+            if (message == 'ready' && !ready.isCompleted) ready.complete();
+          },
         );
 
         await fp.start();
@@ -187,17 +192,14 @@ void main() {
 
       tearDown(() async {
         await fp.stop();
+        await fake.server.close(force: true);
       });
 
       test(
         'when the shim emits app.progress, app.webLaunchUrl, app.debugPort, app.dtd, app.started '
         'then onProgress fires, flutterAppUrl is captured, dtdUri is captured, and vmServiceUri is the http form of the daemon\'s wsUri',
         () async {
-          // Wait until the URI shows up (the shim emits it ~immediately).
-          final deadline = DateTime.now().add(const Duration(seconds: 5));
-          while (fp.vmServiceUri == null && DateTime.now().isBefore(deadline)) {
-            await Future<void>.delayed(const Duration(milliseconds: 20));
-          }
+          await ready.future.timeout(const Duration(seconds: 20));
 
           expect(
             fp.vmServiceUri,
@@ -210,7 +212,6 @@ void main() {
           expect(progressMessages, contains('ready'));
 
           await fp.stop(timeout: const Duration(seconds: 1));
-          await fake.server.close(force: true);
         },
         timeout: const Timeout(Duration(seconds: 30)),
       );
@@ -518,6 +519,7 @@ void main() {
         );
         await fp.launched.timeout(const Duration(milliseconds: 100));
         expect(fp.flutterAppUrl, isNull);
+        expect(fp.vmServiceUri, 'http://127.0.0.1:1111');
       },
     );
   });


### PR DESCRIPTION
_Replace this paragraph with a description of what this PR is changing or adding, and why._

_List which issues are fixed by this PR. You must list at least one issue._

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

_If you have done any breaking changes, make sure to outline them here, so that they can be included in the notes for the next release._