### PR TITLE
docs: Clarify MCP server instructions and tool descriptions for AI agents

### DIFF
--- a/tools/serverpod_cli/lib/src/mcp/bridge_mcp_server.dart
+++ b/tools/serverpod_cli/lib/src/mcp/bridge_mcp_server.dart
@@ -37,10 +37,13 @@ base class BridgeMcpServer extends MCPServer
     : super.fromStreamChannel(
         implementation: _bridgeImplementation,
         instructions:
-            'Bridge to the server running with `serverpod start` for this '
-            'project. Tools and resources auto-connect to the runner on '
-            'demand. If the runner is not currently available, ask the '
-            'user to start it with `serverpod start`.',
+            'Manage a Serverpod server and its Flutter app running under '
+            '`serverpod start`. Use these tools to read Serverpod and Flutter '
+            'logs, create and apply database migrations, hot reload or restart '
+            "the server and Flutter app, and get the Flutter app's Dart "
+            'Tooling Daemon (DTD) URI. If a tool reports the server is not '
+            'running, ask the user to start it with `serverpod start` in the '
+            'project directory.',
       ) {
     for (final tool in runnerStaticTools) {
       registerTool(tool, _makeToolForwarder(tool.name));

--- a/tools/serverpod_cli/lib/src/mcp/runner_surface.dart
+++ b/tools/serverpod_cli/lib/src/mcp/runner_surface.dart
@@ -63,19 +63,20 @@ final Tool createRepairMigrationTool = Tool(
 final Tool hotReloadTool = Tool(
   name: 'hot_reload',
   description:
-      'Hot-reload the running server isolate, preserving in-memory state. '
-      'Falls back to a restart if reload is not possible. In `--watch` '
-      'mode the runner auto-reloads on file changes, so this is mainly '
-      'useful with `--no-watch`.',
+      'Hot-reload the running server isolate, preserving in-memory state, '
+      'and hot-reload the Flutter app (if one is running) so it picks up '
+      'the changes. In `--watch` mode the runner auto-reloads on file '
+      'changes, so this is mainly useful with `--no-watch`.',
   inputSchema: Schema.object(),
 );
 
 final Tool hotRestartTool = Tool(
   name: 'hot_restart',
   description:
-      'Restart the running server process, dropping all in-memory state. '
-      'Use when reload would not suffice (e.g. `main()` changes) or to '
-      'recover a stuck isolate.',
+      'Restart the running server process, dropping all in-memory state, '
+      'then hot-restart the Flutter app (if one is running) so it '
+      'reconnects to the fresh server. Use when reload would not suffice '
+      '(e.g. `main()` changes) or to recover a stuck isolate.',
   inputSchema: Schema.object(),
 );
 


### PR DESCRIPTION
The MCP server's top-level `instructions` told AI agents they were talking to a "bridge to the runner". This rewrites the agent facing message to describe the capabilities instead.

It also corrects the `hot_reload` and `hot_restart` tool descriptions, which omitted that both operations also act on the running Flutter app, and drops a stale claim that `hot_reload` falls back to a restart.

Fixes #5238 

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes
None