### PR TITLE
feat: Keep `serverpod start` open when the project fails to build

### DIFF
--- a/tools/serverpod_cli/lib/src/commands/messages.dart
+++ b/tools/serverpod_cli/lib/src/commands/messages.dart
@@ -8,7 +8,21 @@ const generatedCodeAlreadyUpToDate = '✓ Generated code is already up to date.'
 // Start command messages
 const serverRunning = 'Server running.';
 
+/// Shown when `serverpod start --watch` cannot bring the server up because the
+/// project does not generate or compile. The file watcher keeps running, so a
+/// fix is picked up automatically.
+const startBlockedByErrorsWatch =
+    'Waiting for the project to build. Once the errors above are resolved, '
+    'the server will start automatically.';
+
+/// Shown in `--no-watch` mode, where there is no file watcher to recover; the
+/// user triggers a rebuild manually (the "R" action in the TUI).
+const startBlockedByErrorsManual =
+    'Waiting for the project to build. Once the errors above are resolved, '
+    'press "R" to rebuild and start the server.';
+
 // Watch command messages
+const serverStarted = '✓ Server started.';
 const serverReloaded = '✓ Server reloaded.';
 const serverRestarted = '✓ Server restarted.';
 const serverNativeAssetsChanged =

--- a/tools/serverpod_cli/lib/src/commands/start.dart
+++ b/tools/serverpod_cli/lib/src/commands/start.dart
@@ -29,6 +29,7 @@ import 'package:serverpod_cli/src/commands/watcher.dart';
 import 'package:serverpod_cli/src/config/config.dart';
 import 'package:serverpod_cli/src/config/flutter_app_config.dart';
 import 'package:serverpod_cli/src/config_info/config_info.dart';
+import 'package:serverpod_cli/src/generator/generation_staleness.dart';
 import 'package:serverpod_cli/src/generator/isolated_analyzers.dart';
 import 'package:serverpod_cli/src/mcp/socket_directory.dart';
 import 'package:serverpod_cli/src/migrations/cli_migration_runner.dart';
@@ -216,6 +217,9 @@ class StartCommand extends ServerpodCommand<StartOption> {
         serverArgs: serverArgs,
         watch: watch,
         docker: docker,
+        // No TUI here, so the only recovery from a broken project is the file
+        // watcher (watch mode). Without it there is nothing to wait for.
+        keepOpenOnFailure: watch,
         launchFlutterApp: launchFlutterApp,
         shutdown: shutdown,
       );
@@ -378,6 +382,11 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
   required ServerArgsRef serverArgs,
   required bool watch,
   required bool docker,
+  // When the project fails to generate or compile: if `true`, keep the session
+  // open with no server running and recover later (the file watcher auto-boots
+  // in watch mode; [WatchSession.retryStart] boots on demand otherwise). If
+  // `false`, there is no way to recover (non-TUI `--no-watch`), so fail fast.
+  required bool keepOpenOnFailure,
   required bool launchFlutterApp,
   required _ShutdownSignal shutdown,
   IOSink? serverStdoutSink,
@@ -476,12 +485,18 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
     await rollbackStartup();
     rethrow;
   }
-  if (!genResult.success) {
+
+  // Whether the project is currently buildable. A clean generation failure no
+  // longer aborts: in a recoverable session we keep watching with no server
+  // and boot it once the user fixes the errors.
+  var buildOk = genResult.success;
+  if (!buildOk) {
     log.error('Code generation failed.');
-    await rollbackStartup();
-    return const WatchLoopAborted(1);
-  }
-  if (genResult.upToDate) {
+    if (!keepOpenOnFailure) {
+      await rollbackStartup();
+      return const WatchLoopAborted(1);
+    }
+  } else if (genResult.upToDate) {
     log.info(generatedCodeAlreadyUpToDate, type: TextLogType.success);
   }
 
@@ -533,13 +548,26 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
     // Compile if the cached dill is stale. The FES starts in the background
     // (KernelCompiler gates compile/reset calls internally until start
     // completes), so if the dill is up to date we boot immediately.
-    if (!await localCompiler.compileIfNeeded(
-      config.watchPaths(includeWeb: true, includeClientPackage: true),
-    )) {
-      await localCompiler.dispose();
-      log.error('Initial compilation failed.');
-      await rollbackStartup();
-      return const WatchLoopAborted(1);
+    //
+    // Skip the compile when generation already failed - the generated code is
+    // invalid, so the compile would only fail noisily. The FES stays in its
+    // fresh post-start state, ready for the watch session to compile from
+    // scratch once the project is fixed.
+    if (buildOk) {
+      if (!await localCompiler.compileIfNeeded(
+        config.watchPaths(includeWeb: true, includeClientPackage: true),
+      )) {
+        // Reject the failed compile so the FES returns to its last accepted
+        // (empty) state, leaving it ready for a clean full compile on recovery.
+        await localCompiler.reject();
+        log.error('Initial compilation failed.');
+        buildOk = false;
+        if (!keepOpenOnFailure) {
+          await localCompiler.dispose();
+          await rollbackStartup();
+          return const WatchLoopAborted(1);
+        }
+      }
     }
 
     compiler = localCompiler;
@@ -608,12 +636,18 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
     return serverProcess;
   }
 
-  late final ServerProcess initialServerProcess;
-  await log.progress('Starting server', () async {
-    final initialDill = watch ? p.join(serverpodToolDir, 'server.dill') : null;
-    initialServerProcess = await serverProcessFactory(initialDill);
-    return true;
-  });
+  // Null in a degraded start: the project failed to build, so no server boots
+  // now. The watch session brings it up once the project is fixed.
+  ServerProcess? initialServerProcess;
+  if (buildOk) {
+    await log.progress('Starting server', () async {
+      final initialDill = watch ? p.join(serverpodToolDir, 'server.dill') : null;
+      initialServerProcess = await serverProcessFactory(initialDill);
+      return true;
+    });
+  } else {
+    log.warning(watch ? startBlockedByErrorsWatch : startBlockedByErrorsManual);
+  }
 
   // Construct the watch session.
   session = WatchSession(
@@ -626,6 +660,19 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
         affectedPaths: affectedPaths,
         incremental: true,
         requirements: requirements,
+      );
+    },
+    // Full-project regeneration for on-demand recovery from a degraded start
+    // (retryStart), where there is no incremental change event to scope it.
+    fullGenerate: () async {
+      final allSources = await enumerateSourceFiles(config);
+      return analyzeAndGenerate(
+        analyzers: await analyzersFuture,
+        config: config,
+        affectedPaths: allSources.keys.toSet(),
+        incremental: false,
+        verifyStaleness: false,
+        sourceStats: allSources,
       );
     },
     createServer: serverProcessFactory,
@@ -733,7 +780,7 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
   return WatchLoopReady(
     WatchLoopContext(
       session: session,
-      proxy: proxy,
+      proxy: () => proxy,
       flutterManager: flutterManager,
       mcpSocket: mcpSocket,
       fileChangeSub: fileChangeSub,
@@ -1059,6 +1106,9 @@ Future<void> _runTuiBackend({
       serverArgs: argsRef,
       watch: watch,
       docker: docker,
+      // The TUI always stays open on a broken project: in watch mode the file
+      // watcher auto-recovers; otherwise the user triggers a rebuild manually.
+      keepOpenOnFailure: true,
       launchFlutterApp: launchFlutterApp,
       shutdown: shutdown,
       serverStdoutSink: stdoutSink,
@@ -1117,6 +1167,12 @@ Future<void> _runTuiBackend({
         holder.markDirty();
       },
       onServerStart: (server) async {
+        // Fires on every server boot - the initial start, a restart, and the
+        // first boot after recovering from a degraded start. Mark the UI ready
+        // so a degraded->running transition lights up the action buttons.
+        holder.state.serverReady = true;
+        holder.state.serverStartable = false;
+        holder.markDirty();
         final vmService = server.vmService;
         if (vmService == null) return;
         await vmService.streamListen('Extension');
@@ -1180,7 +1236,15 @@ Future<void> _runTuiBackend({
           runTrackedAction(holder, 'Hot reload', ctx.session.forceReload);
         };
         holder.onHotRestart = () {
-          runTrackedAction(holder, 'Hot restart', ctx.session.forceRestart);
+          // While degraded (no server yet), the R action rebuilds and boots the
+          // server via retryStart; once running it is an ordinary hot restart.
+          final running = ctx.session.isRunning;
+          runTrackedAction(
+            holder,
+            running ? 'Hot restart' : 'Rebuild & start',
+            running ? ctx.session.forceRestart : ctx.session.retryStart,
+            allowWhenStartable: !running,
+          );
         };
         holder.onRestartFlutterApp = () {
           runTrackedAction(
@@ -1223,6 +1287,9 @@ Future<void> _runTuiBackend({
         };
 
         holder.state.serverReady = ctx.session.isRunning;
+        // Degraded start (no server yet): expose the manual "Start server"
+        // recovery action. The watcher also auto-recovers in watch mode.
+        holder.state.serverStartable = !ctx.session.isRunning;
         holder.markDirty();
 
         if (ctx.session.isRunning) log.info(serverRunning);

--- a/tools/serverpod_cli/lib/src/commands/start.dart
+++ b/tools/serverpod_cli/lib/src/commands/start.dart
@@ -641,7 +641,9 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
   ServerProcess? initialServerProcess;
   if (buildOk) {
     await log.progress('Starting server', () async {
-      final initialDill = watch ? p.join(serverpodToolDir, 'server.dill') : null;
+      final initialDill = watch
+          ? p.join(serverpodToolDir, 'server.dill')
+          : null;
       initialServerProcess = await serverProcessFactory(initialDill);
       return true;
     });

--- a/tools/serverpod_cli/lib/src/commands/start/tui/event_handler.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/tui/event_handler.dart
@@ -75,15 +75,21 @@ void handleServerLogEvent(TuiAppStateHolder holder, Event event) {
 
 /// Runs an async action as a tracked operation with spinner in the TUI.
 ///
-/// Guards against concurrent actions - if [state.actionBusy] is true or
-/// [state.serverReady] is false, the action is silently ignored.
+/// Guards against concurrent actions - if [state.actionBusy] is true the action
+/// is silently ignored. The action also requires [state.serverReady], unless
+/// [allowWhenStartable] is set and the session is degraded but
+/// [state.serverStartable] (used by the "Start server" recovery action, which
+/// runs precisely when no server is up yet).
 void runTrackedAction(
   StartAppStateHolder holder,
   String label,
-  Future<void> Function() action,
-) {
+  Future<void> Function() action, {
+  bool allowWhenStartable = false,
+}) {
   final state = holder.state;
-  if (state.actionBusy || !state.serverReady) return;
+  final ready =
+      state.serverReady || (allowWhenStartable && state.serverStartable);
+  if (state.actionBusy || !ready) return;
 
   state.actionBusy = true;
   final id =

--- a/tools/serverpod_cli/lib/src/commands/start/tui/main_screen.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/tui/main_screen.dart
@@ -562,7 +562,23 @@ class MainScreen extends StatelessComponent {
 
     return ButtonBar(
       buttons: [
-        if (state.watchModeEnabled)
+        // Degraded start: no server is running because the project has errors.
+        // The same "R" key rebuilds and starts it once the user has fixed them.
+        // Only while degraded - during a normal startup the server is on its
+        // way, so the usual (disabled) reload/restart button is shown instead.
+        if (state.serverStartable && !state.serverReady)
+          Button(
+            name: 'Start server',
+            activationChar: 'R',
+            activationKeys: const [LogicalKey.keyR],
+            onActivate: (_) => onHotRestart?.call(),
+            enabled: !state.actionBusy && onHotRestart != null,
+          )
+        // In watch mode the incremental compiler already hot reloads on file
+        // changes, so the manual action is a hot restart (with no shift
+        // variant, Shift+R restarts too). Without watch, R hot reloads and
+        // Shift+R hot restarts.
+        else if (state.watchModeEnabled)
           Button(
             name: 'Hot restart',
             activationChar: 'R',

--- a/tools/serverpod_cli/lib/src/commands/start/tui/state.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/tui/state.dart
@@ -91,6 +91,11 @@ class ServerWatchState extends TuiState {
   /// Whether the server is running and ready for actions.
   bool serverReady = false;
 
+  /// Whether the session is degraded: no server is running because the project
+  /// failed to generate or compile, but it can be (re)built and started on
+  /// demand. Enables the "Start server" action while [serverReady] is false.
+  bool serverStartable = false;
+
   /// Whether to show the splash overlay. Starts true, set to false
   /// after 5 seconds or explicitly by the backend.
   bool showSplash = true;

--- a/tools/serverpod_cli/lib/src/commands/start/watch_loop.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/watch_loop.dart
@@ -32,7 +32,11 @@ final class WatchLoopAborted extends WatchLoopSetupResult {
 /// single, idempotent [dispose] for cleanup.
 class WatchLoopContext {
   final WatchSession session;
-  final VmServiceProxy? proxy;
+
+  /// Resolves the server VM-service proxy at call time. A function rather than
+  /// a value because a degraded start has no proxy yet — it is mounted only
+  /// when the server first boots, after this context is constructed.
+  final VmServiceProxy? Function() proxy;
   final FlutterAppManager flutterManager;
   final McpSocketServer? mcpSocket;
   final StreamSubscription<void>? fileChangeSub;
@@ -62,7 +66,7 @@ class WatchLoopContext {
     await mcpSocket?.close();
     await closeAnalyzers();
     await session.dispose();
-    await proxy?.close();
+    await proxy()?.close();
     await flutterManager.dispose();
     await File(vmServiceInfoFile).deleteIfExists();
     await stopDocker?.call();

--- a/tools/serverpod_cli/lib/src/commands/start/watch_session.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/watch_session.dart
@@ -789,6 +789,7 @@ class WatchSession {
       await _server?.stop();
       final server = await _createServer!(dillPath);
       _server = server;
+      if (_state == SessionState.restarting) _state = SessionState.idle;
       _monitorExit(server);
       _trackVmServiceUri(server);
       log.info(wasRunning ? serverRestarted : serverStarted);

--- a/tools/serverpod_cli/lib/src/commands/start/watch_session.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/watch_session.dart
@@ -32,6 +32,13 @@ typedef GenerateAction =
 /// server via `dart run` and the VM's own kernel service drives reloads.
 typedef ServerProcessFactory = Future<ServerProcess> Function(String? dillPath);
 
+/// Runs a full code generation across the whole project (not just the changed
+/// paths), returning the result.
+///
+/// Used to recover from a degraded start via [WatchSession.retryStart], where
+/// there is no incremental change event to drive generation.
+typedef FullGenerateAction = Future<GenerateResult> Function();
+
 /// The lifecycle state of a [WatchSession].
 ///
 /// Used to suppress spurious crash detection during intentional server
@@ -96,10 +103,18 @@ typedef ApplyMigrationsAction = Future<void> Function();
 /// When [compiler] is `null`, the session runs code generation and triggers
 /// VM service reloads via the VM's built-in kernel service rather than the
 /// Frontend Server. Static file change handling is unaffected.
+///
+/// When [initialServer] is `null`, the session starts in a *degraded* state:
+/// the project failed to generate or compile at launch, so no server is
+/// running yet. The session keeps watching; the first file change that makes
+/// generation and compilation succeed boots the server (in watch mode), and
+/// [retryStart] does the same on demand (used by `--no-watch`, which has no
+/// file watcher to recover automatically).
 class WatchSession {
   final KernelCompiler? _compiler;
   final NativeAssetsApplier? _nativeAssetsBuilder;
   final GenerateAction _generate;
+  final FullGenerateAction? _fullGenerate;
   final ServerProcessFactory? _createServer;
   final Set<String> _generatedDirPaths;
   final ProtocolChangeClassifier _classifyProtocolChange;
@@ -132,7 +147,9 @@ class WatchSession {
   /// `package_config.json` write.
   bool _pendingPackageConfig = false;
 
-  ServerProcess _server;
+  /// The running server, or `null` while the session is degraded (no server
+  /// has booted yet because the project failed to build at launch).
+  ServerProcess? _server;
 
   SessionState _state = SessionState.idle;
 
@@ -173,8 +190,9 @@ class WatchSession {
     KernelCompiler? compiler,
     NativeAssetsApplier? nativeAssetsBuilder,
     required GenerateAction generate,
+    FullGenerateAction? fullGenerate,
     ServerProcessFactory? createServer,
-    required ServerProcess initialServer,
+    ServerProcess? initialServer,
     required Set<String> generatedDirPaths,
     ProtocolChangeClassifier classifyProtocolChange =
         defaultProtocolChangeClassifier,
@@ -184,6 +202,7 @@ class WatchSession {
   }) : _compiler = compiler,
        _nativeAssetsBuilder = nativeAssetsBuilder,
        _generate = generate,
+       _fullGenerate = fullGenerate,
        _createServer = createServer,
        _server = initialServer,
        _generatedDirPaths = generatedDirPaths,
@@ -195,19 +214,26 @@ class WatchSession {
       nativeAssetsBuilder == null || compiler != null,
       'nativeAssetsBuilder requires a compiler.',
     );
-    _monitorExit(initialServer);
-    _trackVmServiceUri(initialServer);
+    assert(
+      initialServer != null || createServer != null,
+      'A degraded session (null initialServer) needs a createServer to boot.',
+    );
+    if (initialServer != null) {
+      _monitorExit(initialServer);
+      _trackVmServiceUri(initialServer);
+    }
   }
 
   /// Completes when the server exits unexpectedly (crash).
   Future<int> get done => _done.future;
 
-  /// Returns `true` if the server is currently running.
-  bool get isRunning => !_done.isCompleted;
+  /// Returns `true` if a server process is currently running. `false` while the
+  /// session is degraded (no server booted yet) or after it has shut down.
+  bool get isRunning => _server != null && !_done.isCompleted;
 
   /// The current HTTP VM service URI of the running server, or `null` if not
-  /// yet available.
-  String? get vmServiceUri => _server.vmServiceUri;
+  /// yet available (including while degraded).
+  String? get vmServiceUri => _server?.vmServiceUri;
 
   /// Fires each time a new server process publishes its VM service URI. The
   /// URI itself is read via [vmServiceUri]; the stream just signals "changed".
@@ -303,6 +329,18 @@ class WatchSession {
       genOutputFiles = genResult.generatedFiles;
     }
 
+    // Degraded start: no server is running yet because the project failed to
+    // build at launch. Generation just succeeded (or was unnecessary), so try
+    // a full compile and boot the server from scratch. A still-failing compile
+    // leaves the session degraded for the next change to retry.
+    if (_server == null) {
+      if (await _fullCompileAndRestart()) {
+        await _restartAllFlutterApps();
+        await _notifyBrowserRefresh();
+      }
+      return;
+    }
+
     // Without a compiler, drive a reload through the VM's own kernel
     // service instead of the FES pipeline.
     if (_compiler == null) {
@@ -383,12 +421,13 @@ class WatchSession {
   /// both for static file changes and after the server reloads new Dart code,
   /// so server-rendered web pages stay in sync.
   Future<void> _notifyBrowserRefresh() async {
-    if (!_server.isVmServiceConnected) {
+    final server = _server;
+    if (server == null || !server.isVmServiceConnected) {
       log.debug('Server VM service not connected; skipping browser refresh.');
       return;
     }
     try {
-      await _server.notifyStaticChange();
+      await server.notifyStaticChange();
       log.info(browserRefreshTriggered);
     } catch (e) {
       log.warning('Browser refresh failed: $e');
@@ -627,6 +666,42 @@ class WatchSession {
     }, whenDisposed: () {});
   }
 
+  /// Recovers from a degraded start: re-runs a full code generation and, on
+  /// success, compiles and boots the server.
+  ///
+  /// This is the manual counterpart to the automatic recovery that the file
+  /// watcher drives in watch mode — it is the recovery path for `--no-watch`,
+  /// where no watcher exists. A no-op if a server is already running (use
+  /// [forceRestart] then). Throws a [StateError] if the session has been
+  /// disposed.
+  Future<void> retryStart() {
+    if (_state == SessionState.disposed) {
+      throw StateError('Session has been disposed.');
+    }
+    if (_createServer == null) {
+      throw StateError('Restart is not supported in this session.');
+    }
+    return _chain(() async {
+      // The session may have been disposed while this call was queued, or a
+      // concurrent change may have already booted the server.
+      if (_state == SessionState.disposed || _server != null) return;
+
+      final fullGenerate = _fullGenerate;
+      if (fullGenerate != null) {
+        final genResult = await fullGenerate();
+        if (!genResult.success) {
+          log.error('Code generation failed. Server not started.');
+          return;
+        }
+      }
+
+      if (await _fullCompileAndRestart()) {
+        await _restartAllFlutterApps();
+        await _notifyBrowserRefresh();
+      }
+    });
+  }
+
   /// Fully (re)launches the Flutter app: kills the running `flutter run`
   /// process (if any) and launches a fresh one - including launching it from
   /// scratch when none is running, e.g. after a `--no-flutter` start. Unlike
@@ -692,11 +767,12 @@ class WatchSession {
   /// Returns `true` on success, `false` if the VM service is not connected
   /// or the reload itself reports failure.
   Future<bool> _reload(String? dillPath) async {
-    if (!_server.isVmServiceConnected) {
+    final server = _server;
+    if (server == null || !server.isVmServiceConnected) {
       log.warning('Cannot reload: VM service not connected.');
       return false;
     }
-    final reloaded = await _server.reload(dillPath);
+    final reloaded = await server.reload(dillPath);
     if (reloaded) {
       log.info(serverReloaded);
     } else {
@@ -708,11 +784,14 @@ class WatchSession {
   Future<void> _restartServer(String? dillPath) async {
     _state = SessionState.restarting;
     try {
-      await _server.stop();
-      _server = await _createServer!(dillPath);
-      _monitorExit(_server);
-      _trackVmServiceUri(_server);
-      log.info(serverRestarted);
+      // Null while degraded: this is the first boot, not a restart.
+      final wasRunning = _server != null;
+      await _server?.stop();
+      final server = await _createServer!(dillPath);
+      _server = server;
+      _monitorExit(server);
+      _trackVmServiceUri(server);
+      log.info(wasRunning ? serverRestarted : serverStarted);
     } finally {
       if (_state == SessionState.restarting) {
         _state = SessionState.idle;
@@ -724,7 +803,8 @@ class WatchSession {
   Future<void> dispose() async {
     _state = SessionState.disposed;
     await _vmServiceUriChangesController.close();
-    final code = await _server.stop();
+    // `_server` is null when disposing a degraded session that never booted.
+    final code = await _server?.stop() ?? 0;
     // Stop Flutter after the server: an in-flight Flutter reload
     // mustn't see a half-shut-down server VM service.
     await _flutterManager?.stopAll();

--- a/tools/serverpod_cli/test/commands/start/watch_loop_test.dart
+++ b/tools/serverpod_cli/test/commands/start/watch_loop_test.dart
@@ -208,7 +208,7 @@ void main() {
     WatchLoopContext build({bool startedDocker = false}) {
       return WatchLoopContext(
         session: _buildSession(compiler, server),
-        proxy: proxy,
+        proxy: () => proxy,
         flutterManager: flutterManager,
         mcpSocket: mcp,
         fileChangeSub: fileSub,
@@ -303,7 +303,7 @@ void main() {
       () async {
         final ctx = WatchLoopContext(
           session: _buildSession(compiler, server),
-          proxy: null,
+          proxy: () => null,
           flutterManager: flutterManager,
           mcpSocket: null,
           fileChangeSub: null,

--- a/tools/serverpod_cli/test/commands/start/watch_session_test.dart
+++ b/tools/serverpod_cli/test/commands/start/watch_session_test.dart
@@ -335,10 +335,11 @@ void main() {
   late WatchSession session;
 
   WatchSession buildSession({
-    required KernelCompiler compiler,
-    required ServerProcess initialServer,
+    required KernelCompiler? compiler,
+    required ServerProcess? initialServer,
     ServerProcessFactory? createServer,
     GenerateAction? generate,
+    FullGenerateAction? fullGenerate,
     ApplyMigrationsAction? applyMigrationsAction,
     ProtocolChangeClassifier? classifyProtocolChange,
     NativeAssetsApplier? nativeAssetsBuilder,
@@ -358,6 +359,7 @@ void main() {
               generatedFiles: generatedFiles,
             );
           },
+      fullGenerate: fullGenerate,
       createServer:
           createServer ??
           (String? dillPath) async {
@@ -2540,6 +2542,176 @@ class Counter {
       'then it throws a StateError',
       () {
         expect(() => noFactorySession.forceRestart(), throwsStateError);
+      },
+    );
+  });
+
+  group('Given a degraded session that booted with no server', () {
+    late int fullGenerateCalls;
+    late bool fullGenerateSuccess;
+    late WatchSession degradedSession;
+
+    setUp(() {
+      fullGenerateCalls = 0;
+      fullGenerateSuccess = true;
+      degradedSession = buildSession(
+        compiler: compiler,
+        initialServer: null,
+        fullGenerate: () async {
+          fullGenerateCalls++;
+          return (success: fullGenerateSuccess, generatedFiles: <String>{});
+        },
+      );
+    });
+
+    test(
+      'when checking its state, '
+      'then it reports not running with no VM service URI',
+      () {
+        expect(degradedSession.isRunning, isFalse);
+        expect(degradedSession.vmServiceUri, isNull);
+      },
+    );
+
+    test(
+      'when a dart file change generates and compiles successfully, '
+      'then it boots the server with a fresh full compile',
+      () async {
+        await degradedSession.handleFileChange(
+          FileChangeEvent(dartFiles: {'/lib/a.dart'}),
+        );
+
+        expect(generateCalls, [
+          {'/lib/a.dart'},
+        ]);
+        // A from-scratch full compile (reset + compile), not an incremental
+        // one, since there is no running server to hot reload into.
+        expect(compiler.calls, ['reset', 'compile', 'accept']);
+        expect(factoryCalls, ['createServer:/out.dill']);
+        expect(degradedSession.isRunning, isTrue);
+      },
+    );
+
+    test(
+      'when generation fails on a file change, '
+      'then it stays degraded without compiling or booting',
+      () async {
+        generateSuccess = false;
+
+        await degradedSession.handleFileChange(
+          FileChangeEvent(dartFiles: {'/lib/a.dart'}),
+        );
+
+        expect(compiler.calls, isEmpty);
+        expect(factoryCalls, isEmpty);
+        expect(degradedSession.isRunning, isFalse);
+      },
+    );
+
+    test(
+      'when the compile fails on a file change, '
+      'then it stays degraded without booting',
+      () async {
+        compiler.nextCompileResult = _failResult();
+
+        await degradedSession.handleFileChange(
+          FileChangeEvent(dartFiles: {'/lib/a.dart'}),
+        );
+
+        expect(compiler.calls, ['reset', 'compile', 'reject']);
+        expect(factoryCalls, isEmpty);
+        expect(degradedSession.isRunning, isFalse);
+      },
+    );
+
+    test(
+      'when retryStart regenerates and compiles successfully, '
+      'then it boots the server',
+      () async {
+        await degradedSession.retryStart();
+
+        expect(fullGenerateCalls, 1);
+        expect(compiler.calls, ['reset', 'compile', 'accept']);
+        expect(factoryCalls, ['createServer:/out.dill']);
+        expect(degradedSession.isRunning, isTrue);
+      },
+    );
+
+    test(
+      'when retryStart full generation fails, '
+      'then it stays degraded without compiling or booting',
+      () async {
+        fullGenerateSuccess = false;
+
+        await degradedSession.retryStart();
+
+        expect(fullGenerateCalls, 1);
+        expect(compiler.calls, isEmpty);
+        expect(factoryCalls, isEmpty);
+        expect(degradedSession.isRunning, isFalse);
+      },
+    );
+
+    test(
+      'when disposed, '
+      'then done completes with zero without stopping a server',
+      () async {
+        await degradedSession.dispose();
+
+        await expectLater(degradedSession.done, completion(0));
+      },
+    );
+
+    test(
+      'when retryStart is called after dispose, '
+      'then it throws a StateError',
+      () async {
+        await degradedSession.dispose();
+
+        expect(() => degradedSession.retryStart(), throwsStateError);
+      },
+    );
+  });
+
+  group('Given a degraded session with no compiler', () {
+    late int fullGenerateCalls;
+    late WatchSession degradedNoCompilerSession;
+
+    setUp(() {
+      fullGenerateCalls = 0;
+      degradedNoCompilerSession = buildSession(
+        compiler: null,
+        initialServer: null,
+        fullGenerate: () async {
+          fullGenerateCalls++;
+          return (success: true, generatedFiles: <String>{});
+        },
+      );
+    });
+
+    test(
+      'when retryStart regenerates successfully, '
+      'then it boots the server via dart run with a null dill',
+      () async {
+        await degradedNoCompilerSession.retryStart();
+
+        expect(fullGenerateCalls, 1);
+        expect(factoryCalls, ['createServer:null']);
+        expect(degradedNoCompilerSession.isRunning, isTrue);
+      },
+    );
+  });
+
+  group('Given a running session', () {
+    test(
+      'when retryStart is called, '
+      'then it is a no-op (recovery only applies while degraded)',
+      () async {
+        await session.retryStart();
+
+        expect(factoryCalls, isEmpty);
+        expect(compiler.calls, isEmpty);
+        expect(server.calls, isEmpty);
       },
     );
   });

--- a/tools/serverpod_cli/test/commands/start/watch_session_test.dart
+++ b/tools/serverpod_cli/test/commands/start/watch_session_test.dart
@@ -2653,6 +2653,21 @@ class Counter {
     );
 
     test(
+      'when the server booted from a degraded start later crashes, '
+      'then done completes with its exit code',
+      () async {
+        await degradedSession.handleFileChange(
+          FileChangeEvent(dartFiles: {'/lib/a.dart'}),
+        );
+        expect(degradedSession.isRunning, isTrue);
+
+        factoryServer.simulateExit(7);
+
+        await expectLater(degradedSession.done, completion(7));
+      },
+    );
+
+    test(
       'when disposed, '
       'then done completes with zero without stopping a server',
       () async {


### PR DESCRIPTION
`serverpod start` used to exit immediately when a model change produced invalid generated code. It now stays open, shows the errors, and starts the server once the project builds.

On failure the watch session is built with no running server and keeps watching:
- `--watch` recovers automatically fixing the model regenerates, compiles, and boots the server.
- `--no-watch` the TUI shows a `Start server` (`R`) action that runs `retryStart`  which does a full regenerate, compile, and boot.

`WatchSession` is now server optional (`_server`) and boots from a degraded state through the existing full-compile-and-restart path.

Fixes #5165 

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes
None