### PR TITLE
feat: Show only Hot restart action in the TUI when watch mode is enabled

### DIFF
--- a/tools/serverpod_cli/lib/src/commands/start.dart
+++ b/tools/serverpod_cli/lib/src/commands/start.dart
@@ -1017,7 +1017,9 @@ Future<int> _runWithTui({
   required List<String> serverArgs,
   required GeneratorConfig config,
 }) async {
-  final holder = StartAppStateHolder(ServerWatchState());
+  final holder = StartAppStateHolder(
+    ServerWatchState()..watchModeEnabled = watch,
+  );
   var backendStarted = false;
 
   // Shared shutdown signal

--- a/tools/serverpod_cli/lib/src/commands/start/tui/app.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/tui/app.dart
@@ -252,7 +252,7 @@ class ServerpodWatchAppState extends TuiAppState<ServerpodWatchApp> {
     // or launch it if it isn't running yet (e.g. after a `--no-flutter` start).
     // Handled here rather than as a ButtonBar entry because the Button widget
     // matches only plain/Shift keys. Always consumed so it never falls through
-    // to the plain-R hot reload.
+    // to the plain-R hot reload / restart.
     if (event.logicalKey == LogicalKey.keyR && event.isControlPressed) {
       if (state.showFlutterOutput || state.flutterRestartAvailable) {
         onRestartFlutterApp?.call();

--- a/tools/serverpod_cli/lib/src/commands/start/tui/main_screen.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/tui/main_screen.dart
@@ -46,7 +46,7 @@ class MainScreen extends StatelessComponent {
   final VoidCallback? onClearLogs;
   final VoidCallback? onQuit;
 
-  static const _helpBindings = [
+  List<(String, List<(String, String)>)> get _helpBindings => [
     (
       'Navigation',
       [
@@ -74,7 +74,10 @@ class MainScreen extends StatelessComponent {
     (
       'Actions',
       [
-        ('R / Shift+R', 'Hot reload / restart'),
+        if (state.watchModeEnabled)
+          ('R', 'Hot restart')
+        else
+          ('R / Shift+R', 'Hot reload / restart'),
         ('Ctrl+R', 'Start / restart Flutter app'),
         ('M / Shift+M', 'Create migration (⇧ = force)'),
         ('P / Shift+P', 'Repair migration (⇧ = force)'),
@@ -388,14 +391,27 @@ class MainScreen extends StatelessComponent {
 
     return ButtonBar(
       buttons: [
-        Button(
-          name: 'Hot reload / restart',
-          activationChar: 'R',
-          activationKeys: const [LogicalKey.keyR],
-          onActivate: (_) => onHotReload?.call(),
-          onShiftActivate: (_) => onHotRestart?.call(),
-          enabled: actionsEnabled && onHotReload != null,
-        ),
+        // In watch mode the incremental compiler already hot reloads on file
+        // changes, so the manual action is a hot restart (with no shift
+        // variant, Shift+R restarts too). Without watch, R hot reloads and
+        // Shift+R hot restarts.
+        if (state.watchModeEnabled)
+          Button(
+            name: 'Hot restart',
+            activationChar: 'R',
+            activationKeys: const [LogicalKey.keyR],
+            onActivate: (_) => onHotRestart?.call(),
+            enabled: actionsEnabled && onHotRestart != null,
+          )
+        else
+          Button(
+            name: 'Hot reload / restart',
+            activationChar: 'R',
+            activationKeys: const [LogicalKey.keyR],
+            onActivate: (_) => onHotReload?.call(),
+            onShiftActivate: (_) => onHotRestart?.call(),
+            enabled: actionsEnabled && onHotReload != null,
+          ),
         Button(
           name: 'Create migration',
           activationChar: 'M',

--- a/tools/serverpod_cli/lib/src/commands/start/tui/state.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/tui/state.dart
@@ -40,6 +40,12 @@ class ServerWatchState extends TuiState {
   /// Whether a tracked action (hot reload, migration) is in progress.
   bool actionBusy = false;
 
+  /// Whether the server runs in watch mode (incremental compilation with
+  /// automatic hot reload on file changes). Swaps the manual
+  /// `Hot reload / restart` button for a plain `Hot restart`, since reloads
+  /// are already handled by the incremental compiler.
+  bool watchModeEnabled = false;
+
   /// Whether the server is running and ready for actions.
   bool serverReady = false;
 

--- a/tools/serverpod_cli/test/commands/start/tui/app_test.dart
+++ b/tools/serverpod_cli/test/commands/start/tui/app_test.dart
@@ -26,6 +26,15 @@ Future<void> _sendCtrlR(NoctermTester tester) {
   );
 }
 
+Future<void> _sendShiftR(NoctermTester tester) {
+  return tester.sendKeyEvent(
+    const KeyboardEvent(
+      logicalKey: LogicalKey.keyR,
+      modifiers: ModifierKeys(shift: true),
+    ),
+  );
+}
+
 void main() {
   late NoctermTester tester;
   late ServerWatchState state;
@@ -213,6 +222,77 @@ void main() {
         expect(restartCalls, 0);
       },
     );
+  });
+
+  group('Given a ready TUI start app in watch mode', () {
+    late int reloadCalls;
+    late int restartCalls;
+
+    setUp(() async {
+      reloadCalls = 0;
+      restartCalls = 0;
+      // Hot reload and hot restart callbacks wired so the button is enabled.
+      holder.onHotReload = () => reloadCalls++;
+      holder.onHotRestart = () => restartCalls++;
+      state.watchModeEnabled = true;
+      state.serverReady = true;
+      state.showSplash = false;
+      // Rebuild so the button bar picks up the enabled state.
+      holder.widgetState?.rebuild();
+      await tester.pump();
+    });
+
+    test(
+      'when R is pressed then hot restart is invoked instead of hot reload',
+      () async {
+        await _sendKey(tester, LogicalKey.keyR);
+
+        expect(restartCalls, 1);
+        expect(reloadCalls, 0);
+      },
+    );
+
+    test('when Shift+R is pressed then hot restart is invoked', () async {
+      await _sendShiftR(tester);
+
+      expect(restartCalls, 1);
+      expect(reloadCalls, 0);
+    });
+  });
+
+  group('Given a ready TUI start app without watch mode', () {
+    late int reloadCalls;
+    late int restartCalls;
+
+    setUp(() async {
+      reloadCalls = 0;
+      restartCalls = 0;
+      // Hot reload and hot restart callbacks wired so the button is enabled.
+      holder.onHotReload = () => reloadCalls++;
+      holder.onHotRestart = () => restartCalls++;
+      state.serverReady = true;
+      state.showSplash = false;
+      // Rebuild so the button bar picks up the enabled state.
+      holder.widgetState?.rebuild();
+      await tester.pump();
+    });
+
+    test(
+      'when R is pressed then hot reload is invoked instead of hot restart',
+      () async {
+        await _sendKey(tester, LogicalKey.keyR);
+
+        expect(reloadCalls, 1);
+        expect(restartCalls, 0);
+      },
+    );
+
+    test('when Shift+R is pressed then hot restart is invoked', () async {
+      await _sendShiftR(tester);
+
+      expect(restartCalls, 1);
+      expect(reloadCalls, 0);
+    });
   });
 
   group('Given a running TUI start app with the help overlay open', () {


### PR DESCRIPTION
When running `serverpod start` in watch mode (the default), hot reload is already handled automatically by the incremental compiler on every file change.

With this change, in watch mode the button bar shows `R Hot restart`, plain `R` triggers a hot restart, and the help overlay lists `R → Hot restart`. `Shift+R` also still triggers a hot restart, so existing muscle memory keeps working. When running with `--no-watch`, the previous behavior is unchanged: `R` hot reloads and `Shift+R` hot restarts.


Fixes #5166 

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes
None