### PR TITLE
fix: Exclude static methods from endpoint code generation

### DIFF
--- a/tools/serverpod_cli/lib/src/analyzer/dart/endpoint_analyzers/endpoint_method_analyzer.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/dart/endpoint_analyzers/endpoint_method_analyzer.dart
@@ -80,6 +80,7 @@ abstract class EndpointMethodAnalyzer {
   /// be validated and parsed.
   static bool isEndpointMethod(MethodElement method) {
     if (method.isPrivate) return false;
+    if (method.isStatic) return false;
     if (method.markedAsIgnored) return false;
 
     if (_excludedMethodNameSet.contains(method.name)) return false;

--- a/tools/serverpod_cli/test/integration/analyzer/dart/endpoint_validation/endpoint_method_test.dart
+++ b/tools/serverpod_cli/test/integration/analyzer/dart/endpoint_validation/endpoint_method_test.dart
@@ -949,6 +949,86 @@ class ExampleEndpoint extends Endpoint {
     });
   });
 
+  group('Given a valid endpoint with static method when analyzed', () {
+    var collector = CodeGenerationCollector();
+    var testDirectory = Directory(
+      path.join(testProjectDirectory.path, const Uuid().v4()),
+    );
+
+    late List<EndpointDefinition> endpointDefinitions;
+    late EndpointsAnalyzer analyzer;
+    setUpAll(() async {
+      var endpointFile = File(path.join(testDirectory.path, 'endpoint.dart'));
+      endpointFile.createSync(recursive: true);
+      endpointFile.writeAsStringSync('''
+import 'package:serverpod/serverpod.dart';
+
+class ExampleEndpoint extends Endpoint {
+  static Future<String> hello(Session session, String name) async {
+    return 'Hello \$name';
+  }
+}
+''');
+      analyzer = EndpointsAnalyzer(testDirectory);
+      endpointDefinitions = await analyzer.analyze(collector: collector);
+    });
+
+    test('then no validation errors are reported.', () {
+      expect(collector.errors, isEmpty);
+    });
+
+    test('then endpoint definition is created.', () {
+      expect(endpointDefinitions, hasLength(1));
+    });
+
+    test('then endpoint definition does not have method defined.', () {
+      var methods = endpointDefinitions.firstOrNull?.methods;
+      expect(methods, isEmpty);
+    });
+  });
+
+  group(
+    'Given a valid endpoint with static and instance methods when analyzed',
+    () {
+      var collector = CodeGenerationCollector();
+      var testDirectory = Directory(
+        path.join(testProjectDirectory.path, const Uuid().v4()),
+      );
+
+      late List<EndpointDefinition> endpointDefinitions;
+      late EndpointsAnalyzer analyzer;
+      setUpAll(() async {
+        var endpointFile = File(path.join(testDirectory.path, 'endpoint.dart'));
+        endpointFile.createSync(recursive: true);
+        endpointFile.writeAsStringSync('''
+import 'package:serverpod/serverpod.dart';
+
+class ExampleEndpoint extends Endpoint {
+  static Future<String> staticHelper(Session session, String name) async {
+    return 'Hello \$name';
+  }
+
+  Future<String> hello(Session session, String name) async {
+    return 'Hello \$name';
+  }
+}
+''');
+        analyzer = EndpointsAnalyzer(testDirectory);
+        endpointDefinitions = await analyzer.analyze(collector: collector);
+      });
+
+      test('then no validation errors are reported.', () {
+        expect(collector.errors, isEmpty);
+      });
+
+      test('then endpoint definition has only the instance method.', () {
+        var methods = endpointDefinitions.firstOrNull?.methods;
+        expect(methods, hasLength(1));
+        expect(methods?.firstOrNull?.name, 'hello');
+      });
+    },
+  );
+
   group(
     'Given a valid endpoint with multiple methods defined when analyzed',
     () {


### PR DESCRIPTION
## Summary

Closes #1533

Static methods on `Endpoint` subclasses were silently included in code generation. The generated dispatch layer instance-casts the endpoint before calling the method (e.g. `(endpoints['x'] as XEndpoint).method(session, ...)`), which is a compile error for `static` members.

### Root cause

`EndpointMethodAnalyzer.isEndpointMethod` checked `isPrivate` and `markedAsIgnored` but not `isStatic`. `ClassElement.methods` (iterated by the endpoints analyzer) includes static methods, so they reached the generator unchanged.

### Fix

One-line guard — `if (method.isStatic) return false;` — mirrors the existing `isPrivate` check.

`@doNotGenerate` remains the opt-out for other cases where an instance method should not be generated.

## Test plan

- [ ] Existing 108 endpoint method tests still pass
- [ ] New test: endpoint with only a static method → 0 methods in the definition, no errors
- [ ] New test: endpoint with static + instance method → only the instance method is generated
- [ ] 110/110 tests passing