### PR TITLE
feat: Add withSession method on Serverpod for manual session usage

### DIFF
--- a/examples/legacy/chat/chat_server/lib/server.dart
+++ b/examples/legacy/chat/chat_server/lib/server.dart
@@ -55,31 +55,27 @@ void run(List<String> args) async {
 }
 
 Future<void> _populateDatabase(Serverpod pod) async {
-  // Create a session so that we can access the database.
-  var session = await pod.createSession();
+  // withSession creates a session to access the database and closes it for
+  // us when we are done, even if an error is thrown along the way.
+  await pod.withSession((session) async {
+    var numChannels = await Channel.db.count(session);
+    if (numChannels != 0) {
+      // There are already entries in the database, whe shouldn't add them again.
+      return;
+    }
 
-  var numChannels = await Channel.db.count(session);
-  if (numChannels != 0) {
-    // There are already entries in the database, whe shouldn't add them again.
-    await session.close();
-    return;
-  }
-
-  // Insert an initial set of channels.
-  await Channel.db.insertRow(
-    session,
-    Channel(name: 'General', channel: 'general'),
-  );
-  await Channel.db.insertRow(
-    session,
-    Channel(name: 'Serverpod', channel: 'serverpod'),
-  );
-  await Channel.db.insertRow(
-    session,
-    Channel(name: 'Introductions', channel: 'intros'),
-  );
-
-  // Make sure to close the session when we are done, or it will hold up
-  // resources.
-  await session.close();
+    // Insert an initial set of channels.
+    await Channel.db.insertRow(
+      session,
+      Channel(name: 'General', channel: 'general'),
+    );
+    await Channel.db.insertRow(
+      session,
+      Channel(name: 'Serverpod', channel: 'serverpod'),
+    );
+    await Channel.db.insertRow(
+      session,
+      Channel(name: 'Introductions', channel: 'intros'),
+    );
+  });
 }

--- a/packages/serverpod/CHANGELOG.md
+++ b/packages/serverpod/CHANGELOG.md
@@ -1,6 +1,5 @@
 ## 3.5.0-beta.10
 
-- feat: Adds a `withSession` method to `Serverpod` that creates a session, runs a callback with it, and closes it afterwards, including on error.
 - feat: Hides the "Hot restart" action in the `start` TUI when on watch mode (default).
 - feat: Restarts the Flutter app automatically when its dependencies change.
 - feat: Adds IDE selection screen to the `quickstart` command for a complete experience.

--- a/packages/serverpod/CHANGELOG.md
+++ b/packages/serverpod/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 3.5.0-beta.10
 
+- feat: Adds a `withSession` method to `Serverpod` that creates a session, runs a callback with it, and closes it afterwards, including on error.
 - feat: Hides the "Hot restart" action in the `start` TUI when on watch mode (default).
 - feat: Restarts the Flutter app automatically when its dependencies change.
 - feat: Adds IDE selection screen to the `quickstart` command for a complete experience.

--- a/packages/serverpod/lib/src/server/serverpod.dart
+++ b/packages/serverpod/lib/src/server/serverpod.dart
@@ -1226,6 +1226,29 @@ class Serverpod {
     return session;
   }
 
+  /// Creates a new [InternalSession], runs [callback] with it, and closes
+  /// the session afterwards. Used to access the database and do logging
+  /// outside of sessions triggered by external events, without having to
+  /// manage the session lifecycle manually.
+  ///
+  /// If [callback] throws, the session is closed with the error and
+  /// [StackTrace] attached (so they are written to the logs) before the
+  /// error is rethrown.
+  Future<T> withSession<T>(
+    Future<T> Function(Session session) callback, {
+    bool enableLogging = true,
+  }) async {
+    var session = await createSession(enableLogging: enableLogging);
+    try {
+      var result = await callback(session);
+      await session.close();
+      return result;
+    } catch (e, stackTrace) {
+      await session.close(error: e, stackTrace: stackTrace);
+      rethrow;
+    }
+  }
+
   /// Stops accepting new requests on the user-facing servers (the API
   /// server and, if enabled, the web server), waits for in-flight requests
   /// to settle, runs [action], then resumes request handling.

--- a/packages/serverpod/test/server/with_session_test.dart
+++ b/packages/serverpod/test/server/with_session_test.dart
@@ -64,10 +64,12 @@ void main() {
         expect(sessionUsedByCallback, isNotNull);
       });
 
-      test('then the returned value is the value produced by the callback.',
-          () {
-        expect(result, equals('the result'));
-      });
+      test(
+        'then the returned value is the value produced by the callback.',
+        () {
+          expect(result, equals('the result'));
+        },
+      );
 
       test('then the session is closed once the callback completes.', () {
         expect(sessionWasClosed, isTrue);

--- a/packages/serverpod/test/server/with_session_test.dart
+++ b/packages/serverpod/test/server/with_session_test.dart
@@ -1,0 +1,108 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:serverpod/serverpod.dart';
+import 'package:serverpod/src/generated/protocol.dart' as internal;
+import 'package:test/test.dart';
+
+import 'test_helpers/empty_endpoints.dart';
+
+final _portZeroConfig = ServerConfig(
+  port: 0,
+  publicScheme: 'http',
+  publicHost: 'localhost',
+  publicPort: 0,
+);
+
+void main() {
+  group('Given a Serverpod,', () {
+    late Directory tempDir;
+    late Serverpod pod;
+
+    setUp(() async {
+      tempDir = await Directory.systemTemp.createTemp('with_session_');
+      pod = Serverpod(
+        [],
+        internal.Protocol(),
+        EmptyEndpoints(),
+        config: ServerpodConfig(
+          apiServer: _portZeroConfig,
+          webServer: _portZeroConfig,
+          database: SqliteDatabaseConfig(
+            filePath: p.join(tempDir.path, 'test.db'),
+          ),
+        ),
+      );
+    });
+
+    tearDown(() async {
+      await pod.shutdown(exitProcess: false);
+      if (tempDir.existsSync()) {
+        await tempDir.delete(recursive: true);
+      }
+    });
+
+    group('when calling withSession with a callback that succeeds,', () {
+      late Session? sessionUsedByCallback;
+      late bool sessionWasClosed;
+      late String result;
+
+      setUp(() async {
+        sessionUsedByCallback = null;
+        sessionWasClosed = false;
+
+        result = await pod.withSession((session) async {
+          sessionUsedByCallback = session;
+          session.addWillCloseListener((_) {
+            sessionWasClosed = true;
+          });
+          return 'the result';
+        });
+      });
+
+      test('then the callback is called with a session.', () {
+        expect(sessionUsedByCallback, isNotNull);
+      });
+
+      test('then the returned value is the value produced by the callback.',
+          () {
+        expect(result, equals('the result'));
+      });
+
+      test('then the session is closed once the callback completes.', () {
+        expect(sessionWasClosed, isTrue);
+      });
+    });
+
+    group('when calling withSession with a callback that throws,', () {
+      late bool sessionWasClosed;
+      late Object caughtError;
+      late Object? thrownError;
+
+      setUp(() async {
+        sessionWasClosed = false;
+        caughtError = Exception('boom');
+        thrownError = null;
+
+        try {
+          await pod.withSession((session) async {
+            session.addWillCloseListener((_) {
+              sessionWasClosed = true;
+            });
+            throw caughtError;
+          });
+        } catch (e) {
+          thrownError = e;
+        }
+      });
+
+      test('then the error from the callback is rethrown.', () {
+        expect(thrownError, same(caughtError));
+      });
+
+      test('then the session is still closed.', () {
+        expect(sessionWasClosed, isTrue);
+      });
+    });
+  });
+}


### PR DESCRIPTION
Expose a withSession helper that creates a session, runs a callback with it, and closes it afterwards (including on error), so callers outside of endpoint contexts don't need to manage session lifecycle manually. Updates the chat example to use it.

_Replace this paragraph with a description of what this PR is changing or adding, and why._

_List which issues are fixed by this PR. You must list at least one issue._

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

_If you have done any breaking changes, make sure to outline them here, so that they can be included in the notes for the next release._