### PR TITLE
feat: Add IDE selection screen to quickstart command

### DIFF
--- a/tools/serverpod_cli/lib/src/commands/create.dart
+++ b/tools/serverpod_cli/lib/src/commands/create.dart
@@ -143,19 +143,6 @@ class CreateCommand extends ServerpodCommand<CreateOption> {
     final useTui = (interactive ?? true) && !ci.isCI;
 
     if (useTui && !template.isMini) {
-      // Dry run to collect early errors and exit if needed.
-      final dryRunProjectPath = await performCreate(
-        name,
-        force,
-        dryRun: true,
-        interactive: interactive,
-        context: context,
-      );
-
-      if (dryRunProjectPath == null) {
-        throw ExitException.error();
-      }
-
       await performCreateWithTui(
         name,
         force,

--- a/tools/serverpod_cli/lib/src/commands/create.dart
+++ b/tools/serverpod_cli/lib/src/commands/create.dart
@@ -1,18 +1,15 @@
 import 'package:ci/ci.dart' as ci;
 import 'package:cli_tools/cli_tools.dart';
 import 'package:config/config.dart';
-import 'package:serverpod_cli/src/commands/create/tui/app.dart';
+import 'package:serverpod_cli/src/commands/create/tui/runner.dart';
 import 'package:serverpod_cli/src/commands/create/tui/state.dart';
-import 'package:serverpod_cli/src/commands/create/tui/state_holder.dart';
 import 'package:serverpod_cli/src/create/create.dart';
 import 'package:serverpod_cli/src/create/ide.dart';
 import 'package:serverpod_cli/src/create/template_context.dart';
 import 'package:serverpod_cli/src/downloads/resource_manager.dart';
 import 'package:serverpod_cli/src/runner/serverpod_command.dart';
 import 'package:serverpod_cli/src/runner/serverpod_command_runner.dart';
-import 'package:serverpod_cli/src/util/command_line_tools.dart';
 import 'package:serverpod_cli/src/util/serverpod_cli_logger.dart';
-import 'package:serverpod_tui/serverpod_tui.dart';
 
 enum CreateOption<V> implements OptionDefinition<V> {
   force(
@@ -159,10 +156,10 @@ class CreateCommand extends ServerpodCommand<CreateOption> {
         throw ExitException.error();
       }
 
-      await _performCreateWithTui(
+      await performCreateWithTui(
         name,
-        template,
         force,
+        state: CreateConfigState(template),
         interactive: true,
       );
       return;
@@ -178,83 +175,5 @@ class CreateCommand extends ServerpodCommand<CreateOption> {
     if (projectPath == null) {
       throw ExitException.error();
     }
-  }
-
-  /// Shuts down TUI and closes the TuiLogWriter.
-  /// Initializes the default logger for post-tui logs.
-  Future<void> _shutdownTuiApp([int exitCode = 0]) async {
-    await closeLogger();
-    initializeLogger();
-    shutdownTuiApp(exitCode);
-  }
-
-  /// Flushes success logs if [projectPath] is not null.
-  /// Error logs are flushed if any.
-  /// This is done when shutting down TUI but before exiting
-  /// the Dart process.
-  Future<void> _preExit({
-    required ServerpodTemplateType template,
-    String? projectPath,
-  }) async {
-    CommandLineTools.flushErrors();
-    flushPerformCreateErrors();
-
-    if (projectPath != null) {
-      log.info(
-        'Serverpod project created.',
-        newParagraph: true,
-        type: TextLogType.success,
-      );
-
-      if (template.isServer) logStartInstructions(projectPath);
-      if (template.isMini) logMiniStartInstructions(projectPath);
-    }
-
-    await log.flush();
-  }
-
-  /// Creates Serverpod project with TUI.
-  Future<void> _performCreateWithTui(
-    String name,
-    ServerpodTemplateType template,
-    bool force, {
-    required bool? interactive,
-  }) async {
-    final state = CreateConfigState(template);
-    final holder = CreateAppStateHolder(state);
-
-    final tuiWriter = TuiLogWriter();
-    initializeLoggerWith(ServerpodCliLogger(tuiWriter));
-    tuiWriter.attach(holder);
-
-    String? projectPath;
-
-    final backend = ServerpodTerminalBackend(
-      preExit: () => _preExit(
-        template: state.template,
-        projectPath: projectPath,
-      ),
-    );
-
-    await runTuiApp(
-      backend: backend,
-      ServerpodCreateApp(
-        name: name,
-        holder: holder,
-        onCreate: () async {
-          projectPath = await performCreate(
-            name,
-            force,
-            interactive: interactive,
-            context: state.toTemplateContext(),
-          );
-
-          final success = projectPath != null;
-
-          await _shutdownTuiApp(success ? 0 : 1);
-        },
-        onQuit: () => _shutdownTuiApp(1),
-      ),
-    );
   }
 }

--- a/tools/serverpod_cli/lib/src/commands/create/tui/main_screen.dart
+++ b/tools/serverpod_cli/lib/src/commands/create/tui/main_screen.dart
@@ -85,7 +85,7 @@ class MainScreen extends StatelessComponent {
         Button(
           name: 'Create Project',
           activationChar: 'Enter',
-          enabled: !creatingProject,
+          enabled: !creatingProject && state.canCreate,
           activationKeys: const [LogicalKey.enter],
           onActivate: (_) {
             state.markCreatingProject();
@@ -149,7 +149,10 @@ class MainScreen extends StatelessComponent {
             onQuit.call();
           },
         ),
-        const Tip('Click to select'),
+        if (state.canCreate)
+          const Tip('Click to select')
+        else
+          const Tip('Select at least one IDE'),
       ],
     );
   }

--- a/tools/serverpod_cli/lib/src/commands/create/tui/runner.dart
+++ b/tools/serverpod_cli/lib/src/commands/create/tui/runner.dart
@@ -9,12 +9,28 @@ import 'package:serverpod_tui/serverpod_tui.dart';
 
 /// Creates a Serverpod project with the create TUI.
 /// The configurations exposed in the TUI form are determined by [state].
+///
+/// Performs a dry run before starting the TUI to collect early errors,
+/// throwing an [ExitException] if any are found.
 Future<void> performCreateWithTui(
   String name,
   bool force, {
   required CreateConfigState state,
   required bool? interactive,
 }) async {
+  // Dry run to collect early errors and exit if needed.
+  final dryRunProjectPath = await performCreate(
+    name,
+    force,
+    dryRun: true,
+    interactive: interactive,
+    context: state.toTemplateContext(),
+  );
+
+  if (dryRunProjectPath == null) {
+    throw ExitException.error();
+  }
+
   final holder = CreateAppStateHolder(state);
 
   final tuiWriter = TuiLogWriter();

--- a/tools/serverpod_cli/lib/src/commands/create/tui/runner.dart
+++ b/tools/serverpod_cli/lib/src/commands/create/tui/runner.dart
@@ -1,0 +1,86 @@
+import 'package:cli_tools/cli_tools.dart';
+import 'package:serverpod_cli/src/commands/create/tui/app.dart';
+import 'package:serverpod_cli/src/commands/create/tui/state.dart';
+import 'package:serverpod_cli/src/commands/create/tui/state_holder.dart';
+import 'package:serverpod_cli/src/create/create.dart';
+import 'package:serverpod_cli/src/util/command_line_tools.dart';
+import 'package:serverpod_cli/src/util/serverpod_cli_logger.dart';
+import 'package:serverpod_tui/serverpod_tui.dart';
+
+/// Creates a Serverpod project with the create TUI.
+/// The configurations exposed in the TUI form are determined by [state].
+Future<void> performCreateWithTui(
+  String name,
+  bool force, {
+  required CreateConfigState state,
+  required bool? interactive,
+}) async {
+  final holder = CreateAppStateHolder(state);
+
+  final tuiWriter = TuiLogWriter();
+  initializeLoggerWith(ServerpodCliLogger(tuiWriter));
+  tuiWriter.attach(holder);
+
+  String? projectPath;
+
+  final backend = ServerpodTerminalBackend(
+    preExit: () => _preExit(
+      template: state.template,
+      projectPath: projectPath,
+    ),
+  );
+
+  await runTuiApp(
+    backend: backend,
+    ServerpodCreateApp(
+      name: name,
+      holder: holder,
+      onCreate: () async {
+        projectPath = await performCreate(
+          name,
+          force,
+          interactive: interactive,
+          context: state.toTemplateContext(),
+        );
+
+        final success = projectPath != null;
+
+        await _shutdownTui(success ? 0 : 1);
+      },
+      onQuit: () => _shutdownTui(1),
+    ),
+  );
+}
+
+/// Shuts down TUI and closes the TuiLogWriter.
+/// Initializes the default logger for post-tui logs.
+Future<void> _shutdownTui([int exitCode = 0]) async {
+  await closeLogger();
+  initializeLogger();
+  shutdownTuiApp(exitCode);
+}
+
+/// Flushes success logs if [projectPath] is not null.
+/// Error logs are flushed if any.
+/// This is done when shutting down TUI but before exiting
+/// the Dart process.
+Future<void> _preExit({
+  required ServerpodTemplateType template,
+  String? projectPath,
+}) async {
+  CommandLineTools.flushErrors();
+  flushPerformCreateErrors();
+
+  if (projectPath != null) {
+    log.info(
+      'Serverpod project created.',
+      newParagraph: true,
+      type: TextLogType.success,
+    );
+
+    if (template.isServer) logStartInstructions(projectPath);
+    if (template.isMini) logMiniStartInstructions(projectPath);
+  }
+
+  await log.flush();
+}

--- a/tools/serverpod_cli/lib/src/commands/create/tui/state.dart
+++ b/tools/serverpod_cli/lib/src/commands/create/tui/state.dart
@@ -5,16 +5,35 @@ import 'package:serverpod_tui/serverpod_tui.dart';
 
 /// Central state for [ServerpodCreateApp] rendered by nocterm.
 class CreateConfigState extends TuiState {
-  CreateConfigState(this.startingTemplate) {
-    form.updateSelectedOption(
-      ServerpodCreateConfig.template,
-      startingTemplate.toConfigOption,
-    );
+  CreateConfigState(
+    this.startingTemplate, {
+    this.configs = ServerpodCreateConfig.values,
+    TemplateContext? defaults,
+    this.requireIde = false,
+  }) : defaults = defaults ?? TemplateContext() {
+    if (configs.contains(ServerpodCreateConfig.template)) {
+      form.updateSelectedOption(
+        ServerpodCreateConfig.template,
+        startingTemplate.toConfigOption,
+      );
+    }
   }
 
   final ServerpodTemplateType startingTemplate;
 
-  late final form = FormState(ServerpodCreateConfig.values);
+  /// The configurations exposed in the form.
+  final List<ServerpodCreateConfig> configs;
+
+  /// Fallback values for configurations not exposed in the form.
+  /// Configurations hidden by an unsatisfied [FormRequirement] are
+  /// not affected and resolve from the form as usual.
+  final TemplateContext defaults;
+
+  /// Whether at least one IDE must be selected
+  /// before the project can be created.
+  final bool requireIde;
+
+  late final form = FormState(configs);
 
   bool _creatingProject = false;
   bool get creatingProject => _creatingProject;
@@ -29,6 +48,14 @@ class CreateConfigState extends TuiState {
       form.getSelectedOptionFor(ServerpodCreateConfig.template)?.toTemplate ??
       startingTemplate;
 
+  /// True when all required selections are made
+  /// and the project can be created.
+  bool get canCreate {
+    if (!requireIde) return true;
+    final selectedIdes = form.getSelectedOptionsFor(ServerpodCreateConfig.ide);
+    return selectedIdes != null && selectedIdes.isNotEmpty;
+  }
+
   /// Called when project creation starts.
   /// This transitions the UI to a log viewer.
   void markCreatingProject() {
@@ -42,27 +69,43 @@ class CreateConfigState extends TuiState {
 
     return TemplateContext(
       template: template,
-      auth: form.isOptionSelectedForConfig(
+      auth: _isOptionSelected(
         ServerpodCreateConfig.auth,
         BoolFormConfigOption.enabled,
+        fallback: defaults.auth,
       ),
-      redis: form.isOptionSelectedForConfig(
+      redis: _isOptionSelected(
         ServerpodCreateConfig.redis,
         BoolFormConfigOption.enabled,
+        fallback: defaults.redis,
       ),
-      postgres: form.isOptionSelectedForConfig(
+      postgres: _isOptionSelected(
         ServerpodCreateConfig.database,
         DatabaseConfigOption.postgres,
+        fallback: defaults.postgres,
       ),
-      sqlite: form.isOptionSelectedForConfig(
+      sqlite: _isOptionSelected(
         ServerpodCreateConfig.database,
         DatabaseConfigOption.sqlite,
+        fallback: defaults.sqlite,
       ),
-      web: form.isOptionSelectedForConfig(
+      web: _isOptionSelected(
         ServerpodCreateConfig.web,
         BoolFormConfigOption.enabled,
+        fallback: defaults.web,
       ),
       ides: selectedIdes.toTemplateIdes,
     );
+  }
+
+  /// Returns whether [option] is selected for [config] in the form,
+  /// or [fallback] if [config] is not exposed in the form at all.
+  bool _isOptionSelected<T extends FormConfigOption>(
+    ServerpodCreateConfig<T> config,
+    T option, {
+    required bool fallback,
+  }) {
+    if (!configs.contains(config)) return fallback;
+    return form.isOptionSelectedForConfig(config, option);
   }
 }

--- a/tools/serverpod_cli/lib/src/commands/quickstart.dart
+++ b/tools/serverpod_cli/lib/src/commands/quickstart.dart
@@ -124,6 +124,7 @@ class QuickstartCommand extends ServerpodCommand<QuickstartOption> {
     final context = TemplateContext(
       template: template,
       auth: true,
+      redis: true,
       postgres: true,
       web: true,
       ides: [TemplateIde.claude, TemplateIde.cursor, TemplateIde.vscode],
@@ -138,7 +139,12 @@ class QuickstartCommand extends ServerpodCommand<QuickstartOption> {
         state: CreateConfigState(
           template,
           configs: const [ServerpodCreateConfig.ide],
-          defaults: TemplateContext(auth: true, postgres: true, web: true),
+          defaults: TemplateContext(
+            auth: true,
+            redis: true,
+            postgres: true,
+            web: true,
+          ),
           requireIde: true,
         ),
         interactive: true,

--- a/tools/serverpod_cli/lib/src/commands/quickstart.dart
+++ b/tools/serverpod_cli/lib/src/commands/quickstart.dart
@@ -123,6 +123,7 @@ class QuickstartCommand extends ServerpodCommand<QuickstartOption> {
 
     final context = TemplateContext(
       template: template,
+      auth: true,
       postgres: true,
       web: true,
       ides: [TemplateIde.claude, TemplateIde.cursor, TemplateIde.vscode],
@@ -131,26 +132,13 @@ class QuickstartCommand extends ServerpodCommand<QuickstartOption> {
     final useTui = (interactive ?? true) && !ci.isCI;
 
     if (useTui) {
-      // Dry run to collect early errors and exit if needed.
-      final dryRunProjectPath = await performCreate(
-        name,
-        force,
-        dryRun: true,
-        interactive: interactive,
-        context: context,
-      );
-
-      if (dryRunProjectPath == null) {
-        throw ExitException.error();
-      }
-
       await performCreateWithTui(
         name,
         force,
         state: CreateConfigState(
           template,
           configs: const [ServerpodCreateConfig.ide],
-          defaults: TemplateContext(postgres: true, web: true),
+          defaults: TemplateContext(auth: true, postgres: true, web: true),
           requireIde: true,
         ),
         interactive: true,

--- a/tools/serverpod_cli/lib/src/commands/quickstart.dart
+++ b/tools/serverpod_cli/lib/src/commands/quickstart.dart
@@ -1,5 +1,9 @@
+import 'package:ci/ci.dart' as ci;
 import 'package:cli_tools/cli_tools.dart';
 import 'package:config/config.dart';
+import 'package:serverpod_cli/src/commands/create/tui/config.dart';
+import 'package:serverpod_cli/src/commands/create/tui/runner.dart';
+import 'package:serverpod_cli/src/commands/create/tui/state.dart';
 import 'package:serverpod_cli/src/create/create.dart';
 import 'package:serverpod_cli/src/create/ide.dart';
 import 'package:serverpod_cli/src/create/template_context.dart';
@@ -117,16 +121,48 @@ class QuickstartCommand extends ServerpodCommand<QuickstartOption> {
       }
     }
 
+    final context = TemplateContext(
+      template: template,
+      postgres: true,
+      web: true,
+      ides: [TemplateIde.claude, TemplateIde.cursor, TemplateIde.vscode],
+    );
+
+    final useTui = (interactive ?? true) && !ci.isCI;
+
+    if (useTui) {
+      // Dry run to collect early errors and exit if needed.
+      final dryRunProjectPath = await performCreate(
+        name,
+        force,
+        dryRun: true,
+        interactive: interactive,
+        context: context,
+      );
+
+      if (dryRunProjectPath == null) {
+        throw ExitException.error();
+      }
+
+      await performCreateWithTui(
+        name,
+        force,
+        state: CreateConfigState(
+          template,
+          configs: const [ServerpodCreateConfig.ide],
+          defaults: TemplateContext(postgres: true, web: true),
+          requireIde: true,
+        ),
+        interactive: true,
+      );
+      return;
+    }
+
     final projectPath = await performCreate(
       name,
       force,
       interactive: interactive,
-      context: TemplateContext(
-        template: template,
-        postgres: true,
-        web: true,
-        ides: [TemplateIde.claude, TemplateIde.cursor, TemplateIde.vscode],
-      ),
+      context: context,
     );
 
     if (projectPath == null) {

--- a/tools/serverpod_cli/test/commands/create/tui/state_test.dart
+++ b/tools/serverpod_cli/test/commands/create/tui/state_test.dart
@@ -144,8 +144,7 @@ void main() {
   );
 
   group(
-    'Given a CreateConfigState exposing only the ide config '
-    'with default values for the other configs, '
+    'Given a CreateConfigState exposing only the ide config with default values for the other configs, '
     'when converting to template context',
     () {
       late CreateConfigState state;
@@ -159,8 +158,7 @@ void main() {
       });
 
       test(
-        'then TemplateContext has the default values '
-        'for configs not exposed in the form',
+        'then TemplateContext has the default values for configs not exposed in the form',
         () {
           final context = state.toTemplateContext();
           expect(context.postgres, isTrue);
@@ -179,14 +177,29 @@ void main() {
         },
       );
 
-      test(
-        'and ides are selected then TemplateContext contains ides',
-        () {
-          state.form.updateSelectedOption(
-            ServerpodCreateConfig.ide,
-            IdeOption.claude,
-          );
+    },
+  );
 
+  group(
+    'Given a CreateConfigState exposing only the ide config with an ide selected, '
+    'when converting to template context',
+    () {
+      late CreateConfigState state;
+
+      setUp(() {
+        state = CreateConfigState(
+          ServerpodTemplateType.server,
+          configs: const [ServerpodCreateConfig.ide],
+        );
+        state.form.updateSelectedOption(
+          ServerpodCreateConfig.ide,
+          IdeOption.claude,
+        );
+      });
+
+      test(
+        'then TemplateContext contains the selected ide',
+        () {
           final context = state.toTemplateContext();
           expect(context.ides, [TemplateIde.claude]);
         },

--- a/tools/serverpod_cli/test/commands/create/tui/state_test.dart
+++ b/tools/serverpod_cli/test/commands/create/tui/state_test.dart
@@ -176,7 +176,6 @@ void main() {
           expect(context.template, ServerpodTemplateType.server);
         },
       );
-
     },
   );
 

--- a/tools/serverpod_cli/test/commands/create/tui/state_test.dart
+++ b/tools/serverpod_cli/test/commands/create/tui/state_test.dart
@@ -2,6 +2,7 @@ import 'package:serverpod_cli/src/commands/create/tui/config.dart';
 import 'package:serverpod_cli/src/commands/create/tui/state.dart';
 import 'package:serverpod_cli/src/create/create.dart';
 import 'package:serverpod_cli/src/create/ide.dart';
+import 'package:serverpod_cli/src/create/template_context.dart';
 import 'package:serverpod_tui/serverpod_tui.dart';
 import 'package:test/test.dart';
 
@@ -137,6 +138,156 @@ void main() {
             context.ides,
             containsAll([TemplateIde.antigravity, TemplateIde.vscode]),
           );
+        },
+      );
+    },
+  );
+
+  group(
+    'Given a CreateConfigState exposing only the ide config '
+    'with default values for the other configs, '
+    'when converting to template context',
+    () {
+      late CreateConfigState state;
+
+      setUp(() {
+        state = CreateConfigState(
+          ServerpodTemplateType.server,
+          configs: const [ServerpodCreateConfig.ide],
+          defaults: TemplateContext(postgres: true, web: true),
+        );
+      });
+
+      test(
+        'then TemplateContext has the default values '
+        'for configs not exposed in the form',
+        () {
+          final context = state.toTemplateContext();
+          expect(context.postgres, isTrue);
+          expect(context.web, isTrue);
+          expect(context.auth, isFalse);
+          expect(context.redis, isFalse);
+          expect(context.sqlite, isFalse);
+        },
+      );
+
+      test(
+        'then TemplateContext has the starting template',
+        () {
+          final context = state.toTemplateContext();
+          expect(context.template, ServerpodTemplateType.server);
+        },
+      );
+
+      test(
+        'and ides are selected then TemplateContext contains ides',
+        () {
+          state.form.updateSelectedOption(
+            ServerpodCreateConfig.ide,
+            IdeOption.claude,
+          );
+
+          final context = state.toTemplateContext();
+          expect(context.ides, [TemplateIde.claude]);
+        },
+      );
+    },
+  );
+
+  group(
+    'Given a CreateConfigState with all configs '
+    'and default values for the constrainable configs, '
+    'when a config is hidden by an unsatisfied requirement',
+    () {
+      late CreateConfigState state;
+
+      setUp(() {
+        state = CreateConfigState(
+          ServerpodTemplateType.server,
+          defaults: TemplateContext(auth: true, web: true),
+        );
+        state.form.updateSelectedOption(
+          ServerpodCreateConfig.template,
+          TemplateTypeOption.module,
+        );
+      });
+
+      test(
+        'then TemplateContext resolves the hidden config from the form '
+        'and not from the default values',
+        () {
+          final context = state.toTemplateContext();
+          expect(context.web, isFalse);
+          expect(context.auth, isFalse);
+        },
+      );
+    },
+  );
+
+  group(
+    'Given a CreateConfigState that requires an ide selection',
+    () {
+      late CreateConfigState state;
+
+      setUp(() {
+        state = CreateConfigState(
+          ServerpodTemplateType.server,
+          configs: const [ServerpodCreateConfig.ide],
+          requireIde: true,
+        );
+      });
+
+      test(
+        'when no ide is selected then the project can not be created',
+        () {
+          expect(state.canCreate, isFalse);
+        },
+      );
+
+      test(
+        'when an ide is selected then the project can be created',
+        () {
+          state.form.updateSelectedOption(
+            ServerpodCreateConfig.ide,
+            IdeOption.vsCode,
+          );
+
+          expect(state.canCreate, isTrue);
+        },
+      );
+
+      test(
+        'when the only selected ide is deselected '
+        'then the project can not be created',
+        () {
+          state.form.updateSelectedOption(
+            ServerpodCreateConfig.ide,
+            IdeOption.vsCode,
+          );
+          state.form.updateSelectedOption(
+            ServerpodCreateConfig.ide,
+            IdeOption.vsCode,
+          );
+
+          expect(state.canCreate, isFalse);
+        },
+      );
+    },
+  );
+
+  group(
+    'Given a CreateConfigState that does not require an ide selection',
+    () {
+      late CreateConfigState state;
+
+      setUp(() {
+        state = CreateConfigState(ServerpodTemplateType.server);
+      });
+
+      test(
+        'when no ide is selected then the project can be created',
+        () {
+          expect(state.canCreate, isTrue);
         },
       );
     },


### PR DESCRIPTION
This PR reuses the `create` command's TUI for `quickstart`, exposing only the IDEs row. The selection starts empty and at least one IDE must be selected before the project can be created.

- `CreateConfigState` now accepts the set of configs to expose, fallback values for configs not shown in the form
- The TUI launch plumbing is extracted from `CreateCommand` into a shared `performCreateWithTui()` used by both commands.
- In non-interactive runs (`--no-interactive` or CI), where no selection screen is possible, `quickstart` keeps its previous behavior including the default IDE set.

Fixes #5216 

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes
None