### PR TITLE
fix: Hide the start TUI splash screen when it is remounted hidden

### DIFF
--- a/tools/serverpod_cli/lib/src/commands/start/tui/loading_screen.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/tui/loading_screen.dart
@@ -59,7 +59,15 @@ class _LoadingScreenState extends State<LoadingScreen>
   Component build(BuildContext context) {
     final theme = ServerpodTheme.of(context);
     final t = _controller.value;
-    if (t <= 0 && _fadingOut) return const SizedBox.shrink();
+    // Hidden when not visible, unless a fade-out is still in flight. The
+    // explicit !visible check matters: ancestors changing their tree shape
+    // (e.g. the Ctrl-C hint row appearing, or NoctermApp wrapping the app
+    // once theme detection lands) remount this component, and a fresh mount
+    // with visible=false never sees the true->false transition that arms
+    // the fade - without this guard it would render the splash forever.
+    if (!component.visible && (!_fadingOut || t <= 0)) {
+      return const SizedBox.shrink();
+    }
 
     final baseColor = Color.lerp(Color.defaultColor, theme.primary, t)!;
     final highlightColor = Color.lerp(Color.defaultColor, Colors.white, t)!;

--- a/tools/serverpod_cli/test/commands/start/tui/loading_screen_test.dart
+++ b/tools/serverpod_cli/test/commands/start/tui/loading_screen_test.dart
@@ -1,0 +1,74 @@
+import 'package:nocterm/nocterm.dart' hide isEmpty;
+import 'package:serverpod_cli/src/commands/start/tui/app.dart';
+import 'package:serverpod_cli/src/commands/start/tui/loading_screen.dart';
+import 'package:serverpod_cli/src/commands/start/tui/state.dart';
+import 'package:test/test.dart';
+
+Future<void> _sendCtrlC(NoctermTester tester) {
+  return tester.sendKeyEvent(
+    const KeyboardEvent(
+      logicalKey: LogicalKey.keyC,
+      modifiers: ModifierKeys(ctrl: true),
+    ),
+  );
+}
+
+void main() {
+  group('Given a loading screen mounted hidden', () {
+    late NoctermTester tester;
+
+    setUp(() async {
+      tester = await NoctermTester.create(size: const Size(80, 24));
+      await tester.pumpComponent(const LoadingScreen(visible: false));
+    });
+
+    tearDown(() {
+      tester.dispose();
+    });
+
+    // Ancestors that change their tree shape (e.g. the Ctrl-C hint row
+    // appearing) remount the loading screen. A fresh mount never observes
+    // the visible true->false transition, so it must hide on its own.
+    test('when rendered then the splash is not shown', () {
+      final screen = tester.renderToString(showBorders: false);
+
+      expect(screen.trim(), isEmpty);
+    });
+  });
+
+  group('Given a running TUI start app whose splash has been dismissed', () {
+    late NoctermTester tester;
+    late ServerWatchState state;
+    late StartAppStateHolder holder;
+
+    setUp(() async {
+      state = ServerWatchState();
+      state.showSplash = false;
+      holder = StartAppStateHolder(state);
+      tester = await NoctermTester.create(size: const Size(80, 24));
+      await tester.pumpComponent(
+        ServerpodWatchApp(holder: holder, onReady: (_) {}),
+      );
+    });
+
+    tearDown(() async {
+      tester.dispose();
+      await holder.dispose();
+    });
+
+    test('when rendered then the splash is not shown', () {
+      final screen = tester.renderToString(showBorders: false);
+
+      expect(screen, isNot(contains('Serverpod')));
+    });
+
+    test('when Ctrl-C arms exit then the splash does not reappear', () async {
+      await _sendCtrlC(tester);
+      await tester.pump();
+
+      final screen = tester.renderToString(showBorders: false);
+      expect(state.ctrlCHint, 'Press Ctrl-C again to exit');
+      expect(screen, isNot(contains('Serverpod')));
+    });
+  });
+}


### PR DESCRIPTION
In the `serverpod start` TUI, the splash banner dismissed correctly after startup, but pressing Ctrl+C made it reappear and stick on screen forever.

`LoadingScreen` only hid itself after observing a `visible: true → false` transition in `didUpdateComponent`, which arms the fade-out. When an ancestor changes its tree shape, nocterm remounts the whole subtree, and a freshly mounted `LoadingScreen(visible: false)` never sees that transition so its `build` rendered the splash at full opacity indefinitely. One trigger that would cause this is the Ctrl-C hint row appearing or disappearing.

This PR makes `LoadingScreen.build` return nothing whenever it is not visible and no fade-out is in flight, so the splash is robust against subtree remounts regardless of their origin. The normal startup fade-out behavior is unchanged. Includes regression tests that exercise the Ctrl-C remount path (verified to fail without the fix).

Fixed #5284 

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes
None