### PR TITLE
feat: Improve serverpod create upgrade TUI path

### DIFF
--- a/.github/workflows/dart-tests.yaml
+++ b/.github/workflows/dart-tests.yaml
@@ -525,7 +525,9 @@ jobs:
           colima start
       - name: Run unit tests
         shell: bash
-        run: util/run_tests_bootstrap
+        run: |
+          export SERVERPOD_HOME="$(pwd)"
+          util/run_tests_bootstrap
         working-directory: ${{ matrix.path }}
 
   migration_e2e_tests:

--- a/.github/workflows/dart-tests.yaml
+++ b/.github/workflows/dart-tests.yaml
@@ -525,9 +525,7 @@ jobs:
           colima start
       - name: Run unit tests
         shell: bash
-        run: |
-          export SERVERPOD_HOME="$(cd ../.. && pwd)"
-          util/run_tests_bootstrap
+        run: util/run_tests_bootstrap
         working-directory: ${{ matrix.path }}
 
   migration_e2e_tests:

--- a/.github/workflows/dart-tests.yaml
+++ b/.github/workflows/dart-tests.yaml
@@ -506,7 +506,6 @@ jobs:
       matrix:
         flutter-version: ["3.38.4", "3.41.5"]
         os: [windows-latest, ubuntu-latest]
-        path: ["tests/bootstrap_project"]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
@@ -525,10 +524,7 @@ jobs:
           colima start
       - name: Run unit tests
         shell: bash
-        run: |
-          export SERVERPOD_HOME="$(pwd)"
-          util/run_tests_bootstrap
-        working-directory: ${{ matrix.path }}
+        run: util/run_tests_bootstrap
 
   migration_e2e_tests:
     name: Migration e2e tests

--- a/.github/workflows/dart-tests.yaml
+++ b/.github/workflows/dart-tests.yaml
@@ -525,12 +525,9 @@ jobs:
           colima start
       - name: Run unit tests
         shell: bash
-        # TODO: Switch to util/run_tests_bootstrap once we manage to run all
-        # tests in a reasonable time. Currently they take up to 40 minutes.
-        # run: cd ../.. && util/run_tests_bootstrap
         run: |
           export SERVERPOD_HOME="$(cd ../.. && pwd)"
-          dart test --concurrency=1 --reporter=failures-only
+          util/run_tests_bootstrap
         working-directory: ${{ matrix.path }}
 
   migration_e2e_tests:

--- a/tests/bootstrap_project/test_perform_create/dry_run_test.dart
+++ b/tests/bootstrap_project/test_perform_create/dry_run_test.dart
@@ -27,7 +27,7 @@ void main() {
       group(
         'when calling performCreate with a valid name and dryRun set to true',
         () {
-          String? result;
+          CreateResult? result;
           final projectName = 'test';
 
           setUp(() async {
@@ -41,16 +41,23 @@ void main() {
             );
           });
 
-          test('then returns relative project directory path', () {
-            expect(result, projectName);
-          });
+          test(
+            'then returns success result with relative project directory path',
+            () {
+              expect(result, isA<CreateSuccess>());
+              expect(
+                (result as CreateSuccess).projectDirectoryPath,
+                projectName,
+              );
+            },
+          );
         },
       );
 
       group(
         'when calling performCreate with invalid name and dryRun set to true',
         () {
-          String? result;
+          CreateResult? result;
 
           setUp(() async {
             result = await performCreate(
@@ -63,8 +70,8 @@ void main() {
             );
           });
 
-          test('then returns null', () {
-            expect(result, isNull);
+          test('then returns failure', () {
+            expect(result, isA<CreateFailure>());
           });
         },
       );
@@ -72,7 +79,7 @@ void main() {
       group(
         'when calling performCreate with an existing project name and dryRun set to true',
         () {
-          String? result;
+          CreateResult? result;
           final projectName =
               'temp_test_${const Uuid().v4().replaceAll('-', '_').toLowerCase()}';
 
@@ -91,8 +98,8 @@ void main() {
             );
           });
 
-          test('then returns null', () {
-            expect(result, isNull);
+          test('then returns a failure', () {
+            expect(result, isA<CreateFailure>());
           });
         },
       );

--- a/tests/bootstrap_project/test_perform_create/upgrade_test.dart
+++ b/tests/bootstrap_project/test_perform_create/upgrade_test.dart
@@ -1,0 +1,135 @@
+import 'dart:io';
+
+import 'package:bootstrap_project/src/util.dart';
+import 'package:path/path.dart' as p;
+import 'package:serverpod_cli/src/commands/create/tui/config.dart';
+import 'package:serverpod_cli/src/commands/create/tui/runner.dart';
+import 'package:serverpod_cli/src/create/create.dart';
+import 'package:serverpod_cli/src/create/ide.dart';
+import 'package:serverpod_cli/src/create/template_context.dart';
+import 'package:test/test.dart';
+
+import 'util.dart';
+
+void main() {
+  final rootPath = p.join(Directory.current.path, '..', '..');
+  final cliProjectPath = getServerpodCliProjectPath(rootPath: rootPath);
+
+  setUpAll(() async {
+    final pubGetProcess = await startProcess('dart', [
+      'pub',
+      'get',
+    ], workingDirectory: cliProjectPath);
+    assert(await pubGetProcess.exitCode == 0);
+  });
+
+  group(
+    'Given a mini project, '
+    'when creating CreateConfigState in the upgrade path for the TUI',
+    () {
+      late CreateConfigStateResult result;
+
+      final project = setUpPerformCreateInTempDir(
+        context: TemplateContext(
+          template: ServerpodTemplateType.mini,
+          auth: true,
+          redis: true,
+          postgres: true,
+          webapp: true,
+          ides: [TemplateIde.claude, TemplateIde.cursor, TemplateIde.vscode],
+        ),
+      );
+
+      setUpAll(() async {
+        result = await getCreateConfigState(
+          name: '.',
+          force: false,
+          template: ServerpodTemplateType.server,
+          interactive: false,
+          configs: ServerpodCreateConfig.values,
+          workingDirectory: Directory(project.projectRoot),
+        );
+      });
+
+      test(
+        'then CreateConfigState contains all configs except template config',
+        () {
+          final configs = [...ServerpodCreateConfig.values];
+          configs.removeWhere(
+            (config) => config == ServerpodCreateConfig.template,
+          );
+
+          expect(
+            result.state.configs,
+            isNot(contains(ServerpodCreateConfig.template)),
+          );
+
+          expect(result.state.configs, containsAll(configs));
+        },
+      );
+
+      test('then the result indicates upgrade is true', () {
+        expect(result.isUpgrade, isTrue);
+      });
+
+      test('then default migration can be created', () {
+        expect(result.createDefaultMigrationForUpgrade, isTrue);
+      });
+    },
+  );
+
+  group(
+    'Given a server project without IDE configurations, '
+    'when creating CreateConfigState in the upgrade path for the TUI',
+    () {
+      late CreateConfigStateResult result;
+
+      final project = setUpPerformCreateInTempDir(
+        context: TemplateContext(
+          template: ServerpodTemplateType.server,
+          auth: true,
+          redis: true,
+          postgres: true,
+          webapp: true,
+          ides: [],
+        ),
+      );
+
+      setUpAll(() async {
+        result = await getCreateConfigState(
+          name: '.',
+          force: false,
+          template: ServerpodTemplateType.server,
+          interactive: false,
+          configs: ServerpodCreateConfig.values,
+          workingDirectory: Directory(project.projectRoot),
+        );
+      });
+
+      test(
+        'then CreateConfigState contains only IDE config',
+        () {
+          expect(result.state.configs, [ServerpodCreateConfig.ide]);
+        },
+      );
+
+      test(
+        'then CreateConfigState requires IDE selection',
+        () {
+          expect(result.state.requireIde, isTrue);
+        },
+      );
+
+      test('then the result indicates upgrade is true', () {
+        expect(result.isUpgrade, isTrue);
+      });
+
+      test(
+        'then default migration can not be created',
+        () {
+          expect(result.createDefaultMigrationForUpgrade, isFalse);
+        },
+      );
+    },
+  );
+}

--- a/tests/bootstrap_project/test_perform_create/upgrade_test.dart
+++ b/tests/bootstrap_project/test_perform_create/upgrade_test.dart
@@ -24,7 +24,7 @@ void main() {
   });
 
   group(
-    'Given a mini project, '
+    'Given a project without a database, '
     'when creating CreateConfigState in the upgrade path for the TUI',
     () {
       late CreateConfigStateResult result;

--- a/tests/bootstrap_project/test_perform_create/web_test.dart
+++ b/tests/bootstrap_project/test_perform_create/web_test.dart
@@ -84,6 +84,28 @@ void main() {
       );
 
       test(
+        'then the build Flutter app page uses a non-WASM build by default',
+        () async {
+          final buildFlutterAppPage = File(
+            p.join(project.serverDir, 'web', 'pages', 'build_flutter_app.html'),
+          );
+          final content = await buildFlutterAppPage.readAsString();
+
+          expect(
+            content,
+            contains(
+              'flutter build web --base-href /app/ '
+              '-o ../${project.name}_server/web/app',
+            ),
+          );
+          expect(
+            content,
+            isNot(contains('flutter build web --base-href /app/ --wasm')),
+          );
+        },
+      );
+
+      test(
         'then the server config for development contains webserver configurations',
         () async {
           final config = File(
@@ -178,7 +200,13 @@ void main() {
           expect(
             content,
             contains(
-              'Remove this line if you build the Flutter app with --wasm',
+              'If building the Flutter app with WASM, set the below parameter to',
+            ),
+          );
+          expect(
+            content,
+            contains(
+              'true and add the --wasm flag to the flutter build command.',
             ),
           );
           expect(content, contains('enableWasmHeaders: false'));
@@ -194,28 +222,6 @@ void main() {
 
           expect(content, contains('flutter build web --base-href /app/'));
           expect(content, isNot(contains('--wasm')));
-        },
-      );
-
-      test(
-        'then the build Flutter app page uses a non-WASM build by default',
-        () async {
-          final buildFlutterAppPage = File(
-            p.join(project.serverDir, 'web', 'pages', 'build_flutter_app.html'),
-          );
-          final content = await buildFlutterAppPage.readAsString();
-
-          expect(
-            content,
-            contains(
-              'flutter build web --base-href /app/ '
-              '-o ../${project.name}_server/web/app',
-            ),
-          );
-          expect(
-            content,
-            isNot(contains('flutter build web --base-href /app/ --wasm')),
-          );
         },
       );
 
@@ -366,18 +372,22 @@ void main() {
     },
   );
 
-  test(
+  group(
     'Given a TemplateContext with a module template type, '
-    'when performCreate is called, '
-    'then the server test config contains webserver configuration',
-    () async {
+    'when performCreate is called, ',
+    () {
       final project = setUpPerformCreateInTempDir(
         context: TemplateContext(template: ServerpodTemplateType.module),
       );
 
-      final file = File(p.join(project.serverDir, 'config', 'test.yaml'));
-      final content = await file.readAsString();
-      expect(content, contains('webServer:'));
+      test(
+        'then the server test config contains webserver configuration',
+        () async {
+          final file = File(p.join(project.serverDir, 'config', 'test.yaml'));
+          final content = await file.readAsString();
+          expect(content, contains('webServer:'));
+        },
+      );
     },
   );
 }

--- a/tools/serverpod_cli/lib/src/commands/create.dart
+++ b/tools/serverpod_cli/lib/src/commands/create.dart
@@ -2,7 +2,6 @@ import 'package:ci/ci.dart' as ci;
 import 'package:cli_tools/cli_tools.dart';
 import 'package:config/config.dart';
 import 'package:serverpod_cli/src/commands/create/tui/runner.dart';
-import 'package:serverpod_cli/src/commands/create/tui/state.dart';
 import 'package:serverpod_cli/src/create/create.dart';
 import 'package:serverpod_cli/src/create/ide.dart';
 import 'package:serverpod_cli/src/create/template_context.dart';
@@ -146,20 +145,20 @@ class CreateCommand extends ServerpodCommand<CreateOption> {
       await performCreateWithTui(
         name,
         force,
-        state: CreateConfigState(template),
+        template: template,
         interactive: true,
       );
       return;
     }
 
-    final projectPath = await performCreate(
+    final result = await performCreate(
       name,
       force,
       interactive: interactive,
       context: context,
     );
 
-    if (projectPath == null) {
+    if (result is! CreateSuccess) {
       throw ExitException.error();
     }
   }

--- a/tools/serverpod_cli/lib/src/commands/create/tui/app.dart
+++ b/tools/serverpod_cli/lib/src/commands/create/tui/app.dart
@@ -10,10 +10,14 @@ class ServerpodCreateApp extends TuiApp<CreateAppStateHolder> {
     required super.holder,
     required this.onCreate,
     required this.onQuit,
+    this.isUpgrade = false,
   });
 
   final VoidCallback onCreate;
   final VoidCallback onQuit;
+
+  /// Whether the app was launched to upgrade a project.
+  final bool isUpgrade;
 
   @override
   TuiAppState createState() => ServerpodCreateAppState();
@@ -45,6 +49,7 @@ class ServerpodCreateAppState extends TuiAppState<ServerpodCreateApp> {
         scrollController: _scrollController,
         onCreate: component.onCreate,
         onQuit: component.onQuit,
+        isUpgrade: component.isUpgrade,
       ),
     );
   }

--- a/tools/serverpod_cli/lib/src/commands/create/tui/config.dart
+++ b/tools/serverpod_cli/lib/src/commands/create/tui/config.dart
@@ -63,6 +63,10 @@ enum ServerpodCreateConfig<T extends FormConfigOption>
         config: ServerpodCreateConfig.template,
         configOption: TemplateTypeOption.server,
       ),
+      FormRequirement<DatabaseConfigOption>(
+        config: ServerpodCreateConfig.database,
+        configOption: DatabaseConfigOption.database,
+      ),
     ],
   ),
   ide<IdeOption>(

--- a/tools/serverpod_cli/lib/src/commands/create/tui/main_screen.dart
+++ b/tools/serverpod_cli/lib/src/commands/create/tui/main_screen.dart
@@ -12,6 +12,7 @@ class MainScreen extends StatelessComponent {
     required this.logScrollController,
     required this.onCreate,
     required this.onQuit,
+    required this.isUpgrade,
   });
 
   final CreateAppStateHolder holder;
@@ -19,6 +20,7 @@ class MainScreen extends StatelessComponent {
   final ScrollController logScrollController;
   final VoidCallback onCreate;
   final VoidCallback onQuit;
+  final bool isUpgrade;
 
   @override
   Component build(BuildContext context) {
@@ -49,7 +51,7 @@ class MainScreen extends StatelessComponent {
             ),
           ),
         ),
-        _buildButtonBar(theme, state),
+        _buildButtonBar(theme, state, isUpgrade: isUpgrade),
       ],
     );
   }
@@ -66,11 +68,14 @@ class MainScreen extends StatelessComponent {
   Component _buildHeader(ServerpodThemeData theme, CreateConfigState state) {
     final showingSummary = state.isSummary;
     final creatingProject = state.creatingProject;
-    final title = creatingProject
-        ? 'Creating project'
-        : showingSummary
-        ? 'Summary'
-        : 'Create new project';
+
+    final title = switch (creatingProject) {
+      true => isUpgrade ? 'Upgrading project' : 'Creating project',
+      false => switch (showingSummary) {
+        true => 'Summary',
+        false => isUpgrade ? 'Upgrade project' : 'Create new project',
+      },
+    };
 
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 1),
@@ -288,18 +293,23 @@ class MainScreen extends StatelessComponent {
 
   Component _buildButtonBar(
     ServerpodThemeData theme,
-    CreateConfigState state,
-  ) {
+    CreateConfigState state, {
+    required bool isUpgrade,
+  }) {
     final creatingProject = state.creatingProject;
     final isFirstScreen = state.currentScreenIndex == 0;
     final isSummary = state.isSummary;
     final hasSingleScreen = state.hasSingleScreen;
     final createEnabled = !isSummary || state.canCreate;
+    final enterButtonLabel = switch (hasSingleScreen || isSummary) {
+      true => isUpgrade ? 'Upgrade Project' : 'Create Project',
+      false => 'Next',
+    };
 
     return ButtonBar(
       buttons: [
         Button(
-          name: hasSingleScreen || isSummary ? 'Create Project' : 'Next',
+          name: enterButtonLabel,
           activationChar: 'Enter',
           activationKeys: const [LogicalKey.enter],
           onActivate: (_) {

--- a/tools/serverpod_cli/lib/src/commands/create/tui/runner.dart
+++ b/tools/serverpod_cli/lib/src/commands/create/tui/runner.dart
@@ -1,26 +1,46 @@
+import 'dart:io';
+
 import 'package:cli_tools/cli_tools.dart';
+import 'package:path/path.dart' as p;
 import 'package:serverpod_cli/src/commands/create/tui/app.dart';
+import 'package:serverpod_cli/src/commands/create/tui/config.dart';
 import 'package:serverpod_cli/src/commands/create/tui/state.dart';
 import 'package:serverpod_cli/src/commands/create/tui/state_holder.dart';
 import 'package:serverpod_cli/src/create/create.dart';
+import 'package:serverpod_cli/src/create/template_context.dart';
 import 'package:serverpod_cli/src/util/command_line_tools.dart';
 import 'package:serverpod_cli/src/util/serverpod_cli_logger.dart';
 import 'package:serverpod_logging_cli/serverpod_logging_cli.dart';
 import 'package:serverpod_tui/serverpod_tui.dart';
 
 /// Creates a Serverpod project with the create TUI.
-/// The configurations exposed in the TUI form are determined by [state].
+/// The configurations exposed in the TUI form are determined by [configs].
+/// The configurations are narrowed for a project upgrade
+/// to include only what's necessary for an upgrade.
 ///
 /// Performs a dry run before starting the TUI to collect early errors,
 /// throwing an [ExitException] if any are found.
 Future<void> performCreateWithTui(
   String name,
   bool force, {
-  required CreateConfigState state,
+  required ServerpodTemplateType template,
   required bool? interactive,
+  List<ServerpodCreateConfig> configs = ServerpodCreateConfig.values,
+  TemplateContext? defaultContext,
+  bool requireIde = false,
 }) async {
+  var isUpgrade = false;
+  var createDefaultMigrationForUpgrade = false;
+
+  var state = CreateConfigState(
+    template,
+    configs: configs,
+    defaults: defaultContext,
+    requireIde: requireIde,
+  );
+
   // Dry run to collect early errors and exit if needed.
-  final dryRunProjectPath = await performCreate(
+  final result = await performCreate(
     name,
     force,
     dryRun: true,
@@ -28,8 +48,42 @@ Future<void> performCreateWithTui(
     context: state.toTemplateContext(),
   );
 
-  if (dryRunProjectPath == null) {
+  if (result is! CreateSuccess) {
     throw ExitException.error();
+  }
+
+  // All form configurations are not shown in the TUI
+  // for upgrade path. If the project already has migrations
+  // then the TUI should only allow for IDEs to be selected.
+  // Otherwise, assume we're dealing with a mini to server upgrade.
+  // In that case, the TUI should show all configurations except
+  // for project type which will always be Server and cannot be changed.
+  if (name == '.') {
+    isUpgrade = true;
+
+    final migrationsDir = Directory(
+      p.join(result.serverDirectoryPath, 'migrations'),
+    );
+
+    if (await migrationsDir.exists()) {
+      state = CreateConfigState(
+        template,
+        configs: [ServerpodCreateConfig.ide],
+        requireIde: true,
+      );
+    } else {
+      createDefaultMigrationForUpgrade = true;
+      final effectiveConfigs = List<ServerpodCreateConfig>.from(configs);
+      effectiveConfigs.removeWhere(
+        (config) => config == ServerpodCreateConfig.template,
+      );
+      state = CreateConfigState(
+        template,
+        configs: effectiveConfigs,
+        defaults: defaultContext,
+        requireIde: requireIde,
+      );
+    }
   }
 
   final holder = CreateAppStateHolder(state);
@@ -44,22 +98,29 @@ Future<void> performCreateWithTui(
     preExit: () => _preExit(
       template: state.template,
       projectPath: projectPath,
+      isUpgrade: isUpgrade,
     ),
   );
 
   await runTuiApp(
     backend: backend,
     ServerpodCreateApp(
+      isUpgrade: isUpgrade,
       holder: holder,
       onCreate: () async {
-        projectPath = await performCreate(
+        final result = await performCreate(
           name,
           force,
           interactive: interactive,
+          createDefaultMigrationForUpgrade: createDefaultMigrationForUpgrade,
           context: state.toTemplateContext(),
         );
 
-        final success = projectPath != null;
+        final success = result is CreateSuccess;
+
+        if (success) {
+          projectPath = result.projectDirectoryPath;
+        }
 
         await _shutdownTui(success ? 0 : 1);
       },
@@ -82,14 +143,16 @@ Future<void> _shutdownTui([int exitCode = 0]) async {
 /// the Dart process.
 Future<void> _preExit({
   required ServerpodTemplateType template,
+  required bool isUpgrade,
   String? projectPath,
 }) async {
   CommandLineTools.flushErrors();
   flushPerformCreateErrors();
 
   if (projectPath != null) {
+    final suffix = isUpgrade ? 'upgraded' : 'created';
     log.info(
-      'Serverpod project created.',
+      'Serverpod project $suffix.',
       newParagraph: true,
       type: TextLogType.success,
     );

--- a/tools/serverpod_cli/lib/src/commands/create/tui/runner.dart
+++ b/tools/serverpod_cli/lib/src/commands/create/tui/runner.dart
@@ -13,21 +13,33 @@ import 'package:serverpod_cli/src/util/serverpod_cli_logger.dart';
 import 'package:serverpod_logging_cli/serverpod_logging_cli.dart';
 import 'package:serverpod_tui/serverpod_tui.dart';
 
-/// Creates a Serverpod project with the create TUI.
-/// The configurations exposed in the TUI form are determined by [configs].
-/// The configurations are narrowed for a project upgrade
-/// to include only what's necessary for an upgrade.
-///
-/// Performs a dry run before starting the TUI to collect early errors,
-/// throwing an [ExitException] if any are found.
-Future<void> performCreateWithTui(
-  String name,
-  bool force, {
+/// [CreateConfigState] creation result type.
+class CreateConfigStateResult {
+  CreateConfigStateResult({
+    required this.state,
+    required this.isUpgrade,
+    required this.createDefaultMigrationForUpgrade,
+  });
+
+  final CreateConfigState state;
+  final bool isUpgrade;
+  final bool createDefaultMigrationForUpgrade;
+}
+
+/// Performs dry run to collect errors and exit early if needed.
+/// Returns [CreateConfigState] to be used by the TUI app
+/// when no errors are found by the dry run.
+/// The returned [CreateConfigState] will contain narrowed
+/// configs if project upgrade is detected.
+Future<CreateConfigStateResult> getCreateConfigState({
+  required String name,
+  required bool force,
   required ServerpodTemplateType template,
   required bool? interactive,
-  List<ServerpodCreateConfig> configs = ServerpodCreateConfig.values,
+  required List<ServerpodCreateConfig> configs,
   TemplateContext? defaultContext,
   bool requireIde = false,
+  Directory? workingDirectory,
 }) async {
   var isUpgrade = false;
   var createDefaultMigrationForUpgrade = false;
@@ -46,6 +58,7 @@ Future<void> performCreateWithTui(
     dryRun: true,
     interactive: interactive,
     context: state.toTemplateContext(),
+    workingDirectory: workingDirectory,
   );
 
   if (result is! CreateSuccess) {
@@ -85,6 +98,44 @@ Future<void> performCreateWithTui(
       );
     }
   }
+
+  return CreateConfigStateResult(
+    state: state,
+    isUpgrade: isUpgrade,
+    createDefaultMigrationForUpgrade: createDefaultMigrationForUpgrade,
+  );
+}
+
+/// Creates a Serverpod project with the create TUI.
+/// The configurations exposed in the TUI form are determined by [configs].
+/// The configurations are narrowed for a project upgrade
+/// to include only what's necessary for an upgrade.
+///
+/// Performs a dry run before starting the TUI to collect early errors,
+/// throwing an [ExitException] if any are found.
+Future<void> performCreateWithTui(
+  String name,
+  bool force, {
+  required ServerpodTemplateType template,
+  required bool? interactive,
+  List<ServerpodCreateConfig> configs = ServerpodCreateConfig.values,
+  TemplateContext? defaultContext,
+  bool requireIde = false,
+}) async {
+  final result = await getCreateConfigState(
+    name: name,
+    force: force,
+    template: template,
+    configs: configs,
+    interactive: interactive,
+    defaultContext: defaultContext,
+    requireIde: requireIde,
+  );
+
+  final state = result.state;
+  final isUpgrade = result.isUpgrade;
+  final createDefaultMigrationForUpgrade =
+      result.createDefaultMigrationForUpgrade;
 
   final holder = CreateAppStateHolder(state);
 

--- a/tools/serverpod_cli/lib/src/commands/quickstart.dart
+++ b/tools/serverpod_cli/lib/src/commands/quickstart.dart
@@ -136,18 +136,16 @@ class QuickstartCommand extends ServerpodCommand<QuickstartOption> {
       await performCreateWithTui(
         name,
         force,
-        state: CreateConfigState(
-          template,
-          configs: const [ServerpodCreateConfig.ide],
-          defaults: TemplateContext(
-            auth: true,
-            redis: true,
-            postgres: true,
-            webapp: true,
-          ),
-          requireIde: true,
-        ),
+        template: template,
+        configs: const [ServerpodCreateConfig.ide],
+        requireIde: true,
         interactive: true,
+        defaultContext: TemplateContext(
+          auth: true,
+          redis: true,
+          postgres: true,
+          webapp: true,
+        ),
       );
       return;
     }

--- a/tools/serverpod_cli/lib/src/commands/quickstart.dart
+++ b/tools/serverpod_cli/lib/src/commands/quickstart.dart
@@ -3,7 +3,6 @@ import 'package:cli_tools/cli_tools.dart';
 import 'package:config/config.dart';
 import 'package:serverpod_cli/src/commands/create/tui/config.dart';
 import 'package:serverpod_cli/src/commands/create/tui/runner.dart';
-import 'package:serverpod_cli/src/commands/create/tui/state.dart';
 import 'package:serverpod_cli/src/create/create.dart';
 import 'package:serverpod_cli/src/create/ide.dart';
 import 'package:serverpod_cli/src/create/template_context.dart';
@@ -157,7 +156,7 @@ class QuickstartCommand extends ServerpodCommand<QuickstartOption> {
       context: context,
     );
 
-    if (projectPath == null) {
+    if (projectPath is! CreateSuccess) {
       throw ExitException.error();
     }
   }

--- a/tools/serverpod_cli/lib/src/commands/quickstart.dart
+++ b/tools/serverpod_cli/lib/src/commands/quickstart.dart
@@ -149,14 +149,14 @@ class QuickstartCommand extends ServerpodCommand<QuickstartOption> {
       return;
     }
 
-    final projectPath = await performCreate(
+    final result = await performCreate(
       name,
       force,
       interactive: interactive,
       context: context,
     );
 
-    if (projectPath is! CreateSuccess) {
+    if (result is! CreateSuccess) {
       throw ExitException.error();
     }
   }

--- a/tools/serverpod_cli/lib/src/create/create.dart
+++ b/tools/serverpod_cli/lib/src/create/create.dart
@@ -70,8 +70,10 @@ extension TemplateIdeExtension on List<TemplateIde> {
   }
 }
 
+/// Project creation result type.
 sealed class CreateResult {}
 
+/// Project creation success result type.
 final class CreateSuccess extends CreateResult {
   CreateSuccess({
     required this.projectDirectoryPath,
@@ -82,6 +84,7 @@ final class CreateSuccess extends CreateResult {
   final String serverDirectoryPath;
 }
 
+/// Project creation failure result type.
 final class CreateFailure extends CreateResult {}
 
 /// Holds error messages to be flushed at a later time.
@@ -103,8 +106,8 @@ void flushPerformCreateErrors() {
 }
 
 /// Creates a project for the provided [context].
-/// If successful, a future that resolves to the project directory path
-/// is returned. Otherwise, a future that resolves to null is returned.
+/// Returns a future that resolves to [CreateSuccess] if successful.
+/// Otherwise, returns a future that resolves to [CreateFailure.
 Future<CreateResult> performCreate(
   String name,
   bool force, {
@@ -113,7 +116,7 @@ Future<CreateResult> performCreate(
   required TemplateContext context,
   Directory? workingDirectory,
 
-  /// Whether to create initial migrations for the upgrade path.
+  /// Whether to create default migration for the upgrade path.
   bool createDefaultMigrationForUpgrade = true,
 }) async {
   _errorBuffer.clear();
@@ -468,8 +471,8 @@ Future<void> _createFileAndWrite(String path, String content) async {
 }
 
 /// Upgrades a server project.
-/// If successful, a future that resolves to the project directory path
-/// is returned. Otherwise, a future that resolves to null is returned.
+/// Returns a future that resolves to [CreateSuccess] if successful.
+/// Otherwise, returns a future that resolves to [CreateFailure.
 Future<CreateResult> _performUpgrade({
   bool dryRun = false,
   required bool? interactive,

--- a/tools/serverpod_cli/lib/src/create/create.dart
+++ b/tools/serverpod_cli/lib/src/create/create.dart
@@ -70,6 +70,20 @@ extension TemplateIdeExtension on List<TemplateIde> {
   }
 }
 
+sealed class CreateResult {}
+
+final class CreateSuccess extends CreateResult {
+  CreateSuccess({
+    required this.projectDirectoryPath,
+    required this.serverDirectoryPath,
+  });
+
+  final String projectDirectoryPath;
+  final String serverDirectoryPath;
+}
+
+final class CreateFailure extends CreateResult {}
+
 /// Holds error messages to be flushed at a later time.
 /// This is typically used to replay logs to the terminal
 /// after exiting the tui's alternate screen
@@ -91,13 +105,16 @@ void flushPerformCreateErrors() {
 /// Creates a project for the provided [context].
 /// If successful, a future that resolves to the project directory path
 /// is returned. Otherwise, a future that resolves to null is returned.
-Future<String?> performCreate(
+Future<CreateResult> performCreate(
   String name,
   bool force, {
   bool dryRun = false,
   required bool? interactive,
   required TemplateContext context,
   Directory? workingDirectory,
+
+  /// Whether to create initial migrations for the upgrade path.
+  bool createDefaultMigrationForUpgrade = true,
 }) async {
   _errorBuffer.clear();
   // Resolve where the project will be created relative to [workingDirectory]
@@ -120,6 +137,7 @@ Future<String?> performCreate(
         dryRun: dryRun,
         interactive: interactive,
         context: context,
+        createDefaultMigration: createDefaultMigrationForUpgrade,
         workingDirectory: cwd,
       );
     }
@@ -134,7 +152,7 @@ Future<String?> performCreate(
       'Invalid project name. Project names can only contain letters, numbers, '
       'and underscores.',
     );
-    return null;
+    return CreateFailure();
   }
 
   var serverpodDirs = ServerpodDirectories(
@@ -144,10 +162,15 @@ Future<String?> performCreate(
   var pubspecFile = File(p.join(serverpodDirs.projectDir.path, 'pubspec.yaml'));
   if (pubspecFile.existsSync()) {
     _logError('Project $name already exists.');
-    return null;
+    return CreateFailure();
   }
 
-  if (dryRun) return p.basename(serverpodDirs.projectDir.path);
+  if (dryRun) {
+    return CreateSuccess(
+      projectDirectoryPath: p.basename(serverpodDirs.projectDir.path),
+      serverDirectoryPath: serverpodDirs.serverDir.path,
+    );
+  }
 
   final template = context.template;
   if (template == ServerpodTemplateType.module) {
@@ -261,6 +284,39 @@ Future<String?> performCreate(
     });
   }
 
+  await _configureAgentSkillsAndMcp(
+    serverpodDirs: serverpodDirs,
+    context: context,
+  );
+
+  if (success || force) {
+    log.info(
+      'Serverpod project created.',
+      newParagraph: true,
+      type: TextLogType.success,
+    );
+
+    var projectDirPath = p.basename(serverpodDirs.projectDir.path);
+
+    if (template == ServerpodTemplateType.server) {
+      logStartInstructions(projectDirPath);
+    } else if (template == ServerpodTemplateType.mini) {
+      logMiniStartInstructions(projectDirPath);
+    }
+
+    return CreateSuccess(
+      projectDirectoryPath: projectDirPath,
+      serverDirectoryPath: serverpodDirs.serverDir.path,
+    );
+  }
+
+  return CreateFailure();
+}
+
+Future<void> _configureAgentSkillsAndMcp({
+  required ServerpodDirectories serverpodDirs,
+  required TemplateContext context,
+}) async {
   if (context.ides.isNotEmpty) {
     await _configureProjectMcpServers(serverpodDirs, context.ides);
 
@@ -325,26 +381,6 @@ Future<String?> performCreate(
       return true;
     });
   }
-
-  if (success || force) {
-    log.info(
-      'Serverpod project created.',
-      newParagraph: true,
-      type: TextLogType.success,
-    );
-
-    var projectDirPath = p.basename(serverpodDirs.projectDir.path);
-
-    if (template == ServerpodTemplateType.server) {
-      logStartInstructions(projectDirPath);
-    } else if (template == ServerpodTemplateType.mini) {
-      logMiniStartInstructions(projectDirPath);
-    }
-
-    return projectDirPath;
-  }
-
-  return null;
 }
 
 Future<void> _moveDirectoryContents(
@@ -434,35 +470,41 @@ Future<void> _createFileAndWrite(String path, String content) async {
 /// Upgrades a server project.
 /// If successful, a future that resolves to the project directory path
 /// is returned. Otherwise, a future that resolves to null is returned.
-Future<String?> _performUpgrade({
+Future<CreateResult> _performUpgrade({
   bool dryRun = false,
   required bool? interactive,
   required TemplateContext context,
+  required bool createDefaultMigration,
   Directory? workingDirectory,
 }) async {
   if (context.template != ServerpodTemplateType.server) {
     _logError('The upgrade command can only be used with server templates.');
-    return null;
+    return CreateFailure();
   }
 
   var serverDir = findServerDirectory(workingDirectory ?? Directory.current);
   if (serverDir == null) {
     _logError('Could not find a Serverpod project in the current directory.');
-    return null;
+    return CreateFailure();
   }
 
   var name = await getProjectName(serverDir);
   if (name == null) {
     _logError('Could not find a project name in the pubspec.yaml file.');
-    return null;
+    return CreateFailure();
   }
-
-  if (dryRun) return name;
 
   var serverpodDir = ServerpodDirectories(
     name: name,
     projectDir: serverDir.parent,
   );
+
+  if (dryRun) {
+    return CreateSuccess(
+      projectDirectoryPath: name,
+      serverDirectoryPath: serverpodDir.serverDir.path,
+    );
+  }
 
   final writtenPaths = <String>{};
   var success = true;
@@ -489,13 +531,20 @@ Future<String?> _performUpgrade({
     interactive: interactive,
   );
 
-  success &= await log.progress('Creating default database migration.', () {
-    return DatabaseSetup.createDefaultMigration(
-      serverpodDir.serverDir,
-      name,
-      interactive: interactive,
-    );
-  });
+  if (createDefaultMigration) {
+    success &= await log.progress('Creating default database migration.', () {
+      return DatabaseSetup.createDefaultMigration(
+        serverpodDir.serverDir,
+        name,
+        interactive: interactive,
+      );
+    });
+  }
+
+  await _configureAgentSkillsAndMcp(
+    serverpodDirs: serverpodDir,
+    context: context,
+  );
 
   await _configureProjectMcpServers(serverpodDir, context.ides);
 
@@ -507,10 +556,13 @@ Future<String?> _performUpgrade({
     );
 
     logStartInstructions(name);
-    return name;
+    return CreateSuccess(
+      projectDirectoryPath: name,
+      serverDirectoryPath: serverpodDir.serverDir.path,
+    );
   }
 
-  return null;
+  return CreateFailure();
 }
 
 /// Renders Mustache directives in the file paths the copiers just wrote.


### PR DESCRIPTION
The upgrade path for the create command (`serverpod create .`) previously showed all of the configurations. Those configurations are now narrowed so users only select what has not been configured.

For mini to server upgrade, the database and IDE configurations are shown.
For upgrade on an existing server project, only the IDE configurations are shown.

This PR also fixes some broken bootstrap tests and runs the full suite in CI now that `performCreate` tests are concurrent without mutating working directory.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None