### PR TITLE
feat: Project-local MCP config for Antigravity via .agents plugin

### DIFF
--- a/tests/bootstrap_project/test_perform_create/ide_test.dart
+++ b/tests/bootstrap_project/test_perform_create/ide_test.dart
@@ -71,6 +71,7 @@ void main() {
         'then the created project',
         () {
           final serverDirRelative = '${project.name}_server';
+          const antigravityPluginDir = '.agents/plugins/serverpod-local';
           final genericConfig =
               '''
 {
@@ -93,13 +94,33 @@ void main() {
               final config = File(
                 p.join(
                   project.projectRoot,
-                  '.gemini/antigravity/mcp_config.json',
+                  '$antigravityPluginDir/mcp_config.json',
                 ),
               );
               expect(config.existsSync(), isTrue);
               expect(
                 config.readAsStringSync(),
                 genericConfig.replaceAll('"dart":', '"dart-mcp-server":'),
+              );
+            },
+          );
+
+          test(
+            'has an Antigravity plugin manifest registering the local plugin',
+            () {
+              final manifest = File(
+                p.join(
+                  project.projectRoot,
+                  '$antigravityPluginDir/plugin.json',
+                ),
+              );
+              expect(manifest.existsSync(), isTrue);
+              expect(
+                manifest.readAsStringSync(),
+                '''{
+  "name": "serverpod-local"
+}
+''',
               );
             },
           );

--- a/tools/serverpod_cli/lib/src/create/create.dart
+++ b/tools/serverpod_cli/lib/src/create/create.dart
@@ -261,19 +261,9 @@ Future<String?> performCreate(
     });
   }
 
-  if (context.ides.isNotEmpty) {
-    await log.progress('Configuring Serverpod MCP server', () async {
-      await _configureMcpServer(
-        serverpodDirs.projectDir.path,
-        context.ides,
-        serverDirRelative: p.relative(
-          serverpodDirs.serverDir.path,
-          from: serverpodDirs.projectDir.path,
-        ),
-      );
-      return true;
-    });
+  await _configureProjectMcpServers(serverpodDirs, context.ides);
 
+  if (context.ides.isNotEmpty) {
     await log.progress('Installing agent skills', () async {
       try {
         if (context.template != ServerpodTemplateType.module &&
@@ -374,6 +364,10 @@ Future<void> _moveDirectoryContents(
     final newPath = p.join(destination.path, p.basename(entity.path));
 
     if (entity is File) {
+      // Never overwrite files already present at the destination, such as the
+      // Antigravity plugin config written under .agents/plugins/ before this
+      // move runs.
+      if (await File(newPath).exists()) continue;
       await entity.rename(newPath);
     } else if (entity is Directory) {
       final newDir = await Directory(newPath).create(recursive: true);
@@ -381,6 +375,25 @@ Future<void> _moveDirectoryContents(
       await entity.delete();
     }
   }
+}
+
+/// Writes the MCP config files for [ides] under [dirs], showing progress.
+Future<void> _configureProjectMcpServers(
+  ServerpodDirectories dirs,
+  List<TemplateIde> ides,
+) async {
+  if (ides.isEmpty) return;
+  await log.progress('Configuring Serverpod MCP server', () async {
+    await _configureMcpServer(
+      dirs.projectDir.path,
+      ides,
+      serverDirRelative: p.relative(
+        dirs.serverDir.path,
+        from: dirs.projectDir.path,
+      ),
+    );
+    return true;
+  });
 }
 
 Future<void> _configureMcpServer(
@@ -395,6 +408,12 @@ Future<void> _configureMcpServer(
         p.join(projectDirPath, ide.filePath),
         ide.effectiveConfig(serverDirRelative: serverDirRelative),
       );
+      for (final entry in ide.additionalFiles.entries) {
+        await _createFileAndWrite(
+          p.join(projectDirPath, entry.key),
+          ide.render(entry.value, serverDirRelative: serverDirRelative),
+        );
+      }
     },
   );
 }
@@ -404,8 +423,8 @@ Future<void> _createFileAndWrite(String path, String content) async {
   try {
     await file.create(recursive: true);
     await file.writeAsString(content);
-  } on FileSystemException {
-    //
+  } on FileSystemException catch (e) {
+    _logError('Failed to write $path: ${e.osError?.message ?? e.message}');
   }
 }
 
@@ -474,6 +493,8 @@ Future<String?> _performUpgrade({
       interactive: interactive,
     );
   });
+
+  await _configureProjectMcpServers(serverpodDir, context.ides);
 
   if (success) {
     log.info(

--- a/tools/serverpod_cli/lib/src/create/create.dart
+++ b/tools/serverpod_cli/lib/src/create/create.dart
@@ -261,9 +261,9 @@ Future<String?> performCreate(
     });
   }
 
-  await _configureProjectMcpServers(serverpodDirs, context.ides);
-
   if (context.ides.isNotEmpty) {
+    await _configureProjectMcpServers(serverpodDirs, context.ides);
+
     await log.progress('Installing agent skills', () async {
       try {
         if (context.template != ServerpodTemplateType.module &&
@@ -367,7 +367,10 @@ Future<void> _moveDirectoryContents(
       // Never overwrite files already present at the destination, such as the
       // Antigravity plugin config written under .agents/plugins/ before this
       // move runs.
-      if (await File(newPath).exists()) continue;
+      if (await File(newPath).exists()) {
+        log.debug('Skipped moving ${entity.path}: $newPath already exists.');
+        continue;
+      }
       await entity.rename(newPath);
     } else if (entity is Directory) {
       final newDir = await Directory(newPath).create(recursive: true);

--- a/tools/serverpod_cli/lib/src/create/ide.dart
+++ b/tools/serverpod_cli/lib/src/create/ide.dart
@@ -2,11 +2,17 @@ import 'package:serverpod_cli/src/create/copier.dart';
 
 enum TemplateIde {
   antigravity(
-    filePath: '.gemini/antigravity/mcp_config.json',
+    filePath: '$_antigravityPluginDir/mcp_config.json',
     config: _genericConfig,
     replacements: [
+      // The Antigravity ecosystem names the Dart MCP server "dart-mcp-server",
+      // so reuse key to avoid duplicates.
       Replacement(slotName: '"dart":', replacement: '"dart-mcp-server":'),
     ],
+    // Antigravity discovers project-local MCP config through its plugin system.
+    additionalFiles: {
+      '$_antigravityPluginDir/plugin.json': _antigravityPluginManifest,
+    },
   ),
   codex(filePath: '.codex/config.toml', config: _codexConfig),
   cursor(filePath: '.cursor/mcp.json', config: _genericConfig),
@@ -25,6 +31,7 @@ enum TemplateIde {
     required this.filePath,
     required this.config,
     this.replacements = const [],
+    this.additionalFiles = const {},
   });
 
   /// Path where the config file for the IDE should be created,
@@ -36,14 +43,22 @@ enum TemplateIde {
 
   /// Optional replacements to be applied to the config content before writing.
   final List<Replacement> replacements;
+
+  /// Additional files to write alongside [filePath], keyed by their project-root-relative path.
+  /// Content goes through the same [TemplateIdeExtension.render] pipeline as [config].
+  final Map<String, String> additionalFiles;
 }
 
 extension TemplateIdeExtension on TemplateIde {
   // Pinning the bridge to this project's server dir avoids walking up from cwd
   // at startup and disambiguates workspaces that contain multiple server
   // projects sharing one agent config.
-  String effectiveConfig({required String serverDirRelative}) {
-    String result = config.replaceAll(
+  String effectiveConfig({required String serverDirRelative}) =>
+      render(config, serverDirRelative: serverDirRelative);
+
+  /// Renders [content] with the server dir slot and this IDE's [replacements].
+  String render(String content, {required String serverDirRelative}) {
+    String result = content.replaceAll(
       _serverDirRelativeSlot,
       serverDirRelative,
     );
@@ -55,6 +70,19 @@ extension TemplateIdeExtension on TemplateIde {
 }
 
 const _serverDirRelativeSlot = '{serverDirRelative}';
+
+/// Folder holding the generated Antigravity plugin. The folder name and the
+/// manifest "name" must match for Antigravity to index the plugin!
+const _antigravityPluginDir = '.agents/plugins/$_antigravityPluginName';
+const _antigravityPluginName = 'serverpod-local';
+
+/// Marker that registers the generated folder as an Antigravity plugin so its
+/// sibling mcp_config.json is ingested.
+const _antigravityPluginManifest =
+    '''{
+  "name": "$_antigravityPluginName"
+}
+''';
 
 /// Generic MCP server config for IDEs.
 const _genericConfig = '''{

--- a/tools/serverpod_cli/test/commands/create/ide_test.dart
+++ b/tools/serverpod_cli/test/commands/create/ide_test.dart
@@ -1,0 +1,95 @@
+import 'dart:convert';
+
+import 'package:path/path.dart' as p;
+import 'package:serverpod_cli/src/create/ide.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Given the Antigravity IDE', () {
+    const ide = TemplateIde.antigravity;
+
+    group('when reading its file layout', () {
+      test('then the MCP config lives in the .agents plugin folder', () {
+        expect(
+          ide.filePath,
+          '.agents/plugins/serverpod-local/mcp_config.json',
+        );
+      });
+
+      test('then the plugin manifest is a sibling of the MCP config', () {
+        expect(
+          ide.additionalFiles.keys.map(p.dirname),
+          everyElement(p.dirname(ide.filePath)),
+        );
+      });
+
+      test('then the manifest name matches the plugin folder name', () {
+        final manifestPath = ide.additionalFiles.keys.single;
+        final manifest =
+            jsonDecode(ide.additionalFiles[manifestPath]!)
+                as Map<String, dynamic>;
+
+        expect(manifest['name'], p.basename(p.dirname(manifestPath)));
+      });
+    });
+
+    group('when rendering its config', () {
+      final config = ide.effectiveConfig(serverDirRelative: 'my_app_server');
+
+      test('then the server dir is embedded in the serverpod entry', () {
+        expect(config, contains('"--server-dir", "my_app_server"'));
+      });
+
+      test('then the dart entry is renamed to dart-mcp-server', () {
+        expect(config, contains('"dart-mcp-server":'));
+        expect(config, isNot(contains('"dart":')));
+      });
+    });
+
+    group('when rendering a companion file that uses slots', () {
+      test('then the server dir slot and replacements are applied', () {
+        final rendered = ide.render(
+          '"dart": "{serverDirRelative}"',
+          serverDirRelative: 'my_app_server',
+        );
+
+        expect(rendered, '"dart-mcp-server": "my_app_server"');
+      });
+    });
+  });
+
+  group('Given the VS Code IDE', () {
+    group('when rendering its config', () {
+      final config = TemplateIde.vscode.effectiveConfig(
+        serverDirRelative: 'my_app_server',
+      );
+
+      test('then the mcpServers key is replaced with servers', () {
+        expect(config, contains('"servers":'));
+        expect(config, isNot(contains('"mcpServers":')));
+      });
+    });
+  });
+
+  group('Given every IDE', () {
+    group('when rendering all of its files', () {
+      test('then no unrendered server dir slot remains', () {
+        for (final ide in TemplateIde.values) {
+          final renderedFiles = [
+            ide.effectiveConfig(serverDirRelative: 'my_app_server'),
+            for (final content in ide.additionalFiles.values)
+              ide.render(content, serverDirRelative: 'my_app_server'),
+          ];
+
+          for (final content in renderedFiles) {
+            expect(
+              content,
+              isNot(contains('{serverDirRelative}')),
+              reason: ide.name,
+            );
+          }
+        }
+      });
+    });
+  });
+}

--- a/tools/serverpod_cli/test/commands/create/ide_test.dart
+++ b/tools/serverpod_cli/test/commands/create/ide_test.dart
@@ -46,34 +46,40 @@ void main() {
       });
     });
 
-    group('when rendering a companion file that uses slots', () {
-      test('then the server dir slot and replacements are applied', () {
+    test(
+      'when rendering a companion file that uses slots '
+      'then the server dir slot and replacements are applied',
+      () {
         final rendered = ide.render(
           '"dart": "{serverDirRelative}"',
           serverDirRelative: 'my_app_server',
         );
 
         expect(rendered, '"dart-mcp-server": "my_app_server"');
-      });
-    });
+      },
+    );
   });
 
   group('Given the VS Code IDE', () {
-    group('when rendering its config', () {
-      final config = TemplateIde.vscode.effectiveConfig(
-        serverDirRelative: 'my_app_server',
-      );
+    test(
+      'when rendering its config '
+      'then the mcpServers key is replaced with servers',
+      () {
+        final config = TemplateIde.vscode.effectiveConfig(
+          serverDirRelative: 'my_app_server',
+        );
 
-      test('then the mcpServers key is replaced with servers', () {
         expect(config, contains('"servers":'));
         expect(config, isNot(contains('"mcpServers":')));
-      });
-    });
+      },
+    );
   });
 
   group('Given every IDE', () {
-    group('when rendering all of its files', () {
-      test('then no unrendered server dir slot remains', () {
+    test(
+      'when rendering all of its files '
+      'then no unrendered server dir slot remains',
+      () {
         for (final ide in TemplateIde.values) {
           final renderedFiles = [
             ide.effectiveConfig(serverDirRelative: 'my_app_server'),
@@ -89,7 +95,7 @@ void main() {
             );
           }
         }
-      });
-    });
+      },
+    );
   });
 }


### PR DESCRIPTION
Antigravity discovers project-local MCP servers through plugin folders under .agents/plugins/ that contain a plugin.json marker.

- `TemplateIde` gains `additionalFiles`: companion files rendered through the same slot/replacement pipeline as the main config.
- `serverpod create .` (upgrade) now also writes IDE MCP configs, so projects created by earlier CLI versions pick up the new layout.
- `_createFileAndWrite` logs write failures instead of swallowing them
- `_moveDirectoryContents` no longer overwrites destination files, so the .agent -> .agents merge cannot clobber _.agents/plugins/_.
- The plugin dir and manifest name derive from one constant

Fixes: #5220 (at least for antigravity-cli)

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

## Breaking changes

None (only changes behaviour of pre-release)