### PR TITLE
refactor: Reload package_config.json in place instead of restarting t…

### DIFF
--- a/tools/serverpod_cli/lib/src/commands/messages.dart
+++ b/tools/serverpod_cli/lib/src/commands/messages.dart
@@ -11,6 +11,8 @@ const serverRunning = 'Server running.';
 // Watch command messages
 const serverReloaded = '✓ Server reloaded.';
 const serverRestarted = '✓ Server restarted.';
+const serverNativeAssetsChanged =
+    'Server native assets changed. Restarting the server...';
 const flutterAppReloaded = '✓ Flutter app reloaded.';
 const flutterAppRestarted = '✓ Flutter app restarted.';
 const browserRefreshTriggered = '✓ Browser refresh triggered.';

--- a/tools/serverpod_cli/lib/src/commands/start.dart
+++ b/tools/serverpod_cli/lib/src/commands/start.dart
@@ -5,12 +5,14 @@ import 'dart:io';
 import 'package:args/args.dart';
 import 'package:cli_tools/cli_tools.dart';
 import 'package:config/config.dart';
+import 'package:meta/meta.dart' show visibleForTesting;
 import 'package:path/path.dart' as p;
 import 'package:serverpod_cli/analyzer.dart';
 import 'package:serverpod_cli/src/commands/generate.dart';
 import 'package:serverpod_cli/src/commands/messages.dart';
 import 'package:serverpod_cli/src/commands/start/file_watcher.dart';
 import 'package:serverpod_cli/src/commands/start/flutter_app_manager.dart';
+import 'package:serverpod_cli/src/commands/start/flutter_dependency_tracker.dart';
 import 'package:serverpod_cli/src/commands/start/flutter_process.dart';
 import 'package:serverpod_cli/src/commands/start/kernel_compiler.dart';
 import 'package:serverpod_cli/src/commands/start/mcp_server.dart';
@@ -484,12 +486,22 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
   KernelCompiler? compiler;
   NativeAssetsBuilder? nativeAssetsBuilder;
   String? dartExecutable;
+  // The resolution's `.dart_tool` whose package_config.json the FES reads;
+  // watched below so a dependency change is picked up in place.
+  String? serverDartToolDir;
   if (watch) {
     final entryPoint = p.join(serverDir, 'bin', 'main.dart');
     final initialDill = p.join(serverpodToolDir, 'server.dill');
+    // The package_config.json the Frontend Server resolves for the server
+    // package. Passed explicitly so invalidating it on a dependency change
+    // targets the exact URI the CFE loaded (see KernelCompiler).
+    final projectRoot = await discoverProjectRootFrom(serverDir);
+    serverDartToolDir = p.join(projectRoot, '.dart_tool');
+    final packageConfigPath = p.join(serverDartToolDir, 'package_config.json');
     final localCompiler = KernelCompiler(
       entryPoint: entryPoint,
       outputDill: initialDill,
+      packagesPath: packageConfigPath,
     );
 
     final localBuilder = _createNativeAssetsBuilder(
@@ -661,20 +673,30 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
   // serialize through session.handleFileChange via WatchSession._chain.
   StreamSubscription<void>? fileChangeSub;
   if (watch) {
+    // One tracker per Flutter app that has a resolved dependency closure. Reused
+    // both to widen the watched directories and to pin the exact pub artifacts
+    // below.
+    final flutterDependencyTrackers = [
+      for (final app in flutterApps)
+        ?flutterManager.dependencyTrackerFor(app.id),
+    ];
     final watcher = FileWatcher(
-      watchPaths: {
-        p.absolute(p.joinAll(config.libSourcePathParts)),
-        ...config.sharedModelsLibSourcePaths.map(p.absolute),
-        p.absolute(p.joinAll([...config.clientPackagePathParts, 'lib'])),
-        p.absolute(
-          p.joinAll([...config.serverPackageDirectoryPathParts, 'web']),
-        ),
-        for (final app in flutterApps) ...[
-          p.absolute(p.joinAll([...app.pathParts, 'lib'])),
-          p.absolute(p.joinAll([...app.pathParts, 'pubspec.yaml'])),
-          if (flutterManager.dependencyTrackerFor(app.id) case final tracker?)
-            p.absolute(tracker.dartToolDir),
-        ],
+      watchPaths: buildWatchPaths(
+        config: config,
+        flutterApps: flutterApps,
+        serverDartToolDir: serverDartToolDir,
+        flutterDependencyTrackers: flutterDependencyTrackers,
+      ),
+      // Exact files so a change to one resolution's artifact never triggers the
+      // other's action (matters only in a non-workspace layout). The server has
+      // a single package_config.json; each Flutter app contributes its own
+      // package_graph.json (they collapse to one entry in a workspace layout).
+      packageConfigPath: serverDartToolDir == null
+          ? null
+          : p.join(serverDartToolDir, 'package_config.json'),
+      packageGraphPaths: {
+        for (final tracker in flutterDependencyTrackers)
+          p.join(tracker.dartToolDir, 'package_graph.json'),
       },
     );
     fileChangeSub = watcher.onFilesChanged
@@ -694,6 +716,47 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
       vmServiceInfoFile: vmServiceInfoFile,
     ),
   );
+}
+
+/// The directories the watch-mode [FileWatcher] observes: server/shared/client
+/// source, the server's web dir, each Flutter app's lib and pubspec.yaml, and
+/// the resolution `.dart_tool`(s) carrying `package_config.json` /
+/// `package_graph.json`.
+///
+/// [serverDartToolDir] is the server's resolution `.dart_tool` (workspace root
+/// or the package itself); watching it is what makes a dependency change reload
+/// the server in place. In a workspace it equals each Flutter app's
+/// [FlutterDependencyTracker.dartToolDir] and dedupes to a single watch.
+@visibleForTesting
+Set<String> buildWatchPaths({
+  required GeneratorConfig config,
+  List<FlutterAppConfig> flutterApps = const [],
+  String? serverDartToolDir,
+  Iterable<FlutterDependencyTracker> flutterDependencyTrackers = const [],
+}) {
+  return {
+    p.absolute(p.joinAll(config.libSourcePathParts)),
+    ...config.sharedModelsLibSourcePaths.map(p.absolute),
+    p.absolute(p.joinAll([...config.clientPackagePathParts, 'lib'])),
+    p.absolute(p.joinAll([...config.serverPackageDirectoryPathParts, 'web'])),
+    for (final app in flutterApps) ...[
+      p.absolute(p.joinAll([...app.pathParts, 'lib'])),
+      // The app's pubspec.yaml, watched as an exact file (it lives in the app
+      // root, not under lib/) so an assets/fonts/dependency change triggers a
+      // full Flutter relaunch.
+      p.absolute(p.joinAll([...app.pathParts, 'pubspec.yaml'])),
+    ],
+    // The server's resolution .dart_tool, watched for package_config.json
+    // (reloaded into the FES in place) and, in a workspace, the shared
+    // package_graph.json. Dedupes against the Flutter trackers' dirs in a
+    // workspace layout.
+    if (serverDartToolDir != null) p.absolute(serverDartToolDir),
+    // Each Flutter resolution's .dart_tool holds package_graph.json, watched to
+    // detect Flutter dependency changes (workspace root or, in a non-workspace
+    // project, the Flutter package's own .dart_tool).
+    for (final tracker in flutterDependencyTrackers)
+      p.absolute(tracker.dartToolDir),
+  };
 }
 
 /// Mounts a fresh [VmServiceProxy] in front of [serverProcess] (writing

--- a/tools/serverpod_cli/lib/src/commands/start.dart
+++ b/tools/serverpod_cli/lib/src/commands/start.dart
@@ -240,12 +240,14 @@ class StartCommand extends ServerpodCommand<StartOption> {
 /// root if needed).
 NativeAssetsBuilder _createNativeAssetsBuilder({
   required String serverDir,
+  required String projectRoot,
   required String serverpodToolDir,
   required String dartExecutable,
 }) {
   return NativeAssetsBuilder(
     dartExecutable: dartExecutable,
     serverDir: serverDir,
+    projectRoot: projectRoot,
     outputDir: p.join(serverpodToolDir, 'native_assets'),
   );
 }
@@ -492,9 +494,10 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
   if (watch) {
     final entryPoint = p.join(serverDir, 'bin', 'main.dart');
     final initialDill = p.join(serverpodToolDir, 'server.dill');
-    // The package_config.json the Frontend Server resolves for the server
-    // package. Passed explicitly so invalidating it on a dependency change
-    // targets the exact URI the CFE loaded (see KernelCompiler).
+    // Resolve the server's resolution root once and reuse it everywhere it is
+    // needed: the compiler's `--packages` (so the in-place invalidation targets
+    // the exact URI the CFE loaded, see KernelCompiler), the native-assets
+    // builder, and the watch set below. Single walk, single source of truth.
     final projectRoot = await discoverProjectRootFrom(serverDir);
     serverDartToolDir = p.join(projectRoot, '.dart_tool');
     final packageConfigPath = p.join(serverDartToolDir, 'package_config.json');
@@ -506,6 +509,7 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
 
     final localBuilder = _createNativeAssetsBuilder(
       serverDir: serverDir,
+      projectRoot: projectRoot,
       serverpodToolDir: serverpodToolDir,
       dartExecutable: localCompiler.dartExecutable,
     );

--- a/tools/serverpod_cli/lib/src/commands/start.dart
+++ b/tools/serverpod_cli/lib/src/commands/start.dart
@@ -18,6 +18,7 @@ import 'package:serverpod_cli/src/commands/start/kernel_compiler.dart';
 import 'package:serverpod_cli/src/commands/start/mcp_server.dart';
 import 'package:serverpod_cli/src/commands/start/mcp_socket.dart';
 import 'package:serverpod_cli/src/commands/start/native_assets_builder.dart';
+import 'package:serverpod_cli/src/commands/start/package_dependency_tracker.dart';
 import 'package:serverpod_cli/src/commands/start/server_process.dart';
 import 'package:serverpod_cli/src/commands/start/tui/app.dart';
 import 'package:serverpod_cli/src/commands/start/tui/event_handler.dart';
@@ -491,6 +492,10 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
   // The resolution's `.dart_tool` whose package_config.json the FES reads;
   // watched below so a dependency change is picked up in place.
   String? serverDartToolDir;
+  // Scopes a shared (workspace) package_config.json change to the server's own
+  // dependency closure so the pod reloads only when its closure actually
+  // changed. Null disables the gate (always reload), matching prior behavior.
+  PackageDependencyTracker? serverDependencyTracker;
   if (watch) {
     final entryPoint = p.join(serverDir, 'bin', 'main.dart');
     final initialDill = p.join(serverpodToolDir, 'server.dill');
@@ -540,6 +545,22 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
     compiler = localCompiler;
     nativeAssetsBuilder = localBuilder;
     dartExecutable = localCompiler.dartExecutable;
+
+    // Seed the closure baseline now (before any file event) so the first
+    // package_config.json change computes a real delta. resolveDartToolDir
+    // validates the resolution lists the server package; a null disables the
+    // gate. Reads the same `.dart_tool` the FES resolves, so no extra watch.
+    final serverResolutionDartTool =
+        PackageDependencyTracker.resolveDartToolDir(
+          serverDir,
+          packageName: config.serverPackage,
+        );
+    serverDependencyTracker = serverResolutionDartTool == null
+        ? null
+        : PackageDependencyTracker(
+            dartToolDir: serverResolutionDartTool,
+            packageName: config.serverPackage,
+          );
   }
 
   // IDE-facing Flutter VM-service proxies. Bound now so info files exist at
@@ -610,6 +631,7 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
     createServer: serverProcessFactory,
     initialServer: initialServerProcess,
     generatedDirPaths: config.generatedDirPaths,
+    serverDependencyTracker: serverDependencyTracker,
     flutterManager: flutterManager,
     applyMigrationsAction: () => _applyMigrationsForSession(
       serverDir: serverDir,
@@ -623,7 +645,7 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
 
   // Auto-launch every app flagged with `auto_launch` (the synthesized default
   // sibling app is flagged, preserving the historical single-app behavior).
-  // When no app opts in, none launch — the user starts them with Ctrl+R.
+  // When no app opts in, none launch - the user starts them with Ctrl+R.
   if (launchFlutterApp) {
     await Future.wait([
       for (final app in flutterApps.where((app) => app.autoLaunch))
@@ -1091,7 +1113,7 @@ Future<void> _runTuiBackend({
         tab.url = null;
         // Replace the breadcrumb's spinner-y "connecting" with a terminal
         // state so it doesn't hang; the build error is in the app's log.
-        tab.startupStage = 'launch failed — see log';
+        tab.startupStage = 'launch failed - see log';
         holder.markDirty();
       },
       onServerStart: (server) async {
@@ -1121,7 +1143,7 @@ Future<void> _runTuiBackend({
         shutdown.complete(exitCode);
         return;
       case WatchLoopReady(:final ctx):
-        // Offer Ctrl+R whenever a Flutter app could run here — even after a
+        // Offer Ctrl+R whenever a Flutter app could run here - even after a
         // `--no-flutter` start, where it acts as a "launch the app" button.
         holder.state.canLaunchApps =
             flutterApps.isNotEmpty &&

--- a/tools/serverpod_cli/lib/src/commands/start/file_watcher.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/file_watcher.dart
@@ -91,15 +91,37 @@ extension FileChangeEventMerge on List<FileChangeEvent> {
 /// categorized by file type.
 class FileWatcher {
   final Set<String> _watchPaths;
+
+  /// The exact `package_config.json` whose change sets `packageConfigChanged`
+  /// (the server's resolution), or `null` if not tracked. Matched by full path
+  /// rather than basename so that, in a non-workspace layout where the server
+  /// and Flutter app have separate `.dart_tool` dirs, only the server's file
+  /// drives a server reload.
+  final String? _packageConfigPath;
+
+  /// The exact `package_graph.json` files whose change sets
+  /// `flutterDependenciesChanged` (one per Flutter app's resolution). Empty when
+  /// no Flutter dependency closures are tracked. A workspace layout collapses to
+  /// a single entry shared with the server's resolution.
+  final Set<String> _packageGraphPaths;
+
   final Duration debounceDelay;
 
   /// Creates a file watcher.
   ///
-  /// [watchPaths] is the set of directories to watch.
+  /// [watchPaths] is the set of directories to watch. [packageConfigPath] and
+  /// [packageGraphPaths] are the exact pub-artifact files whose changes map to
+  /// `packageConfigChanged` / `flutterDependenciesChanged`.
   FileWatcher({
     required Iterable<String> watchPaths,
+    String? packageConfigPath,
+    Iterable<String> packageGraphPaths = const [],
     this.debounceDelay = const Duration(milliseconds: 100),
-  }) : _watchPaths = watchPaths.map(p.canonicalize).toSet();
+  }) : _watchPaths = watchPaths.map(p.canonicalize).toSet(),
+       _packageConfigPath = packageConfigPath == null
+           ? null
+           : p.canonicalize(packageConfigPath),
+       _packageGraphPaths = packageGraphPaths.map(p.canonicalize).toSet();
 
   late final List<w.Watcher> _watchers = [
     for (final watchPath in _watchPaths) ...{
@@ -141,16 +163,30 @@ class FileWatcher {
 
           for (final event in events) {
             final filePath = event.path;
-            if (_isWithinDartTool(filePath)) {
-              // Inside .dart_tool only the dependency graph is relevant;
-              // everything else is ignored. Notably this keeps
-              // packageConfigChanged (the FES restart path) dormant, exactly
-              // as before .dart_tool was watched at all.
-              if (p.basename(filePath) == 'package_graph.json') {
-                flutterDependenciesChanged = true;
-              }
-            } else if (p.basename(filePath) == 'package_config.json') {
+            final canonical = p.canonicalize(filePath);
+            // Two pub artifacts matter, each matched by its EXACT path (not
+            // just basename):
+            //
+            // - package_config.json (the server's resolution): makes the
+            //   server's Frontend Server reload its package map in place, no
+            //   restart (KernelCompiler.invalidatePackageConfig).
+            // - package_graph.json (each Flutter app's resolution): drives the
+            //   Flutter dependency-closure check (hot reload vs restart vs
+            //   relaunch).
+            //
+            // Exact-path matching means that in a non-workspace layout, where
+            // the server and Flutter apps have separate .dart_tool dirs, the
+            // *other* resolution's same-named file does not cross-trigger.
+            // pub writes both back-to-back on `pub get`, but they are flagged
+            // separately so a debounce window that splits them still triggers
+            // each action - at worst as two reload steps instead of one.
+            if (_packageConfigPath != null && canonical == _packageConfigPath) {
               packageConfigChanged = true;
+            } else if (_packageGraphPaths.contains(canonical)) {
+              flutterDependenciesChanged = true;
+            } else if (_isWithinDartTool(filePath)) {
+              // Any other .dart_tool churn (build artifacts, the output dill,
+              // a sibling resolution's pub artifacts) is ignored.
             } else if (_isModelFile(filePath)) {
               modelFiles.add(filePath);
             } else if (p.extension(filePath) == '.dart') {

--- a/tools/serverpod_cli/lib/src/commands/start/flutter_app_manager.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/flutter_app_manager.dart
@@ -6,6 +6,7 @@ import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
 import 'package:serverpod_cli/src/commands/start/flutter_dependency_tracker.dart';
 import 'package:serverpod_cli/src/commands/start/flutter_process.dart';
+import 'package:serverpod_cli/src/commands/start/package_dependency_tracker.dart';
 import 'package:serverpod_cli/src/config/flutter_app_config.dart';
 import 'package:serverpod_cli/src/util/pubspec_helpers.dart';
 import 'package:serverpod_cli/src/util/serverpod_cli_logger.dart';
@@ -106,7 +107,7 @@ class FlutterAppManager {
   }
 
   /// DTD URIs of running apps, keyed by app id. A running app that has not
-  /// published its DTD URI yet maps to `null`. Stopped apps are omitted — this
+  /// published its DTD URI yet maps to `null`. Stopped apps are omitted - this
   /// backs the `get_flutter_app_dtd` MCP tool, so stopping an app drops it from
   /// the tool's output.
   Map<String, String?> get dtdUris => {
@@ -320,9 +321,9 @@ class FlutterAppManager {
       final flutterPackageName = parsePubspec(
         File(p.join(flutterPackageDir, 'pubspec.yaml')),
       ).name;
-      final dartToolDir = FlutterDependencyTracker.resolveDartToolDir(
+      final dartToolDir = PackageDependencyTracker.resolveDartToolDir(
         flutterPackageDir,
-        flutterPackageName: flutterPackageName,
+        packageName: flutterPackageName,
       );
       if (dartToolDir != null) {
         runtime.dependencyTracker = FlutterDependencyTracker(

--- a/tools/serverpod_cli/lib/src/commands/start/flutter_app_manager.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/flutter_app_manager.dart
@@ -58,7 +58,7 @@ class FlutterAppManager {
 
   /// Test-only override for [checkDependencyChange].
   @visibleForTesting
-  FlutterDependencyChange Function(String appId)?
+  PackageDependencyChange Function(String appId)?
   dependencyChangeOverrideForTesting;
 
   /// Test-only override for [restart].
@@ -145,12 +145,12 @@ class FlutterAppManager {
       _runtimes[appId]?.dependencyTracker;
 
   /// Checks dependency changes for [appId].
-  FlutterDependencyChange checkDependencyChange(String appId) {
+  PackageDependencyChange checkDependencyChange(String appId) {
     if (dependencyChangeOverrideForTesting != null) {
       return dependencyChangeOverrideForTesting!(appId);
     }
     return _runtimes[appId]?.dependencyTracker?.refresh() ??
-        FlutterDependencyChange.none;
+        PackageDependencyChange.none;
   }
 
   /// Returns running app ids whose `lib` directory contains any of [paths].

--- a/tools/serverpod_cli/lib/src/commands/start/flutter_dependency_tracker.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/flutter_dependency_tracker.dart
@@ -4,31 +4,12 @@ import 'package:path/path.dart' as p;
 import 'package:serverpod_cli/src/commands/start/package_dependency_tracker.dart';
 import 'package:yaml/yaml.dart';
 
-/// How the Flutter app's dependency closure changed, ordered by the severity
-/// of the response required to pick the change up.
-enum FlutterDependencyChange {
-  /// No change to the closure; source edits are covered by a hot reload.
-  none,
-
-  /// Only pure-Dart dependencies changed; a hot restart picks them up.
-  dartOnly,
-
-  /// A dependency with native code changed; only a full process relaunch
-  /// rebuilds the native host (a hot restart would leave the new native code
-  /// out of the binary, failing at runtime with a MissingPluginException).
-  native,
-
-  /// Assets or fonts declared in `pubspec.yaml` changed. These are bundled at
-  /// build time so only a full process relaunch picks them up.
-  assets,
-}
-
 /// A [PackageDependencyTracker] for a companion Flutter app, adding the
 /// asset/font fingerprint on top of the shared dependency-closure tracking.
 ///
 /// Beyond the closure (native vs. pure-Dart) classification inherited from the
 /// base, a change to the `flutter.assets` or `flutter.fonts` sections of the
-/// app's `pubspec.yaml` maps to [FlutterDependencyChange.assets]: those are
+/// app's `pubspec.yaml` maps to [PackageDependencyChange.assets]: those are
 /// bundled at build time, so only a full process relaunch picks them up.
 class FlutterDependencyTracker extends PackageDependencyTracker {
   /// The package directory of the Flutter app, whose `pubspec.yaml` is read
@@ -58,19 +39,15 @@ class FlutterDependencyTracker extends PackageDependencyTracker {
   /// Assets and fonts are checked first: they are bundled at build time so they
   /// always need a full relaunch, regardless of whether the dependency closure
   /// also changed.
-  FlutterDependencyChange refresh() {
+  PackageDependencyChange refresh() {
     final nextFingerprint = _computeAssetFingerprint();
     final previousFingerprint = _cachedAssetFingerprint;
     _cachedAssetFingerprint = nextFingerprint;
     if (nextFingerprint != previousFingerprint) {
-      return FlutterDependencyChange.assets;
+      return PackageDependencyChange.assets;
     }
 
-    return switch (refreshClosure()) {
-      PackageDependencyChange.none => FlutterDependencyChange.none,
-      PackageDependencyChange.dartOnly => FlutterDependencyChange.dartOnly,
-      PackageDependencyChange.native => FlutterDependencyChange.native,
-    };
+    return refreshClosure();
   }
 
   /// Reads the Flutter app's `pubspec.yaml` and produces a fingerprint

--- a/tools/serverpod_cli/lib/src/commands/start/flutter_dependency_tracker.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/flutter_dependency_tracker.dart
@@ -1,8 +1,7 @@
-import 'dart:convert';
 import 'dart:io';
 
-import 'package:collection/collection.dart';
 import 'package:path/path.dart' as p;
+import 'package:serverpod_cli/src/commands/start/package_dependency_tracker.dart';
 import 'package:yaml/yaml.dart';
 
 /// How the Flutter app's dependency closure changed, ordered by the severity
@@ -24,123 +23,42 @@ enum FlutterDependencyChange {
   assets,
 }
 
-/// Tracks the Flutter app's dependency closure so the watcher can escalate to
-/// a hot restart or a full relaunch only when its dependencies actually
-/// change.
+/// A [PackageDependencyTracker] for a companion Flutter app, adding the
+/// asset/font fingerprint on top of the shared dependency-closure tracking.
 ///
-/// The closure is derived from `.dart_tool/package_graph.json`, which lists
-/// every resolved package with its version and direct dependencies. Starting
-/// from the Flutter package and following `dependencies` (not
-/// `devDependencies`) yields the app's transitive closure, fingerprinted as
-/// `name -> version`.
-///
-/// Scoping to the closure is what keeps a pub *workspace* from
-/// over-triggering: in a workspace the `package_graph.json` is shared across
-/// all members, but a change to a server-only dependency leaves the Flutter
-/// app's closure untouched, so nothing fires.
-///
-/// When the closure does change, the added or version-changed packages are
-/// classified via their pubspecs (located through `package_config.json`):
-/// packages with native code ([FlutterDependencyChange.native]) need a full
-/// relaunch, while pure-Dart changes ([FlutterDependencyChange.dartOnly]) only
-/// need a hot restart. Unreadable or unlocatable packages are conservatively
-/// treated as native, so a classification miss degrades to a
-/// slower-but-correct relaunch, never a broken app.
-class FlutterDependencyTracker {
-  /// The `.dart_tool` directory holding `package_graph.json` for the resolution
-  /// the Flutter package belongs to — the workspace root in a workspace layout,
-  /// or the package's own `.dart_tool` in a non-workspace project.
-  final String dartToolDir;
-
-  /// The package name of the Flutter app, as it appears in `package_graph.json`.
-  final String flutterPackageName;
-
+/// Beyond the closure (native vs. pure-Dart) classification inherited from the
+/// base, a change to the `flutter.assets` or `flutter.fonts` sections of the
+/// app's `pubspec.yaml` maps to [FlutterDependencyChange.assets]: those are
+/// bundled at build time, so only a full process relaunch picks them up.
+class FlutterDependencyTracker extends PackageDependencyTracker {
   /// The package directory of the Flutter app, whose `pubspec.yaml` is read
   /// to fingerprint assets and fonts so their changes trigger a full relaunch.
   final String flutterPackageDir;
-
-  Map<String, String>? _cachedClosureVersions;
 
   /// Cached fingerprint of the Flutter app's `pubspec.yaml` assets and
   /// fonts sections. `null` when the file could not be read or when
   /// the sections are missing from the pubspec.
   String? _cachedAssetFingerprint;
 
-  /// Memoized native-code verdicts, keyed by `name@version`. Pub cache
-  /// contents are immutable per version, so entries never invalidate.
-  final Map<String, bool> _nativeCache = {};
-
   FlutterDependencyTracker({
-    required this.dartToolDir,
-    required this.flutterPackageName,
+    required super.dartToolDir,
+    required String flutterPackageName,
     required this.flutterPackageDir,
-  }) {
-    _cachedClosureVersions = _computeClosureVersions();
+  }) : super(packageName: flutterPackageName) {
     _cachedAssetFingerprint = _computeAssetFingerprint();
   }
 
-  /// Resolves the `.dart_tool` directory whose `package_graph.json` describes
-  /// [flutterPackageDir]'s dependency resolution: the nearest ancestor
-  /// (including itself) with a `.dart_tool/package_config.json` — the
-  /// workspace root in a workspace, the package's own directory otherwise.
-  /// Returns `null` if there is none (e.g. dependencies have not been fetched
-  /// yet) or if the one found does not list [flutterPackageName].
-  static String? resolveDartToolDir(
-    String flutterPackageDir, {
-    required String flutterPackageName,
-  }) {
-    var dir = p.absolute(flutterPackageDir);
-    while (true) {
-      final dartTool = p.join(dir, '.dart_tool');
-      if (File(p.join(dartTool, 'package_config.json')).existsSync()) {
-        // The nearest resolution root must list the package. An unrelated
-        // resolution (e.g. found after the package's own .dart_tool was
-        // deleted) disables tracking rather than risking a wrong root
-        // further up that merely contains a same-named package.
-        return _packageConfigContains(dartTool, flutterPackageName)
-            ? dartTool
-            : null;
-      }
-      final parent = p.dirname(dir);
-      if (parent == dir) return null; // Reached the filesystem root.
-      dir = parent;
-    }
-  }
+  /// The package name of the Flutter app, as it appears in
+  /// `package_graph.json`.
+  String get flutterPackageName => packageName;
 
-  /// Whether `<dartTool>/package_config.json` parses and lists a package
-  /// named [packageName]. Unreadable or malformed files count as a non-match.
-  static bool _packageConfigContains(String dartTool, String packageName) {
-    final file = File(p.join(dartTool, 'package_config.json'));
-    if (!file.existsSync()) return false;
-
-    final Object? decoded;
-    try {
-      decoded = jsonDecode(file.readAsStringSync());
-    } on FormatException {
-      return false;
-    } on IOException {
-      return false;
-    }
-    if (decoded is! Map<String, dynamic>) return false;
-
-    final packages = decoded['packages'];
-    if (packages is! List) return false;
-    return packages.any(
-      (pkg) => pkg is Map<String, dynamic> && pkg['name'] == packageName,
-    );
-  }
-
-  /// Recomputes the dependency closure and the asset/font fingerprint, compares
+  /// Recomputes the asset/font fingerprint and the dependency closure, compares
   /// them to the cached values, and classifies the change. Updates the caches.
   ///
-  /// A transition to or from an unreadable closure (the graph file missing or
-  /// unparseable, e.g. mid-`pub get` or after `flutter clean`) is treated as
-  /// [FlutterDependencyChange.none], so a transient state never triggers a
-  /// restart — the next valid closure simply reseeds the cache.
+  /// Assets and fonts are checked first: they are bundled at build time so they
+  /// always need a full relaunch, regardless of whether the dependency closure
+  /// also changed.
   FlutterDependencyChange refresh() {
-    // Check asset/font changes first. Assets and fonts are bundled at build
-    // time so they always need a full relaunch, regardless of whether the
-    // dependency closure also changed.
     final nextFingerprint = _computeAssetFingerprint();
     final previousFingerprint = _cachedAssetFingerprint;
     _cachedAssetFingerprint = nextFingerprint;
@@ -148,77 +66,10 @@ class FlutterDependencyTracker {
       return FlutterDependencyChange.assets;
     }
 
-    final next = _computeClosureVersions();
-    final previous = _cachedClosureVersions;
-    if (next != null) _cachedClosureVersions = next;
-    if (next == null || previous == null) return FlutterDependencyChange.none;
-    if (const MapEquality<String, String>().equals(next, previous)) {
-      return FlutterDependencyChange.none;
-    }
-
-    // Removed packages never force a relaunch — their stale native code in
-    // the running binary is harmless. Only added or version-changed packages
-    // can introduce native code.
-    final delta = next.entries
-        .where((entry) => previous[entry.key] != entry.value)
-        .toList();
-    if (delta.isEmpty) return FlutterDependencyChange.dartOnly;
-
-    final packageRoots = _readPackageRoots() ?? const {};
-    final hasNative = delta.any(
-      (entry) => _hasNativeCode(entry.key, entry.value, packageRoots),
-    );
-    return hasNative
-        ? FlutterDependencyChange.native
-        : FlutterDependencyChange.dartOnly;
-  }
-
-  /// Computes the Flutter app's transitive dependency closure as a
-  /// `name -> version` map from `package_graph.json`, or `null` if the file
-  /// cannot be read/parsed or the Flutter package is absent from the graph.
-  Map<String, String>? _computeClosureVersions() {
-    final file = File(p.join(dartToolDir, 'package_graph.json'));
-    if (!file.existsSync()) return null;
-
-    final Object? decoded;
-    try {
-      decoded = jsonDecode(file.readAsStringSync());
-    } on FormatException {
-      return null;
-    } on IOException {
-      return null;
-    }
-    if (decoded is! Map<String, dynamic>) return null;
-
-    final packages = decoded['packages'];
-    if (packages is! List) return null;
-
-    final byName = <String, Map<String, dynamic>>{};
-    for (final pkg in packages) {
-      if (pkg is Map<String, dynamic> && pkg['name'] is String) {
-        byName[pkg['name'] as String] = pkg;
-      }
-    }
-    if (!byName.containsKey(flutterPackageName)) return null;
-
-    // Collect the transitive closure by following `dependencies` only;
-    // `devDependencies` don't affect the running app, so they are skipped to
-    // avoid restarting on test/lint dependency changes.
-    final closure = <String>{};
-    final stack = <String>[flutterPackageName];
-    while (stack.isNotEmpty) {
-      final name = stack.removeLast();
-      if (!closure.add(name)) continue;
-      final deps = byName[name]?['dependencies'];
-      if (deps is List) {
-        for (final dep in deps) {
-          if (dep is String && !closure.contains(dep)) stack.add(dep);
-        }
-      }
-    }
-
-    return {
-      for (final name in closure) name: '${byName[name]?['version'] ?? ''}',
+    return switch (refreshClosure()) {
+      PackageDependencyChange.none => FlutterDependencyChange.none,
+      PackageDependencyChange.dartOnly => FlutterDependencyChange.dartOnly,
+      PackageDependencyChange.native => FlutterDependencyChange.native,
     };
   }
 
@@ -238,7 +89,7 @@ class FlutterDependencyTracker {
     }
     if (pubspec is! YamlMap) return null;
 
-    final flutter = _lookup(pubspec, ['flutter']);
+    final flutter = PackageDependencyTracker.lookupYaml(pubspec, ['flutter']);
     if (flutter is! YamlMap) return null;
 
     final buffer = StringBuffer();
@@ -254,92 +105,5 @@ class FlutterDependencyTracker {
     }
 
     return buffer.toString();
-  }
-
-  /// Maps each resolved package to its root directory via
-  /// `package_config.json`, or `null` if the file cannot be read. Relative
-  /// `rootUri`s are resolved against the file's own location, per spec.
-  Map<String, String>? _readPackageRoots() {
-    final file = File(p.join(dartToolDir, 'package_config.json'));
-    if (!file.existsSync()) return null;
-
-    final Object? decoded;
-    try {
-      decoded = jsonDecode(file.readAsStringSync());
-    } on FormatException {
-      return null;
-    } on IOException {
-      return null;
-    }
-    if (decoded is! Map<String, dynamic>) return null;
-
-    final packages = decoded['packages'];
-    if (packages is! List) return null;
-
-    final baseUri = file.absolute.uri;
-    final roots = <String, String>{};
-    for (final pkg in packages) {
-      if (pkg is! Map<String, dynamic>) continue;
-      final name = pkg['name'];
-      final rootUri = pkg['rootUri'];
-      if (name is! String || rootUri is! String) continue;
-      try {
-        roots[name] = p.fromUri(baseUri.resolve(rootUri));
-      } on FormatException {
-        continue;
-      }
-    }
-    return roots;
-  }
-
-  /// Whether the package ships native code that a hot restart cannot pick up:
-  /// a classic plugin platform implementation (`pluginClass` in a compiled
-  /// host language, or `ffiPlugin`) or a native-assets build hook.
-  /// `dartPluginClass`-only platforms and the `pluginClass: none` convention
-  /// are pure Dart. Conservatively returns `true` when the package cannot be
-  /// located or its pubspec cannot be read.
-  bool _hasNativeCode(
-    String name,
-    String version,
-    Map<String, String> packageRoots,
-  ) {
-    return _nativeCache.putIfAbsent('$name@$version', () {
-      final root = packageRoots[name];
-      if (root == null) return true;
-
-      final Object? pubspec;
-      try {
-        pubspec = loadYaml(
-          File(p.join(root, 'pubspec.yaml')).readAsStringSync(),
-        );
-      } on IOException {
-        return true;
-      } on YamlException {
-        return true;
-      }
-      if (pubspec is! YamlMap) return true;
-
-      final platforms = _lookup(pubspec, ['flutter', 'plugin', 'platforms']);
-      if (platforms is! YamlMap) {
-        // Not a classic plugin. Packages using the native-assets mechanism
-        // compile native code through a build hook instead.
-        return File(p.join(root, 'hook', 'build.dart')).existsSync();
-      }
-      return platforms.values.any((platform) {
-        if (platform is! YamlMap) return false;
-        final pluginClass = platform['pluginClass'];
-        return (pluginClass != null && pluginClass != 'none') ||
-            platform['ffiPlugin'] == true;
-      });
-    });
-  }
-
-  static Object? _lookup(YamlMap map, List<String> path) {
-    Object? node = map;
-    for (final key in path) {
-      if (node is! YamlMap) return null;
-      node = node[key];
-    }
-    return node;
   }
 }

--- a/tools/serverpod_cli/lib/src/commands/start/kernel_compiler.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/kernel_compiler.dart
@@ -107,7 +107,7 @@ class KernelCompiler {
 
     final result = await compileWithProgress('Compiling server', this);
     if (result == null) return false;
-    accept();
+    await accept();
     return true;
   }
 
@@ -116,7 +116,15 @@ class KernelCompiler {
   /// If a full compile is needed (after [start], [reset], or [restart]),
   /// [changedPaths] is ignored and a complete kernel is produced.
   /// Otherwise, performs an incremental recompile for [changedPaths].
-  Future<CompileResult> compile({Set<String> changedPaths = const {}}) async {
+  ///
+  /// When [invalidatePackageConfig] is `true`, the package-config file is
+  /// added to the invalidated set. The Frontend Server's incremental compiler
+  /// re-reads it and rebuilds its package map in place, so a `package_config`
+  /// change is picked up without restarting the process.
+  Future<CompileResult> compile({
+    Set<String> changedPaths = const {},
+    bool invalidatePackageConfig = false,
+  }) async {
     final client = await _client;
 
     if (_needsFullCompile) {
@@ -126,13 +134,29 @@ class KernelCompiler {
       return result;
     }
 
-    log.debug('compile: $changedPaths');
-    final invalidatedUris = changedPaths.map(Uri.file).toList();
+    // Invalidate the exact URI the FES was started with (see
+    // [FrontendServerClient.packageConfigUri]) so the resident compiler
+    // reloads its package map in place instead of the reload silently no-op'ing
+    // on a mismatched URI.
+    final packageConfigUri = invalidatePackageConfig
+        ? client.packageConfigUri
+        : null;
+    log.debug(
+      'compile: $changedPaths'
+      '${packageConfigUri != null ? ' (+package_config.json)' : ''}',
+    );
+    final invalidatedUris = [
+      ...changedPaths.map(Uri.file),
+      ?packageConfigUri,
+    ];
     return client.compile(invalidatedUris);
   }
 
   /// Accept the last compile result.
-  void accept() => _client.then((c) => c.accept());
+  ///
+  /// Awaitable so callers can order it before disposing or reloading; the
+  /// underlying FES `accept` is a fire-and-forget stdin write.
+  Future<void> accept() => _client.then((c) => c.accept());
 
   /// Reject the last compile result.
   Future<void> reject() => _client.then((c) => c.reject());
@@ -150,8 +174,12 @@ class KernelCompiler {
 
   /// Restart the Frontend Server process.
   ///
-  /// Required when package_config.json changes, since the FES reads it
-  /// only at startup. Kills the existing process and starts a fresh one.
+  /// Required when the native-assets manifest (`--native-assets`) changes,
+  /// since the FES reads that argument only at startup. Kills the existing
+  /// process and starts a fresh one.
+  ///
+  /// A `package_config.json` change does *not* need a restart - pass
+  /// `invalidatePackageConfig: true` to [compile] instead.
   Future<void> restart() async {
     await dispose();
     await start();
@@ -209,11 +237,15 @@ Future<CompileResult?> compileWithProgress(
   String message,
   KernelCompiler compiler, {
   Set<String> changedPaths = const {},
+  bool invalidatePackageConfig = false,
   bool rejectOnFailure = false,
 }) async {
   late CompileResult result;
   final success = await log.progress(message, () async {
-    result = await compiler.compile(changedPaths: changedPaths);
+    result = await compiler.compile(
+      changedPaths: changedPaths,
+      invalidatePackageConfig: invalidatePackageConfig,
+    );
     return result.errorCount == 0;
   });
 

--- a/tools/serverpod_cli/lib/src/commands/start/native_assets_builder.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/native_assets_builder.dart
@@ -10,7 +10,6 @@ import 'package:hooks/hooks.dart';
 // the serverpod CLI [log]; there are no log calls of our own against it.
 import 'package:hooks_runner/hooks_runner.dart' as hr;
 import 'package:logging/logging.dart' show Level, Logger, LogRecord;
-import 'package:meta/meta.dart' show visibleForTesting;
 import 'package:package_config/package_config.dart' as pc;
 import 'package:path/path.dart' as p;
 import 'package:serverpod_cli/src/commands/start/kernel_compiler.dart';
@@ -126,16 +125,21 @@ class NativeAssetsBuilder {
   /// Path to the dart executable (used to compile and run individual hooks).
   final String dartExecutable;
 
-  /// The server package directory. The package_config.json lives either here
-  /// (standalone) or in the workspace root above it; [discoverProjectRoot]
-  /// walks up to find it.
+  /// The server package directory. Its own `pubspec.yaml` is read to name the
+  /// root package; [projectRoot] (not necessarily this directory) holds the
+  /// `package_config.json`.
   final String serverDir;
+
+  /// The resolution root whose `.dart_tool/` holds the `package_config.json` /
+  /// `package_graph.json` (the workspace root, or [serverDir] when standalone).
+  /// Resolved once by the caller via [discoverProjectRootFrom] and passed in,
+  /// so the walk is not repeated here. Stable for the builder's lifetime.
+  final String projectRoot;
 
   /// Output directory for the assets and the manifest yaml (typically
   /// `<serverDir>/.dart_tool/serverpod/native_assets/`).
   final String outputDir;
 
-  Future<String>? _projectRootFuture;
   Future<hr.PackageLayout>? _packageLayoutFuture;
   Future<hr.NativeAssetsBuildRunner>? _runnerFuture;
   String? _lastManifestContent;
@@ -149,6 +153,7 @@ class NativeAssetsBuilder {
   NativeAssetsBuilder({
     required this.dartExecutable,
     required this.serverDir,
+    required this.projectRoot,
     required this.outputDir,
   });
 
@@ -156,28 +161,23 @@ class NativeAssetsBuilder {
   /// been written yet).
   String get manifestPath => p.join(outputDir, 'native_assets.yaml');
 
-  /// Drops every cache so the next [build] re-discovers the workspace,
-  /// reloads `package_config.json`, and treats the next manifest as freshly
-  /// generated. Call after a `pub get` or other change that adds or removes
-  /// packages with build hooks.
+  /// Drops the cached package layout and build runner so the next [build]
+  /// re-reads `package_config.json` and re-discovers build-hook packages. Call
+  /// after a `pub get` or other change that adds or removes packages with build
+  /// hooks. ([projectRoot] is stable and not re-resolved.)
+  ///
+  /// The manifest/encoded-asset caches are deliberately kept: the next [build]
+  /// re-runs the hooks and compares its result to them, so a dependency change
+  /// that leaves the native assets unchanged still reports
+  /// `manifestChanged: false` and avoids a needless FES restart.
   void reset() {
-    _projectRootFuture = null;
     _packageLayoutFuture = null;
     _runnerFuture = null;
-    _lastManifestContent = null;
-    _lastEncodedAssets = null;
   }
 
-  /// The resolution root for [serverDir] (workspace root or the package
-  /// itself), whose `.dart_tool/` holds the `package_config.json` /
-  /// `package_graph.json` this builder reads. See [discoverProjectRootFrom].
-  @visibleForTesting
-  Future<String> discoverProjectRoot() => discoverProjectRootFrom(serverDir);
-
   Future<hr.PackageLayout> _loadPackageLayout() async {
-    final root = await (_projectRootFuture ??= discoverProjectRoot());
     final pkgConfigUri = Uri.file(
-      p.join(root, '.dart_tool', 'package_config.json'),
+      p.join(projectRoot, '.dart_tool', 'package_config.json'),
     );
 
     // Run the package_config load and the server pubspec read in parallel.
@@ -200,14 +200,13 @@ class NativeAssetsBuilder {
 
   Future<hr.NativeAssetsBuildRunner> _createRunner() async {
     final layout = await (_packageLayoutFuture ??= _loadPackageLayout());
-    final root = await (_projectRootFuture ??= discoverProjectRoot());
     return hr.NativeAssetsBuildRunner(
       dartExecutable: Uri.file(dartExecutable),
       logger: _logger,
       fileSystem: _fileSystem,
       packageLayout: layout,
       userDefines: hr.UserDefines(
-        workspacePubspec: Uri.file(p.join(root, 'pubspec.yaml')),
+        workspacePubspec: Uri.file(p.join(projectRoot, 'pubspec.yaml')),
       ),
     );
   }

--- a/tools/serverpod_cli/lib/src/commands/start/native_assets_builder.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/native_assets_builder.dart
@@ -74,6 +74,43 @@ class NativeAssetsApplyFailure extends NativeAssetsApplyOutcome {
   const NativeAssetsApplyFailure(this.message);
 }
 
+/// Walks up from [fromDir] to the first pubspec that is *not* a workspace
+/// member (i.e. `resolution != 'workspace'`). The directory containing that
+/// pubspec is either the workspace root (when a workspace is in use) or the
+/// package itself (when it isn't); pub places `.dart_tool/` only there, so its
+/// `package_config.json` is the one the Frontend Server resolves for the
+/// server package.
+///
+/// Validates that `package_config.json` and `package_graph.json` exist
+/// alongside the pubspec, so callers can trust the returned root without
+/// re-checking.
+Future<String> discoverProjectRootFrom(String fromDir) async {
+  var dir = p.canonicalize(fromDir);
+  while (true) {
+    final pubspec = await tryParsePubspecAt(dir);
+    if (pubspec != null && pubspec.resolution != 'workspace') {
+      final cfg = p.join(dir, '.dart_tool', 'package_config.json');
+      final graph = p.join(dir, '.dart_tool', 'package_graph.json');
+      if (!await File(cfg).exists() || !await File(graph).exists()) {
+        throw StateError(
+          'Found project root at $dir but its .dart_tool is missing '
+          'package_config.json / package_graph.json. Run `dart pub get`.',
+        );
+      }
+      return dir;
+    }
+    final parent = p.dirname(dir);
+    if (parent == dir) {
+      throw StateError(
+        'No project root pubspec found walking up from $fromDir. '
+        'Server packages with `resolution: workspace` need a workspace '
+        'root pubspec above them.',
+      );
+    }
+    dir = parent;
+  }
+}
+
 /// Orchestrates `package:hooks_runner` on behalf of `serverpod start`.
 ///
 /// `dart compile` refuses to run build hooks, and `frontend_server` does not
@@ -131,41 +168,11 @@ class NativeAssetsBuilder {
     _lastEncodedAssets = null;
   }
 
-  /// Walks up from [serverDir] to the first pubspec that is *not* a workspace
-  /// member (i.e. `resolution != 'workspace'`). The directory containing that
-  /// pubspec is either the workspace root (when a workspace is in use) or the
-  /// package itself (when it isn't); pub places `.dart_tool/` only there.
-  ///
-  /// Validates that `package_config.json` and `package_graph.json` exist
-  /// alongside the pubspec, so callers can trust the returned root without
-  /// re-checking.
+  /// The resolution root for [serverDir] (workspace root or the package
+  /// itself), whose `.dart_tool/` holds the `package_config.json` /
+  /// `package_graph.json` this builder reads. See [discoverProjectRootFrom].
   @visibleForTesting
-  Future<String> discoverProjectRoot() async {
-    var dir = p.canonicalize(serverDir);
-    while (true) {
-      final pubspec = await tryParsePubspecAt(dir);
-      if (pubspec != null && pubspec.resolution != 'workspace') {
-        final cfg = p.join(dir, '.dart_tool', 'package_config.json');
-        final graph = p.join(dir, '.dart_tool', 'package_graph.json');
-        if (!await File(cfg).exists() || !await File(graph).exists()) {
-          throw StateError(
-            'Found project root at $dir but its .dart_tool is missing '
-            'package_config.json / package_graph.json. Run `dart pub get`.',
-          );
-        }
-        return dir;
-      }
-      final parent = p.dirname(dir);
-      if (parent == dir) {
-        throw StateError(
-          'No project root pubspec found walking up from $serverDir. '
-          'Server packages with `resolution: workspace` need a workspace '
-          'root pubspec above them.',
-        );
-      }
-      dir = parent;
-    }
-  }
+  Future<String> discoverProjectRoot() => discoverProjectRootFrom(serverDir);
 
   Future<hr.PackageLayout> _loadPackageLayout() async {
     final root = await (_projectRootFuture ??= discoverProjectRoot());

--- a/tools/serverpod_cli/lib/src/commands/start/native_assets_builder.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/native_assets_builder.dart
@@ -110,6 +110,19 @@ Future<String> discoverProjectRootFrom(String fromDir) async {
   }
 }
 
+/// The subset of [NativeAssetsBuilder] that [WatchSession] drives, factored out
+/// so the session can be exercised with a fake in tests. [NativeAssetsBuilder]
+/// is the only production implementation.
+abstract interface class NativeAssetsApplier {
+  /// Runs build hooks and applies the result to [compiler]. See
+  /// [NativeAssetsBuilder.applyTo].
+  Future<NativeAssetsApplyOutcome> applyTo(KernelCompiler compiler);
+
+  /// Drops cached package-discovery state so the next apply re-reads
+  /// `package_config.json`. See [NativeAssetsBuilder.reset].
+  void reset();
+}
+
 /// Orchestrates `package:hooks_runner` on behalf of `serverpod start`.
 ///
 /// `dart compile` refuses to run build hooks, and `frontend_server` does not
@@ -121,7 +134,7 @@ Future<String> discoverProjectRootFrom(String fromDir) async {
 /// Hook execution is internally cached by `hooks_runner` keyed on hook
 /// inputs/dependencies/environment, so re-invoking each watch cycle is cheap
 /// when nothing changed.
-class NativeAssetsBuilder {
+class NativeAssetsBuilder implements NativeAssetsApplier {
   /// Path to the dart executable (used to compile and run individual hooks).
   final String dartExecutable;
 
@@ -170,6 +183,7 @@ class NativeAssetsBuilder {
   /// re-runs the hooks and compares its result to them, so a dependency change
   /// that leaves the native assets unchanged still reports
   /// `manifestChanged: false` and avoids a needless FES restart.
+  @override
   void reset() {
     _packageLayoutFuture = null;
     _runnerFuture = null;
@@ -217,7 +231,13 @@ class NativeAssetsBuilder {
 
     final hookPackages = await runner.packagesWithBuildHooks();
     if (hookPackages.isEmpty) {
-      return const NativeAssetsBuildSkipped();
+      // No build-hook packages in the closure. If a manifest was produced
+      // earlier this session - i.e. the last native dependency was just removed
+      // - tear it down and report the change so the FES restarts without
+      // `--native-assets`; otherwise the running pod keeps loading the removed
+      // package's stale assets. With no prior manifest there is nothing to do.
+      if (_lastManifestContent == null) return const NativeAssetsBuildSkipped();
+      return _dropManifest();
     }
 
     final target = hr.Target.current;
@@ -245,23 +265,10 @@ class NativeAssetsBuilder {
 
     final encodedAssets = result.success.encodedAssets;
 
-    // No bundleable assets -> no manifest needed. Tell the caller to ensure
-    // FES is running without a --native-assets argument.
+    // Hooks ran but produced no bundleable assets -> no manifest needed. Tell
+    // the caller to ensure the FES is running without a --native-assets arg.
     if (encodedAssets.isEmpty) {
-      final changed = _lastManifestContent != null;
-      _lastManifestContent = null;
-      _lastEncodedAssets = const [];
-      // Best-effort cleanup of a stale manifest from a prior run. Avoid
-      // exists() + delete() (TOCTOU); just delete and ignore "not found".
-      try {
-        await File(manifestPath).delete();
-      } on PathNotFoundException {
-        // Already gone.
-      }
-      return NativeAssetsBuildSuccess(
-        manifestPath: null,
-        manifestChanged: changed,
-      );
+      return _dropManifest();
     }
 
     // hooks_runner caches build results internally, so the encoded asset list
@@ -304,6 +311,29 @@ class NativeAssetsBuilder {
     );
   }
 
+  /// Tears down any previously built manifest: clears the cached state and
+  /// deletes the on-disk yaml, returning a success that tells the caller to drop
+  /// the FES `--native-assets` argument. [NativeAssetsBuildSuccess.manifestChanged]
+  /// reflects whether a manifest existed before, so the caller restarts the FES
+  /// only when something actually went away. Shared by the "no build-hook
+  /// packages left" and "hooks emitted nothing" paths.
+  Future<NativeAssetsBuildSuccess> _dropManifest() async {
+    final changed = _lastManifestContent != null;
+    _lastManifestContent = null;
+    _lastEncodedAssets = const [];
+    // Best-effort cleanup of a stale manifest from a prior run. Avoid
+    // exists() + delete() (TOCTOU); just delete and ignore "not found".
+    try {
+      await File(manifestPath).delete();
+    } on PathNotFoundException {
+      // Already gone.
+    }
+    return NativeAssetsBuildSuccess(
+      manifestPath: null,
+      manifestChanged: changed,
+    );
+  }
+
   /// Runs build hooks and applies the result to [compiler]:
   ///  - `nativeAssetsPath` is updated to the freshly built manifest (if any)
   ///  - if the manifest content changed AND [compiler] has already started,
@@ -311,6 +341,7 @@ class NativeAssetsBuilder {
   ///
   /// Centralises the "did we restart?" bookkeeping that callers in the watch
   /// loop and migration path need to avoid double-restarting.
+  @override
   Future<NativeAssetsApplyOutcome> applyTo(KernelCompiler compiler) async {
     final outcome = await build();
     switch (outcome) {

--- a/tools/serverpod_cli/lib/src/commands/start/package_dependency_tracker.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/package_dependency_tracker.dart
@@ -6,7 +6,9 @@ import 'package:path/path.dart' as p;
 import 'package:yaml/yaml.dart';
 
 /// How a package's resolved dependency closure changed, ordered by the severity
-/// of the response required to pick the change up.
+/// of the response required to pick the change up. [assets] is the one
+/// exception - a Flutter build-input change rather than a dependency change -
+/// folded in so the watcher classifies every change kind with a single type.
 enum PackageDependencyChange {
   /// No change to the closure.
   none,
@@ -16,6 +18,13 @@ enum PackageDependencyChange {
 
   /// A dependency with native code changed.
   native,
+
+  /// A Flutter app's bundled assets or fonts changed (the `flutter.assets` /
+  /// `flutter.fonts` sections of its `pubspec.yaml`). Not a dependency-closure
+  /// change, but it shares this enum so a single type covers every reason a
+  /// watched app may need to react; only the Flutter app tracker emits it, and
+  /// [refreshClosure] never returns it.
+  assets,
 }
 
 /// Tracks a package's transitive dependency closure so a watcher can react only

--- a/tools/serverpod_cli/lib/src/commands/start/package_dependency_tracker.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/package_dependency_tracker.dart
@@ -1,0 +1,285 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:collection/collection.dart';
+import 'package:path/path.dart' as p;
+import 'package:yaml/yaml.dart';
+
+/// How a package's resolved dependency closure changed, ordered by the severity
+/// of the response required to pick the change up.
+enum PackageDependencyChange {
+  /// No change to the closure.
+  none,
+
+  /// Only pure-Dart dependencies changed.
+  dartOnly,
+
+  /// A dependency with native code changed.
+  native,
+}
+
+/// Tracks a package's transitive dependency closure so a watcher can react only
+/// when *that package's* dependencies actually change - and classify the change
+/// as pure-Dart vs. native.
+///
+/// The closure is derived from `.dart_tool/package_graph.json`, which lists
+/// every resolved package with its version and direct dependencies. Starting
+/// from [packageName] and following `dependencies` (not `devDependencies`)
+/// yields the transitive closure, fingerprinted as `name -> version`.
+///
+/// Scoping to the closure is what keeps a pub *workspace* from over-triggering:
+/// in a workspace the `package_graph.json` is shared across all members, but a
+/// change to a dependency outside this package's closure leaves the fingerprint
+/// untouched, so nothing fires.
+///
+/// When the closure does change, the added or version-changed packages are
+/// classified via their pubspecs (located through `package_config.json`):
+/// packages with native code ([PackageDependencyChange.native]) need the
+/// heaviest response, while pure-Dart changes
+/// ([PackageDependencyChange.dartOnly]) are lighter. Unreadable or unlocatable
+/// packages are conservatively treated as native, so a classification miss
+/// degrades to the slower-but-correct response.
+class PackageDependencyTracker {
+  /// The `.dart_tool` directory holding `package_graph.json` for the resolution
+  /// [packageName] belongs to - the workspace root in a workspace layout, or the
+  /// package's own `.dart_tool` in a non-workspace project.
+  final String dartToolDir;
+
+  /// The package name whose closure is tracked, as it appears in
+  /// `package_graph.json`.
+  final String packageName;
+
+  Map<String, String>? _cachedClosureVersions;
+
+  /// Memoized native-code verdicts, keyed by `name@version`. Pub cache
+  /// contents are immutable per version, so entries never invalidate.
+  final Map<String, bool> _nativeCache = {};
+
+  PackageDependencyTracker({
+    required this.dartToolDir,
+    required this.packageName,
+  }) {
+    _cachedClosureVersions = _computeClosureVersions();
+  }
+
+  /// Resolves the `.dart_tool` directory whose `package_graph.json` describes
+  /// [packageDir]'s dependency resolution: the nearest ancestor (including
+  /// itself) with a `.dart_tool/package_config.json` - the workspace root in a
+  /// workspace, the package's own directory otherwise. Returns `null` if there
+  /// is none (e.g. dependencies have not been fetched yet) or if the one found
+  /// does not list [packageName].
+  static String? resolveDartToolDir(
+    String packageDir, {
+    required String packageName,
+  }) {
+    var dir = p.absolute(packageDir);
+    while (true) {
+      final dartTool = p.join(dir, '.dart_tool');
+      if (File(p.join(dartTool, 'package_config.json')).existsSync()) {
+        // The nearest resolution root must list the package. An unrelated
+        // resolution (e.g. found after the package's own .dart_tool was
+        // deleted) disables tracking rather than risking a wrong root
+        // further up that merely contains a same-named package.
+        return _packageConfigContains(dartTool, packageName) ? dartTool : null;
+      }
+      final parent = p.dirname(dir);
+      if (parent == dir) return null; // Reached the filesystem root.
+      dir = parent;
+    }
+  }
+
+  /// Whether `<dartTool>/package_config.json` parses and lists a package
+  /// named [packageName]. Unreadable or malformed files count as a non-match.
+  static bool _packageConfigContains(String dartTool, String packageName) {
+    final file = File(p.join(dartTool, 'package_config.json'));
+    if (!file.existsSync()) return false;
+
+    final Object? decoded;
+    try {
+      decoded = jsonDecode(file.readAsStringSync());
+    } on FormatException {
+      return false;
+    } on IOException {
+      return false;
+    }
+    if (decoded is! Map<String, dynamic>) return false;
+
+    final packages = decoded['packages'];
+    if (packages is! List) return false;
+    return packages.any(
+      (pkg) => pkg is Map<String, dynamic> && pkg['name'] == packageName,
+    );
+  }
+
+  /// Recomputes the dependency closure, compares it to the cached value, and
+  /// classifies the change. Updates the cache.
+  ///
+  /// A transition to or from an unreadable closure (the graph file missing or
+  /// unparseable, e.g. mid-`pub get` or after `flutter clean`) is treated as
+  /// [PackageDependencyChange.none], so a transient state never triggers a
+  /// response - the next valid closure simply reseeds the cache.
+  PackageDependencyChange refreshClosure() {
+    final next = _computeClosureVersions();
+    final previous = _cachedClosureVersions;
+    if (next != null) _cachedClosureVersions = next;
+    if (next == null || previous == null) return PackageDependencyChange.none;
+    if (const MapEquality<String, String>().equals(next, previous)) {
+      return PackageDependencyChange.none;
+    }
+
+    // Removed packages never force the native response - their stale native
+    // code in a running binary is harmless. Only added or version-changed
+    // packages can introduce native code.
+    final delta = next.entries
+        .where((entry) => previous[entry.key] != entry.value)
+        .toList();
+    if (delta.isEmpty) return PackageDependencyChange.dartOnly;
+
+    final packageRoots = _readPackageRoots() ?? const {};
+    final hasNative = delta.any(
+      (entry) => _hasNativeCode(entry.key, entry.value, packageRoots),
+    );
+    return hasNative
+        ? PackageDependencyChange.native
+        : PackageDependencyChange.dartOnly;
+  }
+
+  /// Computes [packageName]'s transitive dependency closure as a
+  /// `name -> version` map from `package_graph.json`, or `null` if the file
+  /// cannot be read/parsed or [packageName] is absent from the graph.
+  Map<String, String>? _computeClosureVersions() {
+    final file = File(p.join(dartToolDir, 'package_graph.json'));
+    if (!file.existsSync()) return null;
+
+    final Object? decoded;
+    try {
+      decoded = jsonDecode(file.readAsStringSync());
+    } on FormatException {
+      return null;
+    } on IOException {
+      return null;
+    }
+    if (decoded is! Map<String, dynamic>) return null;
+
+    final packages = decoded['packages'];
+    if (packages is! List) return null;
+
+    final byName = <String, Map<String, dynamic>>{};
+    for (final pkg in packages) {
+      if (pkg is Map<String, dynamic> && pkg['name'] is String) {
+        byName[pkg['name'] as String] = pkg;
+      }
+    }
+    if (!byName.containsKey(packageName)) return null;
+
+    // Collect the transitive closure by following `dependencies` only;
+    // `devDependencies` don't affect the running app/pod, so they are skipped to
+    // avoid reacting to test/lint dependency changes.
+    final closure = <String>{};
+    final stack = <String>[packageName];
+    while (stack.isNotEmpty) {
+      final name = stack.removeLast();
+      if (!closure.add(name)) continue;
+      final deps = byName[name]?['dependencies'];
+      if (deps is List) {
+        for (final dep in deps) {
+          if (dep is String && !closure.contains(dep)) stack.add(dep);
+        }
+      }
+    }
+
+    return {
+      for (final name in closure) name: '${byName[name]?['version'] ?? ''}',
+    };
+  }
+
+  /// Maps each resolved package to its root directory via
+  /// `package_config.json`, or `null` if the file cannot be read. Relative
+  /// `rootUri`s are resolved against the file's own location, per spec.
+  Map<String, String>? _readPackageRoots() {
+    final file = File(p.join(dartToolDir, 'package_config.json'));
+    if (!file.existsSync()) return null;
+
+    final Object? decoded;
+    try {
+      decoded = jsonDecode(file.readAsStringSync());
+    } on FormatException {
+      return null;
+    } on IOException {
+      return null;
+    }
+    if (decoded is! Map<String, dynamic>) return null;
+
+    final packages = decoded['packages'];
+    if (packages is! List) return null;
+
+    final baseUri = file.absolute.uri;
+    final roots = <String, String>{};
+    for (final pkg in packages) {
+      if (pkg is! Map<String, dynamic>) continue;
+      final name = pkg['name'];
+      final rootUri = pkg['rootUri'];
+      if (name is! String || rootUri is! String) continue;
+      try {
+        roots[name] = p.fromUri(baseUri.resolve(rootUri));
+      } on FormatException {
+        continue;
+      }
+    }
+    return roots;
+  }
+
+  /// Whether the package ships native code that an in-process reload cannot pick
+  /// up: a classic plugin platform implementation (`pluginClass` in a compiled
+  /// host language, or `ffiPlugin`) or a native-assets build hook.
+  /// `dartPluginClass`-only platforms and the `pluginClass: none` convention
+  /// are pure Dart. Conservatively returns `true` when the package cannot be
+  /// located or its pubspec cannot be read.
+  bool _hasNativeCode(
+    String name,
+    String version,
+    Map<String, String> packageRoots,
+  ) {
+    return _nativeCache.putIfAbsent('$name@$version', () {
+      final root = packageRoots[name];
+      if (root == null) return true;
+
+      final Object? pubspec;
+      try {
+        pubspec = loadYaml(
+          File(p.join(root, 'pubspec.yaml')).readAsStringSync(),
+        );
+      } on IOException {
+        return true;
+      } on YamlException {
+        return true;
+      }
+      if (pubspec is! YamlMap) return true;
+
+      final platforms = lookupYaml(pubspec, ['flutter', 'plugin', 'platforms']);
+      if (platforms is! YamlMap) {
+        // Not a classic plugin. Packages using the native-assets mechanism
+        // compile native code through a build hook instead.
+        return File(p.join(root, 'hook', 'build.dart')).existsSync();
+      }
+      return platforms.values.any((platform) {
+        if (platform is! YamlMap) return false;
+        final pluginClass = platform['pluginClass'];
+        return (pluginClass != null && pluginClass != 'none') ||
+            platform['ffiPlugin'] == true;
+      });
+    });
+  }
+
+  /// Walks [path] keys through nested [YamlMap]s, returning the value at the end
+  /// or `null` if any segment is missing or not a map. Shared with subclasses
+  /// that inspect other pubspec sections.
+  static Object? lookupYaml(YamlMap map, List<String> path) {
+    Object? node = map;
+    for (final key in path) {
+      if (node is! YamlMap) return null;
+      node = node[key];
+    }
+    return node;
+  }
+}

--- a/tools/serverpod_cli/lib/src/commands/start/watch_session.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/watch_session.dart
@@ -119,6 +119,13 @@ class WatchSession {
   /// rolled back to its last accepted state and no longer knows about them.
   final Set<String> _pendingPaths = {};
 
+  /// Whether a prior `package_config.json` change still needs to be invalidated
+  /// because the compile that carried it failed (and was rolled back). Without
+  /// this, a dependency change that races a transient compile error would be
+  /// dropped, and the new package would stay unresolved until the next
+  /// `package_config.json` write.
+  bool _pendingPackageConfig = false;
+
   ServerProcess _server;
 
   SessionState _state = SessionState.idle;
@@ -380,6 +387,10 @@ class WatchSession {
     // Compile changes. Merge any paths carried over from prior rejected
     // compiles so the FES re-invalidates them (reject rolls back its state).
     final changedPaths = {..._pendingPaths, ...dartFiles};
+    // Likewise carry a package_config change forward if a prior compile that
+    // should have invalidated it failed.
+    final invalidatePackageConfig =
+        packageConfigChanged || _pendingPackageConfig;
 
     // 1. Run native build hooks (if configured). The hook runner caches on
     //    input hashes, so this is cheap when nothing changed. A manifest
@@ -394,6 +405,7 @@ class WatchSession {
         case NativeAssetsApplyFailure(:final message):
           log.error('$message Server not reloaded.');
           if (changedPaths.isNotEmpty) _pendingPaths.addAll(changedPaths);
+          if (invalidatePackageConfig) _pendingPackageConfig = true;
           return false;
         case NativeAssetsApplySuccess(:final restarted):
           if (restarted) {
@@ -413,21 +425,19 @@ class WatchSession {
         compiler,
         rejectOnFailure: true,
       );
-    } else if (packageConfigChanged) {
-      // FES reads package_config.json only at startup - must restart it.
-      // After restart the FES is in initial state, so we do a full compile.
-      _pendingPaths.clear();
-      if (!compilerRestartedByHooks) await compiler.restart();
-      result = await compileWithProgress(
-        'Compiling server',
-        compiler,
-        rejectOnFailure: true,
-      );
-    } else if (changedPaths.isNotEmpty || compilerRestartedByHooks) {
+    } else if (changedPaths.isNotEmpty ||
+        invalidatePackageConfig ||
+        compilerRestartedByHooks) {
+      // A package_config.json change is picked up incrementally: passing its
+      // URI in the invalidated set makes the Frontend Server reload the
+      // package map in place, so no process restart is needed. (When the
+      // hooks already restarted the FES it's in initial state, so the next
+      // compile is full and reads package_config.json fresh anyway.)
       result = await compileWithProgress(
         'Compiling server',
         compiler,
         changedPaths: changedPaths,
+        invalidatePackageConfig: invalidatePackageConfig,
         rejectOnFailure: true,
       );
     } else {
@@ -436,13 +446,15 @@ class WatchSession {
     }
 
     if (result == null) {
-      // Compilation failed - remember which paths need re-invalidation.
+      // Compilation failed - remember what needs re-invalidation next time.
       _pendingPaths.addAll(changedPaths);
+      if (invalidatePackageConfig) _pendingPackageConfig = true;
       return false;
     }
 
     _pendingPaths.clear();
-    compiler.accept();
+    _pendingPackageConfig = false;
+    await compiler.accept();
 
     return _reloadOrRestart(result);
   }
@@ -468,6 +480,7 @@ class WatchSession {
     final compiler = _compiler;
     if (compiler != null) {
       _pendingPaths.clear();
+      _pendingPackageConfig = false;
       await compiler.reset();
       final fullResult = await compileWithProgress(
         'Compiling server',
@@ -475,7 +488,7 @@ class WatchSession {
         rejectOnFailure: true,
       );
       if (fullResult == null) return false;
-      compiler.accept();
+      await compiler.accept();
       dillPath = fullResult.dillOutput!;
     }
 

--- a/tools/serverpod_cli/lib/src/commands/start/watch_session.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/watch_session.dart
@@ -9,6 +9,7 @@ import 'package:serverpod_cli/src/commands/start/flutter_app_manager.dart';
 import 'package:serverpod_cli/src/commands/start/flutter_dependency_tracker.dart';
 import 'package:serverpod_cli/src/commands/start/kernel_compiler.dart';
 import 'package:serverpod_cli/src/commands/start/native_assets_builder.dart';
+import 'package:serverpod_cli/src/commands/start/package_dependency_tracker.dart';
 import 'package:serverpod_cli/src/commands/start/server_process.dart';
 import 'package:serverpod_cli/src/generator/analyzers.dart';
 import 'package:serverpod_cli/src/util/serverpod_cli_logger.dart';
@@ -98,12 +99,18 @@ typedef ApplyMigrationsAction = Future<void> Function();
 /// Frontend Server. Static file change handling is unaffected.
 class WatchSession {
   final KernelCompiler? _compiler;
-  final NativeAssetsBuilder? _nativeAssetsBuilder;
+  final NativeAssetsApplier? _nativeAssetsBuilder;
   final GenerateAction _generate;
   final ServerProcessFactory? _createServer;
   final Set<String> _generatedDirPaths;
   final ProtocolChangeClassifier _classifyProtocolChange;
   final ApplyMigrationsAction _applyMigrationsAction;
+
+  /// Tracks the server package's own dependency closure so a shared-resolution
+  /// (workspace) `package_config.json` change only drives a server reload when
+  /// the server's closure actually changed. `null` disables the gate (no
+  /// compiler / unresolved resolution), preserving the always-reload behavior.
+  final PackageDependencyTracker? _serverDependencyTracker;
 
   final FlutterAppManager? _flutterManager;
 
@@ -144,8 +151,8 @@ class WatchSession {
 
   /// Queues [body] via [_chain], guarding the disposed state on both edges:
   /// throws a [StateError] synchronously if the session is already disposed
-  /// when called, and — because the session may be disposed while the call
-  /// sits queued — returns [whenDisposed] without running [body] if disposal
+  /// when called, and - because the session may be disposed while the call
+  /// sits queued - returns [whenDisposed] without running [body] if disposal
   /// happens before it reaches the front of the queue.
   Future<T> _chainGuarded<T>(
     Future<T> Function() body, {
@@ -165,7 +172,7 @@ class WatchSession {
 
   WatchSession({
     KernelCompiler? compiler,
-    NativeAssetsBuilder? nativeAssetsBuilder,
+    NativeAssetsApplier? nativeAssetsBuilder,
     required GenerateAction generate,
     ServerProcessFactory? createServer,
     required ServerProcess initialServer,
@@ -173,6 +180,7 @@ class WatchSession {
     ProtocolChangeClassifier classifyProtocolChange =
         defaultProtocolChangeClassifier,
     required ApplyMigrationsAction applyMigrationsAction,
+    PackageDependencyTracker? serverDependencyTracker,
     FlutterAppManager? flutterManager,
   }) : _compiler = compiler,
        _nativeAssetsBuilder = nativeAssetsBuilder,
@@ -182,6 +190,7 @@ class WatchSession {
        _generatedDirPaths = generatedDirPaths,
        _classifyProtocolChange = classifyProtocolChange,
        _applyMigrationsAction = applyMigrationsAction,
+       _serverDependencyTracker = serverDependencyTracker,
        _flutterManager = flutterManager {
     assert(
       nativeAssetsBuilder == null || compiler != null,
@@ -210,10 +219,25 @@ class WatchSession {
       _chain(() => _handleFileChange(event));
 
   Future<void> _handleFileChange(FileChangeEvent event) async {
+    // Scope a package_config.json change to the SERVER's own dependency closure.
+    // In a pub workspace the resolution is shared, so a Flutter-only (or
+    // dev/test-only) dependency change rewrites package_config.json without
+    // touching the server's closure - and must not reload the server. Always
+    // call refreshClosure() when the file changed so the tracker's baseline
+    // advances even when we suppress; only a `none` result downgrades, and a
+    // pending invalidation from a prior failed compile still rides along
+    // independently (see _pendingPackageConfig in _compileAndReload).
+    var serverDepsChanged = event.packageConfigChanged;
+    if (event.packageConfigChanged &&
+        _serverDependencyTracker?.refreshClosure() ==
+            PackageDependencyChange.none) {
+      serverDepsChanged = false;
+    }
+
     final hasDartChanges =
         event.dartFiles.isNotEmpty ||
         event.modelFiles.isNotEmpty ||
-        event.packageConfigChanged;
+        serverDepsChanged;
 
     // Static-only changes (HTML, JS, CSS, templates) and dependency-only
     // changes: no compilation needed. The browser refresh is tied to static
@@ -245,7 +269,7 @@ class WatchSession {
       log.debug('  .dart (generated): $generatedDartFiles');
     }
     if (event.modelFiles.isNotEmpty) log.debug('  .spy: ${event.modelFiles}');
-    if (event.packageConfigChanged) log.debug('  package_config.json changed');
+    if (serverDepsChanged) log.debug('  package_config.json changed');
 
     // Narrow source files to those that may affect the generated protocol.
     // Helper files and pure business logic that don't declare endpoints or
@@ -301,7 +325,7 @@ class WatchSession {
 
     final reloaded = await _compileAndReload(
       dartFiles: allDartChanges,
-      packageConfigChanged: event.packageConfigChanged,
+      packageConfigChanged: serverDepsChanged,
     );
     // Always refresh Flutter: flutter/lib-only changes short-circuit the server
     // compile but still need a Flutter refresh (escalated when dependencies
@@ -456,6 +480,20 @@ class WatchSession {
     _pendingPackageConfig = false;
     await compiler.accept();
 
+    if (compilerRestartedByHooks) {
+      // The FES restart inside applyTo put it back in initial state, so the
+      // compile above was a FULL one (see the `|| compilerRestartedByHooks`
+      // branch) and result.dillOutput is a bootable full kernel here - unlike a
+      // normal accepted increment. The running isolate linked the OLD native
+      // assets at startup, and a hot reload never re-resolves them, so the pod
+      // must be process-restarted to pick up the rebuilt dylibs. Mirrors the
+      // Flutter `native` -> relaunch escalation.
+      if (_state == SessionState.disposed) return false;
+      log.info(serverNativeAssetsChanged);
+      await _restartServer(result.dillOutput!);
+      return true;
+    }
+
     return _reloadOrRestart(result);
   }
 
@@ -591,7 +629,7 @@ class WatchSession {
   }
 
   /// Fully (re)launches the Flutter app: kills the running `flutter run`
-  /// process (if any) and launches a fresh one — including launching it from
+  /// process (if any) and launches a fresh one - including launching it from
   /// scratch when none is running, e.g. after a `--no-flutter` start. Unlike
   /// the Flutter hot restart bundled into [forceRestart], this only drives the
   /// Flutter process and is independent of the server's compiler, so it works

--- a/tools/serverpod_cli/lib/src/commands/start/watch_session.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/watch_session.dart
@@ -6,7 +6,6 @@ import 'package:serverpod_cli/src/commands/generate.dart';
 import 'package:serverpod_cli/src/commands/messages.dart';
 import 'package:serverpod_cli/src/commands/start/file_watcher.dart';
 import 'package:serverpod_cli/src/commands/start/flutter_app_manager.dart';
-import 'package:serverpod_cli/src/commands/start/flutter_dependency_tracker.dart';
 import 'package:serverpod_cli/src/commands/start/kernel_compiler.dart';
 import 'package:serverpod_cli/src/commands/start/native_assets_builder.dart';
 import 'package:serverpod_cli/src/commands/start/package_dependency_tracker.dart';
@@ -344,7 +343,7 @@ class WatchSession {
     final appIds = manager.appIdsForChangedPaths(changedPaths);
     await appIds.map((appId) async {
       final change = manager.checkDependencyChange(appId);
-      if (changedPaths.isEmpty && change == FlutterDependencyChange.none) {
+      if (changedPaths.isEmpty && change == PackageDependencyChange.none) {
         return;
       }
       await _reloadOrRestartFlutterApp(change, appId: appId);
@@ -357,20 +356,20 @@ class WatchSession {
   /// code changed. The relaunch calls the action directly rather than via
   /// [restartFlutterApp] since we are already running inside [_chain].
   Future<void> _reloadOrRestartFlutterApp(
-    FlutterDependencyChange change, {
+    PackageDependencyChange change, {
     required String appId,
   }) async {
     switch (change) {
-      case FlutterDependencyChange.assets:
+      case PackageDependencyChange.assets:
         log.info(flutterAssetsFontsChanged);
         await _flutterManager?.restart(appId);
-      case FlutterDependencyChange.native:
+      case PackageDependencyChange.native:
         log.info(flutterDependenciesChangedNative);
         await _flutterManager!.restart(appId);
-      case FlutterDependencyChange.dartOnly:
+      case PackageDependencyChange.dartOnly:
         log.info(flutterDependenciesChangedDart);
         await _restartFlutter(appId);
-      case FlutterDependencyChange.none:
+      case PackageDependencyChange.none:
         await _reloadFlutter(appId);
     }
   }

--- a/tools/serverpod_cli/lib/src/vendored/frontend_server_client.dart
+++ b/tools/serverpod_cli/lib/src/vendored/frontend_server_client.dart
@@ -55,14 +55,21 @@ class FrontendServerClient {
   final Process _feServer;
   final StreamQueue<String> _feServerStdoutLines;
 
+  /// The `file:` URI passed to the CFE as `--packages`, or `null` if none was
+  /// given. This is the exact URI the resident compiler associates with the
+  /// package config, so callers must invalidate *this* value (not a separately
+  /// reconstructed one) to have the package map reloaded in place by [compile].
+  final Uri? packageConfigUri;
+
   _ClientState _state;
 
   FrontendServerClient._(
     this._entrypoint,
     this._feServer,
     this._feServerStdoutLines,
-    IOSink errorSink,
-  ) : _state = _ClientState.waitingForFirstCompile {
+    IOSink errorSink, {
+    this.packageConfigUri,
+  }) : _state = _ClientState.waitingForFirstCompile {
     _feServer.stderr.transform(utf8.decoder).listen(errorSink.write);
   }
 
@@ -77,6 +84,9 @@ class FrontendServerClient {
     IOSink? errorSink,
   }) async {
     final entrypointUri = Uri.file(p.absolute(entrypoint));
+    final packageConfigUri = packagesJson == null
+        ? null
+        : Uri.file(p.absolute(packagesJson));
     final arguments = <String>[
       '--sdk-root',
       sdkRoot,
@@ -84,8 +94,7 @@ class FrontendServerClient {
       '--target=$target',
       '--output-dill',
       outputDillPath,
-      if (packagesJson != null)
-        '--packages=${Uri.file(p.absolute(packagesJson))}',
+      if (packageConfigUri != null) '--packages=$packageConfigUri',
       if (nativeAssetsPath != null) ...[
         '--native-assets',
         p.absolute(nativeAssetsPath),
@@ -124,6 +133,7 @@ class FrontendServerClient {
       feServer,
       feServerStdoutLines,
       errorSink ?? stderr,
+      packageConfigUri: packageConfigUri,
     );
   }
 

--- a/tools/serverpod_cli/test/commands/start/file_watcher_test.dart
+++ b/tools/serverpod_cli/test/commands/start/file_watcher_test.dart
@@ -113,6 +113,8 @@ void main() {
 
       watcher = FileWatcher(
         watchPaths: [dartToolDir],
+        packageConfigPath: p.join(dartToolDir, 'package_config.json'),
+        packageGraphPaths: [p.join(dartToolDir, 'package_graph.json')],
         debounceDelay: const Duration(milliseconds: 200),
       );
     });
@@ -140,29 +142,160 @@ void main() {
     );
 
     test(
-      'when package_config.json and other .dart_tool files change alongside package_graph.json, '
-      'then only flutterDependenciesChanged is set',
+      'when package_config.json changes, '
+      'then it emits a FileChangeEvent with only packageConfigChanged set',
       () async {
         final firstEvent = watcher.onFilesChanged.first;
         await watcher.ready;
 
-        // All within one debounce window. package_config.json and the build
-        // artifact must be ignored inside .dart_tool.
         await File(
           p.join(dartToolDir, 'package_config.json'),
         ).writeAsString('{"configVersion":2,"packages":[]}');
+
+        final event = await firstEvent;
+
+        expect(event.packageConfigChanged, isTrue);
+        expect(event.flutterDependenciesChanged, isFalse);
+        expect(event.staticFilesChanged, isFalse);
+        expect(event.dartFiles, isEmpty);
+      },
+    );
+
+    test(
+      'when package_config and package_graph change alongside other .dart_tool files, '
+      'then only packageConfigChanged and flutterDependenciesChanged are set',
+      () async {
+        final firstEvent = watcher.onFilesChanged.first;
+        await watcher.ready;
+
+        // A `pub get` rewrites both pub artifacts within one debounce window
         await File(
-          p.join(dartToolDir, 'version'),
-        ).writeAsString('3.12.0');
+          p.join(dartToolDir, 'package_config.json'),
+        ).writeAsString('{"configVersion":2,"packages":[]}');
         await File(
           p.join(dartToolDir, 'package_graph.json'),
         ).writeAsString('{"roots":[],"packages":[]}');
 
         final event = await firstEvent;
 
+        expect(event.packageConfigChanged, isTrue);
+        expect(event.flutterDependenciesChanged, isTrue);
+        expect(event.staticFilesChanged, isFalse);
+      },
+    );
+  });
+
+  group('Given separate server and Flutter .dart_tool directories', () {
+    late FileWatcher watcher;
+    late String serverDartTool;
+    late String flutterDartTool;
+
+    setUp(() async {
+      serverDartTool = p.join(tempDir.path, 'server', '.dart_tool');
+      flutterDartTool = p.join(tempDir.path, 'flutter', '.dart_tool');
+      await Directory(serverDartTool).create(recursive: true);
+      await Directory(flutterDartTool).create(recursive: true);
+
+      watcher = FileWatcher(
+        watchPaths: [serverDartTool, flutterDartTool],
+        packageConfigPath: p.join(serverDartTool, 'package_config.json'),
+        packageGraphPaths: [p.join(flutterDartTool, 'package_graph.json')],
+        debounceDelay: const Duration(milliseconds: 200),
+      );
+    });
+
+    test(
+      "when the Flutter app's package_config.json changes, "
+      'then it does not trigger a server reload',
+      () async {
+        final firstEvent = watcher.onFilesChanged.first;
+        await watcher.ready;
+
+        // A `pub get` in the Flutter app rewrites its own pub artifacts.
+        await File(
+          p.join(flutterDartTool, 'package_config.json'),
+        ).writeAsString('{"configVersion":2,"packages":[]}');
+        await File(
+          p.join(flutterDartTool, 'package_graph.json'),
+        ).writeAsString('{"roots":[],"packages":[]}');
+
+        final event = await firstEvent;
+
+        expect(event.flutterDependenciesChanged, isTrue);
+        expect(
+          event.packageConfigChanged,
+          isFalse,
+          reason: "the Flutter app's package_config must not reload the server",
+        );
+      },
+    );
+
+    test(
+      "when the server's package_graph.json changes, "
+      'then it does not trigger the Flutter dependency check',
+      () async {
+        final firstEvent = watcher.onFilesChanged.first;
+        await watcher.ready;
+
+        await File(
+          p.join(serverDartTool, 'package_config.json'),
+        ).writeAsString('{"configVersion":2,"packages":[]}');
+        await File(
+          p.join(serverDartTool, 'package_graph.json'),
+        ).writeAsString('{"roots":[],"packages":[]}');
+
+        final event = await firstEvent;
+
+        expect(event.packageConfigChanged, isTrue);
+        expect(
+          event.flutterDependenciesChanged,
+          isFalse,
+          reason: "the server's package_graph must not refresh the Flutter app",
+        );
+      },
+    );
+  });
+
+  group('Given multiple Flutter app resolutions (non-workspace layout)', () {
+    late FileWatcher watcher;
+    late String serverDartTool;
+    late String appADartTool;
+    late String appBDartTool;
+
+    setUp(() async {
+      serverDartTool = p.join(tempDir.path, 'server', '.dart_tool');
+      appADartTool = p.join(tempDir.path, 'app_a', '.dart_tool');
+      appBDartTool = p.join(tempDir.path, 'app_b', '.dart_tool');
+      for (final dir in [serverDartTool, appADartTool, appBDartTool]) {
+        await Directory(dir).create(recursive: true);
+      }
+
+      watcher = FileWatcher(
+        watchPaths: [serverDartTool, appADartTool, appBDartTool],
+        packageConfigPath: p.join(serverDartTool, 'package_config.json'),
+        packageGraphPaths: [
+          p.join(appADartTool, 'package_graph.json'),
+          p.join(appBDartTool, 'package_graph.json'),
+        ],
+        debounceDelay: const Duration(milliseconds: 200),
+      );
+    });
+
+    test(
+      "when any tracked Flutter app's package_graph.json changes, "
+      'then it sets flutterDependenciesChanged',
+      () async {
+        final firstEvent = watcher.onFilesChanged.first;
+        await watcher.ready;
+
+        await File(
+          p.join(appBDartTool, 'package_graph.json'),
+        ).writeAsString('{"roots":[],"packages":[]}');
+
+        final event = await firstEvent;
+
         expect(event.flutterDependenciesChanged, isTrue);
         expect(event.packageConfigChanged, isFalse);
-        expect(event.staticFilesChanged, isFalse);
       },
     );
   });

--- a/tools/serverpod_cli/test/commands/start/flutter_dependency_tracker_test.dart
+++ b/tools/serverpod_cli/test/commands/start/flutter_dependency_tracker_test.dart
@@ -168,7 +168,7 @@ void main() {
         writeThirdParty('dep_server_only', version: '1.0.1');
         await _pubGet(wsDir);
 
-        expect(tracker.refresh(), FlutterDependencyChange.none);
+        expect(tracker.refresh(), PackageDependencyChange.none);
       },
     );
 
@@ -180,7 +180,7 @@ void main() {
         writeThirdParty('dep_pure', version: '1.0.1');
         await _pubGet(wsDir);
 
-        expect(tracker.refresh(), FlutterDependencyChange.dartOnly);
+        expect(tracker.refresh(), PackageDependencyChange.dartOnly);
       },
     );
 
@@ -197,7 +197,7 @@ void main() {
         );
         await _pubGet(wsDir);
 
-        expect(tracker.refresh(), FlutterDependencyChange.dartOnly);
+        expect(tracker.refresh(), PackageDependencyChange.dartOnly);
       },
     );
 
@@ -210,7 +210,7 @@ void main() {
         writeAppFlutterPubspec(deps: {});
         await _pubGet(wsDir);
 
-        expect(tracker.refresh(), FlutterDependencyChange.dartOnly);
+        expect(tracker.refresh(), PackageDependencyChange.dartOnly);
       },
     );
 
@@ -221,7 +221,7 @@ void main() {
         writeThirdParty('dep_dev', version: '1.0.1');
         await _pubGet(wsDir);
 
-        expect(tracker.refresh(), FlutterDependencyChange.none);
+        expect(tracker.refresh(), PackageDependencyChange.none);
       },
     );
 
@@ -231,7 +231,7 @@ void main() {
       () async {
         await _pubGet(wsDir);
 
-        expect(tracker.refresh(), FlutterDependencyChange.none);
+        expect(tracker.refresh(), PackageDependencyChange.none);
       },
     );
   });
@@ -252,7 +252,7 @@ void main() {
       'when assets are unchanged, '
       'then no change is reported',
       () {
-        expect(tracker.refresh(), FlutterDependencyChange.none);
+        expect(tracker.refresh(), PackageDependencyChange.none);
       },
     );
 
@@ -267,7 +267,7 @@ void main() {
               '    - assets/image.png\n'
               '    - assets/new_asset.png\n',
         );
-        expect(tracker.refresh(), FlutterDependencyChange.assets);
+        expect(tracker.refresh(), PackageDependencyChange.assets);
       },
     );
 
@@ -281,7 +281,7 @@ void main() {
               '  assets:\n'
               '    - assets/other.png\n',
         );
-        expect(tracker.refresh(), FlutterDependencyChange.assets);
+        expect(tracker.refresh(), PackageDependencyChange.assets);
       },
     );
 
@@ -294,7 +294,7 @@ void main() {
               'flutter:\n'
               '  assets: []\n',
         );
-        expect(tracker.refresh(), FlutterDependencyChange.assets);
+        expect(tracker.refresh(), PackageDependencyChange.assets);
       },
     );
   });
@@ -317,7 +317,7 @@ void main() {
       'when fonts are unchanged, '
       'then no change is reported',
       () {
-        expect(tracker.refresh(), FlutterDependencyChange.none);
+        expect(tracker.refresh(), PackageDependencyChange.none);
       },
     );
 
@@ -336,7 +336,7 @@ void main() {
               '      fonts:\n'
               '        - asset: fonts/NewFont-Regular.ttf\n',
         );
-        expect(tracker.refresh(), FlutterDependencyChange.assets);
+        expect(tracker.refresh(), PackageDependencyChange.assets);
       },
     );
 
@@ -352,7 +352,7 @@ void main() {
               '      fonts:\n'
               '        - asset: fonts/MyFont-Bold.ttf\n',
         );
-        expect(tracker.refresh(), FlutterDependencyChange.assets);
+        expect(tracker.refresh(), PackageDependencyChange.assets);
       },
     );
 
@@ -365,7 +365,7 @@ void main() {
               'flutter:\n'
               '  fonts: []\n',
         );
-        expect(tracker.refresh(), FlutterDependencyChange.assets);
+        expect(tracker.refresh(), PackageDependencyChange.assets);
       },
     );
   });
@@ -373,7 +373,7 @@ void main() {
   /// Resolves a standalone app depending on `dep@1.0.0` (described by
   /// [depFlutterBlock]) with a real `pub get`, bumps it to 1.0.1, re-resolves,
   /// and returns the tracker's classification of the bump.
-  Future<FlutterDependencyChange> classifyRealDependencyBump({
+  Future<PackageDependencyChange> classifyRealDependencyBump({
     String? depFlutterBlock,
     bool withBuildHook = false,
     bool corruptDepPubspecAfterResolve = false,
@@ -423,7 +423,7 @@ void main() {
             '        pluginClass: DepPlugin\n',
       );
 
-      expect(change, FlutterDependencyChange.native);
+      expect(change, PackageDependencyChange.native);
     },
   );
 
@@ -441,7 +441,7 @@ void main() {
             '        ffiPlugin: true\n',
       );
 
-      expect(change, FlutterDependencyChange.native);
+      expect(change, PackageDependencyChange.native);
     },
   );
 
@@ -459,7 +459,7 @@ void main() {
             '        dartPluginClass: DepPluginLinux\n',
       );
 
-      expect(change, FlutterDependencyChange.dartOnly);
+      expect(change, PackageDependencyChange.dartOnly);
     },
   );
 
@@ -477,7 +477,7 @@ void main() {
             '        pluginClass: none\n',
       );
 
-      expect(change, FlutterDependencyChange.dartOnly);
+      expect(change, PackageDependencyChange.dartOnly);
     },
   );
 
@@ -488,7 +488,7 @@ void main() {
     () async {
       final change = await classifyRealDependencyBump(withBuildHook: true);
 
-      expect(change, FlutterDependencyChange.native);
+      expect(change, PackageDependencyChange.native);
     },
   );
 
@@ -501,7 +501,7 @@ void main() {
         corruptDepPubspecAfterResolve: true,
       );
 
-      expect(change, FlutterDependencyChange.native);
+      expect(change, PackageDependencyChange.native);
     },
   );
 
@@ -679,7 +679,7 @@ void main() {
       'when the closure is refreshed, '
       'then no change is reported',
       () {
-        expect(tracker.refresh(), FlutterDependencyChange.none);
+        expect(tracker.refresh(), PackageDependencyChange.none);
       },
     );
   });
@@ -700,7 +700,7 @@ void main() {
       'when the closure is refreshed, '
       'then no change is reported',
       () {
-        expect(tracker.refresh(), FlutterDependencyChange.none);
+        expect(tracker.refresh(), PackageDependencyChange.none);
       },
     );
   });
@@ -720,7 +720,7 @@ void main() {
         'when the closure is refreshed, '
         'then no change is reported',
         () {
-          expect(tracker.refresh(), FlutterDependencyChange.none);
+          expect(tracker.refresh(), PackageDependencyChange.none);
         },
       );
     },
@@ -742,10 +742,10 @@ void main() {
         // Simulate a transient state (e.g. mid-pub-get / flutter clean): the
         // file vanishes and is then recreated with identical contents.
         File(p.join(syntheticDartTool, 'package_graph.json')).deleteSync();
-        expect(tracker.refresh(), FlutterDependencyChange.none);
+        expect(tracker.refresh(), PackageDependencyChange.none);
 
         writeGraph(minimalGraph());
-        expect(tracker.refresh(), FlutterDependencyChange.none);
+        expect(tracker.refresh(), PackageDependencyChange.none);
       },
     );
   });
@@ -782,7 +782,7 @@ void main() {
         'when the closure is refreshed, '
         'then a native change is conservatively reported',
         () {
-          expect(tracker.refresh(), FlutterDependencyChange.native);
+          expect(tracker.refresh(), PackageDependencyChange.native);
         },
       );
     },

--- a/tools/serverpod_cli/test/commands/start/flutter_dependency_tracker_test.dart
+++ b/tools/serverpod_cli/test/commands/start/flutter_dependency_tracker_test.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 
 import 'package:path/path.dart' as p;
 import 'package:serverpod_cli/src/commands/start/flutter_dependency_tracker.dart';
+import 'package:serverpod_cli/src/commands/start/package_dependency_tracker.dart';
 import 'package:test/test.dart';
 
 /// Runs a real `dart pub get` in [dir]. Fixtures use only path and workspace
@@ -511,9 +512,9 @@ void main() {
     () async {
       await createWorkspaceTracker();
 
-      final resolved = FlutterDependencyTracker.resolveDartToolDir(
+      final resolved = PackageDependencyTracker.resolveDartToolDir(
         p.join(wsDir, 'app_flutter'),
-        flutterPackageName: 'app_flutter',
+        packageName: 'app_flutter',
       );
 
       expect(resolved, p.join(wsDir, '.dart_tool'));
@@ -529,9 +530,9 @@ void main() {
       write(p.join(appDir, 'pubspec.yaml'), _pubspec('app_flutter'));
       await _pubGet(appDir);
 
-      final resolved = FlutterDependencyTracker.resolveDartToolDir(
+      final resolved = PackageDependencyTracker.resolveDartToolDir(
         appDir,
-        flutterPackageName: 'app_flutter',
+        packageName: 'app_flutter',
       );
 
       expect(resolved, p.join(appDir, '.dart_tool'));
@@ -545,9 +546,9 @@ void main() {
     () async {
       final pkg = await Directory(p.join(tempDir.path, 'unresolved')).create();
 
-      final resolved = FlutterDependencyTracker.resolveDartToolDir(
+      final resolved = PackageDependencyTracker.resolveDartToolDir(
         pkg.path,
-        flutterPackageName: 'app_flutter',
+        packageName: 'app_flutter',
       );
 
       expect(resolved, isNull);
@@ -577,9 +578,9 @@ void main() {
         'when resolving its .dart_tool, '
         'then it does not latch onto the unrelated resolution',
         () {
-          final resolved = FlutterDependencyTracker.resolveDartToolDir(
+          final resolved = PackageDependencyTracker.resolveDartToolDir(
             pkg.path,
-            flutterPackageName: 'app_flutter',
+            packageName: 'app_flutter',
           );
 
           expect(resolved, isNull);
@@ -614,9 +615,9 @@ void main() {
         'when resolving its .dart_tool, '
         'then it resolves to null',
         () {
-          final resolved = FlutterDependencyTracker.resolveDartToolDir(
+          final resolved = PackageDependencyTracker.resolveDartToolDir(
             pkg.path,
-            flutterPackageName: 'app_flutter',
+            packageName: 'app_flutter',
           );
 
           expect(resolved, isNull);

--- a/tools/serverpod_cli/test/commands/start/kernel_compiler_test.dart
+++ b/tools/serverpod_cli/test/commands/start/kernel_compiler_test.dart
@@ -67,7 +67,7 @@ void main() {
         // Initial compile.
         final initial = await compiler.compile();
         expect(initial.errorCount, 0);
-        compiler.accept();
+        await compiler.accept();
 
         // Modify the file.
         await File(mainFile).writeAsString(
@@ -77,7 +77,7 @@ void main() {
         // Incremental compile.
         final recompiled = await compiler.compile(changedPaths: {mainFile});
         expect(recompiled.errorCount, 0);
-        compiler.accept();
+        await compiler.accept();
       },
       timeout: const Timeout(Duration(seconds: 60)),
     );
@@ -125,6 +125,99 @@ void main() {
         final result = await compiler.compile();
 
         expect(result.errorCount, greaterThan(0));
+      },
+      timeout: const Timeout(Duration(seconds: 60)),
+    );
+  });
+
+  group('Given a dependency added to package_config.json', () {
+    late Directory tempDir;
+    late KernelCompiler compiler;
+    late String mainFile;
+    late String packageConfigFile;
+
+    setUp(() async {
+      tempDir = await Directory.systemTemp.createTemp('kernel_compiler_test_');
+      await _createMinimalDartProject(tempDir.path);
+      mainFile = p.join(tempDir.path, 'bin', 'main.dart');
+      packageConfigFile = p.join(
+        tempDir.path,
+        '.dart_tool',
+        'package_config.json',
+      );
+
+      // A sibling package the app will import once it's mapped in
+      // package_config.json. Only the source file and the mapping matter to
+      // the Frontend Server's resolution, so no pubspec is needed.
+      File(p.join(tempDir.path, 'dep', 'lib', 'dep.dart'))
+        ..createSync(recursive: true)
+        ..writeAsStringSync("String depGreeting() => 'hi from dep';");
+
+      compiler = KernelCompiler(
+        entryPoint: mainFile,
+        outputDill: p.join(
+          tempDir.path,
+          '.dart_tool',
+          'serverpod',
+          'server.dill',
+        ),
+        packagesPath: packageConfigFile,
+      );
+    });
+
+    tearDown(() async {
+      await compiler.dispose();
+      await tempDir.delete(recursive: true);
+    });
+
+    test(
+      'when compile is called with invalidatePackageConfig, '
+      'then the new package resolves without a restart',
+      () async {
+        await compiler.start();
+
+        // Baseline: main does not import the new package yet.
+        expect((await compiler.compile()).errorCount, 0);
+        await compiler.accept();
+
+        // The app now imports the package, but package_config.json doesn't map
+        // it yet. The resident compiler only knows the packages it read at
+        // startup, so without reloading the map the import can't resolve.
+        await File(mainFile).writeAsString(
+          "import 'package:dep/dep.dart';\n"
+          'void main() => print(depGreeting());',
+        );
+        final beforeReload = await compiler.compile(changedPaths: {mainFile});
+        expect(
+          beforeReload.errorCount,
+          greaterThan(0),
+          reason: 'package:dep is not in package_config.json yet',
+        );
+        await compiler.reject();
+
+        // Map the package in package_config.json (as `pub get` would) and
+        // recompile, invalidating the package config so the FES re-reads it.
+        await File(packageConfigFile).writeAsString('''
+{
+  "configVersion": 2,
+  "packages": [
+    { "name": "test_server", "rootUri": "..", "packageUri": "lib/" },
+    { "name": "dep", "rootUri": "../dep", "packageUri": "lib/" }
+  ]
+}
+''');
+        final afterReload = await compiler.compile(
+          changedPaths: {mainFile},
+          invalidatePackageConfig: true,
+        );
+        expect(
+          afterReload.errorCount,
+          0,
+          reason:
+              'invalidating package_config.json should reload the package map '
+              'so package:dep resolves',
+        );
+        await compiler.accept();
       },
       timeout: const Timeout(Duration(seconds: 60)),
     );

--- a/tools/serverpod_cli/test/commands/start/native_assets_builder_test.dart
+++ b/tools/serverpod_cli/test/commands/start/native_assets_builder_test.dart
@@ -20,6 +20,7 @@ void main() {
       builder = NativeAssetsBuilder(
         dartExecutable: _dartExecutable(),
         serverDir: tempDir.path,
+        projectRoot: tempDir.path,
         outputDir: p.join(tempDir.path, '.dart_tool', 'serverpod', 'na'),
       );
     });
@@ -63,7 +64,6 @@ void main() {
 
   group('Given a workspace with the server as a member package', () {
     late Directory tempDir;
-    late NativeAssetsBuilder builder;
     late String serverDir;
 
     setUp(() async {
@@ -75,11 +75,6 @@ void main() {
         rootDir: tempDir.path,
         memberDir: serverDir,
       );
-      builder = NativeAssetsBuilder(
-        dartExecutable: _dartExecutable(),
-        serverDir: serverDir,
-        outputDir: p.join(serverDir, '.dart_tool', 'serverpod', 'na'),
-      );
     });
 
     tearDown(() async {
@@ -87,10 +82,10 @@ void main() {
     });
 
     test(
-      'when discoverProjectRoot is called from the member dir, '
+      'when discoverProjectRootFrom is called from the member dir, '
       'then it walks up to the workspace root',
       () async {
-        final root = await builder.discoverProjectRoot();
+        final root = await discoverProjectRootFrom(serverDir);
 
         expect(
           p.equals(root, tempDir.path),
@@ -121,6 +116,7 @@ void main() {
         builder = NativeAssetsBuilder(
           dartExecutable: _dartExecutable(),
           serverDir: tempDir.path,
+          projectRoot: tempDir.path,
           outputDir: p.join(tempDir.path, '.dart_tool', 'serverpod', 'na'),
         );
       });

--- a/tools/serverpod_cli/test/commands/start/native_assets_builder_test.dart
+++ b/tools/serverpod_cli/test/commands/start/native_assets_builder_test.dart
@@ -160,7 +160,82 @@ void main() {
     },
     skip: Platform.isWindows
         ? 'hooks_runner subprocesses keep .dart_tool handles open on Windows '
-              'long enough to race tearDown — see CI run 25155561001'
+              'long enough to race tearDown - see CI run 25155561001'
+        : null,
+  );
+
+  group(
+    'Given a build hook that emits a data asset',
+    () {
+      late Directory tempDir;
+      late NativeAssetsBuilder builder;
+
+      setUp(() async {
+        tempDir = await Directory.systemTemp.createTemp(
+          'native_assets_builder_drop_test_',
+        );
+        await _createProjectWithBuildHook(
+          dir: tempDir.path,
+          extraImports: const [
+            "import 'dart:io';",
+            "import 'package:data_assets/data_assets.dart';",
+          ],
+          hookBody: '''
+final file = File.fromUri(input.outputDirectory.resolve('asset.txt'));
+await file.writeAsString('hello');
+output.assets.data.add(
+  DataAsset(package: input.packageName, name: 'asset.txt', file: file.uri),
+);
+''',
+        );
+        builder = NativeAssetsBuilder(
+          dartExecutable: _dartExecutable(),
+          serverDir: tempDir.path,
+          projectRoot: tempDir.path,
+          outputDir: p.join(tempDir.path, '.dart_tool', 'serverpod', 'na'),
+        );
+      });
+
+      tearDown(() async {
+        await tempDir.deleteWithRetry(recursive: true);
+      });
+
+      test(
+        'when the last build-hook package is removed after a manifest was '
+        'built, then the next build tears the manifest down and reports the '
+        'change',
+        () async {
+          // First build produces a manifest from the emitted data asset.
+          final first = await builder.build();
+          expect(first, isA<NativeAssetsBuildSuccess>());
+          expect((first as NativeAssetsBuildSuccess).manifestPath, isNotNull);
+          expect(first.manifestChanged, isTrue);
+          expect(File(builder.manifestPath).existsSync(), isTrue);
+
+          // Drop the build hook, mirroring a `pub get` that removed the last
+          // native dependency, and re-discover packages as the watch loop does
+          // on a package_config change.
+          File(p.join(tempDir.path, 'hook', 'build.dart')).deleteSync();
+          builder.reset();
+
+          final second = await builder.build();
+
+          // It must NOT silently skip: the stale manifest is torn down and the
+          // change is reported, so applyTo restarts the FES without
+          // --native-assets (which in turn restarts the pod). Skipping would
+          // leave the pod loading the removed package's assets.
+          expect(second, isA<NativeAssetsBuildSuccess>());
+          final success = second as NativeAssetsBuildSuccess;
+          expect(success.manifestPath, isNull);
+          expect(success.manifestChanged, isTrue);
+          expect(File(builder.manifestPath).existsSync(), isFalse);
+        },
+        timeout: const Timeout(Duration(minutes: 2)),
+      );
+    },
+    skip: Platform.isWindows
+        ? 'hooks_runner subprocesses keep .dart_tool handles open on Windows '
+              'long enough to race tearDown - see CI run 25155561001'
         : null,
   );
 }
@@ -284,6 +359,7 @@ environment:
 Future<void> _createProjectWithBuildHook({
   required String dir,
   required String hookBody,
+  List<String> extraImports = const [],
 }) async {
   await Directory(p.join(dir, '.dart_tool')).create(recursive: true);
   await Directory(p.join(dir, 'hook')).create(recursive: true);
@@ -298,6 +374,7 @@ dependencies:
 
   await File(p.join(dir, 'hook', 'build.dart')).writeAsString('''
 import 'package:hooks/hooks.dart';
+${extraImports.join('\n')}
 
 void main(List<String> args) async {
   await build(args, (input, output) async {

--- a/tools/serverpod_cli/test/commands/start/package_dependency_tracker_test.dart
+++ b/tools/serverpod_cli/test/commands/start/package_dependency_tracker_test.dart
@@ -1,0 +1,382 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:serverpod_cli/src/commands/start/package_dependency_tracker.dart';
+import 'package:test/test.dart';
+
+/// Runs a real `dart pub get` in [dir]. Fixtures use only path and workspace
+/// dependencies, so resolution works offline and the tests exercise the actual
+/// `package_graph.json` / `package_config.json` files pub generates.
+Future<void> _pubGet(String dir) async {
+  final result = await Process.run(Platform.resolvedExecutable, [
+    'pub',
+    'get',
+    '--offline',
+  ], workingDirectory: dir);
+  if (result.exitCode != 0) {
+    fail('pub get failed in $dir:\n${result.stdout}\n${result.stderr}');
+  }
+}
+
+String _pubspec(
+  String name, {
+  String version = '1.0.0',
+  List<String>? workspace,
+  bool workspaceMember = false,
+  Map<String, String> deps = const {},
+  Map<String, String> devDeps = const {},
+}) {
+  final buffer = StringBuffer()
+    ..writeln('name: $name')
+    ..writeln('version: $version')
+    ..writeln('environment:')
+    ..writeln('  sdk: ^3.6.0');
+  if (workspace != null) {
+    buffer.writeln('workspace:');
+    for (final member in workspace) {
+      buffer.writeln('  - $member');
+    }
+  }
+  if (workspaceMember) buffer.writeln('resolution: workspace');
+  if (deps.isNotEmpty) {
+    buffer.writeln('dependencies:');
+    deps.forEach((dep, path) {
+      buffer
+        ..writeln('  $dep:')
+        ..writeln('    path: $path');
+    });
+  }
+  if (devDeps.isNotEmpty) {
+    buffer.writeln('dev_dependencies:');
+    devDeps.forEach((dep, path) {
+      buffer
+        ..writeln('  $dep:')
+        ..writeln('    path: $path');
+    });
+  }
+  return buffer.toString();
+}
+
+void main() {
+  late Directory tempDir;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('pkg_dep_tracker_');
+  });
+
+  tearDown(() async {
+    await tempDir.delete(recursive: true);
+  });
+
+  void write(String path, String contents) {
+    File(path)
+      ..createSync(recursive: true)
+      ..writeAsStringSync(contents);
+  }
+
+  // ---------------------------------------------------------------------
+  // Real-resolution fixture: a workspace shared by a server and a Flutter app,
+  // mirroring a generated Serverpod project. The package_graph.json is shared
+  // across all members, so the tracker rooted at the SERVER must ignore changes
+  // that only touch the app's closure - the core workspace-scoping guarantee.
+  //
+  // Layout: app_server -> dep_server, app_flutter -> dep_app (app-only).
+  // Third-party packages live outside the workspace as path deps.
+  // ---------------------------------------------------------------------
+
+  late String wsDir;
+
+  void writeThirdParty(
+    String name, {
+    String version = '1.0.0',
+    bool withBuildHook = false,
+  }) {
+    write(
+      p.join(tempDir.path, 'third_party', name, 'pubspec.yaml'),
+      _pubspec(name, version: version),
+    );
+    if (withBuildHook) {
+      write(
+        p.join(tempDir.path, 'third_party', name, 'hook', 'build.dart'),
+        'void main() {}',
+      );
+    }
+  }
+
+  void writeAppServerPubspec({Map<String, String>? deps}) {
+    write(
+      p.join(wsDir, 'app_server', 'pubspec.yaml'),
+      _pubspec(
+        'app_server',
+        workspaceMember: true,
+        deps: deps ?? {'dep_server': '../../third_party/dep_server'},
+        devDeps: {'dep_dev': '../../third_party/dep_dev'},
+      ),
+    );
+  }
+
+  Future<PackageDependencyTracker> createServerTracker({
+    bool serverDepHasBuildHook = false,
+  }) async {
+    wsDir = p.join(tempDir.path, 'ws');
+    writeThirdParty('dep_server', withBuildHook: serverDepHasBuildHook);
+    writeThirdParty('dep_app');
+    writeThirdParty('dep_dev');
+    write(
+      p.join(wsDir, 'pubspec.yaml'),
+      _pubspec('fixture_root', workspace: ['app_server', 'app_flutter']),
+    );
+    writeAppServerPubspec();
+    write(
+      p.join(wsDir, 'app_flutter', 'pubspec.yaml'),
+      _pubspec(
+        'app_flutter',
+        workspaceMember: true,
+        deps: {'dep_app': '../../third_party/dep_app'},
+      ),
+    );
+    await _pubGet(wsDir);
+    return PackageDependencyTracker(
+      dartToolDir: p.join(wsDir, '.dart_tool'),
+      packageName: 'app_server',
+    );
+  }
+
+  group('Given a real pub workspace shared by a server and a Flutter app,', () {
+    late PackageDependencyTracker tracker;
+
+    setUp(() async {
+      tracker = await createServerTracker();
+    });
+
+    test(
+      'when an app-only dependency changes version, '
+      'then no change is reported for the server closure',
+      () async {
+        // The shared package_graph.json changes, but dep_app is not in the
+        // server's closure - the workspace-scoping guarantee.
+        writeThirdParty('dep_app', version: '1.0.1');
+        await _pubGet(wsDir);
+
+        expect(tracker.refreshClosure(), PackageDependencyChange.none);
+      },
+    );
+
+    test(
+      'when a server dependency changes version, '
+      'then a pure-Dart change is reported',
+      () async {
+        writeThirdParty('dep_server', version: '1.0.1');
+        await _pubGet(wsDir);
+
+        expect(tracker.refreshClosure(), PackageDependencyChange.dartOnly);
+      },
+    );
+
+    test(
+      'when a pure-Dart dependency is added to the server, '
+      'then a pure-Dart change is reported',
+      () async {
+        writeThirdParty('dep_added');
+        writeAppServerPubspec(
+          deps: {
+            'dep_server': '../../third_party/dep_server',
+            'dep_added': '../../third_party/dep_added',
+          },
+        );
+        await _pubGet(wsDir);
+
+        expect(tracker.refreshClosure(), PackageDependencyChange.dartOnly);
+      },
+    );
+
+    test(
+      'when a server dependency is removed, '
+      'then a pure-Dart change is reported (a removal never needs a relaunch)',
+      () async {
+        // Removing a dep shrinks the closure; its compiled code may linger in
+        // the running process but nothing references it anymore, so the lighter
+        // response is correct - never the native escalation.
+        writeAppServerPubspec(deps: {});
+        await _pubGet(wsDir);
+
+        expect(tracker.refreshClosure(), PackageDependencyChange.dartOnly);
+      },
+    );
+
+    test(
+      'when a dev dependency of the server changes, '
+      'then no change is reported',
+      () async {
+        writeThirdParty('dep_dev', version: '1.0.1');
+        await _pubGet(wsDir);
+
+        expect(tracker.refreshClosure(), PackageDependencyChange.none);
+      },
+    );
+
+    test(
+      'when pub get runs again with no pubspec changes, '
+      'then no change is reported',
+      () async {
+        await _pubGet(wsDir);
+
+        expect(tracker.refreshClosure(), PackageDependencyChange.none);
+      },
+    );
+  });
+
+  test(
+    'Given a server dependency with a native-assets build hook, '
+    'when its version changes, '
+    'then a native change is reported',
+    () async {
+      final tracker = await createServerTracker(serverDepHasBuildHook: true);
+
+      writeThirdParty('dep_server', version: '1.0.1', withBuildHook: true);
+      await _pubGet(wsDir);
+
+      expect(tracker.refreshClosure(), PackageDependencyChange.native);
+    },
+  );
+
+  test(
+    'Given a server package directory in a workspace, '
+    'when resolving its .dart_tool, '
+    'then it resolves to the workspace root .dart_tool',
+    () async {
+      await createServerTracker();
+
+      final resolved = PackageDependencyTracker.resolveDartToolDir(
+        p.join(wsDir, 'app_server'),
+        packageName: 'app_server',
+      );
+
+      expect(resolved, p.join(wsDir, '.dart_tool'));
+    },
+  );
+
+  // ---------------------------------------------------------------------
+  // Corruption and race states. Hand-written: pub never produces malformed or
+  // partially-missing dependency files, so synthetic fixtures are the only way
+  // to cover the tracker's tolerance of them.
+  // ---------------------------------------------------------------------
+
+  late String syntheticDartTool;
+
+  Future<void> createSyntheticDartTool() async {
+    syntheticDartTool = p.join(tempDir.path, '.dart_tool');
+    await Directory(syntheticDartTool).create(recursive: true);
+  }
+
+  void writeGraph(Map<String, dynamic> graph) {
+    write(p.join(syntheticDartTool, 'package_graph.json'), jsonEncode(graph));
+  }
+
+  Map<String, dynamic> minimalGraph({String depVersion = '1.0.0'}) => {
+    'roots': ['app_server'],
+    'packages': [
+      {
+        'name': 'app_server',
+        'version': '1.0.0',
+        'dependencies': ['dep'],
+      },
+      {'name': 'dep', 'version': depVersion, 'dependencies': <String>[]},
+    ],
+  };
+
+  PackageDependencyTracker createSyntheticTracker({
+    String packageName = 'app_server',
+  }) => PackageDependencyTracker(
+    dartToolDir: syntheticDartTool,
+    packageName: packageName,
+  );
+
+  group('Given a resolution whose dependency graph file is absent,', () {
+    setUp(createSyntheticDartTool);
+
+    test(
+      'when the closure is refreshed, '
+      'then no change is reported',
+      () {
+        final tracker = createSyntheticTracker();
+        expect(tracker.refreshClosure(), PackageDependencyChange.none);
+      },
+    );
+  });
+
+  group('Given a malformed dependency graph file,', () {
+    setUp(() async {
+      await createSyntheticDartTool();
+      write(
+        p.join(syntheticDartTool, 'package_graph.json'),
+        '{ not valid json',
+      );
+    });
+
+    test(
+      'when the closure is refreshed, '
+      'then no change is reported',
+      () {
+        final tracker = createSyntheticTracker();
+        expect(tracker.refreshClosure(), PackageDependencyChange.none);
+      },
+    );
+  });
+
+  group('Given a graph that does not list the tracked package,', () {
+    setUp(() async {
+      await createSyntheticDartTool();
+      writeGraph(minimalGraph());
+    });
+
+    test(
+      'when the closure is refreshed, '
+      'then no change is reported',
+      () {
+        final tracker = createSyntheticTracker(packageName: 'not_in_graph');
+        expect(tracker.refreshClosure(), PackageDependencyChange.none);
+      },
+    );
+  });
+
+  group('Given a seeded synthetic graph,', () {
+    test(
+      'when a dependency version changes after construction, '
+      'then a change is reported (the baseline was seeded at construction)',
+      () async {
+        await createSyntheticDartTool();
+        writeGraph(minimalGraph());
+        final tracker = createSyntheticTracker();
+
+        // Bump the dep. With no package_config.json to locate it, the changed
+        // package cannot be classified and is conservatively treated as native
+        // - the point here is that a change is detected at all (proving the
+        // constructor seeded the baseline), not the exact severity.
+        writeGraph(minimalGraph(depVersion: '1.0.1'));
+
+        expect(
+          tracker.refreshClosure(),
+          isNot(PackageDependencyChange.none),
+        );
+      },
+    );
+
+    test(
+      'when the graph disappears then reappears unchanged, '
+      'then no change is reported',
+      () async {
+        await createSyntheticDartTool();
+        writeGraph(minimalGraph());
+        final tracker = createSyntheticTracker();
+
+        File(p.join(syntheticDartTool, 'package_graph.json')).deleteSync();
+        expect(tracker.refreshClosure(), PackageDependencyChange.none);
+
+        writeGraph(minimalGraph());
+        expect(tracker.refreshClosure(), PackageDependencyChange.none);
+      },
+    );
+  });
+}

--- a/tools/serverpod_cli/test/commands/start/server_process_test.dart
+++ b/tools/serverpod_cli/test/commands/start/server_process_test.dart
@@ -186,7 +186,7 @@ void main() {
           'Failed to compile kernel: ${result.compilerOutputLines.join('\n')}',
         );
       }
-      compiler.accept();
+      await compiler.accept();
       await compiler.dispose();
 
       serverProcess = ServerProcess(
@@ -292,7 +292,7 @@ void main() {
             'Failed to compile kernel: ${result.compilerOutputLines.join('\n')}',
           );
         }
-        compiler.accept();
+        await compiler.accept();
         await compiler.dispose();
 
         expect(dillPath.contains(' '), isTrue);

--- a/tools/serverpod_cli/test/commands/start/watch_loop_test.dart
+++ b/tools/serverpod_cli/test/commands/start/watch_loop_test.dart
@@ -30,12 +30,15 @@ class _FakeCompiler extends Fake implements KernelCompiler {
   String get outputDill => '/tmp/fake.dill';
 
   @override
-  Future<CompileResult> compile({Set<String> changedPaths = const {}}) async {
+  Future<CompileResult> compile({
+    Set<String> changedPaths = const {},
+    bool invalidatePackageConfig = false,
+  }) async {
     return _successResult();
   }
 
   @override
-  void accept() {}
+  Future<void> accept() async {}
 
   @override
   Future<void> reject() async {}

--- a/tools/serverpod_cli/test/commands/start/watch_paths_test.dart
+++ b/tools/serverpod_cli/test/commands/start/watch_paths_test.dart
@@ -1,0 +1,72 @@
+import 'package:path/path.dart' as p;
+import 'package:serverpod_cli/src/commands/start.dart';
+import 'package:serverpod_cli/src/commands/start/flutter_dependency_tracker.dart';
+import 'package:test/test.dart';
+
+import '../../test_util/builders/generator_config_builder.dart';
+
+void main() {
+  group('Given the watch-mode watch paths', () {
+    final config = GeneratorConfigBuilder().build();
+
+    test(
+      'when there is no Flutter dependency tracker (server-only project), '
+      'then the server resolution .dart_tool is still watched',
+      () {
+        final serverDartTool = p.absolute('some_server', '.dart_tool');
+
+        final paths = buildWatchPaths(
+          config: config,
+          serverDartToolDir: serverDartTool,
+        );
+
+        // Without this, package_config.json changes are never observed and the
+        // server can't pick up a new dependency without a full restart.
+        expect(paths, contains(serverDartTool));
+      },
+    );
+
+    test(
+      'when the server and Flutter resolutions differ (non-workspace layout), '
+      'then both .dart_tool directories are watched',
+      () {
+        final serverDartTool = p.absolute('server_pkg', '.dart_tool');
+        final flutterDartTool = p.absolute('flutter_pkg', '.dart_tool');
+        final tracker = FlutterDependencyTracker(
+          dartToolDir: flutterDartTool,
+          flutterPackageName: 'my_flutter',
+          flutterPackageDir: p.absolute('flutter_pkg'),
+        );
+
+        final paths = buildWatchPaths(
+          config: config,
+          serverDartToolDir: serverDartTool,
+          flutterDependencyTrackers: [tracker],
+        );
+
+        expect(paths, containsAll([serverDartTool, flutterDartTool]));
+      },
+    );
+
+    test(
+      'when the server and Flutter share a resolution (workspace layout), '
+      'then the shared .dart_tool is watched exactly once',
+      () {
+        final sharedDartTool = p.absolute('workspace_root', '.dart_tool');
+        final tracker = FlutterDependencyTracker(
+          dartToolDir: sharedDartTool,
+          flutterPackageName: 'my_flutter',
+          flutterPackageDir: p.absolute('workspace_root', 'my_flutter'),
+        );
+
+        final paths = buildWatchPaths(
+          config: config,
+          serverDartToolDir: sharedDartTool,
+          flutterDependencyTrackers: [tracker],
+        );
+
+        expect(paths.where((path) => path == sharedDartTool), hasLength(1));
+      },
+    );
+  });
+}

--- a/tools/serverpod_cli/test/commands/start/watch_session_test.dart
+++ b/tools/serverpod_cli/test/commands/start/watch_session_test.dart
@@ -44,17 +44,21 @@ class _FakeCompiler extends Fake implements KernelCompiler {
   String get outputDill => '/tmp/fake.dill';
 
   @override
-  Future<CompileResult> compile({Set<String> changedPaths = const {}}) async {
+  Future<CompileResult> compile({
+    Set<String> changedPaths = const {},
+    bool invalidatePackageConfig = false,
+  }) async {
+    final suffix = invalidatePackageConfig ? '+package_config' : '';
     if (changedPaths.isEmpty) {
-      calls.add('compile');
+      calls.add('compile$suffix');
       return nextCompileResult;
     }
-    calls.add('compile(changed):${changedPaths.toList()..sort()}');
+    calls.add('compile(changed):${changedPaths.toList()..sort()}$suffix');
     return nextIncrementalResult;
   }
 
   @override
-  void accept() => calls.add('accept');
+  Future<void> accept() async => calls.add('accept');
 
   @override
   Future<void> reject() async => calls.add('reject');
@@ -633,7 +637,7 @@ void main() {
   group('Given package_config.json changed', () {
     test(
       'when dart files also changed, '
-      'then it runs codegen, restarts compiler, and does a full compile',
+      'then it recompiles incrementally and invalidates the package config',
       () async {
         final event = FileChangeEvent(
           dartFiles: {'/lib/a.dart'},
@@ -645,13 +649,16 @@ void main() {
         expect(generateCalls, [
           {'/lib/a.dart'},
         ]);
-        expect(compiler.calls, ['restart', 'compile', 'accept']);
+        expect(compiler.calls, [
+          'compile(changed):[/lib/a.dart]+package_config',
+          'accept',
+        ]);
       },
     );
 
     test(
-      'when both package_config and model files changed, '
-      'then it runs codegen and restarts compiler',
+      'when package_config and model files changed, '
+      'then it recompiles and invalidates the package config',
       () async {
         final event = FileChangeEvent(
           dartFiles: {},
@@ -664,7 +671,40 @@ void main() {
         expect(generateCalls, [
           {'/models/user.spy.yaml'},
         ]);
-        expect(compiler.calls, ['restart', 'compile', 'accept']);
+        expect(compiler.calls, ['compile+package_config', 'accept']);
+      },
+    );
+
+    test(
+      'when the package_config compile fails, '
+      'then the package config is re-invalidated on the next compile',
+      () async {
+        // First cycle: package_config changed, but the compile fails and is
+        // rolled back - the new package map never took effect.
+        compiler.nextIncrementalResult = _failResult();
+        await session.handleFileChange(
+          FileChangeEvent(
+            dartFiles: {'/lib/a.dart'},
+            packageConfigChanged: true,
+          ),
+        );
+        expect(compiler.calls, contains('reject'));
+        expect(compiler.calls, isNot(contains('accept')));
+
+        // Next cycle: an unrelated dart change that does NOT set
+        // packageConfigChanged. The dropped invalidation must ride along.
+        compiler.calls.clear();
+        compiler.nextIncrementalResult = _successResult();
+        await session.handleFileChange(
+          FileChangeEvent(dartFiles: {'/lib/b.dart'}),
+        );
+
+        expect(
+          compiler.calls.where((c) => c.contains('+package_config')),
+          isNotEmpty,
+          reason: 'a failed package_config compile must not drop the signal',
+        );
+        expect(compiler.calls, contains('accept'));
       },
     );
   });

--- a/tools/serverpod_cli/test/commands/start/watch_session_test.dart
+++ b/tools/serverpod_cli/test/commands/start/watch_session_test.dart
@@ -6,7 +6,6 @@ import 'package:path/path.dart' as p;
 import 'package:serverpod_cli/src/commands/messages.dart';
 import 'package:serverpod_cli/src/commands/start/file_watcher.dart';
 import 'package:serverpod_cli/src/commands/start/flutter_app_manager.dart';
-import 'package:serverpod_cli/src/commands/start/flutter_dependency_tracker.dart';
 import 'package:serverpod_cli/src/commands/start/flutter_process.dart';
 import 'package:serverpod_cli/src/commands/start/kernel_compiler.dart';
 import 'package:serverpod_cli/src/commands/start/native_assets_builder.dart';
@@ -201,7 +200,7 @@ Future<
 >
 _createFlutterManagerHarness({
   _FakeFlutter? flutter,
-  FlutterDependencyChange Function(String appId)? dependencyChange,
+  PackageDependencyChange Function(String appId)? dependencyChange,
   Future<void> Function(String appId)? restartOverride,
   Future<void> Function(String appId)? launchOverride,
 }) async {
@@ -1837,7 +1836,7 @@ void main() {
         flutter = _FakeFlutter();
         final harness = await _createFlutterManagerHarness(
           flutter: flutter,
-          dependencyChange: (_) => FlutterDependencyChange.native,
+          dependencyChange: (_) => PackageDependencyChange.native,
           restartOverride: (_) async {
             restartActionCalls++;
           },
@@ -1908,7 +1907,7 @@ void main() {
         flutter = _FakeFlutter();
         final harness = await _createFlutterManagerHarness(
           flutter: flutter,
-          dependencyChange: (_) => FlutterDependencyChange.dartOnly,
+          dependencyChange: (_) => PackageDependencyChange.dartOnly,
           restartOverride: (_) async {
             restartActionCalls++;
           },
@@ -1976,7 +1975,7 @@ void main() {
         flutter = _FakeFlutter();
         final harness = await _createFlutterManagerHarness(
           flutter: flutter,
-          dependencyChange: (_) => FlutterDependencyChange.none,
+          dependencyChange: (_) => PackageDependencyChange.none,
           restartOverride: (_) async {
             restartActionCalls++;
           },
@@ -2043,7 +2042,7 @@ void main() {
         flutter = _FakeFlutter();
         final harness = await _createFlutterManagerHarness(
           flutter: flutter,
-          dependencyChange: (_) => FlutterDependencyChange.assets,
+          dependencyChange: (_) => PackageDependencyChange.assets,
           restartOverride: (_) async {
             restartActionCalls++;
           },

--- a/tools/serverpod_cli/test/commands/start/watch_session_test.dart
+++ b/tools/serverpod_cli/test/commands/start/watch_session_test.dart
@@ -9,6 +9,8 @@ import 'package:serverpod_cli/src/commands/start/flutter_app_manager.dart';
 import 'package:serverpod_cli/src/commands/start/flutter_dependency_tracker.dart';
 import 'package:serverpod_cli/src/commands/start/flutter_process.dart';
 import 'package:serverpod_cli/src/commands/start/kernel_compiler.dart';
+import 'package:serverpod_cli/src/commands/start/native_assets_builder.dart';
+import 'package:serverpod_cli/src/commands/start/package_dependency_tracker.dart';
 import 'package:serverpod_cli/src/commands/start/server_process.dart';
 import 'package:serverpod_cli/src/commands/start/watch_session.dart';
 import 'package:serverpod_cli/src/config/flutter_app_config.dart';
@@ -71,6 +73,42 @@ class _FakeCompiler extends Fake implements KernelCompiler {
 
   @override
   Future<void> dispose() async => calls.add('dispose');
+}
+
+/// Stand-in for [NativeAssetsBuilder] so the session's hook/restart bookkeeping
+/// can be driven without running real build hooks. [nextOutcome] controls what
+/// the next [applyTo] reports; `restarted: true` simulates a native-assets
+/// manifest change that restarted the Frontend Server.
+class _FakeNativeAssetsApplier implements NativeAssetsApplier {
+  final List<String> calls = [];
+  NativeAssetsApplyOutcome nextOutcome = const NativeAssetsApplySuccess();
+
+  @override
+  Future<NativeAssetsApplyOutcome> applyTo(KernelCompiler compiler) async {
+    calls.add('applyTo');
+    return nextOutcome;
+  }
+
+  @override
+  void reset() => calls.add('reset');
+}
+
+/// Stand-in for the server's [PackageDependencyTracker] whose closure verdict is
+/// scripted via [next]. The base constructor reads a nonexistent `.dart_tool`,
+/// which seeds an empty (null) closure without throwing; [refreshClosure] is
+/// overridden so file contents never matter.
+class _FakeServerDependencyTracker extends PackageDependencyTracker {
+  _FakeServerDependencyTracker()
+    : super(dartToolDir: '/nonexistent', packageName: 'app_server');
+
+  PackageDependencyChange next = PackageDependencyChange.dartOnly;
+  int refreshCalls = 0;
+
+  @override
+  PackageDependencyChange refreshClosure() {
+    refreshCalls++;
+    return next;
+  }
 }
 
 class _FakeServer extends Fake implements ServerProcess {
@@ -304,10 +342,14 @@ void main() {
     GenerateAction? generate,
     ApplyMigrationsAction? applyMigrationsAction,
     ProtocolChangeClassifier? classifyProtocolChange,
+    NativeAssetsApplier? nativeAssetsBuilder,
+    PackageDependencyTracker? serverDependencyTracker,
     FlutterAppManager? flutterManager,
   }) {
     return WatchSession(
       compiler: compiler,
+      nativeAssetsBuilder: nativeAssetsBuilder,
+      serverDependencyTracker: serverDependencyTracker,
       generate:
           generate ??
           (affectedPaths, requirements) async {
@@ -703,6 +745,180 @@ void main() {
           compiler.calls.where((c) => c.contains('+package_config')),
           isNotEmpty,
           reason: 'a failed package_config compile must not drop the signal',
+        );
+        expect(compiler.calls, contains('accept'));
+      },
+    );
+  });
+
+  group('Given a native-assets builder', () {
+    late _FakeNativeAssetsApplier builder;
+    late WatchSession nativeSession;
+
+    setUp(() {
+      builder = _FakeNativeAssetsApplier();
+      nativeSession = buildSession(
+        compiler: compiler,
+        initialServer: server,
+        nativeAssetsBuilder: builder,
+      );
+    });
+
+    test(
+      'when the native-assets manifest changed (the FES was restarted), '
+      'then the pod is restarted with the full dill instead of hot reloaded',
+      () async {
+        builder.nextOutcome = const NativeAssetsApplySuccess(restarted: true);
+
+        await nativeSession.handleFileChange(
+          FileChangeEvent(dartFiles: const {}, packageConfigChanged: true),
+        );
+
+        // A hot reload would never re-link native assets, so the pod is
+        // process-restarted via the factory; the old server only gets `stop`.
+        expect(builder.calls, ['reset', 'applyTo']);
+        expect(compiler.calls, contains('accept'));
+        expect(server.calls, ['stop']);
+        expect(server.calls, isNot(contains('reload:/out.dill')));
+        expect(factoryCalls, ['createServer:/out.dill']);
+        expect(testLogger.infoMessages, contains(serverNativeAssetsChanged));
+      },
+    );
+
+    test(
+      'when the native-assets manifest is unchanged, '
+      'then the pod is hot reloaded as usual',
+      () async {
+        builder.nextOutcome = const NativeAssetsApplySuccess();
+
+        await nativeSession.handleFileChange(
+          FileChangeEvent(dartFiles: {'/lib/a.dart'}),
+        );
+
+        expect(server.calls, contains('reload:/out.dill'));
+        expect(factoryCalls, isEmpty);
+        expect(
+          testLogger.infoMessages,
+          isNot(contains(serverNativeAssetsChanged)),
+        );
+      },
+    );
+
+    test(
+      'when the build hooks fail, '
+      'then the server is not reloaded or restarted',
+      () async {
+        builder.nextOutcome = const NativeAssetsApplyFailure('boom');
+
+        await nativeSession.handleFileChange(
+          FileChangeEvent(dartFiles: {'/lib/a.dart'}),
+        );
+
+        expect(server.calls, isEmpty);
+        expect(factoryCalls, isEmpty);
+      },
+    );
+  });
+
+  group('Given a server dependency tracker', () {
+    late _FakeServerDependencyTracker tracker;
+    late WatchSession gatedSession;
+
+    setUp(() {
+      tracker = _FakeServerDependencyTracker();
+      gatedSession = buildSession(
+        compiler: compiler,
+        initialServer: server,
+        serverDependencyTracker: tracker,
+      );
+    });
+
+    test(
+      'when package_config changed but the server closure did not, '
+      'then nothing is recompiled or reloaded',
+      () async {
+        tracker.next = PackageDependencyChange.none;
+
+        await gatedSession.handleFileChange(
+          FileChangeEvent(dartFiles: const {}, packageConfigChanged: true),
+        );
+
+        expect(tracker.refreshCalls, 1);
+        expect(compiler.calls, isEmpty);
+        expect(server.calls, isEmpty);
+      },
+    );
+
+    test(
+      'when the server closure changed, '
+      'then it recompiles and invalidates the package config',
+      () async {
+        tracker.next = PackageDependencyChange.dartOnly;
+
+        await gatedSession.handleFileChange(
+          FileChangeEvent(dartFiles: const {}, packageConfigChanged: true),
+        );
+
+        expect(tracker.refreshCalls, 1);
+        expect(compiler.calls, ['compile+package_config', 'accept']);
+        expect(server.calls, contains('reload:/out.dill'));
+      },
+    );
+
+    test(
+      'when package_config changed without a closure change but dart files '
+      'also changed, '
+      'then it recompiles the dart files without invalidating the package config',
+      () async {
+        tracker.next = PackageDependencyChange.none;
+
+        await gatedSession.handleFileChange(
+          FileChangeEvent(
+            dartFiles: {'/lib/a.dart'},
+            packageConfigChanged: true,
+          ),
+        );
+
+        // Source files always compile; only the dependency-driven invalidation
+        // is suppressed when the server's closure is untouched.
+        expect(compiler.calls, ['compile(changed):[/lib/a.dart]', 'accept']);
+        expect(server.calls, contains('reload:/out.dill'));
+      },
+    );
+
+    test(
+      'when a package_config compile fails and the next event has no closure '
+      'change, '
+      'then the pending invalidation still rides along',
+      () async {
+        // First cycle: a real closure change whose compile fails and rolls back.
+        tracker.next = PackageDependencyChange.dartOnly;
+        compiler.nextIncrementalResult = _failResult();
+        await gatedSession.handleFileChange(
+          FileChangeEvent(
+            dartFiles: {'/lib/a.dart'},
+            packageConfigChanged: true,
+          ),
+        );
+        expect(compiler.calls, contains('reject'));
+
+        // Next cycle: the closure is unchanged, so the gate downgrades the event
+        // flag - but the dropped invalidation must still ride along.
+        compiler.calls.clear();
+        compiler.nextIncrementalResult = _successResult();
+        tracker.next = PackageDependencyChange.none;
+        await gatedSession.handleFileChange(
+          FileChangeEvent(
+            dartFiles: {'/lib/b.dart'},
+            packageConfigChanged: true,
+          ),
+        );
+
+        expect(
+          compiler.calls.where((c) => c.contains('+package_config')),
+          isNotEmpty,
+          reason:
+              'a pending invalidation must survive a no-closure-change gate',
         );
         expect(compiler.calls, contains('accept'));
       },


### PR DESCRIPTION
KernelCompiler.compile now takes invalidatePackageConfig and appends to the invalidated set, turning the restart + full compile into an in-place incremental recompile, when deps changes.

Fixes: #5290

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

## Breaking changes

None