### PR TITLE
fix: Add deploy workflow template and deployment docs to project template

### DIFF
--- a/templates/serverpod_templates/github/workflows/deploy.yml
+++ b/templates/serverpod_templates/github/workflows/deploy.yml
@@ -1,0 +1,103 @@
+name: Deploy
+
+# This workflow is triggered manually from the GitHub Actions UI.
+# To automate it on every push to main, change the trigger below to:
+#
+#   on:
+#     push:
+#       branches: [main]
+#
+# Before running, add these secrets in your GitHub repository settings
+# (Settings → Secrets and variables → Actions):
+#
+#   REGISTRY_USER   — your container registry username
+#   REGISTRY_TOKEN  — your container registry password or access token
+#
+# Then uncomment ONE of the platform-specific deploy jobs at the bottom.
+# See https://docs.serverpod.dev/deployment for full setup guides.
+
+on:
+  workflow_dispatch:
+
+env:
+  IMAGE: ghcr.io/${{ github.repository_owner }}/projectname-server
+
+jobs:
+  build-and-push:
+    name: Build and push Docker image
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to container registry
+        # Replace ghcr.io with your registry if needed (docker.io, gcr.io, public.ecr.aws, etc.)
+        run: |
+          echo "${{ secrets.REGISTRY_TOKEN }}" | \
+            docker login ghcr.io -u "${{ secrets.REGISTRY_USER }}" --password-stdin
+
+      - name: Build Docker image
+        run: |
+          docker build \
+            -f projectname_server/Dockerfile \
+            -t ${{ env.IMAGE }}:${{ github.sha }} \
+            -t ${{ env.IMAGE }}:latest \
+            .
+
+      - name: Push Docker image
+        run: |
+          docker push ${{ env.IMAGE }}:${{ github.sha }}
+          docker push ${{ env.IMAGE }}:latest
+
+  # ── Uncomment ONE of the deploy jobs below ───────────────────────────────────
+
+  # ── GCP Cloud Run ────────────────────────────────────────────────────────────
+  # Required secrets: GCP_CREDENTIALS_JSON
+  #
+  # deploy-cloud-run:
+  #   needs: build-and-push
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: google-github-actions/auth@v2
+  #       with:
+  #         credentials_json: ${{ secrets.GCP_CREDENTIALS_JSON }}
+  #     - uses: google-github-actions/deploy-cloudrun@v2
+  #       with:
+  #         service: projectname-server
+  #         region: us-central1
+  #         image: ghcr.io/${{ github.repository_owner }}/projectname-server:${{ github.sha }}
+  #         env_vars: runmode=production,serverid=default,logging=normal,role=monolith
+
+  # ── AWS ECS ──────────────────────────────────────────────────────────────────
+  # Required secrets: AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY
+  # Update MY_CLUSTER and MY_SERVICE to match your ECS cluster and service names.
+  #
+  # deploy-ecs:
+  #   needs: build-and-push
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: aws-actions/configure-aws-credentials@v4
+  #       with:
+  #         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  #         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  #         aws-region: us-east-1
+  #     - name: Force new ECS deployment
+  #       run: |
+  #         aws ecs update-service \
+  #           --cluster MY_CLUSTER \
+  #           --service MY_SERVICE \
+  #           --force-new-deployment
+
+  # ── fly.io ───────────────────────────────────────────────────────────────────
+  # Required secrets: FLY_API_TOKEN
+  # Run `fly launch` once locally to generate fly.toml, then commit it.
+  #
+  # deploy-fly:
+  #   needs: build-and-push
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - uses: superfly/flyctl-actions/setup-flyctl@master
+  #     - run: flyctl deploy --remote-only
+  #       env:
+  #         FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/templates/serverpod_templates/projectname_server/README.md
+++ b/templates/serverpod_templates/projectname_server/README.md
@@ -13,3 +13,30 @@ Then you can start the Serverpod server.
 When you are finished, you can shut down Serverpod with `Ctrl-C`, then stop Postgres and Redis.
 
     docker compose stop
+
+## Production Deployment
+
+This server includes a multi-stage `Dockerfile` for building a self-contained
+production image. Build and run it from the project root:
+
+    docker build -f projectname_server/Dockerfile -t projectname_server:latest .
+    docker run \
+      -e runmode=production \
+      -e serverid=default \
+      -e logging=normal \
+      -e role=monolith \
+      -p 8080:8080 -p 8081:8081 -p 8082:8082 \
+      projectname_server:latest
+
+The server reads `config/production.yaml` and `config/passwords.yaml` for
+database and Redis connection details. Run database migrations before starting:
+
+    dart run bin/main.dart --apply-migrations
+
+A ready-to-customize GitHub Actions deploy workflow is included at
+`.github/workflows/deploy.yml`. Open it and uncomment the platform section
+that matches your hosting provider (GCP Cloud Run, AWS ECS, or fly.io).
+
+For managed hosting, see [Serverpod Cloud](https://serverpod.dev/cloud).
+For self-hosting setup guides, see the
+[Serverpod deployment documentation](https://docs.serverpod.dev/deployment).

--- a/tests/bootstrap_project/test/project_test.dart
+++ b/tests/bootstrap_project/test/project_test.dart
@@ -614,6 +614,22 @@ void main() async {
             reason: 'analyze.yml workflow does not exist.',
           );
         });
+
+        test('has deploy workflow', () {
+          expect(
+            File(
+              path.join(
+                tempPath,
+                projectName,
+                '.github',
+                'workflows',
+                'deploy.yml',
+              ),
+            ).existsSync(),
+            isTrue,
+            reason: 'deploy.yml workflow does not exist.',
+          );
+        });
       });
 
       group('then the workspace', () {


### PR DESCRIPTION
## Summary

- Adds a `.github/workflows/deploy.yml` to the project template — a manually triggered (`workflow_dispatch`) GitHub Actions workflow that builds the existing `Dockerfile`, pushes the image to a container registry (ghcr.io by default), and provides commented-out deploy blocks for GCP Cloud Run, AWS ECS, and fly.io. Using `workflow_dispatch` means it never auto-runs and breaks CI for unconfigured new projects.
- Updates `projectname_server/README.md` with a "Production Deployment" section covering `docker build`/`docker run`, the four env vars (`runmode`, `serverid`, `logging`, `role`), running migrations, and links to Serverpod Cloud and the deployment docs.
- Adds a bootstrap test assertion that `deploy.yml` is present in the generated `.github/workflows/` directory.

No changes to `create.dart` — the existing `github` copier inside `_copyServerUpgrade` automatically picks up new files. The `projectname` Mustache slot in `deploy.yml` is replaced by the copier for each project name. Mini-template projects are unaffected (they don't invoke the github copier).

## Context

The deploy folder (AWS Terraform + GCP scripts + deployment CI/CD workflows) was removed in #4259 before v3.1.0. This left users of v3.x with no first-party deployment guidance beyond a bare `Dockerfile`. This PR replaces the old provider-specific Terraform approach with a lightweight, container-native workflow that works with any hosting platform.

## Test plan

- [ ] Run `dart test tests/bootstrap_project/` — new `'has deploy workflow'` assertion passes
- [ ] Run `serverpod create test_project` and verify `test_project/.github/workflows/deploy.yml` exists with `projectname` replaced
- [ ] Verify the generated `test_project_server/README.md` contains the "Production Deployment" section
- [ ] Confirm `serverpod create --template mini` does NOT generate `deploy.yml` (mini does not use the github copier)

Fixes #4703