### PR TITLE
fix: Keep the Flutter status line pinned to the top after resizing the start TUI

### DIFF
--- a/tools/serverpod_cli/lib/src/commands/start/tui/main_screen.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/tui/main_screen.dart
@@ -114,10 +114,18 @@ class MainScreen extends StatelessComponent {
                                 padding: const EdgeInsets.only(left: 1),
                                 child: _buildTabBar(st, showSideBySide),
                               ),
-                              if (!showSideBySide) ?_buildFlutterStatusLine(st),
                               Expanded(
                                 child: !showSideBySide
-                                    ? _buildTabContent(state.selectedTab)
+                                    ? Column(
+                                        children: [
+                                          ?_buildFlutterStatusLine(st),
+                                          Expanded(
+                                            child: _buildTabContent(
+                                              state.selectedTab,
+                                            ),
+                                          ),
+                                        ],
+                                      )
                                     : Row(
                                         crossAxisAlignment:
                                             CrossAxisAlignment.stretch,


### PR DESCRIPTION
Starting `serverpod start` in a large terminal lays the server and Flutter logs out side by side. Shrinking the window down to the point where it flips to tabbed mode dropped the `Flutter app │ http://localhost:PORT` header to the bottom of the panel, underneath the logs, instead of keeping it pinned at the top.

Instead of toggling the status line in and out as a top-level sibling, the tabbed layout now nests it inside the always present Expanded as a header above the log view

Fixes #5239 

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes
None