### PR TITLE
fix: Allow using the `id` as conflict target on `upsert` and `upsertRow`

### DIFF
--- a/packages/serverpod_database/lib/src/adapters/postgres/sql_query_builder.dart
+++ b/packages/serverpod_database/lib/src/adapters/postgres/sql_query_builder.dart
@@ -460,13 +460,6 @@ class InsertQueryBuilder {
             'Column "${col.columnName}" is not a column of table "${table.tableName}"',
           );
         }
-        if (col.columnName == 'id') {
-          throw ArgumentError.value(
-            conflictColumns,
-            'conflictColumns',
-            'The "id" column cannot be used as a conflict column for upsert',
-          );
-        }
       }
 
       if (updateColumns != null) {

--- a/packages/serverpod_database/test/database_query/insert_sql_query_test.dart
+++ b/packages/serverpod_database/test/database_query/insert_sql_query_test.dart
@@ -366,16 +366,20 @@ SELECT * FROM insertWithIdNotNull
     );
 
     test(
-      'when instantiating upsert query with id as conflict column then argument error is thrown.',
+      'when instantiating upsert query with id as conflict column then query is built successfully.',
       () {
         var table = PersonTable();
+        var query = InsertQueryBuilder(
+          table: table,
+          rows: [PersonClass(id: 33, name: 'Alex', age: 33)],
+          conflictColumns: [table.id],
+        ).build();
+
         expect(
-          () => InsertQueryBuilder(
-            table: table,
-            rows: [PersonClass(name: 'Alex', age: 33)],
-            conflictColumns: [table.id],
-          ),
-          throwsArgumentError,
+          query,
+          'INSERT INTO "person" ("id", "name", "age") VALUES (33, \'Alex\', 33) '
+          'ON CONFLICT ("id") DO UPDATE SET "name" = EXCLUDED."name", "age" = EXCLUDED."age" '
+          'RETURNING *',
         );
       },
     );

--- a/tests/serverpod_test_server/test_integration/database_operations/crud/upsert_test.dart
+++ b/tests/serverpod_test_server/test_integration/database_operations/crud/upsert_test.dart
@@ -464,21 +464,64 @@ void main() async {
     },
   );
 
-  test(
-    'Given an upsert operation with id as conflictColumn '
-    'when executing it '
-    'then it throws an ArgumentError.',
-    () async {
-      await expectLater(
-        UpsertTestModel.db.upsert(
-          session,
-          [UpsertTestModel(code: 'A', category: 'c1', value: 1)],
-          conflictColumns: (t) => [t.id],
-        ),
-        throwsA(isA<ArgumentError>()),
+  group('Given an existing row', () {
+    late SimpleData existingRow;
+
+    setUp(() async {
+      existingRow = await SimpleData.db.insertRow(
+        session,
+        SimpleData(num: 1),
       );
-    },
-  );
+    });
+
+    tearDown(() async {
+      await SimpleData.db.deleteWhere(
+        session,
+        where: (t) => Constant.bool(true),
+      );
+    });
+
+    test(
+      'when upserting with id as conflictColumn then the existing row is updated.',
+      () async {
+        var updated = (await SimpleData.db.upsertRow(
+          session,
+          SimpleData(id: existingRow.id, num: 2),
+          conflictColumns: (t) => [t.id],
+        ))!;
+
+        expect(updated.id, existingRow.id);
+        expect(updated.num, 2);
+      },
+    );
+
+    test(
+      'when batch upserting a mix of existing and new rows by id '
+      'then existing rows are updated and new rows are inserted.',
+      () async {
+        var result = await SimpleData.db.upsert(
+          session,
+          [
+            SimpleData(id: existingRow.id, num: 10),
+            SimpleData(num: 20),
+          ],
+          conflictColumns: (t) => [t.id],
+        );
+
+        expect(result, hasLength(2));
+
+        var updated = result.firstWhere((r) => r.id == existingRow.id);
+        expect(updated.num, 10);
+
+        var inserted = result.firstWhere((r) => r.id != existingRow.id);
+        expect(inserted.id, isNotNull);
+        expect(inserted.num, 20);
+
+        var allRows = await SimpleData.db.find(session);
+        expect(allRows, hasLength(2));
+      },
+    );
+  });
 
   test(
     'Given an upsert operation with column from different table '

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/test_integration/database_operations/crud/upsert_test.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/test_integration/database_operations/crud/upsert_test.dart
@@ -429,21 +429,64 @@ void main() async {
     },
   );
 
-  test(
-    'Given an upsert operation with id as conflictColumn '
-    'when executing it '
-    'then it throws an ArgumentError.',
-    () async {
-      await expectLater(
-        UpsertTestModel.db.upsert(
-          session,
-          [UpsertTestModel(code: 'A', category: 'c1', value: 1)],
-          conflictColumns: (t) => [t.id],
-        ),
-        throwsA(isA<ArgumentError>()),
+  group('Given an existing row', () {
+    late SimpleData existingRow;
+
+    setUp(() async {
+      existingRow = await SimpleData.db.insertRow(
+        session,
+        SimpleData(num: 1),
       );
-    },
-  );
+    });
+
+    tearDown(() async {
+      await SimpleData.db.deleteWhere(
+        session,
+        where: (t) => Constant.bool(true),
+      );
+    });
+
+    test(
+      'when upserting with id as conflictColumn then the existing row is updated.',
+      () async {
+        var updated = (await SimpleData.db.upsertRow(
+          session,
+          SimpleData(id: existingRow.id, num: 2),
+          conflictColumns: (t) => [t.id],
+        ))!;
+
+        expect(updated.id, existingRow.id);
+        expect(updated.num, 2);
+      },
+    );
+
+    test(
+      'when batch upserting a mix of existing and new rows by id '
+      'then existing rows are updated and new rows are inserted.',
+      () async {
+        var result = await SimpleData.db.upsert(
+          session,
+          [
+            SimpleData(id: existingRow.id, num: 10),
+            SimpleData(num: 20),
+          ],
+          conflictColumns: (t) => [t.id],
+        );
+
+        expect(result, hasLength(2));
+
+        var updated = result.firstWhere((r) => r.id == existingRow.id);
+        expect(updated.num, 10);
+
+        var inserted = result.firstWhere((r) => r.id != existingRow.id);
+        expect(inserted.id, isNotNull);
+        expect(inserted.num, 20);
+
+        var allRows = await SimpleData.db.find(session);
+        expect(allRows, hasLength(2));
+      },
+    );
+  });
 
   test(
     'Given an upsert operation with column from different table '


### PR DESCRIPTION
Fixes a wrong premise in the `upsert`/`upsertRow` methods that forbid its usage with the `id` as primary key.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.