### PR TITLE
fix: Ignore `runtimeParametersBuilder` on SQLite instead of throwing `UnsupportedError`

### DIFF
--- a/packages/serverpod_database/lib/src/adapters/sqlite/database_provider.dart
+++ b/packages/serverpod_database/lib/src/adapters/sqlite/database_provider.dart
@@ -1,3 +1,4 @@
+import 'package:serverpod_shared/log.dart';
 import 'package:serverpod_shared/serverpod_shared.dart';
 
 import '../../../serverpod_database.dart';
@@ -24,7 +25,9 @@ class SqliteDatabaseProvider implements DatabaseProvider {
     SqliteDatabaseConfig config,
   ) {
     if (runtimeParametersBuilder != null) {
-      throw UnsupportedError('SQLite does not support runtime parameters.');
+      log.warning(
+        'Runtime parameters are not supported on SQLite and will be ignored.',
+      );
     }
     return SqlitePoolManager(
       serializationManager,

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/test_integration/database_operations/runtime_parameters/runtime_parameters_test.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/test_integration/database_operations/runtime_parameters/runtime_parameters_test.dart
@@ -1,20 +1,34 @@
+import 'package:serverpod_shared/log.dart';
 import 'package:serverpod_test_sqlite_server/test_util/test_serverpod.dart';
 import 'package:test/test.dart';
 
 void main() {
-  group('Given server with runtime parameters builder', () {
-    final serverBuilder = () => IntegrationTestServer(
-      runtimeParametersBuilder: (params) => [],
-    );
+  test(
+    'Given server with runtime parameters builder, '
+    'when creating the server, '
+    'then a warning is logged since SQLite does not support SET runtime parameters.',
+    () async {
+      final testWriter = TestLogWriter();
+      logWriter.add(testWriter);
+      addTearDown(() => logWriter.remove(testWriter));
 
-    test(
-      'when creating the server '
-      'then an exception is thrown since SQLite does not support SET runtime parameters.',
-      () {
-        // NOTE: The ideal would be to use throwsUnsupportedError, but the
-        // Serverpod start catches it first and exits the process.
-        expect(serverBuilder, isNot(completes));
-      },
-    );
-  });
+      IntegrationTestServer(
+        runtimeParametersBuilder: (params) => [],
+      );
+
+      await log.flush();
+
+      var warnings = testWriter.entries
+          .where((e) => e.level == LogLevel.warning)
+          .map((e) => e.message)
+          .toList();
+
+      expect(
+        warnings,
+        contains(
+          'Runtime parameters are not supported on SQLite and will be ignored.',
+        ),
+      );
+    },
+  );
 }


### PR DESCRIPTION
Fixes an asymmetry on the behavior of SQLite regarding runtime parameters (no-op on transactions, throw on global level). With this change, both places will be a no-op, with a proper warning on the global level.

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.