### PR TITLE
refactor: Make `id == null` checks in attach/detach repositories conditional on id nullability

### DIFF
--- a/modules/serverpod_auth/serverpod_auth_bridge/serverpod_auth_bridge_server/lib/src/generated/legacy_email_password.dart
+++ b/modules/serverpod_auth/serverpod_auth_bridge/serverpod_auth_bridge_server/lib/src/generated/legacy_email_password.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/modules/serverpod_auth/serverpod_auth_bridge/serverpod_auth_bridge_server/lib/src/generated/legacy_external_user_identifier.dart
+++ b/modules/serverpod_auth/serverpod_auth_bridge/serverpod_auth_bridge_server/lib/src/generated/legacy_external_user_identifier.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/modules/serverpod_auth/serverpod_auth_bridge/serverpod_auth_bridge_server/lib/src/generated/legacy_session.dart
+++ b/modules/serverpod_auth/serverpod_auth_bridge/serverpod_auth_bridge_server/lib/src/generated/legacy_session.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_server/lib/src/generated/jwt/models/refresh_token.dart
+++ b/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_server/lib/src/generated/jwt/models/refresh_token.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_server/lib/src/generated/profile/models/user_profile.dart
+++ b/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_server/lib/src/generated/profile/models/user_profile.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_server/lib/src/generated/profile/models/user_profile_image.dart
+++ b/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_server/lib/src/generated/profile/models/user_profile_image.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_server/lib/src/generated/session/models/server_side_session.dart
+++ b/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_server/lib/src/generated/session/models/server_side_session.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/generated/providers/anonymous/models/anonymous_account.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/generated/providers/anonymous/models/anonymous_account.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/generated/providers/apple/models/apple_account.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/generated/providers/apple/models/apple_account.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/generated/providers/email/models/email_account.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/generated/providers/email/models/email_account.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/generated/providers/email/models/email_account_password_reset_request.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/generated/providers/email/models/email_account_password_reset_request.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/generated/providers/email/models/email_account_request.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/generated/providers/email/models/email_account_request.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/generated/providers/facebook/models/facebook_account.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/generated/providers/facebook/models/facebook_account.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/generated/providers/firebase/models/firebase_account.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/generated/providers/firebase/models/firebase_account.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/generated/providers/github/models/github_account.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/generated/providers/github/models/github_account.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/generated/providers/google/models/google_account.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/generated/providers/google/models/google_account.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/generated/providers/microsoft/models/microsoft_account.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/generated/providers/microsoft/models/microsoft_account.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/generated/providers/passkey/models/passkey_account.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/generated/providers/passkey/models/passkey_account.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/modules/serverpod_auth/serverpod_auth_migration/serverpod_auth_migration_server/lib/src/generated/migrated_user.dart
+++ b/modules/serverpod_auth/serverpod_auth_migration/serverpod_auth_migration_server/lib/src/generated/migrated_user.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/packages/serverpod/lib/src/generated/session_log_entry.dart
+++ b/packages/serverpod/lib/src/generated/session_log_entry.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/tests/serverpod_auth_test/serverpod_auth_test_server/lib/src/generated/challenge_tracker.dart
+++ b/tests/serverpod_auth_test/serverpod_auth_test_server/lib/src/generated/challenge_tracker.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/tests/serverpod_auth_test/serverpod_auth_test_server/lib/src/generated/session_metadata.dart
+++ b/tests/serverpod_auth_test/serverpod_auth_test_server/lib/src/generated/session_metadata.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/tests/serverpod_auth_test/serverpod_auth_test_server/lib/src/generated/token_metadata.dart
+++ b/tests/serverpod_auth_test/serverpod_auth_test_server/lib/src/generated/token_metadata.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/tests/serverpod_auth_test/serverpod_auth_test_server/lib/src/generated/user_data.dart
+++ b/tests/serverpod_auth_test/serverpod_auth_test_server/lib/src/generated/user_data.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/tests/serverpod_test_server/lib/src/generated/changed_id_type/many_to_many/course.dart
+++ b/tests/serverpod_test_server/lib/src/generated/changed_id_type/many_to_many/course.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/tests/serverpod_test_server/lib/src/generated/changed_id_type/many_to_many/enrollment.dart
+++ b/tests/serverpod_test_server/lib/src/generated/changed_id_type/many_to_many/enrollment.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/tests/serverpod_test_server/lib/src/generated/changed_id_type/many_to_many/student.dart
+++ b/tests/serverpod_test_server/lib/src/generated/changed_id_type/many_to_many/student.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/tests/serverpod_test_server/lib/src/generated/changed_id_type/nested_one_to_many/arena.dart
+++ b/tests/serverpod_test_server/lib/src/generated/changed_id_type/nested_one_to_many/arena.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
@@ -635,9 +634,6 @@ class ArenaUuidAttachRowRepository {
     if (team.id == null) {
       throw ArgumentError.notNull('team.id');
     }
-    if (arenaUuid.id == null) {
-      throw ArgumentError.notNull('arenaUuid.id');
-    }
 
     var $team = team.copyWith(arenaId: arenaUuid.id);
     await session.db.updateRow<_i2.TeamInt>(
@@ -668,9 +664,6 @@ class ArenaUuidDetachRowRepository {
     }
     if ($team.id == null) {
       throw ArgumentError.notNull('arenaUuid.team.id');
-    }
-    if (arenaUuid.id == null) {
-      throw ArgumentError.notNull('arenaUuid.id');
     }
 
     var $$team = $team.copyWith(arenaId: null);

--- a/tests/serverpod_test_server/lib/src/generated/changed_id_type/nested_one_to_many/player.dart
+++ b/tests/serverpod_test_server/lib/src/generated/changed_id_type/nested_one_to_many/player.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/tests/serverpod_test_server/lib/src/generated/changed_id_type/nested_one_to_many/team.dart
+++ b/tests/serverpod_test_server/lib/src/generated/changed_id_type/nested_one_to_many/team.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
@@ -769,9 +768,6 @@ class TeamIntAttachRowRepository {
   }) async {
     if (teamInt.id == null) {
       throw ArgumentError.notNull('teamInt.id');
-    }
-    if (arena.id == null) {
-      throw ArgumentError.notNull('arena.id');
     }
 
     var $teamInt = teamInt.copyWith(arenaId: arena.id);

--- a/tests/serverpod_test_server/lib/src/generated/changed_id_type/one_to_many/comment.dart
+++ b/tests/serverpod_test_server/lib/src/generated/changed_id_type/one_to_many/comment.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
@@ -659,9 +658,6 @@ class CommentIntAttachRowRepository {
   }) async {
     if (commentInt.id == null) {
       throw ArgumentError.notNull('commentInt.id');
-    }
-    if (order.id == null) {
-      throw ArgumentError.notNull('order.id');
     }
 
     var $commentInt = commentInt.copyWith(orderId: order.id);

--- a/tests/serverpod_test_server/lib/src/generated/changed_id_type/one_to_many/customer.dart
+++ b/tests/serverpod_test_server/lib/src/generated/changed_id_type/one_to_many/customer.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
@@ -661,9 +660,6 @@ class CustomerIntAttachRepository {
     List<_i2.OrderUuid> orderUuid, {
     _i1.Transaction? transaction,
   }) async {
-    if (orderUuid.any((e) => e.id == null)) {
-      throw ArgumentError.notNull('orderUuid.id');
-    }
     if (customerInt.id == null) {
       throw ArgumentError.notNull('customerInt.id');
     }
@@ -690,9 +686,6 @@ class CustomerIntAttachRowRepository {
     _i2.OrderUuid orderUuid, {
     _i1.Transaction? transaction,
   }) async {
-    if (orderUuid.id == null) {
-      throw ArgumentError.notNull('orderUuid.id');
-    }
     if (customerInt.id == null) {
       throw ArgumentError.notNull('customerInt.id');
     }
@@ -719,10 +712,6 @@ class CustomerIntDetachRepository {
     List<_i2.OrderUuid> orderUuid, {
     _i1.Transaction? transaction,
   }) async {
-    if (orderUuid.any((e) => e.id == null)) {
-      throw ArgumentError.notNull('orderUuid.id');
-    }
-
     var $orderUuid = orderUuid
         .map((e) => e.copyWith(customerId: null))
         .toList();
@@ -747,10 +736,6 @@ class CustomerIntDetachRowRepository {
     _i2.OrderUuid orderUuid, {
     _i1.Transaction? transaction,
   }) async {
-    if (orderUuid.id == null) {
-      throw ArgumentError.notNull('orderUuid.id');
-    }
-
     var $orderUuid = orderUuid.copyWith(customerId: null);
     await session.db.updateRow<_i2.OrderUuid>(
       $orderUuid,

--- a/tests/serverpod_test_server/lib/src/generated/changed_id_type/one_to_many/order.dart
+++ b/tests/serverpod_test_server/lib/src/generated/changed_id_type/one_to_many/order.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
@@ -738,9 +737,6 @@ class OrderUuidAttachRepository {
     if (commentInt.any((e) => e.id == null)) {
       throw ArgumentError.notNull('commentInt.id');
     }
-    if (orderUuid.id == null) {
-      throw ArgumentError.notNull('orderUuid.id');
-    }
 
     var $commentInt = commentInt
         .map((e) => e.copyWith(orderId: orderUuid.id))
@@ -764,9 +760,6 @@ class OrderUuidAttachRowRepository {
     _i2.CustomerInt customer, {
     _i1.Transaction? transaction,
   }) async {
-    if (orderUuid.id == null) {
-      throw ArgumentError.notNull('orderUuid.id');
-    }
     if (customer.id == null) {
       throw ArgumentError.notNull('customer.id');
     }
@@ -789,9 +782,6 @@ class OrderUuidAttachRowRepository {
   }) async {
     if (commentInt.id == null) {
       throw ArgumentError.notNull('commentInt.id');
-    }
-    if (orderUuid.id == null) {
-      throw ArgumentError.notNull('orderUuid.id');
     }
 
     var $commentInt = commentInt.copyWith(orderId: orderUuid.id);

--- a/tests/serverpod_test_server/lib/src/generated/changed_id_type/one_to_one/address.dart
+++ b/tests/serverpod_test_server/lib/src/generated/changed_id_type/one_to_one/address.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
@@ -660,9 +659,6 @@ class AddressUuidAttachRowRepository {
     _i2.CitizenInt inhabitant, {
     _i1.Transaction? transaction,
   }) async {
-    if (addressUuid.id == null) {
-      throw ArgumentError.notNull('addressUuid.id');
-    }
     if (inhabitant.id == null) {
       throw ArgumentError.notNull('inhabitant.id');
     }
@@ -689,10 +685,6 @@ class AddressUuidDetachRowRepository {
     AddressUuid addressUuid, {
     _i1.Transaction? transaction,
   }) async {
-    if (addressUuid.id == null) {
-      throw ArgumentError.notNull('addressUuid.id');
-    }
-
     var $addressUuid = addressUuid.copyWith(inhabitantId: null);
     await session.db.updateRow<AddressUuid>(
       $addressUuid,

--- a/tests/serverpod_test_server/lib/src/generated/changed_id_type/one_to_one/citizen.dart
+++ b/tests/serverpod_test_server/lib/src/generated/changed_id_type/one_to_one/citizen.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
@@ -785,9 +784,6 @@ class CitizenIntAttachRowRepository {
     _i2.AddressUuid address, {
     _i1.Transaction? transaction,
   }) async {
-    if (address.id == null) {
-      throw ArgumentError.notNull('address.id');
-    }
     if (citizenInt.id == null) {
       throw ArgumentError.notNull('citizenInt.id');
     }
@@ -864,9 +860,6 @@ class CitizenIntDetachRowRepository {
 
     if ($address == null) {
       throw ArgumentError.notNull('citizenInt.address');
-    }
-    if ($address.id == null) {
-      throw ArgumentError.notNull('citizenInt.address.id');
     }
     if (citizenInt.id == null) {
       throw ArgumentError.notNull('citizenInt.id');

--- a/tests/serverpod_test_server/lib/src/generated/changed_id_type/one_to_one/company.dart
+++ b/tests/serverpod_test_server/lib/src/generated/changed_id_type/one_to_one/company.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/tests/serverpod_test_server/lib/src/generated/changed_id_type/one_to_one/town.dart
+++ b/tests/serverpod_test_server/lib/src/generated/changed_id_type/one_to_one/town.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/tests/serverpod_test_server/lib/src/generated/changed_id_type/self.dart
+++ b/tests/serverpod_test_server/lib/src/generated/changed_id_type/self.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/tests/serverpod_test_server/lib/src/generated/empty_model/relation_empy_model.dart
+++ b/tests/serverpod_test_server/lib/src/generated/empty_model/relation_empy_model.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/tests/serverpod_test_server/lib/src/generated/explicit_column_name/relations/one_to_many/department.dart
+++ b/tests/serverpod_test_server/lib/src/generated/explicit_column_name/relations/one_to_many/department.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/tests/serverpod_test_server/lib/src/generated/explicit_column_name/relations/one_to_one/contractor.dart
+++ b/tests/serverpod_test_server/lib/src/generated/explicit_column_name/relations/one_to_one/contractor.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/tests/serverpod_test_server/lib/src/generated/inheritance/child_with_inherited_id.dart
+++ b/tests/serverpod_test_server/lib/src/generated/inheritance/child_with_inherited_id.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import '../protocol.dart' as _i1;
@@ -668,13 +667,6 @@ class ChildWithInheritedIdAttachRowRepository {
     _i3.ChildWithInheritedId parent, {
     _i2.Transaction? transaction,
   }) async {
-    if (childWithInheritedId.id == null) {
-      throw ArgumentError.notNull('childWithInheritedId.id');
-    }
-    if (parent.id == null) {
-      throw ArgumentError.notNull('parent.id');
-    }
-
     var $childWithInheritedId = childWithInheritedId.copyWith(
       parentId: parent.id,
     );
@@ -699,10 +691,6 @@ class ChildWithInheritedIdDetachRowRepository {
     ChildWithInheritedId childWithInheritedId, {
     _i2.Transaction? transaction,
   }) async {
-    if (childWithInheritedId.id == null) {
-      throw ArgumentError.notNull('childWithInheritedId.id');
-    }
-
     var $childWithInheritedId = childWithInheritedId.copyWith(parentId: null);
     await session.db.updateRow<ChildWithInheritedId>(
       $childWithInheritedId,

--- a/tests/serverpod_test_server/lib/src/generated/inheritance/list_relation_of_child/parent_entity.dart
+++ b/tests/serverpod_test_server/lib/src/generated/inheritance/list_relation_of_child/parent_entity.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/deep_includes/city_with_long_table_name.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/deep_includes/city_with_long_table_name.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/deep_includes/organization_with_long_table_name.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/deep_includes/organization_with_long_table_name.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/deep_includes/person_with_long_table_name.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/deep_includes/person_with_long_table_name.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/long_implicit_id_field_collection.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/long_implicit_id_field_collection.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/relation_to_mutiple_max_field_name.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/relation_to_mutiple_max_field_name.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/user_note_collection.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/user_note_collection.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/user_note_collection_with_a_long_name.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/user_note_collection_with_a_long_name.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/tests/serverpod_test_server/lib/src/generated/models_with_list_relations/city.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_list_relations/city.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/tests/serverpod_test_server/lib/src/generated/models_with_list_relations/organization.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_list_relations/organization.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/tests/serverpod_test_server/lib/src/generated/models_with_list_relations/person.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_list_relations/person.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/column_alias_collision/bleed_root.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/column_alias_collision/bleed_root.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/many_to_many/course.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/many_to_many/course.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/many_to_many/enrollment.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/many_to_many/enrollment.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/many_to_many/student.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/many_to_many/student.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/module/object_user.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/module/object_user.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/nested_one_to_many/arena.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/nested_one_to_many/arena.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/nested_one_to_many/player.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/nested_one_to_many/player.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/nested_one_to_many/team.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/nested_one_to_many/team.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/comment.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/comment.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/customer.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/customer.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/implicit/book.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/implicit/book.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/order.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/order.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/address.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/address.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/citizen.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/citizen.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/company.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/company.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/town.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/town.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/many_to_many/blocking.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/many_to_many/blocking.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/many_to_many/member.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/many_to_many/member.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/one_to_many/cat.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/one_to_many/cat.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/one_to_one/post.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/one_to_one/post.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/tests/serverpod_test_server/lib/src/generated/related_unique_data.dart
+++ b/tests/serverpod_test_server/lib/src/generated/related_unique_data.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/empty_model/relation_empy_model.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/empty_model/relation_empy_model.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_database/serverpod_database.dart' as _i1;

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_list_relations/city.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_list_relations/city.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_database/serverpod_database.dart' as _i1;

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_list_relations/organization.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_list_relations/organization.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_database/serverpod_database.dart' as _i1;

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_list_relations/person.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_list_relations/person.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_database/serverpod_database.dart' as _i1;

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/many_to_many/course.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/many_to_many/course.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_database/serverpod_database.dart' as _i1;

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/many_to_many/enrollment.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/many_to_many/enrollment.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_database/serverpod_database.dart' as _i1;

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/many_to_many/student.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/many_to_many/student.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_database/serverpod_database.dart' as _i1;

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/nested_one_to_many/arena.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/nested_one_to_many/arena.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_database/serverpod_database.dart' as _i1;

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/nested_one_to_many/player.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/nested_one_to_many/player.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_database/serverpod_database.dart' as _i1;

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/nested_one_to_many/team.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/nested_one_to_many/team.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_database/serverpod_database.dart' as _i1;

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/one_to_many/comment.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/one_to_many/comment.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_database/serverpod_database.dart' as _i1;

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/one_to_many/customer.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/one_to_many/customer.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_database/serverpod_database.dart' as _i1;

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/one_to_many/implicit/book.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/one_to_many/implicit/book.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_database/serverpod_database.dart' as _i1;

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/one_to_many/order.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/one_to_many/order.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_database/serverpod_database.dart' as _i1;

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/one_to_one/address.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/one_to_one/address.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_database/serverpod_database.dart' as _i1;

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/one_to_one/citizen.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/one_to_one/citizen.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_database/serverpod_database.dart' as _i1;

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/one_to_one/company.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/one_to_one/company.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_database/serverpod_database.dart' as _i1;

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/one_to_one/town.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/one_to_one/town.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_database/serverpod_database.dart' as _i1;

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/self_relation/many_to_many/blocking.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/self_relation/many_to_many/blocking.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_database/serverpod_database.dart' as _i1;

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/self_relation/many_to_many/member.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/self_relation/many_to_many/member.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_database/serverpod_database.dart' as _i1;

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/self_relation/one_to_many/cat.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/self_relation/one_to_many/cat.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_database/serverpod_database.dart' as _i1;

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/self_relation/one_to_one/post.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/self_relation/one_to_one/post.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_database/serverpod_database.dart' as _i1;

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/related_unique_data.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/related_unique_data.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_database/serverpod_database.dart' as _i1;

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/changed_id_type/many_to_many/course.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/changed_id_type/many_to_many/course.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/changed_id_type/many_to_many/enrollment.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/changed_id_type/many_to_many/enrollment.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/changed_id_type/many_to_many/student.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/changed_id_type/many_to_many/student.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/changed_id_type/nested_one_to_many/arena.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/changed_id_type/nested_one_to_many/arena.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
@@ -636,9 +635,6 @@ class ArenaUuidAttachRowRepository {
     if (team.id == null) {
       throw ArgumentError.notNull('team.id');
     }
-    if (arenaUuid.id == null) {
-      throw ArgumentError.notNull('arenaUuid.id');
-    }
 
     var $team = team.copyWith(arenaId: arenaUuid.id);
     await session.db.updateRow<_i2.TeamInt>(
@@ -669,9 +665,6 @@ class ArenaUuidDetachRowRepository {
     }
     if ($team.id == null) {
       throw ArgumentError.notNull('arenaUuid.team.id');
-    }
-    if (arenaUuid.id == null) {
-      throw ArgumentError.notNull('arenaUuid.id');
     }
 
     var $$team = $team.copyWith(arenaId: null);

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/changed_id_type/nested_one_to_many/player.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/changed_id_type/nested_one_to_many/player.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/changed_id_type/nested_one_to_many/team.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/changed_id_type/nested_one_to_many/team.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
@@ -770,9 +769,6 @@ class TeamIntAttachRowRepository {
   }) async {
     if (teamInt.id == null) {
       throw ArgumentError.notNull('teamInt.id');
-    }
-    if (arena.id == null) {
-      throw ArgumentError.notNull('arena.id');
     }
 
     var $teamInt = teamInt.copyWith(arenaId: arena.id);

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/changed_id_type/one_to_many/comment.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/changed_id_type/one_to_many/comment.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
@@ -660,9 +659,6 @@ class CommentIntAttachRowRepository {
   }) async {
     if (commentInt.id == null) {
       throw ArgumentError.notNull('commentInt.id');
-    }
-    if (order.id == null) {
-      throw ArgumentError.notNull('order.id');
     }
 
     var $commentInt = commentInt.copyWith(orderId: order.id);

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/changed_id_type/one_to_many/customer.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/changed_id_type/one_to_many/customer.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
@@ -662,9 +661,6 @@ class CustomerIntAttachRepository {
     List<_i2.OrderUuid> orderUuid, {
     _i1.Transaction? transaction,
   }) async {
-    if (orderUuid.any((e) => e.id == null)) {
-      throw ArgumentError.notNull('orderUuid.id');
-    }
     if (customerInt.id == null) {
       throw ArgumentError.notNull('customerInt.id');
     }
@@ -691,9 +687,6 @@ class CustomerIntAttachRowRepository {
     _i2.OrderUuid orderUuid, {
     _i1.Transaction? transaction,
   }) async {
-    if (orderUuid.id == null) {
-      throw ArgumentError.notNull('orderUuid.id');
-    }
     if (customerInt.id == null) {
       throw ArgumentError.notNull('customerInt.id');
     }
@@ -720,10 +713,6 @@ class CustomerIntDetachRepository {
     List<_i2.OrderUuid> orderUuid, {
     _i1.Transaction? transaction,
   }) async {
-    if (orderUuid.any((e) => e.id == null)) {
-      throw ArgumentError.notNull('orderUuid.id');
-    }
-
     var $orderUuid = orderUuid
         .map((e) => e.copyWith(customerId: null))
         .toList();
@@ -748,10 +737,6 @@ class CustomerIntDetachRowRepository {
     _i2.OrderUuid orderUuid, {
     _i1.Transaction? transaction,
   }) async {
-    if (orderUuid.id == null) {
-      throw ArgumentError.notNull('orderUuid.id');
-    }
-
     var $orderUuid = orderUuid.copyWith(customerId: null);
     await session.db.updateRow<_i2.OrderUuid>(
       $orderUuid,

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/changed_id_type/one_to_many/order.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/changed_id_type/one_to_many/order.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
@@ -739,9 +738,6 @@ class OrderUuidAttachRepository {
     if (commentInt.any((e) => e.id == null)) {
       throw ArgumentError.notNull('commentInt.id');
     }
-    if (orderUuid.id == null) {
-      throw ArgumentError.notNull('orderUuid.id');
-    }
 
     var $commentInt = commentInt
         .map((e) => e.copyWith(orderId: orderUuid.id))
@@ -765,9 +761,6 @@ class OrderUuidAttachRowRepository {
     _i2.CustomerInt customer, {
     _i1.Transaction? transaction,
   }) async {
-    if (orderUuid.id == null) {
-      throw ArgumentError.notNull('orderUuid.id');
-    }
     if (customer.id == null) {
       throw ArgumentError.notNull('customer.id');
     }
@@ -790,9 +783,6 @@ class OrderUuidAttachRowRepository {
   }) async {
     if (commentInt.id == null) {
       throw ArgumentError.notNull('commentInt.id');
-    }
-    if (orderUuid.id == null) {
-      throw ArgumentError.notNull('orderUuid.id');
     }
 
     var $commentInt = commentInt.copyWith(orderId: orderUuid.id);

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/changed_id_type/one_to_one/address.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/changed_id_type/one_to_one/address.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
@@ -661,9 +660,6 @@ class AddressUuidAttachRowRepository {
     _i2.CitizenInt inhabitant, {
     _i1.Transaction? transaction,
   }) async {
-    if (addressUuid.id == null) {
-      throw ArgumentError.notNull('addressUuid.id');
-    }
     if (inhabitant.id == null) {
       throw ArgumentError.notNull('inhabitant.id');
     }
@@ -690,10 +686,6 @@ class AddressUuidDetachRowRepository {
     AddressUuid addressUuid, {
     _i1.Transaction? transaction,
   }) async {
-    if (addressUuid.id == null) {
-      throw ArgumentError.notNull('addressUuid.id');
-    }
-
     var $addressUuid = addressUuid.copyWith(inhabitantId: null);
     await session.db.updateRow<AddressUuid>(
       $addressUuid,

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/changed_id_type/one_to_one/citizen.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/changed_id_type/one_to_one/citizen.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
@@ -786,9 +785,6 @@ class CitizenIntAttachRowRepository {
     _i2.AddressUuid address, {
     _i1.Transaction? transaction,
   }) async {
-    if (address.id == null) {
-      throw ArgumentError.notNull('address.id');
-    }
     if (citizenInt.id == null) {
       throw ArgumentError.notNull('citizenInt.id');
     }
@@ -865,9 +861,6 @@ class CitizenIntDetachRowRepository {
 
     if ($address == null) {
       throw ArgumentError.notNull('citizenInt.address');
-    }
-    if ($address.id == null) {
-      throw ArgumentError.notNull('citizenInt.address.id');
     }
     if (citizenInt.id == null) {
       throw ArgumentError.notNull('citizenInt.id');

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/changed_id_type/one_to_one/company.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/changed_id_type/one_to_one/company.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/changed_id_type/one_to_one/town.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/changed_id_type/one_to_one/town.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/changed_id_type/self.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/changed_id_type/self.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/empty_model/relation_empy_model.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/empty_model/relation_empy_model.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/explicit_column_name/relations/one_to_many/department.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/explicit_column_name/relations/one_to_many/department.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/explicit_column_name/relations/one_to_one/contractor.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/explicit_column_name/relations/one_to_one/contractor.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/long_identifiers/deep_includes/city_with_long_table_name.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/long_identifiers/deep_includes/city_with_long_table_name.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/long_identifiers/deep_includes/organization_with_long_table_name.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/long_identifiers/deep_includes/organization_with_long_table_name.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/long_identifiers/deep_includes/person_with_long_table_name.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/long_identifiers/deep_includes/person_with_long_table_name.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/long_identifiers/models_with_relations/long_implicit_id_field_collection.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/long_identifiers/models_with_relations/long_implicit_id_field_collection.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/long_identifiers/models_with_relations/relation_to_mutiple_max_field_name.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/long_identifiers/models_with_relations/relation_to_mutiple_max_field_name.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/long_identifiers/models_with_relations/user_note_collection.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/long_identifiers/models_with_relations/user_note_collection.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/long_identifiers/models_with_relations/user_note_collection_with_a_long_name.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/long_identifiers/models_with_relations/user_note_collection_with_a_long_name.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_list_relations/city.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_list_relations/city.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_list_relations/organization.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_list_relations/organization.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_list_relations/person.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_list_relations/person.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/many_to_many/course.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/many_to_many/course.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/many_to_many/enrollment.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/many_to_many/enrollment.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/many_to_many/student.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/many_to_many/student.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/nested_one_to_many/arena.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/nested_one_to_many/arena.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/nested_one_to_many/player.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/nested_one_to_many/player.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/nested_one_to_many/team.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/nested_one_to_many/team.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/one_to_many/comment.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/one_to_many/comment.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/one_to_many/customer.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/one_to_many/customer.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/one_to_many/implicit/book.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/one_to_many/implicit/book.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/one_to_many/order.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/one_to_many/order.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/one_to_one/address.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/one_to_one/address.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/one_to_one/citizen.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/one_to_one/citizen.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/one_to_one/company.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/one_to_one/company.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/one_to_one/town.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/one_to_one/town.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/self_relation/many_to_many/blocking.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/self_relation/many_to_many/blocking.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/self_relation/many_to_many/member.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/self_relation/many_to_many/member.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/self_relation/one_to_many/cat.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/self_relation/one_to_many/cat.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/self_relation/one_to_one/post.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/self_relation/one_to_one/post.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/related_unique_data.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/related_unique_data.dart
@@ -8,7 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
-// ignore_for_file: dead_code, unnecessary_null_comparison
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/tools/serverpod_cli/lib/src/analyzer/models/definitions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/definitions.dart
@@ -682,10 +682,17 @@ class ObjectRelationDefinition extends RelationDefinition {
   /// [parentTable].
   String parentTable;
 
-  /// Type of the primary key of the [parentTable]. It is the type that the
-  /// generator needs to build attach/detach methods. It is not the type of
+  /// Type of the primary key of the class that owns the foreign key column.
+  /// For relations where this side holds the foreign key
+  /// ([isForeignKeyOrigin] is true) this is the current class's id type,
+  /// otherwise it is the referenced class's id type. It is not the type of
   /// the [foreignFieldName].
   TypeDefinition parentTableIdType;
+
+  /// Type of the id field of the referenced class - the model on the other
+  /// side of this relation. Used to decide whether the `id == null` guards
+  /// in the generated attach/detach methods are needed.
+  TypeDefinition referenceIdType;
 
   /// References the field in the current object that points to the foreign table.
   final String fieldName;
@@ -703,6 +710,7 @@ class ObjectRelationDefinition extends RelationDefinition {
   ObjectRelationDefinition({
     String? name,
     required this.parentTableIdType,
+    required this.referenceIdType,
     required this.parentTable,
     required this.fieldName,
     required this.foreignFieldName,

--- a/tools/serverpod_cli/lib/src/analyzer/models/entity_dependency_resolver.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/entity_dependency_resolver.dart
@@ -285,6 +285,7 @@ class ModelDependencyResolver {
       parentTableIdType: relation.isForeignKeyOrigin
           ? classDefinition.idField.type
           : referenceClass.idField.type,
+      referenceIdType: referenceClass.idField.type,
       parentTable: tableName,
       fieldName: defaultPrimaryKeyName,
       foreignFieldName: foreignFieldName,
@@ -344,6 +345,7 @@ class ModelDependencyResolver {
     fieldDefinition.relation = ObjectRelationDefinition(
       parentTable: tableName,
       parentTableIdType: classDefinition.idField.type,
+      referenceIdType: referenceDefinition.idField.type,
       fieldName: foreignRelationField.name,
       foreignFieldName: defaultPrimaryKeyName,
       foreignContainerField: foreignContainerField,
@@ -395,6 +397,7 @@ class ModelDependencyResolver {
     fieldDefinition.relation = ObjectRelationDefinition(
       parentTable: tableName,
       parentTableIdType: classDefinition.idField.type,
+      referenceIdType: referenceDefinition.idField.type,
       fieldName: relationFieldName,
       foreignFieldName: defaultPrimaryKeyName,
       foreignContainerField: foreignContainerField,
@@ -500,7 +503,7 @@ class ModelDependencyResolver {
 
       fieldDefinition.relation = ListRelationDefinition(
         name: autoRelationName,
-        foreignKeyOwnerIdType: classDefinition.idField.type,
+        foreignKeyOwnerIdType: referenceClass.idField.type,
         fieldName: defaultPrimaryKeyName,
         foreignFieldName: foreignFieldName,
         foreignContainerField:

--- a/tools/serverpod_cli/lib/src/generator/dart/library_generators/class_generators/repository_classes.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart/library_generators/class_generators/repository_classes.dart
@@ -100,7 +100,7 @@ class BuildRepositoryClass {
   Class buildModelAttachRepositoryClass(
     String className,
     List<SerializableModelFieldDefinition> fields,
-    ClassDefinition classDefinition,
+    ModelClassDefinition classDefinition,
   ) {
     return Class((classBuilder) {
       classBuilder
@@ -125,7 +125,7 @@ class BuildRepositoryClass {
   Class buildModelAttachRowRepositoryClass(
     String className,
     List<SerializableModelFieldDefinition> fields,
-    ClassDefinition classDefinition,
+    ModelClassDefinition classDefinition,
   ) {
     return Class((classBuilder) {
       classBuilder
@@ -150,7 +150,7 @@ class BuildRepositoryClass {
   Class buildModelDetachRepositoryClass(
     String className,
     List<SerializableModelFieldDefinition> fields,
-    ClassDefinition classDefinition,
+    ModelClassDefinition classDefinition,
   ) {
     return Class((classBuilder) {
       classBuilder
@@ -175,7 +175,7 @@ class BuildRepositoryClass {
   Class buildModelDetachRowRepositoryClass(
     String className,
     List<SerializableModelFieldDefinition> fields,
-    ClassDefinition classDefinition,
+    ModelClassDefinition classDefinition,
   ) {
     return Class((classBuilder) {
       classBuilder
@@ -1774,7 +1774,7 @@ class BuildRepositoryClass {
   Iterable<Method> _buildAttachMethods(
     List<SerializableModelFieldDefinition> fields,
     String className,
-    ClassDefinition classDefinition,
+    ModelClassDefinition classDefinition,
   ) {
     return fields
         .where(_isListRelation)
@@ -1790,7 +1790,7 @@ class BuildRepositoryClass {
   Iterable<Method> _buildAttachRowMethods(
     List<SerializableModelFieldDefinition> fields,
     String className,
-    ClassDefinition classDefinition,
+    ModelClassDefinition classDefinition,
   ) {
     return [
       ...fields
@@ -1817,7 +1817,7 @@ class BuildRepositoryClass {
   Method _buildAttachFromListRelationField(
     String className,
     SerializableModelFieldDefinition field,
-    ClassDefinition classDefinition,
+    ModelClassDefinition classDefinition,
   ) {
     return Method((methodBuilder) {
       var classFieldName = className.camelCase;
@@ -1885,12 +1885,18 @@ class BuildRepositoryClass {
                 classFieldName,
                 relation.foreignFieldName,
                 foreignType,
+                nullableClassFieldId: relation.foreignKeyOwnerIdType.nullable,
+                nullableOtherClassFieldId:
+                    classDefinition.idField.type.nullable,
               )
             : _buildAttachImplementationBlockExplicitListRelation(
                 otherClassFieldName,
                 classFieldName,
                 relation.foreignFieldName,
                 foreignType,
+                nullableClassFieldId: relation.foreignKeyOwnerIdType.nullable,
+                nullableOtherClassFieldId:
+                    classDefinition.idField.type.nullable,
               );
       const Code('');
     });
@@ -1899,7 +1905,7 @@ class BuildRepositoryClass {
   Method _buildAttachRowFromListRelationField(
     String className,
     SerializableModelFieldDefinition field,
-    ClassDefinition classDefinition,
+    ModelClassDefinition classDefinition,
   ) {
     return Method((methodBuilder) {
       var classFieldName = className.camelCase;
@@ -1962,12 +1968,18 @@ class BuildRepositoryClass {
                 classFieldName,
                 relation.foreignFieldName,
                 foreignType,
+                nullableClassFieldId: relation.foreignKeyOwnerIdType.nullable,
+                nullableOtherClassFieldId:
+                    classDefinition.idField.type.nullable,
               )
             : _buildAttachRowImplementationBlockExplicit(
                 otherClassFieldName,
                 classFieldName,
                 relation.foreignFieldName,
                 foreignType,
+                nullableClassFieldId: relation.foreignKeyOwnerIdType.nullable,
+                nullableOtherClassFieldId:
+                    classDefinition.idField.type.nullable,
               );
       const Code('');
     });
@@ -1976,7 +1988,7 @@ class BuildRepositoryClass {
   Method _buildAttachRowFromObjectRelationField(
     String className,
     SerializableModelFieldDefinition field,
-    ClassDefinition classDefinition,
+    ModelClassDefinition classDefinition,
   ) {
     return Method((methodBuilder) {
       var classFieldName = className.camelCase;
@@ -2036,12 +2048,17 @@ class BuildRepositoryClass {
                 otherClassFieldName,
                 relation.fieldName,
                 refer(className),
+                nullableClassFieldId: classDefinition.idField.type.nullable,
+                nullableOtherClassFieldId: relation.referenceIdType.nullable,
               )
             : _buildAttachRowImplementationBlockExplicit(
                 otherClassFieldName,
                 classFieldName,
                 relation.foreignFieldName,
                 foreignType,
+                nullableClassFieldId: relation.referenceIdType.nullable,
+                nullableOtherClassFieldId:
+                    classDefinition.idField.type.nullable,
               );
       const Code('');
     });
@@ -2052,15 +2069,20 @@ class BuildRepositoryClass {
     String classFieldName,
     String otherClassFieldName,
     String foreignKeyField,
-    Reference classReference,
-  ) {
+    Reference classReference, {
+    required bool nullableClassFieldId,
+    required bool nullableOtherClassFieldId,
+  }) {
     var implicitForeignKeyFieldName = createImplicitFieldName(foreignKeyField);
 
     return (BlockBuilder()
           ..statements.addAll([
-            _buildCodeBlockThrowIfAnyIdIsNull(classFieldName),
-            _buildCodeBlockThrowIfIdIsNull(otherClassFieldName),
-            const Code(''),
+            if (nullableClassFieldId)
+              _buildCodeBlockThrowIfAnyIdIsNull(classFieldName),
+            if (nullableOtherClassFieldId)
+              _buildCodeBlockThrowIfIdIsNull(otherClassFieldName),
+            if (nullableClassFieldId || nullableOtherClassFieldId)
+              const Code(''),
             _buildImplicitCopyClassListField(
               classReference,
               classFieldName,
@@ -2081,13 +2103,18 @@ class BuildRepositoryClass {
     String classFieldName,
     String otherClassFieldName,
     String foreignKeyField,
-    Reference classReference,
-  ) {
+    Reference classReference, {
+    required bool nullableClassFieldId,
+    required bool nullableOtherClassFieldId,
+  }) {
     return (BlockBuilder()
           ..statements.addAll([
-            _buildCodeBlockThrowIfAnyIdIsNull(classFieldName),
-            _buildCodeBlockThrowIfIdIsNull(otherClassFieldName),
-            const Code(''),
+            if (nullableClassFieldId)
+              _buildCodeBlockThrowIfAnyIdIsNull(classFieldName),
+            if (nullableOtherClassFieldId)
+              _buildCodeBlockThrowIfIdIsNull(otherClassFieldName),
+            if (nullableClassFieldId || nullableOtherClassFieldId)
+              const Code(''),
             _buildCopyWithListField(
               classFieldName,
               foreignKeyField,
@@ -2107,13 +2134,18 @@ class BuildRepositoryClass {
     String classFieldName,
     String otherClassFieldName,
     String foreignKeyField,
-    Reference classReference,
-  ) {
+    Reference classReference, {
+    required bool nullableClassFieldId,
+    required bool nullableOtherClassFieldId,
+  }) {
     return (BlockBuilder()
           ..statements.addAll([
-            _buildCodeBlockThrowIfIdIsNull(classFieldName),
-            _buildCodeBlockThrowIfIdIsNull(otherClassFieldName),
-            const Code(''),
+            if (nullableClassFieldId)
+              _buildCodeBlockThrowIfIdIsNull(classFieldName),
+            if (nullableOtherClassFieldId)
+              _buildCodeBlockThrowIfIdIsNull(otherClassFieldName),
+            if (nullableClassFieldId || nullableOtherClassFieldId)
+              const Code(''),
             _buildCopyWithSingleField(
               classFieldName,
               foreignKeyField,
@@ -2134,14 +2166,19 @@ class BuildRepositoryClass {
     String classFieldName,
     String otherClassFieldName,
     String foreignKeyField,
-    Reference classReference,
-  ) {
+    Reference classReference, {
+    required bool nullableClassFieldId,
+    required bool nullableOtherClassFieldId,
+  }) {
     var implicitForeignKeyFieldName = createImplicitFieldName(foreignKeyField);
     return (BlockBuilder()
           ..statements.addAll([
-            _buildCodeBlockThrowIfIdIsNull(classFieldName),
-            _buildCodeBlockThrowIfIdIsNull(otherClassFieldName),
-            const Code(''),
+            if (nullableClassFieldId)
+              _buildCodeBlockThrowIfIdIsNull(classFieldName),
+            if (nullableOtherClassFieldId)
+              _buildCodeBlockThrowIfIdIsNull(otherClassFieldName),
+            if (nullableClassFieldId || nullableOtherClassFieldId)
+              const Code(''),
             _buildImplicitCopyClassSingleField(
               classReference,
               classFieldName,
@@ -2161,7 +2198,7 @@ class BuildRepositoryClass {
   Iterable<Method> _buildDetachMethods(
     List<SerializableModelFieldDefinition> fields,
     String className,
-    ClassDefinition classDefinition,
+    ModelClassDefinition classDefinition,
   ) {
     return fields
         .where(_isNullableListRelation)
@@ -2177,7 +2214,7 @@ class BuildRepositoryClass {
   Iterable<Method> _buildDetachRowMethods(
     List<SerializableModelFieldDefinition> fields,
     String className,
-    ClassDefinition classDefinition,
+    ModelClassDefinition classDefinition,
   ) {
     return [
       ...fields
@@ -2204,7 +2241,7 @@ class BuildRepositoryClass {
   Method _buildDetachFromListRelationField(
     String className,
     SerializableModelFieldDefinition field,
-    ClassDefinition classDefinition,
+    ModelClassDefinition classDefinition,
   ) {
     return Method((methodBuilder) {
       var firstGeneric = field.type.generics.first;
@@ -2267,6 +2304,7 @@ class BuildRepositoryClass {
                 classFieldName,
                 relation.foreignFieldName,
                 foreignType,
+                nullableFieldId: relation.foreignKeyOwnerIdType.nullable,
               )
             : _buildDetachImplementationBlockExplicitListRelation(
                 className,
@@ -2274,6 +2312,7 @@ class BuildRepositoryClass {
                 classFieldName,
                 relation.foreignFieldName,
                 foreignType,
+                nullableFieldId: relation.foreignKeyOwnerIdType.nullable,
               );
       const Code('');
     });
@@ -2282,7 +2321,7 @@ class BuildRepositoryClass {
   Method _buildDetachRowFromListRelationField(
     String className,
     SerializableModelFieldDefinition field,
-    ClassDefinition classDefinition,
+    ModelClassDefinition classDefinition,
   ) {
     return Method((methodBuilder) {
       var firstGeneric = field.type.generics.first;
@@ -2344,6 +2383,7 @@ class BuildRepositoryClass {
                 classFieldName,
                 relation.foreignFieldName,
                 foreignType,
+                nullableFieldId: relation.foreignKeyOwnerIdType.nullable,
               )
             : _buildDetachRowImplementationBlockExplicitListRelation(
                 className,
@@ -2351,6 +2391,7 @@ class BuildRepositoryClass {
                 classFieldName,
                 relation.foreignFieldName,
                 foreignType,
+                nullableFieldId: relation.foreignKeyOwnerIdType.nullable,
               );
       const Code('');
     });
@@ -2359,7 +2400,7 @@ class BuildRepositoryClass {
   Method _buildDetachRowFromObjectRelationField(
     String className,
     SerializableModelFieldDefinition field,
-    ClassDefinition classDefinition,
+    ModelClassDefinition classDefinition,
   ) {
     return Method((methodBuilder) {
       var classFieldName = className.camelCase;
@@ -2408,6 +2449,7 @@ class BuildRepositoryClass {
                 classFieldName,
                 relation.fieldName,
                 className,
+                nullableClassFieldId: classDefinition.idField.type.nullable,
               )
             : _buildDetachRowImplementationBlockForeignSide(
                 fieldName,
@@ -2419,6 +2461,8 @@ class BuildRepositoryClass {
                   subDirParts: classDefinition.subDirParts,
                   config: config,
                 ),
+                nullableFieldId: relation.referenceIdType.nullable,
+                nullableClassFieldId: classDefinition.idField.type.nullable,
               );
       const Code('');
     });
@@ -2429,14 +2473,17 @@ class BuildRepositoryClass {
     String fieldName,
     String classFieldName,
     String foreignKeyField,
-    Reference foreignClass,
-  ) {
+    Reference foreignClass, {
+    required bool nullableFieldId,
+  }) {
     var implicitForeignKeyFieldName = createImplicitFieldName(foreignKeyField);
     return (BlockBuilder()
           ..statements.addAll(
             [
-              _buildCodeBlockThrowIfAnyIdIsNull(fieldName),
-              const Code(''),
+              if (nullableFieldId) ...[
+                _buildCodeBlockThrowIfAnyIdIsNull(fieldName),
+                const Code(''),
+              ],
               _buildImplicitCopyClassListField(
                 foreignClass,
                 fieldName,
@@ -2459,13 +2506,16 @@ class BuildRepositoryClass {
     String fieldName,
     String classFieldName,
     String foreignKeyField,
-    Reference foreignClass,
-  ) {
+    Reference foreignClass, {
+    required bool nullableFieldId,
+  }) {
     return (BlockBuilder()
           ..statements.addAll(
             [
-              _buildCodeBlockThrowIfAnyIdIsNull(fieldName),
-              const Code(''),
+              if (nullableFieldId) ...[
+                _buildCodeBlockThrowIfAnyIdIsNull(fieldName),
+                const Code(''),
+              ],
               _buildCopyWithListField(
                 fieldName,
                 foreignKeyField,
@@ -2486,13 +2536,16 @@ class BuildRepositoryClass {
     String fieldName,
     String classFieldName,
     String foreignKeyField,
-    String className,
-  ) {
+    String className, {
+    required bool nullableClassFieldId,
+  }) {
     return (BlockBuilder()
           ..statements.addAll(
             [
-              _buildCodeBlockThrowIfIdIsNull(classFieldName),
-              const Code(''),
+              if (nullableClassFieldId) ...[
+                _buildCodeBlockThrowIfIdIsNull(classFieldName),
+                const Code(''),
+              ],
               _buildCopyWithSingleField(
                 classFieldName,
                 foreignKeyField,
@@ -2513,8 +2566,10 @@ class BuildRepositoryClass {
     String fieldName,
     String classFieldName,
     String foreignKeyField,
-    Reference foreignClass,
-  ) {
+    Reference foreignClass, {
+    required bool nullableFieldId,
+    required bool nullableClassFieldId,
+  }) {
     var localCopyVariable = '\$$fieldName';
     return (BlockBuilder()
           ..statements.addAll(
@@ -2527,11 +2582,13 @@ class BuildRepositoryClass {
                 localCopyVariable,
                 '$classFieldName.$fieldName',
               ),
-              _buildCodeBlockThrowIfIdIsNull(
-                localCopyVariable,
-                '$classFieldName.$fieldName.id',
-              ),
-              _buildCodeBlockThrowIfIdIsNull(classFieldName),
+              if (nullableFieldId)
+                _buildCodeBlockThrowIfIdIsNull(
+                  localCopyVariable,
+                  '$classFieldName.$fieldName.id',
+                ),
+              if (nullableClassFieldId)
+                _buildCodeBlockThrowIfIdIsNull(classFieldName),
               const Code(''),
               _buildCopyWithSingleField(
                 localCopyVariable,
@@ -2554,13 +2611,16 @@ class BuildRepositoryClass {
     String fieldName,
     String classFieldName,
     String foreignKeyField,
-    Reference foreignClass,
-  ) {
+    Reference foreignClass, {
+    required bool nullableFieldId,
+  }) {
     return (BlockBuilder()
           ..statements.addAll(
             [
-              _buildCodeBlockThrowIfIdIsNull(fieldName),
-              const Code(''),
+              if (nullableFieldId) ...[
+                _buildCodeBlockThrowIfIdIsNull(fieldName),
+                const Code(''),
+              ],
               _buildCopyWithSingleField(
                 fieldName,
                 foreignKeyField,
@@ -2582,15 +2642,18 @@ class BuildRepositoryClass {
     String fieldName,
     String classFieldName,
     String foreignKeyField,
-    Reference foreignClass,
-  ) {
+    Reference foreignClass, {
+    required bool nullableFieldId,
+  }) {
     var implicitForeignKeyFieldName = createImplicitFieldName(foreignKeyField);
 
     return (BlockBuilder()
           ..statements.addAll(
             [
-              _buildCodeBlockThrowIfIdIsNull(fieldName),
-              const Code(''),
+              if (nullableFieldId) ...[
+                _buildCodeBlockThrowIfIdIsNull(fieldName),
+                const Code(''),
+              ],
               _buildImplicitCopyClassSingleField(
                 foreignClass,
                 fieldName,

--- a/tools/serverpod_cli/lib/src/generator/dart/library_generators/model_library_generator.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart/library_generators/model_library_generator.dart
@@ -225,14 +225,6 @@ class SerializableModelLibraryGenerator {
                 classDefinition,
               ),
           ]);
-
-          // TODO: Remove this workaround when closing issue
-          // https://github.com/serverpod/serverpod/issues/3462
-          if (buildRepository.hasRelationWithNonNullableIds(fields)) {
-            libraryBuilder.ignoreForFile.add('unnecessary_null_comparison');
-            // On Dart 3.10+, this issue becomes a `dead_code` lint.
-            libraryBuilder.ignoreForFile.add('dead_code');
-          }
         }
       },
     );
@@ -3578,17 +3570,6 @@ class SerializableModelLibraryGenerator {
 }
 
 class SimpleData {}
-
-extension on BuildRepositoryClass {
-  bool hasRelationWithNonNullableIds(
-    List<SerializableModelFieldDefinition> fields,
-  ) {
-    return hasAttachOperations(fields) ||
-        hasAttachRowOperations(fields) ||
-        hasDetachOperations(fields) ||
-        hasDetachRowOperations(fields);
-  }
-}
 
 extension on ModelClassDefinition {
   bool isTableOwner(bool serverCode) => switch (database) {

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/relation/relation_changed_field_id_type_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/relation/relation_changed_field_id_type_test.dart
@@ -244,12 +244,12 @@ void main() {
       late final companyClass = definitions.last as ModelClassDefinition;
 
       test(
-        'then the list relation has the foreign key owner id type on the company side of UuidValue.',
+        'then the list relation has the foreign key owner id type on the employee side of int.',
         () {
           var field = companyClass.findField('employees');
           var relation = field?.relation as ListRelationDefinition;
 
-          expect(relation.foreignKeyOwnerIdType.className, 'UuidValue');
+          expect(relation.foreignKeyOwnerIdType.className, 'int');
         },
       );
 
@@ -323,12 +323,12 @@ void main() {
       late final companyClass = definitions.last as ModelClassDefinition;
 
       test(
-        'then the list relation has the foreign key owner id type on the company side of UuidValue.',
+        'then the list relation has the foreign key owner id type on the employee side of int.',
         () {
           var field = companyClass.findField('employees');
           var relation = field?.relation as ListRelationDefinition;
 
-          expect(relation.foreignKeyOwnerIdType.className, 'UuidValue');
+          expect(relation.foreignKeyOwnerIdType.className, 'int');
         },
       );
 

--- a/tools/serverpod_cli/test/generator/dart/server_code_generator/changed_id_type/database_repository_attach_detach_guards_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/server_code_generator/changed_id_type/database_repository_attach_detach_guards_test.dart
@@ -1,0 +1,483 @@
+import 'package:analyzer/dart/analysis/utilities.dart';
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:path/path.dart' as path;
+import 'package:serverpod_cli/src/generator/dart/server_code_generator.dart';
+import 'package:serverpod_cli/src/generator/types.dart';
+import 'package:test/test.dart';
+
+import '../../../../test_util/builders/generator_config_builder.dart';
+import '../../../../test_util/builders/model_class_definition_builder.dart';
+import '../../../../test_util/compilation_unit_helpers.dart';
+
+const projectName = 'example_project';
+final config = GeneratorConfigBuilder().withName(projectName).build();
+const generator = DartServerCodeGenerator();
+
+void main() {
+  var expectedFilePath = path.join('lib', 'src', 'generated', 'example.dart');
+
+  String methodBody(
+    CompilationUnit compilationUnit,
+    String className,
+    String methodName,
+  ) {
+    var classDeclaration = CompilationUnitHelpers.tryFindClassDeclaration(
+      compilationUnit,
+      name: className,
+    );
+    var method = CompilationUnitHelpers.tryFindMethodDeclaration(
+      classDeclaration!,
+      name: methodName,
+    );
+    return method!.body.toSource();
+  }
+
+  group(
+    'Given a class with an object relation where both ids are nullable when generating code',
+    () {
+      var models = [
+        ModelClassDefinitionBuilder()
+            .withFileName('example')
+            .withTableName('example_table')
+            .withObjectRelationField(
+              'company',
+              'Company',
+              'company',
+              referenceIdType: TypeDefinition.int.asNullable,
+              nullableRelation: true,
+            )
+            .build(),
+      ];
+
+      late final codeMap = generator.generateSerializableModelsCode(
+        models: models,
+        config: config,
+      );
+
+      late final compilationUnit = parseString(
+        content: codeMap[expectedFilePath]!,
+      ).unit;
+
+      test('then the attachRow method checks both ids for null', () {
+        var body = methodBody(
+          compilationUnit,
+          'ExampleAttachRowRepository',
+          'company',
+        );
+
+        expect(body, contains("ArgumentError.notNull('example.id')"));
+        expect(body, contains("ArgumentError.notNull('company.id')"));
+      });
+
+      test('then the detachRow method checks the id for null', () {
+        var body = methodBody(
+          compilationUnit,
+          'ExampleDetachRowRepository',
+          'company',
+        );
+
+        expect(body, contains("ArgumentError.notNull('example.id')"));
+      });
+    },
+  );
+
+  group(
+    'Given a class with a non-nullable id and an object relation to a class '
+    'with a nullable id when generating code',
+    () {
+      var models = [
+        ModelClassDefinitionBuilder()
+            .withFileName('example')
+            .withTableName('example_table')
+            .withIdFieldType(SupportedIdType.uuidV4, nullable: false)
+            .withObjectRelationField(
+              'company',
+              'Company',
+              'company',
+              referenceIdType: TypeDefinition.int.asNullable,
+              nullableRelation: true,
+            )
+            .build(),
+      ];
+
+      late final codeMap = generator.generateSerializableModelsCode(
+        models: models,
+        config: config,
+      );
+
+      late final compilationUnit = parseString(
+        content: codeMap[expectedFilePath]!,
+      ).unit;
+
+      test(
+        'then the attachRow method only checks the related id for null',
+        () {
+          var body = methodBody(
+            compilationUnit,
+            'ExampleAttachRowRepository',
+            'company',
+          );
+
+          expect(body, isNot(contains("ArgumentError.notNull('example.id')")));
+          expect(body, contains("ArgumentError.notNull('company.id')"));
+        },
+      );
+
+      test('then the detachRow method has no null check', () {
+        var body = methodBody(
+          compilationUnit,
+          'ExampleDetachRowRepository',
+          'company',
+        );
+
+        expect(body, isNot(contains('ArgumentError.notNull')));
+      });
+    },
+  );
+
+  group(
+    'Given a class with a nullable id and an object relation to a class with '
+    'a non-nullable id when generating code',
+    () {
+      var models = [
+        ModelClassDefinitionBuilder()
+            .withFileName('example')
+            .withTableName('example_table')
+            .withObjectRelationField(
+              'company',
+              'Company',
+              'company',
+              referenceIdType: TypeDefinition.uuid,
+              nullableRelation: true,
+            )
+            .build(),
+      ];
+
+      late final codeMap = generator.generateSerializableModelsCode(
+        models: models,
+        config: config,
+      );
+
+      late final compilationUnit = parseString(
+        content: codeMap[expectedFilePath]!,
+      ).unit;
+
+      test('then the attachRow method only checks the own id for null', () {
+        var body = methodBody(
+          compilationUnit,
+          'ExampleAttachRowRepository',
+          'company',
+        );
+
+        expect(body, contains("ArgumentError.notNull('example.id')"));
+        expect(body, isNot(contains("ArgumentError.notNull('company.id')")));
+      });
+    },
+  );
+
+  group(
+    'Given a class with a foreign-side object relation to a class with a '
+    'non-nullable id when generating code',
+    () {
+      var models = [
+        ModelClassDefinitionBuilder()
+            .withFileName('example')
+            .withTableName('example_table')
+            .withObjectRelationFieldNoForeignKey(
+              'company',
+              'Company',
+              'company',
+              referenceIdType: TypeDefinition.uuid,
+              nullableRelation: true,
+            )
+            .build(),
+      ];
+
+      late final codeMap = generator.generateSerializableModelsCode(
+        models: models,
+        config: config,
+      );
+
+      late final compilationUnit = parseString(
+        content: codeMap[expectedFilePath]!,
+      ).unit;
+
+      test(
+        'then the attachRow method only checks the own id for null',
+        () {
+          var body = methodBody(
+            compilationUnit,
+            'ExampleAttachRowRepository',
+            'company',
+          );
+
+          expect(body, contains("ArgumentError.notNull('example.id')"));
+          expect(body, isNot(contains("ArgumentError.notNull('company.id')")));
+        },
+      );
+
+      test(
+        'then the detachRow method checks the relation field but not its id '
+        'for null',
+        () {
+          var body = methodBody(
+            compilationUnit,
+            'ExampleDetachRowRepository',
+            'company',
+          );
+
+          expect(body, contains("ArgumentError.notNull('example.company')"));
+          expect(
+            body,
+            isNot(contains("ArgumentError.notNull('example.company.id')")),
+          );
+          expect(body, contains("ArgumentError.notNull('example.id')"));
+        },
+      );
+    },
+  );
+
+  group(
+    'Given a class with a named list relation where all ids are nullable when '
+    'generating code',
+    () {
+      var models = [
+        ModelClassDefinitionBuilder()
+            .withFileName('example')
+            .withTableName('example_table')
+            .withListRelationField(
+              'citizens',
+              'Person',
+              'exampleId',
+              nullableRelation: true,
+            )
+            .build(),
+      ];
+
+      late final codeMap = generator.generateSerializableModelsCode(
+        models: models,
+        config: config,
+      );
+
+      late final compilationUnit = parseString(
+        content: codeMap[expectedFilePath]!,
+      ).unit;
+
+      test('then the attach method checks all ids for null', () {
+        var body = methodBody(
+          compilationUnit,
+          'ExampleAttachRepository',
+          'citizens',
+        );
+
+        expect(body, contains('person.any((e) => e.id == null)'));
+        expect(body, contains("ArgumentError.notNull('example.id')"));
+      });
+
+      test('then the attachRow method checks both ids for null', () {
+        var body = methodBody(
+          compilationUnit,
+          'ExampleAttachRowRepository',
+          'citizens',
+        );
+
+        expect(body, contains("ArgumentError.notNull('person.id')"));
+        expect(body, contains("ArgumentError.notNull('example.id')"));
+      });
+
+      test('then the detach method checks the related ids for null', () {
+        var body = methodBody(
+          compilationUnit,
+          'ExampleDetachRepository',
+          'citizens',
+        );
+
+        expect(body, contains('person.any((e) => e.id == null)'));
+      });
+
+      test('then the detachRow method checks the related id for null', () {
+        var body = methodBody(
+          compilationUnit,
+          'ExampleDetachRowRepository',
+          'citizens',
+        );
+
+        expect(body, contains("ArgumentError.notNull('person.id')"));
+      });
+    },
+  );
+
+  group(
+    'Given a class with a named list relation to a class with a non-nullable '
+    'id when generating code',
+    () {
+      var models = [
+        ModelClassDefinitionBuilder()
+            .withFileName('example')
+            .withTableName('example_table')
+            .withListRelationField(
+              'citizens',
+              'Person',
+              'exampleId',
+              foreignKeyOwnerIdType: TypeDefinition.uuid,
+              nullableRelation: true,
+            )
+            .build(),
+      ];
+
+      late final codeMap = generator.generateSerializableModelsCode(
+        models: models,
+        config: config,
+      );
+
+      late final compilationUnit = parseString(
+        content: codeMap[expectedFilePath]!,
+      ).unit;
+
+      test('then the attach method only checks the own id for null', () {
+        var body = methodBody(
+          compilationUnit,
+          'ExampleAttachRepository',
+          'citizens',
+        );
+
+        expect(body, isNot(contains('person.any((e) => e.id == null)')));
+        expect(body, contains("ArgumentError.notNull('example.id')"));
+      });
+
+      test('then the attachRow method only checks the own id for null', () {
+        var body = methodBody(
+          compilationUnit,
+          'ExampleAttachRowRepository',
+          'citizens',
+        );
+
+        expect(body, isNot(contains("ArgumentError.notNull('person.id')")));
+        expect(body, contains("ArgumentError.notNull('example.id')"));
+      });
+
+      test('then the detach method has no null check', () {
+        var body = methodBody(
+          compilationUnit,
+          'ExampleDetachRepository',
+          'citizens',
+        );
+
+        expect(body, isNot(contains('ArgumentError.notNull')));
+      });
+
+      test('then the detachRow method has no null check', () {
+        var body = methodBody(
+          compilationUnit,
+          'ExampleDetachRowRepository',
+          'citizens',
+        );
+
+        expect(body, isNot(contains('ArgumentError.notNull')));
+      });
+    },
+  );
+
+  group(
+    'Given a class with an implicit list relation to a class with a '
+    'non-nullable id when generating code',
+    () {
+      var models = [
+        ModelClassDefinitionBuilder()
+            .withFileName('example')
+            .withTableName('example_table')
+            .withImplicitListRelationField(
+              'citizens',
+              'Person',
+              foreignKeyOwnerIdType: TypeDefinition.uuid,
+            )
+            .build(),
+      ];
+
+      late final codeMap = generator.generateSerializableModelsCode(
+        models: models,
+        config: config,
+      );
+
+      late final compilationUnit = parseString(
+        content: codeMap[expectedFilePath]!,
+      ).unit;
+
+      test('then the attach method only checks the own id for null', () {
+        var body = methodBody(
+          compilationUnit,
+          'ExampleAttachRepository',
+          'citizens',
+        );
+
+        expect(body, isNot(contains('person.any((e) => e.id == null)')));
+        expect(body, contains("ArgumentError.notNull('example.id')"));
+      });
+
+      test('then the attachRow method only checks the own id for null', () {
+        var body = methodBody(
+          compilationUnit,
+          'ExampleAttachRowRepository',
+          'citizens',
+        );
+
+        expect(body, isNot(contains("ArgumentError.notNull('person.id')")));
+        expect(body, contains("ArgumentError.notNull('example.id')"));
+      });
+
+      test('then the detachRow method has no null check', () {
+        var body = methodBody(
+          compilationUnit,
+          'ExampleDetachRowRepository',
+          'citizens',
+        );
+
+        expect(body, isNot(contains('ArgumentError.notNull')));
+      });
+    },
+  );
+
+  group(
+    'Given a class with an implicit list relation where all ids are nullable '
+    'when generating code',
+    () {
+      var models = [
+        ModelClassDefinitionBuilder()
+            .withFileName('example')
+            .withTableName('example_table')
+            .withImplicitListRelationField('citizens', 'Person')
+            .build(),
+      ];
+
+      late final codeMap = generator.generateSerializableModelsCode(
+        models: models,
+        config: config,
+      );
+
+      late final compilationUnit = parseString(
+        content: codeMap[expectedFilePath]!,
+      ).unit;
+
+      test('then the attach method checks all ids for null', () {
+        var body = methodBody(
+          compilationUnit,
+          'ExampleAttachRepository',
+          'citizens',
+        );
+
+        expect(body, contains('person.any((e) => e.id == null)'));
+        expect(body, contains("ArgumentError.notNull('example.id')"));
+      });
+
+      test('then the detach method checks the related ids for null', () {
+        var body = methodBody(
+          compilationUnit,
+          'ExampleDetachRepository',
+          'citizens',
+        );
+
+        expect(body, contains('person.any((e) => e.id == null)'));
+      });
+    },
+  );
+}

--- a/tools/serverpod_cli/test/test_util/builders/model_class_definition_builder.dart
+++ b/tools/serverpod_cli/test/test_util/builders/model_class_definition_builder.dart
@@ -233,6 +233,7 @@ class ModelClassDefinitionBuilder {
     String parentTable, {
     String? foreignKeyFieldName,
     TypeDefinition? foreignIdType,
+    TypeDefinition? referenceIdType,
     bool nullableRelation = false,
   }) {
     _fields.addAll([
@@ -251,6 +252,10 @@ class ModelClassDefinitionBuilder {
               ObjectRelationDefinition(
                 parentTable: parentTable,
                 parentTableIdType: foreignIdType ?? TypeDefinition.int,
+                referenceIdType:
+                    referenceIdType ??
+                    foreignIdType ??
+                    TypeDefinition.int.asNullable,
                 fieldName: foreignFieldName,
                 foreignFieldName: 'id',
                 isForeignKeyOrigin: false,
@@ -269,6 +274,7 @@ class ModelClassDefinitionBuilder {
     String parentTable, {
     String? foreignKeyFieldName,
     TypeDefinition? foreignKeyParentTableIdType,
+    TypeDefinition? referenceIdType,
     bool nullableRelation = false,
   }) {
     var foreignFieldName = foreignKeyFieldName ?? '${fieldName}Id';
@@ -282,6 +288,10 @@ class ModelClassDefinitionBuilder {
             ObjectRelationDefinition(
               parentTable: parentTable,
               parentTableIdType: foreignTableIdType,
+              referenceIdType:
+                  referenceIdType ??
+                  foreignKeyParentTableIdType ??
+                  TypeDefinition.int.asNullable,
               fieldName: foreignFieldName,
               foreignFieldName: 'id',
               nullableRelation: nullableRelation,
@@ -326,7 +336,7 @@ class ModelClassDefinitionBuilder {
             ListRelationDefinition(
               fieldName: 'id',
               foreignKeyOwnerIdType:
-                  foreignKeyOwnerIdType ?? TypeDefinition.int,
+                  foreignKeyOwnerIdType ?? TypeDefinition.int.asNullable,
               foreignFieldName:
                   '\$_${_className.camelCase}${fieldName.pascalCase}${_className.pascalCase}Id',
               nullableRelation: true,
@@ -362,7 +372,7 @@ class ModelClassDefinitionBuilder {
             ListRelationDefinition(
               fieldName: 'id',
               foreignKeyOwnerIdType:
-                  foreignKeyOwnerIdType ?? TypeDefinition.int,
+                  foreignKeyOwnerIdType ?? TypeDefinition.int.asNullable,
               foreignFieldName: foreignKeyFieldName,
               nullableRelation: nullableRelation,
               implicitForeignField: false,


### PR DESCRIPTION
Since #3437, models can declare non-nullable id fields (UUID ids with a `defaultModel` default). The generated attach/detach repository methods still unconditionally emitted `if (x.id == null) { throw ArgumentError.notNull('x.id'); }` guards, which are dead code for non-nullable ids and trigger the `unnecessary_null_comparison` lint (`dead_code` on Dart 3.10+). This was masked by adding a file-wide `ignore_for_file` to every relation-bearing generated file.

This PR makes the guards conditional on the static nullability of the checked model's id, decided per side of the relation, and removes the `hasRelationWithNonNullableIds` workaround as requested in the issue:

- The enclosing model's id nullability comes from `classDefinition.idField.type.nullable` (the attach/detach builder chain now takes `ModelClassDefinition`, which is what the call site already passes).
- The referenced model's id nullability comes from a new `ObjectRelationDefinition.referenceIdType`, populated by the dependency resolver. This has to happen at analysis time: the resolver has the referenced class definition in scope (including module models, e.g. `module:auth:UserInfo`), while the generator pipeline only ever receives project and shared models.
- List-relation element id nullability comes from `ListRelationDefinition.foreignKeyOwnerIdType`. The implicit-relation branch stored the declaring class's id type instead of the foreign-key owner's, contradicting the property's own documentation — fixed to match the named branch. The property has been write-only in the generator since the #3437 refactors, so this had no observable effect before; the two test expectations that snapshotted the old value are updated.
- The nullability flags are threaded into the implementation-block builders as parameters bound to the same parameter slot each guard checks, because the same block builder is invoked by different callers with swapped argument roles (e.g. `_buildAttachRowImplementationBlockExplicit` checks the enclosing model's id via its first slot when called for the foreign-key-origin side, but the referenced model's id via that same slot when called for a list relation).
- The `.any((e) => e.id == null)` list guards are gated by the same rule. The relation-field null check in the foreign-side detachRow (`if ($field == null)`) is kept unconditionally, since object-relation fields are always required to be declared nullable by validation.

Removing a guard is behavior-preserving: a statically non-nullable id can never hold null at runtime (the generated constructor coalesces a default, and `fromJson`/`copyWith`/row mapping all funnel through it), and the database layer independently rejects null ids in `update`. The existing integration tests already encode this — for unsaved rows of non-nullable-id models they expect `DatabaseUpdateRowException`, never the `ArgumentError` from the guard.

All generated code across the repo is regenerated in a separate commit (143 files, deletions only): every relation-bearing file loses the ignore header, and files referencing non-nullable-id models also lose the dead guard blocks. Mixed cases keep exactly the live side, e.g. `CustomerIntAttachRepository.orders` keeps the `customerInt.id` guard (nullable `int?` id) while the `orderUuid.id` guard (non-nullable UUID id) is no longer generated — this is the exact example from the issue. Re-running `util/generate_all` on the result produces no diff.

New tests in `database_repository_attach_detach_guards_test.dart` assert guard presence/absence on the generated method bodies for object relations (origin and foreign side), named and implicit list relations, and mixed-nullability combinations.

Fixes #3462

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

## Breaking changes

None. Generated code only loses statically unreachable guard blocks and the now-unnecessary lint suppressions; runtime behavior is unchanged. (`ObjectRelationDefinition` gains a required constructor parameter, but it is internal to the analyzer and constructed only by the resolver and CLI test utilities.)
