### PR TITLE
feat: Require two consecutive heartbeat failures before tearing down Flutter

### DIFF
--- a/tools/serverpod_cli/lib/src/commands/start/flutter_process.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/flutter_process.dart
@@ -286,10 +286,12 @@ class FlutterProcess {
     // detaches (its keep-alive is hardcoded to ~3000 days). 2s
     // interval + 1s timeout lets us notice within ~3s.
     //
-    // Hot restart briefly empties the isolate list - require two
-    // consecutive empty reads (~4s window at 2s interval) so we
-    // don't race-kill a healthy restart.
+    // Both paths need two consecutive bad reads before tearing down
+    // (~4s at 2s interval): hot restart briefly empties the isolate
+    // list, and a one-off getVM() failure - blip, GC pause - shouldn't
+    // race-kill a live app.
     var emptyReads = 0;
+    var failedReads = 0;
     _vmServiceHeartbeat = Timer.periodic(const Duration(seconds: 2), (
       timer,
     ) async {
@@ -299,6 +301,8 @@ class FlutterProcess {
       }
       try {
         final vmInfo = await vm.getVM().timeout(const Duration(seconds: 1));
+        // A successful read means the connection is alive; clear failures.
+        failedReads = 0;
         if (vmInfo.isolates?.isEmpty ?? true) {
           emptyReads++;
           if (emptyReads >= 2) {
@@ -310,9 +314,12 @@ class FlutterProcess {
           emptyReads = 0;
         }
       } catch (e) {
-        timer.cancel();
-        log.info('Flutter heartbeat failed ($e); tearing down.');
-        await _onAppStop();
+        failedReads++;
+        if (failedReads >= 2) {
+          timer.cancel();
+          log.info('Flutter heartbeat failed ($e); tearing down.');
+          await _onAppStop();
+        }
       }
     });
   }

--- a/tools/serverpod_cli/lib/src/commands/start/flutter_process.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/flutter_process.dart
@@ -287,7 +287,7 @@ class FlutterProcess {
     // interval + 1s timeout lets us notice within ~3s.
     //
     // Both paths need two consecutive bad reads before tearing down
-    // (~4s at 2s interval): hot restart briefly empties the isolate
+    // (~4s at 2s interval): a hot restart briefly empties the isolate
     // list, and a one-off getVM() failure - blip, GC pause - shouldn't
     // race-kill a live app.
     var emptyReads = 0;
@@ -314,6 +314,8 @@ class FlutterProcess {
           emptyReads = 0;
         }
       } catch (e) {
+        // A failure breaks any empty-isolate streak; keep them consecutive.
+        emptyReads = 0;
         failedReads++;
         if (failedReads >= 2) {
           timer.cancel();


### PR DESCRIPTION
The `serverpod start` VM service heartbeat polls `getVM()` every 2s with a 1s timeout. The no-isolates path tolerates a single bad read and only tears down after two consecutive ones.

The exception path doesn't have the same tolerant and a single failed `getVM()` tore the Flutter app down immediately, so any blip would kill an app that could be perfectly alive.

I found this while digging into #5310, where a Windows user's Flutter app kept tearing down with a heartbeat timeout due to a bug that's been fixed upstream in the nocterm repo but am awaiting a new published version.

Note: This doesn't fix 5310. That requires a new nocterm version. This is just an enhancement to add a little more flexibility to the exception path. 

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes
None