### PR TITLE
fix: Lock the sign-in UI during Facebook authentication

### DIFF
--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_flutter/lib/serverpod_auth_idp_flutter.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_flutter/lib/serverpod_auth_idp_flutter.dart
@@ -20,6 +20,7 @@ export 'src/common/oauth2_pkce/oauth2_pkce_client_config.dart';
 export 'src/common/oauth2_pkce/oauth2_pkce_exception.dart';
 export 'src/common/oauth2_pkce/oauth2_pkce_result.dart';
 export 'src/common/oauth2_pkce/oauth2_pkce_util.dart';
+export 'src/common/sign_in_flow_coordinator.dart';
 export 'src/email/email_auth_controller.dart';
 export 'src/email/email_sign_in_widget.dart';
 export 'src/github/github_auth_controller.dart';

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_flutter_facebook/lib/src/facebook_sign_in_widget.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_flutter_facebook/lib/src/facebook_sign_in_widget.dart
@@ -152,7 +152,7 @@ class _FacebookSignInWidgetState extends State<FacebookSignInWidget> {
   @override
   Widget build(BuildContext context) {
     return FacebookSignInButton(
-      onPressed: _controller.signIn,
+      onPressed: _signIn,
       isLoading: _controller.isLoading,
       isDisabled: _controller.isLoading,
       type: widget.type,
@@ -162,5 +162,19 @@ class _FacebookSignInWidgetState extends State<FacebookSignInWidget> {
       minimumWidth: widget.minimumWidth,
       logoAlignment: widget.logoAlignment,
     );
+  }
+
+  Future<void> _signIn() async {
+    final coordinator = SignInFlowCoordinatorWidget.of(context);
+    if (coordinator?.isAuthenticating == true) return;
+
+    coordinator?.lockUI();
+    try {
+      await _controller.signIn();
+    } finally {
+      if (mounted) {
+        coordinator?.unlockUI();
+      }
+    }
   }
 }


### PR DESCRIPTION
The sign-in UI lock from #5109 disables interaction and back navigation while an authentication attempt is in progress, but it only covered the providers in the main `serverpod_auth_idp_flutter` package.

This PR:
- Exports `sign_in_flow_coordinator.dart` from the `serverpod_auth_idp_flutter` package.
- Wraps `FacebookSignInWidget`'s button with the same `lockUI`/`unlockUI` flow the built-in providers use.

Followup to #5109 

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes
None