### PR TITLE
docs: Rewrite MCP server design doc to match project-local socket

### DIFF
--- a/docs/design/mcp_server.md
+++ b/docs/design/mcp_server.md
@@ -1,21 +1,21 @@
-# Design: MCP Server for `serverpod start --watch`
+# Design: MCP Server for `serverpod start`
 
-This document describes the MCP (Model Context Protocol) integration for `serverpod start --watch`, allowing AI agents to programmatically interact with running dev environments.
+This document describes the MCP (Model Context Protocol) integration for `serverpod start`, allowing AI agents to programmatically interact with running dev environments.
 
 The integration has two parts:
 
-- A small **per-runner MCP server** that lives inside each `serverpod start --watch` process and exposes dev operations against that instance (currently: `apply_migrations`, `create_migration`, `hot_reload`, `tail_server_logs`).
-- A long-lived **bridge MCP server** (`serverpod mcp-server`) that sits on stdio between the AI client and the runners. It discovers running instances by scanning a shared socket directory, connects to one at a time, and forwards tool calls. The bridge survives runner restarts.
+- A small **per-runner MCP server** that lives inside each `serverpod start` process and exposes dev operations against that instance (`apply_migrations`, `create_migration`, `create_repair_migration`, `hot_reload`, `hot_restart`, `tail_server_logs`, `tail_flutter_logs`, `get_flutter_app_dtd`, and the `serverpod://vm-service` resource).
+- A long-lived **bridge MCP server** (`serverpod mcp-server`) that sits on stdio between the AI client and one runner. It is configured for a single server project, connects to that project's runner socket on demand, and forwards tool calls. The bridge survives runner restarts.
 
 The per-runner server runs inside the CLI process, alongside the compiler, file watcher, and watch session. It is not part of the server subprocess (the Serverpod application). This keeps dev tooling concerns out of the framework itself - the `serverpod` package should not impose an MCP dependency or dev-time features on the application server. It also means the MCP server has access to the CLI's internal state (the incremental compiler, the server process handle, the restart lifecycle) which the server subprocess does not.
 
 ## Motivation
 
-During development with `serverpod start --watch`, file watching, code generation, compilation, and hot reload are fully automatic. However, some operations require explicit intent - applying database migrations is destructive or schema-altering and should not happen automatically on file change.
+During development with `serverpod start`, file watching, code generation, compilation, and hot reload are fully automatic (when run with the default `--watch`). However, some operations require explicit intent - applying database migrations is destructive or schema-altering and should not happen automatically on file change.
 
 These operations currently require stopping the server, re-running with flags, or manual SQL. An MCP server lets AI agents trigger them in-context during a development session.
 
-The bridge layer solves a separate problem: when the runner process (`serverpod start --watch`) exits or is restarted, the MCP socket it owns goes with it. AI clients do not automatically reconnect to a dropped MCP server, so without a bridge the integration breaks every time the dev process is restarted. A persistent stdio bridge stays up across runner restarts and lets the client `connect` again. The MCP socket is owned by the CLI process, not the pod subprocess, so a pod restart leaves the socket intact.
+The bridge layer solves a separate problem: when the runner process (`serverpod start`) exits or is restarted, the MCP socket it owns goes with it. AI clients do not automatically reconnect to a dropped MCP server, so without a bridge the integration breaks every time the dev process is restarted. A persistent stdio bridge stays up across runner restarts and transparently reconnects to the socket the next time a tool is called. The MCP socket is owned by the CLI process, not the pod subprocess, so a pod restart leaves the socket intact.
 
 ## Architecture
 
@@ -27,14 +27,14 @@ AI client (e.g. Claude Code)
     ▼
 serverpod mcp-server             <- BridgeMcpServer (this process)
     │
-    │  scans .../serverpod/serverpod-<pid>-<project>.sock
-    │  connects to one at a time
+    │  connects to <serverDir>/.dart_tool/serverpod/mcp.sock
+    │  reconnects transparently across runner restarts
     │
-    ▼  unix socket  (re-established on each connect)
-serverpod start --watch   <- ServerpodMcpServer (per-runner)
+    ▼  unix socket  (re-established on demand)
+serverpod start   <- ServerpodMcpServer (per-runner)
 ```
 
-The bridge is **single-instance**: at any moment it forwards to at most one runner. Switching runners is an explicit `disconnect` then `connect` from the client. To bridge multiple AI windows to multiple projects, run one `serverpod mcp-server` per window.
+The bridge is **per-project**: each `serverpod mcp-server` is bound to one server directory and forwards to that project's runner. To work with multiple projects, configure one `serverpod mcp-server` entry per project (each with its own `--server-dir`).
 
 ### Transport: Unix domain sockets
 
@@ -42,24 +42,22 @@ Each runner binds to a Unix domain socket (AF_UNIX) rather than TCP or stdio. Th
 
 Requires Dart 3.11+ for AF_UNIX support on Windows.
 
-### Shared socket directory
+### Project-local socket directory
 
-Sockets live in a shared, per-machine temp directory:
+The socket lives inside the server project's `.dart_tool/`:
 
 ```
-<systemTemp>/serverpod/
-└── serverpod-<pid>-<project>.sock
+<serverDir>/.dart_tool/serverpod/
+└── mcp.sock
 ```
 
-- `<systemTemp>` is `Directory.systemTemp.path` (`/tmp` on Linux when `TMPDIR` is unset, `/var/folders/.../T/` on macOS, `C:\Users\<user>\AppData\Local\Temp` on Windows).
-- `<pid>` is the runner's OS process id.
-- `<project>` is the serverpod app name (`config.name`, with the `_server` suffix already stripped) sanitized to `[a-z0-9-]+`.
+- `<serverDir>` is the server package directory (the package that depends on `serverpod`).
+- There is exactly one socket per project; the filename is fixed (`mcp.sock`).
+- `.dart_tool/` is already VCS-ignored and per-project, so the socket is scoped, easy to locate, and never committed.
 
-**Why a shared dir, not project-local.** A bridge process needs to discover all running instances on the machine via a single `Directory.listSync()`. Embedding the PID in the filename means discovery is stat-only - there is no separate manifest file to keep in sync, and stale files are easy to identify by checking whether the PID is still alive.
+**Why project-local.** Each bridge is configured for a specific project (one MCP-config entry per project, pointed at its `--server-dir`), so it does not need to discover instances machine-wide - it already knows exactly which socket to connect to. A fixed, project-relative path means no manifest, no PID bookkeeping, and no shared directory to manage permissions on: the socket inherits the project directory's permissions, which are already per-user in any normal checkout.
 
-**Permissions.** The `serverpod/` directory is created with mode 0700 on POSIX so other local users cannot enter it - on Linux, where `<systemTemp>` is the shared `/tmp`, this is what keeps the per-runner sockets inaccessible to other users on the same machine. The directory is created via `Directory.systemTemp.createTempSync()` (which goes through `mkdtemp(3)` and gives 0700) and then renamed to the canonical name; rename preserves the inode and mode. Since the parent directory blocks traversal, the socket files inside don't need their own restrictive mode. On macOS and Windows the parent path is already per-user, so the 0700 is incidental there.
-
-The bridge cleans up dead-PID sockets opportunistically the next time it scans.
+**One runner per project.** Because the path is fixed, only one `serverpod start` can own a project's socket at a time. Before a runner takes over, it probes the socket (`_detectExistingInstance`); if another process is already listening, it bails out with a message instead of fighting over the path. A stale socket file left behind by a crashed runner is unlinked by `bindUnixSocket` before the next bind.
 
 ### `serverpod mcp-server` (the bridge)
 
@@ -68,77 +66,78 @@ The bridge cleans up dead-PID sockets opportunistically the next time it scans.
   "mcpServers": {
     "serverpod": {
       "command": "serverpod",
-      "args": ["mcp-server"]
+      "args": ["mcp-server", "--server-dir", "<path-to-server-package>"]
     }
   }
 }
 ```
 
-The bridge does not need a `--directory` flag - it discovers running instances by directory scan. The AI client picks one with the `connect` tool.
+The `--server-dir` (`-s`) flag points the bridge at one server package. It is auto-detected from the current working directory when omitted, but should be passed explicitly in monorepos with multiple server projects. The bridge connects to that project's socket lazily, on the first tool or resource call.
 
 #### Tools and resources exposed by the bridge
 
-The bridge owns four native tools and one native resource. Everything else is **auto-forwarded**: on `connect`, the bridge calls `listTools()` and `listResources()` on the upstream runner and registers a thin forwarder for each item not already owned natively. On `disconnect` the forwarders are unregistered. The MCP `listChanged` capability propagates these registrations to the AI client, so the upstream surface appears and disappears as the connection state changes.
+The bridge mirrors the runner's surface. Both the runner-side server and the bridge build their tool/resource lists from the same definitions in `runner_surface.dart` (`runnerStaticTools`, `runnerStaticResources`), so the two surfaces cannot drift. The bridge registers a thin forwarder for each at construction - so the full surface is advertised to the AI client immediately, before any runner is running - and each forwarder lazily connects to the runner when first invoked.
 
-Native tools (always present):
+Forwarded tools:
 
-| Tool         | Behavior                                                                                                                                                                                                                       |
-| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `connect`    | Attach to a running instance. `instanceId` accepts the project name or PID shown in `serverpod://instances`. Auto-picks if exactly one instance is running and the argument is omitted. Calling `connect` again switches instances. |
-| `disconnect` | Detach from the current instance without stopping it.                                                                                                                                                                          |
-| `spawn`      | Start a new `serverpod start --watch` process detached from the bridge. Optional `directory` to choose the server dir; optional `args` appended to the CLI. Polls the socket dir for up to ~10s for the new instance to appear. Does **not** auto-connect. |
-| `stop`       | Send SIGTERM to the named instance. Auto-disconnects if it was the connected one.                                                                                                                                              |
+| Tool                      | Behavior                                                                                                                        |
+| ------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `apply_migrations`        | Apply pending database migrations without restarting the server. Call after creating a migration.                              |
+| `create_migration`        | Create a new migration from the current model definitions. Writes files only; follow up with `apply_migrations`.               |
+| `create_repair_migration` | Create a repair migration that brings the live database in line with a target migration version (default: latest).             |
+| `hot_reload`              | Hot-reload the running server isolate, preserving in-memory state. Falls back to a restart. Mainly useful with `--no-watch`.    |
+| `hot_restart`             | Restart the running server process, dropping all in-memory state. Use when reload would not suffice or to recover a stuck isolate. |
+| `tail_server_logs`        | Return recent server log entries (structured logs plus completed operations). Newest last.                                     |
+| `tail_flutter_logs`       | Return recent raw stdout/stderr lines from the Flutter app started by `serverpod start`. Newest last.                          |
+| `get_flutter_app_dtd`     | Return the Dart Tooling Daemon (DTD) URI for the Flutter app. Null until the app publishes its DTD endpoint.                   |
 
-Native resource (always present):
+Forwarded resource:
 
-| Resource                | Behavior                                                                                                                                                      |
-| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `serverpod://instances` | JSON list of `{pid, project, socketPath, connected}` for each live runner. Updated when the socket directory changes or when the bridge connects/disconnects. |
+| Resource                 | Behavior                                                                                                                                              |
+| ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `serverpod://vm-service` | Dart VM service HTTP URI for the running server isolate. Stable across hot reloads; changes on restart (`hot_restart` or crash recovery). Subscribable. |
 
-Currently auto-forwarded from the runner once connected: the tools `apply_migrations`, `create_migration`, `hot_reload`, `tail_server_logs`, and the resource `serverpod://vm-service`. Adding a new tool or resource on the runner side requires no bridge changes - it appears in the AI client automatically on the next `connect`. Names that collide with a native bridge tool (`connect`/`disconnect`/`spawn`/`stop`) or URI (`serverpod://instances`) are skipped to keep the bridge's surface authoritative.
+When no runner is listening, tool forwarders return an error telling the agent to start the server with `serverpod start`, and the resource reader returns a `not-running` marker. As soon as a runner is up, the next call connects and succeeds - no client-side reconnect step is needed.
 
-For per-resource updates, the bridge subscribes to each forwarded resource on `connect` and re-emits `notifications/resources/updated` upstream. Resources that don't support subscription are silently skipped (reads still work).
+For per-resource updates, the bridge subscribes to each forwarded resource on connect and re-emits `notifications/resources/updated` to the client. Resources that don't support subscription are silently skipped (reads still work).
 
 ### `apply_migrations` tool (runner side)
 
-Restarts the server subprocess with `--apply-migrations` added to its arguments. This is a one-shot flag - subsequent restarts and reloads use the original args.
+`apply_migrations` connects to the database directly and applies pending migrations against the live schema, leaving the running pod in place (hot reload picks up any model code changes). When an MCP client (the bridge, in practice) calls it:
 
-When an MCP client (the bridge, in practice) calls `apply_migrations`:
+1. The watch session applies pending migrations through the same serialized chain as restart and reload, so a migration cannot interleave with a recompile.
+1. The tool returns success/failure status. On a database error or a disposed session, the tool returns an error.
 
-1. The watch session resets the compiler and does a full compile.
-1. The server subprocess is stopped and restarted with `--apply-migrations` appended.
-1. The tool returns success/failure status. On compilation failure or reentrancy, the tool returns an error.
-
-The runner's MCP socket survives the server-subprocess restart because the socket is owned by the CLI process, not the server subprocess.
+The runner's MCP socket survives this operation because the socket is owned by the CLI process, not the server subprocess.
 
 ## Implementation
 
 ### Shared helpers (`lib/src/mcp/socket_directory.dart`)
 
-- `serverpodMcpSocketDir`, `ensureServerpodMcpSocketDir` - the shared dir under `Directory.systemTemp`.
-- `serverpodMcpSocketPath({pid, project})` - canonical filename.
-- `sanitizeProjectName(name)` - `[^a-z0-9-]` -> `-`, collapse runs, strip ends.
-- `listServerpodMcpSockets()` - returns `(pid, project, path)` tuples for every live socket; deletes stale ones whose PID no longer exists. Liveness check: `kill -0 <pid>` on POSIX, `tasklist` on Windows.
+- `serverpodMcpSocketPath(serverDir)` - the canonical socket path, `<serverDir>/.dart_tool/serverpod/mcp.sock`.
 - `socketChannel(Socket)` - wraps a `Socket` in the line-delimited `StreamChannel<String>` that `dart_mcp` expects.
+
+The shared tool/resource definitions live in `lib/src/mcp/runner_surface.dart` and are consumed by both the runner-side server and the bridge forwarders.
+
+The low-level Unix socket primitives live in `serverpod_shared` (`bindUnixSocket`, `connectUnixSocket`, `hasUnixSocketSupport`, and the `sockaddr_un.sun_path` length checks). `bindUnixSocket` unlinks any stale file before binding and shortens the path to fit the platform's socket-path limit (104 bytes on macOS, 108 on Linux/Windows).
 
 ### Runner side (`lib/src/commands/start/mcp_socket.dart`)
 
-`McpSocketServer({required project})` derives its socket path from the current `pid` and the sanitized project. `start()` ensures the shared dir exists, binds the `ServerSocket`, and accepts at most one client at a time. `close()` shuts down the active MCP server, destroys the client socket, and unlinks the socket file. New connections wait for any in-flight shutdown to settle and are rejected once `close()` has been called.
+`McpSocketServer({required serverDir})` derives its socket path from `serverDir`. `start()` creates the parent directory if missing, binds the `ServerSocket` (unlinking any stale file), and accepts at most one client at a time. `close()` shuts down the active MCP server, destroys the client socket, and deletes the socket file. New connections wait for any in-flight shutdown to settle and are rejected once `close()` has been called.
 
-`ServerpodMcpServer` (`lib/src/commands/start/mcp_server.dart`) extends `MCPServer` with `ToolsSupport` and `ResourcesSupport`. It registers `apply_migrations`, `create_migration`, `hot_reload`, and `tail_server_logs` tools against callbacks wired by `start.dart` (`WatchSession.applyMigration`, a `createMigrationAction`-backed closure, `WatchSession.forceReload`, and a log-history getter respectively). It also exposes the `serverpod://vm-service` resource.
+`ServerpodMcpServer` (`lib/src/commands/start/mcp_server.dart`) extends `MCPServer` with `ToolsSupport` and `ResourcesSupport`. It registers every tool in `runnerStaticTools` against callbacks wired by `start.dart`, and exposes the `serverpod://vm-service` resource, re-emitting an update whenever the `vmServiceUriChanges` stream fires.
 
-### Bridge side (`lib/src/mcp/`)
+### Bridge side (`lib/src/mcp/bridge_mcp_server.dart`)
 
-- `ServerpodMcpBridge` - owns the discovered socket list. `scan()` re-reads the dir; `startWatching()` subscribes to `Directory.watch()` and coalesces bursts into single rescans via `asyncMapBuffer`; `findSocket(id)` matches by project then PID; `dispose()` cancels the watcher.
-- `BridgeMcpServer extends MCPServer with ToolsSupport, ResourcesSupport` - registers the native tools `connect`/`disconnect`/`spawn`/`stop` and the native `serverpod://instances` resource at construction. On each `connect`, calls `listTools()`/`listResources()` on the upstream `ServerConnection`, then `registerTool` / `addResource` for every item not in the bridge-native deny set, with thin closures that delegate via `_connection.callTool`/`readResource`. The corresponding `unregisterTool`/`removeResource` happens in `_disconnectInternal`, so `listChanged` notifications cleanly publish and unpublish the upstream surface as the connection toggles. When the upstream connection completes (runner died), `_disconnectInternal` runs from the `connection.done` callback so forwarded tools/resources disappear from the AI client.
+`BridgeMcpServer({required socketPath})` registers a forwarder for every `runnerStaticTools`/`runnerStaticResources` entry at construction. On the first call it lazily connects to the runner socket via `_ensureConnected`, which coalesces concurrent callers so a burst of tool calls opens a single connection. Each forwarder delegates through `_connection.callTool`/`readResource`; if no runner is listening, the tool forwarder returns a "not running" error and the resource reader returns a `not-running` marker. The bridge subscribes to the static resources and re-emits `resources/updated` to the client. When the upstream `connection.done` fires (the runner died or restarted), it drops the connection so the next call reconnects transparently. There is no `connect`/`disconnect`/`spawn`/`stop` surface - a bridge maps to exactly one project for its whole life.
 
 ### CLI command (`lib/src/commands/mcp.dart`)
 
-Validates Unix socket support, instantiates `ServerpodMcpBridge`, scans + starts watching, then wires `stdin`/`stdout` to a `BridgeMcpServer` via `dart_mcp`'s `stdioChannel`. Blocks on `server.done` so the process stays up as long as the AI client holds stdin open.
+`serverpod mcp-server [--server-dir <path>]` resolves the server directory (auto-detected from the cwd via `ServerDirectoryFinder`, or the explicit flag), validates Unix socket support, computes the socket path, and wires `stdin`/`stdout` to a `BridgeMcpServer` via `dart_mcp`'s `stdioChannel`. It blocks on `server.done` so the process stays up as long as the AI client holds stdin open.
 
 ### Integration with watch mode
 
-In `_startWatchSession()` and `_runTuiBackend()` (`start.dart`), the runner-side `McpSocketServer` is constructed with `project: config.name`. The `apply_migrations` callback is wired to `WatchSession.applyMigration`; the `create_migration` callback is a closure over `createMigrationAction(config: ...)` (the shared helper also used by the `serverpod create-migration` CLI command and the TUI "Create Migration" button); `hot_reload` is `WatchSession.forceReload`; `tail_server_logs` reads from `holder.state.logHistory` in the TUI path. The socket is closed on shutdown (signal, TUI quit, or session exit), which removes the file from the shared dir.
+In `_startWatchSession()` (`start.dart`), `McpSocketServer(serverDir: serverDir)` is started and its callbacks are wired: `apply_migrations` -> `WatchSession.applyMigration`; `create_migration` -> a `_createMigrationForMcp` closure (over the shared `createMigrationAction` helper used by `serverpod create-migration` and the TUI button); `create_repair_migration` -> `_createRepairMigrationForMcp`; `hot_reload` -> `WatchSession.forceReload`; `hot_restart` -> `WatchSession.forceRestart`; `tail_server_logs`/`tail_flutter_logs` -> log-history getters; `serverpod://vm-service` -> the proxy URI; `get_flutter_app_dtd` -> the Flutter process's DTD URI. The MCP server is started regardless of `--watch` (the flag only controls auto-reload on file changes). The socket is closed on shutdown (signal, TUI quit, or session exit), which removes the file.
 
 ### Live migration apply
 
@@ -146,24 +145,24 @@ In `_startWatchSession()` and `_runTuiBackend()` (`start.dart`), the runner-side
 
 ## Design Decisions
 
-### Why a shared temp dir rather than project-local sockets
+### Why a project-local socket rather than a shared temp dir
 
-A project-local socket (e.g. under `.dart_tool/serverpod/`) is invisible to a bridge that doesn't already know which projects to watch. Putting all sockets in one well-known directory means the bridge can discover instances with a stat-only scan. The PID embedded in the filename keeps discovery self-correcting (dead PIDs are obviously stale) without a separate manifest or daemon.
+A bridge is configured per project, so it always knows which socket to connect to - there is nothing to discover. A fixed, project-relative path under `.dart_tool/` avoids a shared machine-wide directory, a manifest file, PID bookkeeping, and any special permission handling: the socket inherits the project directory's (already per-user) permissions and is VCS-ignored. The single fixed path also doubles as a cheap lock - a second `serverpod start` for the same project detects the live socket and bails instead of colliding.
 
 ### Why a bridge at all
 
-Without a bridge, the MCP connection is bound to the runner's lifetime: stopping or restarting the `serverpod start --watch` process tears down the AI client's MCP server, and Claude Code does not auto-reconnect. A persistent stdio bridge breaks that coupling: runners are ephemeral, the bridge survives, and the client just calls `connect` again. (The MCP client never talks to the server subprocess directly, so server restarts triggered by `apply_migrations` or hot reload do not break the connection.)
+Without a bridge, the MCP connection is bound to the runner's lifetime: stopping or restarting the `serverpod start` process tears down the AI client's MCP server, and Claude Code does not auto-reconnect. A persistent stdio bridge breaks that coupling: runners are ephemeral, the bridge survives, and it reconnects to the socket on the next tool call. (The MCP client never talks to the server subprocess directly, so server restarts triggered by `apply_migrations`, `hot_reload`, or `hot_restart` do not break the connection.)
 
-### Single-instance bridge
+### One bridge per project
 
-Forwarding to one runner at a time keeps tool semantics unambiguous - the client always knows which project an `apply_migrations` call lands on. Multi-attach would force every forwarded tool to grow a target argument and risk silent cross-project effects. Users with multiple projects open run one bridge per AI window.
+Binding each bridge to a single project keeps tool semantics unambiguous - the client always knows which project an `apply_migrations` call lands on. A multi-project bridge would force every forwarded tool to grow a target argument and risk silent cross-project effects. Users with multiple projects open configure one bridge entry per project.
 
 ### What belongs on the MCP server
 
 Any operation that the AI agent reaches for mid-session against a running dev environment belongs on the MCP server, whether or not it strictly needs the CLI's in-memory state. Keeping those operations behind the socket gives agents a stable, discoverable interface tied to the specific running instance (no ambiguity about which project directory the action lands in) and avoids forcing the agent to shell out with the right flags and working directory each time.
 
-- Operations that need the CLI's in-memory state (compiler, server lifecycle) - `apply_migrations`, `hot_reload` - must live here.
-- Operations that are conceptually per-instance but don't strictly need in-memory state - `create_migration`, `tail_server_logs` - are exposed here too. The alternative (shelling out to `serverpod create-migration`) forces a context switch, adds a failure mode where the agent runs in the wrong directory, and makes tool discovery dependent on a shipped skill file.
+- Operations that need the CLI's in-memory state (compiler, server lifecycle) - `hot_reload`, `hot_restart` - must live here.
+- Operations that are conceptually per-instance but don't strictly need in-memory state - `apply_migrations`, `create_migration`, `create_repair_migration`, `tail_server_logs`, `tail_flutter_logs` - are exposed here too. The alternative (shelling out to a CLI command) forces a context switch, adds a failure mode where the agent runs in the wrong directory, and makes tool discovery dependent on a shipped skill file.
 
 Commands that are project-setup / one-shot / infrastructure (`serverpod create`, `serverpod generate` outside watch mode, `serverpod mcp-server` itself) stay as CLI commands. They don't belong to a running instance and don't benefit from being forwarded through a socket.
 
@@ -172,15 +171,13 @@ Future MCP tool candidates include `server_status` (only the CLI knows whether t
 ## Dependencies
 
 - `dart_mcp: ^0.5.x` - MCP server and client base classes; `stdioChannel` for the bridge transport.
-- `stream_channel` - bidirectional stream abstraction.
-- `stream_transform` - `asyncMapBuffer` for coalescing socket-dir watcher events.
+- `stream_channel` - bidirectional stream abstraction for the socket channel.
 
-## Migration from the previous design
+## History
 
-The previous integration used a project-local socket at `<server>/.dart_tool/serverpod/mcp.sock` and shipped `serverpod mcp-server` as a transparent stdio-to-socket pipe. That socket path is no longer used. AI client config that just runs `serverpod mcp-server` continues to work; configs that invoked it from a particular project directory no longer need to - the bridge discovers instances independently of the AI client's working directory.
+An earlier iteration of this integration put sockets in a shared, per-machine temp directory (`<systemTemp>/serverpod/serverpod-<pid>-<project>.sock`) and used a multi-instance bridge: a single `serverpod mcp-server` discovered all running runners by scanning that directory and exposed `connect`/`disconnect`/`spawn`/`stop` tools plus a `serverpod://instances` resource for the agent to pick an instance. That was replaced by the current project-local, one-bridge-per-project model. The trade-off: the agent configures one bridge per project (pointed at `--server-dir`) instead of one bridge for the whole machine, in exchange for a much simpler design - no shared directory, no PID-keyed filenames, no discovery scan, no manual `connect` step, and transparent auto-reconnect across runner restarts.
 
 ## Open Questions
 
 1. Should pressing `a` during watch mode also trigger apply-migration? This requires switching stdin to raw mode, which adds complexity (signal handling, non-TTY environments, Windows). May be better as a follow-up.
-1. Should the runner-side server expose resources (e.g. migration status, server state) in addition to tools? This would let AI agents observe state without polling. Adds bridge work because forwarded resources have to be declared upfront in `dart_mcp`.
-1. Should the bridge auto-reconnect when a previously-connected runner reappears (same project name, new PID)? Today the client must call `connect` again. Auto-reconnect is convenient but can mask runner crashes; keep manual until the friction is concrete.
+1. Should the runner expose more state as resources (e.g. migration status, compile/run state) in addition to `serverpod://vm-service`? This would let AI agents observe state without polling. Each new resource has to be declared in `runner_surface.dart` so the bridge can forward it.


### PR DESCRIPTION
Doc updated to match implementation again.

We decided against the control multiple projects mcp-bridge, since "lesser" models had a hard time with the dynamic nature (Having to initiate connections and seeing tools update dynamically). I still think that is a better long term play, when MCP is better supported (not just tools, but ressources, and notifications as well), but for now the doc is now updated to match the simplifications that already happened in code.

I decided against deleting the doc out-right. I still think it holds value and with this PR it is in sync with the code.

Fixes: #5256 

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

## Breaking changes

None.