### PR TITLE
fix: Add checkmark to browser refresh log

### DIFF
--- a/tools/serverpod_cli/lib/src/commands/messages.dart
+++ b/tools/serverpod_cli/lib/src/commands/messages.dart
@@ -13,6 +13,7 @@ const serverReloaded = '✓ Server reloaded.';
 const serverRestarted = '✓ Server restarted.';
 const flutterAppReloaded = '✓ Flutter app reloaded.';
 const flutterAppRestarted = '✓ Flutter app restarted.';
+const browserRefreshTriggered = '✓ Browser refresh triggered.';
 const flutterDependenciesChangedNative =
     'Flutter dependencies with native code changed. '
     'Relaunching the Flutter app...';

--- a/tools/serverpod_cli/lib/src/commands/start/watch_session.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/watch_session.dart
@@ -343,7 +343,7 @@ class WatchSession {
     }
     try {
       await _server.notifyStaticChange();
-      log.info('Browser refresh triggered.');
+      log.info(browserRefreshTriggered);
     } catch (e) {
       log.warning('Browser refresh failed: $e');
     }

--- a/tools/serverpod_cli/test/commands/start/watch_session_test.dart
+++ b/tools/serverpod_cli/test/commands/start/watch_session_test.dart
@@ -1,6 +1,8 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:cli_tools/cli_tools.dart';
+import 'package:serverpod_cli/src/commands/messages.dart';
 import 'package:serverpod_cli/src/commands/start/file_watcher.dart';
 import 'package:serverpod_cli/src/commands/start/flutter_dependency_tracker.dart';
 import 'package:serverpod_cli/src/commands/start/flutter_process.dart';
@@ -145,9 +147,20 @@ class _FakeFlutter extends Fake implements FlutterProcess {
   }
 }
 
+class _TestLogger extends VoidLogger {
+  final List<String> infoMessages = [];
+
+  @override
+  void info(String message, {bool newParagraph = false, LogType? type}) {
+    infoMessages.add(message);
+  }
+}
+
 void main() {
+  final testLogger = _TestLogger();
+
   setUpAll(() {
-    initializeLogger();
+    initializeLoggerWith(testLogger);
   });
 
   tearDownAll(() async {
@@ -210,6 +223,7 @@ void main() {
     generateCalls = [];
     generateSuccess = true;
     generatedFiles = {};
+    testLogger.infoMessages.clear();
 
     session = buildSession(compiler: compiler, initialServer: server);
   });
@@ -291,6 +305,10 @@ void main() {
         // The browser refresh must follow the reload so the page re-fetches
         // the newly loaded server code.
         expect(server.calls, ['reload:/out.dill', 'notifyStaticChange']);
+        expect(
+          testLogger.infoMessages,
+          contains(browserRefreshTriggered),
+        );
       },
     );
   });


### PR DESCRIPTION
Adds the missing checkmark to the browser refresh success log emitted by `serverpod start`, so it matches the server and Flutter reload messages.

Fixes #5308.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

CI has passed for this PR.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.