### PR TITLE
feat: Allow defining a relation on a base class for inherited table models (#4735)

### DIFF
--- a/tools/serverpod_cli/lib/src/analyzer/models/definitions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/definitions.dart
@@ -187,6 +187,10 @@ final class ModelClassDefinition extends ClassDefinition {
   /// If set to true the class is immutable.
   final bool isImmutable;
 
+  /// If set to true, this class is a base for table-backed subclasses and may
+  /// declare relations without having a table itself.
+  final bool isTableBase;
+
   /// If set, the default data type used for serialization of the JSON columns in this class.
   /// It can be overridden for each field.
   final SerializationDataType? serializationDataType;
@@ -202,6 +206,7 @@ final class ModelClassDefinition extends ClassDefinition {
     required super.type,
     required super.isSealed,
     required this.isImmutable,
+    this.isTableBase = false,
     super.childClasses,
     super.extendsClass,
     this.database = ModelDatabaseDefinition.server,

--- a/tools/serverpod_cli/lib/src/analyzer/models/definitions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/definitions.dart
@@ -189,6 +189,10 @@ final class ModelClassDefinition extends ClassDefinition {
   /// If set to true the class is immutable.
   final bool isImmutable;
 
+  /// If set to true, this class is a base for table-backed subclasses and may
+  /// declare relations without having a table itself.
+  final bool isTableBase;
+
   /// If set, the default data type used for serialization of the JSON columns in this class.
   /// It can be overridden for each field.
   final SerializationDataType? serializationDataType;
@@ -204,6 +208,7 @@ final class ModelClassDefinition extends ClassDefinition {
     required super.type,
     required super.isSealed,
     required this.isImmutable,
+    this.isTableBase = false,
     super.childClasses,
     super.extendsClass,
     this.database = ModelDatabaseDefinition.server,

--- a/tools/serverpod_cli/lib/src/analyzer/models/entity_dependency_resolver.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/entity_dependency_resolver.dart
@@ -194,6 +194,10 @@ class ModelDependencyResolver {
     var relation = fieldDefinition.relation;
     if (relation is! UnresolvedObjectRelationDefinition) return;
 
+    if (classDefinition.tableName == null && !classDefinition.isTableBase) {
+      return;
+    }
+
     var referenceClass = modelDefinitions
         .cast<SerializableModelDefinition?>()
         .firstWhere(
@@ -207,10 +211,6 @@ class ModelDependencyResolver {
 
     var tableName = referenceClass.tableName;
     if (tableName is! String) return;
-
-    // Skip resolution if the class defining the relation doesn't have a table.
-    // The validation layer will report the appropriate error message.
-    if (classDefinition.tableName == null) return;
 
     var foreignField = _findForeignFieldByRelationName(
       classDefinition,
@@ -258,6 +258,8 @@ class ModelDependencyResolver {
     String tableName,
     SerializableModelFieldDefinition foreignField,
   ) {
+    if (classDefinition.tableName == null) return;
+
     String? foreignFieldName;
 
     SerializableModelFieldDefinition? foreignContainerField;
@@ -298,6 +300,8 @@ class ModelDependencyResolver {
     UnresolvedObjectRelationDefinition relation,
     String tableName,
   ) {
+    if (classDefinition.tableName == null) return;
+
     var relationFieldType = relation.nullableRelation
         ? referenceDefinition.idField.type.asNullable
         : referenceDefinition.idField.type.asNonNullable;
@@ -391,7 +395,9 @@ class ModelDependencyResolver {
 
     fieldDefinition.relation = ObjectRelationDefinition(
       parentTable: tableName,
-      parentTableIdType: classDefinition.idField.type,
+      parentTableIdType: classDefinition.tableName != null
+          ? classDefinition.idField.type
+          : field.type.asNonNullable,
       fieldName: relationFieldName,
       foreignFieldName: defaultPrimaryKeyName,
       foreignContainerField: foreignContainerField,

--- a/tools/serverpod_cli/lib/src/analyzer/models/entity_dependency_resolver.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/entity_dependency_resolver.dart
@@ -193,6 +193,10 @@ class ModelDependencyResolver {
     var relation = fieldDefinition.relation;
     if (relation is! UnresolvedObjectRelationDefinition) return;
 
+    if (classDefinition.tableName == null && !classDefinition.isTableBase) {
+      return;
+    }
+
     var referenceClass = modelDefinitions
         .cast<SerializableModelDefinition?>()
         .firstWhere(
@@ -206,10 +210,6 @@ class ModelDependencyResolver {
 
     var tableName = referenceClass.tableName;
     if (tableName is! String) return;
-
-    // Skip resolution if the class defining the relation doesn't have a table.
-    // The validation layer will report the appropriate error message.
-    if (classDefinition.tableName == null) return;
 
     var foreignField = _findForeignFieldByRelationName(
       classDefinition,
@@ -257,6 +257,8 @@ class ModelDependencyResolver {
     String tableName,
     SerializableModelFieldDefinition foreignField,
   ) {
+    if (classDefinition.tableName == null) return;
+
     String? foreignFieldName;
 
     SerializableModelFieldDefinition? foreignContainerField;
@@ -297,6 +299,8 @@ class ModelDependencyResolver {
     UnresolvedObjectRelationDefinition relation,
     String tableName,
   ) {
+    if (classDefinition.tableName == null) return;
+
     var relationFieldType = relation.nullableRelation
         ? referenceDefinition.idField.type.asNullable
         : referenceDefinition.idField.type.asNonNullable;
@@ -390,7 +394,9 @@ class ModelDependencyResolver {
 
     fieldDefinition.relation = ObjectRelationDefinition(
       parentTable: tableName,
-      parentTableIdType: classDefinition.idField.type,
+      parentTableIdType: classDefinition.tableName != null
+          ? classDefinition.idField.type
+          : field.type.asNonNullable,
       fieldName: relationFieldName,
       foreignFieldName: defaultPrimaryKeyName,
       foreignContainerField: foreignContainerField,

--- a/tools/serverpod_cli/lib/src/analyzer/models/model_parser/model_parser.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/model_parser/model_parser.dart
@@ -25,6 +25,8 @@ class ModelParser {
 
     var isImmutable = _parseIsImmutable(documentContents);
 
+    var isTableBase = _parseIsTableBase(documentContents);
+
     var extendsClass = _parseExtendsClass(documentContents);
 
     var migrationValue =
@@ -57,6 +59,7 @@ class ModelParser {
               className: className,
               isSealed: isSealed,
               isImmutable: isImmutable,
+              isTableBase: isTableBase,
               extendsClass: extendsClass,
               sourceFileName: protocolSource.yamlSourceUri.path,
               database: database,
@@ -236,6 +239,13 @@ class ModelParser {
     if (isImmutable is! bool) return false;
 
     return isImmutable;
+  }
+
+  static bool _parseIsTableBase(YamlMap documentContents) {
+    var tableBase = documentContents.nodes[Keyword.tableBase]?.value;
+    if (tableBase is! bool) return false;
+
+    return tableBase;
   }
 
   static UnresolvedInheritanceDefinition? _parseExtendsClass(

--- a/tools/serverpod_cli/lib/src/analyzer/models/validation/keywords.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/validation/keywords.dart
@@ -11,6 +11,7 @@ class Keyword {
   static const String extendsClass = 'extends';
 
   static const String serverOnly = 'serverOnly';
+  static const String tableBase = 'tableBase';
   static const String table = 'table';
   static const String managedMigration = 'managedMigration';
   static const String fields = 'fields';

--- a/tools/serverpod_cli/lib/src/analyzer/models/validation/restrictions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/validation/restrictions.dart
@@ -325,6 +325,33 @@ class Restrictions {
     return errors;
   }
 
+  List<SourceSpanSeverityException> validateTableBase(
+    String parentNodeName,
+    dynamic content,
+    SourceSpan? span,
+  ) {
+    var definition = documentDefinition;
+    if (definition is! ModelClassDefinition) return [];
+
+    var hasConcreteChild = definition.descendantClasses.any(
+      (c) => c.tableName != null,
+    );
+
+    if (!hasConcreteChild) {
+      return [
+        SourceSpanSeverityException(
+          'The "tableBase" class "${definition.className}" has no concrete '
+          'subclass with a "table" property defined. Relations declared on '
+          'this class will never generate a foreign key.',
+          span,
+          severity: SourceSpanSeverity.warning,
+        ),
+      ];
+    }
+
+    return [];
+  }
+
   List<SourceSpanSeverityException> validateTable(
     String parentNodeName,
     dynamic tableName,
@@ -833,7 +860,9 @@ class Restrictions {
     var classDefinition = documentDefinition;
     if (classDefinition is! ModelClassDefinition) return [];
 
-    var foreignKeyField = classDefinition.findField(fieldName);
+    var foreignKeyField = classDefinition.fieldsIncludingInherited
+        .where((f) => f.name == fieldName)
+        .firstOrNull;
     if (foreignKeyField == null) {
       return [
         SourceSpanSeverityException(
@@ -1980,10 +2009,12 @@ class Restrictions {
 
     if (definition is! ModelClassDefinition) return [];
 
-    if (definition.tableName == null) {
+    if (definition.tableName == null && !definition.isTableBase) {
       return [
         SourceSpanSeverityException(
-          'The "table" property must be defined in the class to set a relation on a field.',
+          'The "table" property must be defined in the class to set a '
+          'relation on a field. For base classes that declare relations for '
+          'table-backed subclasses, use "tableBase: true".',
           span,
         ),
       ];
@@ -1994,6 +2025,9 @@ class Restrictions {
     if (field == null) return [];
 
     if (field.type.isListType) {
+      // Malformed List with no type parameter — other validators report this
+      if (field.type.generics.isEmpty) return [];
+
       var referenceClass = parsedModels
           .findAllByClassName(field.type.generics.first.className)
           .firstOrNull;

--- a/tools/serverpod_cli/lib/src/analyzer/models/validation/restrictions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/validation/restrictions.dart
@@ -330,6 +330,33 @@ class Restrictions {
     return errors;
   }
 
+  List<SourceSpanSeverityException> validateTableBase(
+    String parentNodeName,
+    dynamic content,
+    SourceSpan? span,
+  ) {
+    var definition = documentDefinition;
+    if (definition is! ModelClassDefinition) return [];
+
+    var hasConcreteChild = definition.descendantClasses.any(
+      (c) => c.tableName != null,
+    );
+
+    if (!hasConcreteChild) {
+      return [
+        SourceSpanSeverityException(
+          'The "tableBase" class "${definition.className}" has no concrete '
+          'subclass with a "table" property defined. Relations declared on '
+          'this class will never generate a foreign key.',
+          span,
+          severity: SourceSpanSeverity.warning,
+        ),
+      ];
+    }
+
+    return [];
+  }
+
   List<SourceSpanSeverityException> validateTable(
     String parentNodeName,
     dynamic tableName,
@@ -838,7 +865,9 @@ class Restrictions {
     var classDefinition = documentDefinition;
     if (classDefinition is! ModelClassDefinition) return [];
 
-    var foreignKeyField = classDefinition.findField(fieldName);
+    var foreignKeyField = classDefinition.fieldsIncludingInherited
+        .where((f) => f.name == fieldName)
+        .firstOrNull;
     if (foreignKeyField == null) {
       return [
         SourceSpanSeverityException(
@@ -2035,10 +2064,12 @@ class Restrictions {
 
     if (definition is! ModelClassDefinition) return [];
 
-    if (definition.tableName == null) {
+    if (definition.tableName == null && !definition.isTableBase) {
       return [
         SourceSpanSeverityException(
-          'The "table" property must be defined in the class to set a relation on a field.',
+          'The "table" property must be defined in the class to set a '
+          'relation on a field. For base classes that declare relations for '
+          'table-backed subclasses, use "tableBase: true".',
           span,
         ),
       ];
@@ -2049,6 +2080,9 @@ class Restrictions {
     if (field == null) return [];
 
     if (field.type.isListType) {
+      // Malformed List with no type parameter — other validators report this
+      if (field.type.generics.isEmpty) return [];
+
       var referenceClass = parsedModels
           .findAllByClassName(field.type.generics.first.className)
           .firstOrNull;

--- a/tools/serverpod_cli/lib/src/analyzer/models/yaml_definitions/class_yaml_definition.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/yaml_definitions/class_yaml_definition.dart
@@ -33,6 +33,13 @@ class ClassYamlDefinition {
         },
       ),
       ValidateNode(
+        Keyword.tableBase,
+        valueRestriction: restrictions.validateTableBase,
+        mutuallyExclusiveKeys: {
+          Keyword.table,
+        },
+      ),
+      ValidateNode(
         Keyword.extendsClass,
         valueRestriction: restrictions.validateExtendingClassName,
       ),

--- a/tools/serverpod_cli/lib/src/database/create_definition.dart
+++ b/tools/serverpod_cli/lib/src/database/create_definition.dart
@@ -104,7 +104,7 @@ DatabaseDefinition createDatabaseDefinitionFromModels(
 List<ForeignKeyDefinition> _createForeignKeys(
   ModelClassDefinition classDefinition,
 ) {
-  var fields = classDefinition.fields
+  var fields = classDefinition.fieldsIncludingInherited
       .where((field) => field.relation is ForeignRelationDefinition)
       .toList();
 

--- a/tools/serverpod_cli/lib/src/database/create_definition.dart
+++ b/tools/serverpod_cli/lib/src/database/create_definition.dart
@@ -108,7 +108,7 @@ DatabaseDefinition createDatabaseDefinitionFromModels(
 List<ForeignKeyDefinition> _createForeignKeys(
   ModelClassDefinition classDefinition,
 ) {
-  var fields = classDefinition.fields
+  var fields = classDefinition.fieldsIncludingInherited
       .where((field) => field.relation is ForeignRelationDefinition)
       .toList();
 

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/relation/relation_keyword_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/relation/relation_keyword_test.dart
@@ -441,11 +441,7 @@ fields:
       expect(
         collector.errors,
         isNotEmpty,
-        reason: 'Expected an error',
-      );
-      expect(
-        collector.errors.first.message,
-        'The "table" property must be defined in the class to set a relation on a field.',
+        reason: 'Expected an error — class has no table and no tableBase: true',
       );
     },
   );

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/relation/relation_mixin_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/relation/relation_mixin_test.dart
@@ -1,0 +1,204 @@
+import 'package:serverpod_cli/src/analyzer/code_analysis_collector.dart';
+import 'package:serverpod_cli/src/analyzer/models/stateful_analyzer.dart';
+import 'package:serverpod_cli/src/generator/code_generation_collector.dart';
+import 'package:test/test.dart';
+
+import '../../../../../test_util/builders/generator_config_builder.dart';
+import '../../../../../test_util/builders/model_source_builder.dart';
+
+void main() {
+  var config = GeneratorConfigBuilder().build();
+
+  group(
+    'Given a tableBase class that declares an unnamed relation(field=...)',
+    () {
+      test(
+        'when a single concrete child class extends it '
+        'then no errors are collected.',
+        () {
+          var models = [
+            ModelSourceBuilder().withYaml(
+              '''
+              class: Base
+              tableBase: true
+              fields:
+                parentId: int
+                parent: Parent?, relation(field=parentId)
+              ''',
+            ).build(),
+            ModelSourceBuilder().withFileName('child').withYaml(
+              '''
+              class: Child
+              table: child
+              extends: Base
+              fields:
+                name: String
+              ''',
+            ).build(),
+            ModelSourceBuilder().withFileName('parent').withYaml(
+              '''
+              class: Parent
+              table: parent
+              fields:
+                name: String
+              ''',
+            ).build(),
+          ];
+
+          var collector = CodeGenerationCollector();
+          StatefulAnalyzer(
+            config,
+            models,
+            onErrorsCollector(collector),
+          ).validateAll();
+
+          expect(collector.errors, isEmpty);
+        },
+      );
+
+      test(
+        'when two concrete child classes extend the same tableBase class '
+        'then no errors are collected.',
+        () {
+          var models = [
+            ModelSourceBuilder().withYaml(
+              '''
+              class: Base
+              tableBase: true
+              fields:
+                parentId: int
+                parent: Parent?, relation(field=parentId)
+              ''',
+            ).build(),
+            ModelSourceBuilder().withFileName('child_one').withYaml(
+              '''
+              class: ChildOne
+              table: child_one
+              extends: Base
+              fields:
+                name: String
+              ''',
+            ).build(),
+            ModelSourceBuilder().withFileName('child_two').withYaml(
+              '''
+              class: ChildTwo
+              table: child_two
+              extends: Base
+              fields:
+                name: String
+              ''',
+            ).build(),
+            ModelSourceBuilder().withFileName('parent').withYaml(
+              '''
+              class: Parent
+              table: parent
+              fields:
+                name: String
+              ''',
+            ).build(),
+          ];
+
+          var collector = CodeGenerationCollector();
+          StatefulAnalyzer(
+            config,
+            models,
+            onErrorsCollector(collector),
+          ).validateAll();
+
+          expect(collector.errors, isEmpty);
+        },
+      );
+
+      test(
+        'when no concrete child class exists '
+        'then a warning is collected.',
+        () {
+          var models = [
+            ModelSourceBuilder().withYaml(
+              '''
+              class: Base
+              tableBase: true
+              fields:
+                parentId: int
+                parent: Parent?, relation(field=parentId)
+              ''',
+            ).build(),
+            ModelSourceBuilder().withFileName('parent').withYaml(
+              '''
+              class: Parent
+              table: parent
+              fields:
+                name: String
+              ''',
+            ).build(),
+          ];
+
+          var collector = CodeGenerationCollector();
+          StatefulAnalyzer(
+            config,
+            models,
+            onErrorsCollector(collector),
+          ).validateAll();
+
+          expect(
+            collector.errors.whereType<SourceSpanSeverityException>().where(
+              (e) => e.severity == SourceSpanSeverity.warning,
+            ),
+            isNotEmpty,
+            reason:
+                'Expected a warning — a tableBase class with no concrete '
+                'table-backed subclass will never generate foreign keys.',
+          );
+        },
+      );
+    },
+  );
+
+  group(
+    'Given a concrete child class that declares relation(field=inheritedFieldName)',
+    () {
+      test(
+        'when the FK field is declared in the base class (not the child) '
+        'then no errors are collected.',
+        () {
+          var models = [
+            ModelSourceBuilder().withYaml(
+              '''
+              class: Base
+              fields:
+                parentId: int
+              ''',
+            ).build(),
+            ModelSourceBuilder().withFileName('child').withYaml(
+              '''
+              class: Child
+              table: child
+              extends: Base
+              fields:
+                name: String
+                parent: Parent?, relation(field=parentId)
+              ''',
+            ).build(),
+            ModelSourceBuilder().withFileName('parent').withYaml(
+              '''
+              class: Parent
+              table: parent
+              fields:
+                name: String
+              ''',
+            ).build(),
+          ];
+
+          var collector = CodeGenerationCollector();
+          StatefulAnalyzer(
+            config,
+            models,
+            onErrorsCollector(collector),
+          ).validateAll();
+
+          expect(collector.errors, isEmpty);
+        },
+      );
+    },
+  );
+}

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/relation/relation_no_table_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/relation/relation_no_table_test.dart
@@ -12,7 +12,7 @@ void main() {
     'Given a class without a table definition when defining a relation',
     () {
       test(
-        'Given a class with an object relation but no table definition when analyzing model then an error is collected that the table property must be defined.',
+        'Given a class with an object relation but no table definition when analyzing model then an error is collected.',
         () {
           var models = [
             ModelSourceBuilder().withYaml(
@@ -44,17 +44,15 @@ void main() {
           expect(
             collector.errors,
             isNotEmpty,
-            reason: 'Expected an error to be collected',
-          );
-          expect(
-            collector.errors.first.message,
-            'The "table" property must be defined in the class to set a relation on a field.',
+            reason:
+                'Expected an error — a class without "table" or "tableBase: true" '
+                'may not declare relations.',
           );
         },
       );
 
       test(
-        'Given a class with a named object relation but no table definition when analyzing model then an error is collected that the table property must be defined.',
+        'Given a class with a named object relation but no table definition when analyzing model then an error is collected that the reference class must have a table.',
         () {
           var models = [
             ModelSourceBuilder().withYaml(
@@ -84,20 +82,19 @@ void main() {
             onErrorsCollector(collector),
           ).validateAll();
 
+          // Owner declares List<Animal>? but Animal has no table — the
+          // reference-side check fires, not the declaring-side check.
           expect(
-            collector.errors,
-            isNotEmpty,
-            reason: 'Expected an error to be collected',
-          );
-          expect(
-            collector.errors.first.message,
-            'The "table" property must be defined in the class to set a relation on a field.',
+            collector.errors.map((e) => e.message),
+            contains(
+              'The class "Animal" must have a "table" property defined to be used in a relation.',
+            ),
           );
         },
       );
 
       test(
-        'Given a class with a manual field relation but no table definition when analyzing model then an error is collected that the table property must be defined.',
+        'Given a class with a manual field relation but no table definition when analyzing model then an error is collected.',
         () {
           var models = [
             ModelSourceBuilder().withYaml(
@@ -130,17 +127,15 @@ void main() {
           expect(
             collector.errors,
             isNotEmpty,
-            reason: 'Expected an error to be collected',
-          );
-          expect(
-            collector.errors.first.message,
-            'The "table" property must be defined in the class to set a relation on a field.',
+            reason:
+                'Expected an error — a class without "table" or "tableBase: true" '
+                'may not declare relations.',
           );
         },
       );
 
       test(
-        'Given a class with a list relation but no table definition when analyzing model then an error is collected that the table property must be defined.',
+        'Given a class with a list relation but no table definition when analyzing model then an error is collected.',
         () {
           var models = [
             ModelSourceBuilder().withYaml(
@@ -172,17 +167,15 @@ void main() {
           expect(
             collector.errors,
             isNotEmpty,
-            reason: 'Expected an error to be collected',
-          );
-          expect(
-            collector.errors.first.message,
-            'The "table" property must be defined in the class to set a relation on a field.',
+            reason:
+                'Expected an error — a class without "table" or "tableBase: true" '
+                'may not declare relations.',
           );
         },
       );
 
       test(
-        'Given a class with an id field but no table definition when setting a relation then an error is collected about missing table property.',
+        'Given a class with an id field but no table definition when setting a relation then an error is collected.',
         () {
           var models = [
             ModelSourceBuilder().withYaml(
@@ -214,11 +207,9 @@ void main() {
           expect(
             collector.errors,
             isNotEmpty,
-            reason: 'Expected an error to be collected',
-          );
-          expect(
-            collector.errors.first.message,
-            'The "table" property must be defined in the class to set a relation on a field.',
+            reason:
+                'Expected an error — a class without "table" or "tableBase: true" '
+                'may not declare relations.',
           );
         },
       );

--- a/tools/serverpod_cli/test/database/create_definition/foreign_key_mixin_definition_test.dart
+++ b/tools/serverpod_cli/test/database/create_definition/foreign_key_mixin_definition_test.dart
@@ -1,0 +1,218 @@
+import 'package:serverpod_cli/src/analyzer/models/stateful_analyzer.dart';
+import 'package:serverpod_cli/src/database/create_definition.dart';
+import 'package:serverpod_cli/src/generator/code_generation_collector.dart';
+import 'package:test/test.dart';
+
+import '../../test_util/builders/generator_config_builder.dart';
+import '../../test_util/builders/model_source_builder.dart';
+
+void main() {
+  var config = GeneratorConfigBuilder().build();
+
+  test(
+    'Given a mixin with an unnamed relation(field=parentId) and a concrete child class, '
+    'when creating database definitions '
+    'then the child table contains the FK constraint and the mixin has no table.',
+    () {
+      var modelSources = [
+        ModelSourceBuilder().withYaml(
+          '''
+          class: Base
+          tableBase: true
+          fields:
+            parentId: int
+            parent: Parent?, relation(field=parentId)
+          ''',
+        ).build(),
+        ModelSourceBuilder().withFileName('child').withYaml(
+          '''
+          class: Child
+          table: child
+          extends: Base
+          fields:
+            name: String
+          ''',
+        ).build(),
+        ModelSourceBuilder().withFileName('parent').withYaml(
+          '''
+          class: Parent
+          table: parent
+          fields:
+            name: String
+          ''',
+        ).build(),
+      ];
+
+      var collector = CodeGenerationCollector();
+      var definitions = StatefulAnalyzer(
+        config,
+        modelSources,
+        onErrorsCollector(collector),
+      ).validateAll();
+
+      expect(collector.errors, isEmpty);
+
+      var databaseDefinition = createDatabaseDefinitionFromModels(
+        definitions,
+        'example',
+        [],
+      );
+
+      var tableNames = databaseDefinition.tables.map((t) => t.name).toList();
+      expect(tableNames, contains('child'));
+      expect(tableNames, contains('parent'));
+      expect(tableNames, isNot(contains('base')));
+
+      var childTable = databaseDefinition.tables.singleWhere(
+        (t) => t.name == 'child',
+      );
+
+      expect(childTable.foreignKeys, hasLength(1));
+
+      var fk = childTable.foreignKeys.first;
+      expect(fk.constraintName, 'child_fk_0');
+      expect(fk.columns, ['parentId']);
+      expect(fk.referenceTable, 'parent');
+      expect(fk.referenceColumns, ['id']);
+    },
+  );
+
+  test(
+    'Given a mixin with an unnamed relation(field=parentId) and two concrete child classes, '
+    'when creating database definitions '
+    'then each child table has its own independent FK constraint.',
+    () {
+      var modelSources = [
+        ModelSourceBuilder().withYaml(
+          '''
+          class: Base
+          tableBase: true
+          fields:
+            parentId: int
+            parent: Parent?, relation(field=parentId)
+          ''',
+        ).build(),
+        ModelSourceBuilder().withFileName('child_one').withYaml(
+          '''
+          class: ChildOne
+          table: child_one
+          extends: Base
+          fields:
+            name: String
+          ''',
+        ).build(),
+        ModelSourceBuilder().withFileName('child_two').withYaml(
+          '''
+          class: ChildTwo
+          table: child_two
+          extends: Base
+          fields:
+            name: String
+          ''',
+        ).build(),
+        ModelSourceBuilder().withFileName('parent').withYaml(
+          '''
+          class: Parent
+          table: parent
+          fields:
+            name: String
+          ''',
+        ).build(),
+      ];
+
+      var collector = CodeGenerationCollector();
+      var definitions = StatefulAnalyzer(
+        config,
+        modelSources,
+        onErrorsCollector(collector),
+      ).validateAll();
+
+      expect(collector.errors, isEmpty);
+
+      var databaseDefinition = createDatabaseDefinitionFromModels(
+        definitions,
+        'example',
+        [],
+      );
+
+      var childOneTable = databaseDefinition.tables.singleWhere(
+        (t) => t.name == 'child_one',
+      );
+      var childTwoTable = databaseDefinition.tables.singleWhere(
+        (t) => t.name == 'child_two',
+      );
+
+      expect(childOneTable.foreignKeys, hasLength(1));
+      expect(childOneTable.foreignKeys.first.constraintName, 'child_one_fk_0');
+      expect(childOneTable.foreignKeys.first.columns, ['parentId']);
+      expect(childOneTable.foreignKeys.first.referenceTable, 'parent');
+
+      expect(childTwoTable.foreignKeys, hasLength(1));
+      expect(childTwoTable.foreignKeys.first.constraintName, 'child_two_fk_0');
+      expect(childTwoTable.foreignKeys.first.columns, ['parentId']);
+      expect(childTwoTable.foreignKeys.first.referenceTable, 'parent');
+    },
+  );
+
+  test(
+    'Given a tableBase class with an implicit relation (no field= specified) and a concrete child class, '
+    'when creating database definitions '
+    'then the child table contains the FK constraint with an auto-generated column name.',
+    () {
+      var modelSources = [
+        ModelSourceBuilder().withYaml(
+          '''
+          class: Base
+          tableBase: true
+          fields:
+            parent: Parent?, relation
+          ''',
+        ).build(),
+        ModelSourceBuilder().withFileName('child').withYaml(
+          '''
+          class: Child
+          table: child
+          extends: Base
+          fields:
+            name: String
+          ''',
+        ).build(),
+        ModelSourceBuilder().withFileName('parent').withYaml(
+          '''
+          class: Parent
+          table: parent
+          fields:
+            name: String
+          ''',
+        ).build(),
+      ];
+
+      var collector = CodeGenerationCollector();
+      var definitions = StatefulAnalyzer(
+        config,
+        modelSources,
+        onErrorsCollector(collector),
+      ).validateAll();
+
+      expect(collector.errors, isEmpty);
+
+      var databaseDefinition = createDatabaseDefinitionFromModels(
+        definitions,
+        'example',
+        [],
+      );
+
+      var childTable = databaseDefinition.tables.singleWhere(
+        (t) => t.name == 'child',
+      );
+
+      expect(childTable.foreignKeys, hasLength(1));
+
+      var fk = childTable.foreignKeys.first;
+      expect(fk.constraintName, 'child_fk_0');
+      expect(fk.columns, ['parentId']);
+      expect(fk.referenceTable, 'parent');
+      expect(fk.referenceColumns, ['id']);
+    },
+  );
+}


### PR DESCRIPTION
This change presents a scoped/partial solution to #4735.

## Problem to solve

The part of #4735 this is addressing: _Currently, relations can only be defined on table models, making impossible to declare a base class with a relation that should be present on all subclasses._

As requested, this change allows a (non-table) base class to declare a `relation` that is then automatically implemented as a foreign key on derived (`extends:`-ing) `table` classes. The `relation` can be implicit (i.e. just `relation`) or specify the field establishing the relationship (e.g. `relation(field=parentId)`).

The part of #4735 this is intentionally leaving unsolved: _It also mean that such relations would be unidirectional only instead of allowing a bidirectional polymorphic relation on the related table._

I'm proposing that we do not (yet?) enable a back-reference from the destination of the relationship. 

If we _did_ enable that, it means the destination class would need to either enumerate the derived `table` classes (which feels like it would break layers of abstraction), _or_ it would need to reference the parent/base class which one could then either treat universally or try to downcast from.

Neither of these is wrong; however, I think this current change already provides self-contained value without back-references, has the benefit of fewer lines of code changed, and does not preclude back-references from being supported in the future. (For full disclosure, this is perhaps just an elaborate rationalization of "this solves _my_ problem of the day and I did not want to scope-creep this PR".)

## Additional considerations implemented

I am proposing that we make this capability opt-in because its success path is otherwise difficult to distinguish from the failure path of "I declared a `relation`, forgot to make it a `table` class, now I am confused why things aren't working".

To that end, I am proposing a new table-level tag, `tableBase: true`, to make it explicit that a given `table`-less base class is exactly that (a base class for `table` classes), which then activates this feature.

## Pre-launch Checklist

- [X] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [X] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [X] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [X] I added new tests to check the change I am making.
- [X] All existing and new tests are passing.
- [X] Any breaking changes are documented below.

## Breaking changes

None.