### PR TITLE
perf: Use staleness check to avoid redundant work on generate

### DIFF
--- a/tools/serverpod_cli/lib/src/commands/generate.dart
+++ b/tools/serverpod_cli/lib/src/commands/generate.dart
@@ -158,12 +158,12 @@ class GenerateCommand extends ServerpodCommand<GenerateOption> {
 /// Generates code if it is stale, returning whether it was already [upToDate]
 /// and, when generation ran, whether it reported [success].
 ///
-/// [createAnalyzers] must return an *unprimed* analyzer (e.g.
-/// [Analyzers.create]); the single full prime happens inside [analyzeAndGenerate].
+/// [createAnalyzers] must return an unprimed analyzer (ie. [Analyzers.create]).
+/// The priming happens inside [analyzeAndGenerate].
 ///
-/// When [keepPrimedWhenFresh] is `false` (one-shot generate) a fresh project
-/// returns before the analyzer is created. When `true` (the watch loops) the
-/// analyzer is always created and primed for the incremental loop.
+/// When [keepPrimedWhenFresh] is `false` a fresh project returns before the
+/// analyzer is created. When `true` the analyzer is always created and primed
+/// for an incremental loop.
 Future<({bool upToDate, bool success})> generateIfStale({
   required GeneratorConfig config,
   required Future<Analyzers> Function() createAnalyzers,
@@ -180,8 +180,9 @@ Future<({bool upToDate, bool success})> generateIfStale({
   final result = await analyzeAndGenerate(
     config: config,
     analyzers: analyzers,
-    affectedPaths: allSources,
+    affectedPaths: allSources.keys.toSet(),
     verifyStaleness: keepPrimedWhenFresh,
+    sourceStats: allSources,
   );
   // A full run only returns an empty file set when it skipped generation
   // because the output was already up to date.
@@ -225,6 +226,7 @@ Future<GenerateResult> analyzeAndGenerate({
   required Set<String> affectedPaths,
   bool incremental = false,
   bool verifyStaleness = true,
+  Map<String, FileStamp>? sourceStats,
   GenerationRequirements requirements = GenerationRequirements.full,
 }) async {
   bool needsGenerate = false;
@@ -239,7 +241,8 @@ Future<GenerateResult> analyzeAndGenerate({
   if (incremental) {
     if (!needsGenerate) return (success: true, generatedFiles: <String>{});
   } else if (verifyStaleness &&
-      await isGenerationUpToDate(config, affectedPaths)) {
+      sourceStats != null &&
+      await isGenerationUpToDate(config, sourceStats)) {
     log.debug('Generated code is up to date, skipping.');
     return (success: true, generatedFiles: <String>{});
   }
@@ -256,9 +259,9 @@ Future<GenerateResult> analyzeAndGenerate({
     await writeGenerationStamp(
       config,
       generatedFiles: result.generatedFiles,
-      // A full run's affectedPaths is the complete source set it just
-      // enumerated; reuse it so the stamp doesn't walk the tree again.
-      sourceFiles: incremental ? null : affectedPaths,
+      // A full run reuses the stamps captured at enumeration; an incremental
+      // run re-enumerates, since its affected paths is only the changed subset.
+      sourceStats: incremental ? null : sourceStats,
     );
     log.debug(incrementalCodeGenerationComplete);
   }
@@ -269,8 +272,8 @@ Future<GenerateResult> analyzeAndGenerate({
 Future<bool> _performGenerateWatch({
   required GeneratorConfig config,
 }) async {
-  // keepPrimedWhenFresh: the incremental loop only updates changed files, so the
-  // analyzer must be primed up front even when nothing needs regenerating.
+  // keepPrimedWhenFresh: the incremental loop only updates changed files, so
+  // the analyzer must be primed up front even when nothing needs regenerating.
   // In-process is fine here; only start's TUI needs the isolate offload.
   final analyzers = await Analyzers.create(config);
   final initialResult = await generateIfStale(

--- a/tools/serverpod_cli/lib/src/commands/generate.dart
+++ b/tools/serverpod_cli/lib/src/commands/generate.dart
@@ -161,10 +161,9 @@ class GenerateCommand extends ServerpodCommand<GenerateOption> {
 /// [createAnalyzers] must return an *unprimed* analyzer (e.g.
 /// [Analyzers.create]); the single full prime happens inside [analyzeAndGenerate].
 ///
-/// When [keepPrimedWhenFresh] is `false` (one-shot generate), a fresh project
-/// returns before the analyzer is created, skipping the spin-up entirely. When
-/// `true` (the watch loops), the analyzer is always created and primed so the
-/// incremental loop has full context, even when there is nothing to generate.
+/// When [keepPrimedWhenFresh] is `false` (one-shot generate) a fresh project
+/// returns before the analyzer is created. When `true` (the watch loops) the
+/// analyzer is always created and primed for the incremental loop.
 Future<({bool upToDate, bool success})> generateIfStale({
   required GeneratorConfig config,
   required Future<Analyzers> Function() createAnalyzers,
@@ -176,14 +175,13 @@ Future<({bool upToDate, bool success})> generateIfStale({
   }
 
   final analyzers = await createAnalyzers();
-  // skipStalenessCheck stays false: update(allSources) is the single full prime,
-  // then performGenerate(affectedPaths: null) reuses it for a cheap generate.
-  // On a fresh project the prime still runs before the staleness check skips
-  // generation, leaving the analyzer ready for the watch loop.
+  // Re-verify staleness only when we skipped the up-front check; the one-shot
+  // path already verified it, so generation runs unconditionally.
   final result = await analyzeAndGenerate(
     config: config,
     analyzers: analyzers,
     affectedPaths: allSources,
+    verifyStaleness: keepPrimedWhenFresh,
   );
   // A full run only returns an empty file set when it skipped generation
   // because the output was already up to date.
@@ -206,9 +204,13 @@ Future<bool> performOneShotGenerate({
 
 /// Analyzes affected paths and runs code generation if needed.
 ///
-/// When [skipStalenessCheck] is `true`, skips the mtime check against the
-/// generation stamp (use when the caller already knows files changed, e.g.
-/// from a file watcher event).
+/// An [incremental] (watcher-driven) run generates only [affectedPaths] and
+/// skips when none of them affect generation; a full run regenerates the whole
+/// project.
+///
+/// [verifyStaleness] applies only to full runs: skip generation when the stamp
+/// is up to date. Pass `false` when the caller already verified staleness, so
+/// generation runs and refreshes the stamp regardless.
 ///
 /// The [requirements] parameter controls which parts of the generation
 /// pipeline run. When model files change, use [GenerationRequirements.full].
@@ -217,16 +219,12 @@ Future<bool> performOneShotGenerate({
 ///
 /// Returns a [GenerateResult] with success status and the set of files
 /// written by code generation (empty when generation was skipped).
-///
-/// When [skipStalenessCheck] is `true` (watcher-driven runs), model hint/info
-/// output is limited to [affectedPaths]. When `false`, all model issues are
-/// reported (one-shot generate and runs that re-check staleness against the
-/// whole project).
 Future<GenerateResult> analyzeAndGenerate({
   required GeneratorConfig config,
   required Analyzers analyzers,
   required Set<String> affectedPaths,
-  bool skipStalenessCheck = false,
+  bool incremental = false,
+  bool verifyStaleness = true,
   GenerationRequirements requirements = GenerationRequirements.full,
 }) async {
   bool needsGenerate = false;
@@ -238,15 +236,10 @@ Future<GenerateResult> analyzeAndGenerate({
     );
     return true;
   });
-  if (skipStalenessCheck) {
-    // Watcher-driven incremental run: the changed files are known, so skip only
-    // when none of them affect generation.
+  if (incremental) {
     if (!needsGenerate) return (success: true, generatedFiles: <String>{});
-  } else if (await isGenerationUpToDate(config, affectedPaths)) {
-    // Full run: the stamp is the source of truth. When it is up to date there
-    // is nothing to do; otherwise fall through and regenerate even if no single
-    // source "needs" it, so deleted sources are cleaned up, a CLI upgrade is
-    // applied, and the stamp is refreshed (avoiding re-analysis every run).
+  } else if (verifyStaleness &&
+      await isGenerationUpToDate(config, affectedPaths)) {
     log.debug('Generated code is up to date, skipping.');
     return (success: true, generatedFiles: <String>{});
   }
@@ -255,12 +248,18 @@ Future<GenerateResult> analyzeAndGenerate({
     result = await analyzers.performGenerate(
       config: config,
       requirements: requirements,
-      affectedPaths: skipStalenessCheck ? affectedPaths : null,
+      affectedPaths: incremental ? affectedPaths : null,
     );
     return result.success;
   });
   if (result.success) {
-    await writeGenerationStamp(config, generatedFiles: result.generatedFiles);
+    await writeGenerationStamp(
+      config,
+      generatedFiles: result.generatedFiles,
+      // A full run's affectedPaths is the complete source set it just
+      // enumerated; reuse it so the stamp doesn't walk the tree again.
+      sourceFiles: incremental ? null : affectedPaths,
+    );
     log.debug(incrementalCodeGenerationComplete);
   }
   return result;
@@ -311,7 +310,7 @@ Future<bool> _performGenerateWatch({
         config: config,
         analyzers: analyzers,
         affectedPaths: affectedPaths,
-        skipStalenessCheck: true,
+        incremental: true,
       );
     } catch (e, stackTrace) {
       log.error(e.toString(), stackTrace: stackTrace);

--- a/tools/serverpod_cli/lib/src/commands/generate.dart
+++ b/tools/serverpod_cli/lib/src/commands/generate.dart
@@ -185,7 +185,9 @@ Future<({bool upToDate, bool success})> generateIfStale({
     analyzers: analyzers,
     affectedPaths: allSources,
   );
-  return (upToDate: false, success: result.success);
+  // A full run only returns an empty file set when it skipped generation
+  // because the output was already up to date.
+  return (upToDate: result.generatedFiles.isEmpty, success: result.success);
 }
 
 /// One-shot code generation in an isolate-friendly function.
@@ -280,6 +282,9 @@ Future<bool> _performGenerateWatch({
   if (!initialResult.success) {
     await analyzers.close();
     return false;
+  }
+  if (initialResult.upToDate) {
+    log.info(generatedCodeAlreadyUpToDate, type: TextLogType.success);
   }
 
   log.debug(initialCodeGenerationComplete);

--- a/tools/serverpod_cli/lib/src/commands/generate.dart
+++ b/tools/serverpod_cli/lib/src/commands/generate.dart
@@ -155,20 +155,50 @@ class GenerateCommand extends ServerpodCommand<GenerateOption> {
   }
 }
 
-/// One-shot code generation in an isolate-friendly function.
-Future<bool> performOneShotGenerate({
+/// Generates code if it is stale, returning whether it was already [upToDate]
+/// and, when generation ran, whether it reported [success].
+///
+/// [createAnalyzers] must return an *unprimed* analyzer (e.g.
+/// [Analyzers.create]); the single full prime happens inside [analyzeAndGenerate].
+///
+/// When [keepPrimedWhenFresh] is `false` (one-shot generate), a fresh project
+/// returns before the analyzer is created, skipping the spin-up entirely. When
+/// `true` (the watch loops), the analyzer is always created and primed so the
+/// incremental loop has full context, even when there is nothing to generate.
+Future<({bool upToDate, bool success})> generateIfStale({
   required GeneratorConfig config,
+  required Future<Analyzers> Function() createAnalyzers,
+  bool keepPrimedWhenFresh = false,
 }) async {
-  final analyzers = await Analyzers.create(config);
   final allSources = await enumerateSourceFiles(config);
+  if (!keepPrimedWhenFresh && await isGenerationUpToDate(config, allSources)) {
+    return (upToDate: true, success: true);
+  }
+
+  final analyzers = await createAnalyzers();
+  // skipStalenessCheck stays false: update(allSources) is the single full prime,
+  // then performGenerate(affectedPaths: null) reuses it for a cheap generate.
+  // On a fresh project the prime still runs before the staleness check skips
+  // generation, leaving the analyzer ready for the watch loop.
   final result = await analyzeAndGenerate(
     config: config,
     analyzers: analyzers,
     affectedPaths: allSources,
-    // Always run generation to prevent bad output from the watch command to be
-    // persisted, since the generation stamp will be greater than source files.
-    skipStalenessCheck: true,
   );
+  return (upToDate: false, success: result.success);
+}
+
+/// One-shot code generation in an isolate-friendly function.
+Future<bool> performOneShotGenerate({
+  required GeneratorConfig config,
+}) async {
+  final result = await generateIfStale(
+    config: config,
+    createAnalyzers: () => Analyzers.create(config),
+  );
+  if (result.upToDate) {
+    log.info(generatedCodeAlreadyUpToDate, type: TextLogType.success);
+  }
   return result.success;
 }
 
@@ -206,10 +236,16 @@ Future<GenerateResult> analyzeAndGenerate({
     );
     return true;
   });
-  if (!needsGenerate) return (success: true, generatedFiles: <String>{});
-  if (!skipStalenessCheck &&
-      await isGenerationUpToDate(config, affectedPaths)) {
-    log.debug('All affected files are older than generation stamp, skipping.');
+  if (skipStalenessCheck) {
+    // Watcher-driven incremental run: the changed files are known, so skip only
+    // when none of them affect generation.
+    if (!needsGenerate) return (success: true, generatedFiles: <String>{});
+  } else if (await isGenerationUpToDate(config, affectedPaths)) {
+    // Full run: the stamp is the source of truth. When it is up to date there
+    // is nothing to do; otherwise fall through and regenerate even if no single
+    // source "needs" it, so deleted sources are cleaned up, a CLI upgrade is
+    // applied, and the stamp is refreshed (avoiding re-analysis every run).
+    log.debug('Generated code is up to date, skipping.');
     return (success: true, generatedFiles: <String>{});
   }
   late final GenerateResult result;
@@ -232,14 +268,19 @@ Future<GenerateResult> analyzeAndGenerate({
 Future<bool> _performGenerateWatch({
   required GeneratorConfig config,
 }) async {
+  // keepPrimedWhenFresh: the incremental loop only updates changed files, so the
+  // analyzer must be primed up front even when nothing needs regenerating.
+  // In-process is fine here; only start's TUI needs the isolate offload.
   final analyzers = await Analyzers.create(config);
-  final allSources = await enumerateSourceFiles(config);
-  final initialResult = await analyzeAndGenerate(
+  final initialResult = await generateIfStale(
     config: config,
-    analyzers: analyzers,
-    affectedPaths: allSources,
+    createAnalyzers: () async => analyzers,
+    keepPrimedWhenFresh: true,
   );
-  if (!initialResult.success) return false;
+  if (!initialResult.success) {
+    await analyzers.close();
+    return false;
+  }
 
   log.debug(initialCodeGenerationComplete);
 

--- a/tools/serverpod_cli/lib/src/commands/generate.dart
+++ b/tools/serverpod_cli/lib/src/commands/generate.dart
@@ -37,6 +37,17 @@ enum GenerateOption<V> implements OptionDefinition<V> {
           'The directory to generate code for (defaults to current directory).',
     ),
   ),
+  force(
+    FlagOption(
+      argName: 'force',
+      argAbbrev: 'f',
+      defaultsTo: false,
+      negatable: false,
+      helpText:
+          'Regenerate even when the output looks up to date. Use this '
+          'to rebuild after hand-editing or reverting generated files.',
+    ),
+  ),
   ;
 
   const GenerateOption(this.option);
@@ -59,6 +70,7 @@ class GenerateCommand extends ServerpodCommand<GenerateOption> {
   ) async {
     // Always do a full generate.
     bool watch = commandConfig.value(GenerateOption.watch);
+    bool force = commandConfig.value(GenerateOption.force);
     String directory = commandConfig.value(GenerateOption.directory);
 
     // Get interactive flag from global configuration
@@ -142,9 +154,9 @@ class GenerateCommand extends ServerpodCommand<GenerateOption> {
 
     late final bool success;
     if (watch) {
-      success = await _performGenerateWatch(config: config);
+      success = await _performGenerateWatch(config: config, force: force);
     } else {
-      success = await performOneShotGenerate(config: config);
+      success = await performOneShotGenerate(config: config, force: force);
     }
 
     if (!success) {
@@ -161,27 +173,34 @@ class GenerateCommand extends ServerpodCommand<GenerateOption> {
 /// [createAnalyzers] must return an unprimed analyzer (ie. [Analyzers.create]).
 /// The priming happens inside [analyzeAndGenerate].
 ///
+/// When [keepPrimedWhenFresh] is `false` (one-shot generate) a fresh project
 /// When [keepPrimedWhenFresh] is `false` a fresh project returns before the
 /// analyzer is created. When `true` the analyzer is always created and primed
 /// for an incremental loop.
+/// When [force] is `true`, the staleness check is bypassed and generation
+/// always runs.
 Future<({bool upToDate, bool success})> generateIfStale({
   required GeneratorConfig config,
   required Future<Analyzers> Function() createAnalyzers,
   bool keepPrimedWhenFresh = false,
+  bool force = false,
 }) async {
   final allSources = await enumerateSourceFiles(config);
-  if (!keepPrimedWhenFresh && await isGenerationUpToDate(config, allSources)) {
+  if (!force &&
+      !keepPrimedWhenFresh &&
+      await isGenerationUpToDate(config, allSources)) {
     return (upToDate: true, success: true);
   }
 
   final analyzers = await createAnalyzers();
-  // Re-verify staleness only when we skipped the up-front check; the one-shot
-  // path already verified it, so generation runs unconditionally.
+  // Re-verify staleness only when we skipped the up-front check (and aren't
+  // forcing); the one-shot path already verified it, so generation runs
+  // unconditionally.
   final result = await analyzeAndGenerate(
     config: config,
     analyzers: analyzers,
     affectedPaths: allSources.keys.toSet(),
-    verifyStaleness: keepPrimedWhenFresh,
+    verifyStaleness: keepPrimedWhenFresh && !force,
     sourceStats: allSources,
   );
   // A full run only returns an empty file set when it skipped generation
@@ -190,12 +209,16 @@ Future<({bool upToDate, bool success})> generateIfStale({
 }
 
 /// One-shot code generation in an isolate-friendly function.
+///
+/// Pass [force] to regenerate even when the output looks up to date.
 Future<bool> performOneShotGenerate({
   required GeneratorConfig config,
+  bool force = false,
 }) async {
   final result = await generateIfStale(
     config: config,
     createAnalyzers: () => Analyzers.create(config),
+    force: force,
   );
   if (result.upToDate) {
     log.info(generatedCodeAlreadyUpToDate, type: TextLogType.success);
@@ -271,6 +294,7 @@ Future<GenerateResult> analyzeAndGenerate({
 /// Watch-mode code generation with persistent analyzers and file watching.
 Future<bool> _performGenerateWatch({
   required GeneratorConfig config,
+  bool force = false,
 }) async {
   // keepPrimedWhenFresh: the incremental loop only updates changed files, so
   // the analyzer must be primed up front even when nothing needs regenerating.
@@ -280,6 +304,7 @@ Future<bool> _performGenerateWatch({
     config: config,
     createAnalyzers: () async => analyzers,
     keepPrimedWhenFresh: true,
+    force: force,
   );
   if (!initialResult.success) {
     await analyzers.close();

--- a/tools/serverpod_cli/lib/src/commands/messages.dart
+++ b/tools/serverpod_cli/lib/src/commands/messages.dart
@@ -3,6 +3,7 @@ const initialCodeGenerationComplete =
     '✓ Initial code generation complete. Listening for changes.';
 const incrementalCodeGenerationComplete =
     '✓ Incremental code generation complete.';
+const generatedCodeAlreadyUpToDate = '✓ Generated code is already up to date.';
 
 // Start command messages
 const serverRunning = 'Server running.';

--- a/tools/serverpod_cli/lib/src/commands/start.dart
+++ b/tools/serverpod_cli/lib/src/commands/start.dart
@@ -461,18 +461,27 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
 
   // keepPrimedWhenFresh: the analyzers are needed by the watch session even when
   // generation is up to date.
-  final genResult = await generateIfStale(
-    config: config,
-    keepPrimedWhenFresh: true,
-    createAnalyzers: () async {
-      late final IsolatedAnalyzers analyzers;
-      await log.progress('Initializing analyzers', () async {
-        analyzers = await analyzersFuture;
-        return true;
-      });
-      return analyzers;
-    },
-  );
+  late final ({bool upToDate, bool success}) genResult;
+  try {
+    genResult = await generateIfStale(
+      config: config,
+      keepPrimedWhenFresh: true,
+      createAnalyzers: () async {
+        late final IsolatedAnalyzers analyzers;
+        await log.progress('Initializing analyzers', () async {
+          analyzers = await analyzersFuture;
+          return true;
+        });
+        return analyzers;
+      },
+    );
+  } catch (_) {
+    // The eager analyzer isolate and any Docker services must be torn down even
+    // when analysis/generation throws, not just on a clean failure.
+    await closeAnalyzers();
+    await rollbackProvisioning();
+    rethrow;
+  }
   if (!genResult.success) {
     log.error('Code generation failed.');
     await closeAnalyzers();

--- a/tools/serverpod_cli/lib/src/commands/start.dart
+++ b/tools/serverpod_cli/lib/src/commands/start.dart
@@ -23,7 +23,6 @@ import 'package:serverpod_cli/src/commands/start/watch_loop.dart';
 import 'package:serverpod_cli/src/commands/start/watch_session.dart';
 import 'package:serverpod_cli/src/commands/watcher.dart';
 import 'package:serverpod_cli/src/config_info/config_info.dart';
-import 'package:serverpod_cli/src/generator/generation_staleness.dart';
 import 'package:serverpod_cli/src/generator/isolated_analyzers.dart';
 import 'package:serverpod_cli/src/mcp/socket_directory.dart';
 import 'package:serverpod_cli/src/migrations/cli_migration_runner.dart';
@@ -455,33 +454,30 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
     rethrow;
   }
 
-  final analyzersFuture = IsolatedAnalyzers.create(config);
+  // prime: false - the single full prime happens inside generateIfStale; here
+  // we only spawn the isolate eagerly so it overlaps the staleness check.
+  final analyzersFuture = IsolatedAnalyzers.create(config, prime: false);
   Future<void> closeAnalyzers() async => (await analyzersFuture).close();
 
-  // Code generation staleness check.
-  final allSources = await enumerateSourceFiles(config);
-  if (!await isGenerationUpToDate(config, allSources)) {
-    late final IsolatedAnalyzers analyzers;
-    await log.progress('Initializing analyzers', () async {
-      analyzers = await analyzersFuture;
-      return true;
-    });
-    late final ({bool success, Set<String> generatedFiles}) genResult;
-    await log.progress('Generating code', () async {
-      genResult = await analyzeAndGenerate(
-        analyzers: analyzers,
-        config: config,
-        affectedPaths: allSources,
-        requirements: GenerationRequirements.full,
-      );
-      return genResult.success;
-    });
-    if (!genResult.success) {
-      log.error('Code generation failed.');
-      await closeAnalyzers();
-      await rollbackProvisioning();
-      return const WatchLoopAborted(1);
-    }
+  // keepPrimedWhenFresh: the analyzers are needed by the watch session even when
+  // generation is up to date.
+  final genResult = await generateIfStale(
+    config: config,
+    keepPrimedWhenFresh: true,
+    createAnalyzers: () async {
+      late final IsolatedAnalyzers analyzers;
+      await log.progress('Initializing analyzers', () async {
+        analyzers = await analyzersFuture;
+        return true;
+      });
+      return analyzers;
+    },
+  );
+  if (!genResult.success) {
+    log.error('Code generation failed.');
+    await closeAnalyzers();
+    await rollbackProvisioning();
+    return const WatchLoopAborted(1);
   }
 
   // FES setup (watch mode only).

--- a/tools/serverpod_cli/lib/src/commands/start.dart
+++ b/tools/serverpod_cli/lib/src/commands/start.dart
@@ -459,6 +459,16 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
   final analyzersFuture = IsolatedAnalyzers.create(config, prime: false);
   Future<void> closeAnalyzers() async => (await analyzersFuture).close();
 
+  // Tear down everything provisioned so far: the analyzer isolate and any
+  // Docker services. A failed/in-flight analyzer future must not prevent the
+  // Docker teardown, so closing it is guarded.
+  Future<void> rollbackStartup() async {
+    try {
+      await closeAnalyzers();
+    } catch (_) {}
+    await rollbackProvisioning();
+  }
+
   // keepPrimedWhenFresh: the analyzers are needed by the watch session even when
   // generation is up to date.
   late final ({bool upToDate, bool success}) genResult;
@@ -476,16 +486,14 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
       },
     );
   } catch (_) {
-    // The eager analyzer isolate and any Docker services must be torn down even
-    // when analysis/generation throws, not just on a clean failure.
-    await closeAnalyzers();
-    await rollbackProvisioning();
+    // Tear down even when analysis/generation throws, not just on a clean
+    // failure.
+    await rollbackStartup();
     rethrow;
   }
   if (!genResult.success) {
     log.error('Code generation failed.');
-    await closeAnalyzers();
-    await rollbackProvisioning();
+    await rollbackStartup();
     return const WatchLoopAborted(1);
   }
   if (genResult.upToDate) {
@@ -515,8 +523,7 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
       return hooksOk;
     });
     if (!hooksOk) {
-      await closeAnalyzers();
-      await rollbackProvisioning();
+      await rollbackStartup();
       return const WatchLoopAborted(1);
     }
 
@@ -530,8 +537,7 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
     )) {
       await localCompiler.dispose();
       log.error('Initial compilation failed.');
-      await closeAnalyzers();
-      await rollbackProvisioning();
+      await rollbackStartup();
       return const WatchLoopAborted(1);
     }
 
@@ -671,7 +677,7 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
         analyzers: await analyzersFuture,
         config: config,
         affectedPaths: affectedPaths,
-        skipStalenessCheck: true,
+        incremental: true,
         requirements: requirements,
       );
     },

--- a/tools/serverpod_cli/lib/src/commands/start.dart
+++ b/tools/serverpod_cli/lib/src/commands/start.dart
@@ -488,6 +488,9 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
     await rollbackProvisioning();
     return const WatchLoopAborted(1);
   }
+  if (genResult.upToDate) {
+    log.info(generatedCodeAlreadyUpToDate, type: TextLogType.success);
+  }
 
   // FES setup (watch mode only).
   KernelCompiler? compiler;

--- a/tools/serverpod_cli/lib/src/config/config.dart
+++ b/tools/serverpod_cli/lib/src/config/config.dart
@@ -227,6 +227,27 @@ class GeneratorConfig implements ModelLoadConfig {
     ..._relativeDartClientPackagePathParts,
   ];
 
+  /// Paths outside the source tree that may influence generated output
+  List<String> get auxiliaryInputPaths => [
+    p.joinAll([...serverPackageDirectoryPathParts, 'config', 'generator.yaml']),
+    p.joinAll([...serverPackageDirectoryPathParts, 'pubspec.yaml']),
+    p.joinAll([...serverPackageDirectoryPathParts, 'pubspec.lock']),
+    p.joinAll([...clientPackagePathParts, 'pubspec.yaml']),
+    p.joinAll([...clientPackagePathParts, 'pubspec.lock']),
+    for (final pathParts in sharedModelsSourcePathsParts.values) ...[
+      p.joinAll([
+        ...serverPackageDirectoryPathParts,
+        ...pathParts,
+        'pubspec.yaml',
+      ]),
+      p.joinAll([
+        ...serverPackageDirectoryPathParts,
+        ...pathParts,
+        'pubspec.lock',
+      ]),
+    ],
+  ];
+
   final List<String> _relativeFlutterPackagePathParts;
 
   /// Absolute path parts to the Flutter package; see [hasFlutterPackage]

--- a/tools/serverpod_cli/lib/src/generated/completion_script_carapace.dart
+++ b/tools/serverpod_cli/lib/src/generated/completion_script_carapace.dart
@@ -68,6 +68,7 @@ commands:
     flags:
       -w, --watch: "Watch for changes and continuously generate code."
       -d, --directory=: "The directory to generate code for (defaults to current directory)."
+      -f, --force: "Regenerate even when the output looks up to date. Use this to rebuild after hand-editing or reverting generated files."
 
   - name: language-server
     flags:

--- a/tools/serverpod_cli/lib/src/generator/analyzers.dart
+++ b/tools/serverpod_cli/lib/src/generator/analyzers.dart
@@ -69,7 +69,7 @@ class Analyzers {
     final analyzers = await Analyzers.create(config);
     await analyzers.update(
       config: config,
-      affectedPaths: await enumerateSourceFiles(config),
+      affectedPaths: (await enumerateSourceFiles(config)).keys.toSet(),
     );
     return analyzers;
   }

--- a/tools/serverpod_cli/lib/src/generator/generation_staleness.dart
+++ b/tools/serverpod_cli/lib/src/generator/generation_staleness.dart
@@ -16,9 +16,24 @@ String _stampFilePath(GeneratorConfig config) => p.joinAll([
   'generation.stamp',
 ]);
 
-/// Returns `true` if all [paths] are older than the generation stamp,
-/// the stamp's CLI version matches the running version, and all previously
-/// generated output files still exist on disk.
+/// Deterministic fingerprint of the source-file *set*.
+///
+/// Used to detect added or removed source files, which the mtime checks alone
+/// cannot: a deleted file has no mtime left to compare against the stamp.
+/// 32-bit FNV-1a over the sorted paths - stable across runs, unlike
+/// [Object.hashCode].
+String _sourceSetFingerprint(Set<String> paths) {
+  final sorted = paths.toList()..sort();
+  var hash = 0x811c9dc5;
+  for (final unit in sorted.join('\n').codeUnits) {
+    hash = ((hash ^ unit) * 0x01000193) & 0xFFFFFFFF;
+  }
+  return hash.toRadixString(16);
+}
+
+/// Returns `true` if all [paths] are older than the generation stamp, the
+/// stamp's CLI version matches the running version, the source-file set is
+/// unchanged, and all previously generated output files still exist on disk.
 Future<bool> isGenerationUpToDate(
   GeneratorConfig config,
   Set<String> paths,
@@ -29,14 +44,18 @@ Future<bool> isGenerationUpToDate(
   final content = (await stampFile.readAsString()).trim();
   if (content.isEmpty) return false;
 
-  // First line is the CLI version.
+  // Line 0: CLI version. Line 1: timestamp. Line 2: source-set fingerprint.
+  // Remaining lines: generated file paths.
   final lines = content.split('\n');
+  if (lines.length < 3) return false;
   if (lines.first.trim() != templateVersion) return false;
 
-  // Remaining lines (after version and timestamp) are generated file paths.
-  // If any are missing, generation must run.
-  if (lines.length > 2) {
-    final generatedFiles = lines.skip(2).where((l) => l.isNotEmpty);
+  // A fingerprint mismatch means a source file was added or removed.
+  if (lines[2].trim() != _sourceSetFingerprint(paths)) return false;
+
+  // If any previously generated file is missing, generation must run.
+  if (lines.length > 3) {
+    final generatedFiles = lines.skip(3).where((l) => l.isNotEmpty);
     for (final filePath in generatedFiles) {
       if (!await File(filePath).exists()) return false;
     }
@@ -74,6 +93,7 @@ Future<bool> isGenerationUpToDate(
 /// ```
 /// <cli-version>
 /// <iso8601-timestamp>
+/// <source-set-fingerprint>
 /// <generated-file-path-1>
 /// <generated-file-path-2>
 /// ...
@@ -82,11 +102,13 @@ Future<void> writeGenerationStamp(
   GeneratorConfig config, {
   required Set<String> generatedFiles,
 }) async {
+  final fingerprint = _sourceSetFingerprint(await enumerateSourceFiles(config));
   final file = File(_stampFilePath(config));
   await file.create(recursive: true);
   final buf = StringBuffer()
     ..writeln(templateVersion)
-    ..writeln(DateTime.now().toIso8601String());
+    ..writeln(DateTime.now().toIso8601String())
+    ..writeln(fingerprint);
   for (final path in generatedFiles) {
     buf.writeln(path);
   }
@@ -100,8 +122,8 @@ Set<String> readGenerationStamp(GeneratorConfig config) {
   try {
     final stampFile = File(_stampFilePath(config));
     final lines = stampFile.readAsLinesSync();
-    // First line is CLI version, second is timestamp, rest are file paths.
-    return lines.skip(2).where((l) => l.isNotEmpty).toSet();
+    // Lines 0-2 are version, timestamp, and fingerprint; the rest are paths.
+    return lines.skip(3).where((l) => l.isNotEmpty).toSet();
   } catch (e) {
     return {};
   }

--- a/tools/serverpod_cli/lib/src/generator/generation_staleness.dart
+++ b/tools/serverpod_cli/lib/src/generator/generation_staleness.dart
@@ -16,75 +16,74 @@ String _stampFilePath(GeneratorConfig config) => p.joinAll([
   'generation.stamp',
 ]);
 
-/// Deterministic fingerprint of the source-file *set*.
-///
-/// Used to detect added or removed source files, which the mtime checks alone
-/// cannot: a deleted file has no mtime left to compare against the stamp.
-/// 32-bit FNV-1a over the sorted paths - stable across runs, unlike
-/// [Object.hashCode].
-String _sourceSetFingerprint(Set<String> paths) {
-  final sorted = paths.toList()..sort();
+/// A [FileStat] viewed as just its staleness-relevant identity.
+extension type FileStamp(FileStat _stat) {
+  /// Fingerprint token for a file that does not exist.
+  static const absent = '-1\t-1';
+
+  /// Returns the [FileStamp] of [path], or `null` if it does not exist.
+  static Future<FileStamp?> of(String path) async {
+    final stat = await FileStat.stat(path);
+    return stat.type == FileSystemEntityType.notFound ? null : FileStamp(stat);
+  }
+
+  /// The fingerprint token
+  String get token => '${_stat.modified.microsecondsSinceEpoch}\t${_stat.size}';
+}
+
+/// Computes a deterministic 32-bit FNV-1a fingerprint of [entries].
+String _fingerprint(Map<String, FileStamp?> entries) {
+  final lines = [
+    for (final path in entries.keys.toList()..sort())
+      '$path\t${entries[path]?.token ?? FileStamp.absent}',
+  ];
   var hash = 0x811c9dc5;
-  for (final unit in sorted.join('\n').codeUnits) {
+  for (final unit in lines.join('\n').codeUnits) {
     hash = ((hash ^ unit) * 0x01000193) & 0xFFFFFFFF;
   }
   return hash.toRadixString(16);
 }
 
-/// Returns `true` if all [paths] are older than the generation stamp, the
-/// stamp's CLI version matches the running version, the source-file set is
-/// unchanged, and all previously generated output files still exist on disk.
+/// Computes the fingerprint for a generation over
+/// - [sourceStats] (inputs stat'd before generation), and
+/// - [generatedFiles]
+Future<String> _computeFingerprint(
+  GeneratorConfig config, {
+  required Map<String, FileStamp> sourceStats,
+  required Set<String> generatedFiles,
+}) async {
+  final entries = <String, FileStamp?>{...sourceStats};
+  for (final path in config.auxiliaryInputPaths) {
+    entries[path] = await FileStamp.of(path);
+  }
+  for (final path in generatedFiles) {
+    entries[path] = await FileStamp.of(path);
+  }
+
+  return _fingerprint(entries);
+}
+
+/// Returns `true` if the running CLI version matches the stamp and the
+/// input+output fingerprint is unchanged since the last generation.
 Future<bool> isGenerationUpToDate(
   GeneratorConfig config,
-  Set<String> paths,
+  Map<String, FileStamp> sources,
 ) async {
   final stampFile = File(_stampFilePath(config));
   if (!await stampFile.exists()) return false;
 
-  final content = (await stampFile.readAsString()).trim();
-  if (content.isEmpty) return false;
+  // Line 0: CLI version. Line 1: fingerprint. Remaining lines: generated paths.
+  final lines = (await stampFile.readAsString()).split('\n');
+  if (lines.length < 2) return false;
+  if (lines[0].trim() != templateVersion) return false;
 
-  // Line 0: CLI version. Line 1: timestamp. Line 2: source-set fingerprint.
-  // Remaining lines: generated file paths.
-  final lines = content.split('\n');
-  if (lines.length < 3) return false;
-  if (lines.first.trim() != templateVersion) return false;
-
-  // A fingerprint mismatch means a source file was added or removed.
-  if (lines[2].trim() != _sourceSetFingerprint(paths)) return false;
-
-  // If any previously generated file is missing, generation must run.
-  if (lines.length > 3) {
-    final generatedFiles = lines.skip(3).where((l) => l.isNotEmpty);
-    for (final filePath in generatedFiles) {
-      if (!await File(filePath).exists()) return false;
-    }
-  }
-
-  final stampMtime = (await stampFile.stat()).modified;
-
-  // Check config/generator.yaml - config changes should trigger regen.
-  final configFile = File(
-    p.joinAll([
-      ...config.serverPackageDirectoryPathParts,
-      'config',
-      'generator.yaml',
-    ]),
+  final generatedFiles = lines.skip(2).where((l) => l.isNotEmpty).toSet();
+  final current = await _computeFingerprint(
+    config,
+    sourceStats: sources,
+    generatedFiles: generatedFiles,
   );
-  if (await configFile.exists() &&
-      (await configFile.stat()).modified.isAfter(stampMtime)) {
-    return false;
-  }
-
-  for (final path in paths) {
-    final file = File(path);
-    if (await file.exists() &&
-        (await file.stat()).modified.isAfter(stampMtime)) {
-      return false;
-    }
-  }
-
-  return true;
+  return lines[1].trim() == current;
 }
 
 /// Writes the generation stamp file after a successful generation.
@@ -92,26 +91,27 @@ Future<bool> isGenerationUpToDate(
 /// The stamp format is:
 /// ```
 /// <cli-version>
-/// <iso8601-timestamp>
-/// <source-set-fingerprint>
+/// <input-output-fingerprint>
 /// <generated-file-path-1>
 /// <generated-file-path-2>
 /// ...
 /// ```
-/// Pass [sourceFiles] (the set already enumerated this run) to skip a second
-/// directory walk; omit it to re-enumerate the full set.
+/// Pass [sourceStats] to reuse them; omit it to re-enumerate the full set.
 Future<void> writeGenerationStamp(
   GeneratorConfig config, {
   required Set<String> generatedFiles,
-  Set<String>? sourceFiles,
+  Map<String, FileStamp>? sourceStats,
 }) async {
-  final sources = sourceFiles ?? await enumerateSourceFiles(config);
-  final fingerprint = _sourceSetFingerprint(sources);
+  final stats = sourceStats ?? await enumerateSourceFiles(config);
+  final fingerprint = await _computeFingerprint(
+    config,
+    sourceStats: stats,
+    generatedFiles: generatedFiles,
+  );
   final file = File(_stampFilePath(config));
   await file.create(recursive: true);
   final buf = StringBuffer()
     ..writeln(templateVersion)
-    ..writeln(DateTime.now().toIso8601String())
     ..writeln(fingerprint);
   for (final path in generatedFiles) {
     buf.writeln(path);
@@ -126,48 +126,45 @@ Set<String> readGenerationStamp(GeneratorConfig config) {
   try {
     final stampFile = File(_stampFilePath(config));
     final lines = stampFile.readAsLinesSync();
-    // Lines 0-2 are version, timestamp, and fingerprint; the rest are paths.
-    return lines.skip(3).where((l) => l.isNotEmpty).toSet();
+    // Lines 0-1 are version and fingerprint; the rest are generated paths.
+    return lines.skip(2).where((l) => l.isNotEmpty).toSet();
   } catch (e) {
     return {};
   }
 }
 
-/// Enumerates all source files that feed into code generation.
-///
-/// Generated output dirs are excluded - they are outputs, and including them
-/// would make the set differ before vs. after a generation.
-Future<Set<String>> enumerateSourceFiles(GeneratorConfig config) async {
-  final sources = <String>{};
-
+/// Enumerates the source files that feed code generation, capturing each one's
+/// [FileStamp] as the walk reads it.
+Future<Map<String, FileStamp>> enumerateSourceFiles(
+  GeneratorConfig config,
+) async {
   final generatedDirs = {
     p.absolute(p.joinAll(config.generatedServeModelPathParts)),
     ...config.generatedSharedModelsPaths.map(p.absolute),
   };
-  bool isGenerated(String path) =>
-      generatedDirs.any((dir) => p.isWithin(dir, p.absolute(path)));
+  bool isOutputDir(Directory dir) =>
+      generatedDirs.any((d) => p.equals(d, p.absolute(dir.path)));
+  bool isSource(String path) =>
+      _sourceExtensions.any((ext) => path.endsWith(ext));
 
-  Future<void> collect(Directory dir, List<String> extensions) async {
+  final sources = <String, FileStamp>{};
+  Future<void> walk(Directory dir) async {
     if (!await dir.exists()) return;
-    await for (final entity in dir.list(recursive: true)) {
-      if (entity is File &&
-          extensions.any((ext) => entity.path.endsWith(ext)) &&
-          !isGenerated(entity.path)) {
-        sources.add(entity.path);
+    await for (final entity in dir.list()) {
+      if (entity is Directory) {
+        if (!isOutputDir(entity)) await walk(entity);
+      } else if (entity is File && isSource(entity.path)) {
+        sources[entity.path] = FileStamp(await entity.stat());
       }
     }
   }
 
-  // Server lib/ directory. Endpoints and models can live anywhere under lib/,
-  // matching the endpoint analyzer and model loader (not just lib/src/).
-  await collect(
-    Directory(p.joinAll(config.libSourcePathParts)),
-    _sourceExtensions,
-  );
-
-  // Shared model packages.
+  // Endpoints and models can live anywhere under lib/ (matching the endpoint
+  // analyzer and model loader, not just lib/src/), so walk it all but the
+  // output dirs.
+  await walk(Directory(p.joinAll(config.libSourcePathParts)));
   for (final path in config.sharedModelsLibSourcePaths) {
-    await collect(Directory(path), _sourceExtensions);
+    await walk(Directory(path));
   }
 
   return sources;

--- a/tools/serverpod_cli/lib/src/generator/generation_staleness.dart
+++ b/tools/serverpod_cli/lib/src/generator/generation_staleness.dart
@@ -98,11 +98,15 @@ Future<bool> isGenerationUpToDate(
 /// <generated-file-path-2>
 /// ...
 /// ```
+/// Pass [sourceFiles] (the set already enumerated this run) to skip a second
+/// directory walk; omit it to re-enumerate the full set.
 Future<void> writeGenerationStamp(
   GeneratorConfig config, {
   required Set<String> generatedFiles,
+  Set<String>? sourceFiles,
 }) async {
-  final fingerprint = _sourceSetFingerprint(await enumerateSourceFiles(config));
+  final sources = sourceFiles ?? await enumerateSourceFiles(config);
+  final fingerprint = _sourceSetFingerprint(sources);
   final file = File(_stampFilePath(config));
   await file.create(recursive: true);
   final buf = StringBuffer()
@@ -130,14 +134,25 @@ Set<String> readGenerationStamp(GeneratorConfig config) {
 }
 
 /// Enumerates all source files that feed into code generation.
+///
+/// Generated output dirs are excluded - they are outputs, and including them
+/// would make the set differ before vs. after a generation.
 Future<Set<String>> enumerateSourceFiles(GeneratorConfig config) async {
   final sources = <String>{};
+
+  final generatedDirs = {
+    p.absolute(p.joinAll(config.generatedServeModelPathParts)),
+    ...config.generatedSharedModelsPaths.map(p.absolute),
+  };
+  bool isGenerated(String path) =>
+      generatedDirs.any((dir) => p.isWithin(dir, p.absolute(path)));
 
   Future<void> collect(Directory dir, List<String> extensions) async {
     if (!await dir.exists()) return;
     await for (final entity in dir.list(recursive: true)) {
       if (entity is File &&
-          extensions.any((ext) => entity.path.endsWith(ext))) {
+          extensions.any((ext) => entity.path.endsWith(ext)) &&
+          !isGenerated(entity.path)) {
         sources.add(entity.path);
       }
     }

--- a/tools/serverpod_cli/lib/src/generator/generation_staleness.dart
+++ b/tools/serverpod_cli/lib/src/generator/generation_staleness.dart
@@ -133,27 +133,35 @@ Set<String> readGenerationStamp(GeneratorConfig config) {
 Future<Set<String>> enumerateSourceFiles(GeneratorConfig config) async {
   final sources = <String>{};
 
-  // Server lib/src/ directory.
-  final srcDir = Directory(p.joinAll(config.srcSourcePathParts));
-  if (await srcDir.exists()) {
-    await for (final entity in srcDir.list(recursive: true)) {
+  Future<void> collect(Directory dir, List<String> extensions) async {
+    if (!await dir.exists()) return;
+    await for (final entity in dir.list(recursive: true)) {
       if (entity is File &&
-          _sourceExtensions.any((ext) => entity.path.endsWith(ext))) {
+          extensions.any((ext) => entity.path.endsWith(ext))) {
         sources.add(entity.path);
       }
     }
   }
 
+  // Server lib/ directory. Endpoints and models can live anywhere under lib/,
+  // matching the endpoint analyzer and model loader (not just lib/src/).
+  await collect(
+    Directory(p.joinAll(config.libSourcePathParts)),
+    _sourceExtensions,
+  );
+
   // Shared model packages.
   for (final path in config.sharedModelsLibSourcePaths) {
-    final dir = Directory(path);
-    if (!await dir.exists()) continue;
-    await for (final entity in dir.list(recursive: true)) {
-      if (entity is File &&
-          _sourceExtensions.any((ext) => entity.path.endsWith(ext))) {
-        sources.add(entity.path);
-      }
-    }
+    await collect(Directory(path), _sourceExtensions);
+  }
+
+  // Dependent modules contribute their models to this project's protocol; only
+  // their model files affect generation here (their endpoints are their own).
+  for (final module in config.modulesDependent) {
+    await collect(
+      Directory(p.joinAll(module.libSourcePathParts)),
+      modelFileExtensions,
+    );
   }
 
   return sources;

--- a/tools/serverpod_cli/lib/src/generator/generation_staleness.dart
+++ b/tools/serverpod_cli/lib/src/generator/generation_staleness.dart
@@ -170,14 +170,5 @@ Future<Set<String>> enumerateSourceFiles(GeneratorConfig config) async {
     await collect(Directory(path), _sourceExtensions);
   }
 
-  // Dependent modules contribute their models to this project's protocol; only
-  // their model files affect generation here (their endpoints are their own).
-  for (final module in config.modulesDependent) {
-    await collect(
-      Directory(p.joinAll(module.libSourcePathParts)),
-      modelFileExtensions,
-    );
-  }
-
   return sources;
 }

--- a/tools/serverpod_cli/lib/src/generator/isolated_analyzers.dart
+++ b/tools/serverpod_cli/lib/src/generator/isolated_analyzers.dart
@@ -52,11 +52,18 @@ final class IsolatedAnalyzers extends IsolatedObject<Analyzers>
 
   IsolatedAnalyzers._(super.create, this._logPort);
 
-  /// Creates and primes analyzers on a worker isolate.
+  /// Creates analyzers on a worker isolate.
+  ///
+  /// When [prime] is `true` (the default) the analyzers are also primed over all
+  /// sources before returning. Pass `false` to only spawn the isolate and defer
+  /// priming to the first [update] call.
   ///
   /// Log messages from the worker are forwarded to the main isolate's
   /// [log] singleton via a [SendPort].
-  static Future<IsolatedAnalyzers> create(GeneratorConfig config) async {
+  static Future<IsolatedAnalyzers> create(
+    GeneratorConfig config, {
+    bool prime = true,
+  }) async {
     final logPort = ReceivePort();
     logPort.listen((message) {
       final event = message as IsolateLogEvent;
@@ -78,7 +85,9 @@ final class IsolatedAnalyzers extends IsolatedObject<Analyzers>
       () {
         // Install a logger on the worker isolate that forwards to main.
         initializeLoggerWith(_PortForwardingLogger(logSendPort));
-        return Analyzers.createAndUpdate(config);
+        return prime
+            ? Analyzers.createAndUpdate(config)
+            : Analyzers.create(config);
       },
       logPort,
     );

--- a/tools/serverpod_cli/test/generator/generation_staleness_test.dart
+++ b/tools/serverpod_cli/test/generator/generation_staleness_test.dart
@@ -20,6 +20,16 @@ class _FakeConfig extends Fake implements GeneratorConfig {
   List<String> get serverPackageDirectoryPathParts => [serverDir];
 
   @override
+  List<String> get clientPackagePathParts => [serverDir, '..', 'client'];
+
+  @override
+  List<String> get auxiliaryInputPaths => [
+    p.join(serverDir, 'config', 'generator.yaml'),
+    p.join(serverDir, 'pubspec.yaml'),
+    p.join(serverDir, 'pubspec.lock'),
+  ];
+
+  @override
   List<String> get libSourcePathParts => [serverDir, 'lib'];
 
   @override
@@ -200,6 +210,114 @@ void main() {
         expect(await isGenerationUpToDate(config, sources), isFalse);
       },
     );
+
+    test(
+      'when a recorded generated file is hand-edited or reverted, '
+      'then isGenerationUpToDate returns false',
+      () async {
+        // The file still exists, but its mtime changed - a git revert or a
+        // manual edit must not be trusted as up to date.
+        final genMtime = generatedFile.statSync().modified;
+        await waitForMtimeAfter(genMtime, tempDir);
+        await generatedFile.writeAsString('// tampered');
+
+        final sources = await enumerateSourceFiles(config);
+        expect(await isGenerationUpToDate(config, sources), isFalse);
+      },
+    );
+  });
+
+  group('Given the server pubspec changes after the stamp', () {
+    late File pubspecFile;
+
+    setUp(() async {
+      pubspecFile = File(p.join(tempDir.path, 'pubspec.yaml'));
+      await pubspecFile.writeAsString('name: server\ndependencies:\n');
+
+      await writeGenerationStamp(config, generatedFiles: {});
+      final stampMtime = stampFile.statSync().modified;
+      await waitForMtimeAfter(stampMtime, tempDir);
+
+      // Adding a module dependency changes the generated output even though no
+      // file under lib/ changed.
+      await pubspecFile.writeAsString(
+        'name: server\ndependencies:\n  serverpod_auth: any\n',
+      );
+    });
+
+    test(
+      'when isGenerationUpToDate is called, '
+      'then it returns false',
+      () async {
+        final sources = await enumerateSourceFiles(config);
+        expect(await isGenerationUpToDate(config, sources), isFalse);
+      },
+    );
+  });
+
+  group('Given a source edited after enumeration but before the stamp is '
+      'written (the mid-generation race)', () {
+    setUp(() async {
+      // The walk stamps each source as it reads it.
+      final stamps = await enumerateSourceFiles(config);
+
+      // A source is edited while generation is still running.
+      final srcMtime = (await endpointFile.stat()).modified;
+      await waitForMtimeAfter(srcMtime, tempDir);
+      await endpointFile.writeAsString(
+        'class MyEndpoint extends Endpoint { /* edited mid-run */ }',
+      );
+
+      // The stamp records the pre-edit stamps, not the post-run state. Were it
+      // to stat live at write time, the edit would be silently swallowed on the
+      // next run.
+      await writeGenerationStamp(
+        config,
+        generatedFiles: {},
+        sourceStats: stamps,
+      );
+    });
+
+    test(
+      'when isGenerationUpToDate is called, '
+      'then it returns false so the mid-run edit is not silently missed',
+      () async {
+        final sources = await enumerateSourceFiles(config);
+        expect(await isGenerationUpToDate(config, sources), isFalse);
+      },
+    );
+  });
+
+  group('Given a source whose size changed but mtime did not '
+      '(a same-tick edit)', () {
+    // A second-aligned mtime so setLastModified round-trips exactly (the
+    // filesystem here truncates mtimes to whole seconds).
+    final pinnedMtime = DateTime(2026, 1, 1, 12, 0, 0);
+
+    setUp(() async {
+      await endpointFile.setLastModified(pinnedMtime);
+      await writeGenerationStamp(config, generatedFiles: {});
+
+      // Change the file's length, then pin the mtime back to the same value -
+      // simulating an edit landing within a single coarse mtime tick.
+      await endpointFile.writeAsString(
+        'class MyEndpoint extends Endpoint { /* a noticeably longer body */ }',
+      );
+      await endpointFile.setLastModified(pinnedMtime);
+    });
+
+    test(
+      'when isGenerationUpToDate is called, '
+      'then it returns false because the size changed',
+      () async {
+        // Precondition: mtime matches what the stamp recorded, so size is the
+        // only signal that changed.
+        expect((await endpointFile.stat()).modified, pinnedMtime);
+
+        final sources = await enumerateSourceFiles(config);
+        expect(await isGenerationUpToDate(config, sources), isFalse);
+      },
+    );
   });
 
   group('Given a shared model package with a newer file', () {
@@ -267,11 +385,11 @@ void main() {
 
         final lines = (await stampFile.readAsString()).trim().split('\n');
 
-        // version, timestamp, then file paths.
-        expect(lines.length, greaterThanOrEqualTo(4));
+        // version, fingerprint, then file paths.
+        expect(lines.length, 4);
         expect(
           lines.skip(2).toSet(),
-          containsAll(['/tmp/a.dart', '/tmp/b.dart']),
+          {'/tmp/a.dart', '/tmp/b.dart'},
         );
       },
     );
@@ -289,8 +407,8 @@ void main() {
 
         final sources = await enumerateSourceFiles(config);
 
-        expect(sources, contains(endsWith('endpoint.dart')));
-        expect(sources, contains(endsWith('model.spy.yaml')));
+        expect(sources.keys, contains(endsWith('endpoint.dart')));
+        expect(sources.keys, contains(endsWith('model.spy.yaml')));
       },
     );
 
@@ -304,7 +422,7 @@ void main() {
 
         final sources = await enumerateSourceFiles(config);
 
-        expect(sources.where((s) => s.endsWith('.md')), isEmpty);
+        expect(sources.keys.where((s) => s.endsWith('.md')), isEmpty);
       },
     );
 
@@ -318,7 +436,7 @@ void main() {
 
         final sources = await enumerateSourceFiles(config);
 
-        expect(sources, contains(endsWith('top_level.spy.yaml')));
+        expect(sources.keys, contains(endsWith('top_level.spy.yaml')));
       },
     );
 
@@ -332,7 +450,7 @@ void main() {
 
         final sources = await enumerateSourceFiles(config);
 
-        expect(sources.where((s) => s.contains('generated')), isEmpty);
+        expect(sources.keys.where((s) => s.contains('generated')), isEmpty);
       },
     );
   });
@@ -348,7 +466,7 @@ void main() {
   );
 
   test(
-    'Given stamp file that exists with only version and timestamp, '
+    'Given stamp file that exists with only version and fingerprint, '
     'when calling readGenerationStamp, '
     'then it returns an empty set.',
     () async {

--- a/tools/serverpod_cli/test/generator/generation_staleness_test.dart
+++ b/tools/serverpod_cli/test/generator/generation_staleness_test.dart
@@ -12,14 +12,9 @@ import '../test_util/mtime_helpers.dart';
 class _FakeConfig extends Fake implements GeneratorConfig {
   final String serverDir;
   final Map<String, List<String>> _sharedModels;
-  final List<ModuleConfig> _modulesDependent;
 
-  _FakeConfig(
-    this.serverDir, {
-    Map<String, List<String>>? sharedModels,
-    List<ModuleConfig>? modulesDependent,
-  }) : _sharedModels = sharedModels ?? {},
-       _modulesDependent = modulesDependent ?? [];
+  _FakeConfig(this.serverDir, {Map<String, List<String>>? sharedModels})
+    : _sharedModels = sharedModels ?? {};
 
   @override
   List<String> get serverPackageDirectoryPathParts => [serverDir];
@@ -52,9 +47,6 @@ class _FakeConfig extends Fake implements GeneratorConfig {
     for (final pathParts in _sharedModels.values)
       p.joinAll([serverDir, ...pathParts, 'lib', 'src', 'generated']),
   ];
-
-  @override
-  List<ModuleConfig> get modulesDependent => _modulesDependent;
 }
 
 void main() {
@@ -246,50 +238,6 @@ void main() {
       () async {
         final sources = await enumerateSourceFiles(sharedConfig);
         expect(await isGenerationUpToDate(sharedConfig, sources), isFalse);
-      },
-    );
-  });
-
-  group('Given a dependent module with a newer model file', () {
-    late _FakeConfig moduleConfig;
-    late File moduleModel;
-
-    setUp(() async {
-      final moduleDir = Directory(p.join(tempDir.path, 'dep_module'));
-      moduleModel = File(
-        p.join(moduleDir.path, 'lib', 'src', 'mod.spy.yaml'),
-      )..createSync(recursive: true);
-      await moduleModel.writeAsString('class: ModModel');
-
-      moduleConfig = _FakeConfig(
-        tempDir.path,
-        modulesDependent: [
-          ModuleConfig(
-            type: PackageType.server,
-            name: 'dep',
-            nickname: 'dep',
-            migrationVersions: [],
-            serverPackageDirectoryPathParts: p.split(moduleDir.path),
-          ),
-        ],
-      );
-
-      await writeGenerationStamp(moduleConfig, generatedFiles: {});
-      final stampMtime = stampFile.statSync().modified;
-      await waitForMtimeAfter(stampMtime, tempDir);
-
-      // Touch the module model file after the stamp.
-      await moduleModel.writeAsString(
-        'class: ModModel\nfields:\n  name: String',
-      );
-    });
-
-    test(
-      'when isGenerationUpToDate is called, '
-      'then it returns false',
-      () async {
-        final sources = await enumerateSourceFiles(moduleConfig);
-        expect(await isGenerationUpToDate(moduleConfig, sources), isFalse);
       },
     );
   });

--- a/tools/serverpod_cli/test/generator/generation_staleness_test.dart
+++ b/tools/serverpod_cli/test/generator/generation_staleness_test.dart
@@ -7,6 +7,8 @@ import 'package:serverpod_cli/src/generator/generation_staleness.dart';
 import 'package:test/fake.dart';
 import 'package:test/test.dart';
 
+import '../test_util/mtime_helpers.dart';
+
 class _FakeConfig extends Fake implements GeneratorConfig {
   final String serverDir;
   final Map<String, List<String>> _sharedModels;
@@ -39,25 +41,6 @@ class _FakeConfig extends Fake implements GeneratorConfig {
 
   @override
   List<ModuleConfig> get modulesDependent => _modulesDependent;
-}
-
-/// Waits until the file system reports an mtime strictly after [reference].
-///
-/// This avoids hard-coded delays that may be too short on platforms with
-/// coarse timestamp resolution (e.g. Windows).
-Future<void> waitForMtimeAfter(DateTime reference, [Directory? dir]) async {
-  dir ??= await Directory.systemTemp.createTemp();
-  final probe = File(p.join(dir.path, '.mtime_probe'));
-  try {
-    for (var i = 0; i < 100; i++) {
-      await probe.writeAsString('$i');
-      if (probe.statSync().modified.isAfter(reference)) return;
-      await Future<void>.delayed(const Duration(milliseconds: 50));
-    }
-    throw StateError('File system mtime did not advance after 5 seconds');
-  } finally {
-    if (probe.existsSync()) await probe.delete();
-  }
 }
 
 void main() {

--- a/tools/serverpod_cli/test/generator/generation_staleness_test.dart
+++ b/tools/serverpod_cli/test/generator/generation_staleness_test.dart
@@ -40,6 +40,20 @@ class _FakeConfig extends Fake implements GeneratorConfig {
   ];
 
   @override
+  List<String> get generatedServeModelPathParts => [
+    serverDir,
+    'lib',
+    'src',
+    'generated',
+  ];
+
+  @override
+  List<String> get generatedSharedModelsPaths => [
+    for (final pathParts in _sharedModels.values)
+      p.joinAll([serverDir, ...pathParts, 'lib', 'src', 'generated']),
+  ];
+
+  @override
   List<ModuleConfig> get modulesDependent => _modulesDependent;
 }
 
@@ -357,6 +371,20 @@ void main() {
         final sources = await enumerateSourceFiles(config);
 
         expect(sources, contains(endsWith('top_level.spy.yaml')));
+      },
+    );
+
+    test(
+      'when generated output exists under lib/src/generated, '
+      'then it is excluded (outputs are not inputs)',
+      () async {
+        await File(
+          p.join(tempDir.path, 'lib', 'src', 'generated', 'protocol.dart'),
+        ).create(recursive: true);
+
+        final sources = await enumerateSourceFiles(config);
+
+        expect(sources.where((s) => s.contains('generated')), isEmpty);
       },
     );
   });

--- a/tools/serverpod_cli/test/generator/generation_staleness_test.dart
+++ b/tools/serverpod_cli/test/generator/generation_staleness_test.dart
@@ -1,7 +1,7 @@
 import 'dart:io';
 
 import 'package:path/path.dart' as p;
-import 'package:serverpod_cli/analyzer.dart';
+import 'package:serverpod_cli/src/config/config.dart';
 import 'package:serverpod_cli/src/generated/version.dart';
 import 'package:serverpod_cli/src/generator/generation_staleness.dart';
 import 'package:test/fake.dart';
@@ -10,12 +10,20 @@ import 'package:test/test.dart';
 class _FakeConfig extends Fake implements GeneratorConfig {
   final String serverDir;
   final Map<String, List<String>> _sharedModels;
+  final List<ModuleConfig> _modulesDependent;
 
-  _FakeConfig(this.serverDir, {Map<String, List<String>>? sharedModels})
-    : _sharedModels = sharedModels ?? {};
+  _FakeConfig(
+    this.serverDir, {
+    Map<String, List<String>>? sharedModels,
+    List<ModuleConfig>? modulesDependent,
+  }) : _sharedModels = sharedModels ?? {},
+       _modulesDependent = modulesDependent ?? [];
 
   @override
   List<String> get serverPackageDirectoryPathParts => [serverDir];
+
+  @override
+  List<String> get libSourcePathParts => [serverDir, 'lib'];
 
   @override
   List<String> get srcSourcePathParts => [serverDir, 'lib', 'src'];
@@ -28,6 +36,9 @@ class _FakeConfig extends Fake implements GeneratorConfig {
     for (final pathParts in _sharedModels.values)
       p.joinAll([...serverPackageDirectoryPathParts, ...pathParts, 'lib']),
   ];
+
+  @override
+  List<ModuleConfig> get modulesDependent => _modulesDependent;
 }
 
 /// Waits until the file system reports an mtime strictly after [reference].
@@ -242,6 +253,50 @@ void main() {
     );
   });
 
+  group('Given a dependent module with a newer model file', () {
+    late _FakeConfig moduleConfig;
+    late File moduleModel;
+
+    setUp(() async {
+      final moduleDir = Directory(p.join(tempDir.path, 'dep_module'));
+      moduleModel = File(
+        p.join(moduleDir.path, 'lib', 'src', 'mod.spy.yaml'),
+      )..createSync(recursive: true);
+      await moduleModel.writeAsString('class: ModModel');
+
+      moduleConfig = _FakeConfig(
+        tempDir.path,
+        modulesDependent: [
+          ModuleConfig(
+            type: PackageType.server,
+            name: 'dep',
+            nickname: 'dep',
+            migrationVersions: [],
+            serverPackageDirectoryPathParts: p.split(moduleDir.path),
+          ),
+        ],
+      );
+
+      await writeGenerationStamp(moduleConfig, generatedFiles: {});
+      final stampMtime = stampFile.statSync().modified;
+      await waitForMtimeAfter(stampMtime, tempDir);
+
+      // Touch the module model file after the stamp.
+      await moduleModel.writeAsString(
+        'class: ModModel\nfields:\n  name: String',
+      );
+    });
+
+    test(
+      'when isGenerationUpToDate is called, '
+      'then it returns false',
+      () async {
+        final sources = await enumerateSourceFiles(moduleConfig);
+        expect(await isGenerationUpToDate(moduleConfig, sources), isFalse);
+      },
+    );
+  });
+
   group('Given writeGenerationStamp is called', () {
     test(
       'when the stamp file is read, '
@@ -305,6 +360,20 @@ void main() {
         final sources = await enumerateSourceFiles(config);
 
         expect(sources.where((s) => s.endsWith('.md')), isEmpty);
+      },
+    );
+
+    test(
+      'when a model lives under lib/ outside lib/src, '
+      'then it is still included',
+      () async {
+        await File(
+          p.join(tempDir.path, 'lib', 'top_level.spy.yaml'),
+        ).writeAsString('class: TopLevel');
+
+        final sources = await enumerateSourceFiles(config);
+
+        expect(sources, contains(endsWith('top_level.spy.yaml')));
       },
     );
   });

--- a/tools/serverpod_cli/test/integration/generate/generate_from_scratch_test.dart
+++ b/tools/serverpod_cli/test/integration/generate/generate_from_scratch_test.dart
@@ -11,24 +11,6 @@ import 'package:test/test.dart';
 import '../../test_util/builders/generator_config_builder.dart';
 import '../../test_util/endpoint_validation_helpers.dart';
 
-/// Creates a [GeneratorConfig] for a test project at [projectDir].
-GeneratorConfig _buildTestConfig(Directory projectDir) {
-  return GeneratorConfigBuilder()
-      .withName('test')
-      .withServerPackageDirectoryPathParts([projectDir.path])
-      .withRelativeDartClientPackagePathParts(['test_client'])
-      .withModules([
-        ModuleConfig(
-          type: PackageType.server,
-          name: 'test',
-          nickname: 'test',
-          migrationVersions: [],
-          serverPackageDirectoryPathParts: [projectDir.path],
-        ),
-      ])
-      .build();
-}
-
 Future<(Directory, Directory)> _buildProject() async {
   final projectDir = Directory.systemTemp.createTempSync('cli_test_');
   final generatedDir = Directory(
@@ -91,7 +73,7 @@ class MyFutureCall extends FutureCall {
 }
 ''');
 
-        config = _buildTestConfig(projectDir);
+        config = buildTestServerConfig(projectDir);
         analyzers = await Analyzers.create(config);
       });
 
@@ -185,7 +167,7 @@ class ItemEndpoint extends Endpoint {
 }
 ''');
 
-      config = _buildTestConfig(projectDir);
+      config = buildTestServerConfig(projectDir);
       analyzers = await Analyzers.create(config);
     });
 
@@ -231,7 +213,7 @@ class ItemEndpoint extends Endpoint {
 
       setUpAll(() async {
         (projectDir, _) = await _buildProject();
-        config = _buildTestConfig(projectDir);
+        config = buildTestServerConfig(projectDir);
         analyzers = await Analyzers.createAndUpdate(config);
 
         modelPath = p.join(

--- a/tools/serverpod_cli/test/integration/generate/one_shot_staleness_test.dart
+++ b/tools/serverpod_cli/test/integration/generate/one_shot_staleness_test.dart
@@ -62,6 +62,23 @@ fields:
     );
 
     test(
+      'when performOneShotGenerate runs with force and no changes '
+      'then it regenerates and rewrites the stamp',
+      () async {
+        final stampMtime = stampFile.statSync().modified;
+        await waitForMtimeAfter(stampMtime, projectDir);
+
+        final success = await performOneShotGenerate(
+          config: config,
+          force: true, // bypass the staleness check
+        );
+
+        expect(success, isTrue);
+        expect(stampFile.statSync().modified.isAfter(stampMtime), isTrue);
+      },
+    );
+
+    test(
       'when a source file changes after the stamp '
       'then performOneShotGenerate regenerates and updates the stamp',
       () async {

--- a/tools/serverpod_cli/test/integration/generate/one_shot_staleness_test.dart
+++ b/tools/serverpod_cli/test/integration/generate/one_shot_staleness_test.dart
@@ -9,42 +9,7 @@ import 'package:test/test.dart';
 
 import '../../test_util/builders/generator_config_builder.dart';
 import '../../test_util/endpoint_validation_helpers.dart';
-
-/// Creates a [GeneratorConfig] for a test project at [projectDir].
-GeneratorConfig _buildTestConfig(Directory projectDir) {
-  return GeneratorConfigBuilder()
-      .withName('test')
-      .withServerPackageDirectoryPathParts([projectDir.path])
-      .withRelativeDartClientPackagePathParts(['test_client'])
-      .withModules([
-        ModuleConfig(
-          type: PackageType.server,
-          name: 'test',
-          nickname: 'test',
-          migrationVersions: [],
-          serverPackageDirectoryPathParts: [projectDir.path],
-        ),
-      ])
-      .build();
-}
-
-/// Waits until the file system reports an mtime strictly after [reference].
-///
-/// Avoids hard-coded delays that may be too short on platforms with coarse
-/// timestamp resolution.
-Future<void> waitForMtimeAfter(DateTime reference, Directory dir) async {
-  final probe = File(p.join(dir.path, '.mtime_probe'));
-  try {
-    for (var i = 0; i < 100; i++) {
-      await probe.writeAsString('$i');
-      if (probe.statSync().modified.isAfter(reference)) return;
-      await Future<void>.delayed(const Duration(milliseconds: 50));
-    }
-    throw StateError('File system mtime did not advance after 5 seconds');
-  } finally {
-    if (probe.existsSync()) await probe.delete();
-  }
-}
+import '../../test_util/mtime_helpers.dart';
 
 void main() {
   group('Given a generated project with a stamp', () {
@@ -68,7 +33,7 @@ fields:
   name: String
 ''');
 
-      config = _buildTestConfig(projectDir);
+      config = buildTestServerConfig(projectDir);
       stampFile = File(
         p.joinAll(
           [projectDir.path, '.dart_tool', 'serverpod', 'generation.stamp'],

--- a/tools/serverpod_cli/test/integration/generate/one_shot_staleness_test.dart
+++ b/tools/serverpod_cli/test/integration/generate/one_shot_staleness_test.dart
@@ -1,0 +1,187 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:serverpod_cli/src/commands/generate.dart';
+import 'package:serverpod_cli/src/config/config.dart';
+import 'package:serverpod_cli/src/generator/generation_staleness.dart';
+import 'package:serverpod_shared/serverpod_shared.dart';
+import 'package:test/test.dart';
+
+import '../../test_util/builders/generator_config_builder.dart';
+import '../../test_util/endpoint_validation_helpers.dart';
+
+/// Creates a [GeneratorConfig] for a test project at [projectDir].
+GeneratorConfig _buildTestConfig(Directory projectDir) {
+  return GeneratorConfigBuilder()
+      .withName('test')
+      .withServerPackageDirectoryPathParts([projectDir.path])
+      .withRelativeDartClientPackagePathParts(['test_client'])
+      .withModules([
+        ModuleConfig(
+          type: PackageType.server,
+          name: 'test',
+          nickname: 'test',
+          migrationVersions: [],
+          serverPackageDirectoryPathParts: [projectDir.path],
+        ),
+      ])
+      .build();
+}
+
+/// Waits until the file system reports an mtime strictly after [reference].
+///
+/// Avoids hard-coded delays that may be too short on platforms with coarse
+/// timestamp resolution.
+Future<void> waitForMtimeAfter(DateTime reference, Directory dir) async {
+  final probe = File(p.join(dir.path, '.mtime_probe'));
+  try {
+    for (var i = 0; i < 100; i++) {
+      await probe.writeAsString('$i');
+      if (probe.statSync().modified.isAfter(reference)) return;
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+    }
+    throw StateError('File system mtime did not advance after 5 seconds');
+  } finally {
+    if (probe.existsSync()) await probe.delete();
+  }
+}
+
+void main() {
+  group('Given a generated project with a stamp', () {
+    late Directory projectDir;
+    late GeneratorConfig config;
+    late File stampFile;
+    late File modelFile;
+
+    tearDownAll(() => projectDir.deleteIfExists(recursive: true));
+
+    setUpAll(() async {
+      projectDir = Directory.systemTemp.createTempSync('cli_oneshot_test_');
+      await createTestEnvironment(projectDir);
+
+      modelFile = File(
+        p.join(projectDir.path, 'lib', 'src', 'protocol', 'my_model.spy.yaml'),
+      )..createSync(recursive: true);
+      modelFile.writeAsStringSync('''
+class: MyModel
+fields:
+  name: String
+''');
+
+      config = _buildTestConfig(projectDir);
+      stampFile = File(
+        p.joinAll(
+          [projectDir.path, '.dart_tool', 'serverpod', 'generation.stamp'],
+        ),
+      );
+
+      // Prime the project so a generation stamp exists for the skip tests.
+      final success = await performOneShotGenerate(config: config);
+      expect(success, isTrue);
+      expect(stampFile.existsSync(), isTrue);
+    });
+
+    test(
+      'when performOneShotGenerate runs again with no changes '
+      'then it skips generation and leaves the stamp untouched',
+      () async {
+        final stampMtime = stampFile.statSync().modified;
+        await waitForMtimeAfter(stampMtime, projectDir);
+
+        final success = await performOneShotGenerate(config: config);
+
+        expect(success, isTrue);
+        // A skipped run does not rewrite the stamp.
+        expect(stampFile.statSync().modified, stampMtime);
+      },
+    );
+
+    test(
+      'when a source file changes after the stamp '
+      'then performOneShotGenerate regenerates and updates the stamp',
+      () async {
+        final stampMtime = stampFile.statSync().modified;
+        await waitForMtimeAfter(stampMtime, projectDir);
+
+        // Modify a model source file so it is newer than the stamp.
+        modelFile.writeAsStringSync('''
+class: MyModel
+fields:
+  name: String
+  count: int
+''');
+
+        final success = await performOneShotGenerate(config: config);
+
+        expect(success, isTrue);
+        // A regeneration rewrites the stamp with a newer mtime.
+        expect(stampFile.statSync().modified.isAfter(stampMtime), isTrue);
+      },
+    );
+
+    test(
+      'when a model source file is deleted '
+      'then performOneShotGenerate regenerates and cleans up its output',
+      () async {
+        final orphanModel =
+            File(
+              p.join(
+                projectDir.path,
+                'lib',
+                'src',
+                'protocol',
+                'orphan.spy.yaml',
+              ),
+            )..writeAsStringSync('''
+class: Orphan
+fields:
+  value: String
+''');
+        await performOneShotGenerate(config: config);
+
+        bool hasOrphanOutput() =>
+            Directory(p.join(projectDir.path, 'lib', 'src', 'generated'))
+                .listSync(recursive: true)
+                .whereType<File>()
+                .any((f) => f.path.contains('orphan'));
+        expect(hasOrphanOutput(), isTrue);
+
+        // Deleting a source file leaves no mtime to compare; the source-set
+        // fingerprint is what flags it as stale.
+        orphanModel.deleteSync();
+        final success = await performOneShotGenerate(config: config);
+
+        expect(success, isTrue);
+        expect(hasOrphanOutput(), isFalse);
+      },
+    );
+
+    test(
+      'when a non-model source is touched without a relevant change '
+      'then the stamp is refreshed so it does not re-analyze every run',
+      () async {
+        // A plain Dart file: editing it does not require generation, but the
+        // stamp must still advance or every later run re-spins the analyzer.
+        final plainFile = File(
+          p.join(projectDir.path, 'lib', 'src', 'helper.dart'),
+        )..writeAsStringSync('class Helper {}');
+        await performOneShotGenerate(config: config);
+
+        final stampMtime = stampFile.statSync().modified;
+        await waitForMtimeAfter(stampMtime, projectDir);
+        plainFile.writeAsStringSync('class Helper {} // touched');
+
+        await performOneShotGenerate(config: config);
+
+        // The stamp advanced past the touched file, so a fresh check passes.
+        expect(
+          await isGenerationUpToDate(
+            config,
+            await enumerateSourceFiles(config),
+          ),
+          isTrue,
+        );
+      },
+    );
+  });
+}

--- a/tools/serverpod_cli/test/integration/generate/protocol_backup_test.dart
+++ b/tools/serverpod_cli/test/integration/generate/protocol_backup_test.dart
@@ -12,23 +12,6 @@ import '../../test_util/endpoint_validation_helpers.dart';
 
 const _protocolBackupMarker = 'UNIQUE_PROTOCOL_BACKUP_MARKER';
 
-GeneratorConfig _buildTestConfig(Directory projectDir) {
-  return GeneratorConfigBuilder()
-      .withName('test')
-      .withServerPackageDirectoryPathParts([projectDir.path])
-      .withRelativeDartClientPackagePathParts(['test_client'])
-      .withModules([
-        ModuleConfig(
-          type: PackageType.server,
-          name: 'test',
-          nickname: 'test',
-          migrationVersions: [],
-          serverPackageDirectoryPathParts: [projectDir.path],
-        ),
-      ])
-      .build();
-}
-
 void main() {
   group(
     'Given an existing protocol.dart when model-only generation runs',
@@ -72,7 +55,7 @@ fields:
   name: String
 ''');
 
-        config = _buildTestConfig(projectDir);
+        config = buildTestServerConfig(projectDir);
         analyzers = await Analyzers.create(config);
         await analyzers.update(
           config: config,

--- a/tools/serverpod_cli/test/test_util/builders/generator_config_builder.dart
+++ b/tools/serverpod_cli/test/test_util/builders/generator_config_builder.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:serverpod_cli/src/config/config.dart';
 import 'package:serverpod_cli/src/config/experimental_feature.dart';
 import 'package:serverpod_cli/src/config/serverpod_feature.dart';
@@ -187,4 +189,23 @@ class GeneratorConfigBuilder {
       relativeServerTestToolsPathParts: _relativeServerTestToolsPathParts,
     );
   }
+}
+
+/// Builds a minimal server [GeneratorConfig] rooted at [projectDir], for
+/// integration tests that generate code from a temporary project.
+GeneratorConfig buildTestServerConfig(Directory projectDir) {
+  return GeneratorConfigBuilder()
+      .withName('test')
+      .withServerPackageDirectoryPathParts([projectDir.path])
+      .withRelativeDartClientPackagePathParts(['test_client'])
+      .withModules([
+        ModuleConfig(
+          type: PackageType.server,
+          name: 'test',
+          nickname: 'test',
+          migrationVersions: [],
+          serverPackageDirectoryPathParts: [projectDir.path],
+        ),
+      ])
+      .build();
 }

--- a/tools/serverpod_cli/test/test_util/mtime_helpers.dart
+++ b/tools/serverpod_cli/test/test_util/mtime_helpers.dart
@@ -1,0 +1,23 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+
+/// Waits until the file system reports an mtime strictly after [reference].
+///
+/// Avoids hard-coded delays that may be too short on platforms with coarse
+/// timestamp resolution (e.g. Windows). A scratch [dir] can be supplied to
+/// probe on the same volume as the files under test.
+Future<void> waitForMtimeAfter(DateTime reference, [Directory? dir]) async {
+  dir ??= await Directory.systemTemp.createTemp();
+  final probe = File(p.join(dir.path, '.mtime_probe'));
+  try {
+    for (var i = 0; i < 100; i++) {
+      await probe.writeAsString('$i');
+      if (probe.statSync().modified.isAfter(reference)) return;
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+    }
+    throw StateError('File system mtime did not advance after 5 seconds');
+  } finally {
+    if (probe.existsSync()) await probe.delete();
+  }
+}


### PR DESCRIPTION
Closes: https://github.com/serverpod/serverpod/issues/4746

- skip generate when output is already up to date
- track all generation inputs and outputs in the staleness check
- enumerate and stats sources once in the staleness check
