### PR TITLE
feat: Automatically restart the Flutter app when its dependencies change

### DIFF
--- a/templates/pubspecs/tools/serverpod_cli/pubspec.yaml
+++ b/templates/pubspecs/tools/serverpod_cli/pubspec.yaml
@@ -53,7 +53,7 @@ dependencies:
   serverpod_serialization: SERVERPOD_VERSION
   serverpod_service_client: SERVERPOD_VERSION
   serverpod_shared: SERVERPOD_VERSION
-  serverpod_tui: ^0.1.0-rc.4
+  serverpod_tui: ^0.1.0-rc.6
   skills: ^0.3.0
   source_span: ^1.10.0
   stream_channel: ^2.1.1

--- a/tools/serverpod_cli/lib/src/commands/messages.dart
+++ b/tools/serverpod_cli/lib/src/commands/messages.dart
@@ -12,6 +12,11 @@ const serverReloaded = '✓ Server reloaded.';
 const serverRestarted = '✓ Server restarted.';
 const flutterAppReloaded = '✓ Flutter app reloaded.';
 const flutterAppRestarted = '✓ Flutter app restarted.';
+const flutterDependenciesChangedNative =
+    'Flutter dependencies with native code changed. '
+    'Relaunching the Flutter app...';
+const flutterDependenciesChangedDart =
+    'Flutter dependencies changed. Hot restarting the Flutter app...';
 const flutterPackageNotFound =
     'No Flutter package found; skipping --flutter. '
     'Pass --no-flutter to silence this notice.';

--- a/tools/serverpod_cli/lib/src/commands/start.dart
+++ b/tools/serverpod_cli/lib/src/commands/start.dart
@@ -584,6 +584,9 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
   // Calling while previous instance is still running is a no-op.
   FlutterProcess? flutterProcess;
   var spawnInFlight = false;
+  // Set by the restart action when the spawn replaces a previously running
+  // app, so the progress message reads as a relaunch rather than a first run.
+  var flutterRelaunchInProgress = false;
   spawnFlutterAppIfNeeded = () async {
     if (runMode != 'development') return;
     if (!config.hasFlutterPackage) {
@@ -594,6 +597,8 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
     if (existing != null && existing.isRunning) return;
     if (spawnInFlight) return;
     spawnInFlight = true;
+    final isRelaunch = flutterRelaunchInProgress;
+    flutterRelaunchInProgress = false;
 
     final fp = FlutterProcess(
       flutterPackageDir: p.joinAll(config.flutterPackagePathParts),
@@ -626,7 +631,9 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
     // On `-d web-server` `launched` pends until a browser attaches.
     unawaited(() async {
       await log.progress(
-        'Launching Flutter app (first run may take 30-60s)',
+        isRelaunch
+            ? 'Relaunching Flutter app'
+            : 'Launching Flutter app (first run may take 30-60s)',
         () async {
           await fp.launched;
           return true;
@@ -704,6 +711,7 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
     // button. `spawnFlutterAppIfNeeded` self-guards on development mode.
     flutterAppRestartAction: config.hasFlutterPackage
         ? () async {
+            flutterRelaunchInProgress = flutterProcess != null;
             await flutterProcess?.stop();
             await spawnFlutterAppIfNeeded();
           }

--- a/tools/serverpod_cli/lib/src/commands/start.dart
+++ b/tools/serverpod_cli/lib/src/commands/start.dart
@@ -669,29 +669,31 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
   FlutterDependencyTracker? flutterDependencyTracker;
   if (config.hasFlutterPackage) {
     final flutterPackageDir = p.joinAll(config.flutterPackagePathParts);
-    final dartToolDir = FlutterDependencyTracker.resolveDartToolDir(
-      flutterPackageDir,
-    );
-    if (dartToolDir != null) {
-      try {
+    try {
+      final flutterPackageName = parsePubspec(
+        File(p.join(flutterPackageDir, 'pubspec.yaml')),
+      ).name;
+      final dartToolDir = FlutterDependencyTracker.resolveDartToolDir(
+        flutterPackageDir,
+        flutterPackageName: flutterPackageName,
+      );
+      if (dartToolDir != null) {
         flutterDependencyTracker = FlutterDependencyTracker(
           dartToolDir: dartToolDir,
-          flutterPackageName: parsePubspec(
-            File(p.join(flutterPackageDir, 'pubspec.yaml')),
-          ).name,
+          flutterPackageName: flutterPackageName,
         );
-      } catch (e) {
-        // A malformed Flutter pubspec must not prevent the server from
-        // starting; it only disables dependency tracking.
+      } else {
         log.debug(
-          'Flutter dependency tracking disabled: could not read the Flutter '
-          'package name from $flutterPackageDir ($e).',
+          'Flutter dependency tracking disabled: no resolution listing '
+          '$flutterPackageName found above $flutterPackageDir.',
         );
       }
-    } else {
+    } catch (e) {
+      // A malformed Flutter pubspec must not prevent the server from
+      // starting; it only disables dependency tracking.
       log.debug(
-        'Flutter dependency tracking disabled: no '
-        '.dart_tool/package_config.json found for $flutterPackageDir.',
+        'Flutter dependency tracking disabled: could not read the Flutter '
+        'package name from $flutterPackageDir ($e).',
       );
     }
   }

--- a/tools/serverpod_cli/lib/src/commands/start.dart
+++ b/tools/serverpod_cli/lib/src/commands/start.dart
@@ -673,12 +673,21 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
       flutterPackageDir,
     );
     if (dartToolDir != null) {
-      flutterDependencyTracker = FlutterDependencyTracker(
-        dartToolDir: dartToolDir,
-        flutterPackageName: parsePubspec(
-          File(p.join(flutterPackageDir, 'pubspec.yaml')),
-        ).name,
-      );
+      try {
+        flutterDependencyTracker = FlutterDependencyTracker(
+          dartToolDir: dartToolDir,
+          flutterPackageName: parsePubspec(
+            File(p.join(flutterPackageDir, 'pubspec.yaml')),
+          ).name,
+        );
+      } catch (e) {
+        // A malformed Flutter pubspec must not prevent the server from
+        // starting; it only disables dependency tracking.
+        log.debug(
+          'Flutter dependency tracking disabled: could not read the Flutter '
+          'package name from $flutterPackageDir ($e).',
+        );
+      }
     } else {
       log.debug(
         'Flutter dependency tracking disabled: no '

--- a/tools/serverpod_cli/lib/src/commands/start.dart
+++ b/tools/serverpod_cli/lib/src/commands/start.dart
@@ -10,6 +10,7 @@ import 'package:serverpod_cli/analyzer.dart';
 import 'package:serverpod_cli/src/commands/generate.dart';
 import 'package:serverpod_cli/src/commands/messages.dart';
 import 'package:serverpod_cli/src/commands/start/file_watcher.dart';
+import 'package:serverpod_cli/src/commands/start/flutter_dependency_tracker.dart';
 import 'package:serverpod_cli/src/commands/start/flutter_process.dart';
 import 'package:serverpod_cli/src/commands/start/kernel_compiler.dart';
 import 'package:serverpod_cli/src/commands/start/mcp_server.dart';
@@ -32,6 +33,7 @@ import 'package:serverpod_cli/src/migrations/create_repair_migration_action.dart
 import 'package:serverpod_cli/src/runner/serverpod_command.dart';
 import 'package:serverpod_cli/src/runner/serverpod_command_runner.dart';
 import 'package:serverpod_cli/src/util/internal_error.dart';
+import 'package:serverpod_cli/src/util/pubspec_helpers.dart';
 import 'package:serverpod_cli/src/util/serverpod_cli_logger.dart';
 import 'package:serverpod_cli/src/vm_proxy/proxy.dart';
 import 'package:serverpod_cli/src/vm_proxy/serverpod_hooks.dart';
@@ -654,6 +656,30 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
     await spawnFlutterAppIfNeeded();
   }
 
+  // Track the Flutter app's resolved dependency closure so a dependency change
+  // (which a hot restart can't pick up) auto-triggers a full relaunch. Disabled
+  // when there is no Flutter package or its dependencies haven't been resolved.
+  FlutterDependencyTracker? flutterDependencyTracker;
+  if (config.hasFlutterPackage) {
+    final flutterPackageDir = p.joinAll(config.flutterPackagePathParts);
+    final dartToolDir = FlutterDependencyTracker.resolveDartToolDir(
+      flutterPackageDir,
+    );
+    if (dartToolDir != null) {
+      flutterDependencyTracker = FlutterDependencyTracker(
+        dartToolDir: dartToolDir,
+        flutterPackageName: parsePubspec(
+          File(p.join(flutterPackageDir, 'pubspec.yaml')),
+        ).name,
+      );
+    } else {
+      log.debug(
+        'Flutter dependency tracking disabled: no '
+        '.dart_tool/package_config.json found for $flutterPackageDir.',
+      );
+    }
+  }
+
   // Construct the watch session.
   session = WatchSession(
     compiler: compiler,
@@ -682,6 +708,8 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
             await spawnFlutterAppIfNeeded();
           }
         : null,
+    flutterDependenciesChangedSinceLastCheck:
+        flutterDependencyTracker?.refreshIfChanged,
     applyMigrationsAction: () => _applyMigrationsForSession(
       serverDir: serverDir,
       runMode: runMode,
@@ -742,6 +770,11 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
         ),
         if (config.hasFlutterPackage)
           p.absolute(p.joinAll([...config.flutterPackagePathParts, 'lib'])),
+        // The resolution's .dart_tool holds package_graph.json, watched to
+        // detect Flutter dependency changes (workspace root or, in a
+        // non-workspace project, the Flutter package's own .dart_tool).
+        if (flutterDependencyTracker != null)
+          p.absolute(flutterDependencyTracker.dartToolDir),
       },
     );
     fileChangeSub = watcher.onFilesChanged

--- a/tools/serverpod_cli/lib/src/commands/start.dart
+++ b/tools/serverpod_cli/lib/src/commands/start.dart
@@ -708,8 +708,7 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
             await spawnFlutterAppIfNeeded();
           }
         : null,
-    flutterDependenciesChangedSinceLastCheck:
-        flutterDependencyTracker?.refreshIfChanged,
+    checkFlutterDependencyChange: flutterDependencyTracker?.refresh,
     applyMigrationsAction: () => _applyMigrationsForSession(
       serverDir: serverDir,
       runMode: runMode,

--- a/tools/serverpod_cli/lib/src/commands/start.dart
+++ b/tools/serverpod_cli/lib/src/commands/start.dart
@@ -1166,7 +1166,9 @@ Future<void> _runTuiBackend({
         holder.onRestartFlutterApp = () {
           runTrackedAction(
             holder,
-            'Restart Flutter app',
+            ctx.session.isFlutterAppRunning
+                ? 'Restart Flutter app'
+                : 'Start Flutter app',
             ctx.session.restartFlutterApp,
           );
         };

--- a/tools/serverpod_cli/lib/src/commands/start/file_watcher.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/file_watcher.dart
@@ -18,6 +18,12 @@ class FileChangeEvent {
   /// Whether package_config.json was modified in this batch.
   final bool packageConfigChanged;
 
+  /// Whether the Flutter app's dependency graph (`package_graph.json`) was
+  /// modified in this batch. Signals that the Flutter app may need a full
+  /// relaunch to pick up new dependencies; the actual decision is made by
+  /// comparing the dependency fingerprint (see `FlutterDependencyTracker`).
+  final bool flutterDependenciesChanged;
+
   /// Whether non-dart, non-model files changed (e.g. HTML, JS, CSS).
   ///
   /// Used to trigger a browser refresh without recompilation.
@@ -27,12 +33,17 @@ class FileChangeEvent {
     required this.dartFiles,
     this.modelFiles = const {},
     this.packageConfigChanged = false,
+    this.flutterDependenciesChanged = false,
     this.staticFilesChanged = false,
   });
 }
 
 bool _isModelFile(String filePath) {
   return spyModelFileExtensions.any((ext) => filePath.endsWith(ext));
+}
+
+bool _isWithinDartTool(String filePath) {
+  return p.split(filePath).contains('.dart_tool');
 }
 
 /// Merges multiple buffered [FileChangeEvent]s into a single event.
@@ -44,12 +55,14 @@ extension FileChangeEventMerge on List<FileChangeEvent> {
     final dartFiles = <String>{};
     final modelFiles = <String>{};
     var packageConfigChanged = false;
+    var flutterDependenciesChanged = false;
     var staticFilesChanged = false;
 
     for (final event in this) {
       dartFiles.addAll(event.dartFiles);
       modelFiles.addAll(event.modelFiles);
       packageConfigChanged |= event.packageConfigChanged;
+      flutterDependenciesChanged |= event.flutterDependenciesChanged;
       staticFilesChanged |= event.staticFilesChanged;
     }
 
@@ -57,6 +70,7 @@ extension FileChangeEventMerge on List<FileChangeEvent> {
       dartFiles: dartFiles,
       modelFiles: modelFiles,
       packageConfigChanged: packageConfigChanged,
+      flutterDependenciesChanged: flutterDependenciesChanged,
       staticFilesChanged: staticFilesChanged,
     );
   }
@@ -108,11 +122,19 @@ class FileWatcher {
           final dartFiles = <String>{};
           final modelFiles = <String>{};
           var packageConfigChanged = false;
+          var flutterDependenciesChanged = false;
           var staticFilesChanged = false;
 
           for (final event in events) {
             final filePath = event.path;
-            if (p.basename(filePath) == 'package_config.json') {
+            if (_isWithinDartTool(filePath)) {
+              // Inside .dart_tool only the dependency graph is relevant.
+              // Everything else (build artifacts, pub metadata) is ignored so
+              // it triggers neither a browser refresh nor the FES restart path.
+              if (p.basename(filePath) == 'package_graph.json') {
+                flutterDependenciesChanged = true;
+              }
+            } else if (p.basename(filePath) == 'package_config.json') {
               packageConfigChanged = true;
             } else if (_isModelFile(filePath)) {
               modelFiles.add(filePath);
@@ -127,6 +149,7 @@ class FileWatcher {
             dartFiles: dartFiles,
             modelFiles: modelFiles,
             packageConfigChanged: packageConfigChanged,
+            flutterDependenciesChanged: flutterDependenciesChanged,
             staticFilesChanged: staticFilesChanged,
           );
         })
@@ -135,6 +158,7 @@ class FileWatcher {
               e.dartFiles.isNotEmpty ||
               e.modelFiles.isNotEmpty ||
               e.packageConfigChanged ||
+              e.flutterDependenciesChanged ||
               e.staticFilesChanged,
         );
   }

--- a/tools/serverpod_cli/lib/src/commands/start/file_watcher.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/file_watcher.dart
@@ -128,9 +128,10 @@ class FileWatcher {
           for (final event in events) {
             final filePath = event.path;
             if (_isWithinDartTool(filePath)) {
-              // Inside .dart_tool only the dependency graph is relevant.
-              // Everything else (build artifacts, pub metadata) is ignored so
-              // it triggers neither a browser refresh nor the FES restart path.
+              // Inside .dart_tool only the dependency graph is relevant;
+              // everything else is ignored. Notably this keeps
+              // packageConfigChanged (the FES restart path) dormant, exactly
+              // as before .dart_tool was watched at all.
               if (p.basename(filePath) == 'package_graph.json') {
                 flutterDependenciesChanged = true;
               }

--- a/tools/serverpod_cli/lib/src/commands/start/flutter_dependency_tracker.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/flutter_dependency_tracker.dart
@@ -1,0 +1,127 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+
+/// Tracks the Flutter app's dependency closure so the watcher can fully
+/// relaunch the app only when its dependencies actually change.
+///
+/// The fingerprint is derived from `.dart_tool/package_graph.json`, which lists
+/// every resolved package with its version and direct dependencies. Starting
+/// from the Flutter package and following `dependencies` (not
+/// `devDependencies`) yields the app's transitive closure; the closure's
+/// `name@version` pairs form the fingerprint.
+///
+/// Scoping to the closure is what keeps a pub *workspace* from over-triggering:
+/// in a workspace the `package_graph.json` is shared across all members, but a
+/// change to a server-only dependency leaves the Flutter app's closure
+/// untouched, so no relaunch fires.
+class FlutterDependencyTracker {
+  /// The `.dart_tool` directory holding `package_graph.json` for the resolution
+  /// the Flutter package belongs to — the workspace root in a workspace layout,
+  /// or the package's own `.dart_tool` in a non-workspace project.
+  final String dartToolDir;
+
+  /// The package name of the Flutter app, as it appears in `package_graph.json`.
+  final String flutterPackageName;
+
+  String? _cachedFingerprint;
+
+  FlutterDependencyTracker({
+    required this.dartToolDir,
+    required this.flutterPackageName,
+  }) {
+    _cachedFingerprint = computeFingerprint();
+  }
+
+  /// Resolves the `.dart_tool` directory whose `package_graph.json` describes
+  /// [flutterPackageDir]'s dependency resolution.
+  ///
+  /// Walks up from [flutterPackageDir] to the nearest ancestor (including
+  /// itself) that contains `.dart_tool/package_config.json` — the canonical
+  /// marker of a pub resolution root, always written by `pub get` (unlike
+  /// `package_graph.json`, which requires a newer SDK). In a workspace this
+  /// resolves to the workspace root; in a non-workspace project it resolves to
+  /// the package's own directory. Returns `null` if no such directory exists
+  /// (e.g. dependencies have not been fetched yet).
+  static String? resolveDartToolDir(String flutterPackageDir) {
+    var dir = p.absolute(flutterPackageDir);
+    while (true) {
+      final dartTool = p.join(dir, '.dart_tool');
+      if (File(p.join(dartTool, 'package_config.json')).existsSync()) {
+        return dartTool;
+      }
+      final parent = p.dirname(dir);
+      if (parent == dir) return null; // Reached the filesystem root.
+      dir = parent;
+    }
+  }
+
+  /// Recomputes the fingerprint, compares it to the cached value, and updates
+  /// the cache. Returns `true` only when the closure changed between two
+  /// successfully computed fingerprints.
+  ///
+  /// A transition to or from `null` (the graph file missing or unparseable,
+  /// e.g. mid-`pub get` or after `flutter clean`) is treated as "no change", so
+  /// a transient state never triggers a relaunch — the next valid fingerprint
+  /// simply reseeds the cache.
+  bool refreshIfChanged() {
+    final next = computeFingerprint();
+    final previous = _cachedFingerprint;
+    if (next != null) _cachedFingerprint = next;
+    if (next == null || previous == null) return false;
+    return next != previous;
+  }
+
+  /// Computes a fingerprint of the Flutter app's transitive dependency closure
+  /// from `package_graph.json`, or `null` if the file cannot be read/parsed or
+  /// the Flutter package is absent from the graph.
+  String? computeFingerprint() {
+    final file = File(p.join(dartToolDir, 'package_graph.json'));
+    if (!file.existsSync()) return null;
+
+    final Object? decoded;
+    try {
+      decoded = jsonDecode(file.readAsStringSync());
+    } on FormatException {
+      return null;
+    } on IOException {
+      return null;
+    }
+    if (decoded is! Map<String, dynamic>) return null;
+
+    final packages = decoded['packages'];
+    if (packages is! List) return null;
+
+    final byName = <String, Map<String, dynamic>>{};
+    for (final pkg in packages) {
+      if (pkg is Map<String, dynamic> && pkg['name'] is String) {
+        byName[pkg['name'] as String] = pkg;
+      }
+    }
+    if (!byName.containsKey(flutterPackageName)) return null;
+
+    // Collect the transitive closure by following `dependencies` only;
+    // `devDependencies` don't affect the running app, so they are skipped to
+    // avoid relaunching on test/lint dependency changes.
+    final closure = <String>{};
+    final stack = <String>[flutterPackageName];
+    while (stack.isNotEmpty) {
+      final name = stack.removeLast();
+      if (!closure.add(name)) continue;
+      final deps = byName[name]?['dependencies'];
+      if (deps is List) {
+        for (final dep in deps) {
+          if (dep is String && !closure.contains(dep)) stack.add(dep);
+        }
+      }
+    }
+
+    // Canonical, order-independent fingerprint: sorted `name@version` pairs.
+    final entries = closure.map((name) {
+      final version = byName[name]?['version'];
+      return '$name@${version ?? ''}';
+    }).toList()..sort();
+    return entries.join(';');
+  }
+}

--- a/tools/serverpod_cli/lib/src/commands/start/flutter_dependency_tracker.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/flutter_dependency_tracker.dart
@@ -1,21 +1,47 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:collection/collection.dart';
 import 'package:path/path.dart' as p;
+import 'package:yaml/yaml.dart';
 
-/// Tracks the Flutter app's dependency closure so the watcher can fully
-/// relaunch the app only when its dependencies actually change.
+/// How the Flutter app's dependency closure changed, ordered by the severity
+/// of the response required to pick the change up.
+enum FlutterDependencyChange {
+  /// No change to the closure; source edits are covered by a hot reload.
+  none,
+
+  /// Only pure-Dart dependencies changed; a hot restart picks them up.
+  dartOnly,
+
+  /// A dependency with native code changed; only a full process relaunch
+  /// rebuilds the native host (a hot restart would leave the new native code
+  /// out of the binary, failing at runtime with a MissingPluginException).
+  native,
+}
+
+/// Tracks the Flutter app's dependency closure so the watcher can escalate to
+/// a hot restart or a full relaunch only when its dependencies actually
+/// change.
 ///
-/// The fingerprint is derived from `.dart_tool/package_graph.json`, which lists
+/// The closure is derived from `.dart_tool/package_graph.json`, which lists
 /// every resolved package with its version and direct dependencies. Starting
 /// from the Flutter package and following `dependencies` (not
-/// `devDependencies`) yields the app's transitive closure; the closure's
-/// `name@version` pairs form the fingerprint.
+/// `devDependencies`) yields the app's transitive closure, fingerprinted as
+/// `name -> version`.
 ///
-/// Scoping to the closure is what keeps a pub *workspace* from over-triggering:
-/// in a workspace the `package_graph.json` is shared across all members, but a
-/// change to a server-only dependency leaves the Flutter app's closure
-/// untouched, so no relaunch fires.
+/// Scoping to the closure is what keeps a pub *workspace* from
+/// over-triggering: in a workspace the `package_graph.json` is shared across
+/// all members, but a change to a server-only dependency leaves the Flutter
+/// app's closure untouched, so nothing fires.
+///
+/// When the closure does change, the added or version-changed packages are
+/// classified via their pubspecs (located through `package_config.json`):
+/// packages with native code ([FlutterDependencyChange.native]) need a full
+/// relaunch, while pure-Dart changes ([FlutterDependencyChange.dartOnly]) only
+/// need a hot restart. Unreadable or unlocatable packages are conservatively
+/// treated as native, so a classification miss degrades to a
+/// slower-but-correct relaunch, never a broken app.
 class FlutterDependencyTracker {
   /// The `.dart_tool` directory holding `package_graph.json` for the resolution
   /// the Flutter package belongs to — the workspace root in a workspace layout,
@@ -25,13 +51,17 @@ class FlutterDependencyTracker {
   /// The package name of the Flutter app, as it appears in `package_graph.json`.
   final String flutterPackageName;
 
-  String? _cachedFingerprint;
+  Map<String, String>? _cachedClosureVersions;
+
+  /// Memoized native-code verdicts, keyed by `name@version`. Pub cache
+  /// contents are immutable per version, so entries never invalidate.
+  final Map<String, bool> _nativeCache = {};
 
   FlutterDependencyTracker({
     required this.dartToolDir,
     required this.flutterPackageName,
   }) {
-    _cachedFingerprint = computeFingerprint();
+    _cachedClosureVersions = _computeClosureVersions();
   }
 
   /// Resolves the `.dart_tool` directory whose `package_graph.json` describes
@@ -57,26 +87,43 @@ class FlutterDependencyTracker {
     }
   }
 
-  /// Recomputes the fingerprint, compares it to the cached value, and updates
-  /// the cache. Returns `true` only when the closure changed between two
-  /// successfully computed fingerprints.
+  /// Recomputes the dependency closure, compares it to the cached value, and
+  /// classifies the change. Updates the cache.
   ///
-  /// A transition to or from `null` (the graph file missing or unparseable,
-  /// e.g. mid-`pub get` or after `flutter clean`) is treated as "no change", so
-  /// a transient state never triggers a relaunch — the next valid fingerprint
-  /// simply reseeds the cache.
-  bool refreshIfChanged() {
-    final next = computeFingerprint();
-    final previous = _cachedFingerprint;
-    if (next != null) _cachedFingerprint = next;
-    if (next == null || previous == null) return false;
-    return next != previous;
+  /// A transition to or from an unreadable closure (the graph file missing or
+  /// unparseable, e.g. mid-`pub get` or after `flutter clean`) is treated as
+  /// [FlutterDependencyChange.none], so a transient state never triggers a
+  /// restart — the next valid closure simply reseeds the cache.
+  FlutterDependencyChange refresh() {
+    final next = _computeClosureVersions();
+    final previous = _cachedClosureVersions;
+    if (next != null) _cachedClosureVersions = next;
+    if (next == null || previous == null) return FlutterDependencyChange.none;
+    if (const MapEquality<String, String>().equals(next, previous)) {
+      return FlutterDependencyChange.none;
+    }
+
+    // Removed packages never force a relaunch — their stale native code in
+    // the running binary is harmless. Only added or version-changed packages
+    // can introduce native code.
+    final delta = next.entries
+        .where((entry) => previous[entry.key] != entry.value)
+        .toList();
+    if (delta.isEmpty) return FlutterDependencyChange.dartOnly;
+
+    final packageRoots = _readPackageRoots() ?? const {};
+    final hasNative = delta.any(
+      (entry) => _hasNativeCode(entry.key, entry.value, packageRoots),
+    );
+    return hasNative
+        ? FlutterDependencyChange.native
+        : FlutterDependencyChange.dartOnly;
   }
 
-  /// Computes a fingerprint of the Flutter app's transitive dependency closure
-  /// from `package_graph.json`, or `null` if the file cannot be read/parsed or
-  /// the Flutter package is absent from the graph.
-  String? computeFingerprint() {
+  /// Computes the Flutter app's transitive dependency closure as a
+  /// `name -> version` map from `package_graph.json`, or `null` if the file
+  /// cannot be read/parsed or the Flutter package is absent from the graph.
+  Map<String, String>? _computeClosureVersions() {
     final file = File(p.join(dartToolDir, 'package_graph.json'));
     if (!file.existsSync()) return null;
 
@@ -103,7 +150,7 @@ class FlutterDependencyTracker {
 
     // Collect the transitive closure by following `dependencies` only;
     // `devDependencies` don't affect the running app, so they are skipped to
-    // avoid relaunching on test/lint dependency changes.
+    // avoid restarting on test/lint dependency changes.
     final closure = <String>{};
     final stack = <String>[flutterPackageName];
     while (stack.isNotEmpty) {
@@ -117,11 +164,95 @@ class FlutterDependencyTracker {
       }
     }
 
-    // Canonical, order-independent fingerprint: sorted `name@version` pairs.
-    final entries = closure.map((name) {
-      final version = byName[name]?['version'];
-      return '$name@${version ?? ''}';
-    }).toList()..sort();
-    return entries.join(';');
+    return {
+      for (final name in closure) name: '${byName[name]?['version'] ?? ''}',
+    };
+  }
+
+  /// Maps each resolved package to its root directory via
+  /// `package_config.json`, or `null` if the file cannot be read. Relative
+  /// `rootUri`s are resolved against the file's own location, per spec.
+  Map<String, String>? _readPackageRoots() {
+    final file = File(p.join(dartToolDir, 'package_config.json'));
+    if (!file.existsSync()) return null;
+
+    final Object? decoded;
+    try {
+      decoded = jsonDecode(file.readAsStringSync());
+    } on FormatException {
+      return null;
+    } on IOException {
+      return null;
+    }
+    if (decoded is! Map<String, dynamic>) return null;
+
+    final packages = decoded['packages'];
+    if (packages is! List) return null;
+
+    final baseUri = file.absolute.uri;
+    final roots = <String, String>{};
+    for (final pkg in packages) {
+      if (pkg is! Map<String, dynamic>) continue;
+      final name = pkg['name'];
+      final rootUri = pkg['rootUri'];
+      if (name is! String || rootUri is! String) continue;
+      try {
+        roots[name] = p.fromUri(baseUri.resolve(rootUri));
+      } on FormatException {
+        continue;
+      }
+    }
+    return roots;
+  }
+
+  /// Whether the package ships native code that a hot restart cannot pick up:
+  /// a classic plugin platform implementation (`pluginClass` in a compiled
+  /// host language, or `ffiPlugin`) or a native-assets build hook.
+  /// `dartPluginClass`-only platforms and the `pluginClass: none` convention
+  /// are pure Dart. Conservatively returns `true` when the package cannot be
+  /// located or its pubspec cannot be read.
+  bool _hasNativeCode(
+    String name,
+    String version,
+    Map<String, String> packageRoots,
+  ) {
+    return _nativeCache.putIfAbsent('$name@$version', () {
+      final root = packageRoots[name];
+      if (root == null) return true;
+
+      final Object? pubspec;
+      try {
+        pubspec = loadYaml(
+          File(p.join(root, 'pubspec.yaml')).readAsStringSync(),
+        );
+      } on IOException {
+        return true;
+      } on YamlException {
+        return true;
+      }
+      if (pubspec is! YamlMap) return true;
+
+      final platforms = _lookup(pubspec, ['flutter', 'plugin', 'platforms']);
+      if (platforms is! YamlMap) {
+        // Not a classic plugin. Packages using the native-assets mechanism
+        // compile native code through a build hook instead.
+        return File(p.join(root, 'hook', 'build.dart')).existsSync();
+      }
+      return platforms.values.any((platform) {
+        if (platform is! YamlMap) return false;
+        final pluginClass = platform['pluginClass'];
+        return (pluginClass != null && pluginClass != 'none') ||
+            platform['ffiPlugin'] == true;
+      });
+    });
+  }
+
+  static Object? _lookup(YamlMap map, List<String> path) {
+    Object? node = map;
+    for (final key in path) {
+      if (node is! YamlMap) return null;
+      node = node[key];
+    }
+    return node;
   }
 }

--- a/tools/serverpod_cli/lib/src/commands/start/flutter_dependency_tracker.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/flutter_dependency_tracker.dart
@@ -66,11 +66,10 @@ class FlutterDependencyTracker {
 
   /// Resolves the `.dart_tool` directory whose `package_graph.json` describes
   /// [flutterPackageDir]'s dependency resolution: the nearest ancestor
-  /// (including itself) whose `.dart_tool/package_config.json` lists
-  /// [flutterPackageName] — the workspace root in a workspace, the package's
-  /// own directory otherwise. The membership check prevents latching onto an
-  /// unrelated resolution root. Returns `null` if none exists (e.g.
-  /// dependencies have not been fetched yet).
+  /// (including itself) with a `.dart_tool/package_config.json` — the
+  /// workspace root in a workspace, the package's own directory otherwise.
+  /// Returns `null` if there is none (e.g. dependencies have not been fetched
+  /// yet) or if the one found does not list [flutterPackageName].
   static String? resolveDartToolDir(
     String flutterPackageDir, {
     required String flutterPackageName,
@@ -78,8 +77,14 @@ class FlutterDependencyTracker {
     var dir = p.absolute(flutterPackageDir);
     while (true) {
       final dartTool = p.join(dir, '.dart_tool');
-      if (_packageConfigContains(dartTool, flutterPackageName)) {
-        return dartTool;
+      if (File(p.join(dartTool, 'package_config.json')).existsSync()) {
+        // The nearest resolution root must list the package. An unrelated
+        // resolution (e.g. found after the package's own .dart_tool was
+        // deleted) disables tracking rather than risking a wrong root
+        // further up that merely contains a same-named package.
+        return _packageConfigContains(dartTool, flutterPackageName)
+            ? dartTool
+            : null;
       }
       final parent = p.dirname(dir);
       if (parent == dir) return null; // Reached the filesystem root.
@@ -87,9 +92,8 @@ class FlutterDependencyTracker {
     }
   }
 
-  /// Whether `<dartTool>/package_config.json` exists, parses, and lists a
-  /// package named [packageName]. Unreadable or malformed files count as a
-  /// non-match so the walk continues to the next ancestor.
+  /// Whether `<dartTool>/package_config.json` parses and lists a package
+  /// named [packageName]. Unreadable or malformed files count as a non-match.
   static bool _packageConfigContains(String dartTool, String packageName) {
     final file = File(p.join(dartTool, 'package_config.json'));
     if (!file.existsSync()) return false;

--- a/tools/serverpod_cli/lib/src/commands/start/flutter_dependency_tracker.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/flutter_dependency_tracker.dart
@@ -65,26 +65,50 @@ class FlutterDependencyTracker {
   }
 
   /// Resolves the `.dart_tool` directory whose `package_graph.json` describes
-  /// [flutterPackageDir]'s dependency resolution.
-  ///
-  /// Walks up from [flutterPackageDir] to the nearest ancestor (including
-  /// itself) that contains `.dart_tool/package_config.json` — the canonical
-  /// marker of a pub resolution root, always written by `pub get` (unlike
-  /// `package_graph.json`, which requires a newer SDK). In a workspace this
-  /// resolves to the workspace root; in a non-workspace project it resolves to
-  /// the package's own directory. Returns `null` if no such directory exists
-  /// (e.g. dependencies have not been fetched yet).
-  static String? resolveDartToolDir(String flutterPackageDir) {
+  /// [flutterPackageDir]'s dependency resolution: the nearest ancestor
+  /// (including itself) whose `.dart_tool/package_config.json` lists
+  /// [flutterPackageName] — the workspace root in a workspace, the package's
+  /// own directory otherwise. The membership check prevents latching onto an
+  /// unrelated resolution root. Returns `null` if none exists (e.g.
+  /// dependencies have not been fetched yet).
+  static String? resolveDartToolDir(
+    String flutterPackageDir, {
+    required String flutterPackageName,
+  }) {
     var dir = p.absolute(flutterPackageDir);
     while (true) {
       final dartTool = p.join(dir, '.dart_tool');
-      if (File(p.join(dartTool, 'package_config.json')).existsSync()) {
+      if (_packageConfigContains(dartTool, flutterPackageName)) {
         return dartTool;
       }
       final parent = p.dirname(dir);
       if (parent == dir) return null; // Reached the filesystem root.
       dir = parent;
     }
+  }
+
+  /// Whether `<dartTool>/package_config.json` exists, parses, and lists a
+  /// package named [packageName]. Unreadable or malformed files count as a
+  /// non-match so the walk continues to the next ancestor.
+  static bool _packageConfigContains(String dartTool, String packageName) {
+    final file = File(p.join(dartTool, 'package_config.json'));
+    if (!file.existsSync()) return false;
+
+    final Object? decoded;
+    try {
+      decoded = jsonDecode(file.readAsStringSync());
+    } on FormatException {
+      return false;
+    } on IOException {
+      return false;
+    }
+    if (decoded is! Map<String, dynamic>) return false;
+
+    final packages = decoded['packages'];
+    if (packages is! List) return false;
+    return packages.any(
+      (pkg) => pkg is Map<String, dynamic> && pkg['name'] == packageName,
+    );
   }
 
   /// Recomputes the dependency closure, compares it to the cached value, and

--- a/tools/serverpod_cli/lib/src/commands/start/flutter_process.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/flutter_process.dart
@@ -412,8 +412,9 @@ class FlutterProcess {
     }
   }
 
-  /// SIGINT -> wait -> SIGKILL. Reaches the daemon because [start]
-  /// spawns flutter_tools directly, bypassing wrappers.
+  /// Graceful daemon `app.stop` -> SIGINT -> wait -> SIGKILL. The signals
+  /// reach the daemon because [start] spawns flutter_tools directly,
+  /// bypassing wrappers.
   Future<int> stop({
     Duration timeout = const Duration(seconds: 5),
   }) async {
@@ -425,6 +426,31 @@ class FlutterProcess {
 
     await _sigtermSub?.cancel();
     _sigtermSub = null;
+
+    // Ask the daemon to stop the app first: in --machine mode a bare SIGINT
+    // can terminate flutter_tools without device cleanup, leaving e.g. the
+    // browser window it spawned open. `app.stop` tears the device session
+    // down properly; signals below remain as the fallback.
+    final daemon = _daemon;
+    final appId = _appId;
+    if (daemon != null && appId != null) {
+      try {
+        await daemon
+            .sendRequest('app.stop', <String, Object?>{'appId': appId})
+            .timeout(timeout);
+        final exitCode = await process.exitCode.timeout(timeout);
+        log.debug(
+          'Flutter stop: PID ${process.pid} exited gracefully with $exitCode',
+        );
+        await _cleanup();
+        return exitCode;
+      } catch (e) {
+        log.debug(
+          'Flutter stop: app.stop failed ($e); falling back to '
+          'signals.',
+        );
+      }
+    }
 
     log.debug('Flutter stop: sending SIGINT to PID ${process.pid}');
     process.kill(ProcessSignal.sigint);

--- a/tools/serverpod_cli/lib/src/commands/start/tui/main_screen.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/tui/main_screen.dart
@@ -75,7 +75,7 @@ class MainScreen extends StatelessComponent {
       'Actions',
       [
         ('R / Shift+R', 'Hot reload / restart'),
-        ('Ctrl+R', 'Restart Flutter app'),
+        ('Ctrl+R', 'Start / restart Flutter app'),
         ('M / Shift+M', 'Create migration (⇧ = force)'),
         ('P / Shift+P', 'Repair migration (⇧ = force)'),
         ('A', 'Apply migrations'),

--- a/tools/serverpod_cli/lib/src/commands/start/watch_session.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/watch_session.dart
@@ -215,12 +215,15 @@ class WatchSession {
               FlutterDependencyChange.none)
         : FlutterDependencyChange.none;
 
-    // Static-only changes (HTML, JS, CSS, templates): no compilation needed.
+    // Static-only changes (HTML, JS, CSS, templates) and dependency-only
+    // changes: no compilation needed. The browser refresh is tied to static
+    // files specifically - a dependency-only change doesn't affect
+    // server-rendered pages.
     if (!hasDartChanges) {
       if (flutterDependencyChange != FlutterDependencyChange.none) {
         await _refreshFlutterApp(flutterDependencyChange);
       }
-      await _notifyBrowserRefresh();
+      if (event.staticFilesChanged) await _notifyBrowserRefresh();
       return;
     }
 

--- a/tools/serverpod_cli/lib/src/commands/start/watch_session.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/watch_session.dart
@@ -5,6 +5,7 @@ import 'package:path/path.dart' as p;
 import 'package:serverpod_cli/src/commands/generate.dart';
 import 'package:serverpod_cli/src/commands/messages.dart';
 import 'package:serverpod_cli/src/commands/start/file_watcher.dart';
+import 'package:serverpod_cli/src/commands/start/flutter_dependency_tracker.dart';
 import 'package:serverpod_cli/src/commands/start/flutter_process.dart';
 import 'package:serverpod_cli/src/commands/start/kernel_compiler.dart';
 import 'package:serverpod_cli/src/commands/start/native_assets_builder.dart';
@@ -114,10 +115,10 @@ class WatchSession {
   /// has no Flutter package to launch.
   final Future<void> Function()? _flutterAppRestartAction;
 
-  /// Returns `true` if the Flutter app's dependency closure changed since the
-  /// last check; when it does, the app is fully relaunched rather than hot
-  /// reloaded. `null` when dependency tracking is unavailable.
-  final bool Function()? _flutterDependenciesChangedSinceLastCheck;
+  /// Classifies how the Flutter app's dependency closure changed since the
+  /// last check (updating its cache); drives the choice between hot reload,
+  /// hot restart, and full relaunch. `null` when tracking is unavailable.
+  final FlutterDependencyChange Function()? _checkFlutterDependencyChange;
 
   final Completer<int> _done = Completer<int>();
 
@@ -157,7 +158,7 @@ class WatchSession {
     required ApplyMigrationsAction applyMigrationsAction,
     FlutterProcess? Function()? flutterProcessProvider,
     Future<void> Function()? flutterAppRestartAction,
-    bool Function()? flutterDependenciesChangedSinceLastCheck,
+    FlutterDependencyChange Function()? checkFlutterDependencyChange,
   }) : _compiler = compiler,
        _nativeAssetsBuilder = nativeAssetsBuilder,
        _generate = generate,
@@ -168,8 +169,7 @@ class WatchSession {
        _applyMigrationsAction = applyMigrationsAction,
        _flutterProcessProvider = flutterProcessProvider ?? (() => null),
        _flutterAppRestartAction = flutterAppRestartAction,
-       _flutterDependenciesChangedSinceLastCheck =
-           flutterDependenciesChangedSinceLastCheck {
+       _checkFlutterDependencyChange = checkFlutterDependencyChange {
     assert(
       nativeAssetsBuilder == null || compiler != null,
       'nativeAssetsBuilder requires a compiler.',
@@ -202,16 +202,20 @@ class WatchSession {
         event.modelFiles.isNotEmpty ||
         event.packageConfigChanged;
 
-    // A full Flutter relaunch is needed when the app's dependency closure
-    // actually changed - a hot restart can't pick up new dependencies. Checked
-    // once here since the check updates the dependency fingerprint cache.
-    final relaunchFlutter =
-        event.flutterDependenciesChanged &&
-        (_flutterDependenciesChangedSinceLastCheck?.call() ?? false);
+    // How the Flutter app must be refreshed after this change: dependency
+    // closure changes escalate from the default hot reload to a hot restart
+    // (pure-Dart deps) or a full relaunch (native code). Checked once here
+    // since the check updates the dependency fingerprint cache.
+    final flutterDependencyChange = event.flutterDependenciesChanged
+        ? (_checkFlutterDependencyChange?.call() ??
+              FlutterDependencyChange.none)
+        : FlutterDependencyChange.none;
 
     // Static-only changes (HTML, JS, CSS, templates): no compilation needed.
     if (!hasDartChanges) {
-      if (relaunchFlutter) await _flutterAppRestartAction?.call();
+      if (flutterDependencyChange != FlutterDependencyChange.none) {
+        await _refreshFlutterApp(flutterDependencyChange);
+      }
       await _notifyBrowserRefresh();
       return;
     }
@@ -273,7 +277,7 @@ class WatchSession {
     // service instead of the FES pipeline.
     if (_compiler == null) {
       final reloaded = await _reloadOrRestart(null);
-      await _refreshOrRelaunchFlutter(relaunchFlutter);
+      await _refreshFlutterApp(flutterDependencyChange);
       if (reloaded) await _notifyBrowserRefresh();
       return;
     }
@@ -291,21 +295,25 @@ class WatchSession {
       packageConfigChanged: event.packageConfigChanged,
     );
     // Always refresh Flutter: flutter/lib-only changes short-circuit the server
-    // compile but still need a Flutter refresh (a full relaunch when its
-    // dependencies changed, otherwise a hot reload).
-    await _refreshOrRelaunchFlutter(relaunchFlutter);
+    // compile but still need a Flutter refresh (escalated when dependencies
+    // changed, otherwise a hot reload).
+    await _refreshFlutterApp(flutterDependencyChange);
     if (reloaded) await _notifyBrowserRefresh();
   }
 
-  /// After a server reload, either fully relaunches the Flutter app (when its
-  /// dependencies changed and a hot restart wouldn't pick them up) or performs
-  /// the usual hot reload. Calls the relaunch action directly rather than via
+  /// Refreshes the Flutter app after a file change with the lightest step that
+  /// picks the change up: a hot reload by default, a hot restart when
+  /// pure-Dart dependencies changed, or a full process relaunch when native
+  /// code changed. The relaunch calls the action directly rather than via
   /// [restartFlutterApp] since we are already running inside [_chain].
-  Future<void> _refreshOrRelaunchFlutter(bool relaunch) async {
-    if (relaunch) {
-      await _flutterAppRestartAction?.call();
-    } else {
-      await _reloadFlutter();
+  Future<void> _refreshFlutterApp(FlutterDependencyChange change) async {
+    switch (change) {
+      case FlutterDependencyChange.native:
+        await _flutterAppRestartAction?.call();
+      case FlutterDependencyChange.dartOnly:
+        await _restartFlutter();
+      case FlutterDependencyChange.none:
+        await _reloadFlutter();
     }
   }
 

--- a/tools/serverpod_cli/lib/src/commands/start/watch_session.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/watch_session.dart
@@ -114,6 +114,11 @@ class WatchSession {
   /// has no Flutter package to launch.
   final Future<void> Function()? _flutterAppRestartAction;
 
+  /// Returns `true` if the Flutter app's dependency closure changed since the
+  /// last check; when it does, the app is fully relaunched rather than hot
+  /// reloaded. `null` when dependency tracking is unavailable.
+  final bool Function()? _flutterDependenciesChangedSinceLastCheck;
+
   final Completer<int> _done = Completer<int>();
 
   /// Dart file paths from prior compile cycles that were rejected.
@@ -152,6 +157,7 @@ class WatchSession {
     required ApplyMigrationsAction applyMigrationsAction,
     FlutterProcess? Function()? flutterProcessProvider,
     Future<void> Function()? flutterAppRestartAction,
+    bool Function()? flutterDependenciesChangedSinceLastCheck,
   }) : _compiler = compiler,
        _nativeAssetsBuilder = nativeAssetsBuilder,
        _generate = generate,
@@ -161,7 +167,9 @@ class WatchSession {
        _classifyProtocolChange = classifyProtocolChange,
        _applyMigrationsAction = applyMigrationsAction,
        _flutterProcessProvider = flutterProcessProvider ?? (() => null),
-       _flutterAppRestartAction = flutterAppRestartAction {
+       _flutterAppRestartAction = flutterAppRestartAction,
+       _flutterDependenciesChangedSinceLastCheck =
+           flutterDependenciesChangedSinceLastCheck {
     assert(
       nativeAssetsBuilder == null || compiler != null,
       'nativeAssetsBuilder requires a compiler.',
@@ -194,8 +202,16 @@ class WatchSession {
         event.modelFiles.isNotEmpty ||
         event.packageConfigChanged;
 
+    // A full Flutter relaunch is needed when the app's dependency closure
+    // actually changed - a hot restart can't pick up new dependencies. Checked
+    // once here since the check updates the dependency fingerprint cache.
+    final relaunchFlutter =
+        event.flutterDependenciesChanged &&
+        (_flutterDependenciesChangedSinceLastCheck?.call() ?? false);
+
     // Static-only changes (HTML, JS, CSS, templates): no compilation needed.
     if (!hasDartChanges) {
+      if (relaunchFlutter) await _flutterAppRestartAction?.call();
       await _notifyBrowserRefresh();
       return;
     }
@@ -257,7 +273,7 @@ class WatchSession {
     // service instead of the FES pipeline.
     if (_compiler == null) {
       final reloaded = await _reloadOrRestart(null);
-      await _reloadFlutter();
+      await _refreshOrRelaunchFlutter(relaunchFlutter);
       if (reloaded) await _notifyBrowserRefresh();
       return;
     }
@@ -274,10 +290,23 @@ class WatchSession {
       dartFiles: allDartChanges,
       packageConfigChanged: event.packageConfigChanged,
     );
-    // Always reload Flutter: flutter/lib-only changes short-circuit
-    // the server compile but still need a Flutter refresh.
-    await _reloadFlutter();
+    // Always refresh Flutter: flutter/lib-only changes short-circuit the server
+    // compile but still need a Flutter refresh (a full relaunch when its
+    // dependencies changed, otherwise a hot reload).
+    await _refreshOrRelaunchFlutter(relaunchFlutter);
     if (reloaded) await _notifyBrowserRefresh();
+  }
+
+  /// After a server reload, either fully relaunches the Flutter app (when its
+  /// dependencies changed and a hot restart wouldn't pick them up) or performs
+  /// the usual hot reload. Calls the relaunch action directly rather than via
+  /// [restartFlutterApp] since we are already running inside [_chain].
+  Future<void> _refreshOrRelaunchFlutter(bool relaunch) async {
+    if (relaunch) {
+      await _flutterAppRestartAction?.call();
+    } else {
+      await _reloadFlutter();
+    }
   }
 
   /// Returns `true` if [path] is inside a generated directory.

--- a/tools/serverpod_cli/lib/src/commands/start/watch_session.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/watch_session.dart
@@ -108,6 +108,10 @@ class WatchSession {
   final FlutterProcess? Function() _flutterProcessProvider;
   FlutterProcess? get _flutterProcess => _flutterProcessProvider();
 
+  /// Whether a Flutter app process is currently running. Used e.g. to label
+  /// the Ctrl+R action as a start or a restart.
+  bool get isFlutterAppRunning => _flutterProcess?.isRunning ?? false;
+
   /// (Re)launches the Flutter app: kills the running `flutter run` process (if
   /// any) and starts a fresh one — launching it from scratch when none is
   /// running yet, e.g. after a `--no-flutter` start. Supplied by the

--- a/tools/serverpod_cli/lib/src/commands/start/watch_session.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/watch_session.dart
@@ -221,7 +221,7 @@ class WatchSession {
     // server-rendered pages.
     if (!hasDartChanges) {
       if (flutterDependencyChange != FlutterDependencyChange.none) {
-        await _refreshFlutterApp(flutterDependencyChange);
+        await _reloadOrRestartFlutterApp(flutterDependencyChange);
       }
       if (event.staticFilesChanged) await _notifyBrowserRefresh();
       return;
@@ -284,7 +284,7 @@ class WatchSession {
     // service instead of the FES pipeline.
     if (_compiler == null) {
       final reloaded = await _reloadOrRestart(null);
-      await _refreshFlutterApp(flutterDependencyChange);
+      await _reloadOrRestartFlutterApp(flutterDependencyChange);
       if (reloaded) await _notifyBrowserRefresh();
       return;
     }
@@ -304,7 +304,7 @@ class WatchSession {
     // Always refresh Flutter: flutter/lib-only changes short-circuit the server
     // compile but still need a Flutter refresh (escalated when dependencies
     // changed, otherwise a hot reload).
-    await _refreshFlutterApp(flutterDependencyChange);
+    await _reloadOrRestartFlutterApp(flutterDependencyChange);
     if (reloaded) await _notifyBrowserRefresh();
   }
 
@@ -313,7 +313,9 @@ class WatchSession {
   /// pure-Dart dependencies changed, or a full process relaunch when native
   /// code changed. The relaunch calls the action directly rather than via
   /// [restartFlutterApp] since we are already running inside [_chain].
-  Future<void> _refreshFlutterApp(FlutterDependencyChange change) async {
+  Future<void> _reloadOrRestartFlutterApp(
+    FlutterDependencyChange change,
+  ) async {
     switch (change) {
       case FlutterDependencyChange.native:
         log.info(flutterDependenciesChangedNative);

--- a/tools/serverpod_cli/lib/src/commands/start/watch_session.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/watch_session.dart
@@ -309,8 +309,10 @@ class WatchSession {
   Future<void> _refreshFlutterApp(FlutterDependencyChange change) async {
     switch (change) {
       case FlutterDependencyChange.native:
+        log.info(flutterDependenciesChangedNative);
         await _flutterAppRestartAction?.call();
       case FlutterDependencyChange.dartOnly:
+        log.info(flutterDependenciesChangedDart);
         await _restartFlutter();
       case FlutterDependencyChange.none:
         await _reloadFlutter();

--- a/tools/serverpod_cli/pubspec.yaml
+++ b/tools/serverpod_cli/pubspec.yaml
@@ -54,7 +54,7 @@ dependencies:
   serverpod_serialization: 3.5.0-beta.9
   serverpod_service_client: 3.5.0-beta.9
   serverpod_shared: 3.5.0-beta.9
-  serverpod_tui: ^0.1.0-rc.4
+  serverpod_tui: ^0.1.0-rc.6
   skills: ^0.3.0
   source_span: ^1.10.0
   stream_channel: ^2.1.1

--- a/tools/serverpod_cli/test/commands/start/file_watcher_test.dart
+++ b/tools/serverpod_cli/test/commands/start/file_watcher_test.dart
@@ -103,6 +103,71 @@ void main() {
     },
   );
 
+  group('Given a FileWatcher watching a .dart_tool directory', () {
+    late FileWatcher watcher;
+    late String dartToolDir;
+
+    setUp(() async {
+      dartToolDir = p.join(tempDir.path, '.dart_tool');
+      await Directory(dartToolDir).create();
+
+      watcher = FileWatcher(
+        watchPaths: [dartToolDir],
+        debounceDelay: const Duration(milliseconds: 200),
+      );
+    });
+
+    test(
+      'when package_graph.json changes, '
+      'then it emits a FileChangeEvent with only flutterDependenciesChanged set',
+      () async {
+        final firstEvent = watcher.onFilesChanged.first;
+        await watcher.ready;
+
+        await File(
+          p.join(dartToolDir, 'package_graph.json'),
+        ).writeAsString('{"roots":[],"packages":[]}');
+
+        final event = await firstEvent;
+
+        expect(event.flutterDependenciesChanged, isTrue);
+        // The Flutter-only scope: package_graph changes must not drive the
+        // server FES restart, and .dart_tool churn is not a static change.
+        expect(event.packageConfigChanged, isFalse);
+        expect(event.staticFilesChanged, isFalse);
+        expect(event.dartFiles, isEmpty);
+      },
+    );
+
+    test(
+      'when package_config.json and other .dart_tool files change alongside '
+      'package_graph.json, '
+      'then only flutterDependenciesChanged is set',
+      () async {
+        final firstEvent = watcher.onFilesChanged.first;
+        await watcher.ready;
+
+        // All within one debounce window. package_config.json and the build
+        // artifact must be ignored inside .dart_tool.
+        await File(
+          p.join(dartToolDir, 'package_config.json'),
+        ).writeAsString('{"configVersion":2,"packages":[]}');
+        await File(
+          p.join(dartToolDir, 'version'),
+        ).writeAsString('3.12.0');
+        await File(
+          p.join(dartToolDir, 'package_graph.json'),
+        ).writeAsString('{"roots":[],"packages":[]}');
+
+        final event = await firstEvent;
+
+        expect(event.flutterDependenciesChanged, isTrue);
+        expect(event.packageConfigChanged, isFalse);
+        expect(event.staticFilesChanged, isFalse);
+      },
+    );
+  });
+
   group('Given a list of FileChangeEvents', () {
     test(
       'when merge is called on a single event, '
@@ -156,6 +221,20 @@ void main() {
         final e2 = FileChangeEvent(dartFiles: {}, packageConfigChanged: true);
         final result = [e1, e2].merge();
         expect(result.packageConfigChanged, isTrue);
+      },
+    );
+
+    test(
+      'when merge is called on events where one has flutterDependenciesChanged, '
+      'then result has flutterDependenciesChanged true',
+      () {
+        final e1 = FileChangeEvent(dartFiles: {});
+        final e2 = FileChangeEvent(
+          dartFiles: {},
+          flutterDependenciesChanged: true,
+        );
+        final result = [e1, e2].merge();
+        expect(result.flutterDependenciesChanged, isTrue);
       },
     );
   });

--- a/tools/serverpod_cli/test/commands/start/file_watcher_test.dart
+++ b/tools/serverpod_cli/test/commands/start/file_watcher_test.dart
@@ -140,8 +140,7 @@ void main() {
     );
 
     test(
-      'when package_config.json and other .dart_tool files change alongside '
-      'package_graph.json, '
+      'when package_config.json and other .dart_tool files change alongside package_graph.json, '
       'then only flutterDependenciesChanged is set',
       () async {
         final firstEvent = watcher.onFilesChanged.first;

--- a/tools/serverpod_cli/test/commands/start/flutter_dependency_tracker_test.dart
+++ b/tools/serverpod_cli/test/commands/start/flutter_dependency_tracker_test.dart
@@ -5,237 +5,273 @@ import 'package:path/path.dart' as p;
 import 'package:serverpod_cli/src/commands/start/flutter_dependency_tracker.dart';
 import 'package:test/test.dart';
 
+/// Runs a real `dart pub get` in [dir]. Fixtures use only path and workspace
+/// dependencies, so resolution works offline and the tests exercise the actual
+/// `package_graph.json` and `package_config.json` files pub generates.
+Future<void> _pubGet(String dir) async {
+  final result = await Process.run(Platform.resolvedExecutable, [
+    'pub',
+    'get',
+    '--offline',
+  ], workingDirectory: dir);
+  if (result.exitCode != 0) {
+    fail('pub get failed in $dir:\n${result.stdout}\n${result.stderr}');
+  }
+}
+
+String _pubspec(
+  String name, {
+  String version = '1.0.0',
+  List<String>? workspace,
+  bool workspaceMember = false,
+  Map<String, String> deps = const {},
+  Map<String, String> devDeps = const {},
+  String? flutterBlock,
+}) {
+  final buffer = StringBuffer()
+    ..writeln('name: $name')
+    ..writeln('version: $version')
+    ..writeln('environment:')
+    ..writeln('  sdk: ^3.6.0');
+  if (workspace != null) {
+    buffer.writeln('workspace:');
+    for (final member in workspace) {
+      buffer.writeln('  - $member');
+    }
+  }
+  if (workspaceMember) buffer.writeln('resolution: workspace');
+  if (deps.isNotEmpty) {
+    buffer.writeln('dependencies:');
+    deps.forEach((dep, path) {
+      buffer
+        ..writeln('  $dep:')
+        ..writeln('    path: $path');
+    });
+  }
+  if (devDeps.isNotEmpty) {
+    buffer.writeln('dev_dependencies:');
+    devDeps.forEach((dep, path) {
+      buffer
+        ..writeln('  $dep:')
+        ..writeln('    path: $path');
+    });
+  }
+  if (flutterBlock != null) buffer.writeln(flutterBlock);
+  return buffer.toString();
+}
+
 void main() {
   late Directory tempDir;
-  late String dartToolDir;
 
   setUp(() async {
     tempDir = await Directory.systemTemp.createTemp('flutter_dep_tracker_');
-    dartToolDir = p.join(tempDir.path, '.dart_tool');
-    await Directory(dartToolDir).create();
   });
 
   tearDown(() async {
     await tempDir.delete(recursive: true);
   });
 
-  void writeGraph(Map<String, dynamic> graph) {
-    File(
-      p.join(dartToolDir, 'package_graph.json'),
-    ).writeAsStringSync(jsonEncode(graph));
+  void write(String path, String contents) {
+    File(path)
+      ..createSync(recursive: true)
+      ..writeAsStringSync(contents);
   }
 
-  Map<String, dynamic> packageNamed(Map<String, dynamic> graph, String name) {
-    return (graph['packages'] as List).cast<Map<String, dynamic>>().firstWhere(
-      (pkg) => pkg['name'] == name,
-    );
-  }
+  // ---------------------------------------------------------------------
+  // Real-resolution fixtures: a workspace whose dependency files are
+  // produced by an actual `pub get`, mirroring generated Serverpod projects.
+  // Layout: app_flutter -> app_client -> dep_pure (transitive), app_server ->
+  // dep_server_only, and dep_dev as a dev dependency of the app. Third-party
+  // packages live outside the workspace and are wired up as path deps.
+  // ---------------------------------------------------------------------
 
-  /// Creates a fake package source directory holding [pubspec], returning its
-  /// rootUri relative to the `.dart_tool` directory.
-  String writePackage(String name, String pubspec) {
-    final dir = Directory(p.join(tempDir.path, 'pkgs', name))
-      ..createSync(recursive: true);
-    File(p.join(dir.path, 'pubspec.yaml')).writeAsStringSync(pubspec);
-    return '../pkgs/$name';
-  }
+  late String wsDir;
 
-  void writePackageConfig(Map<String, String> rootUris) {
-    File(p.join(dartToolDir, 'package_config.json')).writeAsStringSync(
-      jsonEncode({
-        'configVersion': 2,
-        'packages': [
-          for (final entry in rootUris.entries)
-            {'name': entry.key, 'rootUri': entry.value, 'packageUri': 'lib/'},
-        ],
-      }),
-    );
-  }
-
-  // A Flutter app that transitively depends on the client (and http) but not
-  // the server. flutter_test is a dev dependency only.
-  Map<String, dynamic> baseGraph() => {
-    'roots': ['app_flutter', 'app_server', 'app_client'],
-    'packages': [
-      {
-        'name': 'app_flutter',
-        'version': '1.0.0',
-        'dependencies': ['app_client', 'http'],
-        'devDependencies': ['flutter_test'],
-      },
-      {
-        'name': 'app_client',
-        'version': '1.0.0',
-        'dependencies': ['http'],
-      },
-      {
-        'name': 'app_server',
-        'version': '1.0.0',
-        'dependencies': ['postgres'],
-      },
-      {'name': 'http', 'version': '1.2.0', 'dependencies': <String>[]},
-      {'name': 'postgres', 'version': '3.0.0', 'dependencies': <String>[]},
-      {'name': 'flutter_test', 'version': '0.0.0', 'dependencies': <String>[]},
-    ],
-  };
-
-  /// Pure-Dart source dirs + package_config for the app's closure packages.
-  Map<String, String> closureRootUris() => {
-    'app_flutter': writePackage('app_flutter', 'name: app_flutter\n'),
-    'app_client': writePackage('app_client', 'name: app_client\n'),
-    'http': writePackage('http', 'name: http\n'),
-  };
-
-  group(
-    'Given a Flutter app dependency graph of pure-Dart packages '
-    'in a workspace,',
-    () {
-      late FlutterDependencyTracker tracker;
-
-      setUp(() {
-        writeGraph(baseGraph());
-        writePackageConfig(closureRootUris());
-        tracker = FlutterDependencyTracker(
-          dartToolDir: dartToolDir,
-          flutterPackageName: 'app_flutter',
-        );
-      });
-
-      test(
-        'when a server-only dependency version changes, '
-        'then no change is reported',
-        () {
-          final graph = baseGraph();
-          packageNamed(graph, 'postgres')['version'] = '3.1.0';
-          writeGraph(graph);
-
-          expect(tracker.refresh(), FlutterDependencyChange.none);
-        },
-      );
-
-      test(
-        'when a dependency inside the app closure changes version, '
-        'then a pure-Dart change is reported',
-        () {
-          final graph = baseGraph();
-          packageNamed(graph, 'http')['version'] = '1.3.0';
-          writeGraph(graph);
-
-          expect(tracker.refresh(), FlutterDependencyChange.dartOnly);
-        },
-      );
-
-      test(
-        'when a pure-Dart dependency is added to the app, '
-        'then a pure-Dart change is reported',
-        () {
-          final graph = baseGraph();
-          (packageNamed(graph, 'app_flutter')['dependencies'] as List).add(
-            'redis',
-          );
-          (graph['packages'] as List).add({
-            'name': 'redis',
-            'version': '1.0.0',
-            'dependencies': <String>[],
-          });
-          writeGraph(graph);
-          writePackageConfig({
-            ...closureRootUris(),
-            'redis': writePackage('redis', 'name: redis\n'),
-          });
-
-          expect(tracker.refresh(), FlutterDependencyChange.dartOnly);
-        },
-      );
-
-      test(
-        'when a dependency is removed from the app, '
-        'then a pure-Dart change is reported',
-        () {
-          // Stale native code in the running binary is harmless, so removals
-          // never require more than a hot restart.
-          final graph = baseGraph();
-          packageNamed(graph, 'app_flutter')['dependencies'] = ['http'];
-          writeGraph(graph);
-
-          expect(tracker.refresh(), FlutterDependencyChange.dartOnly);
-        },
-      );
-
-      test(
-        'when a dev dependency of the app changes, '
-        'then no change is reported',
-        () {
-          final graph = baseGraph();
-          packageNamed(graph, 'flutter_test')['version'] = '0.1.0';
-          writeGraph(graph);
-
-          expect(tracker.refresh(), FlutterDependencyChange.none);
-        },
-      );
-
-      test(
-        'when the graph is rewritten with identical contents, '
-        'then no change is reported',
-        () {
-          writeGraph(baseGraph());
-
-          expect(tracker.refresh(), FlutterDependencyChange.none);
-        },
-      );
-    },
-  );
-
-  /// Sets up an app depending on a single package `dep@1.0.0` (described by
-  /// [depPubspec]), then bumps it to 1.0.1 in the graph so the next
-  /// `refresh()` classifies the bump.
-  FlutterDependencyTracker prepareBumpedDependency({
-    required String depPubspec,
-    bool listedInPackageConfig = true,
-    bool withBuildHook = false,
+  void writeThirdParty(
+    String name, {
+    String version = '1.0.0',
+    String? flutterBlock,
   }) {
-    Map<String, dynamic> graph(String version) => {
-      'roots': ['app_flutter'],
-      'packages': [
-        {
-          'name': 'app_flutter',
-          'version': '1.0.0',
-          'dependencies': ['dep'],
-        },
-        {'name': 'dep', 'version': version, 'dependencies': <String>[]},
-      ],
-    };
+    write(
+      p.join(tempDir.path, 'third_party', name, 'pubspec.yaml'),
+      _pubspec(name, version: version, flutterBlock: flutterBlock),
+    );
+  }
 
-    final depRoot = writePackage('dep', depPubspec);
-    if (withBuildHook) {
-      final hookDir = Directory(p.join(tempDir.path, 'pkgs', 'dep', 'hook'))
-        ..createSync(recursive: true);
-      File(
-        p.join(hookDir.path, 'build.dart'),
-      ).writeAsStringSync('void main() {}');
-    }
-    writePackageConfig({
-      'app_flutter': writePackage('app_flutter', 'name: app_flutter\n'),
-      if (listedInPackageConfig) 'dep': depRoot,
-    });
+  void writeAppFlutterPubspec({Map<String, String>? deps}) {
+    write(
+      p.join(wsDir, 'app_flutter', 'pubspec.yaml'),
+      _pubspec(
+        'app_flutter',
+        workspaceMember: true,
+        deps: deps ?? {'app_client': '../app_client'},
+        devDeps: {'dep_dev': '../../third_party/dep_dev'},
+      ),
+    );
+  }
 
-    writeGraph(graph('1.0.0'));
-    final tracker = FlutterDependencyTracker(
-      dartToolDir: dartToolDir,
+  Future<FlutterDependencyTracker> createWorkspaceTracker() async {
+    wsDir = p.join(tempDir.path, 'ws');
+    writeThirdParty('dep_pure');
+    writeThirdParty('dep_dev');
+    writeThirdParty('dep_server_only');
+    write(
+      p.join(wsDir, 'pubspec.yaml'),
+      _pubspec(
+        'fixture_root',
+        workspace: ['app_flutter', 'app_client', 'app_server'],
+      ),
+    );
+    writeAppFlutterPubspec();
+    write(
+      p.join(wsDir, 'app_client', 'pubspec.yaml'),
+      _pubspec(
+        'app_client',
+        workspaceMember: true,
+        deps: {'dep_pure': '../../third_party/dep_pure'},
+      ),
+    );
+    write(
+      p.join(wsDir, 'app_server', 'pubspec.yaml'),
+      _pubspec(
+        'app_server',
+        workspaceMember: true,
+        deps: {'dep_server_only': '../../third_party/dep_server_only'},
+      ),
+    );
+    await _pubGet(wsDir);
+    return FlutterDependencyTracker(
+      dartToolDir: p.join(wsDir, '.dart_tool'),
       flutterPackageName: 'app_flutter',
     );
-    writeGraph(graph('1.0.1'));
-    return tracker;
+  }
+
+  group('Given a real pub workspace with a Flutter app,', () {
+    late FlutterDependencyTracker tracker;
+
+    setUp(() async {
+      tracker = await createWorkspaceTracker();
+    });
+
+    test(
+      'when a server-only dependency version changes, '
+      'then no change is reported',
+      () async {
+        writeThirdParty('dep_server_only', version: '1.0.1');
+        await _pubGet(wsDir);
+
+        expect(tracker.refresh(), FlutterDependencyChange.none);
+      },
+    );
+
+    test(
+      'when a transitive dependency of the app changes version, '
+      'then a pure-Dart change is reported',
+      () async {
+        // dep_pure is reached only through app_client.
+        writeThirdParty('dep_pure', version: '1.0.1');
+        await _pubGet(wsDir);
+
+        expect(tracker.refresh(), FlutterDependencyChange.dartOnly);
+      },
+    );
+
+    test(
+      'when a pure-Dart dependency is added to the app, '
+      'then a pure-Dart change is reported',
+      () async {
+        writeThirdParty('dep_added');
+        writeAppFlutterPubspec(
+          deps: {
+            'app_client': '../app_client',
+            'dep_added': '../../third_party/dep_added',
+          },
+        );
+        await _pubGet(wsDir);
+
+        expect(tracker.refresh(), FlutterDependencyChange.dartOnly);
+      },
+    );
+
+    test(
+      'when a dependency is removed from the app, '
+      'then a pure-Dart change is reported',
+      () async {
+        // Stale native code in the running binary is harmless, so removals
+        // never require more than a hot restart.
+        writeAppFlutterPubspec(deps: {});
+        await _pubGet(wsDir);
+
+        expect(tracker.refresh(), FlutterDependencyChange.dartOnly);
+      },
+    );
+
+    test(
+      'when a dev dependency of the app changes, '
+      'then no change is reported',
+      () async {
+        writeThirdParty('dep_dev', version: '1.0.1');
+        await _pubGet(wsDir);
+
+        expect(tracker.refresh(), FlutterDependencyChange.none);
+      },
+    );
+
+    test(
+      'when pub get runs again with no pubspec changes, '
+      'then no change is reported',
+      () async {
+        await _pubGet(wsDir);
+
+        expect(tracker.refresh(), FlutterDependencyChange.none);
+      },
+    );
+  });
+
+  /// Resolves a standalone app depending on `dep@1.0.0` (described by
+  /// [depFlutterBlock]) with a real `pub get`, bumps it to 1.0.1, re-resolves,
+  /// and returns the tracker's classification of the bump.
+  Future<FlutterDependencyChange> classifyRealDependencyBump({
+    String? depFlutterBlock,
+    bool withBuildHook = false,
+    bool corruptDepPubspecAfterResolve = false,
+  }) async {
+    final appDir = p.join(tempDir.path, 'app');
+    writeThirdParty('dep', flutterBlock: depFlutterBlock);
+    if (withBuildHook) {
+      write(
+        p.join(tempDir.path, 'third_party', 'dep', 'hook', 'build.dart'),
+        'void main() {}',
+      );
+    }
+    write(
+      p.join(appDir, 'pubspec.yaml'),
+      _pubspec('app_flutter', deps: {'dep': '../third_party/dep'}),
+    );
+    await _pubGet(appDir);
+    final tracker = FlutterDependencyTracker(
+      dartToolDir: p.join(appDir, '.dart_tool'),
+      flutterPackageName: 'app_flutter',
+    );
+
+    writeThirdParty('dep', version: '1.0.1', flutterBlock: depFlutterBlock);
+    await _pubGet(appDir);
+    if (corruptDepPubspecAfterResolve) {
+      write(
+        p.join(tempDir.path, 'third_party', 'dep', 'pubspec.yaml'),
+        'name: [unclosed',
+      );
+    }
+    return tracker.refresh();
   }
 
   group('Given a changed app dependency declaring a native plugin class,', () {
     test(
       'when the closure is refreshed, '
       'then a native change is reported',
-      () {
-        final tracker = prepareBumpedDependency(
-          depPubspec:
-              'name: dep\n'
+      () async {
+        final change = await classifyRealDependencyBump(
+          depFlutterBlock:
               'flutter:\n'
               '  plugin:\n'
               '    platforms:\n'
@@ -244,7 +280,7 @@ void main() {
               '        pluginClass: DepPlugin\n',
         );
 
-        expect(tracker.refresh(), FlutterDependencyChange.native);
+        expect(change, FlutterDependencyChange.native);
       },
     );
   });
@@ -253,10 +289,9 @@ void main() {
     test(
       'when the closure is refreshed, '
       'then a native change is reported',
-      () {
-        final tracker = prepareBumpedDependency(
-          depPubspec:
-              'name: dep\n'
+      () async {
+        final change = await classifyRealDependencyBump(
+          depFlutterBlock:
               'flutter:\n'
               '  plugin:\n'
               '    platforms:\n'
@@ -264,7 +299,7 @@ void main() {
               '        ffiPlugin: true\n',
         );
 
-        expect(tracker.refresh(), FlutterDependencyChange.native);
+        expect(change, FlutterDependencyChange.native);
       },
     );
   });
@@ -275,10 +310,9 @@ void main() {
       test(
         'when the closure is refreshed, '
         'then a pure-Dart change is reported',
-        () {
-          final tracker = prepareBumpedDependency(
-            depPubspec:
-                'name: dep\n'
+        () async {
+          final change = await classifyRealDependencyBump(
+            depFlutterBlock:
                 'flutter:\n'
                 '  plugin:\n'
                 '    platforms:\n'
@@ -286,7 +320,7 @@ void main() {
                 '        dartPluginClass: DepPluginLinux\n',
           );
 
-          expect(tracker.refresh(), FlutterDependencyChange.dartOnly);
+          expect(change, FlutterDependencyChange.dartOnly);
         },
       );
     },
@@ -296,10 +330,9 @@ void main() {
     test(
       'when the closure is refreshed, '
       'then a pure-Dart change is reported',
-      () {
-        final tracker = prepareBumpedDependency(
-          depPubspec:
-              'name: dep\n'
+      () async {
+        final change = await classifyRealDependencyBump(
+          depFlutterBlock:
               'flutter:\n'
               '  plugin:\n'
               '    platforms:\n'
@@ -307,7 +340,7 @@ void main() {
               '        pluginClass: none\n',
         );
 
-        expect(tracker.refresh(), FlutterDependencyChange.dartOnly);
+        expect(change, FlutterDependencyChange.dartOnly);
       },
     );
   });
@@ -316,28 +349,10 @@ void main() {
     test(
       'when the closure is refreshed, '
       'then a native change is reported',
-      () {
-        final tracker = prepareBumpedDependency(
-          depPubspec: 'name: dep\n',
-          withBuildHook: true,
-        );
+      () async {
+        final change = await classifyRealDependencyBump(withBuildHook: true);
 
-        expect(tracker.refresh(), FlutterDependencyChange.native);
-      },
-    );
-  });
-
-  group('Given a changed app dependency missing from package_config.json,', () {
-    test(
-      'when the closure is refreshed, '
-      'then a native change is conservatively reported',
-      () {
-        final tracker = prepareBumpedDependency(
-          depPubspec: 'name: dep\n',
-          listedInPackageConfig: false,
-        );
-
-        expect(tracker.refresh(), FlutterDependencyChange.native);
+        expect(change, FlutterDependencyChange.native);
       },
     );
   });
@@ -346,17 +361,129 @@ void main() {
     test(
       'when the closure is refreshed, '
       'then a native change is conservatively reported',
-      () {
-        final tracker = prepareBumpedDependency(
-          depPubspec: 'name: [unclosed\n  flutter: {',
+      () async {
+        final change = await classifyRealDependencyBump(
+          corruptDepPubspecAfterResolve: true,
         );
 
-        expect(tracker.refresh(), FlutterDependencyChange.native);
+        expect(change, FlutterDependencyChange.native);
       },
     );
   });
 
+  group('Given a Flutter package directory in a workspace,', () {
+    test(
+      'when resolving its .dart_tool, '
+      'then it resolves to the workspace root .dart_tool',
+      () async {
+        await createWorkspaceTracker();
+
+        final resolved = FlutterDependencyTracker.resolveDartToolDir(
+          p.join(wsDir, 'app_flutter'),
+          flutterPackageName: 'app_flutter',
+        );
+
+        expect(resolved, p.join(wsDir, '.dart_tool'));
+      },
+    );
+  });
+
+  group('Given a standalone (non-workspace) Flutter package directory,', () {
+    test(
+      'when resolving its .dart_tool, '
+      'then it resolves to the package\'s own .dart_tool',
+      () async {
+        final appDir = p.join(tempDir.path, 'standalone');
+        write(p.join(appDir, 'pubspec.yaml'), _pubspec('app_flutter'));
+        await _pubGet(appDir);
+
+        final resolved = FlutterDependencyTracker.resolveDartToolDir(
+          appDir,
+          flutterPackageName: 'app_flutter',
+        );
+
+        expect(resolved, p.join(appDir, '.dart_tool'));
+      },
+    );
+
+    test(
+      'when no resolution exists in any ancestor, '
+      'then it resolves to null',
+      () async {
+        final pkg = await Directory(
+          p.join(tempDir.path, 'unresolved'),
+        ).create();
+
+        final resolved = FlutterDependencyTracker.resolveDartToolDir(
+          pkg.path,
+          flutterPackageName: 'app_flutter',
+        );
+
+        expect(resolved, isNull);
+      },
+    );
+  });
+
+  group(
+    'Given a Flutter package whose own resolution was deleted and an unrelated ancestor resolution,',
+    () {
+      test(
+        'when resolving its .dart_tool, '
+        'then it does not latch onto the unrelated resolution',
+        () async {
+          // E.g. a standalone app under some other Dart project's tree: the
+          // ancestor's resolution is real but doesn't list the app.
+          final ancestorDir = p.join(tempDir.path, 'other_project');
+          write(
+            p.join(ancestorDir, 'pubspec.yaml'),
+            _pubspec('something_unrelated'),
+          );
+          await _pubGet(ancestorDir);
+          final pkg = await Directory(
+            p.join(ancestorDir, 'nested', 'app_flutter'),
+          ).create(recursive: true);
+
+          final resolved = FlutterDependencyTracker.resolveDartToolDir(
+            pkg.path,
+            flutterPackageName: 'app_flutter',
+          );
+
+          expect(resolved, isNull);
+        },
+      );
+    },
+  );
+
+  // ---------------------------------------------------------------------
+  // Corruption and race states. These stay hand-written deliberately: pub
+  // never produces malformed or partially-missing dependency files, so the
+  // only way to cover the tracker's tolerance of them is synthetically.
+  // ---------------------------------------------------------------------
+
   group('Given a missing or malformed dependency graph,', () {
+    late String dartToolDir;
+
+    setUp(() async {
+      dartToolDir = p.join(tempDir.path, '.dart_tool');
+      await Directory(dartToolDir).create();
+    });
+
+    void writeGraph(Map<String, dynamic> graph) {
+      write(p.join(dartToolDir, 'package_graph.json'), jsonEncode(graph));
+    }
+
+    Map<String, dynamic> minimalGraph({String depVersion = '1.0.0'}) => {
+      'roots': ['app_flutter'],
+      'packages': [
+        {
+          'name': 'app_flutter',
+          'version': '1.0.0',
+          'dependencies': ['dep'],
+        },
+        {'name': 'dep', 'version': depVersion, 'dependencies': <String>[]},
+      ],
+    };
+
     test(
       'when the graph file is absent, '
       'then no change is reported',
@@ -375,9 +502,7 @@ void main() {
       'when the graph file is malformed, '
       'then no change is reported',
       () {
-        File(
-          p.join(dartToolDir, 'package_graph.json'),
-        ).writeAsStringSync('{ not valid json');
+        write(p.join(dartToolDir, 'package_graph.json'), '{ not valid json');
 
         final tracker = FlutterDependencyTracker(
           dartToolDir: dartToolDir,
@@ -392,7 +517,7 @@ void main() {
       'when the Flutter package is absent from the graph, '
       'then no change is reported',
       () {
-        writeGraph(baseGraph());
+        writeGraph(minimalGraph());
 
         final tracker = FlutterDependencyTracker(
           dartToolDir: dartToolDir,
@@ -407,7 +532,7 @@ void main() {
       'when the graph disappears then reappears unchanged, '
       'then no change is reported',
       () {
-        writeGraph(baseGraph());
+        writeGraph(minimalGraph());
         final tracker = FlutterDependencyTracker(
           dartToolDir: dartToolDir,
           flutterPackageName: 'app_flutter',
@@ -418,68 +543,39 @@ void main() {
         File(p.join(dartToolDir, 'package_graph.json')).deleteSync();
         expect(tracker.refresh(), FlutterDependencyChange.none);
 
-        writeGraph(baseGraph());
+        writeGraph(minimalGraph());
         expect(tracker.refresh(), FlutterDependencyChange.none);
       },
     );
-  });
 
-  group('Given a Flutter package directory in a workspace,', () {
     test(
-      'when resolving its .dart_tool, '
-      'then it resolves to the workspace root .dart_tool',
-      () async {
-        final root = await Directory(
-          p.join(tempDir.path, 'workspace'),
-        ).create();
-        await Directory(p.join(root.path, '.dart_tool')).create();
-        await File(
-          p.join(root.path, '.dart_tool', 'package_config.json'),
-        ).writeAsString('{}');
-        // Member package with no resolution of its own.
-        final member = await Directory(
-          p.join(root.path, 'app_flutter'),
-        ).create();
-
-        final resolved = FlutterDependencyTracker.resolveDartToolDir(
-          member.path,
+      'when a changed dependency is missing from package_config.json, '
+      'then a native change is conservatively reported',
+      () {
+        // A graph/config mismatch can only arise from a racing or partial
+        // write; the unlocatable package must not be assumed pure-Dart.
+        writeGraph(minimalGraph());
+        write(
+          p.join(dartToolDir, 'package_config.json'),
+          jsonEncode({
+            'configVersion': 2,
+            'packages': [
+              {
+                'name': 'app_flutter',
+                'rootUri': '../',
+                'packageUri': 'lib/',
+              },
+            ],
+          }),
+        );
+        final tracker = FlutterDependencyTracker(
+          dartToolDir: dartToolDir,
+          flutterPackageName: 'app_flutter',
         );
 
-        expect(resolved, p.join(root.path, '.dart_tool'));
-      },
-    );
-  });
+        writeGraph(minimalGraph(depVersion: '1.0.1'));
 
-  group('Given a standalone (non-workspace) Flutter package directory,', () {
-    test(
-      'when resolving its .dart_tool, '
-      'then it resolves to the package\'s own .dart_tool',
-      () async {
-        final pkg = await Directory(
-          p.join(tempDir.path, 'standalone'),
-        ).create();
-        await Directory(p.join(pkg.path, '.dart_tool')).create();
-        await File(
-          p.join(pkg.path, '.dart_tool', 'package_config.json'),
-        ).writeAsString('{}');
-
-        final resolved = FlutterDependencyTracker.resolveDartToolDir(pkg.path);
-
-        expect(resolved, p.join(pkg.path, '.dart_tool'));
-      },
-    );
-
-    test(
-      'when no resolution exists in any ancestor, '
-      'then it resolves to null',
-      () async {
-        final pkg = await Directory(
-          p.join(tempDir.path, 'unresolved'),
-        ).create();
-
-        final resolved = FlutterDependencyTracker.resolveDartToolDir(pkg.path);
-
-        expect(resolved, isNull);
+        expect(tracker.refresh(), FlutterDependencyChange.native);
       },
     );
   });

--- a/tools/serverpod_cli/test/commands/start/flutter_dependency_tracker_test.dart
+++ b/tools/serverpod_cli/test/commands/start/flutter_dependency_tracker_test.dart
@@ -1,0 +1,278 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:serverpod_cli/src/commands/start/flutter_dependency_tracker.dart';
+import 'package:test/test.dart';
+
+void main() {
+  late Directory tempDir;
+  late String dartToolDir;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('flutter_dep_tracker_');
+    dartToolDir = p.join(tempDir.path, '.dart_tool');
+    await Directory(dartToolDir).create();
+  });
+
+  tearDown(() async {
+    await tempDir.delete(recursive: true);
+  });
+
+  void writeGraph(Map<String, dynamic> graph) {
+    File(
+      p.join(dartToolDir, 'package_graph.json'),
+    ).writeAsStringSync(jsonEncode(graph));
+  }
+
+  Map<String, dynamic> packageNamed(Map<String, dynamic> graph, String name) {
+    return (graph['packages'] as List).cast<Map<String, dynamic>>().firstWhere(
+      (pkg) => pkg['name'] == name,
+    );
+  }
+
+  // A Flutter app that transitively depends on the client (and http) but not
+  // the server. flutter_test is a dev dependency only.
+  Map<String, dynamic> baseGraph() => {
+    'roots': ['app_flutter', 'app_server', 'app_client'],
+    'packages': [
+      {
+        'name': 'app_flutter',
+        'version': '1.0.0',
+        'dependencies': ['app_client', 'http'],
+        'devDependencies': ['flutter_test'],
+      },
+      {
+        'name': 'app_client',
+        'version': '1.0.0',
+        'dependencies': ['http'],
+      },
+      {
+        'name': 'app_server',
+        'version': '1.0.0',
+        'dependencies': ['postgres'],
+      },
+      {'name': 'http', 'version': '1.2.0', 'dependencies': <String>[]},
+      {'name': 'postgres', 'version': '3.0.0', 'dependencies': <String>[]},
+      {'name': 'flutter_test', 'version': '0.0.0', 'dependencies': <String>[]},
+    ],
+  };
+
+  group('Given a Flutter app dependency graph in a workspace,', () {
+    late FlutterDependencyTracker tracker;
+
+    setUp(() {
+      writeGraph(baseGraph());
+      tracker = FlutterDependencyTracker(
+        dartToolDir: dartToolDir,
+        flutterPackageName: 'app_flutter',
+      );
+    });
+
+    test(
+      'when a server-only dependency version changes, '
+      'then no change is reported',
+      () {
+        final graph = baseGraph();
+        packageNamed(graph, 'postgres')['version'] = '3.1.0';
+        writeGraph(graph);
+
+        expect(tracker.refreshIfChanged(), isFalse);
+      },
+    );
+
+    test(
+      'when a dependency inside the app closure changes version, '
+      'then a change is reported',
+      () {
+        final graph = baseGraph();
+        packageNamed(graph, 'http')['version'] = '1.3.0';
+        writeGraph(graph);
+
+        expect(tracker.refreshIfChanged(), isTrue);
+      },
+    );
+
+    test(
+      'when a dependency is added to the app, '
+      'then a change is reported',
+      () {
+        final graph = baseGraph();
+        (packageNamed(graph, 'app_flutter')['dependencies'] as List).add(
+          'redis',
+        );
+        (graph['packages'] as List).add({
+          'name': 'redis',
+          'version': '1.0.0',
+          'dependencies': <String>[],
+        });
+        writeGraph(graph);
+
+        expect(tracker.refreshIfChanged(), isTrue);
+      },
+    );
+
+    test(
+      'when a dependency is removed from the app, '
+      'then a change is reported',
+      () {
+        final graph = baseGraph();
+        packageNamed(graph, 'app_flutter')['dependencies'] = ['http'];
+        writeGraph(graph);
+
+        expect(tracker.refreshIfChanged(), isTrue);
+      },
+    );
+
+    test(
+      'when a dev dependency of the app changes, '
+      'then no change is reported',
+      () {
+        final graph = baseGraph();
+        packageNamed(graph, 'flutter_test')['version'] = '0.1.0';
+        writeGraph(graph);
+
+        expect(tracker.refreshIfChanged(), isFalse);
+      },
+    );
+
+    test(
+      'when the graph is rewritten with identical contents, '
+      'then no change is reported',
+      () {
+        writeGraph(baseGraph());
+
+        expect(tracker.refreshIfChanged(), isFalse);
+      },
+    );
+  });
+
+  group('Given a missing or malformed dependency graph,', () {
+    test(
+      'when the graph file is absent, '
+      'then the fingerprint is null and no change is reported',
+      () {
+        // No graph written.
+        final tracker = FlutterDependencyTracker(
+          dartToolDir: dartToolDir,
+          flutterPackageName: 'app_flutter',
+        );
+
+        expect(tracker.computeFingerprint(), isNull);
+        expect(tracker.refreshIfChanged(), isFalse);
+      },
+    );
+
+    test(
+      'when the graph file is malformed, '
+      'then the fingerprint is null',
+      () {
+        File(
+          p.join(dartToolDir, 'package_graph.json'),
+        ).writeAsStringSync('{ not valid json');
+
+        final tracker = FlutterDependencyTracker(
+          dartToolDir: dartToolDir,
+          flutterPackageName: 'app_flutter',
+        );
+
+        expect(tracker.computeFingerprint(), isNull);
+      },
+    );
+
+    test(
+      'when the Flutter package is absent from the graph, '
+      'then the fingerprint is null',
+      () {
+        writeGraph(baseGraph());
+
+        final tracker = FlutterDependencyTracker(
+          dartToolDir: dartToolDir,
+          flutterPackageName: 'not_in_graph',
+        );
+
+        expect(tracker.computeFingerprint(), isNull);
+      },
+    );
+
+    test(
+      'when the graph disappears then reappears unchanged, '
+      'then no change is reported',
+      () {
+        writeGraph(baseGraph());
+        final tracker = FlutterDependencyTracker(
+          dartToolDir: dartToolDir,
+          flutterPackageName: 'app_flutter',
+        );
+
+        // Simulate a transient state (e.g. mid-pub-get / flutter clean): the
+        // file vanishes and is then recreated with identical contents.
+        File(p.join(dartToolDir, 'package_graph.json')).deleteSync();
+        expect(tracker.refreshIfChanged(), isFalse);
+
+        writeGraph(baseGraph());
+        expect(tracker.refreshIfChanged(), isFalse);
+      },
+    );
+  });
+
+  group('Given a Flutter package directory in a workspace,', () {
+    test(
+      'when resolving its .dart_tool, '
+      'then it resolves to the workspace root .dart_tool',
+      () async {
+        final root = await Directory(
+          p.join(tempDir.path, 'workspace'),
+        ).create();
+        await Directory(p.join(root.path, '.dart_tool')).create();
+        await File(
+          p.join(root.path, '.dart_tool', 'package_config.json'),
+        ).writeAsString('{}');
+        // Member package with no resolution of its own.
+        final member = await Directory(
+          p.join(root.path, 'app_flutter'),
+        ).create();
+
+        final resolved = FlutterDependencyTracker.resolveDartToolDir(
+          member.path,
+        );
+
+        expect(resolved, p.join(root.path, '.dart_tool'));
+      },
+    );
+  });
+
+  group('Given a standalone (non-workspace) Flutter package directory,', () {
+    test(
+      'when resolving its .dart_tool, '
+      'then it resolves to the package\'s own .dart_tool',
+      () async {
+        final pkg = await Directory(
+          p.join(tempDir.path, 'standalone'),
+        ).create();
+        await Directory(p.join(pkg.path, '.dart_tool')).create();
+        await File(
+          p.join(pkg.path, '.dart_tool', 'package_config.json'),
+        ).writeAsString('{}');
+
+        final resolved = FlutterDependencyTracker.resolveDartToolDir(pkg.path);
+
+        expect(resolved, p.join(pkg.path, '.dart_tool'));
+      },
+    );
+
+    test(
+      'when no resolution exists in any ancestor, '
+      'then it resolves to null',
+      () async {
+        final pkg = await Directory(
+          p.join(tempDir.path, 'unresolved'),
+        ).create();
+
+        final resolved = FlutterDependencyTracker.resolveDartToolDir(pkg.path);
+
+        expect(resolved, isNull);
+      },
+    );
+  });
+}

--- a/tools/serverpod_cli/test/commands/start/flutter_dependency_tracker_test.dart
+++ b/tools/serverpod_cli/test/commands/start/flutter_dependency_tracker_test.dart
@@ -31,6 +31,27 @@ void main() {
     );
   }
 
+  /// Creates a fake package source directory holding [pubspec], returning its
+  /// rootUri relative to the `.dart_tool` directory.
+  String writePackage(String name, String pubspec) {
+    final dir = Directory(p.join(tempDir.path, 'pkgs', name))
+      ..createSync(recursive: true);
+    File(p.join(dir.path, 'pubspec.yaml')).writeAsStringSync(pubspec);
+    return '../pkgs/$name';
+  }
+
+  void writePackageConfig(Map<String, String> rootUris) {
+    File(p.join(dartToolDir, 'package_config.json')).writeAsStringSync(
+      jsonEncode({
+        'configVersion': 2,
+        'packages': [
+          for (final entry in rootUris.entries)
+            {'name': entry.key, 'rootUri': entry.value, 'packageUri': 'lib/'},
+        ],
+      }),
+    );
+  }
+
   // A Flutter app that transitively depends on the client (and http) but not
   // the server. flutter_test is a dev dependency only.
   Map<String, dynamic> baseGraph() => {
@@ -58,91 +79,279 @@ void main() {
     ],
   };
 
-  group('Given a Flutter app dependency graph in a workspace,', () {
-    late FlutterDependencyTracker tracker;
+  /// Pure-Dart source dirs + package_config for the app's closure packages.
+  Map<String, String> closureRootUris() => {
+    'app_flutter': writePackage('app_flutter', 'name: app_flutter\n'),
+    'app_client': writePackage('app_client', 'name: app_client\n'),
+    'http': writePackage('http', 'name: http\n'),
+  };
 
-    setUp(() {
-      writeGraph(baseGraph());
-      tracker = FlutterDependencyTracker(
-        dartToolDir: dartToolDir,
-        flutterPackageName: 'app_flutter',
+  group(
+    'Given a Flutter app dependency graph of pure-Dart packages '
+    'in a workspace,',
+    () {
+      late FlutterDependencyTracker tracker;
+
+      setUp(() {
+        writeGraph(baseGraph());
+        writePackageConfig(closureRootUris());
+        tracker = FlutterDependencyTracker(
+          dartToolDir: dartToolDir,
+          flutterPackageName: 'app_flutter',
+        );
+      });
+
+      test(
+        'when a server-only dependency version changes, '
+        'then no change is reported',
+        () {
+          final graph = baseGraph();
+          packageNamed(graph, 'postgres')['version'] = '3.1.0';
+          writeGraph(graph);
+
+          expect(tracker.refresh(), FlutterDependencyChange.none);
+        },
       );
+
+      test(
+        'when a dependency inside the app closure changes version, '
+        'then a pure-Dart change is reported',
+        () {
+          final graph = baseGraph();
+          packageNamed(graph, 'http')['version'] = '1.3.0';
+          writeGraph(graph);
+
+          expect(tracker.refresh(), FlutterDependencyChange.dartOnly);
+        },
+      );
+
+      test(
+        'when a pure-Dart dependency is added to the app, '
+        'then a pure-Dart change is reported',
+        () {
+          final graph = baseGraph();
+          (packageNamed(graph, 'app_flutter')['dependencies'] as List).add(
+            'redis',
+          );
+          (graph['packages'] as List).add({
+            'name': 'redis',
+            'version': '1.0.0',
+            'dependencies': <String>[],
+          });
+          writeGraph(graph);
+          writePackageConfig({
+            ...closureRootUris(),
+            'redis': writePackage('redis', 'name: redis\n'),
+          });
+
+          expect(tracker.refresh(), FlutterDependencyChange.dartOnly);
+        },
+      );
+
+      test(
+        'when a dependency is removed from the app, '
+        'then a pure-Dart change is reported',
+        () {
+          // Stale native code in the running binary is harmless, so removals
+          // never require more than a hot restart.
+          final graph = baseGraph();
+          packageNamed(graph, 'app_flutter')['dependencies'] = ['http'];
+          writeGraph(graph);
+
+          expect(tracker.refresh(), FlutterDependencyChange.dartOnly);
+        },
+      );
+
+      test(
+        'when a dev dependency of the app changes, '
+        'then no change is reported',
+        () {
+          final graph = baseGraph();
+          packageNamed(graph, 'flutter_test')['version'] = '0.1.0';
+          writeGraph(graph);
+
+          expect(tracker.refresh(), FlutterDependencyChange.none);
+        },
+      );
+
+      test(
+        'when the graph is rewritten with identical contents, '
+        'then no change is reported',
+        () {
+          writeGraph(baseGraph());
+
+          expect(tracker.refresh(), FlutterDependencyChange.none);
+        },
+      );
+    },
+  );
+
+  /// Sets up an app depending on a single package `dep@1.0.0` (described by
+  /// [depPubspec]), then bumps it to 1.0.1 in the graph so the next
+  /// `refresh()` classifies the bump.
+  FlutterDependencyTracker prepareBumpedDependency({
+    required String depPubspec,
+    bool listedInPackageConfig = true,
+    bool withBuildHook = false,
+  }) {
+    Map<String, dynamic> graph(String version) => {
+      'roots': ['app_flutter'],
+      'packages': [
+        {
+          'name': 'app_flutter',
+          'version': '1.0.0',
+          'dependencies': ['dep'],
+        },
+        {'name': 'dep', 'version': version, 'dependencies': <String>[]},
+      ],
+    };
+
+    final depRoot = writePackage('dep', depPubspec);
+    if (withBuildHook) {
+      final hookDir = Directory(p.join(tempDir.path, 'pkgs', 'dep', 'hook'))
+        ..createSync(recursive: true);
+      File(
+        p.join(hookDir.path, 'build.dart'),
+      ).writeAsStringSync('void main() {}');
+    }
+    writePackageConfig({
+      'app_flutter': writePackage('app_flutter', 'name: app_flutter\n'),
+      if (listedInPackageConfig) 'dep': depRoot,
     });
 
-    test(
-      'when a server-only dependency version changes, '
-      'then no change is reported',
-      () {
-        final graph = baseGraph();
-        packageNamed(graph, 'postgres')['version'] = '3.1.0';
-        writeGraph(graph);
-
-        expect(tracker.refreshIfChanged(), isFalse);
-      },
+    writeGraph(graph('1.0.0'));
+    final tracker = FlutterDependencyTracker(
+      dartToolDir: dartToolDir,
+      flutterPackageName: 'app_flutter',
     );
+    writeGraph(graph('1.0.1'));
+    return tracker;
+  }
 
+  group('Given a changed app dependency declaring a native plugin class,', () {
     test(
-      'when a dependency inside the app closure changes version, '
-      'then a change is reported',
+      'when the closure is refreshed, '
+      'then a native change is reported',
       () {
-        final graph = baseGraph();
-        packageNamed(graph, 'http')['version'] = '1.3.0';
-        writeGraph(graph);
-
-        expect(tracker.refreshIfChanged(), isTrue);
-      },
-    );
-
-    test(
-      'when a dependency is added to the app, '
-      'then a change is reported',
-      () {
-        final graph = baseGraph();
-        (packageNamed(graph, 'app_flutter')['dependencies'] as List).add(
-          'redis',
+        final tracker = prepareBumpedDependency(
+          depPubspec:
+              'name: dep\n'
+              'flutter:\n'
+              '  plugin:\n'
+              '    platforms:\n'
+              '      android:\n'
+              '        package: com.example.dep\n'
+              '        pluginClass: DepPlugin\n',
         );
-        (graph['packages'] as List).add({
-          'name': 'redis',
-          'version': '1.0.0',
-          'dependencies': <String>[],
-        });
-        writeGraph(graph);
 
-        expect(tracker.refreshIfChanged(), isTrue);
+        expect(tracker.refresh(), FlutterDependencyChange.native);
       },
     );
+  });
 
+  group('Given a changed app dependency declaring an FFI plugin,', () {
     test(
-      'when a dependency is removed from the app, '
-      'then a change is reported',
+      'when the closure is refreshed, '
+      'then a native change is reported',
       () {
-        final graph = baseGraph();
-        packageNamed(graph, 'app_flutter')['dependencies'] = ['http'];
-        writeGraph(graph);
+        final tracker = prepareBumpedDependency(
+          depPubspec:
+              'name: dep\n'
+              'flutter:\n'
+              '  plugin:\n'
+              '    platforms:\n'
+              '      windows:\n'
+              '        ffiPlugin: true\n',
+        );
 
-        expect(tracker.refreshIfChanged(), isTrue);
+        expect(tracker.refresh(), FlutterDependencyChange.native);
       },
     );
+  });
 
+  group(
+    'Given a changed app dependency declaring only a Dart plugin class,',
+    () {
+      test(
+        'when the closure is refreshed, '
+        'then a pure-Dart change is reported',
+        () {
+          final tracker = prepareBumpedDependency(
+            depPubspec:
+                'name: dep\n'
+                'flutter:\n'
+                '  plugin:\n'
+                '    platforms:\n'
+                '      linux:\n'
+                '        dartPluginClass: DepPluginLinux\n',
+          );
+
+          expect(tracker.refresh(), FlutterDependencyChange.dartOnly);
+        },
+      );
+    },
+  );
+
+  group('Given a changed app dependency with "pluginClass: none",', () {
     test(
-      'when a dev dependency of the app changes, '
-      'then no change is reported',
+      'when the closure is refreshed, '
+      'then a pure-Dart change is reported',
       () {
-        final graph = baseGraph();
-        packageNamed(graph, 'flutter_test')['version'] = '0.1.0';
-        writeGraph(graph);
+        final tracker = prepareBumpedDependency(
+          depPubspec:
+              'name: dep\n'
+              'flutter:\n'
+              '  plugin:\n'
+              '    platforms:\n'
+              '      web:\n'
+              '        pluginClass: none\n',
+        );
 
-        expect(tracker.refreshIfChanged(), isFalse);
+        expect(tracker.refresh(), FlutterDependencyChange.dartOnly);
       },
     );
+  });
 
+  group('Given a changed app dependency with a native-assets build hook,', () {
     test(
-      'when the graph is rewritten with identical contents, '
-      'then no change is reported',
+      'when the closure is refreshed, '
+      'then a native change is reported',
       () {
-        writeGraph(baseGraph());
+        final tracker = prepareBumpedDependency(
+          depPubspec: 'name: dep\n',
+          withBuildHook: true,
+        );
 
-        expect(tracker.refreshIfChanged(), isFalse);
+        expect(tracker.refresh(), FlutterDependencyChange.native);
+      },
+    );
+  });
+
+  group('Given a changed app dependency missing from package_config.json,', () {
+    test(
+      'when the closure is refreshed, '
+      'then a native change is conservatively reported',
+      () {
+        final tracker = prepareBumpedDependency(
+          depPubspec: 'name: dep\n',
+          listedInPackageConfig: false,
+        );
+
+        expect(tracker.refresh(), FlutterDependencyChange.native);
+      },
+    );
+  });
+
+  group('Given a changed app dependency with an unreadable pubspec,', () {
+    test(
+      'when the closure is refreshed, '
+      'then a native change is conservatively reported',
+      () {
+        final tracker = prepareBumpedDependency(
+          depPubspec: 'name: [unclosed\n  flutter: {',
+        );
+
+        expect(tracker.refresh(), FlutterDependencyChange.native);
       },
     );
   });
@@ -150,7 +359,7 @@ void main() {
   group('Given a missing or malformed dependency graph,', () {
     test(
       'when the graph file is absent, '
-      'then the fingerprint is null and no change is reported',
+      'then no change is reported',
       () {
         // No graph written.
         final tracker = FlutterDependencyTracker(
@@ -158,14 +367,13 @@ void main() {
           flutterPackageName: 'app_flutter',
         );
 
-        expect(tracker.computeFingerprint(), isNull);
-        expect(tracker.refreshIfChanged(), isFalse);
+        expect(tracker.refresh(), FlutterDependencyChange.none);
       },
     );
 
     test(
       'when the graph file is malformed, '
-      'then the fingerprint is null',
+      'then no change is reported',
       () {
         File(
           p.join(dartToolDir, 'package_graph.json'),
@@ -176,13 +384,13 @@ void main() {
           flutterPackageName: 'app_flutter',
         );
 
-        expect(tracker.computeFingerprint(), isNull);
+        expect(tracker.refresh(), FlutterDependencyChange.none);
       },
     );
 
     test(
       'when the Flutter package is absent from the graph, '
-      'then the fingerprint is null',
+      'then no change is reported',
       () {
         writeGraph(baseGraph());
 
@@ -191,7 +399,7 @@ void main() {
           flutterPackageName: 'not_in_graph',
         );
 
-        expect(tracker.computeFingerprint(), isNull);
+        expect(tracker.refresh(), FlutterDependencyChange.none);
       },
     );
 
@@ -208,10 +416,10 @@ void main() {
         // Simulate a transient state (e.g. mid-pub-get / flutter clean): the
         // file vanishes and is then recreated with identical contents.
         File(p.join(dartToolDir, 'package_graph.json')).deleteSync();
-        expect(tracker.refreshIfChanged(), isFalse);
+        expect(tracker.refresh(), FlutterDependencyChange.none);
 
         writeGraph(baseGraph());
-        expect(tracker.refreshIfChanged(), isFalse);
+        expect(tracker.refresh(), FlutterDependencyChange.none);
       },
     );
   });

--- a/tools/serverpod_cli/test/commands/start/flutter_dependency_tracker_test.dart
+++ b/tools/serverpod_cli/test/commands/start/flutter_dependency_tracker_test.dart
@@ -265,184 +265,176 @@ void main() {
     return tracker.refresh();
   }
 
-  group('Given a changed app dependency declaring a native plugin class,', () {
-    test(
-      'when the closure is refreshed, '
-      'then a native change is reported',
-      () async {
-        final change = await classifyRealDependencyBump(
-          depFlutterBlock:
-              'flutter:\n'
-              '  plugin:\n'
-              '    platforms:\n'
-              '      android:\n'
-              '        package: com.example.dep\n'
-              '        pluginClass: DepPlugin\n',
-        );
-
-        expect(change, FlutterDependencyChange.native);
-      },
-    );
-  });
-
-  group('Given a changed app dependency declaring an FFI plugin,', () {
-    test(
-      'when the closure is refreshed, '
-      'then a native change is reported',
-      () async {
-        final change = await classifyRealDependencyBump(
-          depFlutterBlock:
-              'flutter:\n'
-              '  plugin:\n'
-              '    platforms:\n'
-              '      windows:\n'
-              '        ffiPlugin: true\n',
-        );
-
-        expect(change, FlutterDependencyChange.native);
-      },
-    );
-  });
-
-  group(
-    'Given a changed app dependency declaring only a Dart plugin class,',
-    () {
-      test(
-        'when the closure is refreshed, '
-        'then a pure-Dart change is reported',
-        () async {
-          final change = await classifyRealDependencyBump(
-            depFlutterBlock:
-                'flutter:\n'
-                '  plugin:\n'
-                '    platforms:\n'
-                '      linux:\n'
-                '        dartPluginClass: DepPluginLinux\n',
-          );
-
-          expect(change, FlutterDependencyChange.dartOnly);
-        },
+  test(
+    'Given a changed app dependency declaring a native plugin class, '
+    'when the closure is refreshed, '
+    'then a native change is reported',
+    () async {
+      final change = await classifyRealDependencyBump(
+        depFlutterBlock:
+            'flutter:\n'
+            '  plugin:\n'
+            '    platforms:\n'
+            '      android:\n'
+            '        package: com.example.dep\n'
+            '        pluginClass: DepPlugin\n',
       );
+
+      expect(change, FlutterDependencyChange.native);
     },
   );
 
-  group('Given a changed app dependency with "pluginClass: none",', () {
-    test(
-      'when the closure is refreshed, '
-      'then a pure-Dart change is reported',
-      () async {
-        final change = await classifyRealDependencyBump(
-          depFlutterBlock:
-              'flutter:\n'
-              '  plugin:\n'
-              '    platforms:\n'
-              '      web:\n'
-              '        pluginClass: none\n',
-        );
+  test(
+    'Given a changed app dependency declaring an FFI plugin, '
+    'when the closure is refreshed, '
+    'then a native change is reported',
+    () async {
+      final change = await classifyRealDependencyBump(
+        depFlutterBlock:
+            'flutter:\n'
+            '  plugin:\n'
+            '    platforms:\n'
+            '      windows:\n'
+            '        ffiPlugin: true\n',
+      );
 
-        expect(change, FlutterDependencyChange.dartOnly);
-      },
-    );
-  });
+      expect(change, FlutterDependencyChange.native);
+    },
+  );
 
-  group('Given a changed app dependency with a native-assets build hook,', () {
-    test(
-      'when the closure is refreshed, '
-      'then a native change is reported',
-      () async {
-        final change = await classifyRealDependencyBump(withBuildHook: true);
+  test(
+    'Given a changed app dependency declaring only a Dart plugin class, '
+    'when the closure is refreshed, '
+    'then a pure-Dart change is reported',
+    () async {
+      final change = await classifyRealDependencyBump(
+        depFlutterBlock:
+            'flutter:\n'
+            '  plugin:\n'
+            '    platforms:\n'
+            '      linux:\n'
+            '        dartPluginClass: DepPluginLinux\n',
+      );
 
-        expect(change, FlutterDependencyChange.native);
-      },
-    );
-  });
+      expect(change, FlutterDependencyChange.dartOnly);
+    },
+  );
 
-  group('Given a changed app dependency with an unreadable pubspec,', () {
-    test(
-      'when the closure is refreshed, '
-      'then a native change is conservatively reported',
-      () async {
-        final change = await classifyRealDependencyBump(
-          corruptDepPubspecAfterResolve: true,
-        );
+  test(
+    'Given a changed app dependency with "pluginClass: none", '
+    'when the closure is refreshed, '
+    'then a pure-Dart change is reported',
+    () async {
+      final change = await classifyRealDependencyBump(
+        depFlutterBlock:
+            'flutter:\n'
+            '  plugin:\n'
+            '    platforms:\n'
+            '      web:\n'
+            '        pluginClass: none\n',
+      );
 
-        expect(change, FlutterDependencyChange.native);
-      },
-    );
-  });
+      expect(change, FlutterDependencyChange.dartOnly);
+    },
+  );
 
-  group('Given a Flutter package directory in a workspace,', () {
-    test(
-      'when resolving its .dart_tool, '
-      'then it resolves to the workspace root .dart_tool',
-      () async {
-        await createWorkspaceTracker();
+  test(
+    'Given a changed app dependency with a native-assets build hook, '
+    'when the closure is refreshed, '
+    'then a native change is reported',
+    () async {
+      final change = await classifyRealDependencyBump(withBuildHook: true);
 
-        final resolved = FlutterDependencyTracker.resolveDartToolDir(
-          p.join(wsDir, 'app_flutter'),
-          flutterPackageName: 'app_flutter',
-        );
+      expect(change, FlutterDependencyChange.native);
+    },
+  );
 
-        expect(resolved, p.join(wsDir, '.dart_tool'));
-      },
-    );
-  });
+  test(
+    'Given a changed app dependency with an unreadable pubspec, '
+    'when the closure is refreshed, '
+    'then a native change is conservatively reported',
+    () async {
+      final change = await classifyRealDependencyBump(
+        corruptDepPubspecAfterResolve: true,
+      );
 
-  group('Given a standalone (non-workspace) Flutter package directory,', () {
-    test(
-      'when resolving its .dart_tool, '
-      'then it resolves to the package\'s own .dart_tool',
-      () async {
-        final appDir = p.join(tempDir.path, 'standalone');
-        write(p.join(appDir, 'pubspec.yaml'), _pubspec('app_flutter'));
-        await _pubGet(appDir);
+      expect(change, FlutterDependencyChange.native);
+    },
+  );
 
-        final resolved = FlutterDependencyTracker.resolveDartToolDir(
-          appDir,
-          flutterPackageName: 'app_flutter',
-        );
+  test(
+    'Given a Flutter package directory in a workspace, '
+    'when resolving its .dart_tool, '
+    'then it resolves to the workspace root .dart_tool',
+    () async {
+      await createWorkspaceTracker();
 
-        expect(resolved, p.join(appDir, '.dart_tool'));
-      },
-    );
+      final resolved = FlutterDependencyTracker.resolveDartToolDir(
+        p.join(wsDir, 'app_flutter'),
+        flutterPackageName: 'app_flutter',
+      );
 
-    test(
-      'when no resolution exists in any ancestor, '
-      'then it resolves to null',
-      () async {
-        final pkg = await Directory(
-          p.join(tempDir.path, 'unresolved'),
-        ).create();
+      expect(resolved, p.join(wsDir, '.dart_tool'));
+    },
+  );
 
-        final resolved = FlutterDependencyTracker.resolveDartToolDir(
-          pkg.path,
-          flutterPackageName: 'app_flutter',
-        );
+  test(
+    'Given a standalone (non-workspace) Flutter package directory, '
+    'when resolving its .dart_tool, '
+    'then it resolves to the package\'s own .dart_tool',
+    () async {
+      final appDir = p.join(tempDir.path, 'standalone');
+      write(p.join(appDir, 'pubspec.yaml'), _pubspec('app_flutter'));
+      await _pubGet(appDir);
 
-        expect(resolved, isNull);
-      },
-    );
-  });
+      final resolved = FlutterDependencyTracker.resolveDartToolDir(
+        appDir,
+        flutterPackageName: 'app_flutter',
+      );
+
+      expect(resolved, p.join(appDir, '.dart_tool'));
+    },
+  );
+
+  test(
+    'Given a Flutter package directory with no resolution in any ancestor, '
+    'when resolving its .dart_tool, '
+    'then it resolves to null',
+    () async {
+      final pkg = await Directory(p.join(tempDir.path, 'unresolved')).create();
+
+      final resolved = FlutterDependencyTracker.resolveDartToolDir(
+        pkg.path,
+        flutterPackageName: 'app_flutter',
+      );
+
+      expect(resolved, isNull);
+    },
+  );
 
   group(
     'Given a Flutter package whose own resolution was deleted and an unrelated ancestor resolution,',
     () {
+      // E.g. a standalone app under some other Dart project's tree: the
+      // ancestor's resolution is real but doesn't list the app.
+      late Directory pkg;
+
+      setUp(() async {
+        final ancestorDir = p.join(tempDir.path, 'other_project');
+        write(
+          p.join(ancestorDir, 'pubspec.yaml'),
+          _pubspec('something_unrelated'),
+        );
+        await _pubGet(ancestorDir);
+        pkg = await Directory(
+          p.join(ancestorDir, 'nested', 'app_flutter'),
+        ).create(recursive: true);
+      });
+
       test(
         'when resolving its .dart_tool, '
         'then it does not latch onto the unrelated resolution',
-        () async {
-          // E.g. a standalone app under some other Dart project's tree: the
-          // ancestor's resolution is real but doesn't list the app.
-          final ancestorDir = p.join(tempDir.path, 'other_project');
-          write(
-            p.join(ancestorDir, 'pubspec.yaml'),
-            _pubspec('something_unrelated'),
-          );
-          await _pubGet(ancestorDir);
-          final pkg = await Directory(
-            p.join(ancestorDir, 'nested', 'app_flutter'),
-          ).create(recursive: true);
-
+        () {
           final resolved = FlutterDependencyTracker.resolveDartToolDir(
             pkg.path,
             flutterPackageName: 'app_flutter',
@@ -451,26 +443,35 @@ void main() {
           expect(resolved, isNull);
         },
       );
+    },
+  );
+
+  group(
+    'Given a Flutter package under an unrelated resolution with a same-named package resolved further up,',
+    () {
+      // Resolution stops at the nearest root: a same-named package in a
+      // resolution further up must not be mistaken for this app.
+      late Directory pkg;
+
+      setUp(() async {
+        final outerDir = p.join(tempDir.path, 'outer');
+        write(p.join(outerDir, 'pubspec.yaml'), _pubspec('app_flutter'));
+        await _pubGet(outerDir);
+        final midDir = p.join(outerDir, 'mid');
+        write(
+          p.join(midDir, 'pubspec.yaml'),
+          _pubspec('something_unrelated'),
+        );
+        await _pubGet(midDir);
+        pkg = await Directory(
+          p.join(midDir, 'app_flutter'),
+        ).create(recursive: true);
+      });
 
       test(
-        'when an even higher resolution does list the package name, '
-        'then it still resolves to null',
-        () async {
-          // Resolution stops at the nearest root: a same-named package in a
-          // resolution further up must not be mistaken for this app.
-          final outerDir = p.join(tempDir.path, 'outer');
-          write(p.join(outerDir, 'pubspec.yaml'), _pubspec('app_flutter'));
-          await _pubGet(outerDir);
-          final midDir = p.join(outerDir, 'mid');
-          write(
-            p.join(midDir, 'pubspec.yaml'),
-            _pubspec('something_unrelated'),
-          );
-          await _pubGet(midDir);
-          final pkg = await Directory(
-            p.join(midDir, 'app_flutter'),
-          ).create(recursive: true);
-
+        'when resolving its .dart_tool, '
+        'then it resolves to null',
+        () {
           final resolved = FlutterDependencyTracker.resolveDartToolDir(
             pkg.path,
             flutterPackageName: 'app_flutter',
@@ -488,103 +489,131 @@ void main() {
   // only way to cover the tracker's tolerance of them is synthetically.
   // ---------------------------------------------------------------------
 
-  group('Given a missing or malformed dependency graph,', () {
-    late String dartToolDir;
+  late String syntheticDartTool;
+
+  Future<void> createSyntheticDartTool() async {
+    syntheticDartTool = p.join(tempDir.path, '.dart_tool');
+    await Directory(syntheticDartTool).create();
+  }
+
+  void writeGraph(Map<String, dynamic> graph) {
+    write(p.join(syntheticDartTool, 'package_graph.json'), jsonEncode(graph));
+  }
+
+  Map<String, dynamic> minimalGraph({String depVersion = '1.0.0'}) => {
+    'roots': ['app_flutter'],
+    'packages': [
+      {
+        'name': 'app_flutter',
+        'version': '1.0.0',
+        'dependencies': ['dep'],
+      },
+      {'name': 'dep', 'version': depVersion, 'dependencies': <String>[]},
+    ],
+  };
+
+  FlutterDependencyTracker createSyntheticTracker({
+    String flutterPackageName = 'app_flutter',
+  }) => FlutterDependencyTracker(
+    dartToolDir: syntheticDartTool,
+    flutterPackageName: flutterPackageName,
+  );
+
+  group('Given a resolution whose dependency graph file is absent,', () {
+    late FlutterDependencyTracker tracker;
 
     setUp(() async {
-      dartToolDir = p.join(tempDir.path, '.dart_tool');
-      await Directory(dartToolDir).create();
+      await createSyntheticDartTool();
+      tracker = createSyntheticTracker();
     });
 
-    void writeGraph(Map<String, dynamic> graph) {
-      write(p.join(dartToolDir, 'package_graph.json'), jsonEncode(graph));
-    }
-
-    Map<String, dynamic> minimalGraph({String depVersion = '1.0.0'}) => {
-      'roots': ['app_flutter'],
-      'packages': [
-        {
-          'name': 'app_flutter',
-          'version': '1.0.0',
-          'dependencies': ['dep'],
-        },
-        {'name': 'dep', 'version': depVersion, 'dependencies': <String>[]},
-      ],
-    };
-
     test(
-      'when the graph file is absent, '
+      'when the closure is refreshed, '
       'then no change is reported',
       () {
-        // No graph written.
-        final tracker = FlutterDependencyTracker(
-          dartToolDir: dartToolDir,
-          flutterPackageName: 'app_flutter',
-        );
-
         expect(tracker.refresh(), FlutterDependencyChange.none);
       },
     );
+  });
+
+  group('Given a malformed dependency graph file,', () {
+    late FlutterDependencyTracker tracker;
+
+    setUp(() async {
+      await createSyntheticDartTool();
+      write(
+        p.join(syntheticDartTool, 'package_graph.json'),
+        '{ not valid json',
+      );
+      tracker = createSyntheticTracker();
+    });
 
     test(
-      'when the graph file is malformed, '
+      'when the closure is refreshed, '
       'then no change is reported',
       () {
-        write(p.join(dartToolDir, 'package_graph.json'), '{ not valid json');
-
-        final tracker = FlutterDependencyTracker(
-          dartToolDir: dartToolDir,
-          flutterPackageName: 'app_flutter',
-        );
-
         expect(tracker.refresh(), FlutterDependencyChange.none);
       },
     );
+  });
 
-    test(
-      'when the Flutter package is absent from the graph, '
-      'then no change is reported',
-      () {
+  group(
+    'Given a dependency graph that does not list the Flutter package,',
+    () {
+      late FlutterDependencyTracker tracker;
+
+      setUp(() async {
+        await createSyntheticDartTool();
         writeGraph(minimalGraph());
+        tracker = createSyntheticTracker(flutterPackageName: 'not_in_graph');
+      });
 
-        final tracker = FlutterDependencyTracker(
-          dartToolDir: dartToolDir,
-          flutterPackageName: 'not_in_graph',
-        );
+      test(
+        'when the closure is refreshed, '
+        'then no change is reported',
+        () {
+          expect(tracker.refresh(), FlutterDependencyChange.none);
+        },
+      );
+    },
+  );
 
-        expect(tracker.refresh(), FlutterDependencyChange.none);
-      },
-    );
+  group('Given a tracked dependency graph,', () {
+    late FlutterDependencyTracker tracker;
+
+    setUp(() async {
+      await createSyntheticDartTool();
+      writeGraph(minimalGraph());
+      tracker = createSyntheticTracker();
+    });
 
     test(
       'when the graph disappears then reappears unchanged, '
       'then no change is reported',
       () {
-        writeGraph(minimalGraph());
-        final tracker = FlutterDependencyTracker(
-          dartToolDir: dartToolDir,
-          flutterPackageName: 'app_flutter',
-        );
-
         // Simulate a transient state (e.g. mid-pub-get / flutter clean): the
         // file vanishes and is then recreated with identical contents.
-        File(p.join(dartToolDir, 'package_graph.json')).deleteSync();
+        File(p.join(syntheticDartTool, 'package_graph.json')).deleteSync();
         expect(tracker.refresh(), FlutterDependencyChange.none);
 
         writeGraph(minimalGraph());
         expect(tracker.refresh(), FlutterDependencyChange.none);
       },
     );
+  });
 
-    test(
-      'when a changed dependency is missing from package_config.json, '
-      'then a native change is conservatively reported',
-      () {
-        // A graph/config mismatch can only arise from a racing or partial
-        // write; the unlocatable package must not be assumed pure-Dart.
+  group(
+    'Given a changed dependency that is missing from package_config.json,',
+    () {
+      // A graph/config mismatch can only arise from a racing or partial
+      // write; the unlocatable package must not be assumed pure-Dart.
+      late FlutterDependencyTracker tracker;
+
+      setUp(() async {
+        await createSyntheticDartTool();
         writeGraph(minimalGraph());
         write(
-          p.join(dartToolDir, 'package_config.json'),
+          p.join(syntheticDartTool, 'package_config.json'),
           jsonEncode({
             'configVersion': 2,
             'packages': [
@@ -596,15 +625,18 @@ void main() {
             ],
           }),
         );
-        final tracker = FlutterDependencyTracker(
-          dartToolDir: dartToolDir,
-          flutterPackageName: 'app_flutter',
-        );
+        tracker = createSyntheticTracker();
 
         writeGraph(minimalGraph(depVersion: '1.0.1'));
+      });
 
-        expect(tracker.refresh(), FlutterDependencyChange.native);
-      },
-    );
-  });
+      test(
+        'when the closure is refreshed, '
+        'then a native change is conservatively reported',
+        () {
+          expect(tracker.refresh(), FlutterDependencyChange.native);
+        },
+      );
+    },
+  );
 }

--- a/tools/serverpod_cli/test/commands/start/flutter_dependency_tracker_test.dart
+++ b/tools/serverpod_cli/test/commands/start/flutter_dependency_tracker_test.dart
@@ -451,6 +451,34 @@ void main() {
           expect(resolved, isNull);
         },
       );
+
+      test(
+        'when an even higher resolution does list the package name, '
+        'then it still resolves to null',
+        () async {
+          // Resolution stops at the nearest root: a same-named package in a
+          // resolution further up must not be mistaken for this app.
+          final outerDir = p.join(tempDir.path, 'outer');
+          write(p.join(outerDir, 'pubspec.yaml'), _pubspec('app_flutter'));
+          await _pubGet(outerDir);
+          final midDir = p.join(outerDir, 'mid');
+          write(
+            p.join(midDir, 'pubspec.yaml'),
+            _pubspec('something_unrelated'),
+          );
+          await _pubGet(midDir);
+          final pkg = await Directory(
+            p.join(midDir, 'app_flutter'),
+          ).create(recursive: true);
+
+          final resolved = FlutterDependencyTracker.resolveDartToolDir(
+            pkg.path,
+            flutterPackageName: 'app_flutter',
+          );
+
+          expect(resolved, isNull);
+        },
+      );
     },
   );
 

--- a/tools/serverpod_cli/test/commands/start/watch_session_test.dart
+++ b/tools/serverpod_cli/test/commands/start/watch_session_test.dart
@@ -1249,8 +1249,7 @@ void main() {
   );
 
   group(
-    'Given a watch session where the Flutter dependency file changed but the '
-    'closure did not,',
+    'Given a watch session where the Flutter dependency file changed but the closure did not,',
     () {
       late int restartActionCalls;
       late _FakeFlutter flutter;

--- a/tools/serverpod_cli/test/commands/start/watch_session_test.dart
+++ b/tools/serverpod_cli/test/commands/start/watch_session_test.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:serverpod_cli/src/commands/start/file_watcher.dart';
+import 'package:serverpod_cli/src/commands/start/flutter_dependency_tracker.dart';
 import 'package:serverpod_cli/src/commands/start/flutter_process.dart';
 import 'package:serverpod_cli/src/commands/start/kernel_compiler.dart';
 import 'package:serverpod_cli/src/commands/start/server_process.dart';
@@ -168,7 +169,7 @@ void main() {
     ProtocolChangeClassifier? classifyProtocolChange,
     FlutterProcess? flutterProcess,
     Future<void> Function()? flutterAppRestartAction,
-    bool Function()? flutterDependenciesChangedSinceLastCheck,
+    FlutterDependencyChange Function()? checkFlutterDependencyChange,
   }) {
     return WatchSession(
       compiler: compiler,
@@ -194,8 +195,7 @@ void main() {
           classifyProtocolChange ?? defaultProtocolChangeClassifier,
       flutterProcessProvider: () => flutterProcess,
       flutterAppRestartAction: flutterAppRestartAction,
-      flutterDependenciesChangedSinceLastCheck:
-          flutterDependenciesChangedSinceLastCheck,
+      checkFlutterDependencyChange: checkFlutterDependencyChange,
     );
   }
 
@@ -1083,7 +1083,7 @@ void main() {
   });
 
   group(
-    'Given a watch session where the Flutter dependency closure changed,',
+    'Given a watch session where native Flutter dependencies changed,',
     () {
       late int restartActionCalls;
       late _FakeFlutter flutter;
@@ -1098,7 +1098,7 @@ void main() {
           flutterAppRestartAction: () async {
             restartActionCalls++;
           },
-          flutterDependenciesChangedSinceLastCheck: () => true,
+          checkFlutterDependencyChange: () => FlutterDependencyChange.native,
         );
       });
 
@@ -1114,8 +1114,8 @@ void main() {
           await session.handleFileChange(event);
 
           expect(restartActionCalls, 1);
-          // No server compile, and a full relaunch (the action) rather than the
-          // in-process hot reload.
+          // No server compile, and a full relaunch (the action) rather than
+          // the in-process hot reload or hot restart.
           expect(compiler.calls, isEmpty);
           expect(flutter.calls, isEmpty);
         },
@@ -1141,6 +1141,62 @@ void main() {
   );
 
   group(
+    'Given a watch session where only pure-Dart Flutter dependencies changed,',
+    () {
+      late int restartActionCalls;
+      late _FakeFlutter flutter;
+
+      setUp(() {
+        restartActionCalls = 0;
+        flutter = _FakeFlutter();
+        session = buildSession(
+          compiler: compiler,
+          initialServer: server,
+          flutterProcess: flutter,
+          flutterAppRestartAction: () async {
+            restartActionCalls++;
+          },
+          checkFlutterDependencyChange: () => FlutterDependencyChange.dartOnly,
+        );
+      });
+
+      test(
+        'when only the dependencies change, '
+        'then the Flutter app is hot restarted without a full relaunch.',
+        () async {
+          final event = FileChangeEvent(
+            dartFiles: {},
+            flutterDependenciesChanged: true,
+          );
+
+          await session.handleFileChange(event);
+
+          expect(flutter.calls, ['restart']);
+          expect(restartActionCalls, 0);
+          expect(compiler.calls, isEmpty);
+        },
+      );
+
+      test(
+        'when dependencies and dart files change together, '
+        'then the server reloads and the app is hot restarted instead of hot reloaded.',
+        () async {
+          final event = FileChangeEvent(
+            dartFiles: {'/lib/a.dart'},
+            flutterDependenciesChanged: true,
+          );
+
+          await session.handleFileChange(event);
+
+          expect(server.calls, contains('reload:/out.dill'));
+          expect(flutter.calls, ['restart']);
+          expect(restartActionCalls, 0);
+        },
+      );
+    },
+  );
+
+  group(
     'Given a watch session where the Flutter dependency file changed but the '
     'closure did not,',
     () {
@@ -1157,7 +1213,7 @@ void main() {
           flutterAppRestartAction: () async {
             restartActionCalls++;
           },
-          flutterDependenciesChangedSinceLastCheck: () => false,
+          checkFlutterDependencyChange: () => FlutterDependencyChange.none,
         );
       });
 

--- a/tools/serverpod_cli/test/commands/start/watch_session_test.dart
+++ b/tools/serverpod_cli/test/commands/start/watch_session_test.dart
@@ -168,6 +168,7 @@ void main() {
     ProtocolChangeClassifier? classifyProtocolChange,
     FlutterProcess? flutterProcess,
     Future<void> Function()? flutterAppRestartAction,
+    bool Function()? flutterDependenciesChangedSinceLastCheck,
   }) {
     return WatchSession(
       compiler: compiler,
@@ -193,6 +194,8 @@ void main() {
           classifyProtocolChange ?? defaultProtocolChangeClassifier,
       flutterProcessProvider: () => flutterProcess,
       flutterAppRestartAction: flutterAppRestartAction,
+      flutterDependenciesChangedSinceLastCheck:
+          flutterDependenciesChangedSinceLastCheck,
     );
   }
 
@@ -1078,6 +1081,120 @@ void main() {
       },
     );
   });
+
+  group(
+    'Given a watch session where the Flutter dependency closure changed,',
+    () {
+      late int restartActionCalls;
+      late _FakeFlutter flutter;
+
+      setUp(() {
+        restartActionCalls = 0;
+        flutter = _FakeFlutter();
+        session = buildSession(
+          compiler: compiler,
+          initialServer: server,
+          flutterProcess: flutter,
+          flutterAppRestartAction: () async {
+            restartActionCalls++;
+          },
+          flutterDependenciesChangedSinceLastCheck: () => true,
+        );
+      });
+
+      test(
+        'when only the dependencies change, '
+        'then the Flutter app is relaunched without recompiling the server.',
+        () async {
+          final event = FileChangeEvent(
+            dartFiles: {},
+            flutterDependenciesChanged: true,
+          );
+
+          await session.handleFileChange(event);
+
+          expect(restartActionCalls, 1);
+          // No server compile, and a full relaunch (the action) rather than the
+          // in-process hot reload.
+          expect(compiler.calls, isEmpty);
+          expect(flutter.calls, isEmpty);
+        },
+      );
+
+      test(
+        'when dependencies and dart files change together, '
+        'then the server reloads and the app is relaunched instead of hot reloaded.',
+        () async {
+          final event = FileChangeEvent(
+            dartFiles: {'/lib/a.dart'},
+            flutterDependenciesChanged: true,
+          );
+
+          await session.handleFileChange(event);
+
+          expect(server.calls, contains('reload:/out.dill'));
+          expect(restartActionCalls, 1);
+          expect(flutter.calls, isEmpty);
+        },
+      );
+    },
+  );
+
+  group(
+    'Given a watch session where the Flutter dependency file changed but the '
+    'closure did not,',
+    () {
+      late int restartActionCalls;
+      late _FakeFlutter flutter;
+
+      setUp(() {
+        restartActionCalls = 0;
+        flutter = _FakeFlutter();
+        session = buildSession(
+          compiler: compiler,
+          initialServer: server,
+          flutterProcess: flutter,
+          flutterAppRestartAction: () async {
+            restartActionCalls++;
+          },
+          flutterDependenciesChangedSinceLastCheck: () => false,
+        );
+      });
+
+      test(
+        'when dart files also change, '
+        'then the Flutter app is hot reloaded, not relaunched.',
+        () async {
+          final event = FileChangeEvent(
+            dartFiles: {'/lib/a.dart'},
+            flutterDependenciesChanged: true,
+          );
+
+          await session.handleFileChange(event);
+
+          expect(restartActionCalls, 0);
+          expect(flutter.calls, ['reload']);
+        },
+      );
+
+      test(
+        'when only the dependency file changed, '
+        'then nothing is relaunched, reloaded, or recompiled.',
+        () async {
+          final event = FileChangeEvent(
+            dartFiles: {},
+            flutterDependenciesChanged: true,
+          );
+
+          await session.handleFileChange(event);
+
+          expect(restartActionCalls, 0);
+          expect(flutter.calls, isEmpty);
+          expect(compiler.calls, isEmpty);
+        },
+      );
+    },
+  );
 
   group(
     'Given an in-flight forceReload and a Flutter app restart action,',

--- a/tools/serverpod_cli/test/commands/start/watch_session_test.dart
+++ b/tools/serverpod_cli/test/commands/start/watch_session_test.dart
@@ -120,6 +120,9 @@ class _FakeFlutter extends Fake implements FlutterProcess {
   bool restartSuccess = true;
 
   @override
+  bool isRunning = true;
+
+  @override
   bool get isVmServiceConnected => _vmServiceConnected;
   set isVmServiceConnected(bool value) => _vmServiceConnected = value;
 
@@ -1078,6 +1081,52 @@ void main() {
         await session.restartFlutterApp();
 
         expect(server.calls, isEmpty);
+      },
+    );
+  });
+
+  group('Given a watch session with a running Flutter process,', () {
+    setUp(() {
+      session = buildSession(
+        compiler: compiler,
+        initialServer: server,
+        flutterProcess: _FakeFlutter(),
+      );
+    });
+
+    test(
+      'when checking whether the Flutter app is running, '
+      'then it reports true',
+      () {
+        expect(session.isFlutterAppRunning, isTrue);
+      },
+    );
+  });
+
+  group('Given a watch session whose Flutter process has stopped,', () {
+    setUp(() {
+      session = buildSession(
+        compiler: compiler,
+        initialServer: server,
+        flutterProcess: _FakeFlutter()..isRunning = false,
+      );
+    });
+
+    test(
+      'when checking whether the Flutter app is running, '
+      'then it reports false',
+      () {
+        expect(session.isFlutterAppRunning, isFalse);
+      },
+    );
+  });
+
+  group('Given a watch session with no Flutter process,', () {
+    test(
+      'when checking whether the Flutter app is running, '
+      'then it reports false',
+      () {
+        expect(session.isFlutterAppRunning, isFalse);
       },
     );
   });

--- a/tools/serverpod_cli/test/commands/start/watch_session_test.dart
+++ b/tools/serverpod_cli/test/commands/start/watch_session_test.dart
@@ -1164,9 +1164,11 @@ void main() {
 
           expect(restartActionCalls, 1);
           // No server compile, and a full relaunch (the action) rather than
-          // the in-process hot reload or hot restart.
+          // the in-process hot reload or hot restart. The server stays
+          // untouched - no compile, no browser refresh.
           expect(compiler.calls, isEmpty);
           expect(flutter.calls, isEmpty);
+          expect(server.calls, isEmpty);
         },
       );
 
@@ -1223,6 +1225,7 @@ void main() {
           expect(flutter.calls, ['restart']);
           expect(restartActionCalls, 0);
           expect(compiler.calls, isEmpty);
+          expect(server.calls, isEmpty);
         },
       );
 
@@ -1296,6 +1299,7 @@ void main() {
           expect(restartActionCalls, 0);
           expect(flutter.calls, isEmpty);
           expect(compiler.calls, isEmpty);
+          expect(server.calls, isEmpty);
         },
       );
     },


### PR DESCRIPTION
On `pub get`, the watcher classifies how the Flutter app's dependency closure changed and responds with the step that picks the change up:

  | Change | Response |
  | --- | --- |
  | No change to closure (server-only deps, no-op pub get) | nothing |
  | Pure-Dart deps (and removals) | hot restart (~1s) |
  | Native code (pluginClass / ffiPlugin / build hook) | full relaunch |

One minor change I snuck into this PR is a fix for misleading logs for when the flutter app restarts via CTRL+R or via this automated path.

Fixes #5225 #5167 

**NOTE:** Before this is merged in and completed It needs a new version of `serverpod_tui` with this [PR](https://github.com/serverpod/serverpod_tui/pull/13) merged. 

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes
None