### PR TITLE
fix: Recover orphaned embedded Postgres on Windows after unclean exit

### DIFF
--- a/packages/serverpod_embedded_postgres/lib/src/binary/executable.dart
+++ b/packages/serverpod_embedded_postgres/lib/src/binary/executable.dart
@@ -1,0 +1,15 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+
+/// Path to a PG binary [name] (`postgres`, `pg_ctl`, `initdb`) in
+/// [installDir]'s `bin/`, with `.exe` on Windows.
+///
+/// The extension matters: `Process.start` works without it because
+/// `CreateProcess` auto-resolves `name.exe`, but the path we persist must
+/// match what `QueryFullProcessImageNameW` reports so orphan-identity checks
+/// don't classify our own postmaster as foreign.
+String binExecutable(Directory installDir, String name) {
+  var fileName = Platform.isWindows ? '$name.exe' : name;
+  return p.join(installDir.path, 'bin', fileName);
+}

--- a/packages/serverpod_embedded_postgres/lib/src/cluster/cluster_store.dart
+++ b/packages/serverpod_embedded_postgres/lib/src/cluster/cluster_store.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:path/path.dart' as p;
 
+import '../binary/executable.dart';
 import '../exceptions.dart';
 import '../transport.dart';
 import 'postgres_conf_builder.dart';
@@ -79,7 +80,7 @@ class ClusterStore {
     }
 
     try {
-      var initdb = p.join(installDir.path, 'bin', 'initdb');
+      var initdb = binExecutable(installDir, 'initdb');
       var args = [
         '--pgdata=${dataDir.path}',
         '--username=$username',

--- a/packages/serverpod_embedded_postgres/lib/src/embedded_postgres_impl.dart
+++ b/packages/serverpod_embedded_postgres/lib/src/embedded_postgres_impl.dart
@@ -8,6 +8,7 @@ import 'package:serverpod_shared/process_io.dart';
 import 'package:serverpod_shared/serverpod_shared.dart';
 
 import 'binary/binary_store.dart';
+import 'binary/executable.dart';
 import 'binary/maven_url.dart';
 import 'cluster/cluster_store.dart';
 import 'embedded_postgres.dart';
@@ -165,7 +166,7 @@ class EmbeddedPostgresImpl extends EmbeddedPostgres {
       await repairStaleEmbeddedPostgresLocks(
         pgDataDir: pgDataDir,
         serverpodPidFile: pidFile,
-        pgCtlExecutable: File(p.join(installDir.path, 'bin', 'pg_ctl')),
+        pgCtlExecutable: File(binExecutable(installDir, 'pg_ctl')),
       );
     }
 

--- a/packages/serverpod_embedded_postgres/lib/src/supervisor/supervisor.dart
+++ b/packages/serverpod_embedded_postgres/lib/src/supervisor/supervisor.dart
@@ -2,8 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:path/path.dart' as p;
-
+import '../binary/executable.dart';
 import '../exceptions.dart';
 import '../transport.dart';
 import 'log_buffer.dart';
@@ -76,7 +75,7 @@ class Supervisor implements SupervisedProcess {
     required File logFile,
     required bool detach,
   }) async {
-    var executable = p.join(installDir.path, 'bin', 'postgres');
+    var executable = binExecutable(installDir, 'postgres');
 
     _rotateLog(logFile);
     var ring = LogBuffer();

--- a/packages/serverpod_embedded_postgres/test/binary/executable_test.dart
+++ b/packages/serverpod_embedded_postgres/test/binary/executable_test.dart
@@ -1,0 +1,27 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:serverpod_embedded_postgres/src/binary/executable.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Given binExecutable', () {
+    var installDir = Directory(p.join('install', '16.13.0'));
+
+    test('when resolving a binary then it lands in the bin/ directory.', () {
+      var path = binExecutable(installDir, 'postgres');
+
+      expect(p.dirname(path), p.join(installDir.path, 'bin'));
+    });
+
+    test(
+      'when on Windows then the name carries the .exe extension, '
+      'otherwise the bare name is used.',
+      () {
+        var name = p.basename(binExecutable(installDir, 'postgres'));
+
+        expect(name, Platform.isWindows ? 'postgres.exe' : 'postgres');
+      },
+    );
+  });
+}

--- a/packages/serverpod_embedded_postgres/test/binary/executable_test.dart
+++ b/packages/serverpod_embedded_postgres/test/binary/executable_test.dart
@@ -5,18 +5,19 @@ import 'package:serverpod_embedded_postgres/src/binary/executable.dart';
 import 'package:test/test.dart';
 
 void main() {
-  group('Given binExecutable', () {
+  group('Given the host platform', () {
     var installDir = Directory(p.join('install', '16.13.0'));
 
-    test('when resolving a binary then it lands in the bin/ directory.', () {
+    test('when getting the binary executable then it lands in the bin/ '
+        'directory.', () {
       var path = binExecutable(installDir, 'postgres');
 
       expect(p.dirname(path), p.join(installDir.path, 'bin'));
     });
 
     test(
-      'when on Windows then the name carries the .exe extension, '
-      'otherwise the bare name is used.',
+      'when getting the binary executable then the name carries the .exe '
+      'extension on Windows and the bare name otherwise.',
       () {
         var name = p.basename(binExecutable(installDir, 'postgres'));
 


### PR DESCRIPTION
On Windows, if the server exits uncleanly (e.g. the TUI/process crashes), the embedded Postgres process gets orphaned and every restart after that crash-loops with `PostmasterLockBusyException` until you manually kill it. Doesn't happen on macOS/Linux.

The supervisor saved the postmaster's executable path without the `.exe` extension, Windows `CreateProcess` tacks it on automatically at spawn time, so launching worked fine. But on the next start, when we check whether an orphan is ours, Windows reports the real path *with* `.exe`, so the two don't match and we end up treating our own orphan as a foreign process, and refuse to clean it up.

The fix is a small `binExecutable` helper that adds `.exe` on Windows, used for the `postgres`, `pg_ctl`, and `initdb` paths.

Fixes #5315 

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

_If you have done any breaking changes, make sure to outline them here, so that they can be included in the notes for the next release._