### PR TITLE
fix: Fix trying to complete the web socket listener twice

### DIFF
--- a/packages/serverpod_client/lib/src/client_method_stream_manager.dart
+++ b/packages/serverpod_client/lib/src/client_method_stream_manager.dart
@@ -495,7 +495,8 @@ final class ClientMethodStreamManager {
   }
 
   Future<void> _listenToWebSocketStream(WebSocketChannel webSocket) async {
-    _webSocketListenerCompleter = Completer();
+    final webSocketListenerCompleter = Completer();
+    _webSocketListenerCompleter = webSocketListenerCompleter;
     MethodStreamException closeException = const WebSocketClosedException();
     try {
       await for (String jsonData in webSocket.stream) {
@@ -559,7 +560,9 @@ final class ClientMethodStreamManager {
       await webSocket.sink.close();
     } finally {
       _cancelConnectionTimer();
-      _webSocketListenerCompleter.complete();
+      if (!webSocketListenerCompleter.isCompleted) {
+        webSocketListenerCompleter.complete();
+      }
 
       /// Close any still open streams with an exception.
       await closeAllConnections(closeException);

--- a/packages/serverpod_client/lib/src/client_method_stream_manager.dart
+++ b/packages/serverpod_client/lib/src/client_method_stream_manager.dart
@@ -49,6 +49,9 @@ final class ClientMethodStreamManager {
   /// The serialization manager used to serialize and deserialize messages.
   final SerializationManager _serializationManager;
 
+  /// Optional connector used to override [WebSocketChannel.connect] in tests.
+  final WebSocketChannel Function(Uri uri)? _webSocketConnector;
+
   /// Lock used to synchronize access when establishing websocket connection.
   final Lock _lock = Lock();
 
@@ -67,11 +70,13 @@ final class ClientMethodStreamManager {
     required SerializationManager serializationManager,
     @visibleForTesting Duration? pingInterval,
     @visibleForTesting Duration? idleTimeout,
+    @visibleForTesting WebSocketChannel Function(Uri uri)? webSocketConnector,
   }) : _webSocketHost = webSocketHost,
        _connectionTimeout = connectionTimeout,
        _serializationManager = serializationManager,
        _pingInterval = pingInterval ?? _defaultPingInterval,
-       _idleTimeout = idleTimeout ?? _defaultIdleTimeout;
+       _idleTimeout = idleTimeout ?? _defaultIdleTimeout,
+       _webSocketConnector = webSocketConnector;
 
   /// Closes all open connections and streams
   ///
@@ -565,7 +570,9 @@ final class ClientMethodStreamManager {
     await _lock.synchronized(() async {
       if (_webSocket != null) return;
 
-      var webSocket = WebSocketChannel.connect(_webSocketHost);
+      var webSocket =
+          _webSocketConnector?.call(_webSocketHost) ??
+          WebSocketChannel.connect(_webSocketHost);
 
       await webSocket.ready.onError((e, s) {
         throw WebSocketConnectException(e, s);

--- a/packages/serverpod_client/pubspec.yaml
+++ b/packages/serverpod_client/pubspec.yaml
@@ -22,6 +22,7 @@ dependencies:
 dev_dependencies:
   relic: ^1.2.0
   serverpod_lints: 3.5.0-beta.10
+  stream_channel: ^2.1.1
   test: ^1.25.5
 
 dependency_overrides:

--- a/packages/serverpod_client/test/client_method_stream_manager_reconnect_test.dart
+++ b/packages/serverpod_client/test/client_method_stream_manager_reconnect_test.dart
@@ -1,0 +1,110 @@
+@OnPlatform({'browser': Skip('WebSocket tests are not supported in browser')})
+library;
+
+import 'dart:async';
+
+import 'package:serverpod_client/serverpod_client.dart';
+import 'package:serverpod_client/src/client_method_stream_manager.dart';
+import 'package:stream_channel/stream_channel.dart';
+import 'package:test/test.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+import 'test_utils/method_stream_connection_details_builder.dart';
+
+class TestSerializationManager extends SerializationManager {}
+
+void main() {
+  group(
+    'Given a websocket connection whose stream closes asynchronously,',
+    () {
+      late final streamManager = ClientMethodStreamManager(
+        connectionTimeout: const Duration(milliseconds: 10),
+        webSocketHost: Uri.parse('ws://localhost:0'),
+        serializationManager: TestSerializationManager(),
+        webSocketConnector: (_) => _DelayedCloseWebSocketChannel(),
+      );
+
+      test(
+        'when a second connection attempt starts before the first listener shuts down, '
+        'then overlapping listener teardown does not throw a StateError.',
+        () async {
+          final asyncErrors = <Object>[];
+          await runZonedGuarded(() async {
+            final firstConnection = streamManager.openMethodStream(
+              MethodStreamConnectionDetailsBuilder().build(),
+            );
+            final secondConnection = streamManager.openMethodStream(
+              MethodStreamConnectionDetailsBuilder().build(),
+            );
+
+            await expectLater(
+              firstConnection,
+              throwsA(isA<ConnectionAttemptTimedOutException>()),
+            );
+            await expectLater(
+              secondConnection,
+              throwsA(isA<ConnectionAttemptTimedOutException>()),
+            );
+
+            await Future<void>.delayed(const Duration(milliseconds: 200));
+          }, (error, _) => asyncErrors.add(error));
+
+          expect(asyncErrors.whereType<StateError>(), isEmpty);
+        },
+      );
+    },
+  );
+}
+
+/// Keeps [stream] open briefly after [sink.close] to overlap listeners.
+class _DelayedCloseWebSocketChannel
+    with StreamChannelMixin
+    implements WebSocketChannel {
+  final _incoming = StreamController<String>();
+
+  @override
+  Stream get stream => _incoming.stream;
+
+  @override
+  late final WebSocketSink sink = _DelayedCloseWebSocketSink(_incoming);
+
+  @override
+  Future<void> get ready => Future<void>.value();
+
+  @override
+  String? get protocol => null;
+
+  @override
+  int? get closeCode => null;
+
+  @override
+  String? get closeReason => null;
+}
+
+class _DelayedCloseWebSocketSink implements WebSocketSink {
+  _DelayedCloseWebSocketSink(this._incoming);
+
+  final StreamController<String> _incoming;
+
+  @override
+  Future<void> get done => Future<void>.value();
+
+  @override
+  void add(data) {}
+
+  @override
+  void addError(Object error, [StackTrace? stackTrace]) {}
+
+  @override
+  Future<void> addStream(Stream<dynamic> stream) => stream.drain();
+
+  @override
+  Future<void> close([int? closeCode, String? closeReason]) {
+    Timer(const Duration(milliseconds: 50), () {
+      if (!_incoming.isClosed) {
+        _incoming.close();
+      }
+    });
+    return Future<void>.value();
+  }
+}

--- a/templates/pubspecs/packages/serverpod_client/pubspec.yaml
+++ b/templates/pubspecs/packages/serverpod_client/pubspec.yaml
@@ -21,6 +21,7 @@ dependencies:
 dev_dependencies:
   relic: ^1.2.0
   serverpod_lints: SERVERPOD_VERSION
+  stream_channel: ^2.1.1
   test: ^1.25.5
 
 dependency_overrides:


### PR DESCRIPTION
Fixes: #5300

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.