### PR TITLE
fix: Fix syntax highlight for unique shorthand with multiple columns

### DIFF
--- a/tools/serverpod_vscode_extension/syntaxes/serverpod.tmLanguage.json
+++ b/tools/serverpod_vscode_extension/syntaxes/serverpod.tmLanguage.json
@@ -69,6 +69,33 @@
           "include": "#comments"
         },
         {
+          "begin": "(\\[)",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.definition.list.begin.yaml"
+            }
+          },
+          "end": "(\\])",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.definition.list.end.yaml"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#comments"
+            },
+            {
+              "name": "punctuation.separator.comma.yaml",
+              "match": ","
+            },
+            {
+              "name": "string.unquoted.yaml",
+              "match": "\\b([a-zA-Z0-9_-]+)\\b"
+            }
+          ]
+        },
+        {
           "name": "keyword.operator.assignment.yaml",
           "match": "="
         },


### PR DESCRIPTION
The `unique(per=...)` was introduced with #5343, but the syntax highlight was not updated and was producing the wrong colors, as shown in below examples:

- <img width="178" height="30" alt="image" src="https://github.com/user-attachments/assets/96e6fe78-068a-4f4c-9bff-a30e005f6936" />
- <img width="380" height="23" alt="image" src="https://github.com/user-attachments/assets/9dc3eb11-7a09-41cf-8034-d89bdec01b07" />
- <img width="364" height="26" alt="image" src="https://github.com/user-attachments/assets/b8e3ae09-c9e6-4798-b5d0-b67253bd2cba" />

After this change, all fields will be orange inside the list.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.