### PR TITLE
fix: Encode column values correctly in upsert insert queries for SQLite

### DIFF
--- a/packages/serverpod_database/lib/src/adapters/postgres/sql_query_builder.dart
+++ b/packages/serverpod_database/lib/src/adapters/postgres/sql_query_builder.dart
@@ -525,7 +525,8 @@ class InsertQueryBuilder {
           var values = selectedColumns
               .map((column) {
                 var unformattedValue = row[column.columnName];
-                return ValueEncoder.instance.convert(
+                return ValueEncoder.instance.encodeColumnValue(
+                  column,
                   unformattedValue,
                   hasDefaults: column.hasDefault,
                 );

--- a/packages/serverpod_database/lib/src/adapters/postgres/value_encoder.dart
+++ b/packages/serverpod_database/lib/src/adapters/postgres/value_encoder.dart
@@ -4,6 +4,7 @@ import 'dart:typed_data';
 import 'package:postgres/src/types/text_codec.dart';
 import 'package:serverpod_serialization/serverpod_serialization.dart';
 
+import '../../concepts/columns.dart';
 import '../../interface/value_encoder.dart';
 
 /// Overrides the [PostgresTextEncoder] to add support for [ByteData].
@@ -74,5 +75,14 @@ class PostgresValueEncoder extends PostgresTextEncoder implements ValueEncoder {
         escapeStrings: escapeStrings,
       );
     }
+  }
+
+  @override
+  String encodeColumnValue(
+    Column column,
+    dynamic value, {
+    bool hasDefaults = false,
+  }) {
+    return convert(value, hasDefaults: hasDefaults);
   }
 }

--- a/packages/serverpod_database/lib/src/adapters/sqlite/value_encoder.dart
+++ b/packages/serverpod_database/lib/src/adapters/sqlite/value_encoder.dart
@@ -128,6 +128,7 @@ class SqliteValueEncoder implements ValueEncoder {
   }
 
   /// Coerces [value] for [column] as a model value.
+  @override
   String encodeColumnValue(
     Column column,
     dynamic value, {

--- a/packages/serverpod_database/lib/src/interface/value_encoder.dart
+++ b/packages/serverpod_database/lib/src/interface/value_encoder.dart
@@ -1,3 +1,5 @@
+import '../concepts/columns.dart';
+
 /// Interface for value encoders.
 ///
 /// Can be accessed through the [instance] property if a database has been
@@ -29,4 +31,11 @@ abstract interface class ValueEncoder {
   /// Tries to convert an object to a string.
   /// Returns `null` if the conversion fails.
   String? tryConvert(Object? input, {bool escapeStrings = false});
+
+  /// Converts a column value to a string, applying column-specific coercion.
+  String encodeColumnValue(
+    Column column,
+    dynamic value, {
+    bool hasDefaults = false,
+  });
 }

--- a/packages/serverpod_database/test/database_query/upsert_sqlite_query_test.dart
+++ b/packages/serverpod_database/test/database_query/upsert_sqlite_query_test.dart
@@ -1,0 +1,65 @@
+import 'package:serverpod_database/serverpod_database.dart';
+import 'package:serverpod_database/src/adapters/postgres/sql_query_builder.dart';
+import 'package:serverpod_database/src/adapters/sqlite/value_encoder.dart';
+import 'package:serverpod_serialization/serverpod_serialization.dart';
+import 'package:test/test.dart';
+
+class UuidRowTable extends Table<int?> {
+  late final ColumnUuid rowUuid;
+
+  UuidRowTable() : super(tableName: 'uuid_row') {
+    rowUuid = ColumnUuid('rowUuid', this);
+  }
+
+  @override
+  List<Column> get columns => [id, rowUuid];
+}
+
+class UuidRow implements TableRow<int?> {
+  UuidRow({this.id, required this.rowUuid});
+
+  @override
+  int? id;
+
+  final UuidValue rowUuid;
+
+  @override
+  Table<int?> get table => UuidRowTable();
+
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      if (id != null) 'id': id,
+      'rowUuid': rowUuid.toJson(),
+    };
+  }
+}
+
+void main() {
+  ValueEncoder.set(const SqliteValueEncoder());
+
+  test(
+    'Given a model with a UUID column, '
+    'when building an upsert query for SQLite, '
+    'then UUID values are encoded as BLOB literals.',
+    () {
+      var table = UuidRowTable();
+      var uuidString = '550e8400-e29b-41d4-a716-446655440000';
+      var uuidHex = uuidString.replaceAll('-', '').toLowerCase();
+
+      var query = InsertQueryBuilder(
+        table: table,
+        rows: [
+          UuidRow(
+            id: 1,
+            rowUuid: UuidValue.fromString(uuidString),
+          ),
+        ],
+        conflictColumns: [table.id],
+      ).build();
+
+      expect(query, contains("X'$uuidHex'"));
+      expect(query, isNot(contains("'$uuidString'")));
+    },
+  );
+}

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/test_integration/database_operations/crud/upsert_test.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/test_integration/database_operations/crud/upsert_test.dart
@@ -488,6 +488,54 @@ void main() async {
     );
   });
 
+  group('Given a row with a UUID column stored in the database', () {
+    late ObjectWithUuid existingRow;
+
+    setUp(() async {
+      var uuid = UuidValue.fromString(
+        '550e8400-e29b-41d4-a716-446655440000',
+      );
+      var uuidNullable = UuidValue.fromString(
+        '9e107d9d-372b-4d97-92b7-2f0907d0b1d4',
+      );
+
+      existingRow = await ObjectWithUuid.db.insertRow(
+        session,
+        ObjectWithUuid(uuid: uuid, uuidNullable: uuidNullable),
+      );
+    });
+
+    tearDown(() async {
+      await ObjectWithUuid.db.deleteWhere(
+        session,
+        where: (t) => Constant.bool(true),
+      );
+    });
+
+    test(
+      'when upserting the row with an updated UUID column value, '
+      'then the UUID column is updated successfully.',
+      () async {
+        var updatedUuidNullable = UuidValue.fromString(
+          'f47ac10b-58cc-4372-a567-0e02b2c3d479',
+        );
+
+        var updated = await ObjectWithUuid.db.upsertRow(
+          session,
+          ObjectWithUuid(
+            id: existingRow.id,
+            uuid: existingRow.uuid,
+            uuidNullable: updatedUuidNullable,
+          ),
+          conflictColumns: (t) => [t.id],
+        );
+
+        expect(updated, isNotNull);
+        expect(updated!.uuidNullable, updatedUuidNullable);
+      },
+    );
+  });
+
   test(
     'Given an upsert operation with column from different table '
     'when executing it '


### PR DESCRIPTION
Fixes an issue with upsert on SQLite with types that required coercion - like `UuidValue`. The fix was required by `upsert` only because `insert` and `update` did not use the shared `SqlQueryBuilder`.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.