### PR TITLE
fix: Make model doc comment extraction line-ending agnostic

### DIFF
--- a/tools/serverpod_cli/lib/src/util/yaml_docs.dart
+++ b/tools/serverpod_cli/lib/src/util/yaml_docs.dart
@@ -19,7 +19,11 @@ class YamlDocumentationExtractor {
       var match = docStartExp.firstMatch(line);
       if (match != null) {
         documentation.insert(0, '///${match.group(1) ?? ''}');
-      } else if (line.isNotEmpty && RegExp(r'^\ *?[^#]*$').hasMatch(line)) {
+      }
+      // Blank and whitespace-only lines continue the scan; any other
+      // line that is not part of a comment ends it.
+      else if (line.trim().isNotEmpty &&
+          RegExp(r'^\ *?[^#]*$').hasMatch(line)) {
         break;
       }
     }

--- a/tools/serverpod_cli/lib/src/util/yaml_docs.dart
+++ b/tools/serverpod_cli/lib/src/util/yaml_docs.dart
@@ -1,9 +1,15 @@
+import 'dart:convert';
+
 import 'package:source_span/source_span.dart';
 
 class YamlDocumentationExtractor {
   final List<String> lines;
 
-  YamlDocumentationExtractor(String yaml) : lines = yaml.split('\n');
+  /// Splits on LF, CR, and CRLF — the same line break set `package:yaml`
+  /// (via `source_span`) uses for the line numbers in [SourceLocation],
+  /// keeping the scan index-aligned for any line ending style.
+  YamlDocumentationExtractor(String yaml)
+    : lines = const LineSplitter().convert(yaml);
 
   List<String>? getDocumentation(SourceLocation keyStart) {
     var documentation = <String>[];

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/documentation_crlf_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/documentation_crlf_test.dart
@@ -1,0 +1,350 @@
+import 'package:serverpod_cli/src/analyzer/models/definitions.dart';
+import 'package:serverpod_cli/src/analyzer/models/stateful_analyzer.dart';
+import 'package:serverpod_cli/src/generator/code_generation_collector.dart';
+import 'package:source_span/source_span.dart';
+import 'package:test/test.dart';
+
+import '../../../../test_util/builders/generator_config_builder.dart';
+import '../../../../test_util/builders/model_source_builder.dart';
+
+/// Regression tests for https://github.com/serverpod/serverpod/issues/2120
+///
+/// Doc comments in model files must be extracted identically regardless of
+/// whether the file uses LF (`\n`), CRLF (`\r\n`) or CR (`\r`) line endings.
+/// The yaml is built by joining lines with an explicit line ending instead of
+/// using multiline string literals, so the line endings under test cannot be
+/// changed by editor or formatter settings.
+void main() {
+  var config = GeneratorConfigBuilder().build();
+
+  ClassDefinition parseClass(List<String> yamlLines, String eol) {
+    var modelSources = [
+      ModelSourceBuilder().withYaml(yamlLines.join(eol)).build(),
+    ];
+    var analyzer = StatefulAnalyzer(config, modelSources);
+    var definitions = analyzer.validateAll();
+    return definitions.first as ClassDefinition;
+  }
+
+  for (var (eolName, eol) in [('LF', '\n'), ('CRLF', '\r\n'), ('CR', '\r')]) {
+    group('Given a model file with $eolName line endings,', () {
+      test(
+        'when a field has a doc comment directly above it '
+        'then the field documentation is set without stray characters.',
+        () {
+          var definition = parseClass(
+            [
+              'class: Example',
+              'fields:',
+              '  ### This is a doc comment',
+              '  name: String',
+              '',
+            ],
+            eol,
+          );
+
+          expect(
+            definition.fields.first.documentation,
+            ['/// This is a doc comment'],
+          );
+        },
+      );
+
+      test(
+        'when a field has a doc comment separated by one blank line '
+        'then the field documentation is still set.',
+        () {
+          // This is the exact reproduction from issue #2120.
+          var definition = parseClass(
+            [
+              'class: Example',
+              'fields:',
+              '  ### This is a doc comment',
+              '',
+              '  name: String',
+              '',
+            ],
+            eol,
+          );
+
+          expect(
+            definition.fields.first.documentation,
+            ['/// This is a doc comment'],
+          );
+        },
+      );
+
+      test(
+        'when a field has a multiline doc comment '
+        'then the field documentation contains all lines.',
+        () {
+          var definition = parseClass(
+            [
+              'class: Example',
+              'fields:',
+              '  ### This is a multiline',
+              '  ### field comment.',
+              '  name: String',
+              '',
+            ],
+            eol,
+          );
+
+          expect(
+            definition.fields.first.documentation,
+            ['/// This is a multiline', '/// field comment.'],
+          );
+        },
+      );
+
+      test(
+        'when a field has a multiline doc comment with a blank line inside it '
+        'then the field documentation contains all lines.',
+        () {
+          var definition = parseClass(
+            [
+              'class: Example',
+              'fields:',
+              '  ### This is a multiline',
+              '',
+              '  ### field comment.',
+              '  name: String',
+              '',
+            ],
+            eol,
+          );
+
+          expect(
+            definition.fields.first.documentation,
+            ['/// This is a multiline', '/// field comment.'],
+          );
+        },
+      );
+
+      test(
+        'when the class has a doc comment '
+        'then the class documentation is set without stray characters.',
+        () {
+          var definition = parseClass(
+            [
+              '### This is a class comment.',
+              'class: Example',
+              'fields:',
+              '  name: String',
+              '',
+            ],
+            eol,
+          );
+
+          expect(
+            definition.documentation,
+            ['/// This is a class comment.'],
+          );
+        },
+      );
+
+      test(
+        'when the class has a doc comment separated by one blank line '
+        'then the class documentation is still set.',
+        () {
+          var definition = parseClass(
+            [
+              '### This is a class comment.',
+              '',
+              'class: Example',
+              'fields:',
+              '  name: String',
+              '',
+            ],
+            eol,
+          );
+
+          expect(
+            definition.documentation,
+            ['/// This is a class comment.'],
+          );
+        },
+      );
+
+      test(
+        'when the model file has no trailing newline '
+        'then the field documentation is still set.',
+        () {
+          var definition = parseClass(
+            [
+              'class: Example',
+              'fields:',
+              '  ### This is a doc comment',
+              '  name: String',
+            ],
+            eol,
+          );
+
+          expect(
+            definition.fields.first.documentation,
+            ['/// This is a doc comment'],
+          );
+        },
+      );
+
+      test(
+        'when extracted documentation exists '
+        'then no doc line contains a carriage return.',
+        () {
+          var definition = parseClass(
+            [
+              '### Class comment.',
+              'class: Example',
+              'fields:',
+              '  ### Field comment.',
+              '  name: String',
+              '',
+            ],
+            eol,
+          );
+
+          var allDocLines = [
+            ...?definition.documentation,
+            ...?definition.fields.first.documentation,
+          ];
+          expect(allDocLines, isNotEmpty);
+          for (var line in allDocLines) {
+            expect(
+              line.contains('\r'),
+              isFalse,
+              reason: 'Doc line ${line.codeUnits} contains a carriage return.',
+            );
+          }
+        },
+      );
+    });
+  }
+
+  group('Given a model file with mixed line endings,', () {
+    test(
+      'when doc comments are separated by a blank line '
+      'then class and field documentation are both set.',
+      () {
+        var yaml =
+            '### Class comment.\r\n'
+            'class: Example\n'
+            'fields:\r\n'
+            '  ### Field comment.\n'
+            '\r\n'
+            '  name: String\n';
+        var modelSources = [ModelSourceBuilder().withYaml(yaml).build()];
+        var analyzer = StatefulAnalyzer(config, modelSources);
+        var definitions = analyzer.validateAll();
+        var definition = definitions.first as ClassDefinition;
+
+        expect(definition.documentation, ['/// Class comment.']);
+        expect(
+          definition.fields.first.documentation,
+          ['/// Field comment.'],
+        );
+      },
+    );
+
+    test(
+      'when a single line ends with a stray CR '
+      'then documentation below it is still set.',
+      () {
+        // The stray CR makes the yaml parser see one more line than a naive
+        // split on LF would, which used to desync the doc comment lookup for
+        // all keys below it.
+        var yaml =
+            'class: Example\r'
+            'fields:\n'
+            '  ### Field comment.\n'
+            '  name: String\n';
+        var modelSources = [ModelSourceBuilder().withYaml(yaml).build()];
+        var analyzer = StatefulAnalyzer(config, modelSources);
+        var definitions = analyzer.validateAll();
+        var definition = definitions.first as ClassDefinition;
+
+        expect(
+          definition.fields.first.documentation,
+          ['/// Field comment.'],
+        );
+      },
+    );
+  });
+
+  group('Given the same invalid model file with LF and CRLF line endings,', () {
+    test(
+      'when the models are validated '
+      'then the reported errors have identical positions.',
+      () {
+        List<SourceSpanException> errorsFor(String eol) {
+          var collector = CodeGenerationCollector();
+          var modelSources = [
+            ModelSourceBuilder()
+                .withYaml(
+                  [
+                    'class: Example',
+                    'bogus: value',
+                    'fields:',
+                    '  name: String',
+                    '',
+                  ].join(eol),
+                )
+                .build(),
+          ];
+          var analyzer = StatefulAnalyzer(
+            config,
+            modelSources,
+            onErrorsCollector(collector),
+          );
+          analyzer.validateAll();
+          return collector.errors;
+        }
+
+        var lfErrors = errorsFor('\n');
+        var crlfErrors = errorsFor('\r\n');
+
+        expect(lfErrors, isNotEmpty);
+        expect(crlfErrors.length, lfErrors.length);
+        for (var i = 0; i < lfErrors.length; i++) {
+          expect(crlfErrors[i].message, lfErrors[i].message);
+          expect(crlfErrors[i].span?.start.line, lfErrors[i].span?.start.line);
+          expect(
+            crlfErrors[i].span?.start.column,
+            lfErrors[i].span?.start.column,
+          );
+        }
+      },
+    );
+  });
+
+  group('Given a model updated through the single model validation,', () {
+    test(
+      'when the new yaml has CRLF line endings and a blank line below the '
+      'doc comment then the field documentation is still set.',
+      () {
+        // Exercises the same code path the language server uses for live
+        // editor content, which updates an already registered model.
+        var source = ModelSourceBuilder().build();
+        var analyzer = StatefulAnalyzer(config, [source]);
+        analyzer.validateAll();
+
+        var definitions = analyzer.validateModel(
+          [
+            'class: Example',
+            'fields:',
+            '  ### This is a doc comment',
+            '',
+            '  name: String',
+            '',
+          ].join('\r\n'),
+          source.yamlSourceUri,
+        );
+        var definition = definitions.first as ClassDefinition;
+
+        expect(
+          definition.fields.first.documentation,
+          ['/// This is a doc comment'],
+        );
+      },
+    );
+  });
+}

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/documentation_crlf_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/documentation_crlf_test.dart
@@ -75,6 +75,29 @@ void main() {
       );
 
       test(
+        'when a field has a doc comment separated by a whitespace-only line '
+        'then the field documentation is still set.',
+        () {
+          var definition = parseClass(
+            [
+              'class: Example',
+              'fields:',
+              '  ### This is a doc comment',
+              '  ',
+              '  name: String',
+              '',
+            ],
+            eol,
+          );
+
+          expect(
+            definition.fields.first.documentation,
+            ['/// This is a doc comment'],
+          );
+        },
+      );
+
+      test(
         'when a field has a multiline doc comment '
         'then the field documentation contains all lines.',
         () {

--- a/tools/serverpod_cli/test/util/yaml_docs_test.dart
+++ b/tools/serverpod_cli/test/util/yaml_docs_test.dart
@@ -119,6 +119,42 @@ void main() {
     );
 
     test(
+      'when a whitespace-only line separates the doc comment from the key '
+      'then the documentation is returned.',
+      () {
+        var extractor = YamlDocumentationExtractor(
+          '  ### This is a doc comment\n'
+          '   \n'
+          '  name: String\n',
+        );
+
+        expect(
+          extractor.getDocumentation(keyAt(2, 2)),
+          ['/// This is a doc comment'],
+        );
+      },
+    );
+
+    test(
+      'when a tab-only line separates the doc comment from the key '
+      'then the documentation is returned.',
+      () {
+        // Tabs cannot appear as yaml indentation, so this case is only
+        // reachable through the extractor directly.
+        var extractor = YamlDocumentationExtractor(
+          '  ### This is a doc comment\n'
+          '\t\n'
+          '  name: String\n',
+        );
+
+        expect(
+          extractor.getDocumentation(keyAt(2, 2)),
+          ['/// This is a doc comment'],
+        );
+      },
+    );
+
+    test(
       'when a normal comment line separates the doc comment from the key '
       'then the documentation is returned.',
       () {

--- a/tools/serverpod_cli/test/util/yaml_docs_test.dart
+++ b/tools/serverpod_cli/test/util/yaml_docs_test.dart
@@ -1,0 +1,192 @@
+import 'package:serverpod_cli/src/util/yaml_docs.dart';
+import 'package:source_span/source_span.dart';
+import 'package:test/test.dart';
+import 'package:yaml/yaml.dart';
+
+void main() {
+  group('Given yaml content with different line endings,', () {
+    var eolVariants = [
+      ('LF', '\n'),
+      ('CRLF', '\r\n'),
+      ('CR', '\r'),
+    ];
+
+    for (var (eolName, eol) in eolVariants) {
+      test(
+        'when split with $eolName line endings '
+        'then each line matches the line numbers the yaml parser reports.',
+        () {
+          var yaml = [
+            'class: Example',
+            'fields:',
+            '  name: String',
+            '  age: int',
+            '',
+          ].join(eol);
+
+          var extractor = YamlDocumentationExtractor(yaml);
+          var document = loadYaml(yaml) as YamlMap;
+
+          var keyNodes = [
+            ...document.nodes.keys.cast<YamlNode>(),
+            ...(document['fields'] as YamlMap).nodes.keys.cast<YamlNode>(),
+          ];
+          expect(keyNodes, hasLength(4));
+          for (var key in keyNodes) {
+            var start = key.span.start;
+            var lineAtKey = extractor.lines[start.line];
+            expect(
+              lineAtKey.substring(start.column),
+              startsWith('${(key as YamlScalar).value}'),
+              reason:
+                  'The yaml parser puts the key "${key.value}" at line '
+                  '${start.line}, but that line is "$lineAtKey".',
+            );
+          }
+        },
+      );
+    }
+
+    test(
+      'when split with mixed line endings '
+      'then each line matches the line numbers the yaml parser reports.',
+      () {
+        var yaml =
+            'class: Example\r\n'
+            'fields:\n'
+            '  name: String\r'
+            '  age: int\n';
+
+        var extractor = YamlDocumentationExtractor(yaml);
+        var document = loadYaml(yaml) as YamlMap;
+
+        var keyNodes = [
+          ...document.nodes.keys.cast<YamlNode>(),
+          ...(document['fields'] as YamlMap).nodes.keys.cast<YamlNode>(),
+        ];
+        expect(keyNodes, hasLength(4));
+        for (var key in keyNodes) {
+          var start = key.span.start;
+          var lineAtKey = extractor.lines[start.line];
+          expect(
+            lineAtKey.substring(start.column),
+            startsWith('${(key as YamlScalar).value}'),
+            reason:
+                'The yaml parser puts the key "${key.value}" at line '
+                '${start.line}, but that line is "$lineAtKey".',
+          );
+        }
+      },
+    );
+  });
+
+  group('Given a doc comment above a key,', () {
+    SourceLocation keyAt(int line, int column) {
+      return SourceLocation(0, line: line, column: column);
+    }
+
+    test(
+      'when the doc comment is directly above the key '
+      'then the documentation is returned.',
+      () {
+        var extractor = YamlDocumentationExtractor(
+          '  ### This is a doc comment\n'
+          '  name: String\n',
+        );
+
+        expect(
+          extractor.getDocumentation(keyAt(1, 2)),
+          ['/// This is a doc comment'],
+        );
+      },
+    );
+
+    test(
+      'when a blank line separates the doc comment from the key '
+      'then the documentation is returned.',
+      () {
+        var extractor = YamlDocumentationExtractor(
+          '  ### This is a doc comment\n'
+          '\n'
+          '  name: String\n',
+        );
+
+        expect(
+          extractor.getDocumentation(keyAt(2, 2)),
+          ['/// This is a doc comment'],
+        );
+      },
+    );
+
+    test(
+      'when a normal comment line separates the doc comment from the key '
+      'then the documentation is returned.',
+      () {
+        var extractor = YamlDocumentationExtractor(
+          '  ### This is a doc comment\n'
+          '  # This is a normal comment.\n'
+          '  name: String\n',
+        );
+
+        expect(
+          extractor.getDocumentation(keyAt(2, 2)),
+          ['/// This is a doc comment'],
+        );
+      },
+    );
+
+    test(
+      'when a content line with a trailing comment separates the doc comment '
+      'from the key then the documentation is returned.',
+      () {
+        // Documents the existing scan behavior: lines that contain a `#`
+        // anywhere never end the scan, so the doc comment above another field
+        // is picked up here. Tracked separately from the line ending fix.
+        var extractor = YamlDocumentationExtractor(
+          '  ### This is a doc comment\n'
+          '  other: int # trailing comment\n'
+          '  name: String\n',
+        );
+
+        expect(
+          extractor.getDocumentation(keyAt(2, 2)),
+          ['/// This is a doc comment'],
+        );
+      },
+    );
+
+    test(
+      'when a content line separates the doc comment from the key '
+      'then no documentation is returned.',
+      () {
+        var extractor = YamlDocumentationExtractor(
+          '  ### This is a doc comment\n'
+          '  other: int\n'
+          '  name: String\n',
+        );
+
+        expect(extractor.getDocumentation(keyAt(2, 2)), isNull);
+      },
+    );
+
+    test(
+      'when the key is on the first line '
+      'then no documentation is returned.',
+      () {
+        var extractor = YamlDocumentationExtractor('name: String\n');
+
+        expect(extractor.getDocumentation(keyAt(0, 0)), isNull);
+      },
+    );
+
+    test(
+      'when the yaml content is empty '
+      'then no documentation is returned.',
+      () {
+        var extractor = YamlDocumentationExtractor('');
+
+        expect(extractor.getDocumentation(keyAt(0, 0)), isNull);
+      },
+    );
+  });
+}


### PR DESCRIPTION
Doc comments (`###`) in model files were extracted differently depending on the file's line endings. With CRLF line endings — common on Windows via `git core.autocrlf=true` or CRLF-default editors — a doc comment separated from its key by a blank line was silently dropped, while the same file with LF line endings kept it.

`YamlDocumentationExtractor` split the model yaml on `\n` only. Under CRLF, a blank line then became a lone `"\r"` string, which is non-empty and matches the scan's break condition, so the upward doc comment scan stopped at the blank line before reaching the comment. Splitting with `dart:convert`'s `LineSplitter` instead uses the same line break set (LF, CR, CRLF) that `package:yaml` uses for its reported line numbers. This keeps blank lines empty after splitting and keeps the scan index-aligned with the parser for any line ending style. Verified empirically, the same change also fixes three sibling defects of the same root cause:

- multiline doc blocks with an internal blank line were truncated to their last segment under CRLF;
- a stray lone CR desynced the line indexing from the yaml parser, silently dropping doc comments for all keys below it;
- a file with CR-only line endings crashed the CLI with an uncaught `RangeError` instead of generating.

A second, separate commit extends the blank-line handling to whitespace-only lines: a line containing only spaces between a doc comment and its key used to end the scan on all platforms (the LF-reproducible cousin of this bug). This is the only behavior change for LF files — such doc comments now attach where they were previously dropped. It is isolated in its own commit so it can be dropped independently if preferred.

Notes for review:

- The scan's break regex is byte-identical to before; only the splitter and the blank-line test changed, so the existing scan behavior past `#` comment lines is preserved exactly.
- The alignment between `LineSplitter` and the yaml parser's line numbers is pinned by unit tests in `test/util/yaml_docs_test.dart`, so a future change in either package fails CI here rather than regressing users.
- No defensive bounds guard was added on the `lines[i]` access, since the aligned splitter makes out-of-range indices unreachable through the parser. Happy to add a one-line guard if preferred.
- Out of scope, possible follow-ups: lines containing `#` anywhere never end the scan (pre-existing and line-ending-independent), and a few other `split('\n')` call sites outside the model doc pipeline (the error-span excerpt in `model_analyzer.dart`, endpoint doc handling in `string_manipulation.dart` and `build_doc_comment.dart`, and `generation_staleness.dart`).

Fixes #2120

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

## Breaking changes

None. The second commit causes doc comments separated from their key by a whitespace-only line to be included in generated output where they were previously dropped; this only adds `///` lines for model files that already contain such doc comments.