### PR TITLE
feat: Configurable companion Flutter app path for serverpod start

### DIFF
--- a/tools/serverpod_cli/lib/src/commands/start.dart
+++ b/tools/serverpod_cli/lib/src/commands/start.dart
@@ -111,6 +111,18 @@ enum StartOption<V> implements OptionDefinition<V> {
       defaultsTo: [],
     ),
   ),
+  flutterPath(
+    StringOption(
+      argName: 'flutter-path',
+      defaultsTo: '',
+      helpText:
+          'Path to the companion Flutter app to launch, relative to the '
+          'server directory. Overrides the auto-detected `<name>_flutter` '
+          'sibling and the `flutter_package_path` generator config. Useful '
+          'when several Flutter apps share one server (e.g. a user app and an '
+          'admin app) and you want to pick which one to launch.',
+    ),
+  ),
   ;
 
   const StartOption(this.option);
@@ -156,6 +168,10 @@ class StartCommand extends ServerpodCommand<StartOption> {
     final useTui = commandConfig.value(StartOption.tui) && stdout.hasTerminal;
     final launchFlutterApp = commandConfig.value(StartOption.flutter);
     final flutterDevice = commandConfig.value(StartOption.flutterDevice);
+    // A custom companion Flutter app path (relative to the server directory),
+    // overriding auto-detection and the `flutter_package_path` config key.
+    final flutterPathArg = commandConfig.value(StartOption.flutterPath);
+    final flutterPackagePath = flutterPathArg.isEmpty ? null : flutterPathArg;
     // Narrow once: MultiOption.value() returns List<dynamic>.
     final flutterExtraArgs = List<String>.from(
       commandConfig.value(StartOption.flutterOption) as Iterable,
@@ -182,6 +198,7 @@ class StartCommand extends ServerpodCommand<StartOption> {
         interactive: serverpodRunner.globalConfiguration.optionalValue(
           GlobalOption.interactive,
         ),
+        flutterPackagePath: flutterPackagePath,
       );
 
       // Bail before the TUI takes over the terminal
@@ -214,6 +231,7 @@ class StartCommand extends ServerpodCommand<StartOption> {
         config = await GeneratorConfig.load(
           serverRootDir: directory,
           interactive: interactive,
+          flutterPackagePath: flutterPackagePath,
         );
         return true;
       });

--- a/tools/serverpod_cli/lib/src/config/config.dart
+++ b/tools/serverpod_cli/lib/src/config/config.dart
@@ -347,9 +347,16 @@ class GeneratorConfig implements ModelLoadConfig {
   /// The [interactive] parameter controls whether interactive prompts are enabled.
   /// Defaults to true unless running in a CI environment (detected via ci package).
   /// Explicit flag value overrides CI detection.
+  ///
+  /// The [flutterPackagePath] parameter, when provided, overrides the location
+  /// of the companion Flutter package (a path relative to the server
+  /// directory), taking precedence over the `flutter_package_path` key in
+  /// `config/generator.yaml`. This lets callers select, per invocation, which
+  /// Flutter app to launch in projects where several apps share one server.
   static Future<GeneratorConfig> load({
     String serverRootDir = '',
     required bool? interactive,
+    String? flutterPackagePath,
   }) async {
     // Auto-detect server directory if not specified
     if (serverRootDir.isEmpty) {
@@ -406,7 +413,23 @@ class GeneratorConfig implements ModelLoadConfig {
       );
     }
 
-    final relativeFlutterPackagePathParts = ['..', '${name}_flutter'];
+    // The companion Flutter package defaults to the `<name>_flutter` sibling,
+    // can be redirected with the `flutter_package_path` generator config key,
+    // and is finally overridden by an explicit [flutterPackagePath] (e.g. from
+    // `serverpod start --flutter-path`). The override comes last so that, when
+    // several Flutter apps share one server, callers can pick which app to
+    // launch per invocation.
+    var relativeFlutterPackagePathParts = ['..', '${name}_flutter'];
+
+    if (generatorConfig['flutter_package_path'] != null) {
+      relativeFlutterPackagePathParts = p.split(
+        generatorConfig['flutter_package_path'],
+      );
+    }
+
+    if (flutterPackagePath != null) {
+      relativeFlutterPackagePathParts = p.split(flutterPackagePath);
+    }
 
     List<String>? relativeServerTestToolsPathParts;
     if (generatorConfig['server_test_tools_path'] != null) {

--- a/tools/serverpod_cli/test/integration/generator_config/flutter_package_path_config_test.dart
+++ b/tools/serverpod_cli/test/integration/generator_config/flutter_package_path_config_test.dart
@@ -1,0 +1,229 @@
+import 'package:path/path.dart' as path;
+import 'package:serverpod_cli/src/config/config.dart';
+import 'package:serverpod_cli/src/config/experimental_feature.dart';
+import 'package:test/test.dart';
+import 'package:test_descriptor/test_descriptor.dart' as d;
+
+const _serverRootDir = 'project/my_project_server';
+
+void main() {
+  setUpAll(() {
+    CommandLineExperimentalFeatures.initialize([]);
+  });
+
+  String flutterDirOf(GeneratorConfig config) =>
+      path.normalize(path.joinAll(config.flutterPackagePathParts));
+
+  group('Given a generator.yaml without flutter_package_path', () {
+    setUpAll(() async {
+      await _createProject(
+        generatorYamlContent: '''
+type: server
+''',
+      ).create();
+    });
+
+    test(
+      'when loading the config '
+      'then the Flutter package resolves to the `<name>_flutter` sibling.',
+      () async {
+        var config = await GeneratorConfig.load(
+          serverRootDir: path.join(d.sandbox, _serverRootDir),
+          interactive: false,
+        );
+
+        expect(
+          flutterDirOf(config),
+          endsWith(path.join('project', 'my_project_flutter')),
+        );
+      },
+    );
+  });
+
+  group('Given a generator.yaml with flutter_package_path set to an existing '
+      'package', () {
+    setUpAll(() async {
+      await _createProject(
+        generatorYamlContent: '''
+type: server
+flutter_package_path: ../apps/my_app
+''',
+        flutterAppPath: ['apps', 'my_app'],
+      ).create();
+    });
+
+    test(
+      'when loading the config '
+      'then the Flutter package resolves to the configured path.',
+      () async {
+        var config = await GeneratorConfig.load(
+          serverRootDir: path.join(d.sandbox, _serverRootDir),
+          interactive: false,
+        );
+
+        expect(
+          flutterDirOf(config),
+          endsWith(path.join('project', 'apps', 'my_app')),
+        );
+      },
+    );
+
+    test(
+      'when loading the config '
+      'then the configured Flutter package is detected.',
+      () async {
+        var config = await GeneratorConfig.load(
+          serverRootDir: path.join(d.sandbox, _serverRootDir),
+          interactive: false,
+        );
+
+        expect(config.hasFlutterPackage, isTrue);
+      },
+    );
+  });
+
+  group('Given a generator.yaml with flutter_package_path and an existing '
+      'package at a different override path', () {
+    setUpAll(() async {
+      await _createProject(
+        generatorYamlContent: '''
+type: server
+flutter_package_path: ../apps/user_app
+''',
+        flutterAppPath: ['apps', 'admin_app'],
+      ).create();
+    });
+
+    test(
+      'when loading the config with an explicit flutterPackagePath '
+      'then the explicit path takes precedence over the config key.',
+      () async {
+        var config = await GeneratorConfig.load(
+          serverRootDir: path.join(d.sandbox, _serverRootDir),
+          interactive: false,
+          flutterPackagePath: '../apps/admin_app',
+        );
+
+        expect(
+          flutterDirOf(config),
+          endsWith(path.join('project', 'apps', 'admin_app')),
+        );
+      },
+    );
+  });
+
+  group('Given a flutter_package_path pointing to a missing directory', () {
+    setUpAll(() async {
+      await _createProject(
+        generatorYamlContent: '''
+type: server
+flutter_package_path: ../apps/does_not_exist
+''',
+      ).create();
+    });
+
+    test(
+      'when loading the config '
+      'then no Flutter package is detected.',
+      () async {
+        var config = await GeneratorConfig.load(
+          serverRootDir: path.join(d.sandbox, _serverRootDir),
+          interactive: false,
+        );
+
+        expect(config.hasFlutterPackage, isFalse);
+      },
+    );
+  });
+}
+
+/// Creates a minimal Serverpod server/client project descriptor under a
+/// `project/` directory, optionally materializing a Flutter app package at
+/// [flutterAppPath] (relative to `project/`) so that `hasFlutterPackage`
+/// resolves to true for that location.
+d.DirectoryDescriptor _createProject({
+  String projectName = 'my_project',
+  required String generatorYamlContent,
+  List<String>? flutterAppPath,
+}) {
+  var serverDirContents = <d.Descriptor>[
+    d.file('pubspec.yaml', '''
+name: ${projectName}_server
+dependencies:
+  serverpod: ^2.0.0
+'''),
+    d.dir('lib', [
+      d.dir('src', [
+        d.dir('protocol', []),
+      ]),
+    ]),
+    d.dir('.dart_tool', [
+      d.file('package_config.json', '''
+{
+  "configVersion": 2,
+  "packages": [
+    {
+      "name": "${projectName}_server",
+      "rootUri": "../",
+      "packageUri": "lib/"
+    },
+    {
+      "name": "serverpod",
+      "rootUri": "../.pub-cache/hosted/pub.dev/serverpod-2.0.0",
+      "packageUri": "lib/"
+    }
+  ]
+}
+'''),
+    ]),
+    d.dir('config', [
+      d.file('generator.yaml', generatorYamlContent),
+    ]),
+  ];
+
+  var clientDir = d.dir('${projectName}_client', [
+    d.file('pubspec.yaml', '''
+name: ${projectName}_client
+dependencies:
+  serverpod_client: ^2.0.0
+'''),
+    d.dir('lib', [
+      d.dir('src', [
+        d.dir('protocol', []),
+      ]),
+    ]),
+  ]);
+
+  var projectChildren = <d.Descriptor>[
+    d.dir('${projectName}_server', serverDirContents),
+    clientDir,
+  ];
+
+  if (flutterAppPath != null) {
+    projectChildren.add(
+      _nestedDir(flutterAppPath, [
+        d.file('pubspec.yaml', '''
+name: ${projectName}_app
+dependencies:
+  flutter:
+    sdk: flutter
+'''),
+      ]),
+    );
+  }
+
+  return d.dir('project', projectChildren);
+}
+
+/// Wraps [leaf] in nested [d.dir] descriptors so that, e.g.,
+/// `['apps', 'my_app']` becomes `apps/ -> my_app/` containing [leaf].
+d.DirectoryDescriptor _nestedDir(
+  List<String> segments,
+  List<d.Descriptor> leaf,
+) {
+  var contents = leaf;
+  for (var i = segments.length - 1; i >= 0; i--) {
+    contents = [d.dir(segments[i], contents)];
+  }
+  return contents.single as d.DirectoryDescriptor;
+}


### PR DESCRIPTION
`serverpod start --flutter` auto-launches a companion Flutter app, but it only looks for it at a hardcoded location — the `<name>_flutter` sibling of the server directory (`relativeFlutterPackagePathParts = ['..', '${name}_flutter']` in `GeneratorConfig.load`). In projects that don't follow that sibling layout (e.g. a Melos workspace monorepo with apps under `app/`), the path doesn't exist, so `hasFlutterPackage` is `false` and the app is silently skipped. The client package already has a `client_package_path` override, but there was no equivalent for the Flutter package.

This adds two overrides, mirroring `client_package_path`:

- A `flutter_package_path` key in `config/generator.yaml` (path relative to the server directory).
- A `--flutter-path` flag on `serverpod start` that takes precedence over the config key, so projects where several Flutter apps share one server can pick which app to launch per invocation (e.g. a user app vs. an admin app).

Resolution precedence: `--flutter-path` > `flutter_package_path` > `<name>_flutter`. When neither is set, behavior is unchanged — fully backwards compatible.

```yaml
# config/generator.yaml
type: server
client_package_path: ../../app/my_app_client
flutter_package_path: ../../app/my_app
```

```bash
serverpod start --flutter-path ../../app/admin_app
```

Fixes #5348.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

## Breaking changes

None. The new config key and flag are both optional; when unset, the companion Flutter app resolves to the `<name>_flutter` sibling exactly as before.
