### PR TITLE
fix: Fix analysis errors due to `clock` transitive import on generated code

### DIFF
--- a/tests/serverpod_test_server/lib/src/generated/future_calls.dart
+++ b/tests/serverpod_test_server/lib/src/generated/future_calls.dart
@@ -8,6 +8,7 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
+// ignore_for_file: depend_on_referenced_packages
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/future_calls.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/future_calls.dart
@@ -8,6 +8,7 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 // ignore_for_file: invalid_use_of_internal_member
+// ignore_for_file: depend_on_referenced_packages
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;

--- a/tools/serverpod_cli/lib/src/generator/dart/library_generators/future_calls_library_generator.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart/library_generators/future_calls_library_generator.dart
@@ -236,6 +236,9 @@ extension FutureCallsLibraryGenerator on LibraryGenerator {
     _generateFutureCallDispatchers(library);
     _generateServerFutureCalls(library);
 
+    // Ensure users are not alerted due to the import of the clock package.
+    library.ignoreForFile.add('depend_on_referenced_packages');
+
     return library.build();
   }
 

--- a/tools/serverpod_cli/test/generator/dart/server_code_generator/future_calls_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/server_code_generator/future_calls_test.dart
@@ -184,6 +184,18 @@ void main() {
           });
 
           test(
+            'contains "ignore_for_file: depend_on_referenced_packages" directive.',
+            () {
+              expect(
+                futureCallsFile,
+                contains(
+                  '// ignore_for_file: depend_on_referenced_packages',
+                ),
+              );
+            },
+          );
+
+          test(
             'has the future call instance for the method with a Future return type whose first argument is a Session.',
             () {
               expect(


### PR DESCRIPTION
Fixes a behavior reported on Discord of generated future calls getter raising an analysis alert due to the `clock` package being used for recurrent future calls. Using the `clock` package is better for testing purposes, so the fix is just adding a conditional ignore for the `depend_on_referenced_packages` lint.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.