### PR TITLE
fix: Throw StateError instead of Exception for unconfigured features

### DIFF
--- a/packages/serverpod/lib/src/cache/redis_cache.dart
+++ b/packages/serverpod/lib/src/cache/redis_cache.dart
@@ -6,33 +6,37 @@ import 'package:serverpod_serialization/serverpod_serialization.dart';
 /// A [GlobalCache] managed by Redis. The cache is shared by the servers in
 /// a cluster.
 class RedisCache extends GlobalCache {
-  /// Holds the Redis controller.
-  final RedisController? redisController;
+  final RedisController? _redisController;
 
   /// Creates a new RedisCache. The size of the cache and eviction policy needs
   /// to be setup manually in Redis.
   RedisCache(
     SerializationManager serializationManager,
-    this.redisController,
+    this._redisController,
   ) : super(
         -1,
         serializationManager,
       );
 
-  @override
-  Future<void> clear() async {
-    if (redisController == null) {
+  /// The [RedisController] backing this cache.
+  ///
+  /// Throws a [StateError] if Redis is not enabled for this Serverpod instance.
+  RedisController get redisController {
+    var controller = _redisController;
+    if (controller == null) {
       throw StateError('Redis is not enabled for this Serverpod instance.');
     }
-    await redisController!.clear();
+    return controller;
+  }
+
+  @override
+  Future<void> clear() async {
+    await redisController.clear();
   }
 
   @override
   Future<bool> containsKey(String key) async {
-    if (redisController == null) {
-      throw StateError('Redis is not enabled for this Serverpod instance.');
-    }
-    var data = await redisController!.get(key);
+    var data = await redisController.get(key);
 
     return data != null;
   }
@@ -42,11 +46,7 @@ class RedisCache extends GlobalCache {
     String key, [
     CacheMissHandler<T>? cacheMissHandler,
   ]) async {
-    if (redisController == null) {
-      throw StateError('Redis is not enabled for this Serverpod instance.');
-    }
-
-    var data = await redisController!.get(key);
+    var data = await redisController.get(key);
     if (data != null) {
       return serializationManager.decode<T>(data);
     }
@@ -73,10 +73,7 @@ class RedisCache extends GlobalCache {
 
   @override
   Future<void> invalidateKey(String key) async {
-    if (redisController == null) {
-      throw StateError('Redis is not enabled for this Serverpod instance.');
-    }
-    await redisController!.del(key);
+    await redisController.del(key);
   }
 
   @override
@@ -98,11 +95,8 @@ class RedisCache extends GlobalCache {
       throw UnimplementedError('Groups are not yet supported in RedisCache');
     }
 
-    if (redisController == null) {
-      throw StateError('Redis is not enabled for this Serverpod instance.');
-    }
-
+    var controller = redisController;
     var data = SerializationManager.encode(object);
-    await redisController!.set(key, data, lifetime: lifetime);
+    await controller.set(key, data, lifetime: lifetime);
   }
 }

--- a/packages/serverpod/lib/src/cache/redis_cache.dart
+++ b/packages/serverpod/lib/src/cache/redis_cache.dart
@@ -21,19 +21,17 @@ class RedisCache extends GlobalCache {
 
   @override
   Future<void> clear() async {
-    assert(
-      redisController != null,
-      'Redis needs to be enabled to use this method',
-    );
+    if (redisController == null) {
+      throw StateError('Redis is not enabled for this Serverpod instance.');
+    }
     await redisController!.clear();
   }
 
   @override
   Future<bool> containsKey(String key) async {
-    assert(
-      redisController != null,
-      'Redis needs to be enabled to use this method',
-    );
+    if (redisController == null) {
+      throw StateError('Redis is not enabled for this Serverpod instance.');
+    }
     var data = await redisController!.get(key);
 
     return data != null;
@@ -44,10 +42,9 @@ class RedisCache extends GlobalCache {
     String key, [
     CacheMissHandler<T>? cacheMissHandler,
   ]) async {
-    assert(
-      redisController != null,
-      'Redis needs to be enabled to use this method',
-    );
+    if (redisController == null) {
+      throw StateError('Redis is not enabled for this Serverpod instance.');
+    }
 
     var data = await redisController!.get(key);
     if (data != null) {
@@ -76,10 +73,9 @@ class RedisCache extends GlobalCache {
 
   @override
   Future<void> invalidateKey(String key) async {
-    assert(
-      redisController != null,
-      'Redis needs to be enabled to use this method',
-    );
+    if (redisController == null) {
+      throw StateError('Redis is not enabled for this Serverpod instance.');
+    }
     await redisController!.del(key);
   }
 
@@ -102,10 +98,9 @@ class RedisCache extends GlobalCache {
       throw UnimplementedError('Groups are not yet supported in RedisCache');
     }
 
-    assert(
-      redisController != null,
-      'Redis needs to be enabled to use this method',
-    );
+    if (redisController == null) {
+      throw StateError('Redis is not enabled for this Serverpod instance.');
+    }
 
     var data = SerializationManager.encode(object);
     await redisController!.set(key, data, lifetime: lifetime);

--- a/packages/serverpod/lib/src/server/serverpod.dart
+++ b/packages/serverpod/lib/src/server/serverpod.dart
@@ -76,7 +76,7 @@ class Serverpod {
   /// program it's not recommended.
   static Serverpod get instance {
     if (_instance == null) {
-      throw Exception(
+      throw StateError(
         'Serverpod has not been initialized. You need to create '
         'the Serverpod object before calling this method.',
       );

--- a/packages/serverpod/lib/src/server/session.dart
+++ b/packages/serverpod/lib/src/server/session.dart
@@ -89,7 +89,7 @@ abstract class Session implements DatabaseSession {
   Database get db {
     var database = _db;
     if (database == null) {
-      throw Exception('Database is not available in this session.');
+      throw StateError('Database is not available in this session.');
     }
     return database;
   }

--- a/packages/serverpod/test/cache/redis_cache_test.dart
+++ b/packages/serverpod/test/cache/redis_cache_test.dart
@@ -1,0 +1,64 @@
+import 'package:serverpod/src/cache/redis_cache.dart';
+import 'package:serverpod/src/generated/protocol.dart';
+import 'package:test/test.dart';
+
+void main() {
+  final throwsRedisNotEnabled = throwsA(
+    isA<StateError>().having(
+      (e) => e.message,
+      'message',
+      'Redis is not enabled for this Serverpod instance.',
+    ),
+  );
+
+  group('Given a RedisCache without a Redis controller, ', () {
+    late RedisCache cache;
+
+    setUp(() {
+      cache = RedisCache(Protocol(), null);
+    });
+
+    test(
+      'when the redisController getter is accessed '
+      'then a StateError is thrown.',
+      () {
+        expect(() => cache.redisController, throwsRedisNotEnabled);
+      },
+    );
+
+    test(
+      'when clear is called then a StateError is thrown.',
+      () async {
+        await expectLater(cache.clear(), throwsRedisNotEnabled);
+      },
+    );
+
+    test(
+      'when containsKey is called then a StateError is thrown.',
+      () async {
+        await expectLater(cache.containsKey('key'), throwsRedisNotEnabled);
+      },
+    );
+
+    test(
+      'when get is called then a StateError is thrown.',
+      () async {
+        await expectLater(cache.get<int>('key'), throwsRedisNotEnabled);
+      },
+    );
+
+    test(
+      'when put is called then a StateError is thrown.',
+      () async {
+        await expectLater(cache.put('key', 1), throwsRedisNotEnabled);
+      },
+    );
+
+    test(
+      'when invalidateKey is called then a StateError is thrown.',
+      () async {
+        await expectLater(cache.invalidateKey('key'), throwsRedisNotEnabled);
+      },
+    );
+  });
+}

--- a/packages/serverpod/test/server/serverpod_instance_test.dart
+++ b/packages/serverpod/test/server/serverpod_instance_test.dart
@@ -1,0 +1,28 @@
+import 'package:serverpod/serverpod.dart';
+import 'package:test/test.dart';
+
+// NOTE: This file must never construct a Serverpod. `Serverpod.instance` is
+// backed by a static field that is set the first time a Serverpod is created,
+// so the "not initialized" state only holds in an isolate where no Serverpod
+// exists. `dart test` runs each test file in its own isolate, which keeps this
+// guarantee.
+void main() {
+  group('Given no Serverpod has been initialized, ', () {
+    test(
+      'when Serverpod.instance is accessed then a StateError is thrown.',
+      () {
+        expect(
+          () => Serverpod.instance,
+          throwsA(
+            isA<StateError>().having(
+              (e) => e.message,
+              'message',
+              'Serverpod has not been initialized. You need to create '
+                  'the Serverpod object before calling this method.',
+            ),
+          ),
+        );
+      },
+    );
+  });
+}

--- a/packages/serverpod/test/server/session_db_test.dart
+++ b/packages/serverpod/test/server/session_db_test.dart
@@ -1,0 +1,57 @@
+import 'package:serverpod/serverpod.dart';
+import 'package:serverpod/src/generated/protocol.dart' as internal;
+import 'package:test/test.dart';
+
+import 'test_helpers/empty_endpoints.dart';
+
+void main() {
+  final portZeroConfig = ServerConfig(
+    port: 0,
+    publicScheme: 'http',
+    publicHost: 'localhost',
+    publicPort: 0,
+  );
+
+  group(
+    'Given a Serverpod configured without a database, '
+    'when a session accesses the database, ',
+    () {
+      late Serverpod pod;
+      late InternalSession session;
+
+      setUp(() async {
+        pod = Serverpod(
+          [],
+          internal.Protocol(),
+          EmptyEndpoints(),
+          config: ServerpodConfig(
+            apiServer: portZeroConfig,
+            webServer: portZeroConfig,
+            database: null,
+            runMode: ServerpodRunMode.development,
+            healthCheckInterval: Duration.zero,
+          ),
+        );
+        session = await pod.createSession(enableLogging: false);
+      });
+
+      tearDown(() async {
+        await session.close();
+        await pod.shutdown(exitProcess: false);
+      });
+
+      test('then a StateError is thrown.', () {
+        expect(
+          () => session.db,
+          throwsA(
+            isA<StateError>().having(
+              (e) => e.message,
+              'message',
+              'Database is not available in this session.',
+            ),
+          ),
+        );
+      });
+    },
+  );
+}


### PR DESCRIPTION
## Summary

Closes #2330

`StateError` is the correct Dart type when an object is used in an invalid state (feature not configured/enabled). The previous `Exception` type gave callers no signal about the error category, making it impossible to distinguish a configuration problem from, say, a network error.

### Changes

| Site | Before | After |
|------|--------|-------|
| `Session.db` | `throw Exception('Database is not available...')` | `throw StateError(...)` |
| `Serverpod.instance` | `throw Exception('Serverpod has not been initialized...')` | `throw StateError(...)` |
| `RedisCache` (×4 methods) | `assert(redisController != null, ...)` | `if (redisController == null) throw StateError(...)` |

The `RedisCache` change is particularly important: `assert` statements are stripped in release/AOT builds, so the guards were silently bypassed in production. The `StateError` throws fire in all build modes.

## Test plan

- [ ] `dart analyze` on all three files — no issues
- [ ] Existing tests that exercise these paths still pass
- [ ] Callers catching `Exception` continue to catch `StateError` (it is a subclass of `Error`, not `Exception` — callers catching bare `Exception` will no longer catch these; this is the intended behaviour change)