### PR TITLE
fix: Ignore unknown command line flags instead of resetting all flags to defaults

### DIFF
--- a/packages/serverpod/lib/src/server/command_line_args.dart
+++ b/packages/serverpod/lib/src/server/command_line_args.dart
@@ -47,41 +47,9 @@ class CommandLineArgs {
   /// [CommandLineArgs] object. Parse failures are reported through the
   /// global [log].
   CommandLineArgs(List<String> args) {
+    var argParser = _buildArgParser();
     try {
-      var argParser = ArgParser()
-        ..addOption(
-          'mode',
-          abbr: 'm',
-          allowed: [
-            ServerpodRunMode.development,
-            ServerpodRunMode.test,
-            ServerpodRunMode.staging,
-            ServerpodRunMode.production,
-          ],
-        )
-        ..addOption(
-          'server-id',
-          abbr: 'i',
-        )
-        ..addOption(
-          'logging',
-          abbr: 'l',
-          allowed: ['normal', 'verbose'],
-        )
-        ..addOption(
-          'role',
-          abbr: 'r',
-          allowed: ['monolith', 'serverless', 'maintenance'],
-        )
-        ..addFlag(
-          'apply-migrations',
-          abbr: 'a',
-        )
-        ..addFlag(
-          'apply-repair-migration',
-          abbr: 'A',
-        );
-      var results = argParser.parse(args);
+      var results = argParser.parse(_filterUnknownArguments(args, argParser));
 
       _runMode = results['mode'];
       _serverId = results['server-id'];
@@ -116,6 +84,130 @@ class CommandLineArgs {
       _applyMigrations = null;
       _applyRepairMigration = null;
     }
+  }
+
+  /// Builds the [ArgParser] describing Serverpod's own command line options.
+  static ArgParser _buildArgParser() => ArgParser()
+    ..addOption(
+      'mode',
+      abbr: 'm',
+      allowed: [
+        ServerpodRunMode.development,
+        ServerpodRunMode.test,
+        ServerpodRunMode.staging,
+        ServerpodRunMode.production,
+      ],
+    )
+    ..addOption(
+      'server-id',
+      abbr: 'i',
+    )
+    ..addOption(
+      'logging',
+      abbr: 'l',
+      allowed: ['normal', 'verbose'],
+    )
+    ..addOption(
+      'role',
+      abbr: 'r',
+      allowed: ['monolith', 'serverless', 'maintenance'],
+    )
+    ..addFlag(
+      'apply-migrations',
+      abbr: 'a',
+    )
+    ..addFlag(
+      'apply-repair-migration',
+      abbr: 'A',
+    );
+
+  /// Removes unknown options and flags from [args] so that Serverpod's own
+  /// flags are still parsed when a user also passes custom flags (issue #2396).
+  ///
+  /// Classification is driven entirely by the options declared on [parser]
+  /// (via [ArgParser.options] and [ArgParser.findByAbbreviation]), so this needs
+  /// no maintenance when new Serverpod flags are added. Only tokens that the
+  /// parser would reject as *unknown options* are dropped (each is logged as a
+  /// warning). Invalid *values* of known options are left untouched so that
+  /// [ArgParser.parse] still reports them, preserving existing behavior.
+  ///
+  /// The value of a known option provided in space-separated form (e.g.
+  /// `--mode production`) is always kept, mirroring [ArgParser] semantics — a
+  /// known option's value is never stripped, even if it looks like a flag.
+  static List<String> _filterUnknownArguments(
+    List<String> args,
+    ArgParser parser,
+  ) {
+    var kept = <String>[];
+    var i = 0;
+    while (i < args.length) {
+      var arg = args[i];
+
+      // The '--' terminator ends option parsing. Serverpod takes no positional
+      // arguments, so drop the terminator and everything after it.
+      if (arg == '--') break;
+
+      if (arg.startsWith('--')) {
+        var body = arg.substring(2);
+        var equalsIndex = body.indexOf('=');
+        var hasInlineValue = equalsIndex >= 0;
+        var name = hasInlineValue ? body.substring(0, equalsIndex) : body;
+
+        var option = parser.options[name];
+        // Allow negated flags, e.g. `--no-apply-migrations`.
+        if (option == null && name.startsWith('no-')) {
+          var positive = parser.options[name.substring('no-'.length)];
+          if (positive != null &&
+              positive.isFlag &&
+              (positive.negatable ?? true)) {
+            option = positive;
+          }
+        }
+
+        if (option != null) {
+          kept.add(arg);
+          // A value option given as `--name value` consumes the next token as
+          // its value; keep it verbatim so it is never mistaken for a flag.
+          if (!option.isFlag && !hasInlineValue && i + 1 < args.length) {
+            kept.add(args[i + 1]);
+            i += 2;
+            continue;
+          }
+          i++;
+          continue;
+        }
+
+        log.warning('Ignoring unknown command line argument: $arg');
+        i++;
+        continue;
+      }
+
+      if (arg.startsWith('-') && arg.length >= 2) {
+        // Abbreviated option or flag. The first character decides; clustering
+        // that mixes known and unknown abbreviations is an unused form and is
+        // left to fall through to the parser's error handling.
+        var option = parser.findByAbbreviation(arg[1]);
+        if (option != null) {
+          kept.add(arg);
+          if (!option.isFlag && arg.length == 2 && i + 1 < args.length) {
+            kept.add(args[i + 1]);
+            i += 2;
+            continue;
+          }
+          i++;
+          continue;
+        }
+
+        log.warning('Ignoring unknown command line argument: $arg');
+        i++;
+        continue;
+      }
+
+      // A bare token that was not consumed as a known option's value. Serverpod
+      // has no positional arguments, so drop it.
+      i++;
+    }
+    return kept;
   }
 
   /// Returns the raw value for a given command line argument key.

--- a/packages/serverpod/test/server/command_line_args_test.dart
+++ b/packages/serverpod/test/server/command_line_args_test.dart
@@ -1,5 +1,6 @@
 import 'package:serverpod/src/server/command_line_args.dart';
 import 'package:serverpod/src/server/run_mode.dart';
+import 'package:serverpod_shared/log.dart';
 import 'package:serverpod_shared/serverpod_shared.dart';
 import 'package:test/test.dart';
 
@@ -374,5 +375,159 @@ void main() {
       final args3 = CommandLineArgs(['--role', 'maintenance']);
       expect(args3.role, equals(ServerpodRole.maintenance));
     });
+  });
+
+  group('Given an unknown custom flag alongside a known flag', () {
+    test(
+      'when provided in --key=value form then the known flag is still parsed',
+      () {
+        // The exact scenario from issue #2396.
+        final args = CommandLineArgs(['--mode=production', '--myCustomFlag']);
+        expect(args.runMode, equals(ServerpodRunMode.production));
+        expect(args.serverId, equals('default'));
+        expect(args.role, equals(ServerpodRole.monolith));
+        expect(args.loggingMode, equals(ServerpodLoggingMode.normal));
+      },
+    );
+
+    test(
+      'when provided in --key value form then the known flag is still parsed',
+      () {
+        final args = CommandLineArgs([
+          '--mode',
+          'production',
+          '--myCustomFlag',
+        ]);
+        expect(args.runMode, equals(ServerpodRunMode.production));
+      },
+    );
+
+    test('when the unknown flag comes first then the known flag is parsed', () {
+      final args = CommandLineArgs(['--myCustomFlag', '--mode', 'production']);
+      expect(args.runMode, equals(ServerpodRunMode.production));
+    });
+
+    test('when interleaved with multiple known flags then all are parsed', () {
+      final args = CommandLineArgs([
+        '--mode',
+        'production',
+        '--customA',
+        '--server-id',
+        'srv-1',
+        '--customB',
+      ]);
+      expect(args.runMode, equals(ServerpodRunMode.production));
+      expect(args.serverId, equals('srv-1'));
+    });
+
+    test(
+      'when the unknown option uses --key=value form then it is ignored',
+      () {
+        final args = CommandLineArgs([
+          '--customOpt=foo',
+          '--mode',
+          'production',
+        ]);
+        expect(args.runMode, equals(ServerpodRunMode.production));
+      },
+    );
+
+    test('when the unknown option is an abbreviation then it is ignored', () {
+      final args = CommandLineArgs(['-x', '--mode', 'staging']);
+      expect(args.runMode, equals(ServerpodRunMode.staging));
+    });
+
+    test('when a known abbreviation accompanies an unknown one then it is '
+        'parsed', () {
+      final args = CommandLineArgs(['-m', 'staging', '-x']);
+      expect(args.runMode, equals(ServerpodRunMode.staging));
+    });
+
+    test('when a negatable known flag accompanies an unknown flag then it is '
+        'parsed', () {
+      final args = CommandLineArgs([
+        '--mode',
+        'production',
+        '--no-apply-migrations',
+        '--myCustomFlag',
+      ]);
+      expect(args.runMode, equals(ServerpodRunMode.production));
+      // wasParsed -> getRaw is non-null false, proving the flag was kept, not
+      // dropped as unknown (a dropped flag would yield null).
+      expect(args.getRaw<bool>(CliArgsConstants.applyMigrations), isFalse);
+      expect(args.applyMigrations, isFalse);
+    });
+
+    test(
+      'when stopping at the -- terminator then later tokens are ignored',
+      () {
+        final args = CommandLineArgs([
+          '--mode',
+          'production',
+          '--',
+          '--anything',
+          'here',
+        ]);
+        expect(args.runMode, equals(ServerpodRunMode.production));
+      },
+    );
+
+    test('when the same known flag is repeated then the last value wins', () {
+      final args = CommandLineArgs([
+        '--mode',
+        'staging',
+        '--customX',
+        '--mode',
+        'production',
+      ]);
+      expect(args.runMode, equals(ServerpodRunMode.production));
+    });
+  });
+
+  group('Given a known value option whose value looks like a flag', () {
+    test('when the value follows the option then it is never stripped', () {
+      // Mirrors ArgParser semantics: the token after a value option is its
+      // value, even when it looks like an unknown flag.
+      final args = CommandLineArgs(['--server-id', '--myCustomFlag']);
+      expect(args.serverId, equals('--myCustomFlag'));
+      expect(args.runMode, equals(ServerpodRunMode.development));
+    });
+  });
+
+  group('Given a known value option immediately followed by a custom flag '
+      '(known limitation)', () {
+    test('when no value is provided then all values fall back to defaults', () {
+      // --myCustomFlag is consumed as --mode's value, which is not allowed, so
+      // parsing fails and falls back. argv carries no arity info to recover the
+      // intent; this matches ArgParser semantics and is an accepted limitation.
+      final args = CommandLineArgs(['--mode', '--myCustomFlag']);
+      expect(args.runMode, equals(ServerpodRunMode.development));
+    });
+  });
+
+  group('Given an unknown flag that is ignored', () {
+    test(
+      'when parsing then a warning is logged for the ignored flag',
+      () async {
+        await log
+            .flush(); // Drain any warnings still in flight from prior tests.
+        final testWriter = TestLogWriter();
+        logWriter.add(testWriter);
+        try {
+          CommandLineArgs(['--mode', 'production', '--myCustomFlag']);
+          await log.flush();
+          expect(
+            testWriter.entries.any(
+              (e) =>
+                  e.level == LogLevel.warning &&
+                  e.message.contains('--myCustomFlag'),
+            ),
+            isTrue,
+          );
+        } finally {
+          logWriter.remove(testWriter);
+        }
+      },
+    );
   });
 }


### PR DESCRIPTION
## Summary

Serverpod silently ignored **all** of its own command line flags whenever an unknown/custom flag was also present, falling back to default values for everything (most importantly, starting in `development` mode).

`CommandLineArgs` builds an `ArgParser` and calls `argParser.parse(args)` inside a `try`. The `args` package throws an `ArgParserException` on the *first* unrecognized option, and the surrounding `catch (e)` block resets **every** parsed field to `null` — so a single custom flag discards the successfully-recognized `--mode`, `--server-id`, `--role`, etc.

This PR filters out unknown options/flags **before** parsing, so Serverpod's own flags are still parsed when custom flags are present. Classification is driven entirely by the options declared on the `ArgParser` (`parser.options` / `parser.findByAbbreviation`), so no known-flag list is duplicated and the filter needs no maintenance when new flags are added. Each ignored flag is logged as a warning so typos aren't silently swallowed.

## Steps to reproduce

```bash
# In any Serverpod server package:
dart bin/main.dart --mode=production --myCustomFlag
```

**Before this fix:** the server starts in **development** mode — the unknown `--myCustomFlag` makes `ArgParser.parse` throw, and every flag (including `--mode=production`) is reset to its default.

**After this fix:** the server starts in **production** mode. `--myCustomFlag` is ignored (with a warning logged: `Ignoring unknown command line argument: --myCustomFlag`), and `--mode=production` is respected.

Minimal unit-level reproduction (matches the added test):

```dart
// Before: development   After: production
final args = CommandLineArgs(['--mode=production', '--myCustomFlag']);
print(args.runMode);
```

## What changed

- **`packages/serverpod/lib/src/server/command_line_args.dart`**
  - Extracted the parser definition into `_buildArgParser()` so its metadata is available before parsing.
  - Added `_filterUnknownArguments(args, parser)`: a single order-preserving pass that drops only tokens the parser would reject as *unknown options* (handling `--name`, `--name=value`, `--name value`, `-x` abbreviations, `--no-<flag>` negations, and the `--` terminator). A known value-option's value is never stripped, mirroring `ArgParser` semantics.
- **`packages/serverpod/test/server/command_line_args_test.dart`** — 13 new tests covering the issue scenario and edge cases; all 24 existing tests are unchanged and still pass.
- **`CHANGELOG.md`** / **`packages/serverpod/CHANGELOG.md`** — added a `fix:` entry.

## Scope

Intentionally limited to the reported problem — **unknown options**. Invalid *values* of known options (e.g. `--logging=bogus`) keep their current all-default fallback behavior, which is asserted by existing tests; changing that is a separate concern and out of scope here.

## Issues fixed

Fixes #2396.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else.
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

## Breaking changes

No public API changes. One behavioral change worth noting for release notes: an unrecognized command line argument (including a typo of a Serverpod flag, e.g. `--mod=production`) is now ignored with a logged warning rather than causing **all** flags to fall back to their defaults. Code that relied on the previous "any unknown flag resets everything to defaults" behavior would be affected.
