### PR TITLE
fix: Change testObjectToJson return type from dynamic to Map<String, dynamic>

### DIFF
--- a/packages/serverpod_test/lib/src/test_encode.dart
+++ b/packages/serverpod_test/lib/src/test_encode.dart
@@ -4,6 +4,6 @@ import 'package:serverpod/serverpod.dart';
 
 /// A test helper that serializes objects to JSON before passing it to [EndpointDispatch].
 /// Used by the generated code.
-dynamic testObjectToJson(dynamic object) {
+Map<String, dynamic> testObjectToJson(dynamic object) {
   return jsonDecode(SerializationManager.encodeForProtocol(object));
 }


### PR DESCRIPTION
## Summary

Closes #3235

`testObjectToJson` in `packages/serverpod_test/lib/src/test_encode.dart` returned `dynamic`, but its result is passed directly to `EndpointDispatch.getMethodCallContext` which expects `Map<String, dynamic> parameters`. Users with `strict-casts: true` (or `implicit-casts: false`) in their analysis options got an `argument_type_not_assignable` error in the generated test tools.

### Why the narrower type is safe

The generated test tools always call `testObjectToJson` with a `Map<String, String>` literal (e.g. `testObjectToJson({'seconds': seconds})`). `SerializationManager.encodeForProtocol` encodes this to a JSON object string, and `jsonDecode` of a JSON object always returns `Map<String, dynamic>`. The return type annotation now matches the actual runtime type.

## Test plan

- [ ] `dart analyze packages/serverpod_test/lib/src/test_encode.dart` — no issues
- [ ] Existing generated test tools compile without warnings under strict analysis