### PR TITLE
fix: Preserve known CLI args when custom flags are present

### DIFF
--- a/packages/serverpod/lib/src/server/command_line_args.dart
+++ b/packages/serverpod/lib/src/server/command_line_args.dart
@@ -81,7 +81,7 @@ class CommandLineArgs {
           'apply-repair-migration',
           abbr: 'A',
         );
-      var results = argParser.parse(args);
+      var results = argParser.parse(_filterKnownArgs(argParser, args));
 
       _runMode = results['mode'];
       _serverId = results['server-id'];
@@ -146,6 +146,63 @@ class CommandLineArgs {
       CliArgsConstants.applyMigrations: _applyMigrations,
       CliArgsConstants.applyRepairMigration: _applyRepairMigration,
     };
+  }
+
+  // Strips tokens that the ArgParser does not know about so that user-defined
+  // custom flags (e.g. --myCustomFlag) are silently ignored instead of
+  // causing ArgParser.parse to throw and wipe out all known parsed values.
+  static List<String> _filterKnownArgs(ArgParser parser, List<String> args) {
+    final knownLong = <String>{};
+    final knownAbbr = <String>{};
+    final valueOptions = <String>{};
+
+    for (final entry in parser.options.entries) {
+      final longForm = '--${entry.key}';
+      knownLong.add(longForm);
+      final abbr = entry.value.abbr;
+      if (abbr != null) knownAbbr.add('-$abbr');
+      if (entry.value.type != OptionType.flag) {
+        valueOptions.add(longForm);
+        if (abbr != null) valueOptions.add('-$abbr');
+      }
+    }
+
+    final result = <String>[];
+    var i = 0;
+    while (i < args.length) {
+      final arg = args[i];
+      if (arg == '--') break;
+
+      String? name;
+      var hasEmbeddedValue = false;
+
+      if (arg.startsWith('--')) {
+        final eq = arg.indexOf('=');
+        if (eq >= 0) {
+          name = arg.substring(0, eq);
+          hasEmbeddedValue = true;
+        } else {
+          name = arg;
+        }
+      } else if (arg.startsWith('-') && arg.length == 2) {
+        name = arg;
+      }
+
+      if (name != null &&
+          (knownLong.contains(name) || knownAbbr.contains(name))) {
+        result.add(arg);
+        if (!hasEmbeddedValue &&
+            valueOptions.contains(name) &&
+            i + 1 < args.length &&
+            !args[i + 1].startsWith('-')) {
+          i++;
+          result.add(args[i]);
+        }
+      }
+
+      i++;
+    }
+    return result;
   }
 
   /// Returns a string representation of the command line arguments.

--- a/packages/serverpod/test/server/command_line_args_test.dart
+++ b/packages/serverpod/test/server/command_line_args_test.dart
@@ -375,4 +375,69 @@ void main() {
       expect(args3.role, equals(ServerpodRole.maintenance));
     });
   });
+
+  group('Given command line arguments with unknown custom flags', () {
+    test(
+      'when a custom flag follows a known option then the known option is respected',
+      () {
+        final args = CommandLineArgs(['--mode', 'production', '--myCustomFlag']);
+        expect(args.runMode, equals('production'));
+        expect(args.serverId, equals('default'));
+        expect(args.loggingMode, equals(ServerpodLoggingMode.normal));
+        expect(args.role, equals(ServerpodRole.monolith));
+        expect(args.applyMigrations, isFalse);
+        expect(args.applyRepairMigration, isFalse);
+      },
+    );
+
+    test(
+      'when a custom flag precedes a known option then the known option is respected',
+      () {
+        final args = CommandLineArgs(['--myCustomFlag', '--mode', 'production']);
+        expect(args.runMode, equals('production'));
+      },
+    );
+
+    test(
+      'when a custom option with a value precedes a known option then the known option is respected',
+      () {
+        final args = CommandLineArgs([
+          '--myCustomOption',
+          'someValue',
+          '--mode',
+          'production',
+        ]);
+        expect(args.runMode, equals('production'));
+      },
+    );
+
+    test(
+      'when a custom flag is mixed with known options using equals syntax then known options are respected',
+      () {
+        final args = CommandLineArgs([
+          '--mode=production',
+          '--myCustom=someValue',
+        ]);
+        expect(args.runMode, equals('production'));
+      },
+    );
+
+    test(
+      'when multiple known options are mixed with custom flags then all known options are parsed correctly',
+      () {
+        final args = CommandLineArgs([
+          '--mode', 'production',
+          '--myCustomFlag',
+          '--server-id', 'my-server',
+          '--anotherCustom', 'val',
+          '--role', 'serverless',
+          '--apply-migrations',
+        ]);
+        expect(args.runMode, equals('production'));
+        expect(args.serverId, equals('my-server'));
+        expect(args.role, equals(ServerpodRole.serverless));
+        expect(args.applyMigrations, isTrue);
+      },
+    );
+  });
 }

--- a/packages/serverpod/test/server/command_line_args_test.dart
+++ b/packages/serverpod/test/server/command_line_args_test.dart
@@ -380,7 +380,11 @@ void main() {
     test(
       'when a custom flag follows a known option then the known option is respected',
       () {
-        final args = CommandLineArgs(['--mode', 'production', '--myCustomFlag']);
+        final args = CommandLineArgs([
+          '--mode',
+          'production',
+          '--myCustomFlag',
+        ]);
         expect(args.runMode, equals('production'));
         expect(args.serverId, equals('default'));
         expect(args.loggingMode, equals(ServerpodLoggingMode.normal));
@@ -393,7 +397,11 @@ void main() {
     test(
       'when a custom flag precedes a known option then the known option is respected',
       () {
-        final args = CommandLineArgs(['--myCustomFlag', '--mode', 'production']);
+        final args = CommandLineArgs([
+          '--myCustomFlag',
+          '--mode',
+          'production',
+        ]);
         expect(args.runMode, equals('production'));
       },
     );
@@ -426,11 +434,15 @@ void main() {
       'when multiple known options are mixed with custom flags then all known options are parsed correctly',
       () {
         final args = CommandLineArgs([
-          '--mode', 'production',
+          '--mode',
+          'production',
           '--myCustomFlag',
-          '--server-id', 'my-server',
-          '--anotherCustom', 'val',
-          '--role', 'serverless',
+          '--server-id',
+          'my-server',
+          '--anotherCustom',
+          'val',
+          '--role',
+          'serverless',
           '--apply-migrations',
         ]);
         expect(args.runMode, equals('production'));


### PR DESCRIPTION
## Summary

Closes #2396

`ArgParser.parse` throws `ArgParserException` on any unrecognised flag or option. The catch block in `CommandLineArgs` was nulling **all** fields on any parse failure — so passing a custom flag like `--myCustomFlag` alongside `--mode=production` caused the server to silently start in development mode.

### Root cause

```
dart bin/main.dart --mode=production --myCustomFlag
# ArgParser throws on --myCustomFlag
# catch block nulls _runMode, so runMode falls back to "development"
```

### Fix

Added `_filterKnownArgs` — a static helper that walks the raw token list and strips any flag or option the `ArgParser` doesn't know about, based on `parser.options` (so it's always in sync with the registered args). The filtered list is then passed to `parse()`.

- Unknown flags (`--myCustomFlag`) → silently ignored ✓  
- Unknown options with values (`--myCustomOption someValue`) → silently ignored ✓  
- Known options with invalid values (`--logging invalid`) → still trigger the catch + fall back to defaults ✓  
- All existing behaviour for malformed args preserved ✓

## Test plan

- [ ] All 24 existing tests still pass
- [ ] 5 new tests cover: custom flag after known option, before known option, custom option+value before known option, `=`-style syntax, and multiple known options mixed with multiple custom flags
- [ ] 29/29 total tests passing