### PR TITLE
feat: Add --org flag to serverpod create for Flutter app organization

### DIFF
--- a/tools/serverpod_cli/lib/src/commands/create.dart
+++ b/tools/serverpod_cli/lib/src/commands/create.dart
@@ -58,7 +58,15 @@ enum CreateOption<V> implements OptionDefinition<V> {
           'Can also be specified as the first argument.',
       mandatory: true,
     ),
-  )
+  ),
+  org(
+    StringOption(
+      argName: 'org',
+      helpText:
+          'The organization identifier in reverse-domain notation for the '
+          'Flutter app, e.g. com.example. Passed to `flutter create --org`.',
+    ),
+  ),
   ;
 
   static const _templateGroup = MutuallyExclusive(
@@ -98,6 +106,7 @@ class CreateCommand extends ServerpodCommand<CreateOption> {
         : commandConfig.value(CreateOption.template);
     var force = commandConfig.value(CreateOption.force);
     var name = commandConfig.value(CreateOption.name);
+    var org = commandConfig.optionalValue(CreateOption.org);
 
     // Get interactive flag from global configuration
     final interactive = serverpodRunner.globalConfiguration.optionalValue(
@@ -148,6 +157,7 @@ class CreateCommand extends ServerpodCommand<CreateOption> {
         force,
         state: CreateConfigState(template),
         interactive: true,
+        org: org,
       );
       return;
     }
@@ -157,6 +167,7 @@ class CreateCommand extends ServerpodCommand<CreateOption> {
       force,
       interactive: interactive,
       context: context,
+      org: org,
     );
 
     if (projectPath == null) {

--- a/tools/serverpod_cli/lib/src/commands/create.dart
+++ b/tools/serverpod_cli/lib/src/commands/create.dart
@@ -100,7 +100,15 @@ enum CreateOption<V> implements OptionDefinition<V> {
           'Can also be specified as the first argument.',
       mandatory: true,
     ),
-  )
+  ),
+  org(
+    StringOption(
+      argName: 'org',
+      helpText:
+          'The organization identifier in reverse-domain notation for the '
+          'Flutter app, e.g. com.example. Passed to `flutter create --org`.',
+    ),
+  ),
   ;
 
   static const _templateGroup = MutuallyExclusive(
@@ -174,6 +182,7 @@ class CreateCommand extends ServerpodCommand<CreateOption> {
     var template = commandConfig.value(CreateOption.template);
     var force = commandConfig.value(CreateOption.force);
     var name = commandConfig.value(CreateOption.name);
+    var org = commandConfig.optionalValue(CreateOption.org);
 
     // Get interactive flag from global configuration
     final interactive = serverpodRunner.globalConfiguration.optionalValue(
@@ -244,6 +253,7 @@ class CreateCommand extends ServerpodCommand<CreateOption> {
         force,
         template: template,
         interactive: true,
+        org: org,
       );
       return;
     }
@@ -254,6 +264,7 @@ class CreateCommand extends ServerpodCommand<CreateOption> {
       interactive: interactive,
       context: context,
       analyticsMethod: 'create',
+      org: org,
     );
 
     if (result is! CreateSuccess) {

--- a/tools/serverpod_cli/lib/src/commands/create/tui/runner.dart
+++ b/tools/serverpod_cli/lib/src/commands/create/tui/runner.dart
@@ -18,6 +18,7 @@ Future<void> performCreateWithTui(
   bool force, {
   required CreateConfigState state,
   required bool? interactive,
+  String? org,
 }) async {
   // Dry run to collect early errors and exit if needed.
   final dryRunProjectPath = await performCreate(
@@ -26,6 +27,7 @@ Future<void> performCreateWithTui(
     dryRun: true,
     interactive: interactive,
     context: state.toTemplateContext(),
+    org: org,
   );
 
   if (dryRunProjectPath == null) {
@@ -58,6 +60,7 @@ Future<void> performCreateWithTui(
           force,
           interactive: interactive,
           context: state.toTemplateContext(),
+          org: org,
         );
 
         final success = projectPath != null;

--- a/tools/serverpod_cli/lib/src/commands/create/tui/runner.dart
+++ b/tools/serverpod_cli/lib/src/commands/create/tui/runner.dart
@@ -121,6 +121,7 @@ Future<void> performCreateWithTui(
   List<ServerpodCreateConfig> configs = ServerpodCreateConfig.values,
   TemplateContext? defaultContext,
   bool requireIde = false,
+  String? org,
 }) async {
   final result = await getCreateConfigState(
     name: name,
@@ -166,6 +167,7 @@ Future<void> performCreateWithTui(
           createDefaultMigrationForUpgrade: createDefaultMigrationForUpgrade,
           context: state.toTemplateContext(),
           analyticsMethod: analyticsMethod,
+          org: org,
         );
 
         final success = result is CreateSuccess;

--- a/tools/serverpod_cli/lib/src/create/create.dart
+++ b/tools/serverpod_cli/lib/src/create/create.dart
@@ -98,6 +98,7 @@ Future<String?> performCreate(
   required bool? interactive,
   required TemplateContext context,
   Directory? workingDirectory,
+  String? org,
 }) async {
   _errorBuffer.clear();
   // Resolve where the project will be created relative to [workingDirectory]
@@ -234,7 +235,7 @@ Future<String?> performCreate(
     success &= await log.progress(
       'Creating Flutter app platform files.',
       () {
-        return CommandLineTools.flutterCreate(serverpodDirs.flutterDir);
+        return CommandLineTools.flutterCreate(serverpodDirs.flutterDir, org: org);
       },
     );
     await log.progress('Updating Flutter app MacOS entitlements.', () {

--- a/tools/serverpod_cli/lib/src/create/create.dart
+++ b/tools/serverpod_cli/lib/src/create/create.dart
@@ -131,6 +131,10 @@ Future<CreateResult> performCreate(
   /// Identifies which command scaffolded the project (`create` or `quickstart`)
   /// for the `cli.project_created` event. Omit to skip the event.
   String? analyticsMethod,
+
+  /// Organization identifier in reverse-domain notation forwarded to
+  /// `flutter create --org` when scaffolding the companion Flutter app.
+  String? org,
 }) async {
   _errorBuffer.clear();
   // Resolve where the project will be created relative to [workingDirectory]
@@ -281,7 +285,10 @@ Future<CreateResult> performCreate(
     success &= await log.progress(
       'Creating Flutter app platform files.',
       () {
-        return CommandLineTools.flutterCreate(serverpodDirs.flutterDir);
+        return CommandLineTools.flutterCreate(
+          serverpodDirs.flutterDir,
+          org: org,
+        );
       },
     );
     await log.progress('Updating Flutter app MacOS entitlements.', () {

--- a/tools/serverpod_cli/lib/src/generated/completion_script_carapace.dart
+++ b/tools/serverpod_cli/lib/src/generated/completion_script_carapace.dart
@@ -61,6 +61,7 @@ commands:
       --no-website: "Configure the server to host a website."
       --ide=*: "Configure agent skills and MCP servers for one or more IDEs. Use \"none\" to disable all IDE configuration."
       -n, --name=!: "The name of the project to create.\nCan also be specified as the first argument."
+      --org=: "The organization identifier in reverse-domain notation for the Flutter app, e.g. com.example. Passed to `flutter create --org`."
     exclusiveFlags:
       - [database, no-database]
       - [redis, no-redis]

--- a/tools/serverpod_cli/lib/src/util/command_line_tools.dart
+++ b/tools/serverpod_cli/lib/src/util/command_line_tools.dart
@@ -40,12 +40,16 @@ class CommandLineTools {
     return true;
   }
 
-  static Future<bool> flutterCreate(Directory dir) async {
+  static Future<bool> flutterCreate(Directory dir, {String? org}) async {
     log.debug('Running `flutter create .` in ${dir.path}', newParagraph: true);
 
     var exitCode = await _runProcessWithDefaultLogger(
       executable: 'flutter',
-      arguments: ['create', '.'],
+      arguments: [
+        'create',
+        if (org != null) ...['--org', org],
+        '.',
+      ],
       workingDirectory: dir.path,
     );
 

--- a/tools/serverpod_cli/lib/src/util/command_line_tools.dart
+++ b/tools/serverpod_cli/lib/src/util/command_line_tools.dart
@@ -71,12 +71,16 @@ class CommandLineTools {
     return true;
   }
 
-  static Future<bool> flutterCreate(Directory dir) async {
+  static Future<bool> flutterCreate(Directory dir, {String? org}) async {
     log.debug('Running `flutter create .` in ${dir.path}', newParagraph: true);
 
     var exitCode = await _runProcessWithDefaultLogger(
       executable: 'flutter',
-      arguments: ['create', '.'],
+      arguments: [
+        'create',
+        if (org != null) ...['--org', org],
+        '.',
+      ],
       workingDirectory: dir.path,
     );
 

--- a/tools/serverpod_cli/lib/src/util/command_line_tools.dart
+++ b/tools/serverpod_cli/lib/src/util/command_line_tools.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 import 'package:cli_tools/cli_tools.dart';
+import 'package:meta/meta.dart';
 import 'package:serverpod_cli/src/util/serverpod_cli_logger.dart';
 
 class CommandLineTools {
@@ -71,16 +72,22 @@ class CommandLineTools {
     return true;
   }
 
+  /// Arguments for the `flutter create` invocation made by [flutterCreate].
+  /// [org] is forwarded as `--org`, which sets the bundle and package
+  /// identifier prefix of the generated Flutter app.
+  @visibleForTesting
+  static List<String> flutterCreateArguments({String? org}) => [
+    'create',
+    if (org != null) ...['--org', org],
+    '.',
+  ];
+
   static Future<bool> flutterCreate(Directory dir, {String? org}) async {
     log.debug('Running `flutter create .` in ${dir.path}', newParagraph: true);
 
     var exitCode = await _runProcessWithDefaultLogger(
       executable: 'flutter',
-      arguments: [
-        'create',
-        if (org != null) ...['--org', org],
-        '.',
-      ],
+      arguments: flutterCreateArguments(org: org),
       workingDirectory: dir.path,
     );
 

--- a/tools/serverpod_cli/test/commands/create_command_test.dart
+++ b/tools/serverpod_cli/test/commands/create_command_test.dart
@@ -1,0 +1,37 @@
+import 'package:serverpod_cli/src/commands/create.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Given a CreateCommand', () {
+    late CreateCommand command;
+
+    setUp(() {
+      command = CreateCommand();
+    });
+
+    test('when parsing configuration without org, then org is null', () {
+      final argResults = command.argParser.parse(['myproject']);
+      final config = command.resolveConfiguration(argResults);
+
+      expect(config.errors, isEmpty);
+      expect(config.optionalValue(CreateOption.org), isNull);
+    });
+
+    test(
+      'when parsing configuration with org flag, then org is parsed correctly',
+      () {
+        final argResults = command.argParser.parse([
+          'myproject',
+          '--org=com.example',
+        ]);
+        final config = command.resolveConfiguration(argResults);
+
+        expect(config.errors, isEmpty);
+        expect(
+          config.optionalValue(CreateOption.org),
+          equals('com.example'),
+        );
+      },
+    );
+  });
+}

--- a/tools/serverpod_cli/test/util/command_line_tools_test.dart
+++ b/tools/serverpod_cli/test/util/command_line_tools_test.dart
@@ -1,0 +1,20 @@
+import 'package:serverpod_cli/src/util/command_line_tools.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Given the arguments for `flutter create`', () {
+    test('when no org is provided, then --org is omitted', () {
+      expect(
+        CommandLineTools.flutterCreateArguments(),
+        equals(['create', '.']),
+      );
+    });
+
+    test('when an org is provided, then it is passed as --org', () {
+      expect(
+        CommandLineTools.flutterCreateArguments(org: 'com.example'),
+        equals(['create', '--org', 'com.example', '.']),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Closes #2949

Users can now pass a reverse-domain organization identifier when creating a new project:

```
serverpod create --org com.example my_project
```

The value is forwarded as `--org <value>` to `flutter create`, which sets the organization for the generated Flutter app (bundle ID on iOS, application ID on Android, etc.). Omitting `--org` preserves the existing behaviour.

### Changes

| File | Change |
|------|--------|
| `commands/create.dart` | Add `org` `StringOption`; read with `optionalValue`; pass to `performCreate`/`performCreateWithTui` |
| `create/create.dart` | Add `String? org` to `performCreate`; forward to `flutterCreate` |
| `commands/create/tui/runner.dart` | Add `String? org` to `performCreateWithTui`; thread through both `performCreate` calls (dry-run and real) |
| `util/command_line_tools.dart` | Add `String? org` to `flutterCreate`; include `--org <value>` in arguments when present |

## Test plan

- [ ] `dart analyze` on all four changed files — no issues
- [ ] `serverpod create my_project` (no `--org`) — behaviour unchanged
- [ ] `serverpod create --org com.example my_project` — Flutter app is created with correct bundle/application ID