### PR TITLE
fix: Update file path for OpenCode MCP config

### DIFF
--- a/tests/bootstrap_project/test_perform_create/ide_test.dart
+++ b/tests/bootstrap_project/test_perform_create/ide_test.dart
@@ -135,7 +135,7 @@ args = ["mcp-server", "--force-roots-fallback"]
             'has Serverpod and Dart MCP servers configured for OpenCode',
             () {
               final config = File(
-                p.join(projectName, '.opencode/opencode.json'),
+                p.join(projectName, 'opencode.json'),
               );
               expect(config.existsSync(), isTrue);
               expect(

--- a/tools/serverpod_cli/lib/src/create/ide.dart
+++ b/tools/serverpod_cli/lib/src/create/ide.dart
@@ -11,7 +11,7 @@ enum TemplateIde {
   codex(filePath: '.codex/config.toml', config: _codexConfig),
   cursor(filePath: '.cursor/mcp.json', config: _genericConfig),
   claude(filePath: '.mcp.json', config: _genericConfig),
-  openCode(filePath: '.opencode/opencode.json', config: _openCodeConfig),
+  openCode(filePath: 'opencode.json', config: _openCodeConfig),
   vscode(
     filePath: '.vscode/mcp.json',
     config: _genericConfig,


### PR DESCRIPTION
OpenCode's MCP config is now placed at the root of Serverpod projects to be compatible with OpenCode's desktop app.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None