### PR TITLE
fix: Use real server package name in generated test tools imports

### DIFF
--- a/tools/serverpod_cli/lib/src/config/config.dart
+++ b/tools/serverpod_cli/lib/src/config/config.dart
@@ -96,6 +96,14 @@ class GeneratorConfig implements ModelLoadConfig {
 
   /// The name of the serverpod project.
   ///
+  /// This is the project's protocol/module identity, emitted into generated
+  /// code (e.g. `getModuleName()`, `registerHostProtocol`) and used as the
+  /// module name of migrations. It is derived by stripping a trailing
+  /// `_server`/`_client` from the server package's pubspec name, which is a
+  /// no-op for packages that do not follow that naming convention. It must
+  /// therefore never be used to reconstruct package import urls — use
+  /// [serverPackage] or [dartClientPackage] instead.
+  ///
   /// See also:
   ///  - [serverPackage]
   ///  - [dartClientPackage]
@@ -104,7 +112,11 @@ class GeneratorConfig implements ModelLoadConfig {
   /// The [PackageType] of the package this [GeneratorConfig] describes.
   final PackageType type;
 
-  /// The name of the server package.
+  /// The name of the server package, as declared in its pubspec.yaml.
+  ///
+  /// Always use this (never `'${name}_server'`) when emitting `package:`
+  /// import urls for the server package, since the package is not guaranteed
+  /// to be named `<name>_server`.
   ///
   /// See also:
   ///  - [dartClientPackage]
@@ -819,6 +831,10 @@ migrationVersions: $migrationVersions
 
 /// Just get the core name of a package.
 /// (without `_server` or `client`)
+///
+/// This is lossy: the input is returned unchanged when it does not end with
+/// one of the known suffixes (e.g. a server package renamed to `server`), so
+/// the result cannot be used to reconstruct the original package name.
 String _stripPackage(String package) {
   var strippedPackage = package;
   if (strippedPackage.endsWith('_server')) {

--- a/tools/serverpod_cli/lib/src/generator/dart/library_generators/server_test_tools_generator.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart/library_generators/server_test_tools_generator.dart
@@ -49,13 +49,13 @@ class ServerTestToolsGenerator {
 
   void _addPackageDirectives(LibraryBuilder library) {
     var protocolPackageImportPath = [
-      'package:${config.name}_server',
+      'package:${config.serverPackage}',
       ...config.generatedServeModelPackagePathParts,
       'protocol.dart',
     ].join('/');
 
     var endpointsPath = [
-      'package:${config.name}_server',
+      'package:${config.serverPackage}',
       ...config.generatedServeModelPackagePathParts,
       'endpoints.dart',
     ].join('/');

--- a/tools/serverpod_cli/test/generator/dart/server_code_generator/server_package_name_server_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/server_code_generator/server_package_name_server_test.dart
@@ -1,0 +1,123 @@
+import 'package:path/path.dart' as path;
+import 'package:serverpod_cli/src/analyzer/protocol_definition.dart';
+import 'package:serverpod_cli/src/generator/dart/server_code_generator.dart';
+import 'package:test/test.dart';
+
+import '../../../test_util/builders/generator_config_builder.dart';
+
+const generator = DartServerCodeGenerator();
+
+void main() {
+  var expectedFileName = path.join(
+    'integration_test',
+    'test_tools',
+    'serverpod_test_tools.dart',
+  );
+
+  var protocolDefinition = const ProtocolDefinition(
+    endpoints: [],
+    models: [],
+    futureCalls: [],
+  );
+
+  group(
+    'Given a server package named "server" without the _server suffix when '
+    'generating test tools file',
+    () {
+      // `withServerPackage` must be called after `withName`, since `withName`
+      // also sets the server package to '<name>_server'. With the builder's
+      // default name, a reconstructed '<name>_server' import would not
+      // contain 'package:server_server' and the assertions below would pass
+      // without exercising the renamed-package scenario.
+      var config = GeneratorConfigBuilder()
+          .withName('server')
+          .withServerPackage('server')
+          .withRelativeServerTestToolsPathParts(
+            ['integration_test', 'test_tools'],
+          )
+          .build();
+
+      late var codeMap = generator.generateProtocolCode(
+        protocolDefinition: protocolDefinition,
+        config: config,
+      );
+
+      late var testToolsFile = codeMap[expectedFileName];
+
+      test('then the config models the renamed package.', () {
+        expect(config.name, 'server');
+        expect(config.serverPackage, 'server');
+      });
+
+      test('then import path towards project protocol is correct.', () {
+        expect(
+          testToolsFile,
+          contains("import 'package:server/src/generated/protocol.dart';"),
+        );
+      });
+
+      test('then import path towards project endpoints is correct.', () {
+        expect(
+          testToolsFile,
+          contains("import 'package:server/src/generated/endpoints.dart';"),
+        );
+      });
+
+      test(
+        'then no import reconstructs the package name with a _server suffix.',
+        () {
+          expect(testToolsFile, isNot(contains('package:server_server')));
+        },
+      );
+    },
+  );
+
+  group(
+    'Given a server package with a generic name without the _server suffix '
+    'when generating test tools file',
+    () {
+      var config = GeneratorConfigBuilder()
+          .withName('my_backend')
+          .withServerPackage('my_backend')
+          .withRelativeServerTestToolsPathParts(
+            ['integration_test', 'test_tools'],
+          )
+          .build();
+
+      late var codeMap = generator.generateProtocolCode(
+        protocolDefinition: protocolDefinition,
+        config: config,
+      );
+
+      late var testToolsFile = codeMap[expectedFileName];
+
+      test('then the config models the renamed package.', () {
+        expect(config.name, 'my_backend');
+        expect(config.serverPackage, 'my_backend');
+      });
+
+      test('then import path towards project protocol is correct.', () {
+        expect(
+          testToolsFile,
+          contains("import 'package:my_backend/src/generated/protocol.dart';"),
+        );
+      });
+
+      test('then import path towards project endpoints is correct.', () {
+        expect(
+          testToolsFile,
+          contains(
+            "import 'package:my_backend/src/generated/endpoints.dart';",
+          ),
+        );
+      });
+
+      test(
+        'then no import reconstructs the package name with a _server suffix.',
+        () {
+          expect(testToolsFile, isNot(contains('package:my_backend_server')));
+        },
+      );
+    },
+  );
+}


### PR DESCRIPTION
Fixes #3054.

### Problem

Renaming the server package to a name that doesn't end in `_server` (e.g. `testpod_server` → `server`) makes `serverpod generate` emit broken imports in the generated `serverpod_test_tools.dart`:

```dart
import 'package:server_server/src/generated/protocol.dart';
import 'package:server_server/src/generated/endpoints.dart';
```

`_addPackageDirectives` rebuilt the package name as `'package:${config.name}_server'`. `config.name` is derived by stripping a trailing `_server`/`_client` from the pubspec name, which is a no-op for names that don't follow the convention — so `_server` gets appended to the already-suffix-less name.

### Fix

Use `config.serverPackage` (the name read from the server's `pubspec.yaml`) instead, matching the six existing usages in the same file (e.g. the `future_calls.dart` import). These two directives are also what the bare `Protocol`/`Endpoints` references in `withServerpod` resolve through, so no other change is needed.

Also adds doc comments to `GeneratorConfig.name` / `serverPackage` / `_stripPackage` documenting that `name` is the protocol/module identity and must not be used to reconstruct package import urls.

### Notes for review

- Output is unchanged for conventionally named projects: when the pubspec name is `<name>_server`, both expressions produce the same string. Confirmed by the existing assertions in `test_tools_test.dart` (exact import strings, unmodified) and a full `serverpod_cli` suite run (5063 passing, 0 failures).
- `config.name` semantics are untouched (doc comments only) — migration module names, `getModuleName()`, and `registerHostProtocol` behave exactly as before.
- After the fix, a generated file can contain both a prefixed and an unprefixed import of `protocol.dart` (when endpoints use records or non-string-keyed maps). This already occurs in real generated files today and is harmless.
- To reach test tools generation with a renamed server package at all, the client package must be locatable — i.e. `client_package_path` set in `config/generator.yaml` (otherwise config loading fails earlier with "Failed to load client pubspec.yaml").

### Tests

New `test/generator/dart/server_code_generator/server_package_name_server_test.dart`, mirroring the naming of the client-side test added in #4634 (happy to fold these into `test_tools_test.dart` groups instead if preferred):

- covers a server package named `server` and a generic suffix-less name `my_backend`,
- positive assertions on the corrected `protocol.dart`/`endpoints.dart` imports,
- a negative assertion (`isNot(contains('package:server_server'))`) that fails on current main,
- guard assertions on `config.name`/`config.serverPackage`, since `GeneratorConfigBuilder.withName()` also overwrites the server package — with the builder default, the bug would not reproduce.

An end-to-end variant that runs `GeneratorConfig.load` on an on-disk project with pubspec name `server` and asserts the generated imports is prepared as well — left out to keep the diff small, happy to add it on request.

### Related

- #4605 / #4634 fixed the same renamed-package scenario for client-side import rewriting; this PR completes it for the generated test tools. Given that precedent, this is arguably a bug fix rather than an enhancement (#3054 is currently labeled `enhancement`).
- The rename scenario still has separate gaps outside `generate`'s scope: `create-migration` requires the `_server` suffix (#2705), and there is no `flutter_package_path` override for `serverpod start`'s Flutter detection. I can file follow-up issues for those if useful.