### PR TITLE
fix: Add production deployment docs and docker run GLIBC smoke test

### DIFF
--- a/templates/serverpod_templates/projectname_server/README.md
+++ b/templates/serverpod_templates/projectname_server/README.md
@@ -13,3 +13,25 @@ Then you can start the Serverpod server.
 When you are finished, you can shut down Serverpod with `Ctrl-C`, then stop Postgres and Redis.
 
     docker compose stop
+
+## Production Deployment
+
+The server is packaged as a Docker image. Build it from the **project root** (one level above this directory):
+
+    docker build -f projectname_server/Dockerfile . -t my-image
+
+Run the image with the four required environment variables:
+
+    docker run -d \
+      -e runmode=production \
+      -e serverid=default \
+      -e logging=normal \
+      -e role=monolith \
+      -p 8080:8080 -p 8081:8081 -p 8082:8082 \
+      my-image
+
+Before the first run, apply database migrations:
+
+    docker run --rm -e runmode=production my-image --apply-migrations
+
+For cloud-specific deployment guides (GCP Cloud Run, AWS ECS, fly.io, and others), see the [Serverpod deployment documentation](https://docs.serverpod.dev).

--- a/tests/bootstrap_project/test/project_test.dart
+++ b/tests/bootstrap_project/test/project_test.dart
@@ -1095,6 +1095,85 @@ void main() async {
           ? 'Windows does not support Docker builds in GitHub Actions.'
           : null,
     );
+
+    test(
+      'when running the server Docker image it starts without GLIBC errors',
+      () async {
+        // Temporarily remove parameters from server.dart that have not been
+        // published yet, because the Dockerfile won't have access to the local
+        // override. Once published, we can remove these.
+        final serverFile = File(path.join(commandRoot, 'lib', 'server.dart'));
+        final serverSource = serverFile.readAsStringSync();
+        const wasmHeaders = 'enableWasmHeaders: false,';
+        // TODO: Remove once Session.alert is published.
+        const sessionAlert = 'session.alert(';
+        serverFile.writeAsStringSync(
+          serverSource
+              .replaceAll(wasmHeaders, '')
+              .replaceAll(sessionAlert, 'session.log('),
+        );
+
+        final imageTag = '${projectName.toLowerCase()}_smoke';
+
+        final buildResult = await runProcess(
+          'docker',
+          [
+            'build',
+            '-t',
+            imageTag,
+            '-f',
+            path.join('${projectName}_server', 'Dockerfile'),
+            '.',
+          ],
+          workingDirectory: path.join(tempPath, projectName),
+        );
+
+        addTearDown(() async {
+          await runProcess('docker', ['rmi', '-f', imageTag]);
+        });
+
+        expect(
+          buildResult.exitCode,
+          0,
+          reason: 'Failed to build the generated server Docker image.',
+        );
+
+        // Run the server binary briefly with a shell timeout.
+        // A GLIBC dynamic-linker error appears before Dart starts, so if the
+        // server prints its version line ("SERVERPOD version: ..."), the binary
+        // loaded correctly. The server exits once it cannot reach the database.
+        final runResult = await runProcess(
+          'docker',
+          [
+            'run',
+            '--rm',
+            '--entrypoint',
+            'sh',
+            imageTag,
+            '-c',
+            'timeout 10 ./bin/server 2>&1; exit 0',
+          ],
+        );
+
+        final output = '${runResult.stdout}${runResult.stderr}';
+
+        expect(
+          output,
+          isNot(contains('GLIBC')),
+          reason:
+              'Production Docker image failed with a GLIBC error: $output',
+        );
+        expect(
+          output,
+          contains('SERVERPOD'),
+          reason:
+              'Server binary did not produce expected startup output: $output',
+        );
+      },
+      skip: Platform.isWindows
+          ? 'Windows does not support Docker builds in GitHub Actions.'
+          : null,
+    );
   });
 
   group('Given a created project and a running docker environment', () {


### PR DESCRIPTION
Closes #1309

## Summary

Issue #1309 reported a `GLIBC_2.33' not found` error when deploying to GCP Cloud Run with Serverpod v1.1.1. The underlying technical bug was fixed by Dockerfile evolution (PRs #1825 → #2193 → #5260): the `alpine + COPY /runtime/ /` pattern ships Dart's own glibc into the container so the AOT binary never touches Alpine's musl. Two gaps remained:

- The generated server `README.md` had no production deployment guidance (15-line dev-only file).
- CI tested `docker build` but never `docker run`, leaving the GLIBC fix unguarded against regression.

This PR closes both:

- **README template** (`templates/serverpod_templates/projectname_server/README.md`): adds a "Production Deployment" section covering `docker build` from the project root (required by the workspace-aware Dockerfile), `docker run` with the four env vars, applying migrations before first start, and a link to the deployment docs for cloud-specific guides.

- **Bootstrap CI smoke test** (`tests/bootstrap_project/test/project_test.dart`): builds the production image with a tag, runs it via `--entrypoint sh -c "timeout 10 ./bin/server 2>&1; exit 0"`, and asserts the output contains `SERVERPOD` (Dart started — binary loaded correctly) and does not contain `GLIBC` (no dynamic-linker error). The server exits once it cannot reach the database; no Postgres setup is needed. Alpine's BusyBox includes `timeout`, so the 10-second cap is reliable.

## Test plan

- [ ] `dart test tests/bootstrap_project/` — new smoke test passes (requires Docker)
- [ ] `serverpod create myapp` and verify `myapp_server/README.md` contains the "Production Deployment" section with `myapp_server/Dockerfile` in the build command
- [ ] Verify the smoke test correctly catches a regression by temporarily replacing `FROM alpine:latest` with `FROM busybox` (musl) — test should fail on the `contains('SERVERPOD')` assertion