### PR TITLE
feat: Auth cookie

### DIFF
--- a/docs/design/web_auth_httponly_cookies.md
+++ b/docs/design/web_auth_httponly_cookies.md
@@ -1,0 +1,402 @@
+# Design: Web Authentication with httpOnly Cookies
+
+Moves Serverpod's web authentication off JavaScript-readable token storage and
+onto httpOnly cookies. Consolidates the requirement spike and the phased plans
+(issue https://github.com/serverpod/serverpod/issues/4045).
+
+Scope: browser (Flutter/Dart web) clients. Native and desktop clients already use
+OS-backed secure storage (Keychain / encrypted shared preferences) and keep
+header / in-band authentication; they are unchanged.
+
+## Summary
+
+On web today the auth token is held in JS-readable storage and travels in request
+URLs and headers. Target:
+
+- Opaque session token (`AuthStrategy.session`, "SAS"): httpOnly, Secure,
+  SameSite cookie.
+- JWT: access token in memory, refresh token in an httpOnly, Secure, SameSite
+  cookie.
+
+`relic` supports cookies: a `SetCookie` carries `httpOnly`, `secure`,
+`sameSite`, `domain`, `path`, `maxAge` and `expires`, and a response's
+`SetCookieHeader` is the collection of them (`CookieHeader` / `Cookie` on the
+request side), via `headers.setCookie` / `headers.cookie` on responses and
+requests. The work is in the server auth pipeline, the auth modules, and the web
+client, not the transport.
+
+Delivered in phases:
+
+- Phase 0 (tokens out of URLs + WebSocket `Origin` validation) is implemented.
+- Phase 1 (opt-in httpOnly cookie auth for the opaque SAS strategy) is
+  implemented: response-output API, cookie config, server cookie read (HTTP and
+  the modern WebSocket handshake), credentialed CORS, sign-in/out cookie
+  issuance, and the web client wiring.
+- Phase 2 (JWT access-in-memory + refresh cookie) and Phase 3 (cross-subdomain
+  `Domain` + optional CSRF token) are not yet started.
+
+## Motivation
+
+`localStorage`, `sessionStorage` and IndexedDB are readable by any JavaScript on
+the page. An XSS foothold can exfiltrate the token and replay it from anywhere for
+its lifetime.
+
+httpOnly cookies cannot be read by JS. XSS can still ride the session while the
+page is open, but cannot steal the credential for later replay. OWASP: "Do not
+store session identifiers in local storage as the data is always accessible by
+JavaScript. Cookies can mitigate this risk using the httpOnly flag." The common
+SPA pattern is access token in memory, refresh token in an httpOnly cookie.
+
+## Current state
+
+### Client token storage (web)
+
+Client auth is behind `ClientAuthKeyProvider.authHeaderValue`
+(`packages/serverpod_client/lib/src/auth_key_provider.dart`). The auth-core
+client persists `AuthSuccess` via a pluggable `KeyValueStorage`
+(`serverpod_auth_core_client/.../storage/key_value_client_auth_success_storage.dart`).
+Native clients use OS secure storage; on web there is no secure backing store, so
+for header-mode clients it lands in JS-readable storage. A cookie-mode web client
+(`ClientAuthSessionManager(cookieAuth: true)`) returns a null `authHeaderValue`
+and relies on the browser-held httpOnly cookie instead, so no token reaches JS.
+
+### Transport
+
+- HTTP: header-mode clients send the token in the `authorization` header
+  (`serverpod_client_browser.dart` / `serverpod_client_io.dart`); cookie-mode
+  clients send the `x-serverpod-auth-mode: cookie` marker (and, on web, a
+  credentialed request) and carry the token in the httpOnly cookie instead.
+- WebSocket: token sent in-band via the `auth` control message
+  (`serverpod_client_shared.dart`), or, for browser cookie clients, attached
+  automatically to the handshake as a cookie. The token no longer appears in the
+  connection URL (Phase 0).
+
+### Server request authentication
+
+- HTTP (`server.dart`): read from the `Authorization` header. When `authCookie`
+  is configured, fall back to the auth cookie, but only for a request that
+  carries the `x-serverpod-auth-mode: cookie` marker and whose `Origin` (if
+  present) is allow-listed; otherwise the ambient cookie is ignored. The `?auth=`
+  query fallback was removed in Phase 0.
+- WS: every handshake is `Origin`-checked against `allowedOrigins`. The modern
+  `/v1/websocket` handler (`method_websocket_request_handler.dart`) accepts the
+  in-band `OpenMethodStreamCommand.authentication` and falls back to the
+  handshake auth cookie. The legacy `/websocket` handler
+  (`endpoint_websocket_request_handler.dart`) authenticates in-band via the
+  `auth` control message only (no cookie read).
+
+### Token issuance
+
+Sign-in returns the token via `AuthSuccess` (`token`, optional `refreshToken`,
+`tokenExpiresAt`, `authStrategy`, `authUserId`, `scopeNames`). Strategies
+(`AuthStrategy { jwt, session }`): the opaque SAS token
+(`server_side_sessions_token.dart`: `sas` prefix + session UUID + secret) and JWT
+access/refresh (`jwt/jwt.dart`). For a cookie-mode request the SAS sign-in
+(`server_side_sessions.dart`) writes the token as a `Set-Cookie` and returns an
+empty `token` in the body, so it never reaches JS. JWT issuance is unchanged
+(Phase 2).
+
+### Response building
+
+A method-call result becomes `Response.ok(body: ...)` (or `_toResponse` for
+`sendAsRaw`) in `server.dart` with the `MethodCallSession` in scope.
+`httpResponseHeaders` is a single global (CORS) `Headers`. A session now also has
+a response-output API: `Session.setResponseHeader(name, value)` and
+`Session.setResponseCookie(SetCookie)` collect intent during the call, and
+`applyResponseOutput` (`response_output.dart`) applies it when the framework
+builds the response (values set here take precedence; default headers merge
+underneath; cookies append to any existing `Set-Cookie`).
+
+### Transport primitives
+
+`relic` provides `SetCookie` (name, value, expires, maxAge, domain, path,
+secure, httpOnly, sameSite), the `SetCookieHeader` collection that holds them on
+a response, and `CookieHeader` / `Cookie` on the request. The cookie code uses
+relic 2.0's RFC-6265-hardened cookie API: `SetCookie.domain` is a `Host?`
+(host-only, section 5.2.3) and the constructor validates `name` / `value` /
+`domain` / `path`, throwing `FormatException` on bad input -- it also normalizes
+away a leading dot on the `Domain` (`.example.com` -> `example.com`) and rejects a
+port. `auth_cookie.dart` hands the configured domain straight to `Host.parse` and
+rethrows a clear `ArgumentError` so a malformed operator config fails fast rather
+than deep in the sign-in path.
+
+## Goals and non-goals
+
+Goals: secure storage and transport for browser clients (SAS and JWT); opt-in (no
+forced break until a major); cross-subdomain support.
+
+Non-goals here: native/mobile/desktop storage; a BFF / OAuth-confidential-client
+rearchitecture; changes to the auth providers (email, OAuth, passkeys).
+
+## Target design
+
+### Token placement
+
+```
++----------------------+---------------------------------+---------------------------------+
+| Strategy             | Access / session token          | Refresh token                   |
++======================+=================================+=================================+
+| JWT (Phase 2)        | In memory (re-minted on load)   | HttpOnly Secure SameSite cookie |
+| Opaque session (SAS) | HttpOnly Secure SameSite cookie | n/a (server-side session)       |
++----------------------+---------------------------------+---------------------------------+
+```
+
+"In memory" means not in `localStorage`, `sessionStorage`, or a non-httpOnly
+cookie. On load the SPA calls a refresh endpoint; the browser sends the refresh
+cookie and the server returns a fresh access token in the body.
+
+### Server flow
+
+- Sign-in / refresh: set the cookie via `session.setResponseCookie` (the
+  `writeWebAuthCookie` helper) with `httpOnly: true`, `secure`, `sameSite`,
+  `domain` and `path` from `WebAuthCookieConfig`, and a `maxAge` derived from the
+  token's expiry (a session cookie when the expiry is absent or non-positive). For
+  JWT, also return the access token in the body (Phase 2).
+- Authenticated request: after the `Authorization`-header check, fall back to the
+  configured cookie from `request.headers.cookie` (gated on the marker header and
+  the `Origin` check). Token format is unchanged, so the existing
+  `AuthenticationHandler` is reused.
+- Logout: `clearWebAuthCookie` emits a `Set-Cookie` with `maxAge: 0`; for SAS
+  also destroy the server-side session.
+
+### WebSocket / streaming
+
+Browsers attach cookies to the WS handshake automatically (same-origin or
+`Domain`-scoped), so streaming on the modern `/v1/websocket` handler
+authenticates from the handshake cookie, with no URL token and no in-band
+message. The Phase 0 `Origin` check covers CSWSH.
+
+### Web client
+
+- Credentialed requests (`withCredentials` on the browser `http` client) so the
+  browser sends and stores the cookie, plus the `x-serverpod-auth-mode: cookie`
+  marker header on every call.
+- A `CookieAuthKeyProvider` capability interface (`auth_key_provider.dart`): a
+  provider that reports `usesCookies == true` makes the client send the marker /
+  credentialed request and attach no `Authorization` header. The auth-core
+  `ClientAuthSessionManager` implements it behind a `cookieAuth` flag and returns
+  a null `authHeaderValue` in that mode.
+- CORS: when `authCookie` is set, the server echoes a specific
+  `Access-Control-Allow-Origin` (the request `Origin` when it is in
+  `allowedOrigins`) plus `Access-Control-Allow-Credentials: true` and
+  `Vary: Origin`, since the wildcard `*` is invalid with credentials. For a
+  present-but-non-allow-listed browser `Origin` the default wildcard
+  `Access-Control-Allow-Origin` is dropped rather than echoed, so enabling cookie
+  auth requires every cross-origin browser caller -- including callers of public
+  endpoints -- to be in `allowedOrigins`. The marker header is added to the
+  allowed CORS request headers, and re-added when a custom
+  `httpOptionsResponseHeaders` override omits it (`serverpod.dart`).
+  `allowedOrigins` is the single trusted-origins list, shared with the WebSocket
+  handshake `Origin` check.
+
+### Cross-subdomain
+
+`Domain=.example.com` lets the cookie reach `app.example.com`, `api.example.com`,
+etc. `SameSite=Lax`/`Strict` treats sibling subdomains of the same registrable
+domain as same-site, so this works without `SameSite=None`. Exposed via the
+`authCookie.domain` config knob (host-only by default); RFC 6265 sends the
+`Domain` attribute without a leading dot, so a configured `.example.com` is
+normalized to `example.com`.
+
+## Security considerations
+
+Cookie auth reintroduces CSRF (header/bearer auth is immune since the browser
+never auto-attaches it). The chosen posture is defense in depth: SameSite +
+Origin validation + a marker-header requirement, with a double-submit token held
+in reserve for `SameSite=None`. Defenses:
+
+1. SameSite on the auth cookie. `Lax` (default) blocks cross-site POST; `Strict`
+   breaks link-into-authed-page and OAuth redirect returns; `None` only for
+   cross-site embedding (config rejects `None` without `Secure`, since browsers
+   drop such a cookie). SameSite alone does not cover a same-registrable-domain
+   sibling subdomain, which the next two layers do.
+2. Origin validation on state-changing requests and the WS handshake, against
+   `allowedOrigins`. A request whose `Origin` is present but not allow-listed is
+   rejected (403); a missing `Origin` (native / server-to-server) is allowed.
+   Both the WS handshake check and the HTTP cookie-auth check are implemented
+   (`server.dart`), independent of the browser's own CORS enforcement.
+3. Marker-header requirement: the server reads the auth cookie only when the
+   request carries `x-serverpod-auth-mode: cookie`. A cross-site form or simple
+   request cannot set a custom header without a CORS preflight, which fails for
+   non-allow-listed origins, so the ambient cookie never authenticates a
+   cross-site HTTP request. (WebSocket handshakes cannot send custom headers, so
+   the WS path relies on the Origin check in layer 2 instead.)
+4. Optional double-submit CSRF token for `SameSite=None`, deferred to Phase 3.
+
+The cookie read also fails closed on an ambiguous `Cookie` header: when more than
+one cookie carries the configured name (e.g. a sibling subdomain plants a
+`Domain`-scoped duplicate that shadows the host-only cookie), `getCookieValue`
+returns null (logging a warning) rather than trusting whichever the browser
+ordered first (`request_extension.dart`).
+
+httpOnly stops token theft but not session riding (an XSS payload can issue
+authenticated requests while the page is open); mitigate with CSP and dependency
+hygiene. A BFF (no tokens in the browser) is the option for stricter
+requirements.
+
+## Implementation roadmap
+
+### Phase 0: tokens out of URLs + WebSocket Origin validation (implemented)
+
+Standalone breaking change, independent of the relic cookie release.
+
+- Streaming clients authenticate in-band via the `auth` control message instead
+  of `?auth=` (`serverpod_client_shared.dart`).
+- The server no longer reads `auth` from the URL: streaming session
+  (`session.dart`) and HTTP query fallback (`server.dart`).
+- The legacy streaming handler opens endpoint streams on the `auth` control
+  message, which the client sends as its first frame (with a null key when
+  anonymous); a ping does not open them, and an endpoint message before the
+  handshake opens them anonymously as a fallback. This lets `streamOpened`
+  observe the settled auth state (`endpoint_websocket_request_handler.dart`).
+- `allowedOrigins` config (YAML list, comma-separated string, or
+  `SERVERPOD_ALLOWED_ORIGINS`). When set, browser WS handshakes with a
+  disallowed `Origin` get 403; requests without an `Origin` (native /
+  server-to-server) are allowed.
+
+Breaking: `?auth=` is no longer accepted; `streamOpened` for the legacy streaming
+API fires on the `auth` handshake (or the first endpoint message) rather than at
+connect.
+
+### Phase 1: httpOnly-cookie session (opaque / SAS strategy) (implemented)
+
+SAS first: one opaque token, no in-memory access token, no client-driven refresh;
+the carrier moved to a cookie. Opt-in: the server needs an `authCookie` section
+and the client must run in `cookieAuth` mode; otherwise the header path is
+unchanged.
+
+Decision: expose a narrow output API (headers + cookies) rather than handing
+endpoints the relic `Response`. Rationale:
+
+- The `Response` is built after the method returns (`server.dart`), so there is
+  nothing to hand out mid-call; intent-collection applied at build time is the
+  natural fit.
+- For RPC endpoints the framework owns the response envelope (status,
+  content-type, serialized body); a header/cookie API constrains endpoints to the
+  safe surface and prevents clobbering the protocol.
+- The cookie value type is relic's `SetCookie`, not a parallel one: relic
+  is already re-exported by `serverpod` and is Serverpod-maintained, so a wrapper
+  would only duplicate it. The cookie API churn (`#113`) is handled as a
+  coordinated relic upgrade (see sequencing), not by abstracting relic away.
+- Generalizes across transports: the same emitted headers/cookies apply to the
+  HTTP response or the WebSocket handshake response, whereas a raw `Response`
+  accessor is meaningless on streaming sessions.
+- Full-response control already has homes for the cases that need it:
+  `sendAsRaw` endpoints (`_toResponse`) and web `Route.handleCall`, which returns
+  a `Response`.
+
+What shipped:
+
+```
++---------------------+--------------------------------------------------+-----------+
+| Area                | Change                                           | Status    |
++=====================+==================================================+===========+
+| Response output API | session.setResponseHeader/Cookie; apply at build | done      |
+| Cookie config       | WebAuthCookieConfig + allowedOrigins plumbing    | done      |
+| HTTP auth read      | Cookie fallback (marker + Origin gated)          | done      |
+| WS handshake read   | Cookie fallback on modern /v1/websocket          | done      |
+| Sign-in/out issue   | Set/clear cookie in auth-core SAS sessions       | done      |
+| Web client creds    | withCredentials + marker header                  | done      |
+| Web auth provider   | CookieAuthKeyProvider + ClientAuthSessionManager | done      |
+| CORS credentials    | Allow-Credentials + specific-origin echo + Vary  | done      |
+| Unit tests          | auth_cookie / response_output / config tests     | done      |
+| Integration test    | Web sign-in -> cookie -> authed call -> sign-out | pending   |
+| Docs / sample       | This design doc done; user guide + sample        | pending   |
++---------------------+--------------------------------------------------+-----------+
+```
+
+Design divergence to note: the web auth provider was implemented as a
+`CookieAuthKeyProvider` capability interface plus a `cookieAuth` flag on the
+existing `ClientAuthSessionManager`, rather than a separate
+`CookieClientAuthKeyProvider` class as first sketched. The manager still uses the
+pluggable storage but returns a null `authHeaderValue` in cookie mode. This keeps
+one session-manager type for header and cookie clients instead of forking it.
+
+Config (server `config/<run-mode>.yaml`, or `SERVERPOD_*` env vars):
+
+```
+authCookie:
+  name: serverpod_auth   # default
+  domain:                # host-only by default; set .example.com to share
+  path: /                # default
+  secure: true           # default; set false only for http://localhost
+  sameSite: lax          # lax (default) | strict | none (none requires secure)
+allowedOrigins:
+  - https://app.example.com
+```
+
+`authCookie` requires a non-empty `allowedOrigins` (it backs the CSWSH guard and
+credentialed CORS, which cannot use the wildcard origin); the config constructor
+throws otherwise. Env equivalents: `SERVERPOD_AUTH_COOKIE_NAME`,
+`SERVERPOD_AUTH_COOKIE_DOMAIN`, `SERVERPOD_AUTH_COOKIE_PATH`,
+`SERVERPOD_AUTH_COOKIE_SECURE`, `SERVERPOD_AUTH_COOKIE_SAME_SITE`,
+`SERVERPOD_ALLOWED_ORIGINS`.
+
+Remaining for Phase 1: an end-to-end integration test (web sign-in sets the
+cookie; a call authenticates via the cookie; sign-out clears it; native header
+path unchanged) and a web-auth user guide plus sample.
+
+### Phase 2: JWT (access-in-memory + refresh cookie)
+
+Access token in memory, refresh token in an httpOnly cookie with server-side
+rotation (refresh token never transits JS). On load the SPA calls a refresh
+endpoint; the browser sends the refresh cookie and the server returns a fresh
+access token in the body. Reuses the Phase 1 primitive and config.
+
+### Phase 3: cross-subdomain + optional CSRF token + guidance
+
+Cross-subdomain `Domain` config is already in place at the cookie level;
+remaining: optional double-submit CSRF token for `SameSite=None`; BFF guidance.
+
+## Open decisions
+
+1. How a request opts into cookie mode: resolved. The client runs in `cookieAuth`
+   mode and sends `x-serverpod-auth-mode: cookie`; the server enables it via the
+   `authCookie` config section. Native clients keep body/header tokens.
+2. Whether to keep returning `AuthSuccess.token` in the body in cookie mode:
+   resolved. Omitted (empty `token`) for cookie clients, kept for header clients.
+3. SameSite default (`Lax`) and exposing `Strict` / `None`: resolved
+   (`CookieSameSite` enum, default `lax`; `none` validated to require `secure`).
+4. Cookie `Domain` default: resolved. Host-only by default; cross-subdomain via
+   `authCookie.domain`. `secure` relaxation for `http://localhost` is via
+   `authCookie.secure: false`.
+5. CSRF posture for HTTP: resolved. `SameSite=Lax` + server-side Origin
+   validation + a marker-header requirement on the cookie read (layers 1-3
+   above). A double-submit token stays reserved for `SameSite=None` (Phase 3).
+6. Session TTL to cookie `Max-Age` mapping: resolved. Derived from the token's
+   `tokenExpiresAt` (seconds until expiry), falling back to a session cookie for
+   a non-positive lifetime. Rotation on activity is deferred.
+7. Relic sequencing: resolved. The `#113` work shipped in relic 2.0; the pubspec
+   is pinned to `relic: ^2.0.0-beta.0` and the temporary
+   `dependencyOverridePaths` override has been removed (see Dependencies).
+
+## Dependencies
+
+relic 2.0 (RFC-compliant typed headers, the `#113` work) provides the final
+cookie API shape. The pubspec is pinned to `relic: ^2.0.0-beta.0` across
+`serverpod`, `serverpod_client`, `serverpod_test_server` and the templates; the
+earlier temporary melos `dependencyOverridePaths` to a local relic checkout has
+been removed. No new third-party libraries.
+
+## Sources
+
+- OWASP, JSON Web Token Cheat Sheet:
+  https://cheatsheetseries.owasp.org/cheatsheets/JSON_Web_Token_for_Java_Cheat_Sheet.html
+- OWASP, WebSocket Security Cheat Sheet:
+  https://cheatsheetseries.owasp.org/cheatsheets/WebSocket_Security_Cheat_Sheet.html
+- Curity, OAuth for SPAs / BFF:
+  https://curity.io/resources/learn/spa-best-practices/
+- Token storage, localStorage vs httpOnly cookies (wisp):
+  https://www.wisp.blog/blog/understanding-token-storage-local-storage-vs-httponly-cookies
+- Web Authentication: Three Decisions You're Conflating (wempe.dev):
+  https://wempe.dev/blog/authentication-cookie-vs-token-based
+- CORS, SameSite and CSRF (Liran Tal):
+  https://lirantal.com/blog/cors-samesite-csrf-3-dimensions-cookie-authentication
+- Cross-site WebSocket hijacking (PortSwigger):
+  https://portswigger.net/web-security/websockets/cross-site-websocket-hijacking
+- Sending cookies to a WebSocket backend (Medium):
+  https://charithcj.medium.com/how-to-send-cookies-from-browser-to-websocket-backend-and-why-you-cant-see-them-in-chrome-b383b53b22fa
+- MDN, Using HTTP cookies:
+  https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Cookies
+- SameSite and subdomains:
+  https://medium.com/@rramgattie/samesite-and-subdomains-08870bbdd62c

--- a/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_client/lib/src/auth_key_providers/sas_auth_key_provider.dart
+++ b/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_client/lib/src/auth_key_providers/sas_auth_key_provider.dart
@@ -15,6 +15,8 @@ class SasAuthKeyProvider implements ClientAuthKeyProvider {
   Future<String?> get authHeaderValue async {
     final currentAuth = await getAuthInfo();
     if (currentAuth == null) return null;
+    // A cookie-mode sign-in persists an empty token. Don't wrap!
+    if (currentAuth.token.isEmpty) return null;
     return wrapAsBearerAuthHeaderValue(currentAuth.token);
   }
 }

--- a/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_client/lib/src/session_manager.dart
+++ b/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_client/lib/src/session_manager.dart
@@ -7,7 +7,8 @@ import 'package:serverpod_auth_core_client/serverpod_auth_core_client.dart';
 /// or other methods. Please refer to the documentation to see supported
 /// methods. Session information is stored in the storage implementation provided
 /// to the session manager.
-class ClientAuthSessionManager implements RefresherClientAuthKeyProvider {
+class ClientAuthSessionManager
+    implements RefresherClientAuthKeyProvider, CookieAuthKeyProvider {
   /// The auth module's caller.
   Caller? _caller;
 
@@ -16,6 +17,12 @@ class ClientAuthSessionManager implements RefresherClientAuthKeyProvider {
 
   /// The secure storage to keep user authentication info.
   final ClientAuthSuccessStorage storage;
+
+  /// Whether this client authenticates via an `HttpOnly` cookie.
+  ///
+  /// When true the client sends no auth header and signals cookie mode.
+  /// The server issues/clears the cookie.
+  final bool cookieAuth;
 
   /// Optional callback that is invoked when the auth info changes.
   /// The new auth info is passed as a parameter to the callback.
@@ -34,6 +41,9 @@ class ClientAuthSessionManager implements RefresherClientAuthKeyProvider {
     /// The storage to keep user authentication info. This is required for
     /// the platform-agnostic session manager.
     required this.storage,
+
+    /// Authenticate via an `HttpOnly` cookie.
+    this.cookieAuth = false,
 
     /// Optional callback that is invoked when the auth info changes.
     /// The new auth info value is passed as a parameter to the callback.
@@ -102,8 +112,29 @@ class ClientAuthSessionManager implements RefresherClientAuthKeyProvider {
   }
 
   @override
-  Future<String?> get authHeaderValue async =>
-      authKeyProviderDelegate?.authHeaderValue;
+  bool get usesCookies => cookieAuth;
+
+  @override
+  Future<String?> get authHeaderValue async {
+    if (!cookieAuth) return authKeyProviderDelegate?.authHeaderValue;
+
+    // Cookie mode carries the credential in an `HttpOnly` cookie, so no
+    // `Authorization` header is sent. Only the opaque session (SAS) strategy is
+    // supported in cookie mode today; JWT cookie mode (access-in-memory +
+    // refresh cookie) is not implemented yet. Without this guard a JWT client
+    // built with `cookieAuth: true` would send neither a header nor a cookie
+    // and authenticate as nobody, silently. Fail loudly instead.
+    final strategy = authInfo?.authStrategy;
+    if (strategy != null &&
+        AuthStrategy.fromJson(strategy) == AuthStrategy.jwt) {
+      throw StateError(
+        'cookieAuth is not supported with the JWT auth strategy. Use the opaque '
+        'session (SAS) strategy for cookie-based web auth, or run the client in '
+        'header mode (cookieAuth: false).',
+      );
+    }
+    return null;
+  }
 
   @override
   Future<RefreshAuthKeyResult> refreshAuthKey({bool force = false}) async {
@@ -160,6 +191,17 @@ class ClientAuthSessionManager implements RefresherClientAuthKeyProvider {
 
   /// Updates the signed in user on the storage and for open connections.
   Future<void> updateSignedInUser(AuthSuccess? authInfo) async {
+    if (cookieAuth && authInfo != null && authInfo.token.isNotEmpty) {
+      // In cookie mode the server issues the token as an `HttpOnly` cookie and
+      // returns an empty `token` in the body. A non-empty token here means the
+      // server did not issue a cookie. Refuse to persist it and fail loudly so
+      // the misconfiguration surfaces.
+      throw StateError(
+        'cookieAuth is enabled but the server returned the auth token in the '
+        'response body instead of an HttpOnly cookie. Configure `authCookie` '
+        'on the server, or run the client in header mode (cookieAuth: false).',
+      );
+    }
     await storage.set(authInfo);
     _authInfo = authInfo;
     onAuthInfoChanged?.call(_authInfo);

--- a/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_client/lib/src/session_manager.dart
+++ b/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_client/lib/src/session_manager.dart
@@ -114,30 +114,28 @@ class ClientAuthSessionManager
   @override
   bool get usesCookies => cookieAuth;
 
-  @override
-  Future<String?> get authHeaderValue async {
-    if (!cookieAuth) return authKeyProviderDelegate?.authHeaderValue;
-
-    // Cookie mode carries the credential in an `HttpOnly` cookie, so no
-    // `Authorization` header is sent. Only the opaque session (SAS) strategy is
-    // supported in cookie mode today; JWT cookie mode (access-in-memory +
-    // refresh cookie) is not implemented yet. Without this guard a JWT client
-    // built with `cookieAuth: true` would send neither a header nor a cookie
-    // and authenticate as nobody, silently. Fail loudly instead.
+  void _ensureCookieModeSupported() {
+    if (!cookieAuth) return;
     final strategy = authInfo?.authStrategy;
     if (strategy != null &&
         AuthStrategy.fromJson(strategy) == AuthStrategy.jwt) {
       throw StateError(
-        'cookieAuth is not supported with the JWT auth strategy. Use the opaque '
-        'session (SAS) strategy for cookie-based web auth, or run the client in '
-        'header mode (cookieAuth: false).',
+        'cookieAuth is not supported with the JWT auth strategy. '
+        'Use the opaque session (SAS) strategy for cookie-based web auth. ',
       );
     }
+  }
+
+  @override
+  Future<String?> get authHeaderValue async {
+    if (!cookieAuth) return authKeyProviderDelegate?.authHeaderValue;
+    _ensureCookieModeSupported();
     return null;
   }
 
   @override
   Future<RefreshAuthKeyResult> refreshAuthKey({bool force = false}) async {
+    _ensureCookieModeSupported();
     final authKeyProvider = authKeyProviderDelegate;
     if (authKeyProvider is! RefresherClientAuthKeyProvider) {
       return RefreshAuthKeyResult.skipped;

--- a/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_server/lib/src/common/endpoints/status_endpoint.dart
+++ b/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_server/lib/src/common/endpoints/status_endpoint.dart
@@ -18,19 +18,31 @@ class StatusEndpoint extends Endpoint {
 
   /// Signs out a user from the current device.
   Future<void> signOutDevice(final Session session) async {
-    final authInfoIdStr = session.authenticated?.authId;
-    if (authInfoIdStr == null) return;
-    final authInfoId = UuidValue.withValidation(authInfoIdStr);
-
-    await tokenManager.revokeToken(session, tokenId: authInfoId.toString());
+    await _clearCookieThenRevoke(session, () async {
+      final authInfoIdStr = session.authenticated?.authId;
+      if (authInfoIdStr == null) return;
+      final authInfoId = UuidValue.withValidation(authInfoIdStr);
+      await tokenManager.revokeToken(session, tokenId: authInfoId.toString());
+    });
   }
 
   /// Signs out a user from all active devices.
   Future<void> signOutAllDevices(final Session session) async {
-    final authUserIdStr = session.authenticated?.userIdentifier;
-    if (authUserIdStr == null) return;
-    final authUserId = UuidValue.withValidation(authUserIdStr);
+    await _clearCookieThenRevoke(session, () async {
+      final authUserIdStr = session.authenticated?.userIdentifier;
+      if (authUserIdStr == null) return;
+      final authUserId = UuidValue.withValidation(authUserIdStr);
+      await tokenManager.revokeAllTokens(session, authUserId: authUserId);
+    });
+  }
 
-    await tokenManager.revokeAllTokens(session, authUserId: authUserId);
+  /// Expires the web auth cookie on the client (a no-op for non-cookie clients)
+  /// before running [revokeTokens].
+  Future<void> _clearCookieThenRevoke(
+    final Session session,
+    final Future<void> Function() revokeTokens,
+  ) async {
+    session.clearWebAuthCookie();
+    await revokeTokens();
   }
 }

--- a/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_server/lib/src/session/business/server_side_sessions.dart
+++ b/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_server/lib/src/session/business/server_side_sessions.dart
@@ -202,12 +202,24 @@ class ServerSideSessions {
       transaction: transaction,
     );
 
+    final token = buildServerSideSessionToken(
+      secret: secret,
+      serverSideSessionId: serverSideSession.id!,
+    );
+
+    final secondsUntilExpiry = effectiveExpiresAt
+        ?.difference(clock.now())
+        .inSeconds;
+    final issuedAsCookie = session.writeWebAuthCookie(
+      token,
+      maxAgeSeconds: secondsUntilExpiry != null && secondsUntilExpiry > 0
+          ? secondsUntilExpiry
+          : null,
+    );
+
     return AuthSuccess(
       authStrategy: AuthStrategy.session.name,
-      token: buildServerSideSessionToken(
-        secret: secret,
-        serverSideSessionId: serverSideSession.id!,
-      ),
+      token: issuedAsCookie ? '' : token,
       tokenExpiresAt: effectiveExpiresAt,
       authUserId: authUserId,
       scopeNames: scopeNames,

--- a/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_server/lib/src/session/util/auth_success_extension.dart
+++ b/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_server/lib/src/session/util/auth_success_extension.dart
@@ -7,6 +7,13 @@ import '../session.dart';
 extension AuthSuccessServerSideSessionId on AuthSuccess {
   /// Returns the server side session token ID from the [AuthSuccess.token].
   UuidValue get serverSideSessionId {
+    if (token.isEmpty) {
+      throw const FormatException(
+        'AuthSuccess.token is empty! '
+        'A cookie-mode sign-in carries the session token in an HttpOnly cookie, '
+        'so the server side session id cannot be read from AuthSuccess.token.',
+      );
+    }
     final parsedToken = tryParseServerSideSessionToken(null, token);
     if (parsedToken == null) {
       throw const FormatException(

--- a/packages/serverpod/lib/server.dart
+++ b/packages/serverpod/lib/server.dart
@@ -20,7 +20,8 @@ export 'src/server/run_mode.dart';
 export 'src/server/server.dart' hide ServerInternalMethods;
 export 'src/server/serverpod.dart' hide ServerpodInternalMethods;
 export 'src/server/session.dart' hide SessionInternalMethods;
-export 'src/server/auth_cookie.dart' show WebAuthCookieBuilder;
+export 'src/server/auth_cookie.dart'
+    show WebAuthCookieBuilder, WebAuthCookieSession;
 export 'src/config/security_context_config.dart' show SecurityContextConfig;
 export 'src/redis/controller.dart';
 

--- a/packages/serverpod/lib/server.dart
+++ b/packages/serverpod/lib/server.dart
@@ -20,6 +20,7 @@ export 'src/server/run_mode.dart';
 export 'src/server/server.dart' hide ServerInternalMethods;
 export 'src/server/serverpod.dart' hide ServerpodInternalMethods;
 export 'src/server/session.dart' hide SessionInternalMethods;
+export 'src/server/auth_cookie.dart' show WebAuthCookieBuilder;
 export 'src/config/security_context_config.dart' show SecurityContextConfig;
 export 'src/redis/controller.dart';
 

--- a/packages/serverpod/lib/src/server/auth_cookie.dart
+++ b/packages/serverpod/lib/src/server/auth_cookie.dart
@@ -1,5 +1,53 @@
 import 'package:relic/relic.dart';
+import 'package:serverpod/src/server/session.dart';
+import 'package:serverpod_serialization/serverpod_serialization.dart'
+    show webAuthModeHeaderName, webAuthModeCookie;
 import 'package:serverpod_shared/serverpod_shared.dart';
+
+/// Web-auth-cookie helpers on [Session]: decides whether a request wants
+/// cookie-based web auth and writes/clears the auth cookie accordingly.
+extension WebAuthCookieSession on Session {
+  /// Whether the request asked for cookie-based web auth (via the
+  /// [webAuthModeHeaderName] header) and the server has a
+  /// [ServerpodConfig.authCookie] configured.
+  ///
+  /// When true the auth token should be issued as an `HttpOnly` cookie (see
+  /// [writeWebAuthCookie]) and omitted from the response body, so it never
+  /// reaches client-side JavaScript.
+  bool get isWebAuthCookieRequest {
+    if (serverpod.config.authCookie == null) return false;
+    return request?.headers[webAuthModeHeaderName]?.firstOrNull ==
+        webAuthModeCookie;
+  }
+
+  /// If [isWebAuthCookieRequest], writes [token] as the auth cookie and returns
+  /// true. Otherwise returns false and the caller should return the token in
+  /// the response body as usual. [maxAgeSeconds] sets the cookie lifetime;
+  /// omit it for a session cookie.
+  bool writeWebAuthCookie(String token, {int? maxAgeSeconds}) {
+    if (!isWebAuthCookieRequest) return false;
+    // isWebAuthCookieRequest already proved authCookie is non-null.
+    setResponseCookie(
+      serverpod.config.authCookie!.buildSetCookieHeader(
+        token,
+        maxAgeSeconds: maxAgeSeconds,
+      ),
+    );
+    return true;
+  }
+
+  /// Clears the auth cookie for cookie-mode requests (a no-op otherwise).
+  ///
+  /// Gated on [isWebAuthCookieRequest] just like [writeWebAuthCookie], so the
+  /// marker is the single source of truth for "this request participates in
+  /// cookie auth": a header/native client signing out gets no stray
+  /// `Set-Cookie`. Cookie clients send the marker on every call (including
+  /// sign-out), so their cookie is still cleared.
+  void clearWebAuthCookie() {
+    if (!isWebAuthCookieRequest) return;
+    setResponseCookie(serverpod.config.authCookie!.buildClearCookieHeader());
+  }
+}
 
 /// Builds the relic `Set-Cookie` headers for the web authentication cookie
 /// described by a [WebAuthCookieConfig].

--- a/packages/serverpod/lib/src/server/auth_cookie.dart
+++ b/packages/serverpod/lib/src/server/auth_cookie.dart
@@ -1,0 +1,54 @@
+import 'package:relic/relic.dart';
+import 'package:serverpod_shared/serverpod_shared.dart';
+
+/// Builds the relic `Set-Cookie` headers for the web authentication cookie
+/// described by a [WebAuthCookieConfig].
+///
+/// The auth cookie is always `HttpOnly` (the token must never be readable by
+/// JavaScript); `secure`, `sameSite`, `domain` and `path` come from the config.
+extension WebAuthCookieBuilder on WebAuthCookieConfig {
+  /// A `Set-Cookie` that stores [token] as the auth cookie. When
+  /// [maxAgeSeconds] is given it sets the cookie lifetime; omit it for a
+  /// session cookie (cleared when the browser closes).
+  SetCookie buildSetCookieHeader(String token, {int? maxAgeSeconds}) =>
+      _build(token, maxAge: maxAgeSeconds);
+
+  /// A `Set-Cookie` that expires (removes) the auth cookie on the client. The
+  /// attributes match those used to set it, which browsers require to remove a
+  /// cookie.
+  SetCookie buildClearCookieHeader() => _build('', maxAge: 0);
+
+  SetCookie _build(String value, {int? maxAge}) {
+    final domain = this.domain;
+    // SetCookie validates name, value, domain and path, throwing
+    // FormatException on bad input: it rejects a Domain with a port (RFC 6265
+    // 5.2.3) and normalizes away a leading dot (`.example.com` -> `example.com`,
+    // which browsers already treat as covering subdomains). Those values come
+    // from operator config, so report a malformed one as a clear configuration
+    // error rather than letting an opaque parse failure surface deep in the
+    // sign-in path.
+    try {
+      return SetCookie(
+        name: name,
+        value: value,
+        httpOnly: true,
+        secure: secure,
+        sameSite: _toRelicSameSite(sameSite),
+        path: path,
+        domain: domain == null ? null : Host.parse(domain),
+        maxAge: maxAge,
+      );
+    } on FormatException catch (e) {
+      throw ArgumentError(
+        'Invalid authCookie configuration (check name, domain and path): '
+        '${e.message}',
+      );
+    }
+  }
+}
+
+SameSite _toRelicSameSite(CookieSameSite sameSite) => switch (sameSite) {
+  CookieSameSite.lax => SameSite.lax,
+  CookieSameSite.strict => SameSite.strict,
+  CookieSameSite.none => SameSite.none,
+};

--- a/packages/serverpod/lib/src/server/response_output.dart
+++ b/packages/serverpod/lib/src/server/response_output.dart
@@ -1,0 +1,29 @@
+import 'package:relic/relic.dart';
+
+/// Returns [response] with the given response [headers] and [cookies] applied.
+///
+/// Returns [response] unchanged when both are empty (the common case, so
+/// endpoints that set nothing are unaffected). Values set here take precedence;
+/// the server merges its default response headers afterwards for anything not
+/// set here. Each [SetCookie] is appended to any `Set-Cookie` already on
+/// [response] via relic's [SetCookieHeader] collection.
+Response applyResponseOutput(
+  Response response, {
+  required Map<String, String> headers,
+  required List<SetCookie> cookies,
+}) {
+  if (headers.isEmpty && cookies.isEmpty) return response;
+
+  return response.copyWith(
+    headers: response.headers.transform((mh) {
+      for (var entry in headers.entries) {
+        mh[entry.key] = [entry.value];
+      }
+      if (cookies.isNotEmpty) {
+        mh.setCookie = (mh.setCookie ?? const SetCookieHeader.empty()).addAll(
+          cookies,
+        );
+      }
+    }),
+  );
+}

--- a/packages/serverpod/lib/src/server/server.dart
+++ b/packages/serverpod/lib/src/server/server.dart
@@ -292,13 +292,15 @@ class Server implements RouterInjectable {
   Handler _headers(Handler next) {
     return (req) async {
       final isOptions = req.method == Method.options;
-      final headers = isOptions
+      var headers = isOptions
           ? httpResponseHeaders.transform((mh) {
               for (final h in httpOptionsResponseHeaders.entries) {
                 mh[h.key] = h.value;
               }
             })
           : httpResponseHeaders;
+
+      headers = _applyCredentialedCorsHeaders(headers, req);
 
       // early exit on Method.options
       if (isOptions) return Response.ok(headers: headers);
@@ -317,6 +319,42 @@ class Server implements RouterInjectable {
         _ => result,
       };
     };
+  }
+
+  /// When cookie-based web auth is enabled, credentialed CORS requires echoing
+  /// the specific request `Origin` (the wildcard `*` is invalid with
+  /// credentials) plus `Access-Control-Allow-Credentials: true`. Applied only
+  /// for requests whose `Origin` is in [ServerpodConfig.allowedOrigins];
+  /// otherwise [headers] is returned unchanged.
+  Headers _applyCredentialedCorsHeaders(Headers headers, Request req) {
+    if (serverpod.config.authCookie == null) return headers;
+
+    var allowedOrigins = serverpod.config.allowedOrigins;
+    var origin = req.headers[Headers.originHeader]?.firstOrNull?.trim();
+    if (origin == null ||
+        allowedOrigins == null ||
+        !allowedOrigins.contains(origin)) {
+      return headers;
+    }
+
+    // The origin passed the allow-list membership check, but guard the parse so
+    // a malformed-but-allow-listed entry can't turn every response into a 500
+    // from inside this response-building middleware.
+    final Origin parsedOrigin;
+    try {
+      parsedOrigin = Origin.parse(origin);
+    } on FormatException {
+      return headers;
+    }
+
+    return headers.transform((mh) {
+      mh[Headers.accessControlAllowOriginHeader] = [origin];
+      mh[Headers.accessControlAllowCredentialsHeader] = ['true'];
+      // The response varies by Origin, so caches must key on it.
+      var vary = mh[Headers.varyHeader]?.toList() ?? <String>[];
+      if (!vary.contains('Origin')) vary.add('Origin');
+      mh[Headers.varyHeader] = vary;
+    });
   }
 
   FutureOr<Result> _cloudStorage(Request req) async {
@@ -344,7 +382,7 @@ class Server implements RouterInjectable {
       // Reject cross-site WebSocket handshakes when an origin allow-list is
       // configured. Only browsers send an `Origin` header; native, mobile and
       // server-to-server clients don't, and are always allowed.
-      var allowedOrigins = serverpod.config.allowedWebSocketOrigins;
+      var allowedOrigins = serverpod.config.allowedOrigins;
       if (allowedOrigins != null) {
         var origin = req.headers['origin']?.firstOrNull?.trim();
         if (origin != null && !allowedOrigins.contains(origin)) {

--- a/packages/serverpod/lib/src/server/server.dart
+++ b/packages/serverpod/lib/src/server/server.dart
@@ -321,6 +321,19 @@ class Server implements RouterInjectable {
     requestHandler,
   ) {
     return (req) async {
+      // Reject cross-site WebSocket handshakes when an origin allow-list is
+      // configured. Only browsers send an `Origin` header; native, mobile and
+      // server-to-server clients don't, and are always allowed.
+      var allowedOrigins = serverpod.config.allowedWebSocketOrigins;
+      if (allowedOrigins != null) {
+        var origin = req.headers['origin']?.firstOrNull?.trim();
+        if (origin != null && !allowedOrigins.contains(origin)) {
+          return Response.forbidden(
+            body: Body.fromString('WebSocket origin not allowed.'),
+          );
+        }
+      }
+
       return WebSocketUpgrade((webSocket) async {
         try {
           webSocket.pingInterval = serverpod.config.websocketPingInterval;
@@ -391,9 +404,9 @@ class Server implements RouterInjectable {
       }
     }
 
-    // Get the authentication key, if any
-    // If it is provided in the HTTP authorization header we use that,
-    // otherwise we look for it in the query parameters (the old method).
+    // Get the authentication key, if any, from the HTTP authorization header.
+    // Auth tokens are no longer accepted via the `?auth=` query parameter, so
+    // they never appear in request URLs (and thus server/proxy access logs).
     String? authenticationKey;
     String? authenticationHeaderValue;
 
@@ -401,7 +414,6 @@ class Server implements RouterInjectable {
       serverpod.config.validateHeaders,
     );
     authenticationKey = unwrapAuthHeaderValue(authenticationHeaderValue);
-    authenticationKey ??= queryParameters['auth'] as String?;
 
     MethodCallSession? maybeSession;
     try {

--- a/packages/serverpod/lib/src/server/server.dart
+++ b/packages/serverpod/lib/src/server/server.dart
@@ -292,7 +292,7 @@ class Server implements RouterInjectable {
   Handler _headers(Handler next) {
     return (req) async {
       final isOptions = req.method == Method.options;
-      var headers = isOptions
+      final headers = isOptions
           ? httpResponseHeaders.transform((mh) {
               for (final h in httpOptionsResponseHeaders.entries) {
                 mh[h.key] = h.value;
@@ -300,25 +300,52 @@ class Server implements RouterInjectable {
             })
           : httpResponseHeaders;
 
-      headers = _applyCredentialedCorsHeaders(headers, req);
-
       // early exit on Method.options
-      if (isOptions) return Response.ok(headers: headers);
+      if (isOptions) {
+        return Response.ok(
+          headers: _applyCredentialedCorsHeaders(headers, req),
+        );
+      }
 
       final result = await next(req);
-      return switch (result) {
-        Response() => result.copyWith(
-          headers: result.headers.isEmpty
-              ? headers
-              : result.headers.transform((mh) {
-                  for (final h in headers.entries) {
-                    mh[h.key] ??= h.value;
-                  }
-                }),
-        ),
-        _ => result,
-      };
+      if (result is! Response) return result;
+
+      // Merge default headers under any the response already set, then apply
+      // credentialed CORS to the merged result so its Origin echo / Vary land
+      // on the actual response (and append to a Vary the endpoint may have set).
+      var merged = result.headers.isEmpty
+          ? headers
+          : result.headers.transform((mh) {
+              for (final h in headers.entries) {
+                mh[h.key] ??= h.value;
+              }
+            });
+      return result.copyWith(
+        headers: _applyCredentialedCorsHeaders(merged, req),
+      );
     };
+  }
+
+  /// The `Origin` header of [req] normalized to lowercase, or null if absent.
+  ///
+  /// Origins (scheme + host) are case-insensitive, and browsers send a
+  /// canonical lowercase origin; [ServerpodConfig.allowedOrigins] is likewise
+  /// normalized to lowercase, so membership checks match regardless of the
+  /// casing an operator happened to configure.
+  String? _requestOrigin(Request req) =>
+      req.headers[Headers.originHeader]?.firstOrNull?.trim().toLowerCase();
+
+  /// Whether [req] carries an `Origin` that is present but not in
+  /// [ServerpodConfig.allowedOrigins].
+  ///
+  /// A missing `Origin` (native / mobile / server-to-server, which don't send
+  /// one) or an unset allow-list is not rejected. Shared by the WebSocket
+  /// handshake and the HTTP cookie-auth origin gates so the two cannot drift.
+  bool _isOriginDisallowed(Request req) {
+    var allowedOrigins = serverpod.config.allowedOrigins;
+    if (allowedOrigins == null) return false;
+    var origin = _requestOrigin(req);
+    return origin != null && !allowedOrigins.contains(origin);
   }
 
   /// When cookie-based web auth is enabled, credentialed CORS requires echoing
@@ -330,30 +357,47 @@ class Server implements RouterInjectable {
     if (serverpod.config.authCookie == null) return headers;
 
     var allowedOrigins = serverpod.config.allowedOrigins;
-    var origin = req.headers[Headers.originHeader]?.firstOrNull?.trim();
-    if (origin == null ||
-        allowedOrigins == null ||
-        !allowedOrigins.contains(origin)) {
-      return headers;
-    }
+    var origin = _requestOrigin(req);
 
-    // The origin passed the allow-list membership check, but guard the parse so
-    // a malformed-but-allow-listed entry can't turn every response into a 500
+    // Echo the specific origin (the wildcard `*` is invalid with credentials)
+    // only for an allow-listed origin. Guard the parse so a
+    // malformed-but-allow-listed entry can't turn every response into a 500
     // from inside this response-building middleware.
-    final Origin parsedOrigin;
-    try {
-      parsedOrigin = Origin.parse(origin);
-    } on FormatException {
-      return headers;
+    Origin? parsedOrigin;
+    if (origin != null &&
+        allowedOrigins != null &&
+        allowedOrigins.contains(origin)) {
+      try {
+        parsedOrigin = Origin.parse(origin);
+      } on FormatException {
+        parsedOrigin = null;
+      }
     }
 
     return headers.transform((mh) {
-      mh[Headers.accessControlAllowOriginHeader] = [origin];
-      mh[Headers.accessControlAllowCredentialsHeader] = ['true'];
-      // The response varies by Origin, so caches must key on it.
-      var vary = mh[Headers.varyHeader]?.toList() ?? <String>[];
-      if (!vary.contains('Origin')) vary.add('Origin');
-      mh[Headers.varyHeader] = vary;
+      if (parsedOrigin != null) {
+        mh.accessControlAllowOrigin = AccessControlAllowOriginHeader.origin(
+          origin: parsedOrigin,
+        );
+        mh.accessControlAllowCredentials = true;
+      }
+      // The credentialed-CORS response varies by Origin: an allow-listed origin
+      // gets a specific Access-Control-Allow-Origin while every other request
+      // keeps the default wildcard. A shared cache must therefore key on Origin
+      // for *all* responses while authCookie is enabled - not only the ones
+      // that echo a specific origin - otherwise it could serve a cached
+      // wildcard (or another origin's) response to an allow-listed credentialed
+      // request, which the browser then rejects. VaryHeader canonicalizes field
+      // names to lowercase; a wildcard Vary already covers Origin.
+      var vary = mh.vary;
+      if (vary == null) {
+        mh.vary = VaryHeader.headers(fields: const [Headers.originHeader]);
+      } else if (!vary.isWildcard &&
+          !vary.fields.contains(Headers.originHeader)) {
+        mh.vary = VaryHeader.headers(
+          fields: [...vary.fields, Headers.originHeader],
+        );
+      }
     });
   }
 
@@ -382,14 +426,10 @@ class Server implements RouterInjectable {
       // Reject cross-site WebSocket handshakes when an origin allow-list is
       // configured. Only browsers send an `Origin` header; native, mobile and
       // server-to-server clients don't, and are always allowed.
-      var allowedOrigins = serverpod.config.allowedOrigins;
-      if (allowedOrigins != null) {
-        var origin = req.headers['origin']?.firstOrNull?.trim();
-        if (origin != null && !allowedOrigins.contains(origin)) {
-          return Response.forbidden(
-            body: Body.fromString('WebSocket origin not allowed.'),
-          );
-        }
+      if (_isOriginDisallowed(req)) {
+        return Response.forbidden(
+          body: Body.fromString('WebSocket origin not allowed.'),
+        );
       }
 
       return WebSocketUpgrade((webSocket) async {
@@ -475,10 +515,9 @@ class Server implements RouterInjectable {
 
     // Fall back to the web auth cookie when configured and no header was sent
     // (the browser carries it for cookie-based web clients).
-    var authCookie = serverpod.config.authCookie;
-    if (authenticationKey == null && authCookie != null) {
-      authenticationKey = request.getCookieValue(authCookie.name);
-    }
+    authenticationKey ??= request.getAuthCookieValue(
+      serverpod.config.authCookie,
+    );
 
     MethodCallSession? maybeSession;
     try {

--- a/packages/serverpod/lib/src/server/server.dart
+++ b/packages/serverpod/lib/src/server/server.dart
@@ -513,11 +513,25 @@ class Server implements RouterInjectable {
     );
     authenticationKey = unwrapAuthHeaderValue(authenticationHeaderValue);
 
-    // Fall back to the web auth cookie when configured and no header was sent
-    // (the browser carries it for cookie-based web clients).
-    authenticationKey ??= request.getAuthCookieValue(
-      serverpod.config.authCookie,
-    );
+    // Fall back to the web auth cookie for requests that opted into cookie mode
+    // via the marker header (layer 3 CSRF defense). A cross-site form or simple
+    // request cannot set this custom header without a CORS preflight, which
+    // fails for non-allow-listed origins.
+    if (authenticationKey == null &&
+        serverpod.config.authCookie != null &&
+        request.headers[webAuthModeHeaderName]?.firstOrNull ==
+            webAuthModeCookie) {
+      // Reject a cookie-mode request whose `Origin` is present but not in the
+      // allow-list (Layer 2 CSRF defense).
+      if (_isOriginDisallowed(request)) {
+        return Response.forbidden(
+          body: Body.fromString('Request origin not allowed.'),
+        );
+      }
+      authenticationKey = request.getAuthCookieValue(
+        serverpod.config.authCookie,
+      );
+    }
 
     MethodCallSession? maybeSession;
     try {

--- a/packages/serverpod/lib/src/server/server.dart
+++ b/packages/serverpod/lib/src/server/server.dart
@@ -297,6 +297,30 @@ class Server implements RouterInjectable {
               for (final h in httpOptionsResponseHeaders.entries) {
                 mh[h.key] = h.value;
               }
+              // Cookie-auth web clients send the marker header on every request,
+              // so a cross-origin preflight must allow-list it or the browser
+              // blocks the request before it reaches the server.
+              //
+              // The default OPTIONS headers include it,
+              // but a custom httpOptionsResponseHeaders may not.
+              //
+              // Ensure it is present whenever cookie auth is enabled so
+              // the feature can't be silently disabled by a header override.
+              if (serverpod.config.authCookie != null) {
+                final allow = mh.accessControlAllowHeaders;
+                if (allow == null) {
+                  mh.accessControlAllowHeaders =
+                      AccessControlAllowHeadersHeader.headers(
+                        const [webAuthModeHeaderName],
+                      );
+                } else if (!allow.isWildcard &&
+                    !allow.headers.contains(webAuthModeHeaderName)) {
+                  mh.accessControlAllowHeaders =
+                      AccessControlAllowHeadersHeader.headers(
+                        [...allow.headers, webAuthModeHeaderName],
+                      );
+                }
+              }
             })
           : httpResponseHeaders;
 
@@ -380,6 +404,10 @@ class Server implements RouterInjectable {
           origin: parsedOrigin,
         );
         mh.accessControlAllowCredentials = true;
+      } else if (origin != null) {
+        // A browser request from a non-allow-listed origin.
+        // Drop the Allow-Origin header so the browser blocks cleanly.
+        mh.accessControlAllowOrigin = null;
       }
       // The credentialed-CORS response varies by Origin: an allow-listed origin
       // gets a specific Access-Control-Allow-Origin while every other request

--- a/packages/serverpod/lib/src/server/server.dart
+++ b/packages/serverpod/lib/src/server/server.dart
@@ -8,6 +8,7 @@ import 'package:serverpod_shared/log.dart';
 import 'package:serverpod/src/cache/caches.dart';
 import 'package:serverpod/src/server/diagnostic_events/diagnostic_events.dart';
 import 'package:serverpod/src/server/health/health_routes.dart';
+import 'package:serverpod/src/server/response_output.dart';
 import 'package:serverpod/src/server/serverpod.dart';
 import 'package:serverpod/src/server/session.dart';
 import 'package:serverpod/src/server/websocket_request_handlers/endpoint_websocket_request_handler.dart';
@@ -220,18 +221,36 @@ class Server implements RouterInjectable {
     return (req) async {
       try {
         return await next(req);
-      } on MaxBodySizeExceeded catch (e) {
+      } catch (e, stackTrace) {
+        return await _toErrorResponse(e, stackTrace, request: req);
+      }
+    };
+  }
+
+  /// Builds the HTTP [Response] for an [error] thrown while handling a request.
+  ///
+  /// Shared by [_reportException] and the method-call error path so a faulted
+  /// call's queued response output (e.g. a sign-out cookie clear) can be
+  /// applied to the same error response instead of being dropped. An
+  /// unrecognized error is reported as a framework exception and becomes a 500.
+  Future<Response> _toErrorResponse(
+    Object error,
+    StackTrace stackTrace, {
+    Request? request,
+  }) async {
+    switch (error) {
+      case MaxBodySizeExceeded():
         return Response.contentTooLarge(
           body: Body.fromString(
-            'Request size exceeds the maximum allowed size of ${e.maxLength} bytes.',
+            'Request size exceeds the maximum allowed size of ${error.maxLength} bytes.',
           ),
         );
-      } on EndpointDispatchException catch (e) {
-        return switch (e) {
+      case EndpointDispatchException():
+        return switch (error) {
           EndpointNotFoundException() => Response.notFound(
-            body: Body.fromString(e.message),
+            body: Body.fromString(error.message),
           ),
-          NotAuthorizedException() => Response(switch (e.reason) {
+          NotAuthorizedException() => Response(switch (error.reason) {
             AuthenticationFailureReason.unauthenticated =>
               io.HttpStatus.unauthorized,
             AuthenticationFailureReason.insufficientAccess =>
@@ -240,33 +259,34 @@ class Server implements RouterInjectable {
           MethodNotFoundException() ||
           InvalidEndpointMethodTypeException() ||
           InvalidParametersException() => Response.badRequest(
-            body: Body.fromString(e.message),
+            body: Body.fromString(error.message),
           ),
         };
-      } on SerializableException catch (e) {
+      case SerializableException():
         return Response.badRequest(
           body: Body.fromString(
-            serializationManager.encodeWithTypeForProtocol(e),
+            serializationManager.encodeWithTypeForProtocol(error),
             mimeType: MimeType.json,
           ),
         );
-      } on HeaderException catch (e) {
-        return Response.badRequest(body: Body.fromString(e.httpResponseBody));
-      } on AuthHeaderEncodingException catch (_) {
+      case HeaderException():
+        return Response.badRequest(
+          body: Body.fromString(error.httpResponseBody),
+        );
+      case AuthHeaderEncodingException():
         return Response.badRequest(
           body: Body.fromString('Request has invalid "authorization" header'),
         );
-      } catch (e, stackTrace) {
+      default:
         await _reportFrameworkException(
-          e,
+          error,
           stackTrace,
           message:
               'Internal server error. Request handler failed with exception.',
-          request: req,
+          request: request,
         );
         return Response.internalServerError();
-      }
-    };
+    }
   }
 
   Handler _headers(Handler next) {
@@ -457,12 +477,18 @@ class Server implements RouterInjectable {
           session,
           methodCallContext.arguments,
         );
-        if (methodCallContext.endpoint.sendAsRaw) return _toResponse(result);
-        return Response.ok(
-          body: Body.fromString(
-            SerializationManager.encodeForProtocol(result),
-            mimeType: MimeType.json,
-          ),
+        var response = methodCallContext.endpoint.sendAsRaw
+            ? _toResponse(result)
+            : Response.ok(
+                body: Body.fromString(
+                  SerializationManager.encodeForProtocol(result),
+                  mimeType: MimeType.json,
+                ),
+              );
+        return applyResponseOutput(
+          response,
+          headers: session.responseHeaders,
+          cookies: session.responseCookies,
         );
       } catch (e, stackTrace) {
         // Note: In case of malformed argument, the method connector may throw,
@@ -473,7 +499,20 @@ class Server implements RouterInjectable {
           context: contextFromSession(session, request: request),
         );
         await session.close(error: e, stackTrace: stackTrace);
-        rethrow;
+
+        // Apply response output queued before the failure (e.g. a sign-out's
+        // cookie clear) to the error response, so it still reaches the client
+        // instead of being dropped when the call throws. With nothing queued,
+        // defer to _reportException for identical handling.
+        if (session.responseHeaders.isEmpty &&
+            session.responseCookies.isEmpty) {
+          rethrow;
+        }
+        return applyResponseOutput(
+          await _toErrorResponse(e, stackTrace, request: request),
+          headers: session.responseHeaders,
+          cookies: session.responseCookies,
+        );
       }
     } finally {
       await maybeSession?.close(); // safe to close twice

--- a/packages/serverpod/lib/src/server/server.dart
+++ b/packages/serverpod/lib/src/server/server.dart
@@ -350,14 +350,14 @@ class Server implements RouterInjectable {
     };
   }
 
-  /// The `Origin` header of [req] normalized to lowercase, or null if absent.
-  ///
-  /// Origins (scheme + host) are case-insensitive, and browsers send a
-  /// canonical lowercase origin; [ServerpodConfig.allowedOrigins] is likewise
-  /// normalized to lowercase, so membership checks match regardless of the
-  /// casing an operator happened to configure.
-  String? _requestOrigin(Request req) =>
-      req.headers[Headers.originHeader]?.firstOrNull?.trim().toLowerCase();
+  /// The `Origin` header of [req] normalized to lowercase with any trailing
+  /// slash dropped, or null if absent.
+  String? _requestOrigin(Request req) => req
+      .headers[Headers.originHeader]
+      ?.firstOrNull
+      ?.trim()
+      .toLowerCase()
+      .replaceFirst(RegExp(r'/+$'), '');
 
   /// Whether [req] carries an `Origin` that is present but not in
   /// [ServerpodConfig.allowedOrigins].

--- a/packages/serverpod/lib/src/server/server.dart
+++ b/packages/serverpod/lib/src/server/server.dart
@@ -435,6 +435,13 @@ class Server implements RouterInjectable {
     );
     authenticationKey = unwrapAuthHeaderValue(authenticationHeaderValue);
 
+    // Fall back to the web auth cookie when configured and no header was sent
+    // (the browser carries it for cookie-based web clients).
+    var authCookie = serverpod.config.authCookie;
+    if (authenticationKey == null && authCookie != null) {
+      authenticationKey = request.getCookieValue(authCookie.name);
+    }
+
     MethodCallSession? maybeSession;
     try {
       var methodCallContext = await endpoints.getMethodCallContext(

--- a/packages/serverpod/lib/src/server/serverpod.dart
+++ b/packages/serverpod/lib/src/server/serverpod.dart
@@ -401,6 +401,10 @@ class Serverpod {
         'Accept',
         'User-Agent',
         'X-Requested-With',
+        // Cookie-auth web clients send this marker on every request; it must be
+        // allow-listed here or a cross-origin preflight blocks the request
+        // before the cookie flow can run.
+        webAuthModeHeaderName,
       ],
     );
   });

--- a/packages/serverpod/lib/src/server/session.dart
+++ b/packages/serverpod/lib/src/server/session.dart
@@ -34,6 +34,27 @@ abstract class Session implements DatabaseSession {
     _willCloseListeners.remove(listener);
   }
 
+  // Lazily allocated: most sessions never set response output, so the common
+  // path (every method call, every streaming message) allocates nothing.
+  List<SetCookie>? _responseCookies;
+  Map<String, String>? _responseHeaders;
+
+  /// Sets the HTTP response header [name] to [value] for this call.
+  ///
+  /// Applied to the response of method calls (HTTP); other session types (e.g.
+  /// streaming) have no per-call response and ignore it. A header set here
+  /// takes precedence over the server's default response headers.
+  void setResponseHeader(String name, String value) {
+    (_responseHeaders ??= {})[name] = value;
+  }
+
+  /// Adds a `Set-Cookie` to this call's HTTP response. See [setResponseHeader]
+  /// for which calls this applies to. To remove a cookie on the client, set one
+  /// with the same name and `maxAge: 0`.
+  void setResponseCookie(SetCookie cookie) {
+    (_responseCookies ??= []).add(cookie);
+  }
+
   /// The id of the session.
   final UuidValue sessionId;
 
@@ -688,6 +709,16 @@ class MessageCentralAccess {
 /// This is used to provide access to internal methods that should not be
 /// accessed from outside the library.
 extension SessionInternalMethods on Session {
+  /// The cookies queued via [Session.setResponseCookie], applied when building
+  /// the response.
+  List<SetCookie> get responseCookies =>
+      _responseCookies ?? const <SetCookie>[];
+
+  /// The headers queued via [Session.setResponseHeader], applied when building
+  /// the response.
+  Map<String, String> get responseHeaders =>
+      _responseHeaders ?? const <String, String>{};
+
   /// Creates a new [MethodCallSession].
   static Future<MethodCallSession> createMethodCallSession({
     required Server server,

--- a/packages/serverpod/lib/src/server/session.dart
+++ b/packages/serverpod/lib/src/server/session.dart
@@ -391,8 +391,9 @@ class StreamingSession extends Session {
     queryParameters.addAll(uri.queryParameters);
     this.queryParameters = queryParameters;
 
-    // Get the authentication key, if any
-    _authenticationKey = queryParameters['auth'];
+    // The authentication key is no longer read from the URL. Streaming clients
+    // authenticate in-band via the 'auth' control message so the token never
+    // appears in the connection URL (and thus server/proxy logs).
   }
 }
 

--- a/packages/serverpod/lib/src/server/websocket_request_handlers/endpoint_websocket_request_handler.dart
+++ b/packages/serverpod/lib/src/server/websocket_request_handlers/endpoint_websocket_request_handler.dart
@@ -79,9 +79,6 @@ abstract class EndpointWebsocketRequestHandler {
             var args = data['args'] as Map;
 
             if (command == 'ping') {
-              // Open streams (anonymously, if no 'auth' message preceded this)
-              // before responding, so streamOpened fires once per connection.
-              await openAllStreams();
               webSocket.trySendText(
                 SerializationManager.encodeForProtocol(
                   {'command': 'pong'},

--- a/packages/serverpod/lib/src/server/websocket_request_handlers/endpoint_websocket_request_handler.dart
+++ b/packages/serverpod/lib/src/server/websocket_request_handlers/endpoint_websocket_request_handler.dart
@@ -42,22 +42,10 @@ abstract class EndpointWebsocketRequestHandler {
       Future<void> openAllStreams() async {
         if (streamsOpened) return;
         streamsOpened = true;
-        for (var endpointConnector in endpointDispatch.connectors.values) {
-          await _callStreamOpened(
-            session,
-            endpointConnector.endpoint.name,
-            endpointDispatch,
-          );
-        }
-        for (var module in endpointDispatch.modules.values) {
-          for (var endpointConnector in module.connectors.values) {
-            await _callStreamOpened(
-              session,
-              endpointConnector.endpoint.name,
-              module,
-            );
-          }
-        }
+        await _forEachEndpoint(
+          endpointDispatch,
+          (name, dispatch) => _callStreamOpened(session, name, dispatch),
+        );
       }
 
       dynamic error;
@@ -183,22 +171,10 @@ abstract class EndpointWebsocketRequestHandler {
       // closed without any message never fired streamOpened.
       // TODO: Possibly keep a list of open streams instead
       if (streamsOpened) {
-        for (var endpointConnector in server.endpoints.connectors.values) {
-          await _callStreamClosed(
-            session,
-            endpointConnector.endpoint.name,
-            endpointDispatch,
-          );
-        }
-        for (var module in server.endpoints.modules.values) {
-          for (var endpointConnector in module.connectors.values) {
-            await _callStreamClosed(
-              session,
-              endpointConnector.endpoint.name,
-              module,
-            );
-          }
-        }
+        await _forEachEndpoint(
+          endpointDispatch,
+          (name, dispatch) => _callStreamClosed(session, name, dispatch),
+        );
       }
       await session.close(error: error, stackTrace: stackTrace);
     } catch (e, s) {
@@ -209,10 +185,30 @@ abstract class EndpointWebsocketRequestHandler {
     }
   }
 
-  static Future<void> _callStreamOpened(
+  /// Invokes [action] for every endpoint connector on the server.
+  static Future<void> _forEachEndpoint(
+    EndpointDispatch endpointDispatch,
+    Future<void> Function(String endpointName, EndpointDispatch dispatch)
+    action,
+  ) async {
+    for (var endpointConnector in endpointDispatch.connectors.values) {
+      await action(endpointConnector.endpoint.name, endpointDispatch);
+    }
+    for (var module in endpointDispatch.modules.values) {
+      for (var endpointConnector in module.connectors.values) {
+        await action(endpointConnector.endpoint.name, module);
+      }
+    }
+  }
+
+  /// Resolves the connector for [endpointName] and invokes [notify] with its
+  /// endpoint, swallowing an unauthorized stream and reporting any other error
+  /// without tearing down the connection.
+  static Future<void> _notifyEndpoint(
     StreamingSession session,
     String endpointName,
     EndpointDispatch endpointDispatch,
+    Future<void> Function(Endpoint endpoint) notify,
   ) async {
     try {
       session.endpoint = endpointName;
@@ -220,8 +216,7 @@ abstract class EndpointWebsocketRequestHandler {
         session: session,
         endpointPath: endpointName,
       );
-      // ignore: deprecated_member_use_from_same_package
-      await connector.endpoint.streamOpened(session);
+      await notify(connector.endpoint);
     } on NotAuthorizedException catch (_) {
       // User is not authorized to communicate with this endpoint.
       return;
@@ -231,27 +226,29 @@ abstract class EndpointWebsocketRequestHandler {
     }
   }
 
+  static Future<void> _callStreamOpened(
+    StreamingSession session,
+    String endpointName,
+    EndpointDispatch endpointDispatch,
+  ) => _notifyEndpoint(
+    session,
+    endpointName,
+    endpointDispatch,
+    // ignore: deprecated_member_use_from_same_package
+    (endpoint) => endpoint.streamOpened(session),
+  );
+
   static Future<void> _callStreamClosed(
     StreamingSession session,
     String endpointName,
     EndpointDispatch endpointDispatch,
-  ) async {
-    try {
-      session.endpoint = endpointName;
-      var connector = await endpointDispatch.getEndpointConnector(
-        session: session,
-        endpointPath: endpointName,
-      );
-      // ignore: deprecated_member_use_from_same_package
-      await connector.endpoint.streamClosed(session);
-    } on NotAuthorizedException catch (_) {
-      // User is not authorized to communicate with this endpoint.
-      return;
-    } catch (e, s) {
-      _reportException(session.server, e, s, session: session);
-      return;
-    }
-  }
+  ) => _notifyEndpoint(
+    session,
+    endpointName,
+    endpointDispatch,
+    // ignore: deprecated_member_use_from_same_package
+    (endpoint) => endpoint.streamClosed(session),
+  );
 
   static void _reportException(
     Server server,

--- a/packages/serverpod/lib/src/server/websocket_request_handlers/endpoint_websocket_request_handler.dart
+++ b/packages/serverpod/lib/src/server/websocket_request_handlers/endpoint_websocket_request_handler.dart
@@ -31,20 +31,32 @@ abstract class EndpointWebsocketRequestHandler {
       );
 
       var endpointDispatch = server.endpoints;
-      for (var endpointConnector in endpointDispatch.connectors.values) {
-        await _callStreamOpened(
-          session,
-          endpointConnector.endpoint.name,
-          endpointDispatch,
-        );
-      }
-      for (var module in endpointDispatch.modules.values) {
-        for (var endpointConnector in module.connectors.values) {
+
+      // Open streams lazily on the first received message rather than at
+      // connection time. This lets a client authenticate in-band (via the
+      // 'auth' control message) before streams are opened, so each endpoint's
+      // streamOpened sees the authenticated session. Previously the auth token
+      // was available from the connection URL, so streams could open
+      // authenticated immediately; tokens are no longer accepted in the URL.
+      var streamsOpened = false;
+      Future<void> openAllStreams() async {
+        if (streamsOpened) return;
+        streamsOpened = true;
+        for (var endpointConnector in endpointDispatch.connectors.values) {
           await _callStreamOpened(
             session,
             endpointConnector.endpoint.name,
-            module,
+            endpointDispatch,
           );
+        }
+        for (var module in endpointDispatch.modules.values) {
+          for (var endpointConnector in module.connectors.values) {
+            await _callStreamOpened(
+              session,
+              endpointConnector.endpoint.name,
+              module,
+            );
+          }
         }
       }
 
@@ -67,6 +79,9 @@ abstract class EndpointWebsocketRequestHandler {
             var args = data['args'] as Map;
 
             if (command == 'ping') {
+              // Open streams (anonymously, if no 'auth' message preceded this)
+              // before responding, so streamOpened fires once per connection.
+              await openAllStreams();
               webSocket.trySendText(
                 SerializationManager.encodeForProtocol(
                   {'command': 'pong'},
@@ -85,9 +100,16 @@ abstract class EndpointWebsocketRequestHandler {
               await session.updateAuthenticationKey(
                 unwrapAuthHeaderValue(authKey),
               );
+              // Open streams now that authentication has been applied so each
+              // endpoint's streamOpened sees the authenticated session.
+              await openAllStreams();
             }
             continue;
           }
+
+          // A message for an endpoint arrived before any ping/auth; ensure
+          // streams are open before dispatching it.
+          await openAllStreams();
 
           // Handle messages passed to endpoints.
           var endpointName = data['endpoint'] as String;
@@ -155,21 +177,26 @@ abstract class EndpointWebsocketRequestHandler {
         _reportException(server, e, s, session: session);
       }
 
+      // Only notify streamClosed for connections whose streams were opened
+      // (i.e. that sent at least one message). A connection that opened and
+      // closed without any message never fired streamOpened.
       // TODO: Possibly keep a list of open streams instead
-      for (var endpointConnector in server.endpoints.connectors.values) {
-        await _callStreamClosed(
-          session,
-          endpointConnector.endpoint.name,
-          endpointDispatch,
-        );
-      }
-      for (var module in server.endpoints.modules.values) {
-        for (var endpointConnector in module.connectors.values) {
+      if (streamsOpened) {
+        for (var endpointConnector in server.endpoints.connectors.values) {
           await _callStreamClosed(
             session,
             endpointConnector.endpoint.name,
-            module,
+            endpointDispatch,
           );
+        }
+        for (var module in server.endpoints.modules.values) {
+          for (var endpointConnector in module.connectors.values) {
+            await _callStreamClosed(
+              session,
+              endpointConnector.endpoint.name,
+              module,
+            );
+          }
         }
       }
       await session.close(error: error, stackTrace: stackTrace);

--- a/packages/serverpod/lib/src/server/websocket_request_handlers/endpoint_websocket_request_handler.dart
+++ b/packages/serverpod/lib/src/server/websocket_request_handlers/endpoint_websocket_request_handler.dart
@@ -101,7 +101,11 @@ abstract class EndpointWebsocketRequestHandler {
                 unwrapAuthHeaderValue(authKey),
               );
               // Open streams now that authentication has been applied so each
-              // endpoint's streamOpened sees the authenticated session.
+              // endpoint's streamOpened sees the authenticated session. The
+              // 'auth' message must therefore be the first message a client
+              // sends: if a ping or endpoint message arrives first, streams open
+              // (anonymously) and streamOpened does not re-run on this later
+              // auth. The bundled client sends 'auth' before 'ping'.
               await openAllStreams();
             }
             continue;

--- a/packages/serverpod/lib/src/server/websocket_request_handlers/method_websocket_request_handler.dart
+++ b/packages/serverpod/lib/src/server/websocket_request_handlers/method_websocket_request_handler.dart
@@ -329,15 +329,11 @@ class MethodWebsocketRequestHandler {
     // The in-band value (a wrapped header) takes precedence; otherwise fall
     // back to the web auth cookie sent on the handshake (a raw token) when
     // configured.
-    String? authenticationKey;
-    if (authentication != null) {
-      authenticationKey = unwrapAuthHeaderValue(authentication);
-    } else {
-      var authCookie = server.serverpod.config.authCookie;
-      if (authCookie != null) {
-        authenticationKey = webSocket.request.getCookieValue(authCookie.name);
-      }
-    }
+    final authenticationKey =
+        unwrapAuthHeaderValue(authentication) ??
+        webSocket.request.getAuthCookieValue(
+          server.serverpod.config.authCookie,
+        );
 
     MethodStreamSession? maybeSession;
     MethodStreamCallContext methodStreamCallContext;

--- a/packages/serverpod/lib/src/server/websocket_request_handlers/method_websocket_request_handler.dart
+++ b/packages/serverpod/lib/src/server/websocket_request_handlers/method_websocket_request_handler.dart
@@ -326,6 +326,19 @@ class MethodWebsocketRequestHandler {
       );
     }
 
+    // The in-band value (a wrapped header) takes precedence; otherwise fall
+    // back to the web auth cookie sent on the handshake (a raw token) when
+    // configured.
+    String? authenticationKey;
+    if (authentication != null) {
+      authenticationKey = unwrapAuthHeaderValue(authentication);
+    } else {
+      var authCookie = server.serverpod.config.authCookie;
+      if (authCookie != null) {
+        authenticationKey = webSocket.request.getCookieValue(authCookie.name);
+      }
+    }
+
     MethodStreamSession? maybeSession;
     MethodStreamCallContext methodStreamCallContext;
     bool keepSessionOpen = false;
@@ -336,9 +349,7 @@ class MethodWebsocketRequestHandler {
               maybeSession =
                   await SessionInternalMethods.createMethodStreamSession(
                     server: server,
-                    authenticationKey: unwrapAuthHeaderValue(
-                      authentication,
-                    ),
+                    authenticationKey: authenticationKey,
                     endpoint: message.endpoint,
                     method: message.method,
                     connectionId: message.connectionId,

--- a/packages/serverpod/lib/src/util/request_extension.dart
+++ b/packages/serverpod/lib/src/util/request_extension.dart
@@ -49,4 +49,15 @@ extension RequestExtension on Request {
       return headers['authorization']?.firstOrNull;
     }
   }
+
+  /// Returns the value of the cookie named [cookieName] from the request's
+  /// `Cookie` header, or null if it is absent. A malformed `Cookie` header is
+  /// treated as absent rather than failing the request.
+  String? getCookieValue(String cookieName) {
+    try {
+      return headers.cookie?.getCookie(cookieName)?.value;
+    } on Exception {
+      return null;
+    }
+  }
 }

--- a/packages/serverpod/lib/src/util/request_extension.dart
+++ b/packages/serverpod/lib/src/util/request_extension.dart
@@ -1,4 +1,5 @@
 import 'package:relic/relic.dart';
+import 'package:serverpod_shared/log.dart';
 import 'package:serverpod_shared/serverpod_shared.dart';
 
 /// Extends [Request] with useful methods.
@@ -69,7 +70,14 @@ extension RequestExtension on Request {
   String? getCookieValue(String cookieName) {
     try {
       var matching = headers.cookie?.getCookies(cookieName).toList();
-      if (matching == null || matching.length != 1) return null;
+      if (matching == null || matching.isEmpty) return null;
+      if (matching.length != 1) {
+        log.warning(
+          'Received ${matching.length} cookies named "$cookieName". '
+          'Treating it as absent!',
+        );
+        return null;
+      }
       return matching.first.value;
     } on Exception {
       return null;

--- a/packages/serverpod/lib/src/util/request_extension.dart
+++ b/packages/serverpod/lib/src/util/request_extension.dart
@@ -1,4 +1,5 @@
 import 'package:relic/relic.dart';
+import 'package:serverpod_shared/serverpod_shared.dart';
 
 /// Extends [Request] with useful methods.
 extension RequestExtension on Request {
@@ -51,13 +52,34 @@ extension RequestExtension on Request {
   }
 
   /// Returns the value of the cookie named [cookieName] from the request's
-  /// `Cookie` header, or null if it is absent. A malformed `Cookie` header is
-  /// treated as absent rather than failing the request.
+  /// `Cookie` header, or null if it is absent, ambiguous, or the header has no
+  /// valid cookie at all (all treated as absent rather than failing the
+  /// request).
+  ///
+  /// relic's `Cookie` parser skips individual malformed cookies, so an
+  /// unrelated bad cookie does not hide a well-formed one. It only throws when
+  /// no cookie in the header is usable; that is caught here and treated as
+  /// absent.
+  ///
+  /// If the `Cookie` header carries more than one cookie with [cookieName] this
+  /// returns null (fail closed) instead of trusting whichever the browser
+  /// ordered first: a sibling subdomain can plant a `Domain`-scoped duplicate
+  /// that shadows a host-only cookie, so picking the first match would let an
+  /// attacker fixate the session for a security-sensitive cookie.
   String? getCookieValue(String cookieName) {
     try {
-      return headers.cookie?.getCookie(cookieName)?.value;
+      var matching = headers.cookie?.getCookies(cookieName).toList();
+      if (matching == null || matching.length != 1) return null;
+      return matching.first.value;
     } on Exception {
       return null;
     }
+  }
+
+  /// Returns the web auth token carried by the configured [authCookie], or null
+  /// when cookie auth is not configured or the cookie is absent.
+  String? getAuthCookieValue(WebAuthCookieConfig? authCookie) {
+    if (authCookie == null) return null;
+    return getCookieValue(authCookie.name);
   }
 }

--- a/packages/serverpod/pubspec.yaml
+++ b/packages/serverpod/pubspec.yaml
@@ -30,7 +30,7 @@ dependencies:
   path: ^1.8.3
   postgres: ^3.4.0
   redis: ^4.0.0
-  relic: ^1.2.0
+  relic: ^2.0.0-beta.0
   retry: ^3.1.1
   serverpod_database: 3.5.0-beta.12
   serverpod_serialization: 3.5.0-beta.12

--- a/packages/serverpod/test/server/auth_cookie_test.dart
+++ b/packages/serverpod/test/server/auth_cookie_test.dart
@@ -1,0 +1,114 @@
+import 'package:relic/relic.dart';
+import 'package:serverpod/src/server/auth_cookie.dart';
+import 'package:serverpod_shared/serverpod_shared.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Given a default WebAuthCookieConfig', () {
+    var config = const WebAuthCookieConfig();
+
+    test('when building a set-cookie header then it is HttpOnly and Secure '
+        'with the configured defaults.', () {
+      var cookie = config.buildSetCookieHeader('abc123', maxAgeSeconds: 3600);
+
+      expect(cookie.name, WebAuthCookieConfig.defaultName);
+      expect(cookie.value, 'abc123');
+      expect(cookie.httpOnly, isTrue);
+      expect(cookie.secure, isTrue);
+      expect(cookie.sameSite, SameSite.lax);
+      expect(cookie.maxAge, 3600);
+      expect(cookie.path?.toString(), '/');
+      expect(cookie.domain, isNull);
+    });
+
+    test('when no maxAge is given then it is a session cookie.', () {
+      var cookie = config.buildSetCookieHeader('abc123');
+      expect(cookie.maxAge, isNull);
+    });
+
+    test('when building a clear-cookie header then value is empty and '
+        'maxAge is 0.', () {
+      var cookie = config.buildClearCookieHeader();
+      expect(cookie.value, '');
+      expect(cookie.maxAge, 0);
+      expect(cookie.httpOnly, isTrue);
+    });
+  });
+
+  group('Given a SameSite mapping', () {
+    test(
+      'when each CookieSameSite is built then it maps to the relic value.',
+      () {
+        SetCookie build(CookieSameSite s) =>
+            WebAuthCookieConfig(sameSite: s).buildSetCookieHeader('v');
+
+        expect(build(CookieSameSite.lax).sameSite, SameSite.lax);
+        expect(build(CookieSameSite.strict).sameSite, SameSite.strict);
+        expect(build(CookieSameSite.none).sameSite, SameSite.none);
+      },
+    );
+  });
+
+  group('Given a configured domain', () {
+    test('when it has a leading dot then the dot is stripped (host-only).', () {
+      var cookie = const WebAuthCookieConfig(
+        domain: '.example.com',
+      ).buildSetCookieHeader('v');
+      expect(cookie.domain?.toString(), 'example.com');
+    });
+
+    test('when it has no leading dot then it is used as-is.', () {
+      var cookie = const WebAuthCookieConfig(
+        domain: 'example.com',
+      ).buildSetCookieHeader('v');
+      expect(cookie.domain?.toString(), 'example.com');
+    });
+
+    test('when it is malformed then a clear ArgumentError is thrown.', () {
+      // A misconfigured domain must surface as an actionable configuration
+      // error, not an opaque relic FormatException deep in the sign-in path.
+      expect(
+        () => const WebAuthCookieConfig(
+          domain: 'https://example.com',
+        ).buildSetCookieHeader('v'),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('when it includes a port then a clear ArgumentError is thrown.', () {
+      // Host.parse accepts host:port, but a cookie Domain must not carry a port
+      // (RFC 6265 5.2.3); that rejection must also surface as an ArgumentError.
+      expect(
+        () => const WebAuthCookieConfig(
+          domain: 'example.com:8443',
+        ).buildSetCookieHeader('v'),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+  });
+
+  group('Given a malformed cookie path', () {
+    test('when building a header then a clear ArgumentError is thrown.', () {
+      expect(
+        () => const WebAuthCookieConfig(path: 'a;b').buildSetCookieHeader('v'),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+  });
+
+  group('Given a non-default config', () {
+    test('when built then secure/path/name are taken from the config.', () {
+      var cookie = const WebAuthCookieConfig(
+        name: 'my_auth',
+        path: '/app',
+        secure: false,
+        sameSite: CookieSameSite.strict,
+      ).buildSetCookieHeader('tok');
+
+      expect(cookie.name, 'my_auth');
+      expect(cookie.path?.toString(), '/app');
+      expect(cookie.secure, isFalse);
+      expect(cookie.sameSite, SameSite.strict);
+    });
+  });
+}

--- a/packages/serverpod/test/server/response_output_test.dart
+++ b/packages/serverpod/test/server/response_output_test.dart
@@ -1,0 +1,75 @@
+import 'package:relic/relic.dart';
+import 'package:serverpod/src/server/response_output.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Given nothing queued', () {
+    test('when applying response output then the response is unchanged.', () {
+      var response = Response.ok();
+      var result = applyResponseOutput(
+        response,
+        headers: const {},
+        cookies: const [],
+      );
+      expect(identical(result, response), isTrue);
+    });
+  });
+
+  group('Given a queued cookie', () {
+    test('when applying response output then a Set-Cookie is set.', () {
+      var result = applyResponseOutput(
+        Response.ok(),
+        headers: const {},
+        cookies: [
+          SetCookie(
+            name: 'session',
+            value: 'abc123',
+            httpOnly: true,
+            secure: true,
+            sameSite: SameSite.lax,
+          ),
+        ],
+      );
+
+      var setCookie = result.headers[Headers.setCookieHeader]!;
+      expect(setCookie, hasLength(1));
+      expect(setCookie.single, contains('session=abc123'));
+      expect(setCookie.single, contains('HttpOnly'));
+      expect(setCookie.single, contains('Secure'));
+      expect(setCookie.single, contains('SameSite=Lax'));
+    });
+  });
+
+  group('Given multiple queued cookies', () {
+    test(
+      'when applying response output then each gets its own Set-Cookie.',
+      () {
+        var result = applyResponseOutput(
+          Response.ok(),
+          headers: const {},
+          cookies: [
+            SetCookie(name: 'a', value: '1'),
+            SetCookie(name: 'b', value: '2'),
+          ],
+        );
+
+        var setCookie = result.headers[Headers.setCookieHeader]!.toList();
+        expect(setCookie, hasLength(2));
+        expect(setCookie[0], contains('a=1'));
+        expect(setCookie[1], contains('b=2'));
+      },
+    );
+  });
+
+  group('Given a queued header', () {
+    test('when applying response output then the header is set.', () {
+      var result = applyResponseOutput(
+        Response.ok(),
+        headers: const {'cache-control': 'no-store'},
+        cookies: const [],
+      );
+
+      expect(result.headers['cache-control'], ['no-store']);
+    });
+  });
+}

--- a/packages/serverpod_client/lib/src/auth_key_provider.dart
+++ b/packages/serverpod_client/lib/src/auth_key_provider.dart
@@ -8,6 +8,18 @@ abstract interface class ClientAuthKeyProvider {
   Future<String?> get authHeaderValue;
 }
 
+/// Optional capability for a [ClientAuthKeyProvider] that authenticates via an
+/// `HttpOnly` cookie instead of the `Authorization` header.
+///
+/// When the client's provider reports [usesCookies], the client sends the
+/// cookie-mode marker header and makes credentialed (cookie-bearing) requests,
+/// rather than attaching an `Authorization` header.
+abstract interface class CookieAuthKeyProvider
+    implements ClientAuthKeyProvider {
+  /// Whether this provider authenticates via a cookie rather than a header.
+  bool get usesCookies;
+}
+
 /// Provides the authentication key for the client, with a method to refresh it.
 abstract interface class RefresherClientAuthKeyProvider
     implements ClientAuthKeyProvider {

--- a/packages/serverpod_client/lib/src/serverpod_client_browser.dart
+++ b/packages/serverpod_client/lib/src/serverpod_client_browser.dart
@@ -1,3 +1,4 @@
+import 'package:http/browser_client.dart';
 import 'package:http/http.dart' as http;
 import 'package:serverpod_client/serverpod_client.dart';
 
@@ -31,14 +32,21 @@ class ServerpodClientRequestDelegateImpl
     Uri url, {
     required String body,
     String? authenticationValue,
+    bool useCookieAuth = false,
   }) async {
     try {
+      if (useCookieAuth) {
+        // Send the auth cookie with the request and accept Set-Cookie back.
+        var client = _httpClient;
+        if (client is BrowserClient) client.withCredentials = true;
+      }
       var response = await _httpClient
           .post(
             url,
             body: body,
             headers: {
               'authorization': ?authenticationValue,
+              if (useCookieAuth) webAuthModeHeaderName: webAuthModeCookie,
             },
           )
           .timeout(connectionTimeout);

--- a/packages/serverpod_client/lib/src/serverpod_client_browser.dart
+++ b/packages/serverpod_client/lib/src/serverpod_client_browser.dart
@@ -28,6 +28,9 @@ class ServerpodClientRequestDelegateImpl
   }
 
   @override
+  bool get supportsCookieAuth => true;
+
+  @override
   Future<String> serverRequest<T>(
     Uri url, {
     required String body,

--- a/packages/serverpod_client/lib/src/serverpod_client_io.dart
+++ b/packages/serverpod_client/lib/src/serverpod_client_io.dart
@@ -45,6 +45,11 @@ class ServerpodClientRequestDelegateImpl
     }
   }
 
+  // The dart:io HttpClient/IOClient has no cookie jar: it neither resends the
+  // auth cookie nor stores `Set-Cookie`, so it cannot carry cookie-based auth.
+  @override
+  bool get supportsCookieAuth => false;
+
   @override
   Future<String> serverRequest<T>(
     Uri url, {

--- a/packages/serverpod_client/lib/src/serverpod_client_io.dart
+++ b/packages/serverpod_client/lib/src/serverpod_client_io.dart
@@ -50,6 +50,7 @@ class ServerpodClientRequestDelegateImpl
     Uri url, {
     required String body,
     String? authenticationValue,
+    bool useCookieAuth = false,
   }) async {
     try {
       final response = await _httpClient
@@ -59,6 +60,7 @@ class ServerpodClientRequestDelegateImpl
             headers: {
               HttpHeaders.contentTypeHeader: ContentType.json.toString(),
               HttpHeaders.authorizationHeader: ?authenticationValue,
+              if (useCookieAuth) webAuthModeHeaderName: webAuthModeCookie,
             },
           )
           .timeout(connectionTimeout);

--- a/packages/serverpod_client/lib/src/serverpod_client_shared.dart
+++ b/packages/serverpod_client/lib/src/serverpod_client_shared.dart
@@ -59,10 +59,15 @@ class MethodCallContext {
 /// is available.
 abstract class ServerpodClientRequestDelegate {
   /// Performs the actual request to the server and returns the response data.
+  ///
+  /// When [useCookieAuth] is true the request authenticates via an `HttpOnly`
+  /// cookie: it sends the cookie-mode marker header and (on web) makes a
+  /// credentialed request, instead of relying on [authenticationValue].
   Future<String> serverRequest<T>(
     Uri url, {
     required String body,
     String? authenticationValue,
+    bool useCookieAuth = false,
   });
 
   /// Closes the connection to the server.
@@ -549,8 +554,11 @@ abstract class ServerpodClientShared extends EndpointCaller {
     );
 
     try {
-      var authenticationValue = authenticated
-          ? await authKeyProvider?.authHeaderValue
+      var provider = authKeyProvider;
+      var useCookieAuth =
+          provider is CookieAuthKeyProvider && provider.usesCookies;
+      var authenticationValue = authenticated && !useCookieAuth
+          ? await provider?.authHeaderValue
           : null;
       var body = formatArgs(args);
       var url = method.isEmpty
@@ -561,6 +569,7 @@ abstract class ServerpodClientShared extends EndpointCaller {
         url,
         body: body,
         authenticationValue: authenticationValue,
+        useCookieAuth: useCookieAuth,
       );
 
       T result;

--- a/packages/serverpod_client/lib/src/serverpod_client_shared.dart
+++ b/packages/serverpod_client/lib/src/serverpod_client_shared.dart
@@ -352,10 +352,14 @@ abstract class ServerpodClientShared extends EndpointCaller {
       // therefore not in server/proxy access logs or browser history). The
       // wrapped header value is sent as-is; the server validates and unwraps
       // it (matching the method-stream protocol).
+      //
+      // This 'auth' message is the stream-opening handshake and must be the
+      // first frame, so it is always sent - with a null key when anonymous -
+      // not only when a token is present. The server opens its streams on this
+      // frame, so streamOpened observes the settled auth state rather than
+      // racing a later auth message.
       var auth = await authKeyProvider?.authHeaderValue;
-      if (auth != null) {
-        await _sendControlCommandToStream('auth', {'key': auth});
-      }
+      await _sendControlCommandToStream('auth', {'key': auth});
 
       // We are sending the ping message to the server, so that we are
       // guaranteed to get a first message in return. This will verify that we

--- a/packages/serverpod_client/lib/src/serverpod_client_shared.dart
+++ b/packages/serverpod_client/lib/src/serverpod_client_shared.dart
@@ -115,21 +115,6 @@ abstract class ServerpodClientShared extends EndpointCaller {
     return uri;
   }
 
-  Future<String> get _webSocketHostWithAuth async {
-    var uri = _webSocketHost;
-
-    var auth = await authKeyProvider?.authHeaderValue;
-    if (auth != null) {
-      uri = uri.replace(
-        queryParameters: {
-          // Key must be unwrapped here because the server expects it plain.
-          'auth': unwrapAuthHeaderValue(auth),
-        },
-      );
-    }
-    return uri.toString();
-  }
-
   /// The [SerializationManager] used to serialize objects sent to the server.
   final SerializationManager serializationManager;
 
@@ -351,9 +336,18 @@ abstract class ServerpodClientShared extends EndpointCaller {
     try {
       // Connect to the server.
       _firstMessageReceived = false;
-      var host = await _webSocketHostWithAuth;
-      _webSocket = WebSocketChannel.connect(Uri.parse(host));
+      _webSocket = WebSocketChannel.connect(_webSocketHost);
       await _webSocket?.ready;
+
+      // Authenticate in-band via a control message rather than a query
+      // parameter, so the token never appears in the connection URL (and
+      // therefore not in server/proxy access logs or browser history). The
+      // wrapped header value is sent as-is; the server validates and unwraps
+      // it (matching the method-stream protocol).
+      var auth = await authKeyProvider?.authHeaderValue;
+      if (auth != null) {
+        await _sendControlCommandToStream('auth', {'key': auth});
+      }
 
       // We are sending the ping message to the server, so that we are
       // guaranteed to get a first message in return. This will verify that we

--- a/packages/serverpod_client/lib/src/serverpod_client_shared.dart
+++ b/packages/serverpod_client/lib/src/serverpod_client_shared.dart
@@ -70,6 +70,9 @@ abstract class ServerpodClientRequestDelegate {
     bool useCookieAuth = false,
   });
 
+  /// Whether the transport can carry an `HttpOnly` auth cookie.
+  bool get supportsCookieAuth => false;
+
   /// Closes the connection to the server.
   /// This delegate should not be used after calling this.
   void close();
@@ -559,6 +562,12 @@ abstract class ServerpodClientShared extends EndpointCaller {
           authenticated &&
           provider is CookieAuthKeyProvider &&
           provider.usesCookies;
+      if (useCookieAuth && !_requestDelegate.supportsCookieAuth) {
+        throw StateError(
+          'Cookie-based web auth is only supported on the web (browser) platform. '
+          'Run native clients in header mode (cookieAuth: false).',
+        );
+      }
       var authenticationValue = authenticated && !useCookieAuth
           ? await provider?.authHeaderValue
           : null;

--- a/packages/serverpod_client/lib/src/serverpod_client_shared.dart
+++ b/packages/serverpod_client/lib/src/serverpod_client_shared.dart
@@ -556,7 +556,9 @@ abstract class ServerpodClientShared extends EndpointCaller {
     try {
       var provider = authKeyProvider;
       var useCookieAuth =
-          provider is CookieAuthKeyProvider && provider.usesCookies;
+          authenticated &&
+          provider is CookieAuthKeyProvider &&
+          provider.usesCookies;
       var authenticationValue = authenticated && !useCookieAuth
           ? await provider?.authHeaderValue
           : null;

--- a/packages/serverpod_client/pubspec.yaml
+++ b/packages/serverpod_client/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   web_socket_channel: ^3.0.3
 
 dev_dependencies:
-  relic: ^1.2.0
+  relic: ^2.0.0-beta.0
   serverpod_lints: 3.5.0-beta.12
   stream_channel: ^2.1.1
   test: ^1.25.5

--- a/packages/serverpod_client/test/integration/call_server_endpoint_cookie_auth_test.dart
+++ b/packages/serverpod_client/test/integration/call_server_endpoint_cookie_auth_test.dart
@@ -15,16 +15,19 @@ void main() {
   late Uri httpHost;
   late TestServerpodClient client;
   late Future<void> Function() closeServer;
+  late int requestCount;
   late List<String?> receivedAuthModeMarkers;
   late List<String?> receivedAuthHeaders;
 
-  group('Given a cookie-auth client', () {
+  group('Given a cookie-auth client on a transport without a cookie jar', () {
     setUp(() async {
+      requestCount = 0;
       receivedAuthModeMarkers = [];
       receivedAuthHeaders = [];
 
       closeServer = await TestHttpServer.startServer(
         httpRequestHandler: (request) async {
+          requestCount++;
           receivedAuthModeMarkers.add(
             request.headers[webAuthModeHeaderName]?.firstOrNull,
           );
@@ -44,18 +47,20 @@ void main() {
 
     test(
       'when an authenticated call is made '
-      'then the cookie-mode marker is sent and no Authorization header is set.',
+      'then it fails loudly because the transport cannot carry the auth cookie.',
       () async {
-        await client.callServerEndpoint<String>('test', 'method', {});
+        await expectLater(
+          client.callServerEndpoint<String>('test', 'method', {}),
+          throwsA(isA<StateError>()),
+        );
 
-        expect(receivedAuthModeMarkers, [webAuthModeCookie]);
-        expect(receivedAuthHeaders, [null]);
+        expect(requestCount, 0);
       },
     );
 
     test(
       'when an unauthenticated call is made '
-      'then the cookie-mode marker is omitted so the server treats the call as anonymous.',
+      'then cookie mode is suppressed: no marker, no Authorization header, and the call succeeds.',
       () async {
         await client.callServerEndpoint<String>(
           'test',
@@ -64,6 +69,7 @@ void main() {
           authenticated: false,
         );
 
+        expect(requestCount, 1);
         expect(receivedAuthModeMarkers, [null]);
         expect(receivedAuthHeaders, [null]);
       },

--- a/packages/serverpod_client/test/integration/call_server_endpoint_cookie_auth_test.dart
+++ b/packages/serverpod_client/test/integration/call_server_endpoint_cookie_auth_test.dart
@@ -1,0 +1,72 @@
+@OnPlatform({
+  'browser': Skip('HTTP server tests are not supported in browser'),
+})
+library;
+
+import 'package:relic/relic.dart';
+import 'package:serverpod_client/serverpod_client.dart';
+import 'package:test/test.dart';
+
+import '../test_utils/test_auth_key_providers.dart';
+import '../test_utils/test_http_server.dart';
+import '../test_utils/test_serverpod_client.dart';
+
+void main() {
+  late Uri httpHost;
+  late TestServerpodClient client;
+  late Future<void> Function() closeServer;
+  late List<String?> receivedAuthModeMarkers;
+  late List<String?> receivedAuthHeaders;
+
+  group('Given a cookie-auth client', () {
+    setUp(() async {
+      receivedAuthModeMarkers = [];
+      receivedAuthHeaders = [];
+
+      closeServer = await TestHttpServer.startServer(
+        httpRequestHandler: (request) async {
+          receivedAuthModeMarkers.add(
+            request.headers[webAuthModeHeaderName]?.firstOrNull,
+          );
+          receivedAuthHeaders.add(request.headers.authorization?.headerValue);
+          return Response.ok(body: Body.fromString('"ok"'));
+        },
+        onConnected: (host) => httpHost = host,
+      );
+
+      client = TestServerpodClient(
+        host: httpHost,
+        authKeyProvider: TestCookieAuthKeyProvider(),
+      );
+    });
+
+    tearDown(() async => await closeServer());
+
+    test(
+      'when an authenticated call is made '
+      'then the cookie-mode marker is sent and no Authorization header is set.',
+      () async {
+        await client.callServerEndpoint<String>('test', 'method', {});
+
+        expect(receivedAuthModeMarkers, [webAuthModeCookie]);
+        expect(receivedAuthHeaders, [null]);
+      },
+    );
+
+    test(
+      'when an unauthenticated call is made '
+      'then the cookie-mode marker is omitted so the server treats the call as anonymous.',
+      () async {
+        await client.callServerEndpoint<String>(
+          'test',
+          'method',
+          {},
+          authenticated: false,
+        );
+
+        expect(receivedAuthModeMarkers, [null]);
+        expect(receivedAuthHeaders, [null]);
+      },
+    );
+  });
+}

--- a/packages/serverpod_client/test/test_utils/test_auth_key_providers.dart
+++ b/packages/serverpod_client/test/test_utils/test_auth_key_providers.dart
@@ -25,6 +25,20 @@ class TestRefresherAuthKeyProvider implements RefresherClientAuthKeyProvider {
   }
 }
 
+/// Test auth key provider that authenticates via an `HttpOnly` cookie rather
+/// than the `Authorization` header. Mirrors a real cookie-mode client: it
+/// reports [usesCookies] and never yields a header value (the credential rides
+/// in the browser-managed cookie).
+class TestCookieAuthKeyProvider implements CookieAuthKeyProvider {
+  @override
+  final bool usesCookies;
+
+  TestCookieAuthKeyProvider({this.usesCookies = true});
+
+  @override
+  Future<String?> get authHeaderValue async => null;
+}
+
 /// Test auth key provider that does not support refresh functionality.
 class TestNonRefresherAuthKeyProvider implements ClientAuthKeyProvider {
   final String? _authKey;

--- a/packages/serverpod_serialization/lib/src/auth_encoding.dart
+++ b/packages/serverpod_serialization/lib/src/auth_encoding.dart
@@ -11,6 +11,13 @@ const basicAuthSchemeName = 'Basic';
 /// Note, the scheme name is case-insensitive and should be compared in a case-insensitive manner.
 const bearerAuthSchemeName = 'Bearer';
 
+/// The request header a web client sets to ask the server to issue the auth
+/// token as an `HttpOnly` cookie (in `Set-Cookie`).
+const webAuthModeHeaderName = 'x-serverpod-auth-mode';
+
+/// The [webAuthModeHeaderName] value that selects cookie-based web auth.
+const webAuthModeCookie = 'cookie';
+
 /// Regexp for a string adhering to the RFC 4648 base64 encoding alphabet.
 const _base64RegExpStr = r'[a-zA-Z0-9+/]*=*';
 

--- a/packages/serverpod_shared/lib/src/config.dart
+++ b/packages/serverpod_shared/lib/src/config.dart
@@ -1051,15 +1051,15 @@ class WebAuthCookieConfig {
     };
   }
 
-  /// Parses the `secure` value, accepting a bool or a bool-string. A non-bool
-  /// value (e.g. a quoted YAML string) throws rather than silently defaulting,
-  /// so a misconfiguration surfaces instead of producing a surprising cookie.
+  /// Parses the `secure` [value], accepting a [bool] or a [String].
+  ///
+  /// A string is trimmed and matched case-insensitively, so `"True"` or `" true "` is accepted.
   static bool _parseSecure(Object? value) {
     return switch (value) {
       null => true,
       bool b => b,
       String s =>
-        bool.tryParse(s) ??
+        bool.tryParse(s.trim(), caseSensitive: false) ??
             (throw ArgumentError.value(
               s,
               ServerpodEnv.authCookieSecure.configKey,
@@ -1073,10 +1073,9 @@ class WebAuthCookieConfig {
     };
   }
 
-  /// Parses the `sameSite` value. Null falls back to the [CookieSameSite.lax]
-  /// default; a string is matched case-insensitively against [CookieSameSite];
-  /// any other type (or an unknown string) throws, so a wrong-typed value can't
-  /// silently weaken the configured cross-site posture.
+  /// Parses the `sameSite` [value].
+  ///
+  /// Fall back to [CookieSameSite.lax] on `null`. Throws on wrong type
   static CookieSameSite _parseSameSite(Object? value) {
     if (value == null) return CookieSameSite.lax;
 
@@ -1804,10 +1803,13 @@ List<String>? _readAllowedOrigins(
 
   // The environment variable (a comma-separated string) takes precedence over
   // the config file value (which may be a YAML list or a comma-separated
-  // string).
+  // string). An empty or whitespace-only env var is treated as unset so a
+  // blank value injected by a deployment template cannot silently override a
+  // configured allow-list and disable the origin guard.
   Object? value = configMap[configKey];
-  if (environment[envVariable] != null) {
-    value = environment[envVariable];
+  final envValue = environment[envVariable];
+  if (envValue != null && envValue.trim().isNotEmpty) {
+    value = envValue;
   }
 
   List<String>? origins;

--- a/packages/serverpod_shared/lib/src/config.dart
+++ b/packages/serverpod_shared/lib/src/config.dart
@@ -104,6 +104,10 @@ class ServerpodConfig {
   /// allowed. When null or empty (the default), all origins are allowed.
   final List<String>? allowedWebSocketOrigins;
 
+  /// Configuration for the web authentication cookie. Null (the default) when
+  /// no `authCookie` section is configured.
+  final WebAuthCookieConfig? authCookie;
+
   /// Creates a new [ServerpodConfig].
   ServerpodConfig({
     required this.apiServer,
@@ -127,6 +131,7 @@ class ServerpodConfig {
     this.validateHeaders = true,
     this.websocketPingInterval = const Duration(seconds: 30),
     this.allowedWebSocketOrigins,
+    this.authCookie,
   }) : sessionLogs =
            sessionLogs ??
            SessionLogConfig.buildDefault(
@@ -259,6 +264,14 @@ class ServerpodConfig {
       environment,
     );
 
+    var authCookieConfigJson = _buildAuthCookieConfigMap(
+      configMap,
+      environment,
+    );
+    var authCookie = authCookieConfigJson != null
+        ? WebAuthCookieConfig._fromJson(authCookieConfigJson)
+        : null;
+
     return ServerpodConfig(
       runMode: runMode,
       serverId: serverId,
@@ -279,6 +292,7 @@ class ServerpodConfig {
       validateHeaders: validateHeaders,
       websocketPingInterval: websocketPingInterval,
       allowedWebSocketOrigins: allowedWebSocketOrigins,
+      authCookie: authCookie,
     );
   }
 
@@ -338,7 +352,9 @@ class ServerpodConfig {
     FutureCallConfig? futureCall,
     bool? futureCallExecutionEnabled,
     bool? validateHeaders,
+    Duration? websocketPingInterval,
     List<String>? allowedWebSocketOrigins,
+    WebAuthCookieConfig? authCookie,
   }) {
     return ServerpodConfig(
       apiServer: apiServer ?? this.apiServer,
@@ -363,9 +379,11 @@ class ServerpodConfig {
       futureCallExecutionEnabled:
           futureCallExecutionEnabled ?? this.futureCallExecutionEnabled,
       validateHeaders: validateHeaders ?? this.validateHeaders,
-      websocketPingInterval: websocketPingInterval,
+      websocketPingInterval:
+          websocketPingInterval ?? this.websocketPingInterval,
       allowedWebSocketOrigins:
           allowedWebSocketOrigins ?? this.allowedWebSocketOrigins,
+      authCookie: authCookie ?? this.authCookie,
     );
   }
 
@@ -919,6 +937,82 @@ class FutureCallConfig {
   }
 }
 
+/// Configuration for the cookie used to carry the web authentication token.
+///
+/// [domain] and [path] are plain strings. [sameSite] controls cross-site
+/// behaviour. Defaults are suitable for first-party web apps over HTTPS:
+/// host-only domain, `path: /`, `secure: true`, `sameSite: lax`.
+class WebAuthCookieConfig {
+  /// The name of the cookie.
+  final String name;
+
+  /// The domain the cookie applies to. Null (the default) makes it host-only;
+  /// set a registrable domain (e.g. `.example.com`) to share across subdomains.
+  final String? domain;
+
+  /// The path the cookie applies to. Defaults to `/`.
+  final String path;
+
+  /// Whether the cookie is only sent over secure (HTTPS) connections. Defaults
+  /// to true.
+  final bool secure;
+
+  /// The `SameSite` attribute. Defaults to [CookieSameSite.lax].
+  final CookieSameSite sameSite;
+
+  /// The default cookie name.
+  static const String defaultName = 'serverpod_auth';
+
+  /// Creates a new [WebAuthCookieConfig].
+  const WebAuthCookieConfig({
+    this.name = defaultName,
+    this.domain,
+    this.path = '/',
+    this.secure = true,
+    this.sameSite = CookieSameSite.lax,
+  });
+
+  factory WebAuthCookieConfig._fromJson(Map json) {
+    var name = json[ServerpodEnv.authCookieName.configKey];
+    var domain = json[ServerpodEnv.authCookieDomain.configKey];
+    var path = json[ServerpodEnv.authCookiePath.configKey];
+    var secure = json[ServerpodEnv.authCookieSecure.configKey];
+    var sameSite = json[ServerpodEnv.authCookieSameSite.configKey];
+
+    return WebAuthCookieConfig(
+      name: name is String && name.isNotEmpty ? name : defaultName,
+      domain: domain is String && domain.isNotEmpty ? domain : null,
+      path: path is String && path.isNotEmpty ? path : '/',
+      secure: secure is bool ? secure : true,
+      sameSite: sameSite is String
+          ? _parseSameSite(sameSite)
+          : CookieSameSite.lax,
+    );
+  }
+
+  static CookieSameSite _parseSameSite(String value) {
+    return CookieSameSite.values.firstWhere(
+      (s) => s.name == value.toLowerCase(),
+      orElse: () => throw ArgumentError.value(
+        value,
+        ServerpodEnv.authCookieSameSite.configKey,
+        'Expected one of: ${CookieSameSite.values.map((s) => s.name).join(', ')}',
+      ),
+    );
+  }
+
+  @override
+  String toString() {
+    var output = StringBuffer()
+      ..writeln('auth cookie name: $name')
+      ..writeln('auth cookie domain: ${domain ?? '(host-only)'}')
+      ..writeln('auth cookie path: $path')
+      ..writeln('auth cookie secure: $secure')
+      ..writeln('auth cookie sameSite: ${sameSite.name}');
+    return output.toString();
+  }
+}
+
 /// Valid values for console log format.
 enum ConsoleLogFormat {
   /// JSON format.
@@ -1205,6 +1299,23 @@ Map? _buildFutureCallConfigMap(Map configMap, Map<String, String> environment) {
     (ServerpodEnv.futureCallScanInterval, int.parse),
     (ServerpodEnv.futureCallCheckBrokenCalls, bool.parse),
     (ServerpodEnv.futureCallDeleteBrokenCalls, bool.parse),
+  ]);
+}
+
+Map? _buildAuthCookieConfigMap(Map configMap, Map<String, String> environment) {
+  var authCookieConfig = configMap[ServerpodConfigMap.authCookie] ?? {};
+
+  // `secure` is intentionally passed through unconverted (null) so that
+  // WebAuthCookieConfig._parseSecure owns all boolean coercion and reports a
+  // bad value the same way (ArgumentError) whether it came from an env var or
+  // a YAML string, rather than splitting parsing across two layers with
+  // divergent error types.
+  return _buildConfigMap(authCookieConfig, environment, [
+    (ServerpodEnv.authCookieName, null),
+    (ServerpodEnv.authCookieDomain, null),
+    (ServerpodEnv.authCookiePath, null),
+    (ServerpodEnv.authCookieSecure, null),
+    (ServerpodEnv.authCookieSameSite, null),
   ]);
 }
 
@@ -1579,6 +1690,5 @@ List<String>? _readAllowedWebSocketOrigins(
 
   // Treat an empty list as "no restriction" (same as null) so an empty config
   // value doesn't accidentally reject every browser connection.
-  if (origins == null || origins.isEmpty) return null;
-  return origins;
+  return (origins == null || origins.isEmpty) ? null : origins;
 }

--- a/packages/serverpod_shared/lib/src/config.dart
+++ b/packages/serverpod_shared/lib/src/config.dart
@@ -110,6 +110,12 @@ class ServerpodConfig {
   /// server-to-server clients, which don't send one) are always allowed for
   /// WebSocket. When null or empty (the default), all origins are allowed for
   /// WebSocket and no per-origin CORS echo is emitted.
+  ///
+  /// Entries are normalized to lowercase and matched against the (also
+  /// lowercased) request `Origin`, so they must be serialized origins with no
+  /// trailing slash, e.g. `https://app.example.com` or
+  /// `https://app.example.com:8443` (browsers send a canonical, lowercase
+  /// origin without a path); casing in the configured value does not matter.
   final List<String>? allowedOrigins;
 
   /// Configuration for the web authentication cookie. Null (the default) when
@@ -150,6 +156,36 @@ class ServerpodConfig {
     insightsServer?._name = 'insights';
     webServer?._name = 'web';
     sessionLogs?._validate(databaseEnabled: database != null);
+
+    // Cookie-based web auth depends on an origin allow-list: it backs the
+    // cross-site WebSocket hijacking guard and credentialed CORS (which cannot
+    // use the wildcard origin). Enabling it without one would silently leave
+    // those protections off, so require allowedOrigins when authCookie is set.
+    if (authCookie != null &&
+        (allowedOrigins == null || allowedOrigins!.isEmpty)) {
+      throw ArgumentError(
+        'allowedOrigins must be set to a non-empty list of trusted browser '
+        'origins when authCookie is configured. Cookie-based web auth requires '
+        'an origin allow-list for cross-site WebSocket protection and '
+        'credentialed CORS.',
+      );
+    }
+
+    // Browsers ignore (drop) a SameSite=None cookie that is not also Secure, so
+    // the combination would silently disable the auth cookie.
+    if (authCookie != null &&
+        authCookie!.sameSite == CookieSameSite.none &&
+        !authCookie!.secure) {
+      throw ArgumentError(
+        'authCookie.sameSite "none" requires authCookie.secure to be true; '
+        'browsers ignore a SameSite=None cookie that is not Secure.',
+      );
+    }
+
+    // Fail fast on a malformed cookie domain or path so the error surfaces at
+    // startup with a clear message, rather than deep in the first sign-in when
+    // relic parses these into the Set-Cookie header.
+    authCookie?._validate();
   }
 
   /// Creates a default bare bone configuration.
@@ -980,32 +1016,118 @@ class WebAuthCookieConfig {
   });
 
   factory WebAuthCookieConfig._fromJson(Map json) {
-    var name = json[ServerpodEnv.authCookieName.configKey];
-    var domain = json[ServerpodEnv.authCookieDomain.configKey];
-    var path = json[ServerpodEnv.authCookiePath.configKey];
-    var secure = json[ServerpodEnv.authCookieSecure.configKey];
-    var sameSite = json[ServerpodEnv.authCookieSameSite.configKey];
-
     return WebAuthCookieConfig(
-      name: name is String && name.isNotEmpty ? name : defaultName,
-      domain: domain is String && domain.isNotEmpty ? domain : null,
-      path: path is String && path.isNotEmpty ? path : '/',
-      secure: secure is bool ? secure : true,
-      sameSite: sameSite is String
-          ? _parseSameSite(sameSite)
-          : CookieSameSite.lax,
+      name:
+          _parseOptionalString(
+            json[ServerpodEnv.authCookieName.configKey],
+            ServerpodEnv.authCookieName.configKey,
+          ) ??
+          defaultName,
+      domain: _parseOptionalString(
+        json[ServerpodEnv.authCookieDomain.configKey],
+        ServerpodEnv.authCookieDomain.configKey,
+      ),
+      path:
+          _parseOptionalString(
+            json[ServerpodEnv.authCookiePath.configKey],
+            ServerpodEnv.authCookiePath.configKey,
+          ) ??
+          '/',
+      secure: _parseSecure(json[ServerpodEnv.authCookieSecure.configKey]),
+      sameSite: _parseSameSite(json[ServerpodEnv.authCookieSameSite.configKey]),
     );
   }
 
-  static CookieSameSite _parseSameSite(String value) {
+  /// Reads an optional string cookie attribute. Returns null when unset (null
+  /// or empty, so the field falls back to its default) and the value when it is
+  /// a non-empty string. A non-string value (e.g. a YAML number or bool) throws
+  /// rather than silently falling back to the default, mirroring [_parseSecure]
+  /// so every attribute reports a misconfiguration the same way.
+  static String? _parseOptionalString(Object? value, String configKey) {
+    return switch (value) {
+      null => null,
+      String s => s.isEmpty ? null : s,
+      _ => throw ArgumentError.value(value, configKey, 'Expected a string'),
+    };
+  }
+
+  /// Parses the `secure` value, accepting a bool or a bool-string. A non-bool
+  /// value (e.g. a quoted YAML string) throws rather than silently defaulting,
+  /// so a misconfiguration surfaces instead of producing a surprising cookie.
+  static bool _parseSecure(Object? value) {
+    return switch (value) {
+      null => true,
+      bool b => b,
+      String s =>
+        bool.tryParse(s) ??
+            (throw ArgumentError.value(
+              s,
+              ServerpodEnv.authCookieSecure.configKey,
+              'Expected a boolean (true or false)',
+            )),
+      _ => throw ArgumentError.value(
+        value,
+        ServerpodEnv.authCookieSecure.configKey,
+        'Expected a boolean (true or false)',
+      ),
+    };
+  }
+
+  /// Parses the `sameSite` value. Null falls back to the [CookieSameSite.lax]
+  /// default; a string is matched case-insensitively against [CookieSameSite];
+  /// any other type (or an unknown string) throws, so a wrong-typed value can't
+  /// silently weaken the configured cross-site posture.
+  static CookieSameSite _parseSameSite(Object? value) {
+    if (value == null) return CookieSameSite.lax;
+
+    final name = switch (value) {
+      String s => s.toLowerCase(),
+      _ => throw ArgumentError.value(
+        value,
+        ServerpodEnv.authCookieSameSite.configKey,
+        'Expected one of: ${CookieSameSite.values.map((s) => s.name).join(', ')}',
+      ),
+    };
+
     return CookieSameSite.values.firstWhere(
-      (s) => s.name == value.toLowerCase(),
+      (s) => s.name == name,
       orElse: () => throw ArgumentError.value(
         value,
         ServerpodEnv.authCookieSameSite.configKey,
         'Expected one of: ${CookieSameSite.values.map((s) => s.name).join(', ')}',
       ),
     );
+  }
+
+  /// Checks the [domain] and [path] formats, throwing [ArgumentError] on an
+  /// obviously malformed value (a scheme, port, stray separator, etc.) so a
+  /// misconfiguration fails fast at startup instead of only on the first cookie
+  /// sign-in. This is a cheap, dependency-free pre-check; relic performs the
+  /// authoritative parse when the `Set-Cookie` header is built.
+  void _validate() {
+    final domain = this.domain;
+    if (domain != null) {
+      // A cookie Domain is a bare host (RFC 6265 5.2.3): no scheme, port, path
+      // or whitespace. A leading dot is allowed (normalized away at build time).
+      final bare = domain.startsWith('.') ? domain.substring(1) : domain;
+      if (bare.isEmpty || RegExp(r'[\s:/\\]').hasMatch(domain)) {
+        throw ArgumentError.value(
+          domain,
+          ServerpodEnv.authCookieDomain.configKey,
+          'Expected a bare host such as "example.com" or ".example.com" '
+          '(no scheme, port, path or whitespace)',
+        );
+      }
+    }
+    // A cookie Path is an RFC 6265 path-value: reject whitespace and ";"
+    // here; relic validates the full grammar when the cookie is built.
+    if (RegExp(r'[\s;]').hasMatch(path)) {
+      throw ArgumentError.value(
+        path,
+        ServerpodEnv.authCookiePath.configKey,
+        'Must not contain whitespace or ";"',
+      );
+    }
   }
 
   @override
@@ -1694,6 +1816,20 @@ List<String>? _readAllowedOrigins(
   } else if (value is String) {
     origins = _parseList(value);
   }
+
+  // Normalize to lowercase and drop a trailing slash: origins (scheme + host)
+  // are case-insensitive and a browser sends a canonical lowercase origin with
+  // no path, so a mis-cased entry ("https://App.Example.com") or one copied
+  // from a URL bar with a trailing slash ("https://app.example.com/") must
+  // still match the request origin.
+  origins = origins
+      ?.map((origin) => origin.toLowerCase())
+      .map((origin) => origin.replaceFirst(RegExp(r'/+$'), ''))
+      .toList();
+
+  // Drop blank entries so an empty env var ("") or a trailing comma
+  // ("https://a.com,") does not become a deny-all [''] list.
+  origins = origins?.where((origin) => origin.isNotEmpty).toList();
 
   // Treat an empty list as "no restriction" (same as null) so an empty config
   // value doesn't accidentally reject every browser connection.

--- a/packages/serverpod_shared/lib/src/config.dart
+++ b/packages/serverpod_shared/lib/src/config.dart
@@ -95,14 +95,22 @@ class ServerpodConfig {
   /// Default is 30 seconds.
   final Duration websocketPingInterval;
 
-  /// Allowed values of the `Origin` header for WebSocket handshakes.
+  /// Browser origins trusted by the server.
   ///
-  /// When non-empty, a browser WebSocket connection whose `Origin` is not in
-  /// this list is rejected with HTTP 403 - a defense against cross-site
-  /// WebSocket hijacking. Connections without an `Origin` header (e.g. native,
-  /// mobile, or server-to-server clients, which don't send one) are always
-  /// allowed. When null or empty (the default), all origins are allowed.
-  final List<String>? allowedWebSocketOrigins;
+  /// Used in two places:
+  /// - WebSocket handshakes: a browser connection whose `Origin` is not in this
+  ///   list is rejected with HTTP 403 (a defense against cross-site WebSocket
+  ///   hijacking).
+  /// - Credentialed CORS (when [authCookie] is set): the matching `Origin` is
+  ///   echoed in `Access-Control-Allow-Origin` together with
+  ///   `Access-Control-Allow-Credentials: true`, since the wildcard `*` is
+  ///   invalid for credentialed requests.
+  ///
+  /// Requests without an `Origin` header (e.g. native, mobile, or
+  /// server-to-server clients, which don't send one) are always allowed for
+  /// WebSocket. When null or empty (the default), all origins are allowed for
+  /// WebSocket and no per-origin CORS echo is emitted.
+  final List<String>? allowedOrigins;
 
   /// Configuration for the web authentication cookie. Null (the default) when
   /// no `authCookie` section is configured.
@@ -130,7 +138,7 @@ class ServerpodConfig {
     this.futureCallExecutionEnabled = true,
     this.validateHeaders = true,
     this.websocketPingInterval = const Duration(seconds: 30),
-    this.allowedWebSocketOrigins,
+    this.allowedOrigins,
     this.authCookie,
   }) : sessionLogs =
            sessionLogs ??
@@ -259,7 +267,7 @@ class ServerpodConfig {
       environment,
     );
 
-    var allowedWebSocketOrigins = _readAllowedWebSocketOrigins(
+    var allowedOrigins = _readAllowedOrigins(
       configMap,
       environment,
     );
@@ -291,7 +299,7 @@ class ServerpodConfig {
       futureCallExecutionEnabled: futureCallExecutionEnabled,
       validateHeaders: validateHeaders,
       websocketPingInterval: websocketPingInterval,
-      allowedWebSocketOrigins: allowedWebSocketOrigins,
+      allowedOrigins: allowedOrigins,
       authCookie: authCookie,
     );
   }
@@ -353,7 +361,7 @@ class ServerpodConfig {
     bool? futureCallExecutionEnabled,
     bool? validateHeaders,
     Duration? websocketPingInterval,
-    List<String>? allowedWebSocketOrigins,
+    List<String>? allowedOrigins,
     WebAuthCookieConfig? authCookie,
   }) {
     return ServerpodConfig(
@@ -381,8 +389,7 @@ class ServerpodConfig {
       validateHeaders: validateHeaders ?? this.validateHeaders,
       websocketPingInterval:
           websocketPingInterval ?? this.websocketPingInterval,
-      allowedWebSocketOrigins:
-          allowedWebSocketOrigins ?? this.allowedWebSocketOrigins,
+      allowedOrigins: allowedOrigins ?? this.allowedOrigins,
       authCookie: authCookie ?? this.authCookie,
     );
   }
@@ -1666,12 +1673,12 @@ List<String>? _parseList(String? value) {
   return value.split(',').map((e) => e.trim()).toList();
 }
 
-List<String>? _readAllowedWebSocketOrigins(
+List<String>? _readAllowedOrigins(
   Map<dynamic, dynamic> configMap,
   Map<String, String> environment,
 ) {
-  final envVariable = ServerpodEnv.allowedWebSocketOrigins.envVariable;
-  final configKey = ServerpodEnv.allowedWebSocketOrigins.configKey;
+  final envVariable = ServerpodEnv.allowedOrigins.envVariable;
+  final configKey = ServerpodEnv.allowedOrigins.configKey;
 
   // The environment variable (a comma-separated string) takes precedence over
   // the config file value (which may be a YAML list or a comma-separated

--- a/packages/serverpod_shared/lib/src/config.dart
+++ b/packages/serverpod_shared/lib/src/config.dart
@@ -95,6 +95,15 @@ class ServerpodConfig {
   /// Default is 30 seconds.
   final Duration websocketPingInterval;
 
+  /// Allowed values of the `Origin` header for WebSocket handshakes.
+  ///
+  /// When non-empty, a browser WebSocket connection whose `Origin` is not in
+  /// this list is rejected with HTTP 403 - a defense against cross-site
+  /// WebSocket hijacking. Connections without an `Origin` header (e.g. native,
+  /// mobile, or server-to-server clients, which don't send one) are always
+  /// allowed. When null or empty (the default), all origins are allowed.
+  final List<String>? allowedWebSocketOrigins;
+
   /// Creates a new [ServerpodConfig].
   ServerpodConfig({
     required this.apiServer,
@@ -117,6 +126,7 @@ class ServerpodConfig {
     this.futureCallExecutionEnabled = true,
     this.validateHeaders = true,
     this.websocketPingInterval = const Duration(seconds: 30),
+    this.allowedWebSocketOrigins,
   }) : sessionLogs =
            sessionLogs ??
            SessionLogConfig.buildDefault(
@@ -244,6 +254,11 @@ class ServerpodConfig {
       environment,
     );
 
+    var allowedWebSocketOrigins = _readAllowedWebSocketOrigins(
+      configMap,
+      environment,
+    );
+
     return ServerpodConfig(
       runMode: runMode,
       serverId: serverId,
@@ -263,6 +278,7 @@ class ServerpodConfig {
       futureCallExecutionEnabled: futureCallExecutionEnabled,
       validateHeaders: validateHeaders,
       websocketPingInterval: websocketPingInterval,
+      allowedWebSocketOrigins: allowedWebSocketOrigins,
     );
   }
 
@@ -322,6 +338,7 @@ class ServerpodConfig {
     FutureCallConfig? futureCall,
     bool? futureCallExecutionEnabled,
     bool? validateHeaders,
+    List<String>? allowedWebSocketOrigins,
   }) {
     return ServerpodConfig(
       apiServer: apiServer ?? this.apiServer,
@@ -346,6 +363,9 @@ class ServerpodConfig {
       futureCallExecutionEnabled:
           futureCallExecutionEnabled ?? this.futureCallExecutionEnabled,
       validateHeaders: validateHeaders ?? this.validateHeaders,
+      websocketPingInterval: websocketPingInterval,
+      allowedWebSocketOrigins:
+          allowedWebSocketOrigins ?? this.allowedWebSocketOrigins,
     );
   }
 
@@ -1533,4 +1553,32 @@ void _validateJsonConfig(
 List<String>? _parseList(String? value) {
   if (value == null) return null;
   return value.split(',').map((e) => e.trim()).toList();
+}
+
+List<String>? _readAllowedWebSocketOrigins(
+  Map<dynamic, dynamic> configMap,
+  Map<String, String> environment,
+) {
+  final envVariable = ServerpodEnv.allowedWebSocketOrigins.envVariable;
+  final configKey = ServerpodEnv.allowedWebSocketOrigins.configKey;
+
+  // The environment variable (a comma-separated string) takes precedence over
+  // the config file value (which may be a YAML list or a comma-separated
+  // string).
+  Object? value = configMap[configKey];
+  if (environment[envVariable] != null) {
+    value = environment[envVariable];
+  }
+
+  List<String>? origins;
+  if (value is List) {
+    origins = value.map((e) => e.toString().trim()).toList();
+  } else if (value is String) {
+    origins = _parseList(value);
+  }
+
+  // Treat an empty list as "no restriction" (same as null) so an empty config
+  // value doesn't accidentally reject every browser connection.
+  if (origins == null || origins.isEmpty) return null;
+  return origins;
 }

--- a/packages/serverpod_shared/lib/src/enums.dart
+++ b/packages/serverpod_shared/lib/src/enums.dart
@@ -26,3 +26,17 @@ enum ServerpodLoggingMode {
   /// Log all messages, including debugging information.
   verbose,
 }
+
+/// The `SameSite` attribute of a cookie, controlling whether it is sent on
+/// cross-site requests. Maps to the HTTP `SameSite` values.
+enum CookieSameSite {
+  /// Sent on same-site requests and top-level cross-site navigations.
+  lax,
+
+  /// Only sent on same-site requests.
+  strict,
+
+  /// Sent on all requests, including cross-site. Requires the cookie to be
+  /// secure.
+  none,
+}

--- a/packages/serverpod_shared/lib/src/environment_variables.dart
+++ b/packages/serverpod_shared/lib/src/environment_variables.dart
@@ -203,7 +203,7 @@ enum ServerpodEnv {
 
   /// Allowed `Origin` header values for WebSocket handshakes (comma-separated
   /// when set via environment variable).
-  allowedWebSocketOrigins,
+  allowedOrigins,
 
   /// The name of the web authentication cookie.
   authCookieName,
@@ -275,7 +275,7 @@ enum ServerpodEnv {
       (ServerpodEnv.applyRepairMigration) => 'applyRepairMigration',
       (ServerpodEnv.validateHeaders) => 'validateHeaders',
       (ServerpodEnv.websocketPingInterval) => 'websocketPingInterval',
-      (ServerpodEnv.allowedWebSocketOrigins) => 'allowedWebSocketOrigins',
+      (ServerpodEnv.allowedOrigins) => 'allowedOrigins',
       (ServerpodEnv.authCookieName) => 'name',
       (ServerpodEnv.authCookieDomain) => 'domain',
       (ServerpodEnv.authCookiePath) => 'path',
@@ -352,8 +352,7 @@ enum ServerpodEnv {
       (ServerpodEnv.validateHeaders) => 'SERVERPOD_VALIDATE_HEADERS',
       (ServerpodEnv.websocketPingInterval) =>
         'SERVERPOD_WEBSOCKET_PING_INTERVAL',
-      (ServerpodEnv.allowedWebSocketOrigins) =>
-        'SERVERPOD_ALLOWED_WEBSOCKET_ORIGINS',
+      (ServerpodEnv.allowedOrigins) => 'SERVERPOD_ALLOWED_ORIGINS',
       (ServerpodEnv.authCookieName) => 'SERVERPOD_AUTH_COOKIE_NAME',
       (ServerpodEnv.authCookieDomain) => 'SERVERPOD_AUTH_COOKIE_DOMAIN',
       (ServerpodEnv.authCookiePath) => 'SERVERPOD_AUTH_COOKIE_PATH',

--- a/packages/serverpod_shared/lib/src/environment_variables.dart
+++ b/packages/serverpod_shared/lib/src/environment_variables.dart
@@ -197,6 +197,10 @@ enum ServerpodEnv {
 
   /// The interval in seconds between websocket ping messages.
   websocketPingInterval,
+
+  /// Allowed `Origin` header values for WebSocket handshakes (comma-separated
+  /// when set via environment variable).
+  allowedWebSocketOrigins,
   ;
 
   /// The key used in the environment configuration file.
@@ -253,6 +257,7 @@ enum ServerpodEnv {
       (ServerpodEnv.applyRepairMigration) => 'applyRepairMigration',
       (ServerpodEnv.validateHeaders) => 'validateHeaders',
       (ServerpodEnv.websocketPingInterval) => 'websocketPingInterval',
+      (ServerpodEnv.allowedWebSocketOrigins) => 'allowedWebSocketOrigins',
     };
   }
 
@@ -324,6 +329,8 @@ enum ServerpodEnv {
       (ServerpodEnv.validateHeaders) => 'SERVERPOD_VALIDATE_HEADERS',
       (ServerpodEnv.websocketPingInterval) =>
         'SERVERPOD_WEBSOCKET_PING_INTERVAL',
+      (ServerpodEnv.allowedWebSocketOrigins) =>
+        'SERVERPOD_ALLOWED_WEBSOCKET_ORIGINS',
     };
   }
 }

--- a/packages/serverpod_shared/lib/src/environment_variables.dart
+++ b/packages/serverpod_shared/lib/src/environment_variables.dart
@@ -20,6 +20,9 @@ class ServerpodConfigMap {
 
   /// The future call configuration.
   static const String futureCall = 'futureCall';
+
+  /// The web authentication cookie configuration.
+  static const String authCookie = 'authCookie';
 }
 
 /// The configuration sections for the serverpod server configuration file.
@@ -201,6 +204,21 @@ enum ServerpodEnv {
   /// Allowed `Origin` header values for WebSocket handshakes (comma-separated
   /// when set via environment variable).
   allowedWebSocketOrigins,
+
+  /// The name of the web authentication cookie.
+  authCookieName,
+
+  /// The domain of the web authentication cookie.
+  authCookieDomain,
+
+  /// The path of the web authentication cookie.
+  authCookiePath,
+
+  /// Whether the web authentication cookie is only sent over HTTPS.
+  authCookieSecure,
+
+  /// The `SameSite` attribute of the web authentication cookie.
+  authCookieSameSite,
   ;
 
   /// The key used in the environment configuration file.
@@ -258,6 +276,11 @@ enum ServerpodEnv {
       (ServerpodEnv.validateHeaders) => 'validateHeaders',
       (ServerpodEnv.websocketPingInterval) => 'websocketPingInterval',
       (ServerpodEnv.allowedWebSocketOrigins) => 'allowedWebSocketOrigins',
+      (ServerpodEnv.authCookieName) => 'name',
+      (ServerpodEnv.authCookieDomain) => 'domain',
+      (ServerpodEnv.authCookiePath) => 'path',
+      (ServerpodEnv.authCookieSecure) => 'secure',
+      (ServerpodEnv.authCookieSameSite) => 'sameSite',
     };
   }
 
@@ -331,6 +354,11 @@ enum ServerpodEnv {
         'SERVERPOD_WEBSOCKET_PING_INTERVAL',
       (ServerpodEnv.allowedWebSocketOrigins) =>
         'SERVERPOD_ALLOWED_WEBSOCKET_ORIGINS',
+      (ServerpodEnv.authCookieName) => 'SERVERPOD_AUTH_COOKIE_NAME',
+      (ServerpodEnv.authCookieDomain) => 'SERVERPOD_AUTH_COOKIE_DOMAIN',
+      (ServerpodEnv.authCookiePath) => 'SERVERPOD_AUTH_COOKIE_PATH',
+      (ServerpodEnv.authCookieSecure) => 'SERVERPOD_AUTH_COOKIE_SECURE',
+      (ServerpodEnv.authCookieSameSite) => 'SERVERPOD_AUTH_COOKIE_SAME_SITE',
     };
   }
 }

--- a/packages/serverpod_shared/test/config_test.dart
+++ b/packages/serverpod_shared/test/config_test.dart
@@ -2123,15 +2123,69 @@ allowedOrigins: []
         expect(config.allowedOrigins, isNull);
       },
     );
+
+    test(
+      'when the environment variable is an empty string then allowedOrigins '
+      'is null (no restriction), not a deny-all list.',
+      () {
+        var config = ServerpodConfig.loadFromMap(
+          runMode,
+          serverId,
+          passwords,
+          loadYaml(apiServerConfig),
+          environment: {'SERVERPOD_ALLOWED_ORIGINS': ''},
+        );
+
+        expect(config.allowedOrigins, isNull);
+      },
+    );
+
+    test(
+      'when set with a trailing comma then the blank entry is dropped.',
+      () {
+        var config = ServerpodConfig.loadFromMap(
+          runMode,
+          serverId,
+          passwords,
+          loadYaml('''
+$apiServerConfig
+allowedOrigins: "https://app.example.com,"
+'''),
+        );
+
+        expect(config.allowedOrigins, equals(['https://app.example.com']));
+      },
+    );
+
+    test(
+      'when set with a trailing slash then the slash is dropped so the entry '
+      'still matches the (path-less) browser Origin.',
+      () {
+        var config = ServerpodConfig.loadFromMap(
+          runMode,
+          serverId,
+          passwords,
+          loadYaml('''
+$apiServerConfig
+allowedOrigins: "https://app.example.com/"
+'''),
+        );
+
+        expect(config.allowedOrigins, equals(['https://app.example.com']));
+      },
+    );
   });
 
   group('Given authCookie configuration', () {
+    // authCookie requires allowedOrigins, so the base config includes it.
     var apiServerConfig = '''
 apiServer:
   port: 8080
   publicHost: localhost
   publicPort: 8080
   publicScheme: http
+allowedOrigins:
+  - https://app.example.com
 ''';
 
     test('when not set then authCookie is null.', () {
@@ -2198,14 +2252,62 @@ authCookie:
         environment: {
           'SERVERPOD_AUTH_COOKIE_NAME': 'env_auth',
           'SERVERPOD_AUTH_COOKIE_SECURE': 'false',
-          'SERVERPOD_AUTH_COOKIE_SAME_SITE': 'none',
+          'SERVERPOD_AUTH_COOKIE_SAME_SITE': 'strict',
         },
       );
 
       var cookie = config.authCookie!;
       expect(cookie.name, 'env_auth');
       expect(cookie.secure, isFalse);
-      expect(cookie.sameSite, CookieSameSite.none);
+      expect(cookie.sameSite, CookieSameSite.strict);
+    });
+
+    test('when secure is a quoted string then it is parsed as a bool.', () {
+      var config = ServerpodConfig.loadFromMap(
+        runMode,
+        serverId,
+        passwords,
+        loadYaml('''
+$apiServerConfig
+authCookie:
+  secure: "false"
+'''),
+      );
+
+      expect(config.authCookie!.secure, isFalse);
+    });
+
+    test('when secure is not a boolean then it throws.', () {
+      expect(
+        () => ServerpodConfig.loadFromMap(
+          runMode,
+          serverId,
+          passwords,
+          loadYaml('''
+$apiServerConfig
+authCookie:
+  secure: maybe
+'''),
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('when sameSite is none but secure is false then it throws.', () {
+      expect(
+        () => ServerpodConfig.loadFromMap(
+          runMode,
+          serverId,
+          passwords,
+          loadYaml('''
+$apiServerConfig
+authCookie:
+  sameSite: none
+  secure: false
+'''),
+        ),
+        throwsArgumentError,
+      );
     });
 
     test('when sameSite is invalid then it throws.', () {
@@ -2218,6 +2320,93 @@ authCookie:
 $apiServerConfig
 authCookie:
   sameSite: sometimes
+'''),
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test(
+      'when authCookie is set but allowedOrigins is not then it throws.',
+      () {
+        expect(
+          () => ServerpodConfig.loadFromMap(
+            runMode,
+            serverId,
+            passwords,
+            loadYaml('''
+apiServer:
+  port: 8080
+  publicHost: localhost
+  publicPort: 8080
+  publicScheme: http
+authCookie:
+  name: my_auth
+'''),
+          ),
+          throwsArgumentError,
+        );
+      },
+    );
+
+    test('when an attribute is set in both YAML and env then env wins.', () {
+      var config = ServerpodConfig.loadFromMap(
+        runMode,
+        serverId,
+        passwords,
+        loadYaml('''
+$apiServerConfig
+authCookie:
+  name: yaml_auth
+'''),
+        environment: {'SERVERPOD_AUTH_COOKIE_NAME': 'env_auth'},
+      );
+
+      expect(config.authCookie!.name, 'env_auth');
+    });
+
+    test('when sameSite is not a string then it throws.', () {
+      expect(
+        () => ServerpodConfig.loadFromMap(
+          runMode,
+          serverId,
+          passwords,
+          loadYaml('''
+$apiServerConfig
+authCookie:
+  sameSite: true
+'''),
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('when domain carries a scheme or port then it throws.', () {
+      expect(
+        () => ServerpodConfig.loadFromMap(
+          runMode,
+          serverId,
+          passwords,
+          loadYaml('''
+$apiServerConfig
+authCookie:
+  domain: "https://example.com:8443"
+'''),
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('when path contains ";" then it throws.', () {
+      expect(
+        () => ServerpodConfig.loadFromMap(
+          runMode,
+          serverId,
+          passwords,
+          loadYaml('''
+$apiServerConfig
+authCookie:
+  path: "/a;b"
 '''),
         ),
         throwsArgumentError,

--- a/packages/serverpod_shared/test/config_test.dart
+++ b/packages/serverpod_shared/test/config_test.dart
@@ -2014,7 +2014,7 @@ websocketPingInterval: 0
     },
   );
 
-  group('Given allowedWebSocketOrigins configuration', () {
+  group('Given allowedOrigins configuration', () {
     var apiServerConfig = '''
 apiServer:
   port: 8080
@@ -2024,7 +2024,7 @@ apiServer:
 ''';
 
     test(
-      'when not set then allowedWebSocketOrigins defaults to null.',
+      'when not set then allowedOrigins defaults to null.',
       () {
         var config = ServerpodConfig.loadFromMap(
           runMode,
@@ -2033,12 +2033,12 @@ apiServer:
           loadYaml(apiServerConfig),
         );
 
-        expect(config.allowedWebSocketOrigins, isNull);
+        expect(config.allowedOrigins, isNull);
       },
     );
 
     test(
-      'when set as a YAML list then allowedWebSocketOrigins is parsed.',
+      'when set as a YAML list then allowedOrigins is parsed.',
       () {
         var config = ServerpodConfig.loadFromMap(
           runMode,
@@ -2046,21 +2046,21 @@ apiServer:
           passwords,
           loadYaml('''
 $apiServerConfig
-allowedWebSocketOrigins:
+allowedOrigins:
   - https://app.example.com
   - https://admin.example.com
 '''),
         );
 
         expect(
-          config.allowedWebSocketOrigins,
+          config.allowedOrigins,
           equals(['https://app.example.com', 'https://admin.example.com']),
         );
       },
     );
 
     test(
-      'when set as a comma-separated string then allowedWebSocketOrigins is '
+      'when set as a comma-separated string then allowedOrigins is '
       'parsed and trimmed.',
       () {
         var config = ServerpodConfig.loadFromMap(
@@ -2069,12 +2069,12 @@ allowedWebSocketOrigins:
           passwords,
           loadYaml('''
 $apiServerConfig
-allowedWebSocketOrigins: "https://app.example.com, https://admin.example.com"
+allowedOrigins: "https://app.example.com, https://admin.example.com"
 '''),
         );
 
         expect(
-          config.allowedWebSocketOrigins,
+          config.allowedOrigins,
           equals(['https://app.example.com', 'https://admin.example.com']),
         );
       },
@@ -2090,24 +2090,24 @@ allowedWebSocketOrigins: "https://app.example.com, https://admin.example.com"
           passwords,
           loadYaml('''
 $apiServerConfig
-allowedWebSocketOrigins:
+allowedOrigins:
   - https://ignored.example.com
 '''),
           environment: {
-            'SERVERPOD_ALLOWED_WEBSOCKET_ORIGINS':
+            'SERVERPOD_ALLOWED_ORIGINS':
                 'https://app.example.com,https://admin.example.com',
           },
         );
 
         expect(
-          config.allowedWebSocketOrigins,
+          config.allowedOrigins,
           equals(['https://app.example.com', 'https://admin.example.com']),
         );
       },
     );
 
     test(
-      'when set to an empty list then allowedWebSocketOrigins is null '
+      'when set to an empty list then allowedOrigins is null '
       '(no restriction).',
       () {
         var config = ServerpodConfig.loadFromMap(
@@ -2116,11 +2116,11 @@ allowedWebSocketOrigins:
           passwords,
           loadYaml('''
 $apiServerConfig
-allowedWebSocketOrigins: []
+allowedOrigins: []
 '''),
         );
 
-        expect(config.allowedWebSocketOrigins, isNull);
+        expect(config.allowedOrigins, isNull);
       },
     );
   });

--- a/packages/serverpod_shared/test/config_test.dart
+++ b/packages/serverpod_shared/test/config_test.dart
@@ -2124,4 +2124,104 @@ allowedWebSocketOrigins: []
       },
     );
   });
+
+  group('Given authCookie configuration', () {
+    var apiServerConfig = '''
+apiServer:
+  port: 8080
+  publicHost: localhost
+  publicPort: 8080
+  publicScheme: http
+''';
+
+    test('when not set then authCookie is null.', () {
+      var config = ServerpodConfig.loadFromMap(
+        runMode,
+        serverId,
+        passwords,
+        loadYaml(apiServerConfig),
+      );
+
+      expect(config.authCookie, isNull);
+    });
+
+    test('when set as a YAML section then all fields are parsed.', () {
+      var config = ServerpodConfig.loadFromMap(
+        runMode,
+        serverId,
+        passwords,
+        loadYaml('''
+$apiServerConfig
+authCookie:
+  name: my_auth
+  domain: .example.com
+  path: /app
+  secure: false
+  sameSite: strict
+'''),
+      );
+
+      var cookie = config.authCookie!;
+      expect(cookie.name, 'my_auth');
+      expect(cookie.domain, '.example.com');
+      expect(cookie.path, '/app');
+      expect(cookie.secure, isFalse);
+      expect(cookie.sameSite, CookieSameSite.strict);
+    });
+
+    test('when only some fields are set then the rest use defaults.', () {
+      var config = ServerpodConfig.loadFromMap(
+        runMode,
+        serverId,
+        passwords,
+        loadYaml('''
+$apiServerConfig
+authCookie:
+  domain: .example.com
+'''),
+      );
+
+      var cookie = config.authCookie!;
+      expect(cookie.name, WebAuthCookieConfig.defaultName);
+      expect(cookie.domain, '.example.com');
+      expect(cookie.path, '/');
+      expect(cookie.secure, isTrue);
+      expect(cookie.sameSite, CookieSameSite.lax);
+    });
+
+    test('when set via environment variables then they are parsed.', () {
+      var config = ServerpodConfig.loadFromMap(
+        runMode,
+        serverId,
+        passwords,
+        loadYaml(apiServerConfig),
+        environment: {
+          'SERVERPOD_AUTH_COOKIE_NAME': 'env_auth',
+          'SERVERPOD_AUTH_COOKIE_SECURE': 'false',
+          'SERVERPOD_AUTH_COOKIE_SAME_SITE': 'none',
+        },
+      );
+
+      var cookie = config.authCookie!;
+      expect(cookie.name, 'env_auth');
+      expect(cookie.secure, isFalse);
+      expect(cookie.sameSite, CookieSameSite.none);
+    });
+
+    test('when sameSite is invalid then it throws.', () {
+      expect(
+        () => ServerpodConfig.loadFromMap(
+          runMode,
+          serverId,
+          passwords,
+          loadYaml('''
+$apiServerConfig
+authCookie:
+  sameSite: sometimes
+'''),
+        ),
+        throwsArgumentError,
+      );
+    });
+  });
 }

--- a/packages/serverpod_shared/test/config_test.dart
+++ b/packages/serverpod_shared/test/config_test.dart
@@ -2141,7 +2141,28 @@ allowedOrigins: []
     );
 
     test(
-      'when set with a trailing comma then the blank entry is dropped.',
+      'when the environment variable is an empty string '
+      'then a configured allow-list is kept (the blank env var does not override it).',
+      () {
+        var config = ServerpodConfig.loadFromMap(
+          runMode,
+          serverId,
+          passwords,
+          loadYaml('''
+$apiServerConfig
+allowedOrigins:
+  - https://app.example.com
+'''),
+          environment: {'SERVERPOD_ALLOWED_ORIGINS': ''},
+        );
+
+        expect(config.allowedOrigins, equals(['https://app.example.com']));
+      },
+    );
+
+    test(
+      'when set with a trailing comma '
+      'then the blank entry is dropped.',
       () {
         var config = ServerpodConfig.loadFromMap(
           runMode,
@@ -2158,8 +2179,8 @@ allowedOrigins: "https://app.example.com,"
     );
 
     test(
-      'when set with a trailing slash then the slash is dropped so the entry '
-      'still matches the (path-less) browser Origin.',
+      'when set with a trailing slash '
+      'then the entry still matches the browser Origin.',
       () {
         var config = ServerpodConfig.loadFromMap(
           runMode,
@@ -2276,6 +2297,22 @@ authCookie:
 
       expect(config.authCookie!.secure, isFalse);
     });
+
+    test(
+      'when secure is a capitalized bool-string in an env var '
+      'then it is parsed case-insensitively.',
+      () {
+        var config = ServerpodConfig.loadFromMap(
+          runMode,
+          serverId,
+          passwords,
+          loadYaml(apiServerConfig),
+          environment: {'SERVERPOD_AUTH_COOKIE_SECURE': 'TRUE'},
+        );
+
+        expect(config.authCookie!.secure, isTrue);
+      },
+    );
 
     test('when secure is not a boolean then it throws.', () {
       expect(

--- a/packages/serverpod_shared/test/config_test.dart
+++ b/packages/serverpod_shared/test/config_test.dart
@@ -2013,4 +2013,115 @@ websocketPingInterval: 0
       );
     },
   );
+
+  group('Given allowedWebSocketOrigins configuration', () {
+    var apiServerConfig = '''
+apiServer:
+  port: 8080
+  publicHost: localhost
+  publicPort: 8080
+  publicScheme: http
+''';
+
+    test(
+      'when not set then allowedWebSocketOrigins defaults to null.',
+      () {
+        var config = ServerpodConfig.loadFromMap(
+          runMode,
+          serverId,
+          passwords,
+          loadYaml(apiServerConfig),
+        );
+
+        expect(config.allowedWebSocketOrigins, isNull);
+      },
+    );
+
+    test(
+      'when set as a YAML list then allowedWebSocketOrigins is parsed.',
+      () {
+        var config = ServerpodConfig.loadFromMap(
+          runMode,
+          serverId,
+          passwords,
+          loadYaml('''
+$apiServerConfig
+allowedWebSocketOrigins:
+  - https://app.example.com
+  - https://admin.example.com
+'''),
+        );
+
+        expect(
+          config.allowedWebSocketOrigins,
+          equals(['https://app.example.com', 'https://admin.example.com']),
+        );
+      },
+    );
+
+    test(
+      'when set as a comma-separated string then allowedWebSocketOrigins is '
+      'parsed and trimmed.',
+      () {
+        var config = ServerpodConfig.loadFromMap(
+          runMode,
+          serverId,
+          passwords,
+          loadYaml('''
+$apiServerConfig
+allowedWebSocketOrigins: "https://app.example.com, https://admin.example.com"
+'''),
+        );
+
+        expect(
+          config.allowedWebSocketOrigins,
+          equals(['https://app.example.com', 'https://admin.example.com']),
+        );
+      },
+    );
+
+    test(
+      'when set via environment variable then it overrides the config and is '
+      'parsed as a comma-separated list.',
+      () {
+        var config = ServerpodConfig.loadFromMap(
+          runMode,
+          serverId,
+          passwords,
+          loadYaml('''
+$apiServerConfig
+allowedWebSocketOrigins:
+  - https://ignored.example.com
+'''),
+          environment: {
+            'SERVERPOD_ALLOWED_WEBSOCKET_ORIGINS':
+                'https://app.example.com,https://admin.example.com',
+          },
+        );
+
+        expect(
+          config.allowedWebSocketOrigins,
+          equals(['https://app.example.com', 'https://admin.example.com']),
+        );
+      },
+    );
+
+    test(
+      'when set to an empty list then allowedWebSocketOrigins is null '
+      '(no restriction).',
+      () {
+        var config = ServerpodConfig.loadFromMap(
+          runMode,
+          serverId,
+          passwords,
+          loadYaml('''
+$apiServerConfig
+allowedWebSocketOrigins: []
+'''),
+        );
+
+        expect(config.allowedWebSocketOrigins, isNull);
+      },
+    );
+  });
 }

--- a/templates/pubspecs/packages/serverpod/pubspec.yaml
+++ b/templates/pubspecs/packages/serverpod/pubspec.yaml
@@ -29,7 +29,7 @@ dependencies:
   path: ^1.8.3
   postgres: ^3.4.0
   redis: ^4.0.0
-  relic: ^1.2.0
+  relic: ^2.0.0-beta.0
   retry: ^3.1.1
   serverpod_database: SERVERPOD_VERSION
   serverpod_serialization: SERVERPOD_VERSION

--- a/templates/pubspecs/packages/serverpod_client/pubspec.yaml
+++ b/templates/pubspecs/packages/serverpod_client/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   web_socket_channel: ^3.0.3
 
 dev_dependencies:
-  relic: ^1.2.0
+  relic: ^2.0.0-beta.0
   serverpod_lints: SERVERPOD_VERSION
   stream_channel: ^2.1.1
   test: ^1.25.5

--- a/templates/pubspecs/tests/serverpod_test_server/pubspec.yaml
+++ b/templates/pubspecs/tests/serverpod_test_server/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 dependencies:
   clock: ^1.1.1
   http: '>=1.1.0 <2.0.0'
-  relic: ^1.2.0
+  relic: ^2.0.0-beta.0
   serverpod: SERVERPOD_VERSION
   serverpod_auth_server: SERVERPOD_VERSION
   serverpod_cloud_storage_s3: SERVERPOD_VERSION

--- a/tests/serverpod_test_server/pubspec.yaml
+++ b/tests/serverpod_test_server/pubspec.yaml
@@ -13,7 +13,7 @@ environment:
 dependencies:
   clock: ^1.1.1
   http: '>=1.1.0 <2.0.0'
-  relic: ^1.2.0
+  relic: ^2.0.0-beta.0
   serverpod: 3.5.0-beta.12
   serverpod_auth_server: 3.5.0-beta.12
   serverpod_cloud_storage_s3: 3.5.0-beta.12

--- a/tests/serverpod_test_server/test_e2e/auth_key_backwards_compatibility_test.dart
+++ b/tests/serverpod_test_server/test_e2e/auth_key_backwards_compatibility_test.dart
@@ -9,7 +9,8 @@ import 'package:test/scaffolding.dart';
 
 void main() {
   group(
-    'Given a simulated legacy client with old authorization conventions, ',
+    'Given a simulated legacy client sending the auth key via the removed '
+    'URL/query convention, ',
     () {
       late Client client;
       late String authKey;
@@ -41,8 +42,12 @@ void main() {
         client.close();
       });
 
-      test('when calling an authorized endpoint method with old style auth key '
-          'then it should succeed', () async {
+      test('when calling an authorized endpoint method with the old style '
+          'auth key then it is no longer authenticated', () async {
+        // The `auth` request parameter (formerly read from the URL / query
+        // string) is no longer accepted, so even a valid key supplied this way
+        // does not authenticate the request: the login-required endpoint
+        // rejects it like any unauthenticated call.
         var response = await http.post(
           Uri.parse('${serverUrl}echoRequest'),
           body: jsonEncode({
@@ -51,11 +56,11 @@ void main() {
           }),
         );
 
-        expect(response.statusCode, 200);
-        expect(response.body, '"$authKey"');
+        expect(response.statusCode, 401);
+        expect(response.body, '');
       });
 
-      test('when calling an authorizaed endpoint method without auth key '
+      test('when calling an authorized endpoint method without auth key '
           'then it should fail', () async {
         var response = await http.post(
           Uri.parse('${serverUrl}echoRequest'),

--- a/tests/serverpod_test_server/test_e2e/json_protocol_test.dart
+++ b/tests/serverpod_test_server/test_e2e/json_protocol_test.dart
@@ -12,7 +12,7 @@ Future<dynamic> _getWebsocketMessage(
   WebSocket websocket,
 ) async {
   try {
-    return await websocket.textEvents
+    final messageFuture = websocket.textEvents
         .timeout(
           Duration(seconds: 5),
           onTimeout: (sink) => throw TimeoutException(
@@ -22,6 +22,17 @@ Future<dynamic> _getWebsocketMessage(
         .firstWhere(
           (event) => event.contains('serverOnlyScopedFieldModel'),
         );
+
+    // The endpoint websocket opens its streams on the 'auth' handshake,
+    // which a client must send as its first frame.
+    websocket.sendText(
+      jsonEncode({
+        'command': 'auth',
+        'args': {'key': null},
+      }),
+    );
+
+    return await messageFuture;
   } catch (e) {
     return e;
   }


### PR DESCRIPTION
Adds opt-in web authentication that carries the session token in a strict HttpOnly cookie instead of the response body, so the token is never reachable by JavaScript. It only ever travels in an HttpOnly, Secure, SameSite Set-Cookie. This closes the XSS token-theft exposure that header/bearer auth has for browser clients.

CSRF is handled in multiple layers:
- SameSite (default Lax), 
- server-side Origin and WS handshake validation against allowedOrigins, and 
- a marker-header requirement (forces a CORS preflight, which the browser blocks if the origin isn't allowlisted).

Fixes: #4045

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

## Breaking changes

- Auth tokens are no longer accepted via the ?auth= query parameter
- When allowedOrigins is configured, browser WebSocket handshakes with bad Origin are rejected with HTTP 403. 