### PR TITLE
feat: Surface logs flagged with alert metadata as TUI alerts

### DIFF
--- a/packages/serverpod/lib/src/server/log_manager/log_writers/vm_service_log_writer.dart
+++ b/packages/serverpod/lib/src/server/log_manager/log_writers/vm_service_log_writer.dart
@@ -17,6 +17,7 @@ class VmServiceLogWriter extends LogWriter {
       'timestamp': entry.time.toUtc().toIso8601String(),
       'error': entry.error?.toString(),
       'stackTrace': entry.stackTrace?.toString(),
+      'metadata': entry.metadata,
     });
   }
 

--- a/packages/serverpod/lib/src/server/log_manager/log_writers/vm_service_session_log_writer.dart
+++ b/packages/serverpod/lib/src/server/log_manager/log_writers/vm_service_session_log_writer.dart
@@ -47,6 +47,7 @@ class VmServiceSessionLogWriter extends SessionLogWriter {
           'timestamp': e.time.toUtc().toIso8601String(),
           'error': e.error,
           'stackTrace': e.stackTrace?.toString(),
+          'metadata': e.metadata,
           'session': {
             'kind': 'log',
             'order': e.order,

--- a/packages/serverpod/lib/src/server/log_manager/session_log.dart
+++ b/packages/serverpod/lib/src/server/log_manager/session_log.dart
@@ -171,6 +171,7 @@ class SessionLogEntry extends SessionEntry {
     required this.message,
     this.error,
     this.stackTrace,
+    this.metadata,
     super.messageId,
   });
 
@@ -185,6 +186,10 @@ class SessionLogEntry extends SessionEntry {
 
   /// Stack trace for [error], if any.
   final StackTrace? stackTrace;
+
+  /// Structured metadata, forwarded to the VM service stream and ignored by
+  /// the database log.
+  final Map<String, Object?>? metadata;
 
   @override
   SessionEntryKind get kind => SessionEntryKind.log;

--- a/packages/serverpod/lib/src/server/log_manager/session_log_manager.dart
+++ b/packages/serverpod/lib/src/server/log_manager/session_log_manager.dart
@@ -153,6 +153,7 @@ class SessionLogManager {
     required String message,
     String? error,
     StackTrace? stackTrace,
+    Map<String, Object?>? metadata,
   }) {
     _triggerCleanup();
 
@@ -170,6 +171,7 @@ class SessionLogManager {
         message: message,
         error: error,
         stackTrace: stackTrace,
+        metadata: metadata,
         messageId: _session.messageId,
       ),
     );

--- a/packages/serverpod/lib/src/server/session.dart
+++ b/packages/serverpod/lib/src/server/session.dart
@@ -220,17 +220,22 @@ abstract class Session implements DatabaseSession {
 
   /// Logs a message. Default [LogLevel] is [LogLevel.info]. The log is written
   /// to the database when the session is closed.
+  ///
+  /// [metadata] is forwarded to the CLI over the VM service stream but not
+  /// persisted to the database.
   void log(
     String message, {
     LogLevel? level,
     dynamic exception,
     StackTrace? stackTrace,
+    Map<String, Object?>? metadata,
   }) {
     _logManager?.logEntry(
       message: message,
       level: level ?? LogLevel.info,
       error: exception?.toString(),
       stackTrace: stackTrace,
+      metadata: metadata,
     );
   }
 }

--- a/packages/serverpod/lib/src/server/session.dart
+++ b/packages/serverpod/lib/src/server/session.dart
@@ -238,6 +238,14 @@ abstract class Session implements DatabaseSession {
       metadata: metadata,
     );
   }
+
+  /// Logs [message] as an alert. Works like [log], but the `serverpod` CLI
+  /// shows it as a copyable alert in its terminal UI. Wrap a copyable segment
+  /// in angle brackets, e.g. `'Code: <123456>'`. Other log destinations treat
+  /// it as a regular log message.
+  void alert(String message, {LogLevel? level}) {
+    log(message, level: level, metadata: {'alert': true});
+  }
 }
 
 /// A Session used internally in the [ServerPod]. Typically used to access

--- a/templates/pubspecs/tools/serverpod_cli/pubspec.yaml
+++ b/templates/pubspecs/tools/serverpod_cli/pubspec.yaml
@@ -55,7 +55,7 @@ dependencies:
   serverpod_serialization: SERVERPOD_VERSION
   serverpod_service_client: SERVERPOD_VERSION
   serverpod_shared: SERVERPOD_VERSION
-  serverpod_tui: ^0.2.0
+  serverpod_tui: ^0.2.1
   skills: ^0.3.1
   source_span: ^1.10.0
   stream_channel: ^2.1.1

--- a/templates/serverpod_templates/projectname_server_upgrade/lib/server.dart
+++ b/templates/serverpod_templates/projectname_server_upgrade/lib/server.dart
@@ -97,14 +97,10 @@ void _sendRegistrationCode(
   required Transaction? transaction,
 }) {
   // NOTE: Here you call your mail service to send the code to the user. For
-  // testing, we just log it. The `alert` metadata makes the `serverpod` CLI
-  // surface this as a copyable alert in its terminal UI, with the `<...>`
-  // marking the copyable segment. Other log sinks ignore the metadata and
-  // record the message text as-is (angle brackets included).
-  session.log(
-    'Registration code for $email: <$verificationCode>',
-    metadata: {'alert': true},
-  );
+  // testing, we just log it. `session.alert` shows this as a copyable alert in
+  // the `serverpod` CLI's terminal UI and auto-copies the `<...>` segment to
+  // the clipboard. Other log destinations treat it as a regular log message.
+  session.alert('Registration code for $email: <$verificationCode>');
 }
 
 void _sendPasswordResetCode(
@@ -115,14 +111,10 @@ void _sendPasswordResetCode(
   required Transaction? transaction,
 }) {
   // NOTE: Here you call your mail service to send the code to the user. For
-  // testing, we just log it. The `alert` metadata makes the `serverpod` CLI
-  // surface this as a copyable alert in its terminal UI, with the `<...>`
-  // marking the copyable segment. Other log sinks ignore the metadata and
-  // record the message text as-is (angle brackets included).
-  session.log(
-    'Password reset code for $email: <$verificationCode>',
-    metadata: {'alert': true},
-  );
+  // testing, we just log it. `session.alert` shows this as a copyable alert in
+  // the `serverpod` CLI's terminal UI and auto-copies the `<...>` segment to
+  // the clipboard. Other log destinations treat it as a regular log message.
+  session.alert('Password reset code for $email: <$verificationCode>');
 }
 
 // {{/auth}}

--- a/templates/serverpod_templates/projectname_server_upgrade/lib/server.dart
+++ b/templates/serverpod_templates/projectname_server_upgrade/lib/server.dart
@@ -97,8 +97,13 @@ void _sendRegistrationCode(
   required Transaction? transaction,
 }) {
   // NOTE: Here you call your mail service to send the verification code to
-  // the user. For testing, we will just log the verification code.
-  session.log('[EmailIdp] Registration code ($email): $verificationCode');
+  // the user. For testing, we just log it. The angle brackets and the
+  // `alert` metadata make the `serverpod` CLI surface the code as a copyable
+  // alert in its terminal UI; both are ignored when not running in the CLI.
+  session.log(
+    'Verification code: <$verificationCode>',
+    metadata: {'alert': true},
+  );
 }
 
 void _sendPasswordResetCode(
@@ -109,8 +114,13 @@ void _sendPasswordResetCode(
   required Transaction? transaction,
 }) {
   // NOTE: Here you call your mail service to send the verification code to
-  // the user. For testing, we will just log the verification code.
-  session.log('[EmailIdp] Password reset code ($email): $verificationCode');
+  // the user. For testing, we just log it. The angle brackets and the
+  // `alert` metadata make the `serverpod` CLI surface the code as a copyable
+  // alert in its terminal UI; both are ignored when not running in the CLI.
+  session.log(
+    'Password reset code: <$verificationCode>',
+    metadata: {'alert': true},
+  );
 }
 
 // {{/auth}}

--- a/templates/serverpod_templates/projectname_server_upgrade/lib/server.dart
+++ b/templates/serverpod_templates/projectname_server_upgrade/lib/server.dart
@@ -96,12 +96,13 @@ void _sendRegistrationCode(
   required String verificationCode,
   required Transaction? transaction,
 }) {
-  // NOTE: Here you call your mail service to send the verification code to
-  // the user. For testing, we just log it. The angle brackets and the
-  // `alert` metadata make the `serverpod` CLI surface the code as a copyable
-  // alert in its terminal UI; both are ignored when not running in the CLI.
+  // NOTE: Here you call your mail service to send the code to the user. For
+  // testing, we just log it. The `alert` metadata makes the `serverpod` CLI
+  // surface this as a copyable alert in its terminal UI, with the `<...>`
+  // marking the copyable segment. Other log sinks ignore the metadata and
+  // record the message text as-is (angle brackets included).
   session.log(
-    'Verification code: <$verificationCode>',
+    'Registration code for $email: <$verificationCode>',
     metadata: {'alert': true},
   );
 }
@@ -113,12 +114,13 @@ void _sendPasswordResetCode(
   required String verificationCode,
   required Transaction? transaction,
 }) {
-  // NOTE: Here you call your mail service to send the verification code to
-  // the user. For testing, we just log it. The angle brackets and the
-  // `alert` metadata make the `serverpod` CLI surface the code as a copyable
-  // alert in its terminal UI; both are ignored when not running in the CLI.
+  // NOTE: Here you call your mail service to send the code to the user. For
+  // testing, we just log it. The `alert` metadata makes the `serverpod` CLI
+  // surface this as a copyable alert in its terminal UI, with the `<...>`
+  // marking the copyable segment. Other log sinks ignore the metadata and
+  // record the message text as-is (angle brackets included).
   session.log(
-    'Password reset code: <$verificationCode>',
+    'Password reset code for $email: <$verificationCode>',
     metadata: {'alert': true},
   );
 }

--- a/tests/bootstrap_project/test/project_test.dart
+++ b/tests/bootstrap_project/test/project_test.dart
@@ -1062,12 +1062,12 @@ void main() async {
         final serverFile = File(path.join(commandRoot, 'lib', 'server.dart'));
         final serverSource = serverFile.readAsStringSync();
         const wasmHeaders = 'enableWasmHeaders: false,';
-        // TODO: Remove once Session.log(metadata:) is published.
-        const alertMetadata = "metadata: {'alert': true},";
+        // TODO: Remove once Session.alert is published.
+        const sessionAlert = 'session.alert(';
         serverFile.writeAsStringSync(
           serverSource
               .replaceAll(wasmHeaders, '')
-              .replaceAll(alertMetadata, ''),
+              .replaceAll(sessionAlert, 'session.log('),
         );
 
         final dockerBuildProcess = await startProcess(

--- a/tests/bootstrap_project/test/project_test.dart
+++ b/tests/bootstrap_project/test/project_test.dart
@@ -1056,13 +1056,19 @@ void main() async {
     test(
       'when building the server Dockerfile then the image is built successfully',
       () async {
-        // Temporarily remove the `enableWasmHeaders` parameter from server.dart
-        // because it has not been published yet and the Dockerfile won't have
-        // access to the local override. Once published, we can remove this.
+        // Temporarily remove parameters from server.dart that have not been
+        // published yet, because the Dockerfile won't have access to the local
+        // override. Once published, we can remove these.
         final serverFile = File(path.join(commandRoot, 'lib', 'server.dart'));
         final serverSource = serverFile.readAsStringSync();
         const wasmHeaders = 'enableWasmHeaders: false,';
-        serverFile.writeAsStringSync(serverSource.replaceAll(wasmHeaders, ''));
+        // TODO: Remove once Session.log(metadata:) is published.
+        const alertMetadata = "metadata: {'alert': true},";
+        serverFile.writeAsStringSync(
+          serverSource
+              .replaceAll(wasmHeaders, '')
+              .replaceAll(alertMetadata, ''),
+        );
 
         final dockerBuildProcess = await startProcess(
           'docker',

--- a/tools/serverpod_cli/lib/src/commands/create/tui/config.dart
+++ b/tools/serverpod_cli/lib/src/commands/create/tui/config.dart
@@ -53,8 +53,7 @@ enum ServerpodCreateConfig<T extends FormConfigOption>
     options: IdeOption.values,
     multiSelect: true,
     defaultOptions: <IdeOption>{},
-  )
-  ;
+  );
 
   const ServerpodCreateConfig({
     required this.label,
@@ -67,6 +66,9 @@ enum ServerpodCreateConfig<T extends FormConfigOption>
 
   @override
   final String label;
+
+  @override
+  FormDescription? get description => null;
 
   @override
   final List<T> options;
@@ -88,8 +90,7 @@ enum ServerpodCreateConfig<T extends FormConfigOption>
 enum DatabaseConfigOption implements FormConfigOption {
   postgres('Postgres'),
   sqlite('SQLite'),
-  none('None')
-  ;
+  none('None');
 
   const DatabaseConfigOption(this.label);
 
@@ -100,8 +101,7 @@ enum DatabaseConfigOption implements FormConfigOption {
 /// [FormConfigOption] for supported template types.
 enum TemplateTypeOption implements FormConfigOption {
   server('Server'),
-  module('Module')
-  ;
+  module('Module');
 
   const TemplateTypeOption(this.label);
 
@@ -116,8 +116,7 @@ enum IdeOption implements FormConfigOption {
   claude('Claude'),
   cursor('Cursor'),
   openCode('OpenCode'),
-  vsCode('VS Code')
-  ;
+  vsCode('VS Code');
 
   const IdeOption(this.label);
 

--- a/tools/serverpod_cli/lib/src/commands/create/tui/config.dart
+++ b/tools/serverpod_cli/lib/src/commands/create/tui/config.dart
@@ -53,7 +53,8 @@ enum ServerpodCreateConfig<T extends FormConfigOption>
     options: IdeOption.values,
     multiSelect: true,
     defaultOptions: <IdeOption>{},
-  );
+  )
+  ;
 
   const ServerpodCreateConfig({
     required this.label,
@@ -66,9 +67,6 @@ enum ServerpodCreateConfig<T extends FormConfigOption>
 
   @override
   final String label;
-
-  @override
-  FormDescription? get description => null;
 
   @override
   final List<T> options;
@@ -90,7 +88,8 @@ enum ServerpodCreateConfig<T extends FormConfigOption>
 enum DatabaseConfigOption implements FormConfigOption {
   postgres('Postgres'),
   sqlite('SQLite'),
-  none('None');
+  none('None')
+  ;
 
   const DatabaseConfigOption(this.label);
 
@@ -101,7 +100,8 @@ enum DatabaseConfigOption implements FormConfigOption {
 /// [FormConfigOption] for supported template types.
 enum TemplateTypeOption implements FormConfigOption {
   server('Server'),
-  module('Module');
+  module('Module')
+  ;
 
   const TemplateTypeOption(this.label);
 
@@ -116,7 +116,8 @@ enum IdeOption implements FormConfigOption {
   claude('Claude'),
   cursor('Cursor'),
   openCode('OpenCode'),
-  vsCode('VS Code');
+  vsCode('VS Code')
+  ;
 
   const IdeOption(this.label);
 

--- a/tools/serverpod_cli/lib/src/commands/start/tui/event_handler.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/tui/event_handler.dart
@@ -19,12 +19,13 @@ void handleServerLogEvent(TuiAppStateHolder holder, Event event) {
     case 'log':
       final stackTrace = data['stackTrace'] as String?;
       final message = data['message'] as String? ?? '';
+      final time =
+          DateTime.tryParse(data['timestamp'] as String? ?? '') ??
+          DateTime.now();
       state.logHistory.add(
         LogEntry(
           level: parseLogLevel(data['level'] as String? ?? 'info'),
-          time:
-              DateTime.tryParse(data['timestamp'] as String? ?? '') ??
-              DateTime.now(),
+          time: time,
           message: message,
           scope: LogScope.root('server'),
           error: data['error']?.toString(),
@@ -39,7 +40,7 @@ void handleServerLogEvent(TuiAppStateHolder holder, Event event) {
       // keeps the markup.
       final metadata = data['metadata'];
       if (metadata is Map && metadata['alert'] == true) {
-        holder.showAlert(AlertMessage.parse(message));
+        holder.showAlert(AlertMessage.parse(message), time: time);
       }
 
     case 'scope_start':

--- a/tools/serverpod_cli/lib/src/commands/start/tui/event_handler.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/tui/event_handler.dart
@@ -18,13 +18,14 @@ void handleServerLogEvent(TuiAppStateHolder holder, Event event) {
   switch (type) {
     case 'log':
       final stackTrace = data['stackTrace'] as String?;
+      final message = data['message'] as String? ?? '';
       state.logHistory.add(
         LogEntry(
           level: parseLogLevel(data['level'] as String? ?? 'info'),
           time:
               DateTime.tryParse(data['timestamp'] as String? ?? '') ??
               DateTime.now(),
-          message: data['message'] as String? ?? '',
+          message: message,
           scope: LogScope.root('server'),
           error: data['error']?.toString(),
           stackTrace: stackTrace != null && stackTrace.isNotEmpty
@@ -32,6 +33,14 @@ void handleServerLogEvent(TuiAppStateHolder holder, Event event) {
               : null,
         ),
       );
+
+      // An alert carries `metadata: {'alert': true}`. AlertMessage.parse
+      // strips any `<...>` copy markup for display; the raw log line above
+      // keeps the markup.
+      final metadata = data['metadata'];
+      if (metadata is Map && metadata['alert'] == true) {
+        holder.showAlert(AlertMessage.parse(message));
+      }
 
     case 'scope_start':
       final id = data['id'] as String? ?? '';

--- a/tools/serverpod_cli/lib/src/commands/start/tui/main_screen.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/tui/main_screen.dart
@@ -162,6 +162,15 @@ class MainScreen extends StatelessComponent {
                                     operation: op,
                                   ),
                                 ),
+
+                              // Pin the alert as the last line in the panel,
+                              // set apart from the logs by a blank row and a
+                              // divider directly above it.
+                              if (state.alert case final alert?) ...[
+                                const SizedBox(height: 1),
+                                Divider(color: st.subtleDivider),
+                                AlertLine(alert: alert, time: state.alertTime),
+                              ],
                             ],
                           );
                         },

--- a/tools/serverpod_cli/pubspec.yaml
+++ b/tools/serverpod_cli/pubspec.yaml
@@ -56,7 +56,7 @@ dependencies:
   serverpod_serialization: 3.5.0-beta.10
   serverpod_service_client: 3.5.0-beta.10
   serverpod_shared: 3.5.0-beta.10
-  serverpod_tui: ^0.2.0
+  serverpod_tui: ^0.2.1
   skills: ^0.3.1
   source_span: ^1.10.0
   stream_channel: ^2.1.1

--- a/tools/serverpod_cli/test/commands/start/tui/event_handler_test.dart
+++ b/tools/serverpod_cli/test/commands/start/tui/event_handler_test.dart
@@ -114,7 +114,8 @@ void main() {
     });
   });
 
-  group('Given a log event flagged as an alert with copy markup', () {
+  group('Given a log event flagged as an alert with copy markup when '
+      'dispatched', () {
     String? previousClipboard;
 
     setUp(() {
@@ -136,21 +137,22 @@ void main() {
       if (prev != null) ClipboardManager.copy(prev);
     });
 
-    test('when dispatched then shows the alert with the markup stripped', () {
+    test('then shows the alert with the markup stripped', () {
       expect(state.alert?.displayText, 'Registration code: h2k9x3mp');
     });
 
-    test('when dispatched then copies the marked segment to the clipboard', () {
+    test('then copies the marked segment to the clipboard', () {
       expect(ClipboardManager.paste(), 'h2k9x3mp');
     });
 
-    test('when dispatched then the raw log line keeps the markup', () {
+    test('then the raw log line keeps the markup', () {
       final entry = state.logHistory.first as LogEntry;
       expect(entry.message, 'Registration code: <h2k9x3mp>');
     });
   });
 
-  group('Given a log event flagged as an alert without copy markup', () {
+  group('Given a log event flagged as an alert without copy markup when '
+      'dispatched', () {
     setUp(() {
       handleServerLogEvent(
         holder,
@@ -163,16 +165,17 @@ void main() {
       );
     });
 
-    test('when dispatched then shows the alert verbatim', () {
+    test('then shows the alert verbatim', () {
       expect(state.alert?.displayText, 'Server requires a restart');
     });
 
-    test('when dispatched then the alert has no copy text', () {
+    test('then the alert has no copy text', () {
       expect(state.alert?.copyText, isNull);
     });
   });
 
-  group('Given an ordinary log event containing angle brackets', () {
+  group('Given an ordinary log event containing angle brackets when '
+      'dispatched', () {
     setUp(() {
       handleServerLogEvent(
         holder,
@@ -184,7 +187,7 @@ void main() {
       );
     });
 
-    test('when dispatched then no alert is shown', () {
+    test('then no alert is shown', () {
       expect(state.alert, isNull);
     });
 

--- a/tools/serverpod_cli/test/commands/start/tui/event_handler_test.dart
+++ b/tools/serverpod_cli/test/commands/start/tui/event_handler_test.dart
@@ -115,7 +115,10 @@ void main() {
   });
 
   group('Given a log event flagged as an alert with copy markup', () {
+    String? previousClipboard;
+
     setUp(() {
+      previousClipboard = ClipboardManager.paste();
       ClipboardManager.copy('previous clipboard content');
       handleServerLogEvent(
         holder,
@@ -126,6 +129,11 @@ void main() {
           'metadata': {'alert': true},
         }),
       );
+    });
+
+    tearDown(() {
+      final prev = previousClipboard;
+      if (prev != null) ClipboardManager.copy(prev);
     });
 
     test('when dispatched then shows the alert with the markup stripped', () {

--- a/tools/serverpod_cli/test/commands/start/tui/event_handler_test.dart
+++ b/tools/serverpod_cli/test/commands/start/tui/event_handler_test.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:nocterm/nocterm.dart' show ClipboardManager;
 import 'package:serverpod_cli/src/commands/start/tui/app.dart';
 import 'package:serverpod_cli/src/commands/start/tui/event_handler.dart';
 import 'package:serverpod_cli/src/commands/start/tui/state.dart';
@@ -110,6 +111,96 @@ void main() {
 
       final entry = state.logHistory.first as LogEntry;
       expect(entry.stackTrace, isNull);
+    });
+  });
+
+  group('Given a log event flagged as an alert with copy markup', () {
+    setUp(() {
+      ClipboardManager.copy('previous clipboard content');
+      handleServerLogEvent(
+        holder,
+        _logEvent({
+          'type': 'log',
+          'level': 'info',
+          'message': 'Registration code: <h2k9x3mp>',
+          'metadata': {'alert': true},
+        }),
+      );
+    });
+
+    test('when dispatched then shows the alert with the markup stripped', () {
+      expect(state.alert?.displayText, 'Registration code: h2k9x3mp');
+    });
+
+    test('when dispatched then copies the marked segment to the clipboard', () {
+      expect(ClipboardManager.paste(), 'h2k9x3mp');
+    });
+
+    test('when dispatched then the raw log line keeps the markup', () {
+      final entry = state.logHistory.first as LogEntry;
+      expect(entry.message, 'Registration code: <h2k9x3mp>');
+    });
+  });
+
+  group('Given a log event flagged as an alert without copy markup', () {
+    setUp(() {
+      handleServerLogEvent(
+        holder,
+        _logEvent({
+          'type': 'log',
+          'level': 'info',
+          'message': 'Server requires a restart',
+          'metadata': {'alert': true},
+        }),
+      );
+    });
+
+    test('when dispatched then shows the alert verbatim', () {
+      expect(state.alert?.displayText, 'Server requires a restart');
+    });
+
+    test('when dispatched then the alert has no copy text', () {
+      expect(state.alert?.copyText, isNull);
+    });
+  });
+
+  group('Given an ordinary log event containing angle brackets', () {
+    setUp(() {
+      handleServerLogEvent(
+        holder,
+        _logEvent({
+          'type': 'log',
+          'level': 'info',
+          'message': 'Parsed List<int> from <html>',
+        }),
+      );
+    });
+
+    test('when dispatched then no alert is shown', () {
+      expect(state.alert, isNull);
+    });
+
+    test('when dispatched then the markup is left untouched in the log', () {
+      final entry = state.logHistory.first as LogEntry;
+      expect(entry.message, 'Parsed List<int> from <html>');
+    });
+  });
+
+  group('Given a log event whose metadata does not flag an alert', () {
+    setUp(() {
+      handleServerLogEvent(
+        holder,
+        _logEvent({
+          'type': 'log',
+          'level': 'info',
+          'message': 'Some code: <abc>',
+          'metadata': {'alert': false},
+        }),
+      );
+    });
+
+    test('when dispatched then no alert is shown', () {
+      expect(state.alert, isNull);
     });
   });
 

--- a/tools/serverpod_cli/test/commands/start/tui/event_handler_test.dart
+++ b/tools/serverpod_cli/test/commands/start/tui/event_handler_test.dart
@@ -114,106 +114,115 @@ void main() {
     });
   });
 
-  group('Given a log event flagged as an alert with copy markup when '
-      'dispatched', () {
-    String? previousClipboard;
+  group(
+    'Given a log event flagged as an alert with copy markup when dispatched',
+    () {
+      String? previousClipboard;
 
-    setUp(() {
-      previousClipboard = ClipboardManager.paste();
-      ClipboardManager.copy('previous clipboard content');
-      handleServerLogEvent(
-        holder,
-        _logEvent({
-          'type': 'log',
-          'level': 'info',
-          'message': 'Registration code: <h2k9x3mp>',
-          'metadata': {'alert': true},
-        }),
-      );
-    });
+      setUp(() {
+        previousClipboard = ClipboardManager.paste();
+        ClipboardManager.copy('previous clipboard content');
+        handleServerLogEvent(
+          holder,
+          _logEvent({
+            'type': 'log',
+            'level': 'info',
+            'message': 'Registration code: <h2k9x3mp>',
+            'metadata': {'alert': true},
+          }),
+        );
+      });
 
-    tearDown(() {
-      final prev = previousClipboard;
-      if (prev != null) ClipboardManager.copy(prev);
-    });
+      tearDown(() {
+        final prev = previousClipboard;
+        if (prev != null) ClipboardManager.copy(prev);
+      });
 
-    test('then shows the alert with the markup stripped', () {
-      expect(state.alert?.displayText, 'Registration code: h2k9x3mp');
-    });
+      test('then shows the alert with the markup stripped', () {
+        expect(state.alert?.displayText, 'Registration code: h2k9x3mp');
+      });
 
-    test('then copies the marked segment to the clipboard', () {
-      expect(ClipboardManager.paste(), 'h2k9x3mp');
-    });
+      test('then copies the marked segment to the clipboard', () {
+        expect(ClipboardManager.paste(), 'h2k9x3mp');
+      });
 
-    test('then the raw log line keeps the markup', () {
-      final entry = state.logHistory.first as LogEntry;
-      expect(entry.message, 'Registration code: <h2k9x3mp>');
-    });
-  });
+      test('then the raw log line keeps the markup', () {
+        final entry = state.logHistory.first as LogEntry;
+        expect(entry.message, 'Registration code: <h2k9x3mp>');
+      });
+    },
+  );
 
-  group('Given a log event flagged as an alert without copy markup when '
-      'dispatched', () {
-    setUp(() {
-      handleServerLogEvent(
-        holder,
-        _logEvent({
-          'type': 'log',
-          'level': 'info',
-          'message': 'Server requires a restart',
-          'metadata': {'alert': true},
-        }),
-      );
-    });
+  group(
+    'Given a log event flagged as an alert without copy markup when dispatched',
+    () {
+      setUp(() {
+        handleServerLogEvent(
+          holder,
+          _logEvent({
+            'type': 'log',
+            'level': 'info',
+            'message': 'Server requires a restart',
+            'metadata': {'alert': true},
+          }),
+        );
+      });
 
-    test('then shows the alert verbatim', () {
-      expect(state.alert?.displayText, 'Server requires a restart');
-    });
+      test('then shows the alert verbatim', () {
+        expect(state.alert?.displayText, 'Server requires a restart');
+      });
 
-    test('then the alert has no copy text', () {
-      expect(state.alert?.copyText, isNull);
-    });
-  });
+      test('then the alert has no copy text', () {
+        expect(state.alert?.copyText, isNull);
+      });
+    },
+  );
 
-  group('Given an ordinary log event containing angle brackets when '
-      'dispatched', () {
-    setUp(() {
-      handleServerLogEvent(
-        holder,
-        _logEvent({
-          'type': 'log',
-          'level': 'info',
-          'message': 'Parsed List<int> from <html>',
-        }),
-      );
-    });
+  group(
+    'Given an ordinary log event containing angle brackets when dispatched',
+    () {
+      setUp(() {
+        handleServerLogEvent(
+          holder,
+          _logEvent({
+            'type': 'log',
+            'level': 'info',
+            'message': 'Parsed List<int> from <html>',
+          }),
+        );
+      });
 
-    test('then no alert is shown', () {
-      expect(state.alert, isNull);
-    });
+      test('then no alert is shown', () {
+        expect(state.alert, isNull);
+      });
 
-    test('when dispatched then the markup is left untouched in the log', () {
-      final entry = state.logHistory.first as LogEntry;
-      expect(entry.message, 'Parsed List<int> from <html>');
-    });
-  });
+      test('then the markup is left untouched in the log', () {
+        final entry = state.logHistory.first as LogEntry;
+        expect(entry.message, 'Parsed List<int> from <html>');
+      });
+    },
+  );
 
-  group('Given a log event whose metadata does not flag an alert', () {
-    setUp(() {
-      handleServerLogEvent(
-        holder,
-        _logEvent({
-          'type': 'log',
-          'level': 'info',
-          'message': 'Some code: <abc>',
-          'metadata': {'alert': false},
-        }),
-      );
-    });
+  group(
+    'Given a log event whose metadata does not flag an alert when dispatched',
+    () {
+      setUp(() {
+        handleServerLogEvent(
+          holder,
+          _logEvent({
+            'type': 'log',
+            'level': 'info',
+            'message': 'Some code: <abc>',
+            'metadata': {'alert': false},
+          }),
+        );
+      });
 
-    test('when dispatched then no alert is shown', () {
-      expect(state.alert, isNull);
-    });
-  });
+      test('then no alert is shown', () {
+        expect(state.alert, isNull);
+      });
+    },
+  );
 
   group('Given a scope_start event', () {
     setUp(() {


### PR DESCRIPTION
The new `serverpod start` TUI can now pop a dismissable alert for a log entry, used to surface the email verification/activation code during local development so it can be read or copied without digging through the logs.

- `Session.log` gains an optional `metadata` map. It rides the VM service log stream to the CLI but is **not** persisted to the database.
- The CLI's log event handler shows an alert when a log carries `metadata: {'alert': true}`. Angle brackets mark a copyable segment. `Verification code: <123456>` displays as `Verification code: 123456`, with the code auto-copied to the clipboard and re-copyable with `C`. `Esc` dismisses.
- The server template's email callbacks log the registration and password-reset codes with this metadata, so newly created projects get the alert out of the box.

Fixes #5219 

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes
None