### PR TITLE
fix: Add operations to ColumnSerializable

### DIFF
--- a/packages/serverpod_database/lib/src/concepts/columns.dart
+++ b/packages/serverpod_database/lib/src/concepts/columns.dart
@@ -64,7 +64,8 @@ class ColumnByteData extends Column<ByteData> {
 
 /// A [Column] holding an [SerializableModel]. The entity will be stored in the
 /// database as a json column.
-class ColumnSerializable<T> extends Column<T> {
+class ColumnSerializable<T> extends _ValueOperatorColumn<T>
+    with _NullableColumnDefaultOperations<T> {
   /// Creates a new [Column], this is typically done in generated code only.
   ColumnSerializable(
     super.columnName,
@@ -72,6 +73,11 @@ class ColumnSerializable<T> extends Column<T> {
     super.hasDefault,
     super.fieldName,
   });
+
+  @override
+  Expression _encodeValueForQuery(T value) {
+    return EscapedExpression(SerializationManager.encode(value));
+  }
 }
 
 /// A [Column] holding a [SerializableModel]. The entity will be stored in the

--- a/packages/serverpod_database/test/columns/column_serializable_test.dart
+++ b/packages/serverpod_database/test/columns/column_serializable_test.dart
@@ -26,5 +26,84 @@ void main() {
     test('when type is called then String is returned.', () {
       expect(column.type, String);
     });
+
+    group('with _ColumnDefaultOperations mixin', () {
+      test(
+        'when equals compared to NULL value then output is IS NULL expression.',
+        () {
+          var comparisonExpression = column.equals(null);
+
+          expect(comparisonExpression.toString(), '$column IS NULL');
+        },
+      );
+
+      test(
+        'when NOT equals compared to NULL value then output is IS NOT NULL expression.',
+        () {
+          var comparisonExpression = column.notEquals(null);
+
+          expect(comparisonExpression.toString(), '$column IS NOT NULL');
+        },
+      );
+    });
+  });
+
+  group('Given a ColumnSerializable containing a List', () {
+    var columnName = 'values';
+    var column = ColumnSerializable<List<int>>(
+      columnName,
+      Table<int?>(tableName: 'test'),
+    );
+
+    test(
+      'when equals compared to List value then output is escaped equals expression.',
+      () {
+        var comparisonExpression = column.equals([1, 2, 3]);
+
+        expect(comparisonExpression.toString(), '$column = \'[1,2,3]\'');
+      },
+    );
+
+    test(
+      'when NOT equals compared to List value then output is escaped NOT equals expression.',
+      () {
+        var comparisonExpression = column.notEquals([1, 2, 3]);
+
+        expect(
+          comparisonExpression.toString(),
+          '$column IS DISTINCT FROM \'[1,2,3]\'',
+        );
+      },
+    );
+
+    test(
+      'when checking if expression is in value set then output is IN expression.',
+      () {
+        var comparisonExpression = column.inSet({
+          [1, 2],
+          [3, 4],
+        });
+
+        expect(
+          comparisonExpression.toString(),
+          '$column IN (\'[1,2]\', \'[3,4]\')',
+        );
+      },
+    );
+
+    test(
+      'when checking if expression is NOT in value set then output is NOT IN expression.',
+      () {
+        var comparisonExpression = column.notInSet({
+          [1, 2],
+          [3, 4],
+        });
+
+        expect(
+          comparisonExpression.toString(),
+          '($column NOT IN (\'[1,2]\', \'[3,4]\') OR $column IS NULL)',
+        );
+      },
+    );
   });
 }


### PR DESCRIPTION
This adds the standard column operations to `ColumnSerializable`.

`ColumnSerializable` can now use the same comparison API as the other nullable columns:

```dart
column.equals(null)
column.notEquals(null)
column.equals(value)
column.notEquals(value)
column.inSet(values)
column.notInSet(values)
```

Non-null values are serialized before they are used in the SQL expression, so list, map, set, and model values keep the same JSON encoding behavior used elsewhere.

Fixes #1591.

## Tests

From `packages/serverpod_database`:

```bash
dart analyze
dart test
```

Both passed locally with Dart 3.10.3.

I also ran a small smoke check for the missing behavior:

```text
1. Serializable list is not null:
"vouchers"."usersIdsAlreadyUsed" IS NOT NULL

2. Serializable object is null:
"vouchers"."metadata" IS NULL

3. Serializable list equals a value:
"vouchers"."tags" = '["active","paid"]'
```

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.
